### PR TITLE
feat: improve recovery phrase UX and MCP autonomous memory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,7 +244,7 @@ Every new feature implementation MUST include:
 | Conflict resolution (Layers 3-4) | MEDIUM | Spec'd in v0.3.2, not implemented |
 | Client batching (A2) | RESOLVED | Implemented in client/src/userop/batcher.ts -- batch multiple facts per UserOp |
 | Migration tool (testnet to mainnet) | MEDIUM | Designed, not implemented -- re-encrypt + re-store on upgrade |
-| Load testing | IN PROGRESS | Benchmark harness at 1M memories, results in `totalreclaw-internal/e2e/load-test/` |
+| Load testing | IN PROGRESS | Managed service load test at `totalreclaw-internal/e2e/load-test-managed/`. Client-side <140ms p95 PASS up to 10K facts. |
 | Graceful shutdown | LOW | Not yet configured in uvicorn |
 | Candidate pool sizing | RESOLVED | Server-configurable via relay billing endpoint (`max_candidate_pool` in FeatureFlags). Env overrides: `CANDIDATE_POOL_MAX_FREE`, `CANDIDATE_POOL_MAX_PRO`. |
 
@@ -287,7 +287,13 @@ ZAI_API_KEY=xxx ANTHROPIC_API_KEY=xxx npm test           # All paths
 npm run test:mcp                                          # MCP only (fastest)
 ZAI_API_KEY=xxx npm run test:openclaw                    # OpenClaw only
 ANTHROPIC_API_KEY=xxx npm run test:nanoclaw              # NanoClaw only
+
+# Performance Benchmarks (internal repo -- requires Docker + Foundry/Anvil)
+cd ../totalreclaw-internal/e2e/load-test-managed
+npm install && bash setup-local.sh && npx tsx run-scaling-test.ts --queries-per-tier 100
 ```
+
+Performance benchmarks for the managed service search pipeline live in `totalreclaw-internal/e2e/load-test-managed/`. These measure client-side search latency (decryption, cosine, BM25, reranking) at progressive vault sizes against the <140ms p95 target. Run after any change to the search pipeline, LSH parameters, embedding model, or candidate pool sizing. See the README in that directory for full documentation.
 
 ---
 

--- a/mcp/src/cli/setup.ts
+++ b/mcp/src/cli/setup.ts
@@ -186,6 +186,21 @@ function printConfigSnippet(serverUrl: string): void {
 }
 
 // ---------------------------------------------------------------------------
+// Recovery Phrase Warning
+// ---------------------------------------------------------------------------
+
+function printRecoveryPhraseWarning(): void {
+  console.log('');
+  console.log('+------------------------------------------------------------+');
+  console.log('|  CRITICAL: Your recovery phrase is your ONLY identity.     |');
+  console.log('|  If you lose it, you lose ALL your memories forever.       |');
+  console.log('|  There is NO password reset. No recovery. No support.      |');
+  console.log('|  Write it down. Store it securely. Never share it.         |');
+  console.log('+------------------------------------------------------------+');
+  console.log('');
+}
+
+// ---------------------------------------------------------------------------
 // Main Setup Flow
 // ---------------------------------------------------------------------------
 
@@ -217,25 +232,32 @@ export async function runSetup(): Promise<void> {
       }
 
       console.log('\nRecovery phrase validated successfully.');
+
+      // Show critical warning even for returning users
+      printRecoveryPhraseWarning();
     } else {
       // Generate new mnemonic
       mnemonic = generateMnemonic(wordlist, 128); // 128 bits = 12 words
 
       console.log('');
-      console.log('Your new recovery phrase (WRITE THIS DOWN AND KEEP IT SAFE):');
+      console.log('Your new recovery phrase:');
       console.log('');
       console.log(`  ${mnemonic}`);
       console.log('');
-      console.log('WARNING: This is the ONLY way to recover your encrypted memories.');
-      console.log('         Anyone with this phrase can access your data.');
-      console.log('         Store it in a password manager or write it down securely.');
-      console.log('');
 
-      const confirmed = await ask(rl, 'Have you saved your recovery phrase? (yes to continue): ');
-      if (confirmed.toLowerCase() !== 'yes' && confirmed.toLowerCase() !== 'y') {
-        console.log('\nSetup cancelled. Please save your recovery phrase and try again.');
-        rl.close();
-        process.exit(1);
+      printRecoveryPhraseWarning();
+
+      // Require explicit confirmation
+      let confirmed = await ask(rl, 'Have you written down your recovery phrase? (yes/no): ');
+      while (confirmed.toLowerCase() !== 'yes') {
+        if (confirmed.toLowerCase() === 'no' || confirmed.toLowerCase() === 'n') {
+          console.log('');
+          console.log('Please write down your recovery phrase before continuing:');
+          console.log('');
+          console.log(`  ${mnemonic}`);
+          console.log('');
+        }
+        confirmed = await ask(rl, 'Have you written down your recovery phrase? (yes/no): ');
       }
     }
 

--- a/mcp/src/prompts.ts
+++ b/mcp/src/prompts.ts
@@ -3,31 +3,43 @@
 // system prompt, giving the LLM persistent behavioral guidance for the session.
 
 export const SERVER_INSTRUCTIONS = `
-You have access to TotalReclaw, an end-to-end encrypted memory vault that persists across conversations.
+You have access to TotalReclaw, a persistent encrypted memory system. You SHOULD use these tools PROACTIVELY -- do not wait for the user to say "remember this" or "recall that."
 
 ## CRITICAL: Automatic Memory Behaviors
 
 ### At Conversation Start
 ALWAYS call totalreclaw_recall at the beginning of EVERY new conversation with a brief summary of the user's first message as the query. This loads relevant context from past conversations. Present recalled memories naturally as context -- do not announce "I found these memories" or list them explicitly unless the user asks.
 
-### During Conversation
-When the user shares ANY of the following, call totalreclaw_remember to store it:
+### Proactive Memory Storage (IMPORTANT)
+You should call totalreclaw_remember WITHOUT being asked whenever the user shares:
 - Personal preferences ("I prefer...", "I like...", "I hate...")
 - Personal information (name, location, occupation, family details)
-- Decisions or goals ("I decided to...", "I want to...")
-- Corrections to previous information ("Actually, I'm vegan now")
-- Important events or dates ("My birthday is...", "I started a new job")
-- Technical preferences (programming language, tools, frameworks)
+- Decisions or goals ("I decided to...", "I want to...", "I chose X because Y")
+- Corrections to previous information ("Actually, I'm vegan now", "We moved to Berlin")
+- Important events or dates ("My birthday is...", "I started a new job at...")
+- Technical preferences (programming language, tools, frameworks, workflows)
+- Project context (what they're working on, deadlines, team details)
+- Opinions and values that shape future interactions
+
+The user should NOT have to tell you to remember things. If information would be valuable in a future conversation, store it automatically. Think of yourself as a thoughtful assistant who naturally takes notes on important details.
 
 Do NOT store:
-- Temporary/transient context (weather, current task details)
-- Information about third parties the user hasn't asked to remember
+- Temporary/transient context (weather today, a one-time task)
+- Generic knowledge unrelated to the user
 - Sensitive credentials (passwords, API keys, tokens)
+
+### Memory Recall
+Call totalreclaw_recall proactively when:
+- Starting any new conversation (query based on the user's first message)
+- The user asks about something that might relate to past conversations
+- You need context about the user's background, projects, or preferences
+- The user says "remember when...", "what did I say about...", "do you know my..."
 
 ### Memory Hygiene
 - Before storing a new fact, check recalled memories to avoid duplicates
 - When the user corrects information, store the correction (the system handles deduplication)
 - Use importance 7-9 for core identity/preferences, 4-6 for moderate facts, 1-3 for minor details
+- Extract atomic facts: "User prefers dark mode" not "User said they prefer dark mode and also use VS Code"
 
 ### Billing & Quota
 When a totalreclaw_remember call fails with "quota_exceeded":
@@ -46,9 +58,9 @@ export const SYSTEM_PROMPT_FRAGMENT = SERVER_INSTRUCTIONS;
 
 // ── Layer 2: Enhanced Tool Descriptions ──────────────────────────────────────
 
-export const REMEMBER_TOOL_DESCRIPTION = `Store one or more facts in the encrypted memory vault.
+export const REMEMBER_TOOL_DESCRIPTION = `Store important information the user shares. Call this PROACTIVELY -- do not wait for the user to say "remember this."
 
-Call this tool whenever the user shares personal information, preferences, decisions, or important facts worth remembering across conversations.
+Whenever the user mentions preferences, facts about themselves, decisions, project context, goals, or anything they would want remembered across conversations, call this tool immediately. You are the user's memory -- take notes automatically.
 
 IMPORTANT: Extract atomic facts, not entire conversation snippets.
 Good: "User is vegan"
@@ -68,21 +80,21 @@ Each fact needs:
 
 The vault handles deduplication automatically. If a similar fact exists, it will be updated rather than duplicated.`;
 
-export const RECALL_TOOL_DESCRIPTION = `Search your encrypted memory vault for relevant past context.
+export const RECALL_TOOL_DESCRIPTION = `Search your memory for relevant context. Call this at the START of every conversation and whenever the user's question might relate to previously stored information.
 
-IMPORTANT: You SHOULD call this tool at the START of every conversation with a query based on the user's first message. This ensures continuity across sessions.
+IMPORTANT: You MUST call this tool at the beginning of every new conversation with a query summarizing the user's first message. This loads relevant context from past sessions and ensures continuity.
 
-Use this tool when:
-- Starting a new conversation (query = summary of user's first message)
-- User asks about their preferences or past information
-- User references something from a previous conversation
-- You need context about the user's background
+Also call this proactively when:
+- The user asks about their preferences, history, or past decisions
+- The user references something from a previous conversation
+- You need context about the user's background, projects, or work style
+- The user's question could be answered or enriched by stored memories
 
 Parameters:
 - query: Natural language search (required). Keep it concise -- 5-15 words work best.
 - k: Number of results (default 8, max 50). Use 3-5 for quick lookups, 8-12 for broad context.
 
-The results are end-to-end encrypted. The server never sees plaintext.`;
+Present recalled memories naturally as context. Do not announce "I found these memories" unless the user asks.`;
 
 export const FORGET_TOOL_DESCRIPTION = `Delete a specific memory from your vault.
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -24,6 +24,18 @@ metadata:
 
 # TotalReclaw Skill
 
+## Recovery Phrase -- READ THIS FIRST
+
+The recovery phrase is the user's ONLY identity in TotalReclaw. It derives all encryption keys. There is NO password reset, NO recovery mechanism, and NO support channel that can help if it is lost.
+
+**When showing the recovery phrase to the user, ALWAYS include this warning:**
+
+> Your recovery phrase is the ONLY way to access your encrypted memories. If you lose it, your memories are gone forever -- there is no password reset, no recovery, and no support that can help. Write it down and store it somewhere safe. Never share it with anyone.
+
+If the user asks to see their recovery phrase, remind them to store it securely. If they mention losing it, be clear that recovery is impossible and they will need to start fresh with a new phrase.
+
+---
+
 ## Tools
 
 ### totalreclaw_remember


### PR DESCRIPTION
## Summary
- Add prominent recovery phrase warning box in MCP setup wizard for both new and returning users, with a confirmation loop that requires explicit "yes"
- Add recovery phrase warning section at top of OpenClaw SKILL.md so agents proactively warn users
- Rewrite MCP server instructions and tool descriptions to emphasize proactive memory usage -- LLMs should store and recall automatically without waiting for explicit user commands

## Test plan
- [ ] `cd mcp && npx tsc --noEmit` passes (verified)
- [ ] Run `npx @totalreclaw/mcp-server --setup` and verify warning box appears after mnemonic generation
- [ ] Verify MCP server `instructions` field contains proactive language
- [ ] Verify `totalreclaw_remember` tool description says "Call this PROACTIVELY"
- [ ] Verify `totalreclaw_recall` tool description says "MUST call at the beginning"

🤖 Generated with [Claude Code](https://claude.com/claude-code)