### PR TITLE
feat: add upgrade tool to OpenClaw plugin, remove Coinbase Commerce

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ Features across OpenClaw plugin (`skill/plugin/`), MCP server (`mcp/`), and Nano
 | `totalreclaw_status` | Yes | Yes | Yes (via MCP) | |
 | `totalreclaw_import_from` | Yes | Yes | Yes (via MCP) | Mem0 + MCP Memory adapters |
 | `totalreclaw_import` | -- | Yes | Yes (via MCP) | JSON/Markdown re-import (MCP only) |
-| `totalreclaw_upgrade` | -- | Yes | Yes (via MCP) | Stripe/Coinbase checkout URL |
+| `totalreclaw_upgrade` | Yes | Yes | Yes (via MCP) | Stripe checkout URL |
 | `totalreclaw_consolidate` | Yes | Yes | Yes (via MCP) | Self-hosted only (no batch delete on managed service) |
 | **Automatic Memory** | | | | |
 | Auto-search (before_agent_start) | Yes | -- | Yes (hook) | MCP has no lifecycle hooks |
@@ -203,7 +203,7 @@ Managed Service two-tier chain model: **Free** = Base Sepolia testnet (500 memor
 | Bulk consolidation not on managed service | LOW | Bulk consolidation tool requires batch-delete, which has no on-chain equivalent. Store-time dedup supersession now works via tombstones. |
 | MCP no auto-memory | By design | MCP has no lifecycle hooks. Host agent (Claude, Cursor) must call tools explicitly. Documented in beta guide. |
 | Export/import not on managed service (MCP) | LOW | MCP server's export and import tools are self-hosted only. OpenClaw plugin handles both modes. |
-| Crypto payments blocked | MEDIUM | Coinbase Commerce sunset March 31, 2026. Coinbase Business US/Singapore only. Business entity in Portugal. Stripe (fiat) works. |
+| Crypto payments removed | LOW | Coinbase Commerce sunset March 31, 2026. Removed from relay, tools, and website. Stripe (fiat) is the sole payment method. |
 
 ---
 

--- a/mcp/src/prompts.ts
+++ b/mcp/src/prompts.ts
@@ -136,11 +136,7 @@ Use this when:
 
 export const UPGRADE_TOOL_DESCRIPTION = `Upgrade to TotalReclaw Pro for unlimited encrypted memories.
 
-Returns a checkout URL for the user to complete payment.
-
-Payment options:
-- card: Stripe checkout (credit/debit card)
-- crypto: Coinbase Commerce (USDC, USDT, ETH on multiple chains)
+Returns a Stripe checkout URL for the user to complete payment via credit/debit card.
 
 Use this when:
 - User hits their free tier limit

--- a/mcp/src/tools/upgrade.ts
+++ b/mcp/src/tools/upgrade.ts
@@ -1,8 +1,7 @@
 /**
  * TotalReclaw MCP - Billing Upgrade Tool
  *
- * Creates a checkout session for upgrading to Pro tier.
- * Supports both Stripe (card) and Coinbase Commerce (crypto) payment methods.
+ * Creates a Stripe checkout session for upgrading to Pro tier.
  */
 
 import { UPGRADE_TOOL_DESCRIPTION } from '../prompts.js';
@@ -16,12 +15,6 @@ export const upgradeToolDefinition = {
       wallet_address: {
         type: 'string',
         description: 'Smart Account address',
-      },
-      payment_method: {
-        type: 'string',
-        enum: ['card', 'crypto'],
-        default: 'card',
-        description: 'Payment method preference',
       },
     },
     required: ['wallet_address'],
@@ -51,7 +44,6 @@ export async function handleUpgrade(
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   const input = args as Record<string, unknown>;
   const walletAddress = input?.wallet_address as string;
-  const paymentMethod = (input?.payment_method as string) || 'card';
 
   if (!walletAddress || typeof walletAddress !== 'string') {
     return {
@@ -64,22 +56,9 @@ export async function handleUpgrade(
     };
   }
 
-  if (paymentMethod !== 'card' && paymentMethod !== 'crypto') {
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          error: 'payment_method must be "card" or "crypto"',
-        }),
-      }],
-    };
-  }
-
   try {
     const baseUrl = serverUrl.replace(/\/+$/, '');
-    const endpoint = paymentMethod === 'crypto'
-      ? `${baseUrl}/v1/billing/checkout/crypto`
-      : `${baseUrl}/v1/billing/checkout`;
+    const endpoint = `${baseUrl}/v1/billing/checkout`;
 
     const response = await fetch(endpoint, {
       method: 'POST',
@@ -109,16 +88,11 @@ export async function handleUpgrade(
 
     const data = (await response.json()) as CheckoutResponse;
 
-    const methodLabel = paymentMethod === 'crypto'
-      ? 'Coinbase Commerce (USDC, USDT, ETH)'
-      : 'Stripe (credit/debit card)';
-
     return {
       content: [{
         type: 'text',
         text: JSON.stringify({
           checkout_url: data.checkout_url,
-          payment_method: methodLabel,
           message: `Open this URL to complete your upgrade to Pro: ${data.checkout_url}`,
         }),
       }],

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -243,6 +243,31 @@ DRY RUN -- no memories were deleted. Run without dry_run to apply.
 
 ---
 
+### totalreclaw_upgrade
+
+Upgrade to TotalReclaw Pro for unlimited encrypted memories on Gnosis mainnet.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| *(none)* | | | The tool automatically uses the current wallet address |
+
+**Example:**
+```json
+{}
+```
+
+**Returns:**
+```json
+{
+  "checkout_url": "https://checkout.stripe.com/c/pay/...",
+  "message": "Open this URL to upgrade to Pro: https://checkout.stripe.com/c/pay/..."
+}
+```
+
+---
+
 ### totalreclaw_import_from
 
 Import memories from other AI memory tools into TotalReclaw.
@@ -348,7 +373,7 @@ Register TotalReclaw as the memory plugin:
 
 ### Step 5: Restart and verify
 
-Restart the gateway, then confirm the plugin loaded by checking that `totalreclaw_remember`, `totalreclaw_recall`, `totalreclaw_forget`, `totalreclaw_export`, `totalreclaw_consolidate`, and `totalreclaw_import_from` tools are available.
+Restart the gateway, then confirm the plugin loaded by checking that `totalreclaw_remember`, `totalreclaw_recall`, `totalreclaw_forget`, `totalreclaw_export`, `totalreclaw_status`, `totalreclaw_upgrade`, `totalreclaw_consolidate`, and `totalreclaw_import_from` tools are available.
 
 ### Step 6: Explain the free tier
 
@@ -446,6 +471,13 @@ Use when:
 - The user explicitly asks you to forget something ("forget that...", "delete that memory...")
 - The user indicates information is outdated or incorrect and should be removed
 - The user requests a clean slate for a specific topic
+
+#### totalreclaw_upgrade
+
+Use when:
+- The user hits their free tier memory limit (403 quota exceeded)
+- The user asks about upgrading, pricing, or getting Pro
+- After a `totalreclaw_status` call shows the user is on the free tier and they want more
 
 #### totalreclaw_export
 

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -9,6 +9,7 @@
  *   - totalreclaw_status       -- check billing/subscription status
  *   - totalreclaw_consolidate  -- scan and merge near-duplicate memories
  *   - totalreclaw_import_from  -- import memories from other tools (Mem0, MCP Memory, etc.)
+ *   - totalreclaw_upgrade      -- create Stripe checkout for Pro upgrade
  *
  * Also registers a `before_agent_start` hook that automatically injects
  * relevant memories into the agent's context.
@@ -133,6 +134,9 @@ const MAX_FACTS_PER_EXTRACTION = 15;
 
 // Store-time near-duplicate detection (consolidation module)
 const STORE_DEDUP_ENABLED = process.env.TOTALRECLAW_STORE_DEDUP !== 'false';
+
+// One-time welcome-back message for returning Pro users (set during init, consumed by first before_agent_start)
+let welcomeBackMessage: string | null = null;
 
 // B2: Minimum relevance threshold — cosine below this means no memory injection
 const RELEVANCE_THRESHOLD = parseFloat(process.env.TOTALRECLAW_RELEVANCE_THRESHOLD ?? '0.3');
@@ -419,6 +423,45 @@ async function initialize(logger: OpenClawPluginApi['logger']): Promise<void> {
       logger.warn(`Failed to derive Smart Account address: ${err instanceof Error ? err.message : String(err)}`);
       // Fall back to userId — won't match subgraph Bytes format, but better than null
       subgraphOwner = userId;
+    }
+  }
+
+  // One-time billing check for returning users (imported recovery phrase).
+  // If they already have an active Pro subscription, inform them on next conversation start.
+  if (existingUserId && authKeyHex) {
+    try {
+      const walletAddr = subgraphOwner || userId || '';
+      if (walletAddr) {
+        const billingUrl = (process.env.TOTALRECLAW_SERVER_URL || 'https://api.totalreclaw.xyz').replace(/\/+$/, '');
+        const resp = await fetch(`${billingUrl}/v1/billing/status?wallet_address=${encodeURIComponent(walletAddr)}`, {
+          method: 'GET',
+          headers: {
+            'Authorization': `Bearer ${authKeyHex}`,
+            'Accept': 'application/json',
+            'X-TotalReclaw-Client': 'openclaw-plugin',
+          },
+        });
+        if (resp.ok) {
+          const billingData = await resp.json() as Record<string, unknown>;
+          const tier = billingData.tier as string;
+          const expiresAt = billingData.expires_at as string | undefined;
+          // Populate billing cache for future use.
+          writeBillingCache({
+            tier: tier || 'free',
+            free_writes_used: (billingData.free_writes_used as number) ?? 0,
+            free_writes_limit: (billingData.free_writes_limit as number) ?? 0,
+            features: billingData.features as BillingCache['features'] | undefined,
+            checked_at: Date.now(),
+          });
+          if (tier === 'pro' && expiresAt) {
+            const expiryDate = new Date(expiresAt).toLocaleDateString();
+            welcomeBackMessage = `Welcome back! Your Pro subscription is active (expires: ${expiryDate}).`;
+            logger.info(`Returning Pro user detected — expires ${expiryDate}`);
+          }
+        }
+      }
+    } catch {
+      // Best-effort — don't block initialization on billing check failure.
     }
   }
 }
@@ -2184,6 +2227,85 @@ const plugin = {
     );
 
     // ---------------------------------------------------------------
+    // Tool: totalreclaw_upgrade
+    // ---------------------------------------------------------------
+
+    api.registerTool(
+      {
+        name: 'totalreclaw_upgrade',
+        label: 'Upgrade to Pro',
+        description:
+          'Upgrade to TotalReclaw Pro for unlimited encrypted memories. ' +
+          'Returns a Stripe checkout URL for the user to complete payment via credit/debit card.',
+        parameters: {
+          type: 'object',
+          properties: {},
+          additionalProperties: false,
+        },
+        async execute() {
+          try {
+            await requireFullSetup(api.logger);
+
+            if (!authKeyHex) {
+              return {
+                content: [{ type: 'text', text: 'Auth credentials are not available. Please initialize first.' }],
+              };
+            }
+
+            const serverUrl = (process.env.TOTALRECLAW_SERVER_URL || 'https://api.totalreclaw.xyz').replace(/\/+$/, '');
+            const walletAddr = subgraphOwner || userId || '';
+
+            if (!walletAddr) {
+              return {
+                content: [{ type: 'text', text: 'Wallet address not available. Please ensure the plugin is fully initialized.' }],
+              };
+            }
+
+            const response = await fetch(`${serverUrl}/v1/billing/checkout`, {
+              method: 'POST',
+              headers: {
+                'Authorization': `Bearer ${authKeyHex}`,
+                'Content-Type': 'application/json',
+                'X-TotalReclaw-Client': 'openclaw-plugin',
+              },
+              body: JSON.stringify({
+                wallet_address: walletAddr,
+                tier: 'pro',
+              }),
+            });
+
+            if (!response.ok) {
+              const body = await response.text().catch(() => '');
+              return {
+                content: [{ type: 'text', text: `Failed to create checkout session (HTTP ${response.status}): ${body || response.statusText}` }],
+              };
+            }
+
+            const data = await response.json() as { checkout_url?: string };
+
+            if (!data.checkout_url) {
+              return {
+                content: [{ type: 'text', text: 'Failed to create checkout session: no checkout URL returned.' }],
+              };
+            }
+
+            return {
+              content: [{ type: 'text', text: `Open this URL to upgrade to Pro: ${data.checkout_url}` }],
+              details: { checkout_url: data.checkout_url },
+            };
+          } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : String(err);
+            api.logger.error(`totalreclaw_upgrade failed: ${message}`);
+            return {
+              content: [{ type: 'text', text: `Failed to create checkout session: ${message}` }],
+            };
+          }
+        },
+      },
+      { name: 'totalreclaw_upgrade' },
+    );
+
+    // ---------------------------------------------------------------
     // Hook: before_agent_start
     // ---------------------------------------------------------------
 
@@ -2211,6 +2333,13 @@ const plugin = {
                 'TotalReclaw is installed but needs configuration. Follow the "Post-Install Setup" steps in SKILL.md to complete setup.\n' +
                 'Ask the user: "Do you have an existing TotalReclaw recovery phrase, or should I generate a new one?"',
             };
+          }
+
+          // One-time welcome-back message for returning Pro users.
+          let welcomeBack = '';
+          if (welcomeBackMessage) {
+            welcomeBack = `\n\n${welcomeBackMessage}`;
+            welcomeBackMessage = null; // Consume — only show once
           }
 
           // Billing cache check — warn if quota is approaching limit.
@@ -2286,7 +2415,7 @@ const plugin = {
                 const lines = cachedFacts.slice(0, 8).map((f, i) =>
                   `${i + 1}. ${f.text} (importance: ${f.importance}/10, cached)`,
                 );
-                return { prependContext: `## Relevant Memories\n\n${lines.join('\n')}` + billingWarning };
+                return { prependContext: `## Relevant Memories\n\n${lines.join('\n')}` + welcomeBack + billingWarning };
               }
             }
 
@@ -2299,7 +2428,7 @@ const plugin = {
               const lines = cachedFacts.slice(0, 8).map((f, i) =>
                 `${i + 1}. ${f.text} (importance: ${f.importance}/10, cached)`,
               );
-              return { prependContext: `## Relevant Memories\n\n${lines.join('\n')}` + billingWarning };
+              return { prependContext: `## Relevant Memories\n\n${lines.join('\n')}` + welcomeBack + billingWarning };
             }
 
             if (allTrapdoors.length === 0) return undefined;
@@ -2316,7 +2445,7 @@ const plugin = {
                 const lines = cachedFacts.slice(0, 8).map((f, i) =>
                   `${i + 1}. ${f.text} (importance: ${f.importance}/10, cached)`,
                 );
-                return { prependContext: `## Relevant Memories\n\n${lines.join('\n')}` + billingWarning };
+                return { prependContext: `## Relevant Memories\n\n${lines.join('\n')}` + welcomeBack + billingWarning };
               }
               return undefined;
             }
@@ -2328,7 +2457,7 @@ const plugin = {
               const lines = cachedFacts.slice(0, 8).map((f, i) =>
                 `${i + 1}. ${f.text} (importance: ${f.importance}/10, cached)`,
               );
-              return { prependContext: `## Relevant Memories\n\n${lines.join('\n')}` + billingWarning };
+              return { prependContext: `## Relevant Memories\n\n${lines.join('\n')}` + welcomeBack + billingWarning };
             }
 
             // 5. Decrypt subgraph results and build reranker input.
@@ -2434,7 +2563,7 @@ const plugin = {
             });
             const contextString = `## Relevant Memories\n\n${lines.join('\n')}`;
 
-            return { prependContext: contextString + billingWarning };
+            return { prependContext: contextString + welcomeBack + billingWarning };
           }
 
           // --- Server mode (existing behavior) ---
@@ -2546,7 +2675,7 @@ const plugin = {
           });
           const contextString = `## Relevant Memories\n\n${lines.join('\n')}`;
 
-          return { prependContext: contextString + billingWarning };
+          return { prependContext: contextString + welcomeBack + billingWarning };
         } catch (err: unknown) {
           // The hook must NEVER throw -- log and return undefined.
           const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- **Add `totalreclaw_upgrade` tool** to the OpenClaw plugin -- creates a Stripe checkout session and returns the URL to the user. Previously only available in MCP server.
- **Remove Coinbase Commerce** payment option from MCP upgrade tool and prompts (Coinbase Commerce sunsets March 31, 2026).
- **One-time Pro welcome-back check** -- when a returning user imports an existing recovery phrase, the plugin checks billing status during init and shows "Welcome back! Your Pro subscription is active (expires: ...)" on the first conversation.
- **SKILL.md** updated with upgrade tool documentation and usage guidance.
- **CLAUDE.md** compatibility matrix updated (upgrade tool now Yes for OpenClaw Plugin, Known Gaps updated for Coinbase removal).

Companion changes:
- Relay (`totalreclaw-relay`): Coinbase service, webhook, checkout/crypto endpoint, config, and tests removed. Stripe success/cancel URLs updated to `/payment/` pages. Committed and pushed to main.
- Website (`totalreclaw-website`): Pricing Pro CTA updated to direct users to upgrade via agent. Payment success page gains recovery phrase security warning. Payment cancel page links to pricing. Committed and pushed to main.

## Test plan
- [x] Relay tests pass (86/86) after Coinbase removal
- [x] MCP type-check passes (`tsc --noEmit`)
- [x] Client tests pass (251/251)
- [ ] Manual: verify `totalreclaw_upgrade` tool works end-to-end in OpenClaw
- [ ] Manual: verify pricing page renders correctly
- [ ] Manual: verify payment success/cancel pages render correctly

Generated with [Claude Code](https://claude.com/claude-code)