### PR TITLE
feat: expand memory types to 7 categories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,9 @@ Features across OpenClaw plugin (`skill/plugin/`), MCP server (`mcp/`), and Nano
 | Pre-compaction flush | Yes | -- | Yes (hook) | |
 | Pre-reset flush | Yes | -- | -- | OpenClaw only |
 | CLAUDE.md sync | -- | -- | Yes | NanoClaw syncs high-importance facts |
+| **Extraction** | | | | |
+| Expanded memory types (7 categories) | Yes | Yes (via prompt) | Yes | fact, preference, decision, episodic, goal, context, summary |
+| Decision reasoning extraction | Yes | Yes (via prompt) | Yes | Extraction prompts require "chose X because Y" |
 | **Dedup** | | | | |
 | Content fingerprint (exact) | Yes | Yes | Yes | Server-side HMAC-SHA256 |
 | Within-batch semantic dedup | Yes | -- | -- | Cosine >= 0.9, during extraction |
@@ -251,6 +254,7 @@ Every new feature implementation MUST include:
 - **Server-blind**: Server NEVER sees plaintext
 - **Embedding model**: Qwen3-Embedding-0.6B (1024d, 100+ languages, last-token pooling)
 - **Extraction cap**: Max 15 facts per extraction cycle, unified 3-turn interval
+- **Memory types**: 7 categories -- fact, preference, decision (with reasoning), episodic, goal, context, summary
 
 ---
 

--- a/mcp/src/prompts.ts
+++ b/mcp/src/prompts.ts
@@ -64,7 +64,7 @@ Each fact needs:
   - 5-6: Moderate facts (schedule, minor preferences)
   - 3-4: Low priority (casual mentions)
   - 1-2: Ephemeral (likely to change)
-- type: Category (optional) -- "fact", "preference", "decision", "episodic", "goal"
+- type: Category (optional) -- "fact", "preference", "decision", "episodic", "goal", "context", "summary"
 
 The vault handles deduplication automatically. If a similar fact exists, it will be updated rather than duplicated.`;
 

--- a/mcp/src/tools/import-from.ts
+++ b/mcp/src/tools/import-from.ts
@@ -20,7 +20,7 @@ export interface ImportFromInput {
 
 export interface NormalizedFact {
   text: string;
-  type: 'fact' | 'preference' | 'decision' | 'episodic' | 'goal';
+  type: 'fact' | 'preference' | 'decision' | 'episodic' | 'goal' | 'context' | 'summary';
   importance: number;
   source: ImportSource;
   sourceId?: string;

--- a/mcp/src/tools/remember.ts
+++ b/mcp/src/tools/remember.ts
@@ -26,7 +26,7 @@ export interface RememberInputSingle {
 export interface BatchFact {
   text: string;
   importance?: number;
-  type?: 'fact' | 'preference' | 'decision' | 'episodic' | 'goal';
+  type?: 'fact' | 'preference' | 'decision' | 'episodic' | 'goal' | 'context' | 'summary';
 }
 
 export interface RememberInputBatch {
@@ -82,7 +82,7 @@ export const rememberToolDefinition = {
             },
             type: {
               type: 'string',
-              enum: ['fact', 'preference', 'decision', 'episodic', 'goal'],
+              enum: ['fact', 'preference', 'decision', 'episodic', 'goal', 'context', 'summary'],
               description: 'Category of the fact',
             },
           },
@@ -102,7 +102,7 @@ export const rememberToolDefinition = {
         properties: {
           type: {
             type: 'string',
-            enum: ['fact', 'preference', 'decision', 'episodic', 'goal'],
+            enum: ['fact', 'preference', 'decision', 'episodic', 'goal', 'context', 'summary'],
           },
           expires_at: {
             type: 'string',

--- a/skill-nanoclaw/src/extraction/prompts.ts
+++ b/skill-nanoclaw/src/extraction/prompts.ts
@@ -9,7 +9,7 @@
 
 export type ExtractionAction = 'ADD' | 'UPDATE' | 'DELETE' | 'NOOP';
 
-export type FactType = 'fact' | 'preference' | 'decision' | 'episodic' | 'goal';
+export type FactType = 'fact' | 'preference' | 'decision' | 'episodic' | 'goal' | 'context' | 'summary';
 
 export interface Entity {
   id: string;
@@ -46,7 +46,7 @@ export const EXTRACTION_RESPONSE_SCHEMA = {
           factText: { type: 'string', maxLength: 512 },
           type: {
             type: 'string',
-            enum: ['fact', 'preference', 'decision', 'episodic', 'goal'],
+            enum: ['fact', 'preference', 'decision', 'episodic', 'goal', 'context', 'summary'],
           },
           importance: { type: 'integer', minimum: 1, maximum: 10 },
           confidence: { type: 'number', minimum: 0, maximum: 1 },
@@ -100,34 +100,42 @@ const BASE_SYSTEM_PROMPT = `You are a memory extraction engine for an AI assista
 
 ## Extraction Guidelines
 
-1. **Atomicity**: Each fact should be a single, atomic piece of information
-   - GOOD: "User prefers TypeScript over JavaScript for new projects"
+1. **Atomicity**: Each fact should be a single, self-contained piece of information
+   - GOOD: "User chose PostgreSQL because the data model is relational and needs ACID"
    - BAD: "User likes TypeScript, uses VS Code, and works at Google"
 
 2. **Types**:
    - **fact**: Objective information about the user/world
    - **preference**: User's likes, dislikes, or preferences
-   - **decision**: Choices the user has made
+   - **decision**: Choices WITH reasoning ("chose X because Y")
    - **episodic**: Event-based memories (what happened when)
    - **goal**: User's objectives or targets
+   - **context**: Active project/task context (what the user is working on, versions, environments)
+   - **summary**: Key outcome or conclusion from a discussion
 
 3. **Importance Scoring (1-10)**:
    - 1-3: Trivial, unlikely to matter (small talk, pleasantries)
    - 4-6: Useful context (tool preferences, working style)
-   - 7-8: Important (key decisions, major preferences)
+   - 7-8: Important (key decisions with reasoning, project context, major preferences)
    - 9-10: Critical (core values, non-negotiables, safety info)
 
 4. **Confidence (0-1)**:
    - How certain are you that this is accurate and worth storing?
 
-5. **Entities**: Extract named entities (people, projects, tools, concepts)
+5. **Extraction quality cues**:
+   - Decisions: ALWAYS include reasoning. "Chose X" alone is low value.
+   - Context: Include version numbers, environments, status ("v1.2", "staging", "private beta")
+   - Summaries: Only when a conversation reaches a clear conclusion or agreement
+   - Facts: Prefer specific over vague
+
+6. **Entities**: Extract named entities (people, projects, tools, concepts)
    - Use stable IDs: hash of name+type (e.g., "typescript-tool")
    - Types: person, project, tool, preference, concept, location, etc.
 
-6. **Relations**: Extract relationships between entities
+7. **Relations**: Extract relationships between entities
    - Common predicates: prefers, uses, works_on, decided_to_use, dislikes, etc.
 
-7. **Actions (Mem0 pattern)**:
+8. **Actions (Mem0 pattern)**:
    - **ADD**: New fact, no conflict with existing memories
    - **UPDATE**: Modifies or refines an existing fact (provide existingFactId)
    - **DELETE**: Contradicts and replaces an existing fact
@@ -287,7 +295,7 @@ export function validateExtractionResponse(response: unknown): {
       factErrors.push(`facts[${i}].factText must be a non-empty string`);
     }
 
-    const validTypes: FactType[] = ['fact', 'preference', 'decision', 'episodic', 'goal'];
+    const validTypes: FactType[] = ['fact', 'preference', 'decision', 'episodic', 'goal', 'context', 'summary'];
     if (!validTypes.includes(fact.type as FactType)) {
       factErrors.push(`facts[${i}].type must be one of: ${validTypes.join(', ')}`);
     }

--- a/skill-nanoclaw/src/hooks/before-agent-start.ts
+++ b/skill-nanoclaw/src/hooks/before-agent-start.ts
@@ -36,7 +36,7 @@ export async function beforeAgentStart(
       text: r.fact.text,
       score: r.score,
       type: r.fact.metadata.tags?.find(t =>
-        ['fact', 'preference', 'decision', 'episodic', 'goal'].includes(t)
+        ['fact', 'preference', 'decision', 'episodic', 'goal', 'context', 'summary'].includes(t)
       ) || 'fact',
     }));
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -35,7 +35,7 @@ Store a new fact or preference in long-term memory.
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | text | string | Yes | The fact or information to remember |
-| type | string | No | Type of memory: `fact`, `preference`, `decision`, `episodic`, or `goal`. Default: `fact` |
+| type | string | No | Type of memory: `fact`, `preference`, `decision`, `episodic`, `goal`, `context`, or `summary`. Default: `fact` |
 | importance | integer | No | Importance score 1-10. Default: auto-detected by LLM |
 
 **Example:**
@@ -371,11 +371,29 @@ TotalReclaw is an end-to-end encrypted memory vault for AI agents. Think of it a
 
 3. **Universal Compatibility** - Works across any MCP-compatible AI agent, not just OpenClaw.
 
-4. **Intelligent Extraction** - Automatically extracts atomic facts, preferences, decisions, and goals from conversations.
+4. **Intelligent Extraction** - Automatically extracts facts, preferences, decisions with reasoning, project context, conversation summaries, and goals from conversations.
 
 5. **Smart Decay** - Important memories persist; trivial ones fade over time using a decay algorithm.
 
 6. **Graph-Based** - Maintains entity relationships for multi-hop reasoning.
+
+---
+
+## Memory Types
+
+TotalReclaw extracts and stores seven types of memories:
+
+| Type | Description | Example |
+|------|-------------|---------|
+| Fact | Objective information about you | "Lives in Lisbon, Portugal" |
+| Preference | Your likes, dislikes, choices | "Prefers dark mode in all applications" |
+| Decision | Choices you made WITH reasoning | "Chose PostgreSQL because data is relational and needs ACID" |
+| Episodic | Notable events or experiences | "Deployed v1.0 to production on March 15" |
+| Goal | Your objectives or plans | "Wants to launch public beta by end of Q1" |
+| Context | Active project/task context | "Working on TotalReclaw v1.2, staging on Base Sepolia" |
+| Summary | Key outcomes from discussions | "Agreed to use phased rollout for mainnet migration" |
+
+Decisions and context are treated as high-value memories (importance >= 7) because they provide the most useful information for future conversations.
 
 ---
 
@@ -465,7 +483,7 @@ Always run with `dry_run=true` first to preview which memories will be merged, t
 2. **Importance Scoring**:
    - 1-3: Trivial, unlikely to matter (small talk, pleasantries)
    - 4-6: Useful context (tool preferences, working style)
-   - 7-8: Important (key decisions, major preferences)
+   - 7-8: Important (key decisions with reasoning, project context, major preferences)
    - 9-10: Critical (core values, non-negotiables, safety info)
 
 3. **Search Before Storing**: Always recall similar memories before storing new ones to avoid duplicates.
@@ -502,34 +520,42 @@ You are a memory extraction engine for an AI assistant. Your job is to analyze c
 
 ## Extraction Guidelines
 
-1. **Atomicity**: Each fact should be a single, atomic piece of information
-   - GOOD: "User prefers TypeScript over JavaScript for new projects"
+1. **Atomicity**: Each fact should be a single, self-contained piece of information
+   - GOOD: "User chose PostgreSQL because the data model is relational and needs ACID"
    - BAD: "User likes TypeScript, uses VS Code, and works at Google"
 
 2. **Types**:
    - **fact**: Objective information about the user/world
    - **preference**: User's likes, dislikes, or preferences
-   - **decision**: Choices the user has made
+   - **decision**: Choices WITH reasoning ("chose X because Y")
    - **episodic**: Event-based memories (what happened when)
    - **goal**: User's objectives or targets
+   - **context**: Active project/task context (what the user is working on, versions, environments)
+   - **summary**: Key outcome or conclusion from a discussion
 
 3. **Importance Scoring (1-10)**:
    - 1-3: Trivial, unlikely to matter (small talk, pleasantries)
    - 4-6: Useful context (tool preferences, working style)
-   - 7-8: Important (key decisions, major preferences)
+   - 7-8: Important (key decisions with reasoning, project context, major preferences)
    - 9-10: Critical (core values, non-negotiables, safety info)
 
 4. **Confidence (0-1)**:
    - How certain are you that this is accurate and worth storing?
 
-5. **Entities**: Extract named entities (people, projects, tools, concepts)
+5. **Extraction quality cues**:
+   - Decisions: ALWAYS include reasoning. "Chose X" alone is low value.
+   - Context: Include version numbers, environments, status ("v1.2", "staging", "private beta")
+   - Summaries: Only when a conversation reaches a clear conclusion or agreement
+   - Facts: Prefer specific over vague
+
+6. **Entities**: Extract named entities (people, projects, tools, concepts)
    - Use stable IDs: hash of name+type (e.g., "typescript-tool")
    - Types: person, project, tool, preference, concept, location, etc.
 
-6. **Relations**: Extract relationships between entities
+7. **Relations**: Extract relationships between entities
    - Common predicates: prefers, uses, works_on, decided_to_use, dislikes, etc.
 
-7. **Actions (Mem0 pattern)**:
+8. **Actions (Mem0 pattern)**:
    - **ADD**: New fact, no conflict with existing memories
    - **UPDATE**: Modifies or refines an existing fact (provide existingFactId)
    - **DELETE**: Contradicts and replaces an existing fact
@@ -551,7 +577,7 @@ You are reviewing the last 20 turns of conversation before they are compacted. E
 
 ## Instructions:
 1. Review each turn carefully for extractable information
-2. Extract atomic facts, preferences, decisions, episodic memories, and goals
+2. Extract facts, preferences, decisions (with reasoning), episodic memories, goals, project context, and conversation summaries
 3. For each fact, determine if it's NEW (ADD), modifies existing (UPDATE), contradicts existing (DELETE), or is redundant (NOOP)
 4. Score importance based on long-term relevance
 5. Extract entities and relations
@@ -562,7 +588,7 @@ Return a JSON object with:
   "facts": [
     {
       "factText": "string (max 512 chars)",
-      "type": "fact|preference|decision|episodic|goal",
+      "type": "fact|preference|decision|episodic|goal|context|summary",
       "importance": 1-10,
       "confidence": 0-1,
       "action": "ADD|UPDATE|DELETE|NOOP",

--- a/skill/plugin/extractor-dedup.test.ts
+++ b/skill/plugin/extractor-dedup.test.ts
@@ -57,7 +57,7 @@ function parseFactsResponse(response: string): ExtractedFact[] {
           : 'ADD';
         return {
           text: String(fact.text).slice(0, 512),
-          type: (['fact', 'preference', 'decision', 'episodic', 'goal'].includes(String(fact.type))
+          type: (['fact', 'preference', 'decision', 'episodic', 'goal', 'context', 'summary'].includes(String(fact.type))
             ? String(fact.type)
             : 'fact') as ExtractedFact['type'],
           importance: Math.max(1, Math.min(10, Number(fact.importance) || 5)),

--- a/skill/plugin/extractor.ts
+++ b/skill/plugin/extractor.ts
@@ -15,7 +15,7 @@ export type ExtractionAction = 'ADD' | 'UPDATE' | 'DELETE' | 'NOOP';
 
 export interface ExtractedFact {
   text: string;
-  type: 'fact' | 'preference' | 'decision' | 'episodic' | 'goal';
+  type: 'fact' | 'preference' | 'decision' | 'episodic' | 'goal' | 'context' | 'summary';
   importance: number; // 1-10
   action: ExtractionAction;
   existingFactId?: string;
@@ -37,28 +37,36 @@ interface ConversationMessage {
 // Extraction Prompt
 // ---------------------------------------------------------------------------
 
-const EXTRACTION_SYSTEM_PROMPT = `You are a memory extraction engine. Analyze the conversation and extract atomic facts worth remembering long-term.
+const EXTRACTION_SYSTEM_PROMPT = `You are a memory extraction engine. Analyze the conversation and extract valuable long-term memories.
 
 Rules:
-1. Each fact must be a single, atomic piece of information
-2. Focus on user-specific information: preferences, decisions, facts about them, their goals
-3. Skip generic knowledge, greetings, and small talk
-4. Skip information that is only relevant to the current conversation
-5. Score importance 1-10 (7+ = worth storing, below 7 = skip)
-6. Only extract facts with importance >= 6
+1. Each memory must be a single, self-contained piece of information
+2. Focus on user-specific information that would be useful in future conversations
+3. Skip generic knowledge, greetings, small talk, and ephemeral task coordination
+4. Score importance 1-10 (6+ = worth storing)
+5. Only extract memories with importance >= 6
 
 Types:
-- fact: Objective information about the user
-- preference: Likes, dislikes, or preferences
-- decision: Choices the user has made
-- episodic: Events or experiences
-- goal: Objectives or targets
+- fact: Objective information about the user (name, location, job, relationships)
+- preference: Likes, dislikes, or preferences ("prefers dark mode", "allergic to peanuts")
+- decision: Choices WITH reasoning ("chose PostgreSQL because data is relational and needs ACID")
+- episodic: Notable events or experiences ("deployed v1.0 to production on March 15")
+- goal: Objectives, targets, or plans ("wants to launch public beta by end of Q1")
+- context: Active project/task context ("working on TotalReclaw v1.2, staging on Base Sepolia")
+- summary: Key outcome or conclusion from a discussion ("agreed to use phased rollout for migration")
+
+Extraction guidance:
+- For decisions: ALWAYS include the reasoning. "Chose X" is weak. "Chose X because Y" is strong.
+- For context: Capture what the user is actively working on, including versions, environments, and status.
+- For summaries: Only extract when a conversation reaches a clear conclusion or agreement.
+- For facts: Prefer specific over vague. "Lives in Lisbon" beats "lives in Europe".
+- Decisions and context should be importance >= 7 (they are high-value for future conversations).
 
 Actions (compare against existing memories if provided):
-- ADD: New fact, no conflict with existing memories
-- UPDATE: Modifies or refines an existing memory (provide existingFactId)
-- DELETE: Contradicts an existing memory — the old one is now wrong (provide existingFactId)
-- NOOP: Already captured in existing memories or not worth storing
+- ADD: New memory, no conflict with existing
+- UPDATE: Refines or corrects an existing memory (provide existingFactId)
+- DELETE: Contradicts an existing memory -- the old one is now wrong (provide existingFactId)
+- NOOP: Already captured or not worth storing
 
 Return a JSON array (no markdown, no code fences):
 [{"text": "...", "type": "...", "importance": N, "action": "ADD|UPDATE|DELETE|NOOP", "existingFactId": "..."}, ...]
@@ -158,7 +166,7 @@ function parseFactsResponse(response: string): ExtractedFact[] {
           : 'ADD'; // Default to ADD for backward compatibility
         return {
           text: String(fact.text).slice(0, 512),
-          type: (['fact', 'preference', 'decision', 'episodic', 'goal'].includes(String(fact.type))
+          type: (['fact', 'preference', 'decision', 'episodic', 'goal', 'context', 'summary'].includes(String(fact.type))
             ? String(fact.type)
             : 'fact') as ExtractedFact['type'],
           importance: Math.max(1, Math.min(10, Number(fact.importance) || 5)),

--- a/skill/plugin/import-adapters/base-adapter.ts
+++ b/skill/plugin/import-adapters/base-adapter.ts
@@ -44,7 +44,7 @@ export abstract class BaseImportAdapter {
     const text = fact.text.trim().slice(0, 512);
 
     // Normalize type
-    const validTypes = ['fact', 'preference', 'decision', 'episodic', 'goal'] as const;
+    const validTypes = ['fact', 'preference', 'decision', 'episodic', 'goal', 'context', 'summary'] as const;
     const type = validTypes.includes(fact.type as typeof validTypes[number])
       ? (fact.type as NormalizedFact['type'])
       : 'fact';

--- a/skill/plugin/import-adapters/import-adapters.test.ts
+++ b/skill/plugin/import-adapters/import-adapters.test.ts
@@ -453,7 +453,7 @@ async function runTests(): Promise<void> {
 
   // --- type normalization ---
   {
-    const validTypes = ['fact', 'preference', 'decision', 'episodic', 'goal'] as const;
+    const validTypes = ['fact', 'preference', 'decision', 'episodic', 'goal', 'context', 'summary'] as const;
 
     for (const t of validTypes) {
       const result = testAdapter.testValidateFact({ text: 'test fact', type: t });

--- a/skill/plugin/import-adapters/types.ts
+++ b/skill/plugin/import-adapters/types.ts
@@ -6,7 +6,7 @@ export interface NormalizedFact {
   /** The atomic fact text (max 512 chars) */
   text: string;
   /** Fact type matching TotalReclaw's taxonomy */
-  type: 'fact' | 'preference' | 'decision' | 'episodic' | 'goal';
+  type: 'fact' | 'preference' | 'decision' | 'episodic' | 'goal' | 'context' | 'summary';
   /** Importance score 1-10 */
   importance: number;
   /** Original source system */

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -1261,7 +1261,7 @@ const plugin = {
             },
             type: {
               type: 'string',
-              enum: ['fact', 'preference', 'decision', 'episodic', 'goal'],
+              enum: ['fact', 'preference', 'decision', 'episodic', 'goal', 'context', 'summary'],
               description: 'The kind of memory (default: fact)',
             },
             importance: {

--- a/skill/src/extraction/extractor.ts
+++ b/skill/src/extraction/extractor.ts
@@ -422,7 +422,7 @@ export class FactExtractor {
       errors.push(`${prefix}.factText must be a non-empty string`);
     }
 
-    const validTypes: ExtractedFact['type'][] = ['fact', 'preference', 'decision', 'episodic', 'goal'];
+    const validTypes: ExtractedFact['type'][] = ['fact', 'preference', 'decision', 'episodic', 'goal', 'context', 'summary'];
     if (!validTypes.includes(rawFact.type)) {
       errors.push(`${prefix}.type must be one of: ${validTypes.join(', ')}`);
     }

--- a/skill/src/extraction/prompts.ts
+++ b/skill/src/extraction/prompts.ts
@@ -25,7 +25,7 @@ export const EXTRACTION_RESPONSE_SCHEMA = {
           factText: { type: 'string', maxLength: 512 },
           type: {
             type: 'string',
-            enum: ['fact', 'preference', 'decision', 'episodic', 'goal']
+            enum: ['fact', 'preference', 'decision', 'episodic', 'goal', 'context', 'summary']
           },
           importance: { type: 'integer', minimum: 1, maximum: 10 },
           confidence: { type: 'number', minimum: 0, maximum: 1 },
@@ -103,34 +103,42 @@ const BASE_SYSTEM_PROMPT = `You are a memory extraction engine for an AI assista
 
 ## Extraction Guidelines
 
-1. **Atomicity**: Each fact should be a single, atomic piece of information
-   - GOOD: "User prefers TypeScript over JavaScript for new projects"
+1. **Atomicity**: Each fact should be a single, self-contained piece of information
+   - GOOD: "User chose PostgreSQL because the data model is relational and needs ACID"
    - BAD: "User likes TypeScript, uses VS Code, and works at Google"
 
 2. **Types**:
    - **fact**: Objective information about the user/world
    - **preference**: User's likes, dislikes, or preferences
-   - **decision**: Choices the user has made
+   - **decision**: Choices WITH reasoning ("chose X because Y")
    - **episodic**: Event-based memories (what happened when)
    - **goal**: User's objectives or targets
+   - **context**: Active project/task context (what the user is working on, versions, environments)
+   - **summary**: Key outcome or conclusion from a discussion
 
 3. **Importance Scoring (1-10)**:
    - 1-3: Trivial, unlikely to matter (small talk, pleasantries)
    - 4-6: Useful context (tool preferences, working style)
-   - 7-8: Important (key decisions, major preferences)
+   - 7-8: Important (key decisions with reasoning, project context, major preferences)
    - 9-10: Critical (core values, non-negotiables, safety info)
 
 4. **Confidence (0-1)**:
    - How certain are you that this is accurate and worth storing?
 
-5. **Entities**: Extract named entities (people, projects, tools, concepts)
+5. **Extraction quality cues**:
+   - Decisions: ALWAYS include reasoning. "Chose X" alone is low value.
+   - Context: Include version numbers, environments, status ("v1.2", "staging", "private beta")
+   - Summaries: Only when a conversation reaches a clear conclusion or agreement
+   - Facts: Prefer specific over vague
+
+6. **Entities**: Extract named entities (people, projects, tools, concepts)
    - Use stable IDs: hash of name+type (e.g., "typescript-tool")
    - Types: person, project, tool, preference, concept, location, etc.
 
-6. **Relations**: Extract relationships between entities
+7. **Relations**: Extract relationships between entities
    - Common predicates: prefers, uses, works_on, decided_to_use, dislikes, etc.
 
-7. **Actions (Mem0 pattern)**:
+8. **Actions (Mem0 pattern)**:
    - **ADD**: New fact, no conflict with existing memories
    - **UPDATE**: Modifies or refines an existing fact (provide existingFactId)
    - **DELETE**: Contradicts and replaces an existing fact
@@ -483,7 +491,7 @@ export function validateExtractionResponse(response: unknown): {
       factErrors.push(`facts[${i}].factText must be a non-empty string`);
     }
 
-    const validTypes = ['fact', 'preference', 'decision', 'episodic', 'goal'];
+    const validTypes = ['fact', 'preference', 'decision', 'episodic', 'goal', 'context', 'summary'];
     if (!validTypes.includes(fact.type as string)) {
       factErrors.push(`facts[${i}].type must be one of: ${validTypes.join(', ')}`);
     }

--- a/skill/src/tools/remember.ts
+++ b/skill/src/tools/remember.ts
@@ -83,7 +83,7 @@ export async function rememberTool(
   }
 
   // Validate type if provided
-  const validTypes = ['fact', 'preference', 'decision', 'episodic', 'goal'];
+  const validTypes = ['fact', 'preference', 'decision', 'episodic', 'goal', 'context', 'summary'];
   if (params.type !== undefined && !validTypes.includes(params.type)) {
     return {
       success: false,

--- a/skill/src/triggers/before-agent-start.ts
+++ b/skill/src/triggers/before-agent-start.ts
@@ -138,7 +138,7 @@ function getMemoryType(fact: Fact): string {
   // Check tags for type information
   if (fact.metadata?.tags && fact.metadata.tags.length > 0) {
     const typeTag = fact.metadata.tags.find(t =>
-      ['fact', 'preference', 'decision', 'episodic', 'goal'].includes(t)
+      ['fact', 'preference', 'decision', 'episodic', 'goal', 'context', 'summary'].includes(t)
     );
     if (typeTag) return typeTag;
   }

--- a/skill/src/triggers/pre-compaction.ts
+++ b/skill/src/triggers/pre-compaction.ts
@@ -256,7 +256,7 @@ async function getExistingMemories(
     return results.map(r => {
       // Extract type from tags if available
       const typeTag = r.fact.metadata?.tags?.find(t =>
-        ['fact', 'preference', 'decision', 'episodic', 'goal'].includes(t)
+        ['fact', 'preference', 'decision', 'episodic', 'goal', 'context', 'summary'].includes(t)
       ) as ExtractedFact['type'] | undefined;
       const type: ExtractedFact['type'] = typeTag || 'fact';
 

--- a/skill/src/types.ts
+++ b/skill/src/types.ts
@@ -61,7 +61,7 @@ export interface ExtractedFact {
   /** The fact text (atomic, concise) */
   factText: string;
   /** Type of fact */
-  type: 'fact' | 'preference' | 'decision' | 'episodic' | 'goal';
+  type: 'fact' | 'preference' | 'decision' | 'episodic' | 'goal' | 'context' | 'summary';
   /** Importance score (1-10) */
   importance: number;
   /** Confidence (0-1) */


### PR DESCRIPTION
## Summary
- Expand extraction from 5 to 7 memory types: `fact`, `preference`, `decision`, `episodic`, `goal`, `context`, `summary`
- Rewrite extraction prompts with per-type quality cues (decisions require reasoning, context captures versions/environments, summaries only on clear conclusions)
- Updated across all three platforms: OpenClaw plugin, NanoClaw, MCP server
- Updated SKILL.md with memory types documentation table
- Updated CLAUDE.md feature matrix

## Files changed (19)
- Plugin: extractor.ts, index.ts, import adapters, types
- NanoClaw: prompts.ts, hooks
- MCP: remember.ts, import-from.ts, prompts.ts
- Docs: SKILL.md, CLAUDE.md

## Test plan
- [x] MCP type-check: clean
- [x] Client tests: 251/251 passing
- [x] Zero remaining occurrences of old 5-type array
- [ ] E2E validation with expanded types (run after merge via internal E2E suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)