### PR TITLE
feat(nanoclaw): add billing/quota awareness to hooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,15 +157,15 @@ Features across OpenClaw plugin (`skill/plugin/`), MCP server (`mcp/`), and Nano
 | LLM-guided dedup (ADD/UPDATE/DELETE) | Yes (Pro) | -- | Yes | OpenClaw + NanoClaw extraction prompts |
 | Bulk consolidation tool | Yes | Yes | Yes (via MCP) | Self-hosted only (no batch delete on managed service) |
 | **Pro Tier Gating** | | | | |
-| Feature gating via billing cache | Yes | -- | -- | Server returns `features` dict, plugin gates client-side |
-| Server-side extraction config | Yes | -- | -- | Relay returns `extraction_interval` + `max_facts_per_extraction` in billing status |
-| Unified extraction interval (3 turns) | Yes | -- | Yes (env) | Server-tunable via relay config (no npm publish needed) |
+| Feature gating via billing cache | Yes | -- | Yes | Server returns `features` dict, plugin/skill gates client-side |
+| Server-side extraction config | Yes | -- | Yes | Relay returns `extraction_interval` + `max_facts_per_extraction` in billing status |
+| Unified extraction interval (3 turns) | Yes | -- | Yes | Server-tunable via relay config (no npm publish needed) |
 | Max facts per extraction | Yes | -- | Yes | Server-tunable via relay config (default 15) |
 | Dual-chain routing | -- | -- | -- | Relay-side: routes to Base Sepolia (free) or Gnosis mainnet (pro) |
 | **Batching** | | | | |
 | Client batching (multi-call UserOps) | Yes | Yes | Yes (via MCP) | Wired into extraction loops — batch up to 15 facts per UserOp |
 | **Billing** | | | | |
-| Quota warnings (>80%) | Yes | -- | -- | Injected via before_agent_start |
+| Quota warnings (>80%) | Yes | -- | Yes | Injected via before_agent_start hook |
 | 403 handling + cache invalidation | Yes | Yes | Yes | |
 | **Search Optimizations** | | | | |
 | Hot cache + two-tier search | Yes (managed) | -- | -- | Skips remote query if cached query similar |

--- a/skill-nanoclaw/SKILL.md
+++ b/skill-nanoclaw/SKILL.md
@@ -8,7 +8,7 @@ End-to-end encrypted memory for NanoClaw agents, powered by the `@totalreclaw/mc
 
 The **recovery phrase** is a 12-word BIP-39 mnemonic that derives all encryption keys client-side. TotalReclaw never sends it to the server.
 
-- **New user:** Generate a 12-word BIP-39 mnemonic. Save it securely — it's the only way to recover your memories.
+- **New user:** Generate a 12-word BIP-39 mnemonic. Save it securely -- it is the only way to recover your memories.
 - **Returning user:** Use your existing phrase to restore memories on a new device.
 
 ### Step 2: Configure environment
@@ -18,40 +18,296 @@ Set these in your NanoClaw deployment (Docker env, `.env` file, or platform conf
 ```bash
 TOTALRECLAW_SERVER_URL=https://api.totalreclaw.xyz
 TOTALRECLAW_RECOVERY_PHRASE="your twelve word recovery phrase here"
-# Managed service is the default — set TOTALRECLAW_SELF_HOSTED=true only for self-hosted mode
+# Managed service is the default -- set TOTALRECLAW_SELF_HOSTED=true only for self-hosted mode
 ```
 
 The NanoClaw agent-runner automatically spawns the MCP server with these variables.
 
 ### Step 3: Verify
 
-Ask the agent: *"Do you have access to TotalReclaw memory tools?"* It should confirm access to `totalreclaw_remember`, `totalreclaw_recall`, `totalreclaw_forget`, and `totalreclaw_export`.
+Ask the agent: *"Do you have access to TotalReclaw memory tools?"* It should confirm access to `totalreclaw_remember`, `totalreclaw_recall`, `totalreclaw_forget`, `totalreclaw_export`, `totalreclaw_status`, `totalreclaw_upgrade`, `totalreclaw_import_from`, and `totalreclaw_consolidate`.
+
+### Step 4: Free tier
+
+After setup, the agent is on the free tier: 500 memories per month, unlimited reads and searches. The skill warns automatically when quota usage exceeds 80%. For unlimited memories, the user can upgrade via the `totalreclaw_upgrade` tool or visit https://totalreclaw.xyz/pricing.
+
+---
 
 ## How It Works
 
-All encryption happens inside the MCP server process — the TotalReclaw server only sees ciphertext and hashed tokens:
+All encryption happens inside the MCP server process -- the TotalReclaw server only sees ciphertext and hashed tokens:
 
 - Facts encrypted with AES-256-GCM before leaving the container
 - Search uses blind indices (SHA-256 hashes), not plaintext
-- Recovery phrase derives all keys via Argon2id + HKDF
+- Recovery phrase derives all keys via BIP-39 seed + HKDF (managed service) or Argon2id + HKDF (self-hosted)
 - With the managed service, encrypted facts are stored on-chain (Gnosis Chain) and indexed by The Graph
+
+---
+
+## Tools
+
+### totalreclaw_remember
+
+Store a new fact or preference in long-term memory.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| text | string | Yes | The fact or information to remember |
+| type | string | No | Type of memory: `fact`, `preference`, `decision`, `episodic`, `goal`, `context`, or `summary`. Default: `fact` |
+| importance | integer | No | Importance score 1-10. Default: auto-detected by LLM |
+
+---
+
+### totalreclaw_recall
+
+Search and retrieve relevant memories from long-term storage.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| query | string | Yes | Natural language query to search memories |
+| k | integer | No | Number of results to return. Default: 8, Max: 20 |
+
+---
+
+### totalreclaw_forget
+
+Delete a specific fact from memory.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| factId | string | Yes | UUID of the fact to delete |
+
+---
+
+### totalreclaw_export
+
+Export all stored memories in plaintext format.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| format | string | No | Export format: `json` or `markdown`. Default: `json` |
+
+---
+
+### totalreclaw_status
+
+Check subscription status and usage quota.
+
+**Parameters:** None
+
+---
+
+### totalreclaw_upgrade
+
+Upgrade to TotalReclaw Pro for unlimited encrypted memories on Gnosis mainnet.
+
+**Parameters:** None (uses the current wallet address automatically)
+
+**Returns:** A Stripe checkout URL. Share it with the user to complete the upgrade.
+
+---
+
+### totalreclaw_import_from
+
+Import memories from other AI memory tools into TotalReclaw.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| source | string | Yes | Source system: `mem0`, `mcp-memory` |
+| api_key | string | No | API key for the source (Mem0). Used once, never stored. |
+| source_user_id | string | No | User or agent ID in the source system |
+| content | string | No | File content (JSON, JSONL, or CSV) for file-based sources |
+| file_path | string | No | Path to a file on disk for file-based sources |
+| namespace | string | No | Target namespace in TotalReclaw. Default: `imported` |
+| dry_run | boolean | No | Preview without importing. Default: `false` |
+
+Always run with `dry_run=true` first and show the preview before importing. API keys are used in-memory only and never stored.
+
+---
+
+### totalreclaw_consolidate
+
+Scan all stored memories and merge near-duplicates. Keeps the most important/recent version and removes redundant copies.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| dry_run | boolean | No | Preview consolidation without deleting. Default: `false` |
+
+**Note:** Currently only available in self-hosted mode (not managed service).
+
+---
+
+## Memory Types
+
+TotalReclaw extracts and stores seven types of memories:
+
+| Type | Description | Example |
+|------|-------------|---------|
+| Fact | Objective information about the user | "Lives in Lisbon, Portugal" |
+| Preference | Likes, dislikes, choices | "Prefers dark mode in all applications" |
+| Decision | Choices made WITH reasoning | "Chose PostgreSQL because data is relational and needs ACID" |
+| Episodic | Notable events or experiences | "Deployed v1.0 to production on March 15" |
+| Goal | Objectives or plans | "Wants to launch public beta by end of Q1" |
+| Context | Active project/task context | "Working on TotalReclaw v1.2, staging on Base Sepolia" |
+| Summary | Key outcomes from discussions | "Agreed to use phased rollout for mainnet migration" |
+
+Decisions and context are treated as high-value memories (importance >= 7) because they provide the most useful information for future conversations.
+
+---
 
 ## Hooks
 
+NanoClaw integrates TotalReclaw through three lifecycle hooks in the agent-runner:
+
 | Hook | Description |
 |------|-------------|
-| `before-agent-start` | Retrieves relevant memories before processing user message |
-| `agent-end` | Extracts and stores facts periodically after agent turns |
-| `pre-compact` | Full extraction before context truncation |
+| `before-agent-start` | Retrieves relevant memories before processing user message. Checks billing status and injects quota warnings if usage exceeds 80%. |
+| `agent-end` | Extracts and stores facts every 3 turns (configurable). Handles 403/quota errors by invalidating the billing cache. |
+| `pre-compact` | Comprehensive extraction before context truncation. Also handles 403/quota errors. |
+
+---
+
+## Billing and Quota
+
+TotalReclaw has a free tier (500 memories/month, unlimited reads). The skill monitors quota usage automatically:
+
+- At conversation start (`before-agent-start`), billing status is fetched from the relay and cached for 2 hours
+- If usage exceeds 80%, a warning is injected into the agent context
+- If a write fails with quota exceeded (403), the billing cache is invalidated so the next conversation start re-fetches and warns the user
+- Use `totalreclaw_status` when the user asks about their subscription, quota, or billing
+- Use `totalreclaw_upgrade` to generate a Stripe checkout URL for Pro ($5/month, unlimited memories on Gnosis mainnet)
+
+---
+
+## Extraction Behavior
+
+The skill automatically extracts facts from conversations using a Mem0-style pattern:
+
+- **Interval:** Every 3 turns (configurable via `TOTALRECLAW_EXTRACT_INTERVAL`)
+- **Cap:** Maximum 15 facts per extraction cycle
+- **Minimum importance:** 6 (configurable via `TOTALRECLAW_MIN_IMPORTANCE`)
+- **Dedup:** LLM-guided ADD/UPDATE/DELETE/NOOP actions to avoid duplicates
+- **Pre-compaction:** Full extraction before context truncation (no importance filter)
+
+### Extraction Actions
+
+| Action | Description | When to Use |
+|--------|-------------|-------------|
+| ADD | Store as new memory | No similar memory exists |
+| UPDATE | Modify existing memory | New info refines/clarifies existing |
+| DELETE | Remove existing memory | New info contradicts existing |
+| NOOP | Do nothing | Already captured or not worth storing |
+
+---
+
+## Instructions for the LLM
+
+### IMPORTANT: Do Not Write Cleartext Memory Files
+
+TotalReclaw handles all memory storage with end-to-end encryption. **Do NOT write facts, preferences, or decisions to MEMORY.md or memory/*.md files.** All memories are stored encrypted and recalled automatically -- writing cleartext files defeats the E2EE guarantee.
+
+If you need to store a memory, use the `totalreclaw_remember` tool. If you need to recall memories, use `totalreclaw_recall`.
+
+### When to Use Each Tool
+
+#### totalreclaw_remember
+
+Use when:
+- The user explicitly asks to remember something ("remember that...", "note that...", "don't forget...")
+- You detect a significant preference, decision, or fact useful in future conversations
+- The user corrects or updates previous information about themselves
+
+Do NOT use for:
+- Temporary information relevant only to the current conversation
+- Generic knowledge that is not user-specific
+
+#### totalreclaw_recall
+
+Use when:
+- The user asks about past preferences, decisions, or history
+- You need context about the user's projects, tools, or working style
+- The user asks "do you remember..." or "what did I tell you about..."
+- Starting a new conversation to load relevant context
+
+Do NOT use for:
+- Every single message (use sparingly)
+- General knowledge questions unrelated to the user
+
+#### totalreclaw_forget
+
+Use when:
+- The user explicitly asks to forget something
+- Information is outdated or incorrect and should be removed
+
+#### totalreclaw_upgrade
+
+Use when:
+- The user hits their free tier memory limit (403 quota exceeded)
+- The user asks about upgrading, pricing, or getting Pro
+- After a `totalreclaw_status` call shows the user is on the free tier and they want more
+
+#### totalreclaw_export
+
+Use when:
+- The user asks to export, backup, or download their memory data
+- The user wants to see everything stored about them
+- The user is migrating to another system
+
+#### totalreclaw_import_from
+
+Use when:
+- The user mentions migrating from Mem0, MCP Memory Server, or another AI memory tool
+- Always run with `dry_run=true` first and show the preview before importing
+
+#### totalreclaw_consolidate
+
+Use when:
+- The user asks to clean up or deduplicate their memories
+- After a large import to merge near-duplicates
+- Always run with `dry_run=true` first to preview
+
+### Best Practices
+
+1. **Atomic Facts Only**: Each memory should be a single, atomic piece of information.
+   - Good: "User prefers dark mode in all editors"
+   - Bad: "User likes dark mode, uses VS Code, and works at Google"
+
+2. **Importance Scoring**:
+   - 1-3: Trivial, unlikely to matter (small talk, pleasantries)
+   - 4-6: Useful context (tool preferences, working style)
+   - 7-8: Important (key decisions with reasoning, project context, major preferences)
+   - 9-10: Critical (core values, non-negotiables, safety info)
+
+3. **Search Before Storing**: Always recall similar memories before storing new ones to avoid duplicates.
+
+4. **Respect User Privacy**: Never store sensitive information (passwords, API keys, personal secrets) even if requested.
+
+5. **Prefer NOOP**: When in doubt about whether to store something, prefer not storing it. Memory pollution is worse than missing a minor fact.
+
+---
 
 ## Namespace Mapping
 
 The skill maps NanoClaw's `groupFolder` to TotalReclaw's `namespace`:
-- `main` → `main` namespace
-- `work` → `work` namespace
-- `family` → `family` namespace
+- `main` -> `main` namespace
+- `work` -> `work` namespace
+- `family` -> `family` namespace
 
 This provides memory isolation between different contexts.
+
+---
 
 ## Environment Variables
 
@@ -61,16 +317,17 @@ This provides memory isolation between different contexts.
 | `TOTALRECLAW_RECOVERY_PHRASE` | 12-word BIP-39 recovery phrase | Required |
 | `TOTALRECLAW_SELF_HOSTED` | Set to `true` to use your own server instead of the managed service | `false` |
 | `TOTALRECLAW_NAMESPACE` | Default namespace | Group folder name |
-| `TOTALRECLAW_AUTO_EXTRACT` | Enable automatic extraction | `true` |
-| `TOTALRECLAW_EXTRACT_INTERVAL` | Turns between extractions | `3` |
+| `TOTALRECLAW_EXTRACT_INTERVAL` | Turns between automatic extractions | `3` |
+| `TOTALRECLAW_MIN_IMPORTANCE` | Minimum importance for auto-store | `6` |
 | `TOTALRECLAW_CHAIN_ID` | Chain ID (100=Gnosis mainnet, 84532=Base Sepolia staging) | `100` |
+| `TOTALRECLAW_WALLET_ADDRESS` | Smart Account address override (auto-derived if not set) | Auto-derived |
 
-## Available Tools
+---
 
-| Tool | Description |
-|------|-------------|
-| `totalreclaw_remember` | Store a fact in encrypted memory |
-| `totalreclaw_recall` | Search memories by natural language query |
-| `totalreclaw_forget` | Delete a specific memory by ID |
-| `totalreclaw_export` | Export all memories decrypted as Markdown or JSON |
-| `totalreclaw_status` | Check billing status and quota usage |
+## Privacy and Security
+
+- **End-to-End Encrypted**: All encryption happens in the MCP server process. The relay never sees plaintext data.
+- **Recovery Phrase**: Never sent to the server. Used only for key derivation.
+- **Export Portability**: Full plaintext export available anytime via `totalreclaw_export`.
+- **Tombstone Recovery**: Deleted memories can be recovered within 30 days.
+- **Secret Sanitization**: The agent-runner strips `TOTALRECLAW_RECOVERY_PHRASE` from Bash subprocess environments.

--- a/skill-nanoclaw/package-lock.json
+++ b/skill-nanoclaw/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.81",
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "@noble/hashes": "^2.0.1",
+        "@scure/bip39": "^2.0.1",
         "@totalreclaw/client": "file:../client"
       },
       "devDependencies": {
@@ -26,7 +28,7 @@
     },
     "../client": {
       "name": "@totalreclaw/client",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1301,6 +1303,40 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
+      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.0.1.tgz",
+      "integrity": "sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1",
+        "@scure/base": "2.0.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@sinclair/typebox": {

--- a/skill-nanoclaw/package.json
+++ b/skill-nanoclaw/package.json
@@ -23,6 +23,8 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.81",
     "@modelcontextprotocol/sdk": "^1.27.1",
+    "@noble/hashes": "^2.0.1",
+    "@scure/bip39": "^2.0.1",
     "@totalreclaw/client": "file:../client"
   },
   "devDependencies": {

--- a/skill-nanoclaw/src/billing.ts
+++ b/skill-nanoclaw/src/billing.ts
@@ -1,0 +1,415 @@
+/**
+ * TotalReclaw NanoClaw - Billing Utilities
+ *
+ * Provides billing status caching, quota warning detection, and 403 handling
+ * for NanoClaw hooks. Mirrors the OpenClaw plugin's billing awareness:
+ *
+ *   - before-agent-start: fetch/cache billing status, inject quota warnings
+ *   - agent-end: invalidate cache on 403/quota errors so next start re-fetches
+ *
+ * Key derivation reuses the same BIP-39 seed path as the MCP server:
+ *   mnemonic -> mnemonicToSeedSync() -> 512-bit seed
+ *   salt = seed[0..32]
+ *   authKey = HKDF-SHA256(seed, salt, "totalreclaw-auth-key-v1", 32)
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import { mnemonicToSeedSync } from '@scure/bip39';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const BILLING_CACHE_DIR = path.join(process.env.HOME ?? '/home/node', '.totalreclaw');
+const BILLING_CACHE_PATH = path.join(BILLING_CACHE_DIR, 'billing-cache.json');
+const BILLING_CACHE_TTL = 2 * 60 * 60 * 1000; // 2 hours
+const QUOTA_WARNING_THRESHOLD = 0.8; // 80%
+
+// HKDF info string -- must match MCP server and client library exactly.
+const AUTH_KEY_INFO = 'totalreclaw-auth-key-v1';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface BillingCache {
+  tier: string;
+  free_writes_used: number;
+  free_writes_limit: number;
+  features?: {
+    llm_dedup?: boolean;
+    extraction_interval?: number;
+    max_facts_per_extraction?: number;
+    max_candidate_pool?: number;
+  };
+  checked_at: number;
+}
+
+export interface BillingContext {
+  serverUrl: string;
+  authKeyHex: string;
+  walletAddress: string;
+}
+
+// ---------------------------------------------------------------------------
+// Key Derivation (BIP-39 seed path -- synchronous, no RPC needed)
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the auth key hex from a BIP-39 mnemonic.
+ *
+ * Uses the same derivation path as the MCP server's crypto module:
+ *   mnemonic -> BIP-39 seed (512 bits)
+ *   salt = seed[0..32]
+ *   authKey = HKDF-SHA256(seed, salt, "totalreclaw-auth-key-v1", 32)
+ *
+ * This is synchronous and does not require RPC connectivity.
+ */
+export function deriveAuthKeyHex(mnemonic: string): string {
+  const seed = mnemonicToSeedSync(mnemonic.trim());
+  const salt = Buffer.from(seed.slice(0, 32));
+  const seedBuf = Buffer.from(seed);
+
+  const authKey = hkdfSha256(
+    seedBuf,
+    salt,
+    Buffer.from(AUTH_KEY_INFO, 'utf-8'),
+    32,
+  );
+
+  return authKey.toString('hex');
+}
+
+/**
+ * HKDF-SHA256 implementation -- identical to client/src/crypto/kdf.ts.
+ */
+function hkdfSha256(
+  ikm: Buffer,
+  salt: Buffer,
+  info: Buffer,
+  length: number,
+): Buffer {
+  const prk = crypto.createHmac('sha256', salt).update(ikm).digest();
+  const okm = Buffer.alloc(length);
+  let t = Buffer.alloc(0);
+  let offset = 0;
+  let counter = 1;
+
+  while (offset < length) {
+    const hmac = crypto.createHmac('sha256', prk);
+    hmac.update(t);
+    hmac.update(info);
+    hmac.update(Buffer.from([counter]));
+    t = hmac.digest();
+    const copyLength = Math.min(t.length, length - offset);
+    t.copy(okm, offset, 0, copyLength);
+    offset += copyLength;
+    counter++;
+  }
+
+  return okm;
+}
+
+// ---------------------------------------------------------------------------
+// Smart Account Address Derivation
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the Smart Account address from a BIP-39 mnemonic.
+ *
+ * This requires an RPC call to compute the counterfactual CREATE2 address,
+ * so results are cached to disk after the first derivation.
+ *
+ * Falls back to an empty string if derivation fails (e.g. no network).
+ * Can also be set explicitly via TOTALRECLAW_WALLET_ADDRESS env var.
+ */
+let cachedWalletAddress: string | null = null;
+const WALLET_CACHE_PATH = path.join(BILLING_CACHE_DIR, 'wallet-address-cache.json');
+
+export async function getWalletAddress(mnemonic: string, chainId: number = 100): Promise<string> {
+  // Check env var override first
+  if (process.env.TOTALRECLAW_WALLET_ADDRESS) {
+    return process.env.TOTALRECLAW_WALLET_ADDRESS.toLowerCase();
+  }
+
+  if (cachedWalletAddress) return cachedWalletAddress;
+
+  // Try reading from disk cache first
+  try {
+    if (fs.existsSync(WALLET_CACHE_PATH)) {
+      const cached = JSON.parse(fs.readFileSync(WALLET_CACHE_PATH, 'utf-8'));
+      if (cached.address && cached.chainId === chainId) {
+        cachedWalletAddress = cached.address;
+        return cachedWalletAddress;
+      }
+    }
+  } catch {
+    // Cache read failed -- derive fresh
+  }
+
+  // Derive via RPC using the client library's seed module.
+  // Dynamic import from the specific subpath since the barrel export
+  // doesn't always re-export the seed module.
+  try {
+    let mnemonicToSmartAccountAddress: (mnemonic: string, chainId?: number) => Promise<string>;
+    try {
+      // Try the barrel export first (preferred)
+      const clientLib = await import('@totalreclaw/client');
+      mnemonicToSmartAccountAddress = (clientLib as any).mnemonicToSmartAccountAddress;
+    } catch {
+      // Not available via barrel -- this means the export chain is broken
+      mnemonicToSmartAccountAddress = undefined as any;
+    }
+
+    if (!mnemonicToSmartAccountAddress) {
+      console.warn('[billing] mnemonicToSmartAccountAddress not available -- skipping wallet derivation');
+      return '';
+    }
+
+    const address = await mnemonicToSmartAccountAddress(mnemonic.trim(), chainId);
+    cachedWalletAddress = address.toLowerCase();
+
+    // Persist to disk cache
+    try {
+      if (!fs.existsSync(BILLING_CACHE_DIR)) {
+        fs.mkdirSync(BILLING_CACHE_DIR, { recursive: true });
+      }
+      fs.writeFileSync(
+        WALLET_CACHE_PATH,
+        JSON.stringify({ address: cachedWalletAddress, chainId }),
+      );
+    } catch {
+      // Best-effort cache write
+    }
+
+    return cachedWalletAddress;
+  } catch (err) {
+    console.error(
+      `[billing] Failed to derive Smart Account address: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return '';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Billing Cache Operations
+// ---------------------------------------------------------------------------
+
+export function readBillingCache(): BillingCache | null {
+  try {
+    if (!fs.existsSync(BILLING_CACHE_PATH)) return null;
+    const raw = JSON.parse(fs.readFileSync(BILLING_CACHE_PATH, 'utf-8')) as BillingCache;
+    if (!raw.checked_at || Date.now() - raw.checked_at > BILLING_CACHE_TTL) return null;
+    return raw;
+  } catch {
+    return null;
+  }
+}
+
+export function writeBillingCache(cache: BillingCache): void {
+  try {
+    if (!fs.existsSync(BILLING_CACHE_DIR)) {
+      fs.mkdirSync(BILLING_CACHE_DIR, { recursive: true });
+    }
+    fs.writeFileSync(BILLING_CACHE_PATH, JSON.stringify(cache));
+  } catch {
+    // Best-effort -- don't block on cache write failure.
+  }
+}
+
+export function deleteBillingCache(): void {
+  try {
+    fs.unlinkSync(BILLING_CACHE_PATH);
+  } catch {
+    // Ignore -- file may not exist.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Billing Status Fetch
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch billing status from the relay and update the cache.
+ *
+ * @returns The billing cache (fresh or existing), or null on failure.
+ */
+export async function fetchBillingStatus(ctx: BillingContext): Promise<BillingCache | null> {
+  // Return cached if valid
+  const existing = readBillingCache();
+  if (existing) return existing;
+
+  if (!ctx.authKeyHex || !ctx.walletAddress) return null;
+
+  try {
+    const url = `${ctx.serverUrl.replace(/\/+$/, '')}/v1/billing/status?wallet_address=${encodeURIComponent(ctx.walletAddress)}`;
+    const resp = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${ctx.authKeyHex}`,
+        'Accept': 'application/json',
+        'X-TotalReclaw-Client': 'nanoclaw-skill',
+      },
+    });
+
+    if (!resp.ok) return null;
+
+    const data = await resp.json() as Record<string, unknown>;
+    const cache: BillingCache = {
+      tier: (data.tier as string) || 'free',
+      free_writes_used: (data.free_writes_used as number) ?? 0,
+      free_writes_limit: (data.free_writes_limit as number) ?? 0,
+      features: data.features as BillingCache['features'] | undefined,
+      checked_at: Date.now(),
+    };
+
+    writeBillingCache(cache);
+    return cache;
+  } catch {
+    // Best-effort -- don't block on billing check failure.
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Quota Warning Generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a quota warning string if usage exceeds the threshold.
+ *
+ * @returns Warning text to inject into agent context, or empty string.
+ */
+export function getQuotaWarning(cache: BillingCache | null): string {
+  if (!cache || cache.free_writes_limit <= 0) return '';
+
+  const usageRatio = cache.free_writes_used / cache.free_writes_limit;
+  if (usageRatio >= QUOTA_WARNING_THRESHOLD) {
+    return `\n\nTotalReclaw quota warning: ${cache.free_writes_used}/${cache.free_writes_limit} writes used this month (${Math.round(usageRatio * 100)}%). Use the totalreclaw_upgrade tool to upgrade to Pro.`;
+  }
+
+  return '';
+}
+
+/**
+ * Check if the user has an active Pro subscription (for welcome-back message).
+ */
+export async function checkWelcomeBack(ctx: BillingContext): Promise<string> {
+  try {
+    const url = `${ctx.serverUrl.replace(/\/+$/, '')}/v1/billing/status?wallet_address=${encodeURIComponent(ctx.walletAddress)}`;
+    const resp = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${ctx.authKeyHex}`,
+        'Accept': 'application/json',
+        'X-TotalReclaw-Client': 'nanoclaw-skill',
+      },
+    });
+
+    if (!resp.ok) return '';
+
+    const data = await resp.json() as Record<string, unknown>;
+    const tier = data.tier as string;
+    const expiresAt = data.expires_at as string | undefined;
+
+    // Populate billing cache as a side-effect.
+    writeBillingCache({
+      tier: tier || 'free',
+      free_writes_used: (data.free_writes_used as number) ?? 0,
+      free_writes_limit: (data.free_writes_limit as number) ?? 0,
+      features: data.features as BillingCache['features'] | undefined,
+      checked_at: Date.now(),
+    });
+
+    if (tier === 'pro' && expiresAt) {
+      return `\n\nWelcome back! Your TotalReclaw Pro subscription is active (expires ${expiresAt}). All memories are stored on Gnosis mainnet.`;
+    }
+
+    return '';
+  } catch {
+    return '';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 403 / Quota Error Detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if an error indicates a quota/403 issue. If so, invalidate the
+ * billing cache so the next before-agent-start re-fetches fresh status.
+ *
+ * @returns true if this was a quota error (caller should stop retrying).
+ */
+export function handleQuotaError(err: unknown): boolean {
+  const errMsg = err instanceof Error ? err.message : String(err);
+  if (errMsg.includes('403') || errMsg.toLowerCase().includes('quota')) {
+    deleteBillingCache();
+    console.warn(`[billing] Quota exceeded -- billing cache invalidated. ${errMsg}`);
+    return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Feature Gating Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the effective extraction interval from billing cache or env fallback.
+ */
+export function getExtractInterval(): number {
+  const cache = readBillingCache();
+  if (cache?.features?.extraction_interval != null) return cache.features.extraction_interval;
+  return parseInt(process.env.TOTALRECLAW_EXTRACT_INTERVAL || '3', 10);
+}
+
+/**
+ * Get the max facts per extraction from billing cache or constant fallback.
+ */
+export function getMaxFactsPerExtraction(): number {
+  const cache = readBillingCache();
+  if (cache?.features?.max_facts_per_extraction != null) return cache.features.max_facts_per_extraction;
+  return 15;
+}
+
+// ---------------------------------------------------------------------------
+// Billing Context Construction
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a BillingContext from environment variables.
+ *
+ * Returns null if the recovery phrase is not configured (self-hosted mode
+ * without mnemonic doesn't need billing).
+ */
+let cachedBillingContext: BillingContext | null | undefined;
+
+export async function getBillingContext(): Promise<BillingContext | null> {
+  if (cachedBillingContext !== undefined) return cachedBillingContext;
+
+  const mnemonic = process.env.TOTALRECLAW_RECOVERY_PHRASE;
+  const serverUrl = process.env.TOTALRECLAW_SERVER_URL || 'https://api.totalreclaw.xyz';
+
+  if (!mnemonic || mnemonic.trim().split(/\s+/).length < 12) {
+    cachedBillingContext = null;
+    return null;
+  }
+
+  try {
+    const authKeyHex = deriveAuthKeyHex(mnemonic);
+    const chainId = parseInt(process.env.TOTALRECLAW_CHAIN_ID || '100', 10);
+    const walletAddress = await getWalletAddress(mnemonic, chainId);
+
+    cachedBillingContext = { serverUrl, authKeyHex, walletAddress };
+    return cachedBillingContext;
+  } catch (err) {
+    console.error(
+      `[billing] Failed to build billing context: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    cachedBillingContext = null;
+    return null;
+  }
+}

--- a/skill-nanoclaw/src/hooks/agent-end.ts
+++ b/skill-nanoclaw/src/hooks/agent-end.ts
@@ -5,6 +5,11 @@ import {
   validateExtractionResponse,
   formatConversationHistory,
 } from '../extraction/prompts';
+import {
+  getExtractInterval,
+  getMaxFactsPerExtraction,
+  handleQuotaError,
+} from '../billing.js';
 
 export interface AgentEndInput {
   conversationHistory: Array<{
@@ -24,16 +29,15 @@ export type LLMClient = {
   generate: (system: string, user: string, options?: { responseFormat?: { type: string } }) => Promise<string>;
 };
 
-const EXTRACT_INTERVAL = parseInt(process.env.TOTALRECLAW_EXTRACT_INTERVAL || '3', 10);
 const MIN_IMPORTANCE = parseInt(process.env.TOTALRECLAW_MIN_IMPORTANCE || '6', 10);
-const MAX_FACTS_PER_EXTRACTION = 15;
 
 export async function agentEnd(
   client: TotalReclaw,
   llmClient: LLMClient | null,
   input: AgentEndInput
 ): Promise<AgentEndOutput> {
-  if (input.turnCount % EXTRACT_INTERVAL !== 0) {
+  const extractInterval = getExtractInterval();
+  if (input.turnCount % extractInterval !== 0) {
     return { factsExtracted: 0, factsStored: 0 };
   }
 
@@ -78,9 +82,10 @@ export async function agentEnd(
     }
 
     let factsStored = 0;
-    const factsToProcess = validation.facts!.slice(0, MAX_FACTS_PER_EXTRACTION);
-    if (validation.facts!.length > MAX_FACTS_PER_EXTRACTION) {
-      console.log(`Capped extraction from ${validation.facts!.length} to ${MAX_FACTS_PER_EXTRACTION} facts`);
+    const maxFacts = getMaxFactsPerExtraction();
+    const factsToProcess = validation.facts!.slice(0, maxFacts);
+    if (validation.facts!.length > maxFacts) {
+      console.log(`Capped extraction from ${validation.facts!.length} to ${maxFacts} facts`);
     }
     for (const fact of factsToProcess) {
       if (fact.action === 'ADD' && fact.importance >= MIN_IMPORTANCE) {
@@ -93,8 +98,18 @@ export async function agentEnd(
           ],
         };
 
-        await client.remember(fact.factText, metadata);
-        factsStored++;
+        try {
+          await client.remember(fact.factText, metadata);
+          factsStored++;
+        } catch (err: unknown) {
+          // Check for 403 / quota exceeded -- invalidate billing cache so next
+          // before_agent_start re-fetches and warns the user.
+          if (handleQuotaError(err)) {
+            break; // Stop trying to store remaining facts -- they'll all fail too
+          }
+          // Otherwise skip this fact and continue with the rest
+          console.warn(`Failed to store fact: ${err instanceof Error ? err.message : String(err)}`);
+        }
       }
     }
 
@@ -103,6 +118,8 @@ export async function agentEnd(
       factsStored,
     };
   } catch (error) {
+    // Check for quota errors at the top level too (e.g. batch submit failures).
+    handleQuotaError(error);
     console.error('agentEnd error:', error);
     return { factsExtracted: 0, factsStored: 0 };
   }

--- a/skill-nanoclaw/src/hooks/before-agent-start.ts
+++ b/skill-nanoclaw/src/hooks/before-agent-start.ts
@@ -1,4 +1,10 @@
 import type { TotalReclaw } from '@totalreclaw/client';
+import {
+  getBillingContext,
+  fetchBillingStatus,
+  getQuotaWarning,
+  checkWelcomeBack,
+} from '../billing.js';
 
 export interface BeforeAgentStartInput {
   userMessage: string;
@@ -40,9 +46,30 @@ export async function beforeAgentStart(
       ) || 'fact',
     }));
 
+    // --- Billing check ---
+    let billingWarning = '';
+    let welcomeBack = '';
+    try {
+      const ctx = await getBillingContext();
+      if (ctx) {
+        // Fetch (or read cached) billing status.
+        const cache = await fetchBillingStatus(ctx);
+        billingWarning = getQuotaWarning(cache);
+
+        // One-time welcome-back for returning Pro users (first conversation after import).
+        if (!cache && ctx.walletAddress) {
+          welcomeBack = await checkWelcomeBack(ctx);
+        }
+      }
+    } catch {
+      // Best-effort -- don't block on billing check failure.
+    }
+
     const contextString = memories.length > 0
-      ? formatMemoriesForContext(memories)
-      : undefined;
+      ? formatMemoriesForContext(memories) + welcomeBack + billingWarning
+      : (welcomeBack || billingWarning)
+        ? (welcomeBack + billingWarning).trim()
+        : undefined;
 
     return {
       contextString,

--- a/skill-nanoclaw/src/hooks/pre-compact.ts
+++ b/skill-nanoclaw/src/hooks/pre-compact.ts
@@ -5,6 +5,7 @@ import {
   PRE_COMPACTION_PROMPT,
   validateExtractionResponse,
 } from '../extraction/prompts';
+import { handleQuotaError } from '../billing.js';
 
 export interface PreCompactInput {
   transcript: string;
@@ -56,7 +57,10 @@ export async function preCompact(
     }
 
     let factsStored = 0;
+    let quotaExceeded = false;
     for (const fact of validation.facts!) {
+      if (quotaExceeded) break;
+
       const metadata: FactMetadata = {
         importance: fact.importance / 10,
         source: 'pre_compaction',
@@ -68,8 +72,14 @@ export async function preCompact(
 
       switch (fact.action) {
         case 'ADD':
-          await client.remember(fact.factText, metadata);
-          factsStored++;
+          try {
+            await client.remember(fact.factText, metadata);
+            factsStored++;
+          } catch (err: unknown) {
+            if (handleQuotaError(err)) {
+              quotaExceeded = true;
+            }
+          }
           break;
 
         case 'UPDATE':
@@ -81,8 +91,11 @@ export async function preCompact(
                 await client.remember(fact.factText, metadata);
                 factsStored++;
               }
-            } catch {
-              // Skip if delete fails
+            } catch (err: unknown) {
+              if (handleQuotaError(err)) {
+                quotaExceeded = true;
+              }
+              // Skip if delete/update fails for other reasons
             }
           }
           break;
@@ -103,6 +116,7 @@ export async function preCompact(
       claudeMdUpdated,
     };
   } catch (error) {
+    handleQuotaError(error);
     console.error('preCompact error:', error);
     return { factsExtracted: 0, factsStored: 0, claudeMdUpdated: false };
   }

--- a/skill-nanoclaw/src/index.ts
+++ b/skill-nanoclaw/src/index.ts
@@ -1,2 +1,3 @@
 export * from './hooks/index.js';
 export * from './extraction/index.js';
+export * from './billing.js';


### PR DESCRIPTION
## Summary

- Add billing status checking and quota warning injection to NanoClaw's lifecycle hooks (`before-agent-start`, `agent-end`, `pre-compact`), matching the OpenClaw plugin's behavior
- New `billing.ts` module with auth key derivation from BIP-39 mnemonic, billing cache (2h TTL), quota warning generation (>80% usage), 403/quota error handling with cache invalidation, and server-tunable extraction config
- Comprehensive SKILL.md rewrite: all 8 tools documented, 7 memory types, extraction behavior, billing/quota docs, LLM instructions, best practices, and privacy section
- Updated CLAUDE.md feature compatibility matrix to reflect NanoClaw's new billing awareness

## Test plan

- [ ] Type-check passes: `cd skill-nanoclaw && npx tsc --noEmit`
- [ ] Build succeeds: `cd skill-nanoclaw && npx tsc`
- [ ] Verify billing cache file created at `~/.totalreclaw/billing-cache.json` after first conversation
- [ ] Verify quota warning injected when usage >= 80%
- [ ] Verify 403 error invalidates billing cache and next conversation re-fetches
- [ ] Verify extraction interval and max facts respect server-side config from billing cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)