### PR TITLE
feat: server-side candidate pool sizing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,8 @@ Features across OpenClaw plugin (`skill/plugin/`), MCP server (`mcp/`), and Nano
 | 403 handling + cache invalidation | Yes | Yes | Yes | |
 | **Search Optimizations** | | | | |
 | Hot cache + two-tier search | Yes (managed) | -- | -- | Skips remote query if cached query similar |
-| Dynamic candidate pool sizing | Yes | Yes | Yes (via MCP) | 400-5000 based on vault size |
+| Dynamic candidate pool sizing | Yes | Yes | Yes (via MCP) | Server-configurable via billing features; env overrides `CANDIDATE_POOL_MAX_FREE`/`CANDIDATE_POOL_MAX_PRO` |
+| Server-side candidate pool | Yes | Yes | Yes (via MCP) | Relay computes `max_candidate_pool` from vault size + tier; clients read from billing cache with local fallback |
 | BM25 + Cosine + RRF reranking | Yes | Yes | Yes (via MCP) | Intent-weighted |
 | **Admin & Analytics** | | | | |
 | X-TotalReclaw-Client header | Yes | Yes | Yes (via MCP) | Sent on every relay request |
@@ -245,6 +246,7 @@ Every new feature implementation MUST include:
 | Migration tool (testnet to mainnet) | MEDIUM | Designed, not implemented -- re-encrypt + re-store on upgrade |
 | Load testing | IN PROGRESS | Benchmark harness at 1M memories, results in `totalreclaw-internal/e2e/load-test/` |
 | Graceful shutdown | LOW | Not yet configured in uvicorn |
+| Candidate pool sizing | RESOLVED | Server-configurable via relay billing endpoint (`max_candidate_pool` in FeatureFlags). Env overrides: `CANDIDATE_POOL_MAX_FREE`, `CANDIDATE_POOL_MAX_PRO`. |
 
 ---
 

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -31,6 +31,7 @@ import {
   handleStatus,
   handleUpgrade,
 } from './tools/index.js';
+import { getLastBillingResponse } from './tools/status.js';
 import { setOnRememberCallback } from './tools/remember.js';
 import {
   findNearDuplicate,
@@ -96,6 +97,65 @@ const MASTER_PASSWORD = process.env.TOTALRECLAW_RECOVERY_PHRASE;
 
 // Store-time near-duplicate detection (consolidation module)
 const STORE_DEDUP_ENABLED = process.env.TOTALRECLAW_STORE_DEDUP !== 'false';
+
+// ── Billing cache (in-memory, for server-side candidate pool) ───────────────
+
+interface BillingCacheEntry {
+  max_candidate_pool?: number;
+  checked_at: number;
+}
+
+const BILLING_CACHE_TTL = 2 * 60 * 60 * 1000; // 2 hours
+let billingCache: BillingCacheEntry | null = null;
+
+/** Whether a background billing fetch is already in progress. */
+let billingFetchInProgress = false;
+
+/**
+ * Proactively fetch billing status to populate the candidate pool cache.
+ * Fire-and-forget — does not block the caller.
+ */
+function proactiveBillingFetch(state: SubgraphState): void {
+  if (billingFetchInProgress) return;
+  billingFetchInProgress = true;
+  const authKeyHex = Buffer.from(state.authKey).toString('hex');
+  const url = `${state.serverUrl.replace(/\/+$/, '')}/v1/billing/status?wallet_address=${encodeURIComponent(state.smartAccountAddress)}`;
+  fetch(url, {
+    method: 'GET',
+    headers: {
+      'Authorization': `Bearer ${authKeyHex}`,
+      'X-TotalReclaw-Client': 'mcp-server',
+    },
+  })
+    .then(async (resp) => {
+      if (resp.ok) {
+        const raw = (await resp.json()) as Record<string, unknown>;
+        const features = raw.features as Record<string, unknown> | undefined;
+        billingCache = {
+          max_candidate_pool: features?.max_candidate_pool as number | undefined,
+          checked_at: Date.now(),
+        };
+      }
+    })
+    .catch(() => { /* best-effort */ })
+    .finally(() => { billingFetchInProgress = false; });
+}
+
+/**
+ * Get the server-configured max candidate pool size.
+ * Falls back to a local formula if no cached billing response.
+ */
+function getMaxCandidatePool(k: number): number {
+  if (billingCache && Date.now() - billingCache.checked_at < BILLING_CACHE_TTL) {
+    if (billingCache.max_candidate_pool != null) return billingCache.max_candidate_pool;
+  }
+  // Trigger a background fetch if we have subgraph state but no cache
+  if (!billingCache && subgraphState) {
+    proactiveBillingFetch(subgraphState);
+  }
+  // Fallback to local formula
+  return Math.max(k * 50, 400);
+}
 
 // ── Server mode detection ───────────────────────────────────────────────────
 
@@ -581,7 +641,7 @@ async function handleRecallSubgraph(
     const allTrapdoors = [...wordTrapdoors, ...lshTrapdoors];
 
     // 4. Search the subgraph
-    const maxCandidates = Math.max(k * 50, 400); // Fetch more candidates for reranking
+    const maxCandidates = getMaxCandidatePool(k);
     const candidates = await searchSubgraph(
       state.smartAccountAddress,
       allTrapdoors,
@@ -859,7 +919,23 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const authKeyHex = subgraphState
         ? Buffer.from(subgraphState.authKey).toString('hex')
         : '';
-      return await handleStatus(SERVER_URL, authKeyHex, args);
+      const statusResult = await handleStatus(SERVER_URL, authKeyHex, args);
+
+      // Cache billing features for candidate pool sizing.
+      // handleStatus stores the raw response; extract max_candidate_pool from it.
+      try {
+        const raw = getLastBillingResponse();
+        if (raw?.features) {
+          billingCache = {
+            max_candidate_pool: raw.features.max_candidate_pool,
+            checked_at: Date.now(),
+          };
+        }
+      } catch {
+        // Best-effort cache — don't fail the status call
+      }
+
+      return statusResult;
     }
 
     if (name === 'totalreclaw_upgrade') {

--- a/mcp/src/tools/status.ts
+++ b/mcp/src/tools/status.ts
@@ -27,11 +27,29 @@ export const statusToolDefinition = {
   },
 };
 
+export interface BillingFeatures {
+  llm_dedup?: boolean;
+  custom_extract_interval?: boolean;
+  min_extract_interval?: number;
+  extraction_interval?: number;
+  max_facts_per_extraction?: number;
+  max_candidate_pool?: number;
+}
+
 export interface BillingStatusResponse {
   tier: string;
   free_writes_used: number;
   free_writes_limit: number;
   expires_at: string | null;
+  features?: BillingFeatures;
+}
+
+/** Last raw billing response (for candidate pool caching in index.ts). */
+let lastBillingResponse: BillingStatusResponse | null = null;
+
+/** Get the last raw billing response. */
+export function getLastBillingResponse(): BillingStatusResponse | null {
+  return lastBillingResponse;
 }
 
 /**
@@ -84,6 +102,9 @@ export async function handleStatus(
     }
 
     const data = (await response.json()) as BillingStatusResponse;
+
+    // Cache the raw response for candidate pool sizing
+    lastBillingResponse = data;
 
     // Format nicely for the LLM to present
     const tierLabel = data.tier === 'pro' ? 'Pro' : 'Free';

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -142,7 +142,7 @@ const RELEVANCE_THRESHOLD = parseFloat(process.env.TOTALRECLAW_RELEVANCE_THRESHO
 // ---------------------------------------------------------------------------
 
 const BILLING_CACHE_PATH = path.join(process.env.HOME ?? '/home/node', '.totalreclaw', 'billing-cache.json');
-const BILLING_CACHE_TTL = 12 * 60 * 60 * 1000; // 12 hours
+const BILLING_CACHE_TTL = 2 * 60 * 60 * 1000; // 2 hours
 const QUOTA_WARNING_THRESHOLD = 0.8; // 80%
 
 interface BillingCache {
@@ -155,6 +155,7 @@ interface BillingCache {
     min_extract_interval?: number;
     extraction_interval?: number;
     max_facts_per_extraction?: number;
+    max_candidate_pool?: number;
   };
   checked_at: number;
 }
@@ -270,12 +271,18 @@ const FACT_COUNT_CACHE_TTL = 5 * 60 * 1000;
 /**
  * Compute the candidate pool size from a fact count.
  *
- * Formula: pool = min(max(factCount * 3, 400), 5000)
+ * Server-side config takes priority (from billing cache), then local fallback.
+ * The server computes the optimal pool based on vault size and tier caps.
+ *
+ * Local fallback formula: pool = min(max(factCount * 3, 400), 5000)
  *   - At least 400 candidates (even for tiny vaults)
  *   - At most 5000 candidates (to bound decryption + reranking cost)
  *   - 3x fact count in between
  */
 function computeCandidatePool(factCount: number): number {
+  const cache = readBillingCache();
+  if (cache?.features?.max_candidate_pool != null) return cache.features.max_candidate_pool;
+  // Fallback to local formula if no server config
   return Math.min(Math.max(factCount * 3, 400), 5000);
 }
 


### PR DESCRIPTION
## Summary
- **Relay**: Add `max_candidate_pool` to `FeatureFlags`, computed from vault size and tier-specific caps (`CANDIDATE_POOL_MAX_FREE`/`CANDIDATE_POOL_MAX_PRO` env vars). Returned via billing status endpoint.
- **Plugin**: Read `max_candidate_pool` from billing cache (TTL reduced from 12h to 2h) with local fallback formula.
- **MCP**: Cache billing response in-memory (2h TTL), proactively fetch on first recall if cache is empty, update cache on `totalreclaw_status` calls.
- **CLAUDE.md**: Updated Feature Compatibility Matrix and Known Technical Gaps.

## Test plan
- [x] Relay: 98/98 tests pass (`npx jest --forceExit`)
- [x] Client: 251/251 tests pass (`npx jest --forceExit`)
- [x] MCP: TypeScript type-check clean (`npx tsc --noEmit`)
- [x] Verified `deriveFeatures()` includes `max_candidate_pool` with correct values across vault sizes
- [ ] E2E: validate billing status response includes `max_candidate_pool` against live staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)