### PR TITLE
Remove hardcoded prices, defer to Stripe-driven tiers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ Features across OpenClaw plugin (`skill/plugin/`), MCP server (`mcp/`), and Nano
 
 Features across Self-Hosted (PostgreSQL) and Managed Service (default, dual-chain via The Graph).
 
-Managed Service two-tier chain model: **Free** = Base Sepolia testnet (500 memories/month), **Pro** = Gnosis mainnet ($5/month, unlimited, permanent storage).
+Managed Service two-tier chain model: **Free** = Base Sepolia testnet (500 memories/month), **Pro** = Gnosis mainnet (pricing from Stripe, unlimited, permanent storage).
 
 | Feature | Self-Hosted | Managed Service | Notes |
 |---------|:-:|:-:|-------|

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -119,9 +119,9 @@ The server only ever sees ciphertext and hashed tokens.
 | Tier | Memories | Reads | Storage | Price |
 |------|----------|-------|---------|-------|
 | **Free** | 500/month | Unlimited | Testnet (trial) | $0 |
-| **Pro** | Unlimited | Unlimited | Permanent on-chain (Gnosis) | $5/month |
+| **Pro** | Unlimited | Unlimited | Permanent on-chain (Gnosis) | See `totalreclaw_status` |
 
-Pay with card via Stripe. Counter resets monthly.
+Pay with card via Stripe. Use `totalreclaw_status` to check current pricing. Counter resets monthly.
 
 ## Development
 

--- a/skill-nanoclaw/SKILL.md
+++ b/skill-nanoclaw/SKILL.md
@@ -187,7 +187,7 @@ TotalReclaw has a free tier (500 memories/month, unlimited reads). The skill mon
 - If usage exceeds 80%, a warning is injected into the agent context
 - If a write fails with quota exceeded (403), the billing cache is invalidated so the next conversation start re-fetches and warns the user
 - Use `totalreclaw_status` when the user asks about their subscription, quota, or billing
-- Use `totalreclaw_upgrade` to generate a Stripe checkout URL for Pro ($5/month, unlimited memories on Gnosis mainnet)
+- Use `totalreclaw_status` to check current tier and pricing. Use `totalreclaw_upgrade` to generate a Stripe checkout URL for Pro.
 
 ---
 

--- a/skill/plugin/README.md
+++ b/skill/plugin/README.md
@@ -79,9 +79,9 @@ Most of the time you won't use these directly -- the automatic hooks handle memo
 | Tier | Memories | Reads | Storage | Price |
 |------|----------|-------|---------|-------|
 | **Free** | 500/month | Unlimited | Testnet (trial) | $0 |
-| **Pro** | Unlimited | Unlimited | Permanent on-chain (Gnosis) | $5/month |
+| **Pro** | Unlimited | Unlimited | Permanent on-chain (Gnosis) | See `totalreclaw_status` |
 
-Pay with card via Stripe. Counter resets monthly.
+Pay with card via Stripe. Use `totalreclaw_status` to check current pricing. Counter resets monthly.
 
 ## Using with Other Agents
 


### PR DESCRIPTION
## Summary
- Remove hardcoded `$5/month` price references from plugin README, MCP README, NanoClaw SKILL.md, and CLAUDE.md
- Plugin/MCP descriptions now point users to `totalreclaw_status` for current pricing
- Companion to relay-side Stripe-driven tiers work (tier-sync service, public /v1/tiers endpoint, DB-backed deriveFeatures)

## Test plan
- [ ] Verify SKILL.md files render correctly (no stale dollar amounts)
- [ ] Verify `totalreclaw_status` returns `upgrade_price_usd` for free-tier users
- [ ] Verify website pricing page fetches dynamic pricing from relay API

Generated with [Claude Code](https://claude.com/claude-code)