### PR TITLE
feat: LLM-based fact extraction for ChatGPT/Claude imports

### DIFF
--- a/mcp/src/tools/import-from.ts
+++ b/mcp/src/tools/import-from.ts
@@ -28,8 +28,16 @@ export interface NormalizedFact {
   tags?: string[];
 }
 
+export interface ConversationChunk {
+  title: string;
+  messages: Array<{ role: 'user' | 'assistant'; text: string }>;
+  timestamp?: string;
+}
+
 export interface AdapterParseResult {
   facts: NormalizedFact[];
+  chunks: ConversationChunk[];
+  totalMessages: number;
   warnings: string[];
   errors: string[];
   source_metadata?: Record<string, unknown>;
@@ -145,6 +153,17 @@ async function loadAdapter(source: ImportSource): Promise<ImportAdapter> {
 
 // ── Handler ─────────────────────────────────────────────────────────────────
 
+/**
+ * Handle import_from in the MCP context.
+ *
+ * Two paths:
+ * 1. Pre-structured sources (Mem0, MCP Memory) — adapter returns facts directly,
+ *    stored via client.remember().
+ * 2. Conversation-based sources (ChatGPT, Claude) — adapter returns conversation
+ *    chunks. The MCP server does NOT have direct LLM access, so it returns the
+ *    parsed chunks as structured text with instructions for the host agent to
+ *    use totalreclaw_remember for each important fact.
+ */
 export async function handleImportFrom(
   client: TotalReclaw,
   args: unknown,
@@ -171,13 +190,67 @@ export async function handleImportFrom(
       file_path: input.file_path,
     });
 
-    if (parseResult.errors.length > 0 && parseResult.facts.length === 0) {
+    const hasChunks = parseResult.chunks && parseResult.chunks.length > 0;
+    const hasFacts = parseResult.facts && parseResult.facts.length > 0;
+
+    if (parseResult.errors.length > 0 && !hasFacts && !hasChunks) {
       return errorResponse(
         `Failed to parse ${adapter.displayName} data:\n` +
         parseResult.errors.join('\n'),
       );
     }
 
+    // ── Path 2: Conversation chunks (ChatGPT, Claude) ──────────────────
+    // MCP server has no LLM access — return parsed data with instructions
+    // for the host agent to extract and store facts.
+    if (hasChunks) {
+      if (input.dry_run) {
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              dry_run: true,
+              source: input.source,
+              total_chunks: parseResult.chunks.length,
+              total_messages: parseResult.totalMessages,
+              preview: parseResult.chunks.slice(0, 5).map((c) => ({
+                title: c.title,
+                messages: c.messages.length,
+                first_message: c.messages[0]?.text.slice(0, 100),
+              })),
+              warnings: ['DRY RUN — no facts were imported.', ...parseResult.warnings],
+            }),
+          }],
+        };
+      }
+
+      // Format chunks as readable text for the host agent to process.
+      // The agent should read through these and call totalreclaw_remember
+      // for each important fact it identifies.
+      const chunkTexts = parseResult.chunks.map((chunk, i) => {
+        const header = `--- Conversation ${i + 1}/${parseResult.chunks.length}: ${chunk.title} ---`;
+        const msgs = chunk.messages.map((m) => `[${m.role}]: ${m.text}`).join('\n');
+        return `${header}\n${msgs}`;
+      });
+
+      const instructions =
+        `I parsed ${parseResult.chunks.length} conversation chunks (${parseResult.totalMessages} messages) ` +
+        `from ${adapter.displayName}. ` +
+        `Please review the conversations below and use totalreclaw_remember to store each important fact ` +
+        `you identify. Focus on: personal facts, preferences, decisions (with reasoning), goals, ` +
+        `and active project context. Skip greetings, small talk, and ephemeral task coordination.\n\n` +
+        chunkTexts.join('\n\n');
+
+      return {
+        content: [{
+          type: 'text',
+          text: instructions,
+        }],
+      };
+    }
+
+    // ── Path 1: Pre-structured facts (Mem0, MCP Memory) ────────────────
     // Dry run — just report what would be imported
     if (input.dry_run) {
       const result: ImportResult = {

--- a/skill/plugin/import-adapters/base-adapter.ts
+++ b/skill/plugin/import-adapters/base-adapter.ts
@@ -8,12 +8,11 @@ import type {
 /**
  * Abstract base class for import adapters.
  *
- * Each adapter:
- * 1. Fetches or reads source data
- * 2. Parses into NormalizedFact[]
- * 3. Validates each fact
+ * Adapters are PARSERS only — they convert raw export data into either:
+ * - Pre-structured facts (Mem0, MCP Memory — facts are already atomic)
+ * - Conversation chunks (ChatGPT, Claude — need LLM extraction)
  *
- * The caller (import tool) handles encryption + storage.
+ * The caller (import tool) handles LLM extraction, encryption, and storage.
  */
 export abstract class BaseImportAdapter {
   abstract readonly source: ImportSource;

--- a/skill/plugin/import-adapters/chatgpt-adapter.ts
+++ b/skill/plugin/import-adapters/chatgpt-adapter.ts
@@ -1,8 +1,8 @@
 import { BaseImportAdapter } from './base-adapter.js';
 import type {
   ImportSource,
-  NormalizedFact,
   AdapterParseResult,
+  ConversationChunk,
   ProgressCallback,
 } from './types.js';
 import fs from 'node:fs';
@@ -36,95 +36,8 @@ interface ChatGPTConversation {
   mapping: Record<string, ChatGPTMappingNode>;
 }
 
-// ── Pattern matching for fact extraction ────────────────────────────────────
-
-/**
- * Patterns that indicate fact-like statements.
- * Each pattern maps to a NormalizedFact type and importance boost.
- */
-const FACT_PATTERNS: Array<{
-  pattern: RegExp;
-  type: NormalizedFact['type'];
-  importanceBoost: number;
-}> = [
-  // Identity & personal info
-  { pattern: /\bmy name is\b/i, type: 'fact', importanceBoost: 2 },
-  { pattern: /\bi(?:'m| am) (?:a |an |the )?\w/i, type: 'fact', importanceBoost: 1 },
-  { pattern: /\bi work (?:at|for|in|as)\b/i, type: 'fact', importanceBoost: 2 },
-  { pattern: /\bi live (?:in|at|near)\b/i, type: 'fact', importanceBoost: 2 },
-  { pattern: /\bi(?:'m| am) from\b/i, type: 'fact', importanceBoost: 1 },
-  { pattern: /\bmy (?:wife|husband|partner|dog|cat|kid|child|son|daughter|mom|dad|brother|sister)\b/i, type: 'fact', importanceBoost: 2 },
-  { pattern: /\bmy (?:job|role|title|position) is\b/i, type: 'fact', importanceBoost: 2 },
-  { pattern: /\bmy (?:email|phone|address|birthday)\b/i, type: 'fact', importanceBoost: 1 },
-  { pattern: /\bi(?:'m| am) \d{1,3} years old\b/i, type: 'fact', importanceBoost: 1 },
-  { pattern: /\bi speak\b/i, type: 'fact', importanceBoost: 1 },
-  { pattern: /\bi studied\b/i, type: 'fact', importanceBoost: 1 },
-  { pattern: /\bi graduated\b/i, type: 'fact', importanceBoost: 1 },
-
-  // Preferences
-  { pattern: /\bi (?:like|love|enjoy|prefer|favor)\b/i, type: 'preference', importanceBoost: 1 },
-  { pattern: /\bi (?:don'?t like|dislike|hate|avoid|can'?t stand)\b/i, type: 'preference', importanceBoost: 1 },
-  { pattern: /\bi(?:'d| would) (?:rather|prefer)\b/i, type: 'preference', importanceBoost: 1 },
-  { pattern: /\bmy (?:favorite|favourite|preferred)\b/i, type: 'preference', importanceBoost: 1 },
-  { pattern: /\bi always\b/i, type: 'preference', importanceBoost: 0 },
-  { pattern: /\bi never\b/i, type: 'preference', importanceBoost: 0 },
-  { pattern: /\bi usually\b/i, type: 'preference', importanceBoost: 0 },
-
-  // Decisions
-  { pattern: /\bi (?:decided|chose|picked|selected|went with)\b/i, type: 'decision', importanceBoost: 1 },
-  { pattern: /\bwe (?:decided|chose|agreed)\b/i, type: 'decision', importanceBoost: 1 },
-
-  // Goals
-  { pattern: /\bi (?:want to|need to|plan to|hope to|aim to|intend to)\b/i, type: 'goal', importanceBoost: 1 },
-  { pattern: /\bi(?:'m| am) (?:trying to|working on|building|learning|studying)\b/i, type: 'goal', importanceBoost: 1 },
-  { pattern: /\bmy goal is\b/i, type: 'goal', importanceBoost: 2 },
-
-  // Context / work
-  { pattern: /\bi use\b/i, type: 'fact', importanceBoost: 0 },
-  { pattern: /\bi(?:'m| am) using\b/i, type: 'fact', importanceBoost: 0 },
-  { pattern: /\bmy (?:project|app|website|company|team|startup|business)\b/i, type: 'context', importanceBoost: 1 },
-];
-
-/**
- * Classify a user message and determine its fact type and importance.
- * Returns null if the message is too short or doesn't match any patterns.
- */
-function classifyMessage(text: string): { type: NormalizedFact['type']; importance: number } | null {
-  const trimmed = text.trim();
-
-  // Skip very short messages (questions, greetings, etc.)
-  if (trimmed.length < 15) return null;
-
-  // Skip messages that are purely questions (start with question word and end with ?)
-  if (/^(?:what|where|when|who|why|how|can|could|would|should|is|are|do|does|did)\b/i.test(trimmed) && trimmed.endsWith('?')) {
-    return null;
-  }
-
-  // Skip messages that are just greetings or single-word responses
-  if (/^(?:hi|hello|hey|thanks|thank you|ok|okay|yes|no|sure|great|cool|nice|bye|goodbye)\b/i.test(trimmed) && trimmed.length < 30) {
-    return null;
-  }
-
-  let bestType: NormalizedFact['type'] = 'episodic';
-  let bestBoost = -1;
-
-  for (const { pattern, type, importanceBoost } of FACT_PATTERNS) {
-    if (pattern.test(trimmed)) {
-      if (importanceBoost > bestBoost) {
-        bestType = type;
-        bestBoost = importanceBoost;
-      }
-    }
-  }
-
-  if (bestBoost >= 0) {
-    // Matched a pattern -- this is a fact-like statement
-    return { type: bestType, importance: 5 + bestBoost };
-  }
-
-  // No pattern match -- return null to let caller decide whether to include as episodic
-  return null;
-}
+/** Maximum messages per conversation chunk for LLM extraction. */
+const CHUNK_SIZE = 20;
 
 // ── ChatGPT Adapter ─────────────────────────────────────────────────────────
 
@@ -149,7 +62,7 @@ export class ChatGPTAdapter extends BaseImportAdapter {
         content = fs.readFileSync(resolvedPath, 'utf-8');
       } catch (e) {
         errors.push(`Failed to read file: ${e instanceof Error ? e.message : 'Unknown error'}`);
-        return { facts: [], warnings, errors };
+        return { facts: [], chunks: [], totalMessages: 0, warnings, errors };
       }
     } else {
       errors.push(
@@ -157,7 +70,7 @@ export class ChatGPTAdapter extends BaseImportAdapter {
         'Export from ChatGPT: Settings -> Data Controls -> Export Data (conversations.json), ' +
         'or copy from Settings -> Personalization -> Memory -> Manage.',
       );
-      return { facts: [], warnings, errors };
+      return { facts: [], chunks: [], totalMessages: 0, warnings, errors };
     }
 
     // Detect format: JSON array = conversations.json, plain text = memories
@@ -174,6 +87,7 @@ export class ChatGPTAdapter extends BaseImportAdapter {
 
   /**
    * Parse ChatGPT conversations.json — full export with mapping tree.
+   * Returns conversation chunks for LLM extraction (no pattern matching).
    */
   private parseConversationsJson(
     content: string,
@@ -198,11 +112,11 @@ export class ChatGPTAdapter extends BaseImportAdapter {
           'Unrecognized ChatGPT format. Expected an array of conversation objects (conversations.json) ' +
           'or plain text (ChatGPT memories).',
         );
-        return { facts: [], warnings, errors };
+        return { facts: [], chunks: [], totalMessages: 0, warnings, errors };
       }
     } catch (e) {
       errors.push(`Failed to parse ChatGPT JSON: ${e instanceof Error ? e.message : 'Unknown error'}`);
-      return { facts: [], warnings, errors };
+      return { facts: [], chunks: [], totalMessages: 0, warnings, errors };
     }
 
     if (onProgress) {
@@ -214,7 +128,8 @@ export class ChatGPTAdapter extends BaseImportAdapter {
       });
     }
 
-    const rawFacts: Partial<NormalizedFact>[] = [];
+    const chunks: ConversationChunk[] = [];
+    let totalMessages = 0;
     let convIndex = 0;
 
     for (const conv of conversations) {
@@ -223,35 +138,30 @@ export class ChatGPTAdapter extends BaseImportAdapter {
         continue;
       }
 
-      // Extract user messages from the mapping tree
-      const userMessages = this.extractUserMessages(conv.mapping);
+      // Extract user + assistant messages in chronological order
+      const messages = this.extractMessages(conv.mapping);
+      if (messages.length === 0) continue;
 
-      for (const msg of userMessages) {
-        const textParts = this.extractTextFromParts(msg.message?.content?.parts);
-        if (!textParts) continue;
+      totalMessages += messages.length;
 
-        // Split multi-sentence messages into individual sentences for better fact extraction
-        const sentences = this.splitIntoSentences(textParts);
+      // Determine timestamp from first message or conversation
+      const timestamp = conv.create_time
+        ? new Date(conv.create_time * 1000).toISOString()
+        : undefined;
 
-        for (const sentence of sentences) {
-          const classification = classifyMessage(sentence);
+      const title = conv.title || 'Untitled Conversation';
 
-          if (classification) {
-            rawFacts.push({
-              text: sentence.slice(0, 512),
-              type: classification.type,
-              importance: classification.importance,
-              source: 'chatgpt' as ImportSource,
-              sourceId: msg.id,
-              sourceTimestamp: msg.message?.create_time
-                ? new Date(msg.message.create_time * 1000).toISOString()
-                : conv.create_time
-                  ? new Date(conv.create_time * 1000).toISOString()
-                  : undefined,
-              tags: conv.title ? [`conversation:${conv.title.slice(0, 60)}`] : [],
-            });
-          }
-        }
+      // Chunk into batches of CHUNK_SIZE messages
+      for (let i = 0; i < messages.length; i += CHUNK_SIZE) {
+        const batch = messages.slice(i, i + CHUNK_SIZE);
+        const chunkIndex = Math.floor(i / CHUNK_SIZE) + 1;
+        const totalChunks = Math.ceil(messages.length / CHUNK_SIZE);
+
+        chunks.push({
+          title: totalChunks > 1 ? `${title} (part ${chunkIndex}/${totalChunks})` : title,
+          messages: batch,
+          timestamp,
+        });
       }
 
       convIndex++;
@@ -260,33 +170,28 @@ export class ChatGPTAdapter extends BaseImportAdapter {
           current: convIndex,
           total: conversations.length,
           phase: 'parsing',
-          message: `Parsed ${convIndex}/${conversations.length} conversations (${rawFacts.length} facts so far)...`,
+          message: `Parsed ${convIndex}/${conversations.length} conversations (${chunks.length} chunks, ${totalMessages} messages)...`,
         });
       }
     }
 
-    if (rawFacts.length === 0 && conversations.length > 0) {
+    if (chunks.length === 0 && conversations.length > 0) {
       warnings.push(
-        `Parsed ${conversations.length} conversations but extracted 0 facts. ` +
-        'The heuristic extraction looks for personal statements (I am, I like, I work at, etc.). ' +
-        'For better results, export your ChatGPT memories directly: Settings -> Personalization -> Memory -> Manage.',
+        `Parsed ${conversations.length} conversations but found no messages with text content.`,
       );
     }
 
-    const { facts, invalidCount } = this.validateFacts(rawFacts);
-
-    if (invalidCount > 0) {
-      warnings.push(`${invalidCount} extracted statements had invalid/empty text and were skipped`);
-    }
-
     return {
-      facts,
+      facts: [],
+      chunks,
+      totalMessages,
       warnings,
       errors,
       source_metadata: {
         format: 'conversations.json',
         conversations_count: conversations.length,
-        user_messages_extracted: rawFacts.length,
+        chunks_count: chunks.length,
+        total_messages: totalMessages,
       },
     };
   }
@@ -294,6 +199,8 @@ export class ChatGPTAdapter extends BaseImportAdapter {
   /**
    * Parse ChatGPT memories — plain text, one memory per line.
    * Users copy this from Settings -> Personalization -> Memory -> Manage.
+   *
+   * Each line becomes a single-message conversation chunk for LLM extraction.
    */
   private parseMemoriesText(
     content: string,
@@ -317,49 +224,46 @@ export class ChatGPTAdapter extends BaseImportAdapter {
       });
     }
 
-    const rawFacts: Partial<NormalizedFact>[] = lines.map((line, i) => {
-      // Strip leading bullet/dash/number markers
-      const cleaned = line
+    // Clean lines: strip bullet/dash/number markers
+    const cleanedLines = lines.map((line) =>
+      line
         .replace(/^[-*\u2022]\s+/, '')        // bullet points
         .replace(/^\d+[.)]\s+/, '')            // numbered lists
-        .trim();
+        .trim(),
+    ).filter((line) => line.length >= 3);
 
-      // Classify using pattern matching
-      const classification = classifyMessage(cleaned);
-
-      return {
-        text: cleaned.slice(0, 512),
-        type: classification?.type ?? 'fact',
-        // ChatGPT memories are pre-curated by ChatGPT's own memory system, so
-        // they are generally higher quality -- default to importance 6
-        importance: classification?.importance ?? 6,
-        source: 'chatgpt' as ImportSource,
-        sourceId: `chatgpt-memory-${i}`,
-        tags: ['chatgpt-memory'],
-      };
-    });
-
-    const { facts, invalidCount } = this.validateFacts(rawFacts);
-
-    if (invalidCount > 0) {
-      warnings.push(`${invalidCount} memories had invalid/empty text and were skipped`);
+    // Group all memories into chunks of CHUNK_SIZE for efficient LLM extraction
+    const chunks: ConversationChunk[] = [];
+    for (let i = 0; i < cleanedLines.length; i += CHUNK_SIZE) {
+      const batch = cleanedLines.slice(i, i + CHUNK_SIZE);
+      chunks.push({
+        title: `ChatGPT memories (${i + 1}-${Math.min(i + CHUNK_SIZE, cleanedLines.length)})`,
+        messages: batch.map((text) => ({ role: 'user' as const, text })),
+      });
     }
 
     return {
-      facts,
+      facts: [],
+      chunks,
+      totalMessages: cleanedLines.length,
       warnings,
       errors,
       source_metadata: {
         format: 'memories-text',
         total_lines: lines.length,
+        chunks_count: chunks.length,
       },
     };
   }
 
   /**
-   * Traverse the mapping tree and extract user messages in chronological order.
+   * Traverse the mapping tree and extract user + assistant messages in chronological order.
+   * Both roles are included because the assistant's response often provides context
+   * that helps the LLM understand what the user meant.
    */
-  private extractUserMessages(mapping: Record<string, ChatGPTMappingNode>): ChatGPTMappingNode[] {
+  private extractMessages(
+    mapping: Record<string, ChatGPTMappingNode>,
+  ): Array<{ role: 'user' | 'assistant'; text: string }> {
     // Find the root node (the one with no parent or parent not in mapping)
     let rootId: string | undefined;
     for (const [id, node] of Object.entries(mapping)) {
@@ -371,8 +275,8 @@ export class ChatGPTAdapter extends BaseImportAdapter {
 
     if (!rootId) return [];
 
-    // Walk the tree depth-first, following first child (main thread)
-    const messages: ChatGPTMappingNode[] = [];
+    // Walk the tree breadth-first, following children in order (main thread)
+    const messages: Array<{ role: 'user' | 'assistant'; text: string }> = [];
     const visited = new Set<string>();
     const queue: string[] = [rootId];
 
@@ -384,9 +288,13 @@ export class ChatGPTAdapter extends BaseImportAdapter {
       const node = mapping[nodeId];
       if (!node) continue;
 
-      // Only collect user messages
-      if (node.message?.author?.role === 'user') {
-        messages.push(node);
+      const role = node.message?.author?.role;
+      // Only collect user and assistant messages (skip system, tool)
+      if (role === 'user' || role === 'assistant') {
+        const textParts = this.extractTextFromParts(node.message?.content?.parts);
+        if (textParts && textParts.length >= 3) {
+          messages.push({ role, text: textParts });
+        }
       }
 
       // Follow children (add them to queue in order)
@@ -411,22 +319,5 @@ export class ChatGPTAdapter extends BaseImportAdapter {
     if (textParts.length === 0) return null;
 
     return textParts.join(' ').trim();
-  }
-
-  /**
-   * Split a message into individual sentences for finer-grained fact extraction.
-   * Only splits on sentence boundaries; keeps short messages intact.
-   */
-  private splitIntoSentences(text: string): string[] {
-    // If the message is short enough, return as-is
-    if (text.length < 100) return [text];
-
-    // Split on sentence-ending punctuation followed by space and uppercase
-    const sentences = text
-      .split(/(?<=[.!?])\s+(?=[A-Z])/)
-      .map((s) => s.trim())
-      .filter((s) => s.length >= 10);
-
-    return sentences.length > 0 ? sentences : [text];
   }
 }

--- a/skill/plugin/import-adapters/claude-adapter.ts
+++ b/skill/plugin/import-adapters/claude-adapter.ts
@@ -1,8 +1,8 @@
 import { BaseImportAdapter } from './base-adapter.js';
 import type {
   ImportSource,
-  NormalizedFact,
   AdapterParseResult,
+  ConversationChunk,
   ProgressCallback,
 } from './types.js';
 import fs from 'node:fs';
@@ -24,34 +24,8 @@ const BULLET_PREFIX_RE = /^[-*\u2022]\s+/;
  */
 const NUMBERED_PREFIX_RE = /^\d+[.)]\s+/;
 
-/**
- * Patterns for classifying Claude memory entries by type.
- * Claude memories are already curated facts, so we use lighter heuristics.
- */
-const TYPE_PATTERNS: Array<{ pattern: RegExp; type: NormalizedFact['type'] }> = [
-  { pattern: /\bprefers?\b/i, type: 'preference' },
-  { pattern: /\blikes?\b/i, type: 'preference' },
-  { pattern: /\bdislikes?\b/i, type: 'preference' },
-  { pattern: /\bfavorite\b/i, type: 'preference' },
-  { pattern: /\bfavourite\b/i, type: 'preference' },
-  { pattern: /\bavoids?\b/i, type: 'preference' },
-  { pattern: /\bdecided\b/i, type: 'decision' },
-  { pattern: /\bchose\b/i, type: 'decision' },
-  { pattern: /\bwants? to\b/i, type: 'goal' },
-  { pattern: /\bplans? to\b/i, type: 'goal' },
-  { pattern: /\bgoal\b/i, type: 'goal' },
-  { pattern: /\baims? to\b/i, type: 'goal' },
-  { pattern: /\bworking on\b/i, type: 'context' },
-  { pattern: /\bcurrently\b/i, type: 'context' },
-  { pattern: /\bproject\b/i, type: 'context' },
-];
-
-function classifyMemory(text: string): NormalizedFact['type'] {
-  for (const { pattern, type } of TYPE_PATTERNS) {
-    if (pattern.test(text)) return type;
-  }
-  return 'fact';
-}
+/** Maximum messages per conversation chunk for LLM extraction. */
+const CHUNK_SIZE = 20;
 
 export class ClaudeAdapter extends BaseImportAdapter {
   readonly source: ImportSource = 'claude';
@@ -74,24 +48,26 @@ export class ClaudeAdapter extends BaseImportAdapter {
         content = fs.readFileSync(resolvedPath, 'utf-8');
       } catch (e) {
         errors.push(`Failed to read file: ${e instanceof Error ? e.message : 'Unknown error'}`);
-        return { facts: [], warnings, errors };
+        return { facts: [], chunks: [], totalMessages: 0, warnings, errors };
       }
     } else {
       errors.push(
         'Claude import requires either content (pasted text) or file_path. ' +
         'Copy your memories from Claude: Settings -> Memory -> select all and copy.',
       );
-      return { facts: [], warnings, errors };
+      return { facts: [], chunks: [], totalMessages: 0, warnings, errors };
     }
 
     // Claude memory export is plain text, one fact per line.
-    // Sometimes with date prefixes like [2026-03-15] - User prefers TypeScript.
-    // Sometimes with bullet points or numbered lists.
     return this.parseMemoriesText(content.trim(), warnings, errors, onProgress);
   }
 
   /**
    * Parse Claude memories — plain text, one memory per line.
+   * Returns conversation chunks for LLM extraction (no pattern matching).
+   *
+   * Each line is cleaned (date prefixes, bullets, numbers stripped) and
+   * grouped into chunks for the LLM to process.
    */
   private parseMemoriesText(
     content: string,
@@ -115,7 +91,9 @@ export class ClaudeAdapter extends BaseImportAdapter {
       });
     }
 
-    const rawFacts: Partial<NormalizedFact>[] = lines.map((line, i) => {
+    // Clean each line: extract date, strip formatting
+    const cleanedEntries: Array<{ text: string; timestamp?: string }> = [];
+    for (const line of lines) {
       let cleaned = line;
       let timestamp: string | undefined;
 
@@ -132,33 +110,36 @@ export class ClaudeAdapter extends BaseImportAdapter {
         .replace(NUMBERED_PREFIX_RE, '')
         .trim();
 
-      const type = classifyMemory(cleaned);
+      if (cleaned.length >= 3) {
+        cleanedEntries.push({ text: cleaned, timestamp });
+      }
+    }
 
-      return {
-        text: cleaned.slice(0, 512),
-        type,
-        // Claude memories are already curated -- default to importance 6
-        importance: 6,
-        source: 'claude' as ImportSource,
-        sourceId: `claude-memory-${i}`,
-        sourceTimestamp: timestamp,
-        tags: ['claude-memory'],
-      };
-    });
+    // Group memories into chunks of CHUNK_SIZE for efficient LLM extraction
+    const chunks: ConversationChunk[] = [];
+    for (let i = 0; i < cleanedEntries.length; i += CHUNK_SIZE) {
+      const batch = cleanedEntries.slice(i, i + CHUNK_SIZE);
 
-    const { facts, invalidCount } = this.validateFacts(rawFacts);
+      // Use the timestamp from the first entry in the batch (if available)
+      const batchTimestamp = batch.find((e) => e.timestamp)?.timestamp;
 
-    if (invalidCount > 0) {
-      warnings.push(`${invalidCount} memories had invalid/empty text and were skipped`);
+      chunks.push({
+        title: `Claude memories (${i + 1}-${Math.min(i + CHUNK_SIZE, cleanedEntries.length)})`,
+        messages: batch.map((entry) => ({ role: 'user' as const, text: entry.text })),
+        timestamp: batchTimestamp,
+      });
     }
 
     return {
-      facts,
+      facts: [],
+      chunks,
+      totalMessages: cleanedEntries.length,
       warnings,
       errors,
       source_metadata: {
         format: 'memories-text',
         total_lines: lines.length,
+        chunks_count: chunks.length,
       },
     };
   }

--- a/skill/plugin/import-adapters/import-adapters.test.ts
+++ b/skill/plugin/import-adapters/import-adapters.test.ts
@@ -1,9 +1,13 @@
 /**
- * Unit tests for import adapters (Task 9).
+ * Unit tests for import adapters.
  *
  * Run with: npx tsx import-adapters/import-adapters.test.ts
  *
  * Uses TAP-style output (no test framework dependency).
+ *
+ * ChatGPT and Claude adapters return conversation CHUNKS (not facts).
+ * Fact extraction is delegated to the LLM via extractFacts().
+ * Mem0 and MCP Memory adapters return pre-structured facts.
  */
 
 import { Mem0Adapter } from './mem0-adapter.js';
@@ -60,7 +64,7 @@ class TestAdapter extends BaseImportAdapter {
   readonly displayName = 'Test Adapter';
 
   async parse(): Promise<AdapterParseResult> {
-    return { facts: [], warnings: [], errors: [] };
+    return { facts: [], chunks: [], totalMessages: 0, warnings: [], errors: [] };
   }
 
   // Expose protected methods for testing
@@ -104,6 +108,7 @@ async function runTests(): Promise<void> {
     assert(result.facts[0].source === 'mem0', 'Mem0: source is mem0');
     assert(result.facts[1].type === 'fact', 'Mem0: fact category mapped');
     assert(result.facts[1].sourceId === 'mem-2', 'Mem0: sourceId preserved');
+    assert(result.chunks.length === 0, 'Mem0: no chunks (pre-structured source)');
   }
 
   // --- parses export file format ---
@@ -252,13 +257,11 @@ async function runTests(): Promise<void> {
     const result = await adapter.parse({ content });
 
     assert(result.facts.length === 3, 'MCP: 2 entities with 3 total observations -> 3 facts');
-    // "Works at Acme Corp" starts with uppercase verb -> prefixed: "John: Works at Acme Corp"
-    // Actually the adapter checks if it starts lowercase (verb) or uppercase (standalone sentence)
-    // "Works" starts uppercase -> "John: Works at Acme Corp"
     assert(result.facts[0].text.includes('John'), 'MCP: first fact includes entity name');
     assert(result.facts[0].text.includes('Acme Corp'), 'MCP: first fact includes observation');
     assert(result.facts[1].text.includes('TypeScript'), 'MCP: second fact includes TypeScript');
     assert(result.facts[0].source === 'mcp-memory', 'MCP: source is mcp-memory');
+    assert(result.chunks.length === 0, 'MCP: no chunks (pre-structured source)');
   }
 
   // --- contextualizes observations correctly ---
@@ -540,12 +543,12 @@ async function runTests(): Promise<void> {
   }
 
   // =========================================================================
-  // ChatGPTAdapter — conversations.json
+  // ChatGPTAdapter — conversations.json (returns chunks, not facts)
   // =========================================================================
 
-  console.log('# ChatGPTAdapter — conversations.json');
+  console.log('# ChatGPTAdapter — conversations.json (chunks)');
 
-  // --- parses conversations.json with user messages ---
+  // --- returns conversation chunks with user + assistant messages ---
   {
     const conversations = [
       {
@@ -570,7 +573,7 @@ async function runTests(): Promise<void> {
             message: {
               id: 'msg2',
               author: { role: 'assistant' },
-              content: { content_type: 'text', parts: ['That sounds great!'] },
+              content: { content_type: 'text', parts: ['That sounds great! Tell me more about your work.'] },
               create_time: 1700000002,
             },
             parent: 'msg1',
@@ -594,27 +597,33 @@ async function runTests(): Promise<void> {
     const adapter = new ChatGPTAdapter();
     const result = await adapter.parse({ content: JSON.stringify(conversations) });
 
-    assert(result.facts.length >= 2, `ChatGPT conv: extracted at least 2 facts from user messages (got ${result.facts.length})`);
-    assert(result.facts.some((f) => f.text.includes('Google')), 'ChatGPT conv: found "Google" fact');
-    assert(result.facts.some((f) => f.text.includes('TypeScript')), 'ChatGPT conv: found "TypeScript" fact');
-    assert(result.facts[0].source === 'chatgpt', 'ChatGPT conv: source is chatgpt');
-    assert(result.facts.every((f) => f.sourceTimestamp), 'ChatGPT conv: all facts have timestamps');
+    assert(result.facts.length === 0, 'ChatGPT conv: no pre-extracted facts (uses chunks)');
+    assert(result.chunks.length === 1, `ChatGPT conv: 1 conversation chunk (got ${result.chunks.length})`);
+    assert(result.chunks[0].title === 'Test Conversation', 'ChatGPT conv: chunk title matches conversation title');
+    assert(result.chunks[0].messages.length === 3, `ChatGPT conv: 3 messages (user + assistant) (got ${result.chunks[0].messages.length})`);
+    assert(result.chunks[0].messages[0].role === 'user', 'ChatGPT conv: first message is user');
+    assert(result.chunks[0].messages[0].text.includes('Google'), 'ChatGPT conv: first message text correct');
+    assert(result.chunks[0].messages[1].role === 'assistant', 'ChatGPT conv: second message is assistant');
+    assert(result.chunks[0].messages[2].role === 'user', 'ChatGPT conv: third message is user');
+    assert(result.chunks[0].messages[2].text.includes('TypeScript'), 'ChatGPT conv: third message text correct');
+    assert(result.chunks[0].timestamp !== undefined, 'ChatGPT conv: chunk has timestamp');
+    assert(result.totalMessages === 3, `ChatGPT conv: totalMessages is 3 (got ${result.totalMessages})`);
     assert(result.errors.length === 0, 'ChatGPT conv: no errors');
   }
 
-  // --- skips assistant and system messages ---
+  // --- includes both user and assistant messages ---
   {
     const conversations = [
       {
-        title: 'Test',
+        title: 'Context Test',
         mapping: {
           root: { id: 'root', message: null, parent: null, children: ['msg1'] },
           msg1: {
             id: 'msg1',
             message: {
               id: 'msg1',
-              author: { role: 'system' },
-              content: { content_type: 'text', parts: ['I am a helpful assistant working at OpenAI'] },
+              author: { role: 'user' },
+              content: { content_type: 'text', parts: ['I want to migrate to TypeScript'] },
             },
             parent: 'root',
             children: ['msg2'],
@@ -624,7 +633,7 @@ async function runTests(): Promise<void> {
             message: {
               id: 'msg2',
               author: { role: 'assistant' },
-              content: { content_type: 'text', parts: ['I live in the cloud and I prefer helping users'] },
+              content: { content_type: 'text', parts: ['TypeScript migration involves setting up tsconfig and converting files'] },
             },
             parent: 'msg1',
             children: [],
@@ -636,35 +645,47 @@ async function runTests(): Promise<void> {
     const adapter = new ChatGPTAdapter();
     const result = await adapter.parse({ content: JSON.stringify(conversations) });
 
-    assert(result.facts.length === 0, 'ChatGPT conv: no facts from assistant/system messages');
+    assert(result.chunks.length === 1, 'ChatGPT: includes assistant messages for context');
+    assert(result.chunks[0].messages.length === 2, 'ChatGPT: both user and assistant in chunk');
+    assert(result.chunks[0].messages[1].role === 'assistant', 'ChatGPT: assistant message preserved');
   }
 
-  // --- classifies fact types correctly ---
+  // --- skips system and tool messages ---
   {
     const conversations = [
       {
-        title: 'Types Test',
+        title: 'Test',
         mapping: {
-          root: { id: 'root', message: null, parent: null, children: ['msg1', 'msg2', 'msg3', 'msg4'] },
+          root: { id: 'root', message: null, parent: null, children: ['msg1'] },
           msg1: {
             id: 'msg1',
-            message: { id: 'msg1', author: { role: 'user' }, content: { content_type: 'text', parts: ['I work at Microsoft as a developer'] } },
-            parent: 'root', children: [],
+            message: {
+              id: 'msg1',
+              author: { role: 'system' },
+              content: { content_type: 'text', parts: ['You are a helpful assistant'] },
+            },
+            parent: 'root',
+            children: ['msg2'],
           },
           msg2: {
             id: 'msg2',
-            message: { id: 'msg2', author: { role: 'user' }, content: { content_type: 'text', parts: ['I like programming in Rust a lot'] } },
-            parent: 'root', children: [],
+            message: {
+              id: 'msg2',
+              author: { role: 'tool' },
+              content: { content_type: 'text', parts: ['Tool output: search results...'] },
+            },
+            parent: 'msg1',
+            children: ['msg3'],
           },
           msg3: {
             id: 'msg3',
-            message: { id: 'msg3', author: { role: 'user' }, content: { content_type: 'text', parts: ['I decided to use PostgreSQL for the project'] } },
-            parent: 'root', children: [],
-          },
-          msg4: {
-            id: 'msg4',
-            message: { id: 'msg4', author: { role: 'user' }, content: { content_type: 'text', parts: ['I want to learn machine learning this year'] } },
-            parent: 'root', children: [],
+            message: {
+              id: 'msg3',
+              author: { role: 'user' },
+              content: { content_type: 'text', parts: ['I work at Google as a senior engineer'] },
+            },
+            parent: 'msg2',
+            children: [],
           },
         },
       },
@@ -673,20 +694,47 @@ async function runTests(): Promise<void> {
     const adapter = new ChatGPTAdapter();
     const result = await adapter.parse({ content: JSON.stringify(conversations) });
 
-    const workFact = result.facts.find((f) => f.text.includes('Microsoft'));
-    assert(workFact?.type === 'fact', `ChatGPT: "I work at" -> fact (got ${workFact?.type})`);
-
-    const prefFact = result.facts.find((f) => f.text.includes('Rust'));
-    assert(prefFact?.type === 'preference', `ChatGPT: "I like" -> preference (got ${prefFact?.type})`);
-
-    const decFact = result.facts.find((f) => f.text.includes('PostgreSQL'));
-    assert(decFact?.type === 'decision', `ChatGPT: "I decided" -> decision (got ${decFact?.type})`);
-
-    const goalFact = result.facts.find((f) => f.text.includes('machine learning'));
-    assert(goalFact?.type === 'goal', `ChatGPT: "I want to" -> goal (got ${goalFact?.type})`);
+    assert(result.chunks.length === 1, 'ChatGPT: has 1 chunk');
+    assert(result.chunks[0].messages.length === 1, 'ChatGPT: only user message (skips system + tool)');
+    assert(result.chunks[0].messages[0].role === 'user', 'ChatGPT: the surviving message is user');
   }
 
-  // --- handles single conversation object ---
+  // --- chunks large conversations into batches of 20 ---
+  {
+    // Build a conversation with 45 messages
+    const mapping: Record<string, any> = {
+      root: { id: 'root', message: null, parent: null, children: ['msg-0'] },
+    };
+
+    for (let i = 0; i < 45; i++) {
+      const role = i % 2 === 0 ? 'user' : 'assistant';
+      mapping[`msg-${i}`] = {
+        id: `msg-${i}`,
+        message: {
+          id: `msg-${i}`,
+          author: { role },
+          content: { content_type: 'text', parts: [`Message number ${i} from ${role} about various topics`] },
+        },
+        parent: i === 0 ? 'root' : `msg-${i - 1}`,
+        children: i < 44 ? [`msg-${i + 1}`] : [],
+      };
+    }
+
+    const conversations = [{ title: 'Long Conversation', mapping }];
+
+    const adapter = new ChatGPTAdapter();
+    const result = await adapter.parse({ content: JSON.stringify(conversations) });
+
+    assert(result.chunks.length === 3, `ChatGPT: 45 messages -> 3 chunks (got ${result.chunks.length})`);
+    assert(result.chunks[0].messages.length === 20, `ChatGPT: first chunk has 20 messages (got ${result.chunks[0].messages.length})`);
+    assert(result.chunks[1].messages.length === 20, `ChatGPT: second chunk has 20 messages (got ${result.chunks[1].messages.length})`);
+    assert(result.chunks[2].messages.length === 5, `ChatGPT: third chunk has 5 messages (got ${result.chunks[2].messages.length})`);
+    assert(result.chunks[0].title.includes('part 1/3'), `ChatGPT: first chunk title has part indicator (got: ${result.chunks[0].title})`);
+    assert(result.chunks[2].title.includes('part 3/3'), `ChatGPT: last chunk title has part indicator (got: ${result.chunks[2].title})`);
+    assert(result.totalMessages === 45, `ChatGPT: totalMessages is 45 (got ${result.totalMessages})`);
+  }
+
+  // --- handles single conversation object (not array) ---
   {
     const conv = {
       title: 'Single',
@@ -703,62 +751,8 @@ async function runTests(): Promise<void> {
     const adapter = new ChatGPTAdapter();
     const result = await adapter.parse({ content: JSON.stringify(conv) });
 
-    assert(result.facts.length >= 1, 'ChatGPT: single conversation object parses');
-    assert(result.facts[0].text.includes('San Francisco'), 'ChatGPT: single conv fact correct');
-  }
-
-  // --- skips short/question messages ---
-  {
-    const conversations = [
-      {
-        title: 'Short Messages',
-        mapping: {
-          root: { id: 'root', message: null, parent: null, children: ['msg1', 'msg2', 'msg3'] },
-          msg1: {
-            id: 'msg1',
-            message: { id: 'msg1', author: { role: 'user' }, content: { content_type: 'text', parts: ['hi'] } },
-            parent: 'root', children: [],
-          },
-          msg2: {
-            id: 'msg2',
-            message: { id: 'msg2', author: { role: 'user' }, content: { content_type: 'text', parts: ['What is machine learning?'] } },
-            parent: 'root', children: [],
-          },
-          msg3: {
-            id: 'msg3',
-            message: { id: 'msg3', author: { role: 'user' }, content: { content_type: 'text', parts: ['thanks'] } },
-            parent: 'root', children: [],
-          },
-        },
-      },
-    ];
-
-    const adapter = new ChatGPTAdapter();
-    const result = await adapter.parse({ content: JSON.stringify(conversations) });
-
-    assert(result.facts.length === 0, `ChatGPT: short/question messages skipped (got ${result.facts.length})`);
-  }
-
-  // --- invalid JSON returns error ---
-  {
-    const adapter = new ChatGPTAdapter();
-    const result = await adapter.parse({ content: 'not valid json {{{' });
-
-    // This should fall through to the plain-text parser since it doesn't start with [ or {
-    // ... actually "not valid json {{{" doesn't start with [ or {, so it parses as memories text
-    // Let's test explicit JSON failure
-    const result2 = await adapter.parse({ content: '[invalid json array' });
-    assert(result2.facts.length === 0, 'ChatGPT: invalid JSON array yields 0 facts');
-    assert(result2.errors.length > 0, 'ChatGPT: invalid JSON produces error');
-  }
-
-  // --- empty input returns error ---
-  {
-    const adapter = new ChatGPTAdapter();
-    const result = await adapter.parse({});
-
-    assert(result.facts.length === 0, 'ChatGPT: no input yields 0 facts');
-    assert(result.errors.length > 0, 'ChatGPT: no input produces error');
+    assert(result.chunks.length === 1, 'ChatGPT: single conversation object parses into 1 chunk');
+    assert(result.chunks[0].messages[0].text.includes('San Francisco'), 'ChatGPT: single conv message correct');
   }
 
   // --- handles null/non-string parts ---
@@ -784,17 +778,97 @@ async function runTests(): Promise<void> {
     const adapter = new ChatGPTAdapter();
     const result = await adapter.parse({ content: JSON.stringify(conversations) });
 
-    assert(result.facts.length >= 1, 'ChatGPT: handles null/non-string parts');
-    assert(result.facts[0].text.includes('dark mode'), 'ChatGPT: extracted text from valid part');
+    assert(result.chunks.length === 1, 'ChatGPT: handles null/non-string parts');
+    assert(result.chunks[0].messages[0].text.includes('dark mode'), 'ChatGPT: extracted text from valid part');
+  }
+
+  // --- invalid JSON returns error ---
+  {
+    const adapter = new ChatGPTAdapter();
+    const result2 = await adapter.parse({ content: '[invalid json array' });
+    assert(result2.chunks.length === 0, 'ChatGPT: invalid JSON array yields 0 chunks');
+    assert(result2.errors.length > 0, 'ChatGPT: invalid JSON produces error');
+  }
+
+  // --- empty input returns error ---
+  {
+    const adapter = new ChatGPTAdapter();
+    const result = await adapter.parse({});
+
+    assert(result.chunks.length === 0, 'ChatGPT: no input yields 0 chunks');
+    assert(result.errors.length > 0, 'ChatGPT: no input produces error');
+  }
+
+  // --- conversation with no text messages produces no chunks ---
+  {
+    const conversations = [
+      {
+        title: 'Empty',
+        mapping: {
+          root: { id: 'root', message: null, parent: null, children: ['msg1'] },
+          msg1: {
+            id: 'msg1',
+            message: {
+              id: 'msg1',
+              author: { role: 'user' },
+              content: { content_type: 'text', parts: [null] },
+            },
+            parent: 'root', children: [],
+          },
+        },
+      },
+    ];
+
+    const adapter = new ChatGPTAdapter();
+    const result = await adapter.parse({ content: JSON.stringify(conversations) });
+
+    assert(result.chunks.length === 0, 'ChatGPT: conversation with no text -> no chunks');
+  }
+
+  // --- multiple conversations produce multiple chunks ---
+  {
+    const conversations = [
+      {
+        title: 'Conv 1',
+        create_time: 1700000000,
+        mapping: {
+          root: { id: 'root', message: null, parent: null, children: ['msg1'] },
+          msg1: {
+            id: 'msg1',
+            message: { id: 'msg1', author: { role: 'user' }, content: { content_type: 'text', parts: ['First conversation message'] } },
+            parent: 'root', children: [],
+          },
+        },
+      },
+      {
+        title: 'Conv 2',
+        create_time: 1700100000,
+        mapping: {
+          root: { id: 'root', message: null, parent: null, children: ['msg1'] },
+          msg1: {
+            id: 'msg1',
+            message: { id: 'msg1', author: { role: 'user' }, content: { content_type: 'text', parts: ['Second conversation message'] } },
+            parent: 'root', children: [],
+          },
+        },
+      },
+    ];
+
+    const adapter = new ChatGPTAdapter();
+    const result = await adapter.parse({ content: JSON.stringify(conversations) });
+
+    assert(result.chunks.length === 2, `ChatGPT: 2 conversations -> 2 chunks (got ${result.chunks.length})`);
+    assert(result.chunks[0].title === 'Conv 1', 'ChatGPT: first chunk title correct');
+    assert(result.chunks[1].title === 'Conv 2', 'ChatGPT: second chunk title correct');
   }
 
   // =========================================================================
-  // ChatGPTAdapter — memories text
+  // ChatGPTAdapter — memories text (returns chunks, not facts)
   // =========================================================================
 
-  console.log('# ChatGPTAdapter — memories text');
+  console.log('# ChatGPTAdapter — memories text (chunks)');
 
-  // --- parses plain text memories (one per line) ---
+  // --- parses plain text memories into chunks ---
   {
     const memoriesText = `User prefers dark mode
 User works at Google as a software engineer
@@ -804,9 +878,12 @@ User likes hiking on weekends`;
     const adapter = new ChatGPTAdapter();
     const result = await adapter.parse({ content: memoriesText });
 
-    assert(result.facts.length === 4, `ChatGPT memories: parsed 4 lines (got ${result.facts.length})`);
-    assert(result.facts[0].source === 'chatgpt', 'ChatGPT memories: source is chatgpt');
-    assert(result.facts.every((f) => f.tags?.includes('chatgpt-memory')), 'ChatGPT memories: all tagged');
+    assert(result.facts.length === 0, 'ChatGPT memories: no pre-extracted facts');
+    assert(result.chunks.length === 1, `ChatGPT memories: 4 lines -> 1 chunk (got ${result.chunks.length})`);
+    assert(result.chunks[0].messages.length === 4, `ChatGPT memories: 4 messages in chunk (got ${result.chunks[0].messages.length})`);
+    assert(result.chunks[0].messages[0].text === 'User prefers dark mode', 'ChatGPT memories: first message text correct');
+    assert(result.chunks[0].messages[0].role === 'user', 'ChatGPT memories: all messages are user role');
+    assert(result.totalMessages === 4, `ChatGPT memories: totalMessages is 4 (got ${result.totalMessages})`);
   }
 
   // --- handles bullet points and numbered lists ---
@@ -819,9 +896,10 @@ User likes hiking on weekends`;
     const adapter = new ChatGPTAdapter();
     const result = await adapter.parse({ content: memoriesText });
 
-    assert(result.facts.length === 4, `ChatGPT memories: handles bullets/numbers (got ${result.facts.length})`);
-    assert(!result.facts[0].text.startsWith('-'), 'ChatGPT memories: bullet stripped');
-    assert(!result.facts[2].text.startsWith('1'), 'ChatGPT memories: number stripped');
+    assert(result.chunks.length === 1, 'ChatGPT memories: 4 lines -> 1 chunk');
+    assert(result.chunks[0].messages.length === 4, `ChatGPT memories: handles bullets/numbers (got ${result.chunks[0].messages.length})`);
+    assert(!result.chunks[0].messages[0].text.startsWith('-'), 'ChatGPT memories: bullet stripped');
+    assert(!result.chunks[0].messages[2].text.startsWith('1'), 'ChatGPT memories: number stripped');
   }
 
   // --- skips empty lines and header lines ---
@@ -835,7 +913,8 @@ User lives in London`;
     const adapter = new ChatGPTAdapter();
     const result = await adapter.parse({ content: memoriesText });
 
-    assert(result.facts.length === 2, `ChatGPT memories: skips empty/header lines (got ${result.facts.length})`);
+    assert(result.chunks.length === 1, 'ChatGPT memories: skips header/blank');
+    assert(result.chunks[0].messages.length === 2, `ChatGPT memories: only 2 valid lines (got ${result.chunks[0].messages.length})`);
   }
 
   // --- empty text input ---
@@ -843,16 +922,31 @@ User lives in London`;
     const adapter = new ChatGPTAdapter();
     const result = await adapter.parse({ content: '' });
 
-    assert(result.facts.length === 0, 'ChatGPT memories: empty text yields 0 facts');
+    assert(result.chunks.length === 0, 'ChatGPT memories: empty text yields 0 chunks');
+  }
+
+  // --- large memory list chunks into multiple batches ---
+  {
+    const lines = Array.from({ length: 50 }, (_, i) => `User memory item number ${i + 1} about their preferences`);
+    const memoriesText = lines.join('\n');
+
+    const adapter = new ChatGPTAdapter();
+    const result = await adapter.parse({ content: memoriesText });
+
+    assert(result.chunks.length === 3, `ChatGPT memories: 50 lines -> 3 chunks (got ${result.chunks.length})`);
+    assert(result.chunks[0].messages.length === 20, `ChatGPT memories: first chunk has 20 (got ${result.chunks[0].messages.length})`);
+    assert(result.chunks[1].messages.length === 20, `ChatGPT memories: second chunk has 20 (got ${result.chunks[1].messages.length})`);
+    assert(result.chunks[2].messages.length === 10, `ChatGPT memories: third chunk has 10 (got ${result.chunks[2].messages.length})`);
+    assert(result.totalMessages === 50, `ChatGPT memories: totalMessages is 50 (got ${result.totalMessages})`);
   }
 
   // =========================================================================
-  // ClaudeAdapter
+  // ClaudeAdapter (returns chunks, not facts)
   // =========================================================================
 
-  console.log('# ClaudeAdapter');
+  console.log('# ClaudeAdapter (chunks)');
 
-  // --- parses plain text memories ---
+  // --- parses plain text memories into chunks ---
   {
     const memoriesText = `User prefers functional programming
 User works at a startup in Berlin
@@ -862,30 +956,15 @@ User wants to learn machine learning`;
     const adapter = new ClaudeAdapter();
     const result = await adapter.parse({ content: memoriesText });
 
-    assert(result.facts.length === 4, `Claude: parsed 4 memories (got ${result.facts.length})`);
-    assert(result.facts[0].source === 'claude', 'Claude: source is claude');
-    assert(result.facts.every((f) => f.tags?.includes('claude-memory')), 'Claude: all tagged');
+    assert(result.facts.length === 0, 'Claude: no pre-extracted facts (uses chunks)');
+    assert(result.chunks.length === 1, `Claude: 4 memories -> 1 chunk (got ${result.chunks.length})`);
+    assert(result.chunks[0].messages.length === 4, `Claude: 4 messages in chunk (got ${result.chunks[0].messages.length})`);
+    assert(result.chunks[0].messages[0].role === 'user', 'Claude: all messages are user role');
+    assert(result.chunks[0].messages[0].text === 'User prefers functional programming', 'Claude: first message text correct');
+    assert(result.totalMessages === 4, `Claude: totalMessages is 4 (got ${result.totalMessages})`);
   }
 
-  // --- classifies types correctly ---
-  {
-    const memoriesText = `User prefers TypeScript over JavaScript
-User decided to use PostgreSQL for the project
-User wants to launch by end of Q1
-User is currently working on a mobile app
-User is a senior developer at Google`;
-
-    const adapter = new ClaudeAdapter();
-    const result = await adapter.parse({ content: memoriesText });
-
-    assert(result.facts[0].type === 'preference', `Claude: "prefers" -> preference (got ${result.facts[0].type})`);
-    assert(result.facts[1].type === 'decision', `Claude: "decided" -> decision (got ${result.facts[1].type})`);
-    assert(result.facts[2].type === 'goal', `Claude: "wants to" -> goal (got ${result.facts[2].type})`);
-    assert(result.facts[3].type === 'context', `Claude: "working on" -> context (got ${result.facts[3].type})`);
-    assert(result.facts[4].type === 'fact', `Claude: default -> fact (got ${result.facts[4].type})`);
-  }
-
-  // --- handles date prefixes ---
+  // --- handles date prefixes (strips them from text) ---
   {
     const memoriesText = `[2026-03-15] - User prefers dark mode
 [2026-03-10] - User works at Google
@@ -894,11 +973,11 @@ No date prefix here but still a memory`;
     const adapter = new ClaudeAdapter();
     const result = await adapter.parse({ content: memoriesText });
 
-    assert(result.facts.length === 3, `Claude: parsed 3 memories with/without dates (got ${result.facts.length})`);
-    assert(result.facts[0].sourceTimestamp === '2026-03-15', 'Claude: first fact has date from prefix');
-    assert(result.facts[1].sourceTimestamp === '2026-03-10', 'Claude: second fact has date from prefix');
-    assert(!result.facts[0].text.includes('[2026'), 'Claude: date prefix stripped from text');
-    assert(result.facts[2].sourceTimestamp === undefined, 'Claude: third fact has no timestamp');
+    assert(result.chunks.length === 1, 'Claude: parsed into 1 chunk');
+    assert(result.chunks[0].messages.length === 3, `Claude: 3 messages (got ${result.chunks[0].messages.length})`);
+    assert(!result.chunks[0].messages[0].text.includes('[2026'), 'Claude: date prefix stripped from text');
+    assert(result.chunks[0].messages[0].text === 'User prefers dark mode', 'Claude: cleaned text correct');
+    assert(result.chunks[0].timestamp === '2026-03-15', 'Claude: chunk timestamp from first dated entry');
   }
 
   // --- handles bullet points and numbered lists ---
@@ -911,9 +990,10 @@ No date prefix here but still a memory`;
     const adapter = new ClaudeAdapter();
     const result = await adapter.parse({ content: memoriesText });
 
-    assert(result.facts.length === 4, `Claude: handles bullets/numbers (got ${result.facts.length})`);
-    assert(!result.facts[0].text.startsWith('-'), 'Claude: bullet stripped');
-    assert(!result.facts[2].text.startsWith('1'), 'Claude: number stripped');
+    assert(result.chunks.length === 1, 'Claude: 4 lines -> 1 chunk');
+    assert(result.chunks[0].messages.length === 4, `Claude: handles bullets/numbers (got ${result.chunks[0].messages.length})`);
+    assert(!result.chunks[0].messages[0].text.startsWith('-'), 'Claude: bullet stripped');
+    assert(!result.chunks[0].messages[2].text.startsWith('1'), 'Claude: number stripped');
   }
 
   // --- skips empty lines and header lines ---
@@ -927,7 +1007,8 @@ User lives in Tokyo`;
     const adapter = new ClaudeAdapter();
     const result = await adapter.parse({ content: memoriesText });
 
-    assert(result.facts.length === 2, `Claude: skips empty/header lines (got ${result.facts.length})`);
+    assert(result.chunks.length === 1, 'Claude: skips header/blank');
+    assert(result.chunks[0].messages.length === 2, `Claude: only 2 valid lines (got ${result.chunks[0].messages.length})`);
   }
 
   // --- empty input returns error ---
@@ -935,24 +1016,16 @@ User lives in Tokyo`;
     const adapter = new ClaudeAdapter();
     const result = await adapter.parse({});
 
-    assert(result.facts.length === 0, 'Claude: no input yields 0 facts');
+    assert(result.chunks.length === 0, 'Claude: no input yields 0 chunks');
     assert(result.errors.length > 0, 'Claude: no input produces error');
   }
 
-  // --- empty text yields 0 facts ---
+  // --- empty text yields 0 chunks ---
   {
     const adapter = new ClaudeAdapter();
     const result = await adapter.parse({ content: '' });
 
-    assert(result.facts.length === 0, 'Claude: empty text yields 0 facts');
-  }
-
-  // --- importance defaults to 6 for curated memories ---
-  {
-    const adapter = new ClaudeAdapter();
-    const result = await adapter.parse({ content: 'User is a senior developer at Google' });
-
-    assert(result.facts[0].importance === 6, `Claude: importance defaults to 6 (got ${result.facts[0].importance})`);
+    assert(result.chunks.length === 0, 'Claude: empty text yields 0 chunks');
   }
 
   // --- skips very short memories ---
@@ -965,8 +1038,23 @@ User prefers TypeScript over JavaScript`;
     const result = await adapter.parse({ content: memoriesText });
 
     // "ok" and "ab" are < 3 chars after validation
-    assert(result.facts.length === 1, `Claude: skips short memories (got ${result.facts.length})`);
-    assert(result.facts[0].text.includes('TypeScript'), 'Claude: valid fact kept');
+    assert(result.chunks.length === 1, 'Claude: has 1 chunk');
+    assert(result.chunks[0].messages.length === 1, `Claude: skips short memories (got ${result.chunks[0].messages.length})`);
+    assert(result.chunks[0].messages[0].text.includes('TypeScript'), 'Claude: valid memory kept');
+  }
+
+  // --- large memory list chunks correctly ---
+  {
+    const lines = Array.from({ length: 25 }, (_, i) => `Claude memory item number ${i + 1} about their workflow`);
+    const memoriesText = lines.join('\n');
+
+    const adapter = new ClaudeAdapter();
+    const result = await adapter.parse({ content: memoriesText });
+
+    assert(result.chunks.length === 2, `Claude: 25 lines -> 2 chunks (got ${result.chunks.length})`);
+    assert(result.chunks[0].messages.length === 20, `Claude: first chunk has 20 (got ${result.chunks[0].messages.length})`);
+    assert(result.chunks[1].messages.length === 5, `Claude: second chunk has 5 (got ${result.chunks[1].messages.length})`);
+    assert(result.totalMessages === 25, `Claude: totalMessages is 25 (got ${result.totalMessages})`);
   }
 
   // =========================================================================

--- a/skill/plugin/import-adapters/mcp-memory-adapter.ts
+++ b/skill/plugin/import-adapters/mcp-memory-adapter.ts
@@ -67,7 +67,7 @@ export class MCPMemoryAdapter extends BaseImportAdapter {
         content = fs.readFileSync(resolvedPath, 'utf-8');
       } catch (e) {
         errors.push(`Failed to read file: ${e instanceof Error ? e.message : 'Unknown error'}`);
-        return { facts: [], warnings, errors };
+        return { facts: [], chunks: [], totalMessages: 0, warnings, errors };
       }
     } else {
       // Try default MCP memory path
@@ -80,7 +80,7 @@ export class MCPMemoryAdapter extends BaseImportAdapter {
           'No content, file_path, or file at default path (~/.mcp-memory/memory.jsonl). ' +
           'Provide the memory.jsonl content or file path.',
         );
-        return { facts: [], warnings, errors };
+        return { facts: [], chunks: [], totalMessages: 0, warnings, errors };
       }
     }
 
@@ -170,6 +170,8 @@ export class MCPMemoryAdapter extends BaseImportAdapter {
 
     return {
       facts,
+      chunks: [],
+      totalMessages: 0,
       warnings,
       errors,
       source_metadata: {

--- a/skill/plugin/import-adapters/mem0-adapter.ts
+++ b/skill/plugin/import-adapters/mem0-adapter.ts
@@ -81,7 +81,7 @@ export class Mem0Adapter extends BaseImportAdapter {
       );
     } else {
       errors.push('Mem0 import requires either content (export file) or api_key');
-      return { facts: [], warnings, errors };
+      return { facts: [], chunks: [], totalMessages: 0, warnings, errors };
     }
 
     if (onProgress) {
@@ -110,7 +110,7 @@ export class Mem0Adapter extends BaseImportAdapter {
       warnings.push(`${invalidCount} memories had invalid/empty text and were skipped`);
     }
 
-    return { facts, warnings, errors, source_metadata: { total_from_source: memories.length } };
+    return { facts, chunks: [], totalMessages: 0, warnings, errors, source_metadata: { total_from_source: memories.length } };
   }
 
   /**

--- a/skill/plugin/import-adapters/types.ts
+++ b/skill/plugin/import-adapters/types.ts
@@ -73,15 +73,38 @@ export interface ImportResult {
 export type ProgressCallback = (progress: {
   current: number;
   total: number;
-  phase: 'fetching' | 'parsing' | 'storing';
+  phase: 'fetching' | 'parsing' | 'storing' | 'extracting';
   message: string;
 }) => void;
 
 /**
+ * A chunk of conversation messages for LLM-based fact extraction.
+ * Adapters that parse conversation data (ChatGPT, Claude) return these
+ * instead of pre-extracted facts, delegating extraction to the LLM.
+ */
+export interface ConversationChunk {
+  /** Human-readable title for progress reporting */
+  title: string;
+  /** Ordered messages in this chunk */
+  messages: Array<{ role: 'user' | 'assistant'; text: string }>;
+  /** Original timestamp (ISO 8601) if available */
+  timestamp?: string;
+}
+
+/**
  * Adapter parse result — returned by each adapter's parse method.
+ *
+ * Adapters return EITHER `facts` (pre-structured sources like Mem0, MCP Memory)
+ * OR `chunks` (conversation-based sources like ChatGPT, Claude) that need
+ * LLM extraction. The caller checks which field is populated.
  */
 export interface AdapterParseResult {
+  /** Pre-structured facts (Mem0, MCP Memory adapters) */
   facts: NormalizedFact[];
+  /** Conversation chunks needing LLM extraction (ChatGPT, Claude adapters) */
+  chunks: ConversationChunk[];
+  /** Total message count across all chunks */
+  totalMessages: number;
   warnings: string[];
   errors: string[];
   /** Metadata about the source (for logging) */

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -1287,7 +1287,12 @@ async function storeExtractedFacts(
 /**
  * Handle import_from tool calls in the plugin context.
  *
- * Uses the shared adapters to parse, then stores via storeExtractedFacts().
+ * Two paths:
+ * 1. Pre-structured sources (Mem0, MCP Memory) — adapter returns facts directly,
+ *    stored via storeExtractedFacts().
+ * 2. Conversation-based sources (ChatGPT, Claude) — adapter returns conversation
+ *    chunks, each chunk is passed through extractFacts() (the same LLM extraction
+ *    pipeline used for auto-extraction), then stored via storeExtractedFacts().
  */
 async function handlePluginImportFrom(
   params: Record<string, unknown>,
@@ -1314,7 +1319,10 @@ async function handlePluginImportFrom(
       file_path: params.file_path as string | undefined,
     });
 
-    if (parseResult.errors.length > 0 && parseResult.facts.length === 0) {
+    const hasChunks = parseResult.chunks && parseResult.chunks.length > 0;
+    const hasFacts = parseResult.facts && parseResult.facts.length > 0;
+
+    if (parseResult.errors.length > 0 && !hasFacts && !hasChunks) {
       return {
         success: false,
         error: `Failed to parse ${adapter.displayName} data`,
@@ -1322,7 +1330,24 @@ async function handlePluginImportFrom(
       };
     }
 
+    // Dry run: report what was parsed (chunks or facts)
     if (params.dry_run) {
+      if (hasChunks) {
+        return {
+          success: true,
+          dry_run: true,
+          source,
+          total_chunks: parseResult.chunks.length,
+          total_messages: parseResult.totalMessages,
+          preview: parseResult.chunks.slice(0, 5).map((c) => ({
+            title: c.title,
+            messages: c.messages.length,
+            first_message: c.messages[0]?.text.slice(0, 100),
+          })),
+          note: 'Chunks will be processed through LLM extraction (same quality as auto-extraction).',
+          warnings: parseResult.warnings,
+        };
+      }
       return {
         success: true,
         dry_run: true,
@@ -1337,7 +1362,12 @@ async function handlePluginImportFrom(
       };
     }
 
-    // Convert NormalizedFact[] to ExtractedFact[] for storeExtractedFacts()
+    // ── Path 1: Conversation chunks (ChatGPT, Claude) — LLM extraction ──
+    if (hasChunks) {
+      return handleChunkImport(parseResult.chunks, parseResult.totalMessages, source, logger, startTime, parseResult.warnings);
+    }
+
+    // ── Path 2: Pre-structured facts (Mem0, MCP Memory) — direct store ──
     const extractedFacts: ExtractedFact[] = parseResult.facts.map((f) => ({
       text: f.text,
       type: f.type,
@@ -1374,6 +1404,77 @@ async function handlePluginImportFrom(
     logger.error(`Import failed: ${msg}`);
     return { success: false, error: `Import failed: ${msg}` };
   }
+}
+
+/**
+ * Process conversation chunks through LLM extraction and store results.
+ *
+ * Each chunk is passed to extractFacts() — the same extraction pipeline used
+ * for auto-extraction during live conversations. This ensures import quality
+ * matches conversation extraction quality.
+ */
+async function handleChunkImport(
+  chunks: import('./import-adapters/types.js').ConversationChunk[],
+  totalMessages: number,
+  source: string,
+  logger: OpenClawPluginApi['logger'],
+  startTime: number,
+  warnings: string[],
+): Promise<Record<string, unknown>> {
+  let totalExtracted = 0;
+  let totalStored = 0;
+  let chunksProcessed = 0;
+
+  for (const chunk of chunks) {
+    chunksProcessed++;
+    logger.info(
+      `Import: extracting facts from chunk ${chunksProcessed}/${chunks.length}: "${chunk.title}"`,
+    );
+
+    // Convert chunk messages to the format extractFacts() expects.
+    // extractFacts() takes an array of message-like objects with { role, content }.
+    const messages = chunk.messages.map((m) => ({
+      role: m.role,
+      content: m.text,
+    }));
+
+    // Use 'full' mode to extract ALL valuable memories from the chunk
+    // (not just the last few messages like 'turn' mode does).
+    const facts = await extractFacts(messages, 'full');
+
+    if (facts.length > 0) {
+      totalExtracted += facts.length;
+
+      // Store through the normal pipeline (dedup, encrypt, store)
+      const stored = await storeExtractedFacts(facts, logger);
+      totalStored += stored;
+
+      logger.info(
+        `Import chunk ${chunksProcessed}/${chunks.length}: extracted ${facts.length} facts, stored ${stored}`,
+      );
+    }
+  }
+
+  if (totalExtracted === 0 && chunks.length > 0) {
+    warnings.push(
+      `Processed ${chunks.length} conversation chunks (${totalMessages} messages) but the LLM ` +
+      `did not extract any facts worth storing. This can happen if the conversations are mostly ` +
+      `generic/ephemeral content without personal facts, preferences, or decisions.`,
+    );
+  }
+
+  return {
+    success: totalStored > 0 || totalExtracted > 0,
+    source,
+    import_id: crypto.randomUUID(),
+    total_chunks: chunks.length,
+    total_messages: totalMessages,
+    facts_extracted: totalExtracted,
+    imported: totalStored,
+    skipped: totalExtracted - totalStored,
+    warnings,
+    duration_ms: Date.now() - startTime,
+  };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Redesign ChatGPT and Claude import adapters** from regex pattern matching to pure parsers that return conversation chunks, delegating all fact extraction to the existing LLM pipeline (`extractFacts()`)
- **Plugin path**: chunks are processed through `extractFacts('full')` + `storeExtractedFacts()` -- same quality as auto-extraction during live conversations
- **MCP path**: chunks returned as structured text with instructions for the host agent to review and call `totalreclaw_remember` (MCP has no direct LLM access)
- **No changes to Mem0/MCP Memory adapters** -- they return pre-structured facts that don't need LLM extraction

## Changes

### Adapters (pure parsers now)
- `chatgpt-adapter.ts`: Parses conversations.json mapping tree into ordered message chunks (user + assistant, 20 messages/chunk). Parses memory text into chunks. All pattern matching removed.
- `claude-adapter.ts`: Parses memory text into chunks with date/bullet/number cleanup. All pattern matching removed.
- `types.ts`: New `ConversationChunk` type, updated `AdapterParseResult` with `chunks` + `totalMessages` fields
- `base-adapter.ts`: Updated docstring to reflect parser-only role
- `mem0-adapter.ts`, `mcp-memory-adapter.ts`: Added `chunks: []` and `totalMessages: 0` to satisfy updated interface

### Import handlers
- `skill/plugin/index.ts`: New `handleChunkImport()` function routes chunks through `extractFacts('full')` then `storeExtractedFacts()`. Dry run reports chunk preview.
- `mcp/src/tools/import-from.ts`: Returns parsed conversation text with instructions for host agent when chunks are present.

### Tests
- 185 tests passing (up from ~100)
- New tests: chunking logic (20-message batches), tree traversal (user + assistant), part indicators for multi-chunk conversations, short/empty message filtering, multiple conversations, null parts handling

## Test plan

- [x] Run `npx tsx import-adapters/import-adapters.test.ts` -- 185/185 passing
- [ ] Manual test: import ChatGPT conversations.json with real data
- [ ] Manual test: import Claude memory text with real data
- [ ] Verify Mem0 and MCP Memory imports still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)