### PR TITLE
chore: bump versions for npm publish

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@totalreclaw/client",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/client",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/client",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "TypeScript client library for TotalReclaw — E2EE encryption, LSH blind indexing, embedding search, and BM25+cosine reranking for AI agent memory",
   "homepage": "https://totalreclaw.xyz",
   "main": "dist/index.js",

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@totalreclaw/mcp-server",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/mcp-server",
-      "version": "1.0.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/mcp-server",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. MCP server with AES-256-GCM E2EE, semantic search, import/export, and on-chain storage",
   "homepage": "https://totalreclaw.xyz",
   "main": "dist/index.js",
@@ -37,7 +37,7 @@
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@noble/hashes": "^2.0.1",
     "@scure/bip39": "^2.0.1",
-    "@totalreclaw/client": "^0.4.0",
+    "@totalreclaw/client": "^0.5.0",
     "permissionless": "^0.3.4",
     "porter-stemmer": "^0.9.1",
     "tslib": "^2.8.1",

--- a/skill/plugin/package-lock.json
+++ b/skill/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "0.1.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/totalreclaw",
-      "version": "0.1.0",
+      "version": "1.3.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@noble/hashes": "^2.0.1",

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. Automatic extraction, semantic search, and on-chain storage",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary
- Bump `@totalreclaw/client` to 0.5.0
- Bump `@totalreclaw/mcp-server` to 1.3.0 (+ update client dep to ^0.5.0)
- Bump `@totalreclaw/totalreclaw` (plugin) to 1.3.0

All three packages published to npm and verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)