### PR TITLE
feat(python): totalreclaw@2.0.0 — v1 default extraction + Python↔Rust byte-parity

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -4,10 +4,14 @@ End-to-end encrypted memory for AI agents -- the "password manager for AI memory
 
 Store, search, and recall memories across any AI agent with zero-knowledge encryption. Your data is encrypted on-device before it leaves -- the server never sees plaintext.
 
+As of **2.0.0**, the client uses **Memory Taxonomy v1** (6 canonical types: `claim | preference | directive | commitment | episode | summary`) and **Retrieval v2 Tier 1** source-weighted reranking (user-sourced facts rank higher than assistant-sourced facts on tied BM25 + cosine scores). See the [TS plugin 3.0.0 migration notes](https://github.com/p-diogo/totalreclaw/blob/main/skill/plugin/CHANGELOG.md) — the Python client follows the same pattern. Existing pre-v1 vault entries decrypt transparently.
+
 ## Features
 
 - **End-to-end encrypted** -- XChaCha20-Poly1305 encryption, HKDF key derivation from BIP-39 mnemonic
 - **Portable** -- Same recovery phrase works across Hermes, OpenClaw, Claude Desktop, IronClaw
+- **Memory Taxonomy v1** -- 6-type schema with required provenance (`user | user-inferred | assistant | external | derived`) and 8 life-domain scopes
+- **Tier 1 source-weighted reranking** -- user-sourced facts rank higher than assistant-sourced facts on tied scores
 - **Local embeddings** -- Harrier-OSS-v1-270M runs on-device (no API calls)
 - **Hybrid search** -- BM25 + cosine similarity + RRF reranking
 - **LSH bucketing** -- Locality-sensitive hashing for encrypted search
@@ -38,8 +42,14 @@ async def main():
     await client.resolve_address()
     await client.register()
 
-    # Store a memory (importance is a float from 0.0 to 1.0)
-    fact_id = await client.remember("Pedro prefers dark mode for all editors", importance=0.8)
+    # Store a memory — v1 taxonomy defaults: type="claim", source="user", scope="unspecified".
+    # Importance is 1-10 (int) or 0-1 (float, auto-normalized).
+    fact_id = await client.remember(
+        "Pedro prefers dark mode for all editors",
+        fact_type="preference",
+        scope="personal",
+        importance=8,
+    )
 
     # Search memories
     results = await client.recall("What does Pedro prefer?")

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,14 +4,15 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "totalreclaw"
-version = "1.10.0"
-description = "End-to-end encrypted memory for AI agents — Python client"
+version = "2.0.0"
+description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"
 authors = [{ name = "TotalReclaw Team" }]
 dependencies = [
-    "totalreclaw-core>=1.1.0",
+    # Memory Taxonomy v1 + Retrieval v2 Tier 1 reranker live in core 2.0.
+    "totalreclaw-core>=2.0.0",
     "httpx>=0.27",
     "onnxruntime>=1.24",
     "numpy>=1.26",

--- a/python/src/totalreclaw/agent/contradiction.py
+++ b/python/src/totalreclaw/agent/contradiction.py
@@ -74,12 +74,45 @@ async def detect_and_resolve_contradictions(
     try:
         from totalreclaw.embedding import get_embedding
         from totalreclaw.claims_helper import (
-            build_canonical_claim,
+            TYPE_TO_CATEGORY_V1,
             compute_entity_trapdoor,
         )
     except ImportError:
         log.debug("Required modules not available — skipping contradiction detection")
         return list(new_facts)
+
+    def _short_key_claim_for_resolver(
+        *, text: str, fact_type: str, importance: int, confidence: float,
+        source_agent: str, created_at: str,
+    ) -> dict:
+        """Build a short-key canonical claim for core.resolve_with_candidates().
+
+        The resolver accepts the v0 short-key format (``{t, c, cf, i, sa,
+        ea}``) — the v1 claim shape is NOT accepted by core 2.0.0's resolver
+        as of the plugin-v3 pairing. We emit short keys only for the
+        resolver's transient input; the actual on-chain write goes through
+        ``build_canonical_claim_v1`` which emits a v1 JSON blob.
+        """
+        # Map v1 type → short-key category expected by the resolver.
+        # ``TYPE_TO_CATEGORY_V1`` gives v1 type → display short tag; we need
+        # a category the Rust ``ClaimCategory`` enum accepts.
+        v1_to_short = {
+            "claim": "fact",
+            "preference": "pref",
+            "directive": "rule",
+            "commitment": "goal",
+            "episode": "epi",
+            "summary": "sum",
+        }
+        c_key = v1_to_short.get(fact_type, "fact")
+        return {
+            "t": text,
+            "c": c_key,
+            "cf": confidence,
+            "i": importance,
+            "sa": source_agent,
+            "ea": created_at,
+        }
 
     # Load default resolution weights once
     try:
@@ -152,23 +185,19 @@ async def detect_and_resolve_contradictions(
             importance_int = max(1, min(10, int(round(
                 fact.importance if fact.importance > 1 else fact.importance * 10
             ))))
-            fact_stub = {
-                "text": fact.text,
-                "type": fact.type,
-                "confidence": fact.confidence,
-                "entities": [
-                    {
-                        "name": e.name if hasattr(e, "name") else e.get("name", ""),
-                        "type": e.type if hasattr(e, "type") else e.get("type", "concept"),
-                    }
-                    for e in fact.entities
-                ] if fact.entities else None,
-            }
-            new_claim_json = build_canonical_claim(
-                fact_stub,
+            # Build a short-key claim for the resolver only. The on-chain
+            # write pipeline still emits v1 JSON; this transient short-key
+            # shape is the format ``core.resolve_with_candidates`` accepts
+            # as of core 2.0.0.
+            new_claim_json_obj = _short_key_claim_for_resolver(
+                text=fact.text,
+                fact_type=fact.type,
                 importance=importance_int,
+                confidence=fact.confidence,
                 source_agent="hermes-auto",
+                created_at=time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime()),
             )
+            new_claim_json = json.dumps(new_claim_json_obj, ensure_ascii=False, separators=(",", ":"))
             new_claim_id = f"pending-{id(fact)}"
 
             # Build candidates array for the resolver
@@ -181,24 +210,23 @@ async def detect_and_resolve_contradictions(
                 # The results come from the reranker as RerankerResult with
                 # .text, .id, .embedding, .importance, .category
                 try:
-                    # Build a minimal canonical claim for the existing fact
-                    existing_stub = {
-                        "text": result.text,
-                        "type": result.category or "fact",
-                        "confidence": 0.85,
-                        "entities": None,
-                    }
                     existing_importance = max(1, min(10, int(round(
                         result.importance * 10 if result.importance <= 1 else result.importance
                     ))))
-                    existing_claim_json = build_canonical_claim(
-                        existing_stub,
+                    existing_short = _short_key_claim_for_resolver(
+                        text=result.text,
+                        fact_type=result.category or "claim",
                         importance=existing_importance,
+                        confidence=0.85,
                         source_agent="unknown",
+                        created_at=time.strftime(
+                            "%Y-%m-%dT%H:%M:%S.000Z", time.gmtime(result.created_at)
+                        ) if getattr(result, "created_at", None) else time.strftime(
+                            "%Y-%m-%dT%H:%M:%S.000Z", time.gmtime()
+                        ),
                     )
-                    existing_claim = json.loads(existing_claim_json)
                     candidates.append({
-                        "claim": existing_claim,
+                        "claim": existing_short,
                         "id": result.id,
                         "embedding": list(result.embedding),
                     })
@@ -210,10 +238,9 @@ async def detect_and_resolve_contradictions(
                 kept.append(fact)
                 continue
 
-            # Call the Rust core resolver
-            new_claim_obj = json.loads(new_claim_json)
+            # Call the Rust core resolver — short-key claim format.
             actions_json = totalreclaw_core.resolve_with_candidates(
-                json.dumps(new_claim_obj, ensure_ascii=False, separators=(",", ":")),
+                new_claim_json,
                 new_claim_id,
                 json.dumps(embedding),
                 json.dumps(candidates, ensure_ascii=False, separators=(",", ":")),

--- a/python/src/totalreclaw/agent/extraction.py
+++ b/python/src/totalreclaw/agent/extraction.py
@@ -1,11 +1,22 @@
 """
-LLM-guided and heuristic fact extraction for TotalReclaw.
+LLM-guided fact extraction for TotalReclaw (Memory Taxonomy v1).
 
-Uses the same extraction prompt as the OpenClaw plugin for parity.
-Falls back to heuristic extraction if no LLM is available.
+Mirrors the v1 G-pipeline from the OpenClaw plugin's ``extractor.ts``:
 
-This module is framework-agnostic and can be used by any Python agent
-integration (Hermes, LangChain, CrewAI, or custom agents).
+  1. Single merged-topic LLM call → ``{topics, facts}``
+  2. ``apply_provenance_filter_lax`` (tag-don't-drop; assistant-sourced facts
+     are capped at importance 7 rather than filtered out)
+  3. ``comparative_rescore_v1`` (forces re-rank when ``facts >= 5``)
+  4. ``default_volatility`` heuristic fallback
+  5. Lexical importance bumps
+
+As of ``totalreclaw`` 2.0.0 v1 is the DEFAULT AND ONLY extraction path — no
+env-var gate. Legacy v0 tokens (fact, decision, episodic, goal, context,
+rule) are coerced to v1 via ``V0_TO_V1_TYPE`` on the read side so pre-2.0
+vault entries still deserialize, but extraction emits v1 unconditionally.
+
+This module is framework-agnostic — any Python agent integration (Hermes,
+LangChain, CrewAI, or custom agents) can import from here.
 """
 from __future__ import annotations
 
@@ -20,18 +31,68 @@ from .llm_client import LLMConfig, detect_llm_config, chat_completion
 
 logger = logging.getLogger(__name__)
 
-#: The 8 canonical memory types — single source of truth for the Python
-#: package. Keep in sync with ``skill/plugin/extractor.ts`` (VALID_MEMORY_TYPES),
-#: ``mcp/src/memory-types.ts`` (VALID_MEMORY_TYPES), and the Rust
-#: ``ClaimCategory`` enum in ``rust/totalreclaw-core/src/claims.rs``. A cross-
-#: language parity test at ``tests/parity/test_kg_phase1_parity.py`` enforces
-#: this stays in sync.
-#:
-#: Any Python consumer (tool schemas, type mappings, validation whitelists,
-#: canonical-claim builders) MUST import from this constant — never re-declare
-#: the list inline. See ``claims_helper.TYPE_TO_CATEGORY`` for the compact
-#: short-form mapping.
+# ---------------------------------------------------------------------------
+# Memory Taxonomy v1 — the 6 canonical memory types.
+#
+# Plugin 3.0.0 / python 2.0.0 adopt v1 as the ONLY taxonomy. Legacy v0 tokens
+# are retained as ``LEGACY_V0_MEMORY_TYPES`` + ``V0_TO_V1_TYPE`` for the
+# read path (pre-v1 vault entries still carry v0 strings). Extraction and
+# write paths emit v1 exclusively.
+#
+# When adding a new v1 type, update ALL of:
+#   * ``skill/plugin/extractor.ts`` VALID_MEMORY_TYPES
+#   * ``mcp/src/v1-types.ts`` VALID_MEMORY_TYPES
+#   * ``python/src/totalreclaw/agent/extraction.py`` (this constant)
+#   * ``rust/totalreclaw-core/src/claims.rs`` MemoryTypeV1 enum
+#   * ``skill/plugin/claims-helper.ts`` TYPE_TO_CATEGORY_V1
+#   * ``python/src/totalreclaw/claims_helper.py`` TYPE_TO_CATEGORY_V1
+#   * The EXTRACTION_SYSTEM_PROMPT "TYPE" section
+# ---------------------------------------------------------------------------
+
+#: The 6 canonical v1 memory types.
 VALID_MEMORY_TYPES: tuple[str, ...] = (
+    "claim",
+    "preference",
+    "directive",
+    "commitment",
+    "episode",
+    "summary",
+)
+
+#: Backward-compat alias — prefer ``VALID_MEMORY_TYPES`` in new code.
+VALID_TYPES: frozenset[str] = frozenset(VALID_MEMORY_TYPES)
+
+#: The 5 v1 provenance sources.
+VALID_MEMORY_SOURCES: tuple[str, ...] = (
+    "user",
+    "user-inferred",
+    "assistant",
+    "external",
+    "derived",
+)
+
+#: The 8 v1 life-domain scopes.
+VALID_MEMORY_SCOPES: tuple[str, ...] = (
+    "work",
+    "personal",
+    "health",
+    "family",
+    "creative",
+    "finance",
+    "misc",
+    "unspecified",
+)
+
+#: The 3 v1 volatility classes.
+VALID_MEMORY_VOLATILITIES: tuple[str, ...] = (
+    "stable",
+    "updatable",
+    "ephemeral",
+)
+
+#: Legacy v0 memory types — retained so ``read_claim_from_blob`` / legacy
+#: fixtures can still decode pre-v1 vault entries. Do NOT emit on the write path.
+LEGACY_V0_MEMORY_TYPES: tuple[str, ...] = (
     "fact",
     "preference",
     "decision",
@@ -42,8 +103,17 @@ VALID_MEMORY_TYPES: tuple[str, ...] = (
     "rule",
 )
 
-#: Backward-compat alias — prefer ``VALID_MEMORY_TYPES`` in new code.
-VALID_TYPES: frozenset[str] = frozenset(VALID_MEMORY_TYPES)
+#: Legacy v0 → v1 type mapping used on the read path.
+V0_TO_V1_TYPE: dict[str, str] = {
+    "fact": "claim",
+    "preference": "preference",
+    "decision": "claim",
+    "episodic": "episode",
+    "goal": "commitment",
+    "context": "claim",
+    "summary": "summary",
+    "rule": "directive",
+}
 
 VALID_ACTIONS = {"ADD", "UPDATE", "DELETE", "NOOP"}
 
@@ -55,41 +125,64 @@ VALID_ENTITY_TYPES = {"person", "project", "tool", "company", "concept", "place"
 DEFAULT_EXTRACTION_CONFIDENCE: float = 0.85
 
 
+def is_valid_memory_type(value: Any) -> bool:
+    """v1 type guard — returns True iff ``value`` is one of the 6 v1 types."""
+    return isinstance(value, str) and value in VALID_MEMORY_TYPES
+
+
+def normalize_to_v1_type(raw: Any) -> str:
+    """Normalize any type token (v1 or legacy v0) to a v1 type.
+
+    v1 tokens pass through. Legacy v0 tokens are mapped via
+    ``V0_TO_V1_TYPE``. Unknown input falls back to ``"claim"``.
+    """
+    token = str(raw or "").lower()
+    if token in VALID_MEMORY_TYPES:
+        return token
+    return V0_TO_V1_TYPE.get(token, "claim")
+
+
 @dataclass
 class ExtractedEntity:
     """A named entity referenced by an extracted fact.
 
     Mirrors ``skill/plugin/extractor.ts`` ``ExtractedEntity``. The ``type``
     field is one of :data:`VALID_ENTITY_TYPES`. ``role`` is optional free
-    text describing the entity's role in the claim (``"chooser"``, etc.).
+    text describing the entity's role in the claim ("chooser", "employer").
     """
 
     name: str
-    type: str  # person | project | tool | company | concept | place
+    type: str
     role: Optional[str] = None
 
 
 @dataclass
 class ExtractedFact:
+    """Extracted fact carrying full v1 taxonomy fields.
+
+    Mirrors the TS ``ExtractedFact`` (v1). ``source`` is optional on the
+    dataclass but required on the write path — upstream pipelines
+    (:func:`apply_provenance_filter_lax`) tag it during extraction;
+    defensive callers supply ``"user-inferred"`` when upstream fails.
+    """
+
     text: str
-    type: str  # fact, preference, decision, episodic, goal, context, summary
+    type: str  # v1: claim | preference | directive | commitment | episode | summary
     importance: int  # 1-10
-    action: str  # ADD, UPDATE, DELETE, NOOP
+    action: str  # ADD | UPDATE | DELETE | NOOP
     existing_fact_id: Optional[str] = None
     entities: Optional[List[ExtractedEntity]] = None
     confidence: float = DEFAULT_EXTRACTION_CONFIDENCE
+    # v1 additions (all optional at the dataclass level; the write path
+    # populates missing ``source`` with "user-inferred" defensively).
+    source: Optional[str] = None
+    scope: Optional[str] = None
+    reasoning: Optional[str] = None
+    volatility: Optional[str] = None
 
 
 def normalize_confidence(raw: Any) -> float:
-    """Clamp a raw confidence value to ``[0, 1]`` with default fallback.
-
-    Must match ``normalizeConfidence`` in ``skill/plugin/extractor.ts``:
-
-    - numeric in range → returned as-is
-    - numeric > 1 → clamped to 1
-    - numeric < 0 → clamped to 0
-    - non-finite / non-number (strings, None, NaN) → :data:`DEFAULT_EXTRACTION_CONFIDENCE`
-    """
+    """Clamp a raw confidence value to ``[0, 1]`` with default fallback."""
     if isinstance(raw, bool):
         return DEFAULT_EXTRACTION_CONFIDENCE
     if not isinstance(raw, (int, float)):
@@ -128,155 +221,196 @@ def _parse_entity(raw: Any) -> Optional[ExtractedEntity]:
     return entity
 
 
-# Same extraction prompt as OpenClaw plugin (skill/plugin/extractor.ts)
-EXTRACTION_SYSTEM_PROMPT = """You are a memory extraction engine. Analyze the conversation and extract valuable long-term memories.
+# ---------------------------------------------------------------------------
+# Extraction system prompts (v1 merged-topic pipeline)
+# ---------------------------------------------------------------------------
+
+EXTRACTION_SYSTEM_PROMPT = """You are a memory extraction engine using Memory Taxonomy v1. Work in TWO explicit phases within one response:
+
+PHASE 1 — Topic identification.
+Before extracting any fact, identify the 2-3 main topics the user was engaging with. Topics should be short phrases (2-5 words each). If the conversation has no clear user-focused topic, use an empty topics array.
+
+PHASE 2 — Fact extraction anchored to those topics.
+Extract valuable memories. Prefer facts that directly relate to the identified topics (importance 7-9 range). Tangential facts may still be extracted but score lower (6-7 range).
 
 Rules:
-1. Each memory must be a single, self-contained piece of information
-2. Focus on user-specific information that would be useful in future conversations
-3. Skip generic knowledge, greetings, small talk, and ephemeral task coordination
-4. Score importance 1-10 using the rubric below (6+ = worth storing)
-5. Only extract memories with importance >= 6
+1. Each memory = single self-contained piece of information
+2. Focus on user-specific info useful in future conversations
+3. Skip generic knowledge, greetings, small talk, ephemeral task coordination
+4. Score importance 1-10 (6+ = worth storing)
+5. Every memory MUST attribute a source (provenance critical)
 
-Importance rubric (use the FULL 1-10 range, not just 7-8):
-- 10: Critical, core identity, never-forget content. The user explicitly says "remember this forever", "critical", "never forget", or it's a fundamental fact like name/birthday/relationships that defines who they are.
-- 9: Affects many future decisions or interactions. A high-impact rule, a major life decision with reasoning, a deeply held preference that shapes daily work.
-- 8: High-value preference, decision-with-reasoning, or operational rule. The user clearly cares about it AND it will be relevant in many future conversations.
-- 7: Specific durable fact about the user's setup, project, or context. Useful to remember but not life-changing.
-- 6: Borderline — barely passes the "worth storing" threshold. Generic facts, low-signal preferences. If you're hesitating between 5 and 6, prefer 5 (it gets dropped).
-- 5 or below: NOT WORTH STORING. Drop these. Casual mentions, ephemeral state, low-signal chatter.
+Importance rubric (use FULL 1-10 range):
+- 10: Critical, core identity, never-forget content
+- 9: Affects many future decisions
+- 8: High-value preference/decision/rule
+- 7: Specific durable fact
+- 6: Borderline
+- 5 or below: NOT worth storing — drop
 
-DO NOT cluster every fact at 7-8. Use 9-10 for high-signal content and 5-6 for borderline content. The system depends on the full range working — over-clustering at 7-8 produces tied scores in the contradiction resolver and makes ranking/decay impossible.
+DO NOT cluster everything at 7-8-9.
 
-Types:
-- fact: Objective information about the user (name, location, job, relationships)
-- preference: Likes, dislikes, or preferences ("prefers dark mode", "allergic to peanuts")
-- decision: Choices WITH reasoning ("chose PostgreSQL because data is relational and needs ACID")
-- episodic: Notable events or experiences ("deployed v1.0 to production on March 15")
-- goal: Objectives, targets, or plans ("wants to launch public beta by end of Q1")
-- context: Active project/task context ("working on TotalReclaw v1.2, staging on Base Sepolia")
-- summary: Key outcome or conclusion from a discussion ("agreed to use phased rollout for migration")
-- rule: A reusable operational rule, non-obvious gotcha, debugging shortcut, or convention the user wants to remember for next time. Distinct from decisions (which have reasoning for a specific choice) and preferences (which are personal tastes). Rules are impersonal, actionable, and transferable — they would help anyone in the same situation. Examples: "Always check the systemd unit file for environment pins before wiping state", "The subgraph schema uses sequenceId not seqId", "Don't open large JSON files in Neovim — use jq instead".
+═══════════════════════════════════════════════════════════════
+TYPE (6 values)
+═══════════════════════════════════════════════════════════════
+- claim: factual assertion (absorbs fact/context/decision; decisions populate reasoning field)
+- preference: likes/dislikes/tastes
+- directive: imperative rule ("always X", "never Y")
+- commitment: future intent ("will do X")
+- episode: notable event
+- summary: derived synthesis (source must be derived|assistant) — do NOT emit for turn-extraction
 
-Extraction guidance:
-- For decisions: ALWAYS include the reasoning. "Chose X" is weak. "Chose X because Y" is strong.
-- For context: Capture what the user is actively working on, including versions, environments, and status.
-- For summaries: Only extract when a conversation reaches a clear conclusion or agreement.
-- For facts: Prefer specific over vague. "Lives in Lisbon" beats "lives in Europe".
-- For rules: ALWAYS extract when the user explicitly signals "remember this", "gotcha", "rule of thumb", "always", "never", or describes a non-obvious learning. Importance >= 7 when the rule prevented a real bug or wasted time. Include the specific context (which tool, which error, which version) so the rule is actionable later. The boundary test: would this apply to anyone in the same situation? Rules generalize; decisions and preferences don't.
-- Decisions and context should be importance >= 7 (they are high-value for future conversations).
+═══════════════════════════════════════════════════════════════
+SOURCE (provenance, CRITICAL)
+═══════════════════════════════════════════════════════════════
+- user: user explicitly stated it (in [user]: turns)
+- user-inferred: extractor inferred from user signals
+- assistant: assistant authored content — DOWNGRADE unless user affirmed/quoted/used it
+- external, derived: rare
 
-Few-shot examples (rule type — when to use it and when NOT to use it):
+IF fact substance appears ONLY in [assistant]: turns without user affirmation → source:assistant
 
-Example 1 — rule embedded in a debugging narrative:
-  User: "Spent two hours debugging the subgraph because my Python wrapper silently swallowed a GraphQL error and I read it as 'no data'. Turns out the schema field is sequenceId, not seqId. Note to self: always check d.get('errors') before trusting an empty result."
-  Extract:
-  [{"text": "Subgraph Fact schema uses sequenceId, not seqId — check d.get('errors') before trusting an empty facts array", "type": "rule", "importance": 8, "confidence": 1.0, "entities": [{"name": "subgraph", "type": "tool"}, {"name": "GraphQL", "type": "tool"}]}]
+═══════════════════════════════════════════════════════════════
+SCOPE (life domain)
+═══════════════════════════════════════════════════════════════
+work | personal | health | family | creative | finance | misc | unspecified
 
-Example 2 — user stating a convention as a rule:
-  User: "Convention for the team: before any rm -rf on the VPS state dir, stop the gateway first. Otherwise an async flush can recreate stale files mid-cleanup."
-  Extract:
-  [{"text": "Stop the OpenClaw gateway before rm -rf ~/.totalreclaw/ — async flush can recreate stale files mid-cleanup", "type": "rule", "importance": 7, "confidence": 1.0, "entities": [{"name": "OpenClaw gateway", "type": "tool"}]}]
+═══════════════════════════════════════════════════════════════
+ENTITIES
+═══════════════════════════════════════════════════════════════
+- type ∈ {person, project, tool, company, concept, place}
+- prefer specific names ("PostgreSQL" not "database")
+- omit umbrella categories when specific name is present
 
-Example 3 — rule vs decision (distinguishing them):
-  User: "We chose DuckDB over ClickHouse for analytics because DuckDB fits in a single-file deployment and our scale is small."
-  Extract:
-  [{"text": "Chose DuckDB over ClickHouse for analytics because single-file deployment fits small-scale use", "type": "decision", "importance": 8, "confidence": 1.0, "entities": [{"name": "DuckDB", "type": "tool", "role": "chosen"}, {"name": "ClickHouse", "type": "tool", "role": "rejected"}]}]
-  This is a DECISION, not a rule — it's a specific choice with reasoning, not a transferable pattern. The boundary test: it applies to THIS user's THIS analytics deployment, not to anyone in the same situation.
+═══════════════════════════════════════════════════════════════
+REASONING (only for claims that are decisions)
+═══════════════════════════════════════════════════════════════
+For type=claim where the user expressed a decision-with-reasoning, populate "reasoning" with the WHY clause.
 
-Entity extraction (new):
-- Each memory MAY include an "entities" array of named entities it references
-- Entity type must be one of: person | project | tool | company | concept | place
-- Use the user's name when a fact is about them (e.g. "Pedro")
-- role is optional free text ("chooser", "employer")
-- confidence (0.0-1.0) is your self-assessed certainty; default 0.85 if you're unsure
+═══════════════════════════════════════════════════════════════
+OUTPUT FORMAT (no markdown, no code fences)
+═══════════════════════════════════════════════════════════════
+{
+  "topics": ["topic 1", "topic 2"],
+  "facts": [
+    {
+      "text": "...",
+      "type": "claim|preference|directive|commitment|episode",
+      "source": "user|user-inferred|assistant",
+      "scope": "work|personal|health|...",
+      "importance": N,
+      "confidence": 0.9,
+      "action": "ADD",
+      "reasoning": "...",     // optional, only for claim+decision
+      "entities": [{"name": "...", "type": "tool"}]
+    }
+  ]
+}
 
-Actions (compare against existing memories if provided):
-- ADD: New memory, no conflict with existing
-- UPDATE: Refines or corrects an existing memory (provide existingFactId)
-- DELETE: Contradicts an existing memory -- the old one is now wrong (provide existingFactId)
-- NOOP: Already captured or not worth storing
+If nothing worth extracting: {"topics": [], "facts": []}"""
 
-Return a JSON array (no markdown, no code fences):
-[{"text": "...", "type": "...", "importance": N, "confidence": 0.9, "action": "ADD|UPDATE|DELETE|NOOP", "entities": [{"name": "PostgreSQL", "type": "tool"}], "existingFactId": "..."}, ...]
 
-If nothing is worth extracting, return: []"""
+COMPACTION_SYSTEM_PROMPT = """You are extracting memories from a conversation that is about to be compacted. The context will be LOST after this point — this is your LAST CHANCE to capture everything worth remembering. Be more aggressive than usual: err on the side of storing.
+
+Work in TWO explicit phases within one response:
+
+PHASE 1 — Topic identification.
+Identify the 2-3 main topics the user was engaging with before extracting any fact. Topics should be short phrases (2-5 words each). If there's no clear user-focused topic, use an empty topics array.
+
+PHASE 2 — Fact extraction anchored to those topics (plus preserve active context).
+Extract valuable memories. Prefer facts that directly relate to the identified topics (importance 7-9 range). Active project context, decisions in progress, and current working state score 6-8 during compaction — capture them even when they'd normally be marginal.
+
+Rules:
+1. Each memory = single self-contained piece of information
+2. Focus on user-specific info useful in future conversations
+3. Skip generic knowledge, greetings, small talk
+4. Score importance 1-10 (5+ = worth storing during compaction)
+5. Every memory MUST attribute a source (provenance critical)
+
+Importance rubric (full 1-10 range, NOT just 7-8):
+- 10: Core identity, never-forget ("remember this forever", name/birthday)
+- 9: Affects many future decisions / high-impact rules
+- 8: Preference / decision-with-reasoning / operational rule
+- 7: Specific durable fact
+- 6: Borderline — during compaction, capture anyway
+- 5: Would normally drop; keep as compaction safety net
+- 4 or below: DROP (greetings, filler)
+
+═══════════════════════════════════════════════════════════════
+TYPE (6 values)
+═══════════════════════════════════════════════════════════════
+- claim: factual assertion (absorbs v0 fact/context/decision; decisions populate reasoning)
+- preference: likes/dislikes/tastes
+- directive: imperative rule ("always X", "never Y")
+- commitment: future intent ("will do X")
+- episode: notable event
+- summary: derived synthesis (source must be derived|assistant)
+
+═══════════════════════════════════════════════════════════════
+SOURCE (provenance, CRITICAL)
+═══════════════════════════════════════════════════════════════
+- user: user explicitly stated it (in [user]: turns)
+- user-inferred: extractor inferred from user signals
+- assistant: assistant authored — DOWNGRADE unless user affirmed/quoted.
+- external, derived: rare.
+
+IF fact substance appears ONLY in [assistant]: turns without user affirmation → source:assistant.
+
+═══════════════════════════════════════════════════════════════
+SCOPE
+═══════════════════════════════════════════════════════════════
+work | personal | health | family | creative | finance | misc | unspecified
+
+═══════════════════════════════════════════════════════════════
+ENTITIES
+═══════════════════════════════════════════════════════════════
+- type ∈ {person, project, tool, company, concept, place}
+- prefer specific names ("PostgreSQL" not "database")
+- omit umbrella categories when specific name is present
+
+═══════════════════════════════════════════════════════════════
+REASONING (only for claims that are decisions)
+═══════════════════════════════════════════════════════════════
+For type=claim where the user expressed a decision-with-reasoning, populate "reasoning" with the WHY clause.
+
+═══════════════════════════════════════════════════════════════
+FORMAT-AGNOSTIC PARSING (IMPORTANT)
+═══════════════════════════════════════════════════════════════
+The conversation may contain bullet lists, numbered lists, section headers, code snippets, or plain prose. Treat ALL formats as potential sources of extractable memory:
+- Bullets/list items: each item is a candidate.
+- Section headers (Context, Decisions, Key Learnings, Open Questions): use the header as a TYPE HINT (Context → claim, Decisions → claim+reasoning, Learnings → directive, Open Questions → commitment).
+- Plain prose: parse each distinct assertion as a candidate.
+- Code snippets: extract config choices, tool versions, architectural decisions embedded in comments or structure.
+- Mixed format: apply all of the above.
+
+Do NOT skip content just because it's in a summary. The agent has already filtered — your job is to convert into structured memories, not to re-evaluate worth.
+
+═══════════════════════════════════════════════════════════════
+OUTPUT FORMAT (no markdown, no code fences)
+═══════════════════════════════════════════════════════════════
+{
+  "topics": ["topic 1", "topic 2"],
+  "facts": [
+    {
+      "text": "...",
+      "type": "claim|preference|directive|commitment|episode",
+      "source": "user|user-inferred|assistant",
+      "scope": "work|personal|health|...",
+      "importance": N,
+      "confidence": 0.9,
+      "action": "ADD",
+      "reasoning": "...",    // optional, only for claim+decision
+      "entities": [{"name": "...", "type": "tool"}]
+    }
+  ]
+}
+
+If nothing worth extracting: {"topics": [], "facts": []}"""
 
 
 # ---------------------------------------------------------------------------
-# Compaction-Aware Extraction Prompt (Phase 2.3)
+# Helpers — message formatting + response parsing
 # ---------------------------------------------------------------------------
-#
-# Mirrors COMPACTION_SYSTEM_PROMPT from skill/plugin/extractor.ts.
-# Used when the conversation is about to be compacted — last chance to capture
-# knowledge. Importance threshold is 5 (not 6).
-
-COMPACTION_SYSTEM_PROMPT = """You are extracting memories from a conversation that is about to be compacted. The conversation context will be lost after this point — this is your LAST CHANCE to capture everything worth remembering. Be more aggressive than usual: err on the side of storing.
-
-Rules:
-1. Each memory must be a single, self-contained piece of information
-2. Focus on user-specific information that would be useful in future conversations
-3. Skip generic knowledge, greetings, small talk, and ephemeral task coordination
-4. Score importance 1-10 using the rubric below (5+ = worth storing for compaction)
-5. Only extract memories with importance >= 5
-
-Importance rubric (use the FULL 1-10 range, not just 7-8):
-- 10: Critical, core identity, never-forget content. The user explicitly says "remember this forever", "critical", "never forget", or it's a fundamental fact like name/birthday/relationships that defines who they are.
-- 9: Affects many future decisions or interactions. A high-impact rule, a major life decision with reasoning, a deeply held preference that shapes daily work.
-- 8: High-value preference, decision-with-reasoning, or operational rule. The user clearly cares about it AND it will be relevant in many future conversations.
-- 7: Specific durable fact about the user's setup, project, or context. Useful to remember but not life-changing.
-- 6: Borderline in normal extraction — but worth storing during compaction since this context will be lost.
-- 5: Would normally be dropped, but during compaction we capture it as a safety net. Low-signal context, minor preferences, ephemeral project state that may still be useful if the conversation is lost.
-- 4 or below: NOT WORTH STORING even during compaction. Drop these. Greetings, filler, already-known common knowledge.
-
-DO NOT cluster every fact at 7-8. Use 9-10 for high-signal content and 5-6 for borderline content. The system depends on the full range working.
-
-Format-agnostic parsing (IMPORTANT):
-The conversation may contain bullet lists, numbered lists, section headers with paragraphs, code snippets, or plain prose. Treat ALL formats as potential sources of extractable memory:
-- If bullets/list items: each item is a candidate memory.
-- If section headers (Context, Decisions, Key Learnings, Open Questions, etc.): use the header as a type hint (Context → context, Decisions → decision, Learnings → rule, Open Questions → goal).
-- If plain prose: parse each distinct assertion as a candidate memory, even if they run together in paragraph form.
-- If code snippets: extract any configuration choices, tool versions, or architectural decisions embedded in comments or code structure.
-- If mixed format: apply all of the above.
-
-Do NOT skip content just because it appears in a summary. The agent has already done the filtering — your job is to convert the content into structured memories, not to re-evaluate whether each item is worth storing.
-
-Types:
-- fact: Objective information about the user (name, location, job, relationships)
-- preference: Likes, dislikes, or preferences ("prefers dark mode", "allergic to peanuts")
-- decision: Choices WITH reasoning ("chose PostgreSQL because data is relational and needs ACID")
-- episodic: Notable events or experiences ("deployed v1.0 to production on March 15")
-- goal: Objectives, targets, or plans ("wants to launch public beta by end of Q1")
-- context: Active project/task context ("working on TotalReclaw v1.2, staging on Base Sepolia")
-- summary: Key outcome or conclusion from a discussion ("agreed to use phased rollout for migration")
-- rule: A reusable operational rule, non-obvious gotcha, debugging shortcut, or convention the user wants to remember for next time.
-
-Extraction guidance (compaction-specific):
-- Pay special attention to active project context, decisions in progress, and current working state — these are especially valuable to preserve before compaction.
-- For decisions: ALWAYS include the reasoning. "Chose X" is weak. "Chose X because Y" is strong.
-- For context: Capture what the user is actively working on, including versions, environments, and status. During compaction, even minor project state is worth preserving.
-- For summaries: Extract clear conclusions or agreements — compaction is the perfect time since the conversation is being summarized.
-- For rules: Extract non-obvious learnings, gotchas, and conventions. Include specific context (which tool, which error, which version).
-- Decisions and context should be importance >= 7 (they are high-value for future conversations).
-
-Actions (compare against existing memories if provided):
-- ADD: New memory, no conflict with existing
-- UPDATE: Refines or corrects an existing memory (provide existingFactId)
-- DELETE: Contradicts an existing memory -- the old one is now wrong (provide existingFactId)
-- NOOP: Already captured or not worth storing
-
-Entity extraction:
-- Each memory MAY include an "entities" array of named entities it references
-- Entity type must be one of: person | project | tool | company | concept | place
-- Use the user's name when a fact is about them
-- role is optional free text ("chooser", "employer")
-- Prefer SPECIFIC product/tool names over umbrella categories. "PostgreSQL" beats "database".
-- confidence (0.0-1.0) is your self-assessed certainty; default 0.85 if you're unsure
-
-Return a JSON array (no markdown, no code fences):
-[{"text": "...", "type": "...", "importance": N, "confidence": 0.9, "action": "ADD|UPDATE|DELETE|NOOP", "entities": [{"name": "PostgreSQL", "type": "tool"}], "existingFactId": "..."}, ...]
-
-If nothing is worth extracting, return: []"""
 
 
 def _truncate_messages(messages: list[dict], max_chars: int = 12000) -> str:
@@ -292,139 +426,431 @@ def _truncate_messages(messages: list[dict], max_chars: int = 12000) -> str:
     return "\n\n".join(lines)
 
 
-def _parse_response(response: str) -> list[ExtractedFact]:
-    """Parse the LLM extraction response into ExtractedFact objects.
+def _build_fact(
+    raw: dict, default_type: str = "claim", importance_floor: int = 6
+) -> Optional[ExtractedFact]:
+    """Construct an ``ExtractedFact`` from a single raw JSON dict.
 
-    Phase 2.2.6 hardened this function against the three failure modes the
-    Phase 2.2.5 investigation uncovered on the TypeScript side (same issues
-    existed silently in Python):
+    Returns None for items that fail type/text validation. Filters by
+    importance threshold (preserves DELETE actions).
+    """
+    text = str(raw.get("text", "")).strip()
+    if len(text) < 5:
+        return None
 
-    1. **Thinking-model prefix stripping.** Models like glm-5/glm-5.1, Claude
-       reasoning, and gpt-o1 prefix their output with a ``<think>...</think>``
-       or ``<thinking>...</thinking>`` reasoning trace. The old parser handed
-       that straight to ``json.loads`` which silently returned ``[]``.
-       We now strip these tags (case-insensitive) before any parse attempt.
+    # Accept both v1 tokens and legacy v0 tokens — coerce v0 via V0_TO_V1_TYPE.
+    raw_type = str(raw.get("type", default_type)).lower()
+    fact_type = normalize_to_v1_type(raw_type)
 
-    2. **Prose-wrapped JSON.** Models sometimes respond with conversational
-       framing like "Here are the extracted facts: [...]". The old parser
-       would fail the JSON parse. We now fall back to a regex scan for the
-       first ``[...]`` block if the direct parse fails.
+    raw_source = str(raw.get("source", "user-inferred")).lower()
+    source = raw_source if raw_source in VALID_MEMORY_SOURCES else "user-inferred"
 
-    3. **Silent parse failures.** The old parser had a blanket
-       ``except json.JSONDecodeError: return []`` with zero logging. Genuine
-       parse failures now log at WARNING level with a preview of the LLM
-       response so operators can see what the model actually produced.
+    raw_scope = str(raw.get("scope", "unspecified")).lower()
+    scope = raw_scope if raw_scope in VALID_MEMORY_SCOPES else "unspecified"
+
+    reasoning_raw = raw.get("reasoning")
+    reasoning = reasoning_raw[:256] if isinstance(reasoning_raw, str) and reasoning_raw else None
+
+    try:
+        importance = max(1, min(10, int(raw.get("importance", 5))))
+    except (ValueError, TypeError):
+        importance = 5
+
+    action = str(raw.get("action", "ADD")).upper()
+    if action not in VALID_ACTIONS:
+        action = "ADD"
+
+    # Reject illegal type:summary + source:user combination
+    if fact_type == "summary" and source == "user":
+        return None
+
+    # Importance floor (DELETE always passes)
+    if importance < importance_floor and action != "DELETE":
+        return None
+
+    existing_id = raw.get("existingFactId") or raw.get("existing_fact_id")
+
+    raw_entities = raw.get("entities")
+    entities: Optional[List[ExtractedEntity]] = None
+    if isinstance(raw_entities, list):
+        parsed_entities = [e for e in (_parse_entity(r) for r in raw_entities) if e is not None]
+        if parsed_entities:
+            entities = parsed_entities
+
+    confidence = normalize_confidence(raw.get("confidence"))
+
+    volatility_raw = raw.get("volatility")
+    volatility = (
+        volatility_raw if isinstance(volatility_raw, str) and volatility_raw in VALID_MEMORY_VOLATILITIES
+        else None
+    )
+
+    return ExtractedFact(
+        text=text[:512],
+        type=fact_type,
+        importance=importance,
+        action=action,
+        existing_fact_id=str(existing_id) if existing_id else None,
+        entities=entities,
+        confidence=confidence,
+        source=source,
+        scope=scope,
+        reasoning=reasoning,
+        volatility=volatility,
+    )
+
+
+def parse_merged_response_v1(response: str) -> tuple[list[str], list[ExtractedFact]]:
+    """Parse a v1 merged-topic LLM response into ``(topics, facts)``.
+
+    Accepts:
+      - The canonical ``{"topics": [...], "facts": [...]}`` merged shape.
+      - A bare JSON array of fact objects (legacy / test-fixture shape;
+        wrapped into ``{"topics": [], "facts": [...]}`` before validation).
+      - A single fact object without a wrapper (wrapped the same way).
+
+    Invalid entities, unknown sources/scopes, and legacy v0 type tokens are
+    all coerced transparently; the downstream ``_build_fact`` applies type
+    normalization and the importance >= 6 floor.
     """
     original_preview = response.strip()[:200]
     cleaned = response.strip()
 
-    # Phase 2.2.6: strip <think>...</think> and <thinking>...</thinking> tags
-    # (case-insensitive) BEFORE any other cleanup. Multi-tag, nested-line, and
-    # mixed-with-markdown-fence variants all handled by the same regex.
-    cleaned = re.sub(r"<think(?:ing)?>[\s\S]*?</think(?:ing)?>", "", cleaned, flags=re.IGNORECASE).strip()
+    # Strip <think>...</think> (case-insensitive, multiline)
+    cleaned = re.sub(
+        r"<think(?:ing)?>[\s\S]*?</think(?:ing)?>", "", cleaned, flags=re.IGNORECASE
+    ).strip()
 
-    # Strip markdown code fences if present
+    # Strip markdown code fences
     if cleaned.startswith("```"):
         cleaned = re.sub(r"^```(?:json)?\n?", "", cleaned)
         cleaned = re.sub(r"\n?```$", "", cleaned).strip()
 
-    parsed: object = None
+    parsed: Any = None
     try:
         parsed = json.loads(cleaned)
     except json.JSONDecodeError:
-        # Fallback: scan for a JSON array anywhere in the cleaned output
-        # (handles prose-wrapped "Here are the facts: [...]" cases).
-        m = re.search(r"\[[\s\S]*\]", cleaned)
-        if m:
+        # First try outermost-array greedy match (bare-array legacy shape).
+        m_arr = re.search(r"\[[\s\S]*\]", cleaned)
+        if m_arr:
             try:
-                parsed = json.loads(m.group(0))
-                logger.info(
-                    "parseFactsResponse: recovered JSON array via bracket-scan fallback"
-                )
+                parsed = json.loads(m_arr.group(0))
+                logger.info("parse_merged_response_v1: recovered JSON via bracket-scan fallback")
             except json.JSONDecodeError:
                 parsed = None
+        if parsed is None:
+            # Fall back to outermost-object greedy match (merged wrapper).
+            m_obj = re.search(r"\{[\s\S]*\}", cleaned)
+            if m_obj:
+                try:
+                    parsed = json.loads(m_obj.group(0))
+                    logger.info("parse_merged_response_v1: recovered JSON via bracket-scan fallback")
+                except json.JSONDecodeError:
+                    parsed = None
 
     if parsed is None:
         logger.warning(
-            "parseFactsResponse: could not parse LLM output as JSON. Preview: %r",
+            "parse_merged_response_v1: could not parse LLM output as JSON. Preview: %r",
+            original_preview,
+        )
+        return [], []
+
+    # Dual-format acceptance.
+    if isinstance(parsed, list):
+        obj: dict = {"topics": [], "facts": parsed}
+    elif isinstance(parsed, dict) and "facts" not in parsed and isinstance(parsed.get("text"), str):
+        # Single fact object without a wrapper.
+        obj = {"topics": [], "facts": [parsed]}
+    elif isinstance(parsed, dict):
+        obj = parsed
+    else:
+        logger.warning(
+            "parse_merged_response_v1: parsed value is %s, not object/array",
+            type(parsed).__name__,
+        )
+        return [], []
+
+    raw_topics = obj.get("topics")
+    topics: list[str] = []
+    if isinstance(raw_topics, list):
+        topics = [t for t in raw_topics if isinstance(t, str) and t][:3]
+
+    raw_facts = obj.get("facts")
+    if not isinstance(raw_facts, list):
+        return topics, []
+
+    facts: list[ExtractedFact] = []
+    for raw in raw_facts:
+        if not isinstance(raw, dict):
+            continue
+        fact = _build_fact(raw, default_type="claim", importance_floor=6)
+        if fact is not None:
+            facts.append(fact)
+
+    return topics, facts
+
+
+def parse_facts_response(response: str) -> list[ExtractedFact]:
+    """Thin wrapper: discard topics, return the flat fact list."""
+    _, facts = parse_merged_response_v1(response)
+    return facts
+
+
+def parse_facts_response_for_compaction(response: str) -> list[ExtractedFact]:
+    """Parse facts for the compaction prompt (importance floor 5, not 6).
+
+    Same JSON-cleaning + recovery logic as :func:`parse_merged_response_v1`
+    but admits borderline facts (importance >= 5) that would normally be
+    filtered — compaction is the last chance to capture them.
+    """
+    original_preview = response.strip()[:200]
+    cleaned = response.strip()
+
+    cleaned = re.sub(
+        r"<think(?:ing)?>[\s\S]*?</think(?:ing)?>", "", cleaned, flags=re.IGNORECASE
+    ).strip()
+    if cleaned.startswith("```"):
+        cleaned = re.sub(r"^```(?:json)?\n?", "", cleaned)
+        cleaned = re.sub(r"\n?```$", "", cleaned).strip()
+
+    parsed: Any = None
+    try:
+        parsed = json.loads(cleaned)
+    except json.JSONDecodeError:
+        m_arr = re.search(r"\[[\s\S]*\]", cleaned)
+        if m_arr:
+            try:
+                parsed = json.loads(m_arr.group(0))
+                logger.info(
+                    "parse_facts_response_for_compaction: recovered JSON via bracket-scan fallback"
+                )
+            except json.JSONDecodeError:
+                parsed = None
+        if parsed is None:
+            m_obj = re.search(r"\{[\s\S]*\}", cleaned)
+            if m_obj:
+                try:
+                    parsed = json.loads(m_obj.group(0))
+                    logger.info(
+                        "parse_facts_response_for_compaction: recovered JSON via bracket-scan fallback"
+                    )
+                except json.JSONDecodeError:
+                    parsed = None
+
+    if parsed is None:
+        logger.warning(
+            "parse_facts_response_for_compaction: could not parse LLM output as JSON. Preview: %r",
             original_preview,
         )
         return []
 
-    if not isinstance(parsed, list):
+    raw_facts: list
+    if isinstance(parsed, list):
+        raw_facts = parsed
+    elif isinstance(parsed, dict):
+        raw_facts = parsed.get("facts") if isinstance(parsed.get("facts"), list) else []
+    else:
         logger.warning(
-            "parseFactsResponse: parsed value is not an array (type=%s)",
-            type(parsed).__name__,
+            "parse_facts_response_for_compaction: parsed value is %s", type(parsed).__name__
         )
         return []
 
-    facts = []
-    for item in parsed:
-        if not isinstance(item, dict):
+    facts: list[ExtractedFact] = []
+    for raw in raw_facts:
+        if not isinstance(raw, dict):
             continue
-        text = str(item.get("text", "")).strip()
-        if len(text) < 5:
+        fact = _build_fact(raw, default_type="claim", importance_floor=5)
+        if fact is not None:
+            facts.append(fact)
+    return facts
+
+
+# ---------------------------------------------------------------------------
+# v1 provenance filter (tag-don't-drop) + volatility defaults
+# ---------------------------------------------------------------------------
+
+
+def apply_provenance_filter_lax(
+    facts: list[ExtractedFact], conversation_text: str
+) -> list[ExtractedFact]:
+    """Tag-don't-drop provenance filter (pipeline G / F).
+
+    For each fact:
+      - If source is already ``"assistant"``, cap importance at 7.
+      - Otherwise, keyword-match the fact against user turns. If <30% of
+        content words (length >= 4) appear in user turns AND source != "user",
+        tag source as ``"assistant"`` and cap importance at 7 (keep the fact).
+      - Drop facts below importance 5 unless DELETE action.
+    """
+    # Join all user turns for keyword matching.
+    user_turns_lower = " ".join(
+        line for line in conversation_text.split("\n\n") if line.startswith("[user]:")
+    ).lower()
+
+    out: list[ExtractedFact] = []
+    for f in facts:
+        if f.source == "assistant":
+            f.importance = min(f.importance, 7)
+            out.append(f)
             continue
 
-        fact_type = str(item.get("type", "fact"))
-        if fact_type not in VALID_TYPES:
-            fact_type = "fact"
+        # Content words from the fact (length >= 4)
+        fact_words = [
+            w for w in re.sub(r"[^a-z0-9\s]", " ", f.text.lower()).split() if len(w) >= 4
+        ]
+        matched = sum(1 for w in fact_words if w in user_turns_lower)
+        match_ratio = (matched / len(fact_words)) if fact_words else 0.0
 
-        importance = item.get("importance", 5)
-        try:
-            importance = max(1, min(10, int(importance)))
-        except (ValueError, TypeError):
-            importance = 5
+        if match_ratio < 0.3 and f.source != "user":
+            f.source = "assistant"
+            f.importance = min(f.importance, 7)
 
-        action = str(item.get("action", "ADD")).upper()
-        if action not in VALID_ACTIONS:
-            action = "ADD"
+        out.append(f)
 
-        # DELETE actions pass regardless of importance
-        if importance < 6 and action != "DELETE":
-            continue
+    return [f for f in out if f.importance >= 5 or f.action == "DELETE"]
 
-        existing_id = item.get("existingFactId") or item.get("existing_fact_id")
 
-        # Parse entities (new, optional)
-        raw_entities = item.get("entities")
-        entities: Optional[List[ExtractedEntity]] = None
-        if isinstance(raw_entities, list):
-            parsed_entities = [e for e in (_parse_entity(r) for r in raw_entities) if e is not None]
-            if parsed_entities:
-                entities = parsed_entities
+def default_volatility(fact: ExtractedFact) -> str:
+    """Heuristic fallback volatility when the LLM doesn't assign one.
 
-        # Parse confidence (new, optional; defaults to 0.85)
-        confidence = normalize_confidence(item.get("confidence"))
+    Mirrors the TS ``defaultVolatility``.
+    """
+    if fact.type == "commitment":
+        return "updatable"
+    if fact.type == "episode":
+        return "stable"
+    if fact.type == "directive":
+        return "stable"
+    if fact.scope in ("health", "family"):
+        return "stable"
+    return "updatable"
 
-        facts.append(ExtractedFact(
-            text=text[:512],
-            type=fact_type,
-            importance=importance,
-            action=action,
-            existing_fact_id=str(existing_id) if existing_id else None,
-            entities=entities,
-            confidence=confidence,
-        ))
+
+COMPARATIVE_PROMPT_V1 = """You are a memory re-ranker for the v1 taxonomy. You receive facts already extracted from one conversation, each with initial importance. Your job is twofold:
+
+1. RE-RANK importance to spread across the 1-10 range (avoid clustering at 7-8-9)
+2. ASSIGN volatility to each fact
+
+Re-ranking rules:
+- Top 1/3 of facts (most significant for this user): importance 9-10
+- Middle 1/3: importance 7-8
+- Bottom 1/3: importance 5-6 (borderline, may be dropped)
+- A fact may stay at 10 if it's clearly identity-defining (name, birthday) or marked as "never forget"
+- Never raise without justification; never lower below 5 unless clearly noise
+- You MUST produce a spread
+
+Volatility rules:
+- stable: unlikely to change for years (name, allergies, birthplace, fundamental traits)
+- updatable: changes occasionally (current job, active project, partner's name, address)
+- ephemeral: short-lived state (today's task, this week's plan, current trip itinerary)
+
+Use the FULL conversation context to judge volatility — a single claim may be ambiguous, but in context you can usually tell.
+
+Return JSON array, same order as input, ONLY with importance + volatility fields:
+[{"importance": N, "volatility": "stable|updatable|ephemeral"}, ...]
+No markdown."""
+
+
+async def comparative_rescore_v1(
+    facts: list[ExtractedFact],
+    conversation_text: str,
+    llm_config: Optional[LLMConfig] = None,
+) -> list[ExtractedFact]:
+    """Comparative re-scoring pass.
+
+    Forces LLM re-rank when ``len(facts) >= 5`` to spread importance across
+    the 1-10 range. When ``len(facts) < 5`` (or no LLM), fills any missing
+    volatility via :func:`default_volatility` and returns.
+    """
+    # G-tuned behavior: force rescore when >= 5 facts
+    if len(facts) < 2 or len(facts) < 5:
+        for f in facts:
+            if f.volatility is None:
+                f.volatility = default_volatility(f)
+        return facts
+
+    config = llm_config or detect_llm_config()
+    if not config:
+        for f in facts:
+            f.volatility = f.volatility or default_volatility(f)
+        return facts
+
+    facts_for_prompt = "\n".join(
+        f"{i + 1}. [imp: {f.importance}] [type: {f.type}] [scope: {f.scope or 'unspecified'}] {f.text}"
+        for i, f in enumerate(facts)
+    )
+    user_prompt = (
+        f"Conversation context:\n{conversation_text}\n\n"
+        f"Extracted facts:\n{facts_for_prompt}\n\n"
+        f"Return {len(facts)} JSON objects, each with \"importance\" + \"volatility\". Match input order."
+    )
+
+    try:
+        response = await chat_completion(config, COMPARATIVE_PROMPT_V1, user_prompt)
+    except Exception as e:
+        logger.warning("comparative_rescore_v1: chat_completion threw: %s", e)
+        for f in facts:
+            f.volatility = default_volatility(f)
+        return facts
+
+    if not response:
+        for f in facts:
+            f.volatility = default_volatility(f)
+        return facts
+
+    cleaned = response.strip()
+    cleaned = re.sub(
+        r"<think(?:ing)?>[\s\S]*?</think(?:ing)?>", "", cleaned, flags=re.IGNORECASE
+    ).strip()
+    if cleaned.startswith("```"):
+        cleaned = re.sub(r"^```(?:json)?\n?", "", cleaned)
+        cleaned = re.sub(r"\n?```$", "", cleaned).strip()
+    m = re.search(r"\[[\s\S]*\]", cleaned)
+    if m:
+        cleaned = m.group(0)
+
+    try:
+        parsed = json.loads(cleaned)
+    except json.JSONDecodeError:
+        for f in facts:
+            f.volatility = default_volatility(f)
+        return facts
+    if not isinstance(parsed, list):
+        for f in facts:
+            f.volatility = default_volatility(f)
+        return facts
+
+    for i, f in enumerate(facts):
+        entry = parsed[i] if i < len(parsed) and isinstance(parsed[i], dict) else {}
+        raw_imp = entry.get("importance")
+        raw_vol = str(entry.get("volatility", "")).lower()
+
+        if isinstance(raw_imp, (int, float)) and not isinstance(raw_imp, bool):
+            new_imp = max(5, min(10, round(float(raw_imp))))
+            f.importance = int(new_imp)
+
+        if raw_vol in VALID_MEMORY_VOLATILITIES:
+            f.volatility = raw_vol
+        elif f.volatility is None:
+            f.volatility = default_volatility(f)
 
     return facts
 
 
+# ---------------------------------------------------------------------------
+# Phase 2.2.6: lexical importance bumps
+# ---------------------------------------------------------------------------
+
+
 def compute_lexical_importance_bump(fact_text: str, conversation_text: str) -> int:
-    """Phase 2.2.6: post-process bump for under-weighted facts.
+    """Phase 2.2.6: post-process bump (0..2) for under-weighted facts.
 
     Mirrors ``computeLexicalImportanceBump`` in ``skill/plugin/extractor.ts``.
-    See that function's docstring for the full design rationale and signal list.
-
-    Returns an integer in [0, 2] representing how much to add to the LLM's
-    importance score. The bump is additive and never overrides the importance
-    >= 6 filter on its own (a fact still needs to score >= 5 from the LLM to
-    benefit, since +2 from 5 = 7).
+    See that function for the full signal rationale.
     """
     bump = 0
     lower_conv = conversation_text.lower()
 
-    # Signal 1: strong intent phrases anywhere in the conversation
     strong_intent = re.compile(
         r"\b(remember this|never forget|rule of thumb|don't (?:ever )?forget|critical|important|gotcha|note to self)\b",
         re.IGNORECASE,
@@ -432,16 +858,11 @@ def compute_lexical_importance_bump(fact_text: str, conversation_text: str) -> i
     if strong_intent.search(lower_conv):
         bump += 1
 
-    # Signal 2: emphasis markers — double exclamation OR 3+ consecutive all-caps words (3+ chars each)
     double_excl = "!!"
     all_caps_phrase = re.compile(r"\b[A-Z]{3,}(?:\s+[A-Z]{3,}){2,}\b")
     if double_excl in conversation_text or all_caps_phrase.search(conversation_text):
         bump += 1
 
-    # Signal 3: repetition — extract content words (length >= 5, not stop words)
-    # from the fact and check if any single one appears 2+ times in the
-    # conversation. This is more robust to LLM paraphrasing than a leading-chars
-    # fingerprint.
     lower_fact = fact_text.lower()
     stop_words = {
         "about", "after", "again", "against", "because", "before", "being",
@@ -459,7 +880,6 @@ def compute_lexical_importance_bump(fact_text: str, conversation_text: str) -> i
     ]
     triggered = False
     for word in fact_words:
-        # \b word boundary; re.escape handles any regex meta chars
         occurrences = len(re.findall(rf"\b{re.escape(word)}\b", lower_conv))
         if occurrences >= 2:
             triggered = True
@@ -470,35 +890,46 @@ def compute_lexical_importance_bump(fact_text: str, conversation_text: str) -> i
     return min(bump, 2)
 
 
+# ---------------------------------------------------------------------------
+# Main extraction entry points
+# ---------------------------------------------------------------------------
+
+
 async def extract_facts_llm(
     messages: list[dict],
     mode: str = "turn",  # "turn" or "full"
     existing_memories: Optional[list[dict]] = None,
-    llm_config: Optional["LLMConfig"] = None,
+    llm_config: Optional[LLMConfig] = None,
 ) -> list[ExtractedFact]:
-    """Extract facts using LLM. Returns empty list if no LLM available.
+    """Extract facts using the v1 G-pipeline. Returns [] if no LLM available.
 
-    Phase 2.2.6 added observability: every early-return branch now logs at
-    INFO or WARNING level so the auto-extraction path can be diagnosed from
-    the gateway log without having to reproduce the exact failure. Prior to
-    this, silent ``return []`` paths made debugging near-impossible (see
-    QA-PHASE-2-2-5-20260415 for the multi-hour ghost-bug hunt this prevents).
+    Pipeline: single merged-topic LLM call → ``apply_provenance_filter_lax``
+    → ``comparative_rescore_v1`` (forces re-rank when >= 5 facts) →
+    ``default_volatility`` fallback → lexical importance bumps.
 
     Parameters
     ----------
+    messages : list[dict]
+        Conversation turns (role + content).
+    mode : {"turn", "full"}
+        Only affects the user-prompt framing (turn vs full-session).
+    existing_memories : list[dict], optional
+        Used for LLM-side dedup context. Caller should pre-filter.
     llm_config : LLMConfig, optional
-        Pre-resolved LLM configuration. If not provided, falls back to
-        ``detect_llm_config()`` which auto-detects from environment variables.
+        Pre-resolved LLM config (e.g. from Hermes). Falls back to env-var
+        detection via :func:`detect_llm_config` when not provided.
     """
     config = llm_config or detect_llm_config()
     if not config:
         logger.info("extract_facts_llm: no LLM config resolved (skipping extraction)")
         return []
 
-    # Use all provided messages — the caller (hooks.py) already scopes
-    # to unprocessed messages via state.get_unprocessed_messages().
-    # Turn vs full mode only affects the user prompt framing.
-    relevant = messages
+    if not messages:
+        logger.info("extract_facts_llm: no messages to process")
+        return []
+
+    # 'turn' mode trims to the last 6 messages (matches TS extractFacts).
+    relevant = messages[-6:] if mode == "turn" else messages
     conversation_text = _truncate_messages(relevant)
     if len(conversation_text) < 20:
         logger.info(
@@ -509,12 +940,11 @@ async def extract_facts_llm(
         )
         return []
 
-    # Build existing memories context
     memories_ctx = ""
     if existing_memories:
         mem_lines = [f"[ID: {m['id']}] {m['text']}" for m in existing_memories[:50]]
         memories_ctx = (
-            "\n\nExisting memories (classify as UPDATE/DELETE/NOOP if they conflict or overlap):\n"
+            "\n\nExisting memories (use these for dedup — classify as UPDATE/DELETE/NOOP if they conflict or overlap):\n"
             + "\n".join(mem_lines)
         )
 
@@ -535,166 +965,35 @@ async def extract_facts_llm(
         return []
 
     logger.info(
-        "extract_facts_llm: LLM returned %d chars; handing to _parse_response",
+        "extract_facts_llm: LLM returned %d chars; parsing merged response",
         len(response),
     )
-    facts = _parse_response(response)
+    topics, raw_facts = parse_merged_response_v1(response)
+    if topics:
+        logger.info("extract_facts_llm: topics = %s", topics)
 
-    # Phase 2.2.6: lexical importance bumps. Mirrors the TS extractor — see
-    # `compute_lexical_importance_bump` docstring for the full signal list.
+    # Provenance filter (tag-don't-drop).
+    facts = apply_provenance_filter_lax(raw_facts, conversation_text)
+
+    # Comparative rescore — forces re-rank when >= 5 facts.
+    facts = await comparative_rescore_v1(facts, conversation_text, llm_config=config)
+
+    # Defensive: ensure every fact has a volatility.
+    for f in facts:
+        if f.volatility is None:
+            f.volatility = default_volatility(f)
+
+    # Lexical importance bumps.
     for f in facts:
         bump = compute_lexical_importance_bump(f.text, conversation_text)
         if bump > 0:
-            old_importance = f.importance
-            effective_bump = min(bump, 1) if f.importance >= 8 else bump
-            f.importance = min(10, f.importance + effective_bump)
+            old = f.importance
+            effective = min(bump, 1) if f.importance >= 8 else bump
+            f.importance = min(10, f.importance + effective)
             logger.info(
                 "extract_facts_llm: lexical bump +%d for %r (%d -> %d)",
-                bump,
-                f.text[:60],
-                old_importance,
-                f.importance,
+                bump, f.text[:60], old, f.importance,
             )
-
-    return facts
-
-
-def extract_facts_heuristic(messages: list[dict], max_facts: int) -> list[ExtractedFact]:
-    """Simple heuristic fact extraction (no LLM needed).
-
-    Looks for patterns like:
-    - "I prefer/like/want..."
-    - "My name is..."
-    - "Remember that..."
-    - Decisions: "I chose/decided..."
-    - Facts stated by the user
-    """
-    facts: list[ExtractedFact] = []
-    patterns = [
-        (r"(?:I|my)\s+(?:prefer|like|want|need|use|enjoy|love|hate)\s+(.+)", "preference", 7),
-        (r"(?:my name is|I'm called|call me)\s+(.+)", "fact", 8),
-        (r"(?:remember|don't forget|keep in mind)\s+(?:that\s+)?(.+)", "fact", 7),
-        (r"(?:I chose|I decided|we decided|decision:)\s+(.+)", "decision", 7),
-        (r"(?:I work|I'm a|my job|my role)\s+(.+)", "fact", 7),
-    ]
-
-    for msg in messages:
-        if msg.get("role") != "user":
-            continue
-        content = msg.get("content", "")
-        for pattern, category, importance in patterns:
-            matches = re.findall(pattern, content, re.IGNORECASE)
-            for match in matches:
-                text = match.strip().rstrip(".")
-                if len(text) > 10 and len(facts) < max_facts:
-                    facts.append(ExtractedFact(
-                        text=text[:512],
-                        type=category,
-                        importance=importance,
-                        action="ADD",
-                    ))
-
-    return facts
-
-
-# ---------------------------------------------------------------------------
-# Compaction-Aware Extraction (Phase 2.3)
-# ---------------------------------------------------------------------------
-
-
-def _parse_response_compaction(response: str) -> list[ExtractedFact]:
-    """Parse the LLM extraction response with compaction threshold (importance >= 5).
-
-    Identical to ``_parse_response`` except the importance floor is 5 instead
-    of 6. During compaction, we accept borderline facts that would normally be
-    dropped — this is the last chance to capture them.
-    """
-    original_preview = response.strip()[:200]
-    cleaned = response.strip()
-
-    # Strip <think>...</think> and <thinking>...</thinking> tags
-    cleaned = re.sub(r"<think(?:ing)?>[\s\S]*?</think(?:ing)?>", "", cleaned, flags=re.IGNORECASE).strip()
-
-    # Strip markdown code fences if present
-    if cleaned.startswith("```"):
-        cleaned = re.sub(r"^```(?:json)?\n?", "", cleaned)
-        cleaned = re.sub(r"\n?```$", "", cleaned).strip()
-
-    parsed: object = None
-    try:
-        parsed = json.loads(cleaned)
-    except json.JSONDecodeError:
-        m = re.search(r"\[[\s\S]*\]", cleaned)
-        if m:
-            try:
-                parsed = json.loads(m.group(0))
-                logger.info(
-                    "_parse_response_compaction: recovered JSON array via bracket-scan fallback"
-                )
-            except json.JSONDecodeError:
-                parsed = None
-
-    if parsed is None:
-        logger.warning(
-            "_parse_response_compaction: could not parse LLM output as JSON. Preview: %r",
-            original_preview,
-        )
-        return []
-
-    if not isinstance(parsed, list):
-        logger.warning(
-            "_parse_response_compaction: parsed value is not an array (type=%s)",
-            type(parsed).__name__,
-        )
-        return []
-
-    facts = []
-    for item in parsed:
-        if not isinstance(item, dict):
-            continue
-        text = str(item.get("text", "")).strip()
-        if len(text) < 5:
-            continue
-
-        fact_type = str(item.get("type", "fact"))
-        if fact_type not in VALID_TYPES:
-            fact_type = "fact"
-
-        importance = item.get("importance", 5)
-        try:
-            importance = max(1, min(10, int(importance)))
-        except (ValueError, TypeError):
-            importance = 5
-
-        action = str(item.get("action", "ADD")).upper()
-        if action not in VALID_ACTIONS:
-            action = "ADD"
-
-        # Compaction threshold: importance >= 5 (not 6)
-        # DELETE actions pass regardless of importance
-        if importance < 5 and action != "DELETE":
-            continue
-
-        existing_id = item.get("existingFactId") or item.get("existing_fact_id")
-
-        raw_entities = item.get("entities")
-        entities: Optional[List[ExtractedEntity]] = None
-        if isinstance(raw_entities, list):
-            parsed_entities = [e for e in (_parse_entity(r) for r in raw_entities) if e is not None]
-            if parsed_entities:
-                entities = parsed_entities
-
-        confidence = normalize_confidence(item.get("confidence"))
-
-        facts.append(ExtractedFact(
-            text=text[:512],
-            type=fact_type,
-            importance=importance,
-            action=action,
-            existing_fact_id=str(existing_id) if existing_id else None,
-            entities=entities,
-            confidence=confidence,
-        ))
 
     return facts
 
@@ -702,27 +1001,12 @@ def _parse_response_compaction(response: str) -> list[ExtractedFact]:
 async def extract_facts_compaction(
     messages: list[dict],
     existing_memories: Optional[list[dict]] = None,
-    llm_config: Optional["LLMConfig"] = None,
+    llm_config: Optional[LLMConfig] = None,
 ) -> list[ExtractedFact]:
-    """Extract facts using the compaction-aware prompt (importance >= 5).
+    """Compaction-aware extraction (importance floor 5, not 6).
 
-    This is the Python equivalent of ``extractFactsForCompaction`` in the
-    OpenClaw plugin. It uses ``COMPACTION_SYSTEM_PROMPT`` and processes the
-    full conversation (not just recent turns). The importance filter is >= 5
-    instead of >= 6, capturing borderline facts before context is lost.
-
-    Hermes does not currently have a compaction hook (it uses
-    ``on_session_end`` instead), but this function is exported and available
-    for future integration.
-
-    Parameters
-    ----------
-    messages : list[dict]
-        All conversation messages to extract from.
-    existing_memories : list[dict], optional
-        Recent memories for LLM dedup context.
-    llm_config : LLMConfig, optional
-        Pre-resolved LLM configuration. Falls back to ``detect_llm_config()``.
+    Uses :data:`COMPACTION_SYSTEM_PROMPT` and always processes the full
+    conversation. Mirrors ``extractFactsForCompaction`` in the TS plugin.
     """
     config = llm_config or detect_llm_config()
     if not config:
@@ -738,12 +1022,11 @@ async def extract_facts_compaction(
         )
         return []
 
-    # Build existing memories context
     memories_ctx = ""
     if existing_memories:
         mem_lines = [f"[ID: {m['id']}] {m['text']}" for m in existing_memories[:50]]
         memories_ctx = (
-            "\n\nExisting memories (classify as UPDATE/DELETE/NOOP if they conflict or overlap):\n"
+            "\n\nExisting memories (use these for dedup — classify as UPDATE/DELETE/NOOP if they conflict or overlap):\n"
             + "\n".join(mem_lines)
         )
 
@@ -763,24 +1046,90 @@ async def extract_facts_compaction(
         return []
 
     logger.info(
-        "extract_facts_compaction: LLM returned %d chars; handing to _parse_response_compaction",
+        "extract_facts_compaction: LLM returned %d chars; parsing merged response",
         len(response),
     )
-    facts = _parse_response_compaction(response)
+    facts = parse_facts_response_for_compaction(response)
 
-    # Lexical importance bumps (same as regular extraction)
+    # Provenance filter — same tag-don't-drop, importance floor 5 baked in.
+    facts = apply_provenance_filter_lax(facts, conversation_text)
+
+    # Comparative rescore (same trigger as regular extraction).
+    facts = await comparative_rescore_v1(facts, conversation_text, llm_config=config)
+
+    # Defensive: ensure every fact has a volatility.
+    for f in facts:
+        if f.volatility is None:
+            f.volatility = default_volatility(f)
+
+    # Lexical importance bumps.
     for f in facts:
         bump = compute_lexical_importance_bump(f.text, conversation_text)
         if bump > 0:
-            old_importance = f.importance
-            effective_bump = min(bump, 1) if f.importance >= 8 else bump
-            f.importance = min(10, f.importance + effective_bump)
+            old = f.importance
+            effective = min(bump, 1) if f.importance >= 8 else bump
+            f.importance = min(10, f.importance + effective)
             logger.info(
                 "extract_facts_compaction: lexical bump +%d for %r (%d -> %d)",
-                bump,
-                f.text[:60],
-                old_importance,
-                f.importance,
+                bump, f.text[:60], old, f.importance,
             )
 
     return facts
+
+
+# ---------------------------------------------------------------------------
+# Heuristic fallback (no LLM required)
+# ---------------------------------------------------------------------------
+
+
+def extract_facts_heuristic(messages: list[dict], max_facts: int) -> list[ExtractedFact]:
+    """Simple heuristic extraction (no LLM needed).
+
+    Used only when the LLM path is unavailable. Emits v1-shaped facts with
+    ``source="user"`` (patterns all match on the user's own turns) and a
+    best-guess v1 type.
+    """
+    facts: list[ExtractedFact] = []
+    # (pattern, v1 type, importance)
+    patterns: list[tuple[str, str, int]] = [
+        (r"(?:I|my)\s+(?:prefer|like|want|need|use|enjoy|love|hate)\s+(.+)", "preference", 7),
+        (r"(?:my name is|I'm called|call me)\s+(.+)", "claim", 8),
+        (r"(?:remember|don't forget|keep in mind)\s+(?:that\s+)?(.+)", "claim", 7),
+        (r"(?:I chose|I decided|we decided|decision:)\s+(.+)", "claim", 7),
+        (r"(?:I work|I'm a|my job|my role)\s+(.+)", "claim", 7),
+    ]
+    for msg in messages:
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content", "")
+        for pattern, fact_type, importance in patterns:
+            for match in re.findall(pattern, content, re.IGNORECASE):
+                text = match.strip().rstrip(".")
+                if len(text) > 10 and len(facts) < max_facts:
+                    facts.append(
+                        ExtractedFact(
+                            text=text[:512],
+                            type=fact_type,
+                            importance=importance,
+                            action="ADD",
+                            source="user",
+                            scope="unspecified",
+                            volatility="updatable",
+                        )
+                    )
+    return facts
+
+
+# ---------------------------------------------------------------------------
+# Back-compat shims — renamed parsers. Prefer the new names in new code.
+# ---------------------------------------------------------------------------
+
+
+def _parse_response(response: str) -> list[ExtractedFact]:
+    """Deprecated: use :func:`parse_facts_response` instead."""
+    return parse_facts_response(response)
+
+
+def _parse_response_compaction(response: str) -> list[ExtractedFact]:
+    """Deprecated: use :func:`parse_facts_response_for_compaction`."""
+    return parse_facts_response_for_compaction(response)

--- a/python/src/totalreclaw/agent/lifecycle.py
+++ b/python/src/totalreclaw/agent/lifecycle.py
@@ -201,12 +201,23 @@ def auto_extract(state: "AgentState", mode: str = "turn", llm_config=None) -> li
                         logger.debug("Skipping near-duplicate fact: %s", fact.text[:80])
                         continue
 
+                # v1 write path — forward the taxonomy fields the extractor
+                # populated (source/scope/reasoning/volatility). Defensive
+                # fallback for source matches the plugin's
+                # ``storeExtractedFacts`` handling.
                 loop.run_until_complete(
                     client.remember(
                         fact.text,
                         embedding=embedding,
                         importance=fact.importance / 10.0,  # Normalize 1-10 to 0.0-1.0
                         source="hermes-auto",
+                        fact_type=fact.type,
+                        entities=fact.entities,
+                        confidence=fact.confidence,
+                        provenance=fact.source or "user-inferred",
+                        scope=fact.scope or "unspecified",
+                        reasoning=fact.reasoning,
+                        volatility=fact.volatility,
                     )
                 )
                 stored_texts.append(fact.text)
@@ -257,11 +268,18 @@ def session_debrief(state: "AgentState", stored_fact_texts: Optional[list[str]] 
             if debrief_items:
                 for item in debrief_items:
                     try:
+                        # v1 debrief items are summaries with derived
+                        # provenance — the assistant-side debrief pipeline
+                        # synthesized them from the conversation, so the
+                        # v1 source is always "derived" (plugin parity).
                         loop.run_until_complete(
                             client.remember(
                                 item.text,
                                 importance=item.importance / 10.0,
                                 source="hermes_debrief",
+                                fact_type="summary",
+                                provenance="derived",
+                                scope="unspecified",
                             )
                         )
                     except Exception as e:

--- a/python/src/totalreclaw/claims_helper.py
+++ b/python/src/totalreclaw/claims_helper.py
@@ -1,15 +1,25 @@
 """
-TotalReclaw — Knowledge Graph helpers for the write + read path (Phase 1).
+TotalReclaw — Knowledge Graph helpers for the write + read path.
 
 Mirrors ``skill/plugin/claims-helper.ts`` function-for-function in Python so
-that client-produced Claim blobs are byte-identical across TypeScript and
+that client-produced claim blobs are byte-equivalent across TypeScript and
 Python. All canonicalization is delegated to ``totalreclaw_core``; this module
-only handles feature flags, category mapping, entity trapdoor hashing, and
-helpers for reading already-decrypted blobs.
+only handles category mapping, entity trapdoor hashing, and helpers for
+reading already-decrypted blobs.
 
-Canonical Claim schema uses compact short keys (``t, c, cf, i, sa, ea, e, ...``).
-The field order the core serializer emits matches the Rust golden tests and the
-plugin's reference test vectors.
+As of ``totalreclaw`` 2.0.0 / ``@totalreclaw/core`` 2.0.0:
+
+* Memory Taxonomy v1 is the DEFAULT and ONLY write path — no env-var toggles.
+  Extraction emits v1 JSON blobs (long-form fields + ``schema_version: "1.0"``).
+* The legacy ``TOTALRECLAW_CLAIM_FORMAT=legacy`` fallback has been removed —
+  ``build_canonical_claim`` always forwards to :func:`build_canonical_claim_v1`.
+* The legacy v0 short-key ``{t, c, cf, i, sa, ea}`` claim format is read-only:
+  :func:`read_claim_from_blob` still decodes it transparently for pre-v1
+  vault entries, but no Python caller produces it.
+
+The outer protobuf wrapper's ``version`` field MUST be set to
+:data:`PROTOBUF_VERSION_V4` (``4``) when storing a v1 payload — see
+``operations.py::store_fact``.
 """
 from __future__ import annotations
 
@@ -17,6 +27,39 @@ import hashlib
 import json
 import math
 import os
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Literal, Optional, Sequence
+
+import totalreclaw_core as _core
+
+from .agent.extraction import (
+    LEGACY_V0_MEMORY_TYPES,
+    V0_TO_V1_TYPE,
+    VALID_MEMORY_SCOPES,
+    VALID_MEMORY_SOURCES,
+    VALID_MEMORY_TYPES,
+    VALID_MEMORY_VOLATILITIES,
+    is_valid_memory_type,
+    normalize_to_v1_type,
+)
+
+
+# ---------------------------------------------------------------------------
+# Version + schema markers
+# ---------------------------------------------------------------------------
+
+#: Memory Taxonomy v1 schema-version string (matches plugin's V1_SCHEMA_VERSION).
+V1_SCHEMA_VERSION: str = "1.0"
+
+#: Outer protobuf wrapper version tags.
+#:
+#: * ``DEFAULT_PROTOBUF_VERSION`` (3) — legacy callers; inner blob is the
+#:   pre-v1 short-key binary envelope.
+#: * ``PROTOBUF_VERSION_V4`` (4) — Memory Taxonomy v1; inner blob is a JSON
+#:   payload with ``schema_version: "1.0"``.
+DEFAULT_PROTOBUF_VERSION: int = 3
+PROTOBUF_VERSION_V4: int = 4
 
 
 def _js_round(x: float) -> int:
@@ -28,40 +71,19 @@ def _js_round(x: float) -> int:
     """
     return math.floor(x + 0.5)
 
-from datetime import datetime, timezone
-from typing import Any, Dict, Iterable, List, Literal, Optional, Sequence
-
-import totalreclaw_core as _core
-
 
 # ---------------------------------------------------------------------------
-# Feature flags
+# Feature flags (digest mode only — claim-format gate removed in 2.0.0)
 # ---------------------------------------------------------------------------
 
-ClaimFormat = Literal["claim", "legacy"]
 DigestMode = Literal["on", "off", "template"]
-
-
-def resolve_claim_format() -> ClaimFormat:
-    """Resolve ``TOTALRECLAW_CLAIM_FORMAT`` — "claim" (default) or "legacy".
-
-    - ``claim`` (default, unset, or unknown): new canonical Claim blob.
-    - ``legacy``: old ``{text, metadata}`` doc shape; entity trapdoors are
-      still added to blind indices even in legacy mode.
-
-    Read on every call so tests can toggle via env without module reload.
-    """
-    raw = (os.environ.get("TOTALRECLAW_CLAIM_FORMAT") or "").strip().lower()
-    return "legacy" if raw == "legacy" else "claim"
 
 
 def resolve_digest_mode() -> DigestMode:
     """Resolve ``TOTALRECLAW_DIGEST_MODE`` — "on" (default), "off", "template".
 
-    - ``on`` (default, unset, or unknown): digest injection + LLM compilation
-      when an LLM is configured; template fallback otherwise.
-    - ``off``: legacy individual-fact recall path, no digest injection.
-    - ``template``: digest injection but skip LLM entirely.
+    Digest compilation is orthogonal to the v0/v1 taxonomy split; this
+    setting stays. See ``docs/specs/totalreclaw/retrieval-improvements-v3.md``.
     """
     raw = (os.environ.get("TOTALRECLAW_DIGEST_MODE") or "").strip().lower()
     if raw == "off":
@@ -72,10 +94,12 @@ def resolve_digest_mode() -> DigestMode:
 
 
 # ---------------------------------------------------------------------------
-# Category mapping
+# Category mapping (type → compact Claim category short key for display)
 # ---------------------------------------------------------------------------
 
-TYPE_TO_CATEGORY: Dict[str, str] = {
+#: Legacy v0 type → compact category short key. Kept for decoding pre-v1
+#: vault entries whose decrypted blob still carries a v0 token string.
+TYPE_TO_CATEGORY_V0: Dict[str, str] = {
     "fact": "fact",
     "preference": "pref",
     "decision": "dec",
@@ -83,87 +107,217 @@ TYPE_TO_CATEGORY: Dict[str, str] = {
     "goal": "goal",
     "context": "ctx",
     "summary": "sum",
-    # Phase 2.2: rule = reusable operational rule, gotcha, debugging shortcut, or
-    # convention the user wants to remember for next time. Distinct from decision
-    # (which has reasoning for a specific choice) and preference (personal taste).
     "rule": "rule",
+}
+
+#: v1 type → compact category short key for recall display. Matches the
+#: plugin's ``TYPE_TO_CATEGORY_V1``. ``directive`` / ``commitment`` map onto
+#: the ``rule`` / ``goal`` display tags so the recall UI is consistent with
+#: the pre-v1 category labels the user is used to seeing.
+TYPE_TO_CATEGORY_V1: Dict[str, str] = {
+    "claim": "claim",
+    "preference": "pref",
+    "directive": "rule",
+    "commitment": "goal",
+    "episode": "epi",
+    "summary": "sum",
+}
+
+#: Backward-compat alias — prefer the versioned maps in new code.
+TYPE_TO_CATEGORY: Dict[str, str] = {
+    **TYPE_TO_CATEGORY_V0,
+    **TYPE_TO_CATEGORY_V1,
 }
 
 
 def map_type_to_category(fact_type: str) -> str:
-    """Map an ExtractedFact type string → the compact Claim category short key.
+    """Map any memory type (v1 or legacy v0) to the compact category short key.
 
-    Unknown types fall back to ``"fact"`` so a bad LLM response never crashes
-    the write path.
+    v1 types take priority; unknown tokens fall through to the v0 table for
+    pre-v1 vault entries; anything else returns ``"fact"``.
     """
-    return TYPE_TO_CATEGORY.get(fact_type, "fact")
+    if fact_type in TYPE_TO_CATEGORY_V1:
+        return TYPE_TO_CATEGORY_V1[fact_type]
+    return TYPE_TO_CATEGORY_V0.get(fact_type, "fact")
 
 
 # ---------------------------------------------------------------------------
-# Canonical Claim builder
+# Canonical Claim builder (v1 — plugin v3.0.0 / python 2.0.0 default)
 # ---------------------------------------------------------------------------
 
 
 def _now_iso() -> str:
-    """Current time as ``YYYY-MM-DDTHH:MM:SS.sssZ`` (same shape as plugin)."""
-    # Plugin uses ``new Date().toISOString()`` → millisecond precision + ``Z``.
+    """Current time as ``YYYY-MM-DDTHH:MM:SS.sssZ`` (same shape as the TS plugin)."""
     now = datetime.now(timezone.utc)
     return now.strftime("%Y-%m-%dT%H:%M:%S.") + f"{now.microsecond // 1000:03d}Z"
+
+
+def build_canonical_claim_v1(
+    fact: Any,
+    importance: int,
+    created_at: Optional[str] = None,
+    superseded_by: Optional[str] = None,
+    expires_at: Optional[str] = None,
+    claim_id: Optional[str] = None,
+) -> str:
+    """Build a v1 ``MemoryClaimV1`` JSON blob.
+
+    Mirrors the TS plugin's ``buildCanonicalClaimV1`` function-for-function.
+
+    The pipeline:
+
+      1. Build the full v1 payload object (including plugin-only extras
+         like ``volatility`` and ``schema_version``).
+      2. Validate the core-required subset through
+         :func:`totalreclaw_core.validate_memory_claim_v1` (throws on
+         invalid type, source, or missing id).
+      3. Re-attach plugin-only extras (``schema_version``, ``volatility``)
+         to the validated canonical payload and return as a JSON string.
+
+    The outer protobuf wrapper's ``version`` field must be set to
+    :data:`PROTOBUF_VERSION_V4` (4) when storing the returned payload.
+
+    Raises
+    ------
+    ValueError
+        If the fact does not have a valid v1 ``source`` set — v1 requires
+        every claim to carry provenance.
+    """
+    text = _attr(fact, "text")
+    fact_type = normalize_to_v1_type(_attr(fact, "type", "claim"))
+    source = _attr(fact, "source")
+    scope = _attr(fact, "scope", "unspecified")
+    reasoning = _attr(fact, "reasoning", None)
+    entities = _attr(fact, "entities", None)
+    confidence_raw = _attr(fact, "confidence", 0.85)
+    volatility = _attr(fact, "volatility", None)
+
+    if not source:
+        raise ValueError(
+            "build_canonical_claim_v1: fact.source is required (v1 taxonomy mandates provenance)"
+        )
+    if source not in VALID_MEMORY_SOURCES:
+        raise ValueError(f"build_canonical_claim_v1: invalid source {source!r}")
+
+    resolved_id = claim_id or str(uuid.uuid4())
+    resolved_created_at = created_at or _now_iso()
+    resolved_importance = max(1, min(10, _js_round(float(importance))))
+    resolved_confidence = 0.85 if confidence_raw is None else float(confidence_raw)
+    resolved_confidence = max(0.0, min(1.0, resolved_confidence))
+
+    # Core-canonical subset sent through validate_memory_claim_v1.
+    core_payload: Dict[str, Any] = {
+        "id": resolved_id,
+        "text": text,
+        "type": fact_type,
+        "source": source,
+        "created_at": resolved_created_at,
+        "importance": resolved_importance,
+        "confidence": resolved_confidence,
+    }
+
+    if scope and scope in VALID_MEMORY_SCOPES:
+        core_payload["scope"] = scope
+    if isinstance(reasoning, str) and reasoning:
+        core_payload["reasoning"] = reasoning[:256]
+    if entities:
+        ent_list: List[Dict[str, Any]] = []
+        for e in list(entities)[:8]:
+            name = _attr(e, "name")
+            etype = _attr(e, "type")
+            role = _attr(e, "role", None)
+            if not (isinstance(name, str) and isinstance(etype, str)):
+                continue
+            entry: Dict[str, Any] = {"name": name, "type": etype}
+            if role:
+                entry["role"] = role
+            ent_list.append(entry)
+        if ent_list:
+            core_payload["entities"] = ent_list
+    if expires_at:
+        core_payload["expires_at"] = expires_at
+    if superseded_by:
+        core_payload["superseded_by"] = superseded_by
+
+    # Attach schema_version BEFORE validation — core's v1 struct requires it.
+    core_payload["schema_version"] = V1_SCHEMA_VERSION
+
+    validated = _core.validate_memory_claim_v1(
+        json.dumps(core_payload, ensure_ascii=False, separators=(",", ":"))
+    )
+    canonical = json.loads(validated)
+    if not isinstance(canonical, dict):
+        raise RuntimeError("validate_memory_claim_v1 did not return an object")
+
+    # Re-attach plugin-only extras not round-tripped by core's validator.
+    canonical["schema_version"] = V1_SCHEMA_VERSION
+    if volatility and volatility in VALID_MEMORY_VOLATILITIES:
+        canonical["volatility"] = volatility
+
+    return json.dumps(canonical, ensure_ascii=False, separators=(",", ":"))
 
 
 def build_canonical_claim(
     fact: Any,
     importance: int,
-    source_agent: str,
+    source_agent: str = "",
     extracted_at: Optional[str] = None,
 ) -> str:
-    """Construct a canonical Claim JSON string from an ExtractedFact-like object.
+    """Construct a canonical claim JSON string from an ExtractedFact-like object.
 
-    The input ``fact`` can be either an ``ExtractedFact`` dataclass-like object
-    (with ``text``, ``type``, optional ``confidence``, optional ``entities``) or
-    a plain dict with the same keys. The output is byte-identical to what the
-    plugin's TypeScript ``buildCanonicalClaim`` produces for the same logical
-    claim — field order, default omission rules, everything.
+    As of ``totalreclaw`` 2.0.0 this unconditionally emits a Memory Taxonomy
+    v1 JSON blob (``schema_version == "1.0"``) — forwarded to
+    :func:`build_canonical_claim_v1`. The legacy v0 short-key
+    ``{t, c, cf, i, sa, ea}`` format is no longer produced on the write path.
 
-    Encrypt the returned string directly; do not re-stringify it.
+    The outer protobuf wrapper's ``version`` field MUST be set to
+    :data:`PROTOBUF_VERSION_V4` when storing the returned payload.
+
+    ``source_agent`` is retained on the signature for legacy back-compat but
+    is ignored — v1 provenance lives in ``fact.source``. When the input fact
+    has no ``source`` set we supply ``"user-inferred"`` as a defensive
+    default so a misconfigured extraction path does not drop the write.
     """
-    text = _attr(fact, "text")
-    fact_type = _attr(fact, "type")
-    confidence = _attr(fact, "confidence", 0.85)
-    if confidence is None:
-        confidence = 0.85
-    entities = _attr(fact, "entities", None)
+    # Defensive: ensure fact.source is populated before v1 validation.
+    fact_source = _attr(fact, "source")
+    if not fact_source:
+        if isinstance(fact, dict):
+            fact = dict(fact)
+            fact["source"] = "user-inferred"
+        else:
+            # dataclass: set the attribute in place
+            try:
+                setattr(fact, "source", "user-inferred")
+            except Exception:
+                fact = {**_fact_to_dict(fact), "source": "user-inferred"}
 
-    claim: Dict[str, Any] = {
-        "t": text,
-        "c": map_type_to_category(fact_type),
-        "cf": confidence,
-        "i": importance,
-        "sa": source_agent,
-        "ea": extracted_at if extracted_at is not None else _now_iso(),
-    }
+    return build_canonical_claim_v1(
+        fact,
+        importance=importance,
+        created_at=extracted_at,
+    )
 
-    if entities:
-        e_list: List[Dict[str, Any]] = []
-        for e in entities:
-            name = _attr(e, "name")
-            etype = _attr(e, "type")
-            role = _attr(e, "role", None)
-            entry: Dict[str, Any] = {"n": name, "tp": etype}
-            if role:
-                entry["r"] = role
-            e_list.append(entry)
-        if e_list:
-            claim["e"] = e_list
 
-    # json.dumps preserves insertion order for dicts — the canonical_claim
-    # core function reparses and re-emits in the core's own canonical order
-    # anyway, so intermediate dict ordering is irrelevant to correctness.
-    return _core.canonicalize_claim(json.dumps(claim, ensure_ascii=False, separators=(",", ":")))
+def _fact_to_dict(fact: Any) -> Dict[str, Any]:
+    """Last-resort dataclass→dict conversion for the defensive source default."""
+    if isinstance(fact, dict):
+        return dict(fact)
+    out: Dict[str, Any] = {}
+    for key in (
+        "text", "type", "importance", "action", "confidence", "entities",
+        "source", "scope", "reasoning", "volatility",
+    ):
+        if hasattr(fact, key):
+            out[key] = getattr(fact, key)
+    return out
 
 
 # ---------------------------------------------------------------------------
-# Legacy ``{text, metadata}`` doc shape (pre-KG fallback)
+# Legacy ``{text, metadata}`` doc shape — retained for fixture decoding ONLY.
+#
+# Python 2.0.0 does not produce legacy docs; they exist only so pre-v1
+# vault entries remain decodable. Kept here so existing external tests
+# that reference ``build_legacy_doc`` still compile, but tagged deprecated.
 # ---------------------------------------------------------------------------
 
 
@@ -173,11 +327,11 @@ def build_legacy_doc(
     source: str,
     created_at: Optional[str] = None,
 ) -> str:
-    """Build the legacy ``{text, metadata}`` document.
+    """Build a legacy ``{text, metadata}`` doc.
 
-    Kept so the ``TOTALRECLAW_CLAIM_FORMAT=legacy`` fallback emits blobs the
-    existing ``parseClaimOrLegacy`` path has always handled. Output must be
-    byte-identical to the plugin's ``buildLegacyDoc``.
+    .. deprecated:: 2.0.0
+        No Python caller produces legacy docs; v1 is the default write path.
+        This helper is retained only for back-compat decoding tests.
     """
     text = _attr(fact, "text")
     fact_type = _attr(fact, "type")
@@ -197,44 +351,55 @@ def build_legacy_doc(
 # Digest helpers (Stage 3b read path)
 # ---------------------------------------------------------------------------
 
-#: Plain SHA-256("type:digest") as hex. The ``type:`` namespace prefix keeps
-#: it distinct from any user word trapdoor. Uses plain SHA-256 (not HMAC) so
-#: it lives in the existing ``blind_indices`` array alongside word/stem trapdoors.
 DIGEST_TRAPDOOR: str = hashlib.sha256(b"type:digest").hexdigest()
-
-#: Compact category short key for digest claims (ClaimCategory::Digest).
 DIGEST_CATEGORY: str = "dig"
-
-#: Distinctive source marker so operators can grep for Python-origin digest writes.
 DIGEST_SOURCE_AGENT: str = "hermes-agent-digest"
-
-#: Hard ceiling on claim count for LLM-assisted digest compilation.
-#: Above this, the template path is forced to keep token cost bounded.
 DIGEST_CLAIM_CAP: int = 200
 
 
 # ---------------------------------------------------------------------------
-# Decrypted blob reader — handles both new Claim and legacy shapes
+# Decrypted blob reader — handles v1 JSON, v0 short-key Claims, and legacy docs
 # ---------------------------------------------------------------------------
 
 
-def read_claim_from_blob(decrypted_json: str) -> Dict[str, Any]:
-    """Read a decrypted blob as a logical ``{text, importance, category, metadata}``.
+def is_v1_blob(decrypted: str) -> bool:
+    """Heuristic: does a decrypted blob look like a v1 JSON payload?
 
-    Handles:
-
-      * new canonical Claim format with compact short keys (``t, c, i, ...``)
-      * legacy plugin ``{text, metadata: {importance: 0-1}}`` format
-      * malformed JSON and other edge cases
-
-    Output is intentionally the same shape as the plugin's ``readClaimFromBlob``
-    so search / export / re-rank code can be written once and share.
+    Checks for the ``schema_version`` marker plus the long-form ``text`` and
+    ``type`` fields. Returns ``False`` on any parse error.
     """
     try:
-        obj = json.loads(decrypted_json)
+        obj = json.loads(decrypted)
+    except (ValueError, TypeError):
+        return False
+    return (
+        isinstance(obj, dict)
+        and isinstance(obj.get("text"), str)
+        and isinstance(obj.get("type"), str)
+        and isinstance(obj.get("schema_version"), str)
+        and obj["schema_version"].startswith("1.")
+    )
+
+
+def read_blob_unified(decrypted: str) -> Dict[str, Any]:
+    """Unified decrypted blob reader with v1-first precedence.
+
+    Tries in order:
+      1. **v1 JSON** — long-form fields + ``schema_version`` "1.x".
+      2. **v0 short-key Claim** — ``{t, c, cf, i, sa, ea, ...}``.
+      3. **Legacy plugin doc** — ``{text, metadata: {...}}``.
+      4. **Raw text fallback** — unrecognized shape returned as-is.
+
+    Returns the same ``{text, importance, category, metadata}`` shape as the
+    plugin's :func:`readClaimFromBlob`. ``metadata`` carries the v1 source
+    /scope /volatility /reasoning /schema_version when available, so callers
+    applying Tier 1 source-weighted reranking can read the source directly.
+    """
+    try:
+        obj = json.loads(decrypted)
     except (ValueError, TypeError):
         return {
-            "text": decrypted_json,
+            "text": decrypted,
             "importance": 5,
             "category": "fact",
             "metadata": {},
@@ -242,46 +407,68 @@ def read_claim_from_blob(decrypted_json: str) -> Dict[str, Any]:
 
     if not isinstance(obj, dict):
         return {
-            "text": decrypted_json,
+            "text": decrypted,
             "importance": 5,
             "category": "fact",
             "metadata": {},
         }
 
-    # New canonical Claim format: short keys
-    t = obj.get("t")
-    c = obj.get("c")
-    if isinstance(t, str) and isinstance(c, str):
+    # 1. v1 JSON payload: long-form fields + schema_version "1.x"
+    schema_version = obj.get("schema_version")
+    if (
+        isinstance(obj.get("text"), str)
+        and isinstance(obj.get("type"), str)
+        and isinstance(schema_version, str)
+        and schema_version.startswith("1.")
+    ):
+        imp_raw = obj.get("importance")
+        if isinstance(imp_raw, (int, float)) and not isinstance(imp_raw, bool):
+            importance = max(1, min(10, _js_round(float(imp_raw))))
+        else:
+            importance = 5
+        return {
+            "text": obj["text"],
+            "importance": importance,
+            "category": map_type_to_category(obj["type"]),
+            "metadata": {
+                "type": obj["type"],
+                "source": obj.get("source", "user-inferred") if isinstance(obj.get("source"), str) else "user-inferred",
+                "scope": obj.get("scope", "unspecified") if isinstance(obj.get("scope"), str) else "unspecified",
+                "volatility": obj.get("volatility", "updatable") if isinstance(obj.get("volatility"), str) else "updatable",
+                "reasoning": obj.get("reasoning") if isinstance(obj.get("reasoning"), str) else None,
+                "importance": importance / 10,
+                "created_at": obj.get("created_at", "") if isinstance(obj.get("created_at"), str) else "",
+                "schema_version": schema_version,
+            },
+        }
+
+    # 2. v0 canonical Claim format: compact short keys {t, c, ...}
+    t_val = obj.get("t")
+    c_val = obj.get("c")
+    if isinstance(t_val, str) and isinstance(c_val, str):
         raw_i = obj.get("i")
         if isinstance(raw_i, (int, float)) and not isinstance(raw_i, bool):
             importance = max(1, min(10, _js_round(float(raw_i))))
         else:
             importance = 5
-        sa = obj.get("sa")
-        ea = obj.get("ea")
         return {
-            "text": t,
+            "text": t_val,
             "importance": importance,
-            "category": c,
+            "category": c_val,
             "metadata": {
-                "type": c,
+                "type": c_val,
                 "importance": importance / 10,
-                "source": sa if isinstance(sa, str) else "auto-extraction",
-                "created_at": ea if isinstance(ea, str) else "",
+                "source": obj.get("sa") if isinstance(obj.get("sa"), str) else "auto-extraction",
+                "created_at": obj.get("ea") if isinstance(obj.get("ea"), str) else "",
             },
         }
 
-    # Legacy plugin {text, metadata: {importance: 0-1}} format
+    # 3. Legacy plugin {text, metadata: {importance: 0-1}} format
     legacy_text = obj.get("text")
     if isinstance(legacy_text, str):
-        meta = obj.get("metadata")
-        if not isinstance(meta, dict):
-            meta = {}
+        meta = obj.get("metadata") if isinstance(obj.get("metadata"), dict) else {}
         raw_imp = meta.get("importance")
-        if isinstance(raw_imp, (int, float)) and not isinstance(raw_imp, bool):
-            imp_float = float(raw_imp)
-        else:
-            imp_float = 0.5
+        imp_float = float(raw_imp) if isinstance(raw_imp, (int, float)) and not isinstance(raw_imp, bool) else 0.5
         importance = max(1, min(10, _js_round(imp_float * 10)))
         category = meta.get("type") if isinstance(meta.get("type"), str) else "fact"
         return {
@@ -291,21 +478,23 @@ def read_claim_from_blob(decrypted_json: str) -> Dict[str, Any]:
             "metadata": meta,
         }
 
-    # Fallback: unrecognized JSON object shape.
+    # 4. Unrecognized JSON object shape — fall back.
     return {
-        "text": decrypted_json,
+        "text": decrypted,
         "importance": 5,
         "category": "fact",
         "metadata": {},
     }
 
 
-def is_digest_blob(decrypted: str) -> bool:
-    """Does this decrypted blob look like a digest claim?
+#: Back-compat alias — prefer :func:`read_blob_unified` in new code.
+def read_claim_from_blob(decrypted_json: str) -> Dict[str, Any]:
+    """Back-compat alias for :func:`read_blob_unified`."""
+    return read_blob_unified(decrypted_json)
 
-    Returns True only for canonical Claim JSON with ``c == "dig"``.
-    Returns False for legacy docs, malformed JSON, or any other shape.
-    """
+
+def is_digest_blob(decrypted: str) -> bool:
+    """Does this decrypted blob look like a digest claim?"""
     try:
         obj = json.loads(decrypted)
     except (ValueError, TypeError):
@@ -319,10 +508,9 @@ def build_digest_claim(
 ) -> str:
     """Wrap a Digest JSON as a canonical Claim with category ``dig``.
 
-    Stores the raw Digest JSON as the claim's ``t`` field. Reader path is
-    ``parse_claim_or_legacy → extract_digest_from_claim``. Digest claims
-    deliberately carry no entity refs — otherwise entity trapdoors would
-    surface the digest blob in normal recall queries.
+    Digest claims use the v0 short-key format — they are an internal
+    read-path artifact, not a user-facing memory, so they do not need to
+    be in the v1 taxonomy.
     """
     claim: Dict[str, Any] = {
         "t": digest_json,
@@ -340,9 +528,8 @@ def build_digest_claim(
 def extract_digest_from_claim(canonical_claim_json: str) -> Optional[Dict[str, Any]]:
     """Inverse of :func:`build_digest_claim`.
 
-    Given a canonical Claim JSON (as returned by ``parse_claim_or_legacy``),
-    return the wrapped Digest object, or ``None`` if the claim is not a
-    digest or the inner JSON fails to parse.
+    Given a canonical Claim JSON, return the wrapped Digest object,
+    or ``None`` if the claim is not a digest / inner JSON fails to parse.
     """
     try:
         claim = json.loads(canonical_claim_json)
@@ -361,7 +548,6 @@ def extract_digest_from_claim(canonical_claim_json: str) -> Optional[Dict[str, A
         return None
     if not isinstance(digest, dict):
         return None
-    # Minimal shape check: a Digest must at least have prompt_text.
     if not isinstance(digest.get("prompt_text"), str):
         return None
     return digest
@@ -373,15 +559,8 @@ def extract_digest_from_claim(canonical_claim_json: str) -> Optional[Dict[str, A
 
 
 def hours_since(compiled_at_iso: str, now_ms: int) -> float:
-    """Hours between ``compiled_at_iso`` and ``now_ms``.
-
-    Returns ``float('inf')`` if the timestamp is unparseable (forces a
-    recompile, the safe default). Returns 0 for future dates (clock-skew
-    defensive).
-    """
+    """Hours between ``compiled_at_iso`` and ``now_ms``."""
     try:
-        # Python's fromisoformat handles +00:00 but not 'Z' before 3.11;
-        # we're on >=3.11 per pyproject but normalize anyway.
         normalized = compiled_at_iso
         if normalized.endswith("Z"):
             normalized = normalized[:-1] + "+00:00"
@@ -398,16 +577,11 @@ def hours_since(compiled_at_iso: str, now_ms: int) -> float:
 
 
 def is_digest_stale(digest_version: int, current_max_created_at_unix: int) -> bool:
-    """The digest is stale if new claims have been written since compilation.
-
-    Both inputs are Unix seconds. Equal or regressing values (clock skew,
-    empty vault) return False — we only recompile on strictly-newer evidence.
-    """
     return current_max_created_at_unix > digest_version
 
 
 def should_recompile(count_new_claims: int, hours_since_compilation: float) -> bool:
-    """Recompile guard (plan §15.10): 10+ new claims OR 24h+ elapsed."""
+    """Recompile guard: 10+ new claims OR 24h+ elapsed."""
     return count_new_claims >= 10 or hours_since_compilation >= 24
 
 
@@ -417,15 +591,6 @@ def should_recompile(count_new_claims: int, hours_since_compilation: float) -> b
 
 
 def compute_entity_trapdoor(name: str) -> str:
-    """Compute a single entity trapdoor: ``sha256("entity:" + normalized)`` as hex.
-
-    Uses plain SHA-256 (not HMAC) — the same primitive as word/stem
-    trapdoors in ``rust/totalreclaw-core/src/blind.rs`` — so entity
-    trapdoors live in the same ``blind_indices`` array and are findable
-    by the existing search pipeline. The ``entity:`` prefix namespaces the
-    hash so a user named "postgresql" never collides with the word
-    trapdoor for the token "postgresql".
-    """
     normalized = _core.normalize_entity_name(name)
     return hashlib.sha256(b"entity:" + normalized.encode("utf-8")).hexdigest()
 
@@ -433,11 +598,6 @@ def compute_entity_trapdoor(name: str) -> str:
 def compute_entity_trapdoors(
     entities: Optional[Sequence[Any]],
 ) -> List[str]:
-    """Compute trapdoors for every entity on a fact, deduplicated.
-
-    Returns an empty list when the input is ``None`` or empty. Input can be
-    a list of dicts (``{"name": ..., "type": ...}``) or dataclass instances.
-    """
     if not entities:
         return []
     seen: set[str] = set()

--- a/python/src/totalreclaw/client.py
+++ b/python/src/totalreclaw/client.py
@@ -224,18 +224,52 @@ class TotalReclaw:
         embedding: Optional[list[float]] = None,
         importance: float = 0.5,
         source: str = "python-client",
-        fact_type: str = "fact",
+        fact_type: str = "claim",
         entities: Optional[list] = None,
         confidence: float = 0.85,
+        # v1 taxonomy fields — part of the default write path as of 2.0.0.
+        provenance: str = "user",
+        scope: str = "unspecified",
+        reasoning: Optional[str] = None,
+        volatility: Optional[str] = None,
     ) -> str:
         """Store a fact. Returns the fact ID.
 
-        Phase 2.2.6: now forwards ``fact_type``, ``entities``, and ``confidence``
-        through to ``store_fact``, so consumers like Hermes
-        ``tools.remember`` can route explicit remember calls through the
-        canonical Claim path (with a real type classification) instead of
-        storing everything as ``type='fact'``. Backward-compat defaults match
-        the prior silent behavior.
+        Memory Taxonomy v1 is the default (and only) write path. The stored
+        blob is a v1 JSON payload (``schema_version == "1.0"``) and the
+        outer protobuf wrapper is tagged ``version == 4``.
+
+        Parameters
+        ----------
+        text : str
+            The fact text (max 512 chars after v1 normalization).
+        embedding : list[float], optional
+            Pre-computed embedding. When supplied, LSH trapdoors are generated.
+        importance : float
+            1-10 integer, or 0-1 float (auto-normalized). Defaults to 0.5 → 5.
+        source : str
+            The client-source tag written to the outer protobuf ``source``
+            field (legacy / server-side analytics field). For v1 provenance
+            (user vs assistant), use ``provenance`` below.
+        fact_type : str, default "claim"
+            v1 type (claim | preference | directive | commitment | episode
+            | summary). Legacy v0 tokens (fact, decision, episodic, goal,
+            context, rule) are coerced transparently.
+        entities : list, optional
+            List of entity dicts or ``ExtractedEntity`` instances.
+        confidence : float, default 0.85
+            LLM-self-reported confidence.
+        provenance : str, default "user"
+            v1 source field written into the canonical claim. Default
+            ``"user"`` since the explicit tool path means the caller typed it.
+        scope : str, default "unspecified"
+            v1 life-domain scope.
+        reasoning : str, optional
+            "because Y" clause — only meaningful for decision-style claims
+            (type=claim with an explicit reasoning clause).
+        volatility : str, optional
+            Post-extraction rescored volatility; usually left blank on
+            explicit remember calls (the store path picks a default).
         """
         await self._ensure_address()
         await self._ensure_registered()
@@ -252,6 +286,10 @@ class TotalReclaw:
             fact_type=fact_type,
             entities=entities,
             confidence=confidence,
+            provenance=provenance,
+            scope=scope,
+            reasoning=reasoning,
+            volatility=volatility,
             eoa_private_key=self._eoa_private_key,
             eoa_address=self._eoa_address,
             sender=self._wallet_address,

--- a/python/src/totalreclaw/hermes/plugin.yaml
+++ b/python/src/totalreclaw/hermes/plugin.yaml
@@ -1,6 +1,6 @@
 name: totalreclaw
-version: 0.1.0
-description: End-to-end encrypted memory vault for AI agents
+version: 2.0.0
+description: End-to-end encrypted memory vault for AI agents (Memory Taxonomy v1)
 author: TotalReclaw Team
 provides_tools:
   - totalreclaw_remember

--- a/python/src/totalreclaw/hermes/schemas.py
+++ b/python/src/totalreclaw/hermes/schemas.py
@@ -1,13 +1,24 @@
 """Tool schemas for Hermes Agent (OpenAI function-calling format)."""
 
-from totalreclaw.agent.extraction import VALID_MEMORY_TYPES
+from totalreclaw.agent.extraction import (
+    LEGACY_V0_MEMORY_TYPES,
+    VALID_MEMORY_SCOPES,
+    VALID_MEMORY_TYPES,
+)
+
+# Accept both v1 tokens and legacy v0 tokens — the ``normalize_to_v1_type``
+# coercion inside ``remember`` maps v0 → v1 transparently.
+_REMEMBER_TYPE_ENUM = list(VALID_MEMORY_TYPES) + list(LEGACY_V0_MEMORY_TYPES)
 
 REMEMBER = {
     "name": "totalreclaw_remember",
     "description": (
         "Store a memory in TotalReclaw's encrypted vault. Use this to save important "
         "facts, preferences, decisions, rules (reusable gotchas / conventions), or "
-        "context about the user. Memories are E2E encrypted and portable across AI agents."
+        "context about the user. Memories are E2E encrypted and portable across AI agents. "
+        "Uses Memory Taxonomy v1 (claim | preference | directive | commitment | episode | "
+        "summary); legacy v0 tokens (fact, decision, episodic, goal, context, rule) are "
+        "coerced transparently."
     ),
     "parameters": {
         "type": "object",
@@ -18,12 +29,28 @@ REMEMBER = {
             },
             "type": {
                 "type": "string",
-                "enum": list(VALID_MEMORY_TYPES),
+                "enum": _REMEMBER_TYPE_ENUM,
                 "description": (
-                    "Memory category. One of: fact, preference, decision, episodic, goal, "
-                    "context, summary, rule. Use 'rule' for reusable operational gotchas "
-                    '("always X", "never Y"), conventions, and debugging shortcuts the '
-                    "user wants to remember for next time. Default: fact."
+                    "Memory Taxonomy v1 type. Preferred values: claim (factual assertion), "
+                    "preference (likes/dislikes), directive (reusable rule like 'always X'), "
+                    "commitment (future intent), episode (notable event), summary (derived "
+                    "synthesis). Legacy v0 tokens (fact, decision, episodic, goal, context, "
+                    "rule) are accepted and coerced to the v1 equivalent. Default: claim."
+                ),
+            },
+            "scope": {
+                "type": "string",
+                "enum": list(VALID_MEMORY_SCOPES),
+                "description": (
+                    "v1 life-domain scope. One of: work, personal, health, family, "
+                    "creative, finance, misc, unspecified. Default: unspecified."
+                ),
+            },
+            "reasoning": {
+                "type": "string",
+                "description": (
+                    "For decision-style claims (type=claim with a 'because Y' clause), "
+                    "the WHY of the decision. Max 256 chars. Optional."
                 ),
             },
             "importance": {

--- a/python/src/totalreclaw/hermes/tools.py
+++ b/python/src/totalreclaw/hermes/tools.py
@@ -17,15 +17,19 @@ _SMALL_IMPORT_THRESHOLD = 50
 
 
 async def remember(args: dict, state: "PluginState", **kwargs) -> str:
-    """Store a memory in TotalReclaw.
+    """Store a memory in TotalReclaw (v1 taxonomy).
 
-    Phase 2.2.6: now forwards ``type`` + ``importance`` from the tool call to
-    the canonical Claim builder via ``client.remember``. Prior to 2.2.6 the
-    tool accepted only ``text`` + ``importance`` and stored everything as
-    ``type='fact'``, making the rule category structurally unreachable from
-    Hermes.
+    Accepts v1 taxonomy fields: ``type`` (claim | preference | directive |
+    commitment | episode | summary), optional ``scope``, optional
+    ``reasoning`` for decision-style claims, plus the legacy ``importance``
+    slider. Legacy v0 tokens (fact, decision, episodic, goal, context,
+    rule) are coerced transparently via :func:`normalize_to_v1_type`.
     """
-    from totalreclaw.agent.extraction import VALID_MEMORY_TYPES
+    from totalreclaw.agent.extraction import (
+        VALID_MEMORY_TYPES,
+        VALID_MEMORY_SCOPES,
+        normalize_to_v1_type,
+    )
 
     client = state.get_client()
     if not client:
@@ -35,20 +39,24 @@ async def remember(args: dict, state: "PluginState", **kwargs) -> str:
     if not text:
         return json.dumps({"error": "No text provided"})
 
-    # Default importance to 8 for explicit remember (same convention as
-    # the OpenClaw plugin) — higher than auto-extraction's typical 6-7 so
-    # store-time dedup's shouldSupersede prefers the explicit call.
+    # Default importance to 8 for explicit remember (matches plugin).
     raw_importance = args.get("importance", 8)
     try:
         importance_val = float(raw_importance)
     except (TypeError, ValueError):
         importance_val = 8.0
-    # store_fact handles both 0.0-1.0 and 1-10 input, but we clamp to sensible range
     importance_val = max(1.0, min(10.0, importance_val))
 
-    # Validate + default the type
-    fact_type_raw = args.get("type", "fact")
-    fact_type = fact_type_raw if fact_type_raw in VALID_MEMORY_TYPES else "fact"
+    # Validate + normalize the v1 type (legacy v0 tokens coerced).
+    fact_type_raw = args.get("type", "claim")
+    fact_type = normalize_to_v1_type(fact_type_raw)
+
+    # v1 scope + reasoning (both optional)
+    scope_raw = str(args.get("scope", "unspecified")).lower()
+    scope = scope_raw if scope_raw in VALID_MEMORY_SCOPES else "unspecified"
+    reasoning = args.get("reasoning")
+    if reasoning is not None and not isinstance(reasoning, str):
+        reasoning = None
 
     try:
         embedding = None
@@ -63,9 +71,18 @@ async def remember(args: dict, state: "PluginState", **kwargs) -> str:
             embedding=embedding,
             importance=importance_val,
             fact_type=fact_type,
+            provenance="user",  # explicit remember → user provenance
+            scope=scope,
+            reasoning=reasoning,
             confidence=1.0,  # explicit remember = highest confidence
         )
-        return json.dumps({"stored": True, "fact_id": fact_id, "type": fact_type, "importance": importance_val})
+        return json.dumps({
+            "stored": True,
+            "fact_id": fact_id,
+            "type": fact_type,
+            "scope": scope,
+            "importance": importance_val,
+        })
     except Exception as e:
         logger.error("totalreclaw_remember failed: %s", e)
         return json.dumps({"error": str(e)})
@@ -345,7 +362,7 @@ def _make_extractor(state: "PluginState"):
     from totalreclaw.agent.extraction import (
         EXTRACTION_SYSTEM_PROMPT,
         _truncate_messages,
-        _parse_response,
+        parse_facts_response,
     )
     from totalreclaw.agent.llm_client import detect_llm_config, chat_completion
 
@@ -373,13 +390,17 @@ def _make_extractor(state: "PluginState"):
         if not response:
             return []
 
-        parsed = _parse_response(response)
+        # v1 parser returns facts with source/scope/reasoning populated.
+        parsed = parse_facts_response(response)
         return [
             {
                 "text": f.text,
                 "type": f.type,
                 "importance": f.importance,
                 "action": f.action,
+                "source": f.source,
+                "scope": f.scope,
+                "reasoning": f.reasoning,
             }
             for f in parsed
         ]

--- a/python/src/totalreclaw/operations.py
+++ b/python/src/totalreclaw/operations.py
@@ -34,11 +34,12 @@ from .reranker import RerankerCandidate, RerankerResult, rerank
 from .tuning_loop import maybe_write_feedback_for_pin
 from .userop import build_and_send_userop
 from .claims_helper import (
-    build_canonical_claim,
+    PROTOBUF_VERSION_V4,
+    build_canonical_claim_v1,
     compute_entity_trapdoors,
     is_digest_blob,
+    read_blob_unified,
     read_claim_from_blob,
-    resolve_claim_format,
 )
 
 # GraphQL queries — matching TypeScript search.ts
@@ -163,19 +164,42 @@ async def store_fact(
     eoa_address: Optional[str] = None,
     sender: Optional[str] = None,
     chain_id: int = 84532,
-    fact_type: str = "fact",
+    fact_type: str = "claim",
     entities: Optional[list] = None,
     confidence: float = 0.85,
     extracted_at: Optional[str] = None,
+    # v1 taxonomy fields (default path as of totalreclaw 2.0.0)
+    provenance: str = "user",
+    scope: str = "unspecified",
+    reasoning: Optional[str] = None,
+    volatility: Optional[str] = None,
 ) -> str:
     """Encrypt and store a fact on-chain via relay.
 
-    KG Phase 1: when ``TOTALRECLAW_CLAIM_FORMAT != 'legacy'`` (default), the
-    encrypted blob is a canonical ``Claim`` JSON matching the plugin's format.
-    Entity trapdoors are added to blind indices regardless of format so new
-    facts are findable via entity-specific search once the read path is KG-aware.
+    As of ``totalreclaw`` 2.0.0 this unconditionally emits a Memory Taxonomy
+    v1 JSON blob and tags the outer protobuf wrapper with
+    :data:`PROTOBUF_VERSION_V4`. Legacy v0 tokens in ``fact_type`` (e.g.
+    ``"fact"``, ``"decision"``, ``"episodic"``) are coerced to v1 via the
+    v0→v1 map inside :func:`build_canonical_claim_v1`.
 
-    Returns the fact ID.
+    Parameters
+    ----------
+    provenance : str, default "user"
+        v1 source field — one of user | user-inferred | assistant | external |
+        derived. The explicit ``client.remember()`` path defaults to
+        ``"user"`` because the caller explicitly typed the text. Auto-
+        extraction should pass the source tagged by ``apply_provenance_filter_lax``.
+    scope : str, default "unspecified"
+        v1 life-domain scope.
+    reasoning : str, optional
+        "because Y" clause for decision-style claims (v1 claim type).
+    volatility : str, optional
+        Post-extraction rescored volatility; omitted on explicit tool writes.
+
+    Returns
+    -------
+    str
+        The UUID assigned to the stored fact.
     """
     if eoa_private_key is None or eoa_address is None:
         raise ValueError(
@@ -186,23 +210,26 @@ async def store_fact(
     fact_id = str(uuid.uuid4())
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
 
-    claim_format = resolve_claim_format()
     importance_int = max(1, min(10, int(round(importance * 10)) if importance <= 1 else int(importance)))
-    if claim_format == "claim":
-        fact_stub = {
-            "text": text,
-            "type": fact_type,
-            "confidence": confidence,
-            "entities": entities,
-        }
-        blob_plaintext = build_canonical_claim(
-            fact_stub,
-            importance=importance_int,
-            source_agent=source,
-            extracted_at=extracted_at or timestamp,
-        )
-    else:
-        blob_plaintext = text
+
+    # v1 canonical claim (unconditional). source_agent is carried as
+    # ``provenance`` — the v1 `source` field on the claim itself.
+    fact_stub = {
+        "text": text,
+        "type": fact_type,
+        "source": provenance,
+        "scope": scope,
+        "reasoning": reasoning,
+        "confidence": confidence,
+        "entities": entities,
+        "volatility": volatility,
+    }
+    blob_plaintext = build_canonical_claim_v1(
+        fact_stub,
+        importance=importance_int,
+        created_at=extracted_at or timestamp,
+        claim_id=fact_id,
+    )
 
     encrypted_blob = encrypt(blob_plaintext, keys.encryption_key)
     encrypted_hex = base64.b64decode(encrypted_blob).hex()
@@ -225,7 +252,7 @@ async def store_fact(
     if embedding:
         encrypted_emb = encrypt_embedding(embedding, keys.encryption_key)
 
-    # Build protobuf payload
+    # Build protobuf payload — v1 writes ALWAYS tag the outer wrapper v4.
     payload = FactPayload(
         id=fact_id,
         timestamp=timestamp,
@@ -237,6 +264,7 @@ async def store_fact(
         content_fp=content_fp,
         agent_id=agent_id,
         encrypted_embedding=encrypted_emb,
+        version=PROTOBUF_VERSION_V4,
     )
 
     protobuf_bytes = encode_fact_protobuf(payload)
@@ -398,6 +426,13 @@ async def search_facts(
                 except Exception:
                     pass
 
+            # Surface the v1 source from decrypted blob metadata so Tier 1
+            # source-weighted reranking can multiply the fused score.
+            # Legacy v0 blobs have no v1 source — set None so the reranker
+            # applies LEGACY_CLAIM_FALLBACK_WEIGHT (0.85).
+            meta = doc.get("metadata", {}) if isinstance(doc.get("metadata"), dict) else {}
+            candidate_source: Optional[str] = meta.get("source") if isinstance(meta.get("source"), str) else None
+
             candidates.append(
                 RerankerCandidate(
                     id=fact_id,
@@ -406,6 +441,7 @@ async def search_facts(
                     importance=decay,
                     created_at=created_at,
                     category=doc.get("category", "fact"),
+                    source=candidate_source,
                 )
             )
         except Exception as e:
@@ -415,7 +451,9 @@ async def search_facts(
     if not candidates:
         return []
 
-    return rerank(query, query_embedding, candidates, top_k=top_k)
+    # Retrieval v2 Tier 1: source-weighted reranking is always ON as of
+    # totalreclaw 2.0.0, matching the TS plugin's default path.
+    return rerank(query, query_embedding, candidates, top_k=top_k, apply_source_weights=True)
 
 
 async def forget_fact(

--- a/python/src/totalreclaw/protobuf.py
+++ b/python/src/totalreclaw/protobuf.py
@@ -76,12 +76,25 @@ def _write_varint_field(parts: list[bytes], field_number: int, value: int) -> No
 # ---------------------------------------------------------------------------
 
 
+#: Default outer protobuf schema version (v3, for legacy callers).
+DEFAULT_PROTOBUF_VERSION: int = 3
+
+#: Memory Taxonomy v1 outer protobuf schema version. Signals that the
+#: inner encrypted blob is a v1 JSON payload with ``schema_version == "1.0"``.
+PROTOBUF_VERSION_V4: int = 4
+
+
 @dataclass
 class FactPayload:
     """Client-side fact payload ready for protobuf encoding.
 
     Mirrors the TypeScript ``FactPayload`` interface in
     ``mcp/src/subgraph/store.ts``.
+
+    As of ``totalreclaw`` 2.0.0, ``version`` carries the outer protobuf
+    schema version — 3 for legacy writes, 4 for v1 taxonomy writes.
+    A value of 0 (unset) is treated as ``DEFAULT_PROTOBUF_VERSION`` (3)
+    so the existing v3 call sites keep working.
     """
 
     id: str
@@ -94,6 +107,7 @@ class FactPayload:
     content_fp: str = ""
     agent_id: str = ""
     encrypted_embedding: Optional[str] = None
+    version: int = 0  # 0 → default (v3) for back-compat
 
 
 # ---------------------------------------------------------------------------
@@ -120,7 +134,8 @@ def encode_fact_protobuf(fact: FactPayload) -> bytes:
 
     _write_double(parts, 6, fact.decay_score)
     _write_varint_field(parts, 7, 1)  # is_active = true
-    _write_varint_field(parts, 8, 3)  # version = 3 (source/agent_id now encrypted inside field 4)
+    version = fact.version if fact.version else DEFAULT_PROTOBUF_VERSION
+    _write_varint_field(parts, 8, version)  # 3 = legacy, 4 = v1 taxonomy
     # Fields 9 (source) and 11 (agent_id) removed in v3 -- now encrypted inside field 4
     _write_string(parts, 10, fact.content_fp)
     # Field 12 (sequence_id) is assigned by the subgraph mapping, not the client
@@ -130,12 +145,19 @@ def encode_fact_protobuf(fact: FactPayload) -> bytes:
     return b"".join(parts)
 
 
-def encode_tombstone_protobuf(fact_id: str, owner: str) -> bytes:
+def encode_tombstone_protobuf(
+    fact_id: str, owner: str, version: int = DEFAULT_PROTOBUF_VERSION
+) -> bytes:
     """Encode a tombstone payload for soft-deleting a fact on-chain.
 
     Sets ``decay_score=0`` and ``encrypted_blob`` to the bytes of
     ``"tombstone"`` (hex-encoded), matching the managed-service delete
     convention used by the TypeScript client.
+
+    ``version`` is the outer protobuf schema version (3 legacy, 4 v1
+    taxonomy). Tombstones don't carry v1 payloads themselves — ``v4`` is
+    only meaningful when the tombstone terminates a v1-era fact chain
+    (e.g. after a pin/unpin). Default 3 preserves pre-2.0.0 behavior.
     """
     tombstone = FactPayload(
         id=fact_id,
@@ -147,5 +169,6 @@ def encode_tombstone_protobuf(fact_id: str, owner: str) -> bytes:
         source="python_forget",
         content_fp="",
         agent_id="python-client",
+        version=version,
     )
     return encode_fact_protobuf(tombstone)

--- a/python/src/totalreclaw/reranker.py
+++ b/python/src/totalreclaw/reranker.py
@@ -268,6 +268,10 @@ class RerankerCandidate:
     importance: Optional[float] = None
     created_at: Optional[float] = None  # Unix timestamp (seconds)
     category: str = "fact"
+    #: v1 provenance source ("user", "user-inferred", "assistant",
+    #: "external", "derived"). When None, the candidate is treated as a
+    #: pre-v1 legacy blob and receives the legacy-claim fallback weight.
+    source: Optional[str] = None
 
 
 @dataclass
@@ -281,6 +285,8 @@ class RerankerResult:
     category: str = "fact"
     rrf_score: float = 0.0
     cosine_sim: Optional[float] = None
+    source: Optional[str] = None
+    source_weight: Optional[float] = None
 
 
 # ---------------------------------------------------------------------------
@@ -363,12 +369,48 @@ def apply_mmr(
 # Combined Re-Ranker
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Retrieval v2 Tier 1 — source-weighted reranking (v1 taxonomy)
+# ---------------------------------------------------------------------------
+
+#: Weight for a legacy (pre-v1) candidate whose source is unknown.
+#: Mirrors ``reranker::LEGACY_CLAIM_FALLBACK_WEIGHT`` in the Rust core.
+LEGACY_CLAIM_FALLBACK_WEIGHT: float = 0.85
+
+
+def source_weight(source: Optional[str]) -> float:
+    """Return the Tier 1 provenance weight for a given v1 source string.
+
+    Unknown / missing source falls back to the legacy weight (0.85) so a
+    pre-v1 blob does not get nuked at retrieval time.
+
+    Delegates to :func:`totalreclaw_core.source_weight` when available so
+    the weight table stays in lockstep with the Rust core; the pure-Python
+    fallback mirrors the table in ``rust/totalreclaw-core/src/reranker.rs``.
+    """
+    if source is None:
+        return LEGACY_CLAIM_FALLBACK_WEIGHT
+    try:
+        return float(totalreclaw_core.source_weight(source))
+    except Exception:
+        # Fallback — keep in sync with ``MemorySource`` → weight table.
+        table = {
+            "user": 1.0,
+            "user-inferred": 0.9,
+            "external": 0.7,
+            "derived": 0.7,
+            "assistant": 0.55,
+        }
+        return table.get(source, 0.9)  # unknown ≈ user-inferred
+
+
 def rerank(
     query: str,
     query_embedding: Optional[list[float]],
     candidates: list[RerankerCandidate],
     top_k: int = 8,
     weights: Optional[RankingWeights] = None,
+    apply_source_weights: bool = False,
 ) -> list[RerankerResult]:
     """Re-rank decrypted candidates using BM25 + Cosine + Importance + Recency
     with Weighted RRF fusion and MMR diversity.
@@ -471,6 +513,11 @@ def rerank(
     for item in fused:
         c = candidate_map.get(item.id)
         if c:
+            # Retrieval v2 Tier 1: multiply the fused RRF score by the v1
+            # source weight when requested. Candidates without a v1 source
+            # (pre-v1 legacy blobs) receive LEGACY_CLAIM_FALLBACK_WEIGHT.
+            sw = source_weight(c.source) if apply_source_weights else None
+            final_score = item.score * sw if sw is not None else item.score
             rrf_results.append(RerankerResult(
                 id=c.id,
                 text=c.text,
@@ -478,9 +525,16 @@ def rerank(
                 importance=c.importance,
                 created_at=c.created_at,
                 category=c.category,
-                rrf_score=item.score,
+                rrf_score=final_score,
                 cosine_sim=cosine_scores.get(c.id),
+                source=c.source,
+                source_weight=sw,
             ))
+
+    # Re-sort after the source-weight multiply so top-k reflects the
+    # weighted order, not the pre-weight order.
+    if apply_source_weights:
+        rrf_results.sort(key=lambda r: r.rrf_score, reverse=True)
 
     # --- Step 9: Apply MMR for diversity, then return top-k ---
     return apply_mmr(rrf_results, lam=0.7, top_k=top_k)

--- a/python/tests/test_claims_helper.py
+++ b/python/tests/test_claims_helper.py
@@ -1,17 +1,21 @@
-"""Tests for claims_helper.py — the KG Phase 1 Python write + read helpers.
+"""Tests for claims_helper.py — v1 write + read helpers (python 2.0.0).
 
-Mirrors ``skill/plugin/claim-format.test.ts`` and the relevant parts of
-``skill/plugin/digest-injection.test.ts``. Every assertion that touches bytes
-(canonical output, trapdoor hashes) has a hardcoded expected value so the
-test double-checks the core's output has not drifted.
+Mirrors ``skill/plugin/claim-format.test.ts`` (v1 round-trip assertions) and
+keeps the digest / entity-trapdoor parity anchors that were byte-exact
+before the v1 switch.
+
+What changed from python 1.x:
+  * ``build_canonical_claim`` now emits a v1 JSON blob unconditionally.
+  * The ``TOTALRECLAW_CLAIM_FORMAT=legacy`` env-var gate was removed.
+  * Byte-exact reference fixtures for the v0 short-key format are gone —
+    the v1 round-trip assertions replace them.
 """
 from __future__ import annotations
 
 import hashlib
 import json
 import math
-import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import List, Optional
 
 import pytest
@@ -22,7 +26,11 @@ from totalreclaw.claims_helper import (
     DIGEST_CLAIM_CAP,
     DIGEST_SOURCE_AGENT,
     DIGEST_TRAPDOOR,
+    PROTOBUF_VERSION_V4,
+    TYPE_TO_CATEGORY_V1,
+    V1_SCHEMA_VERSION,
     build_canonical_claim,
+    build_canonical_claim_v1,
     build_digest_claim,
     build_legacy_doc,
     compute_entity_trapdoor,
@@ -31,16 +39,17 @@ from totalreclaw.claims_helper import (
     hours_since,
     is_digest_blob,
     is_digest_stale,
+    is_v1_blob,
     map_type_to_category,
+    read_blob_unified,
     read_claim_from_blob,
-    resolve_claim_format,
     resolve_digest_mode,
     should_recompile,
 )
 
 
 # ---------------------------------------------------------------------------
-# Fact fixtures (dataclass-like, mirroring the plugin's ExtractedFact type)
+# Test fixtures (dataclass mirrors the Python ExtractedFact shape)
 # ---------------------------------------------------------------------------
 
 
@@ -60,11 +69,33 @@ class _Fact:
     confidence: Optional[float] = None
     entities: Optional[List[_Entity]] = None
     existing_fact_id: Optional[str] = None
+    # v1 fields
+    source: Optional[str] = "user"
+    scope: Optional[str] = "unspecified"
+    reasoning: Optional[str] = None
+    volatility: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
-# map_type_to_category
+# map_type_to_category — v1 types map to display tags used by the recall UI.
+# Legacy v0 tokens still decode (read path), so their category short keys
+# are retained in ``TYPE_TO_CATEGORY_V0``.
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fact_type,category",
+    [
+        ("claim", "claim"),
+        ("preference", "pref"),
+        ("directive", "rule"),
+        ("commitment", "goal"),
+        ("episode", "epi"),
+        ("summary", "sum"),
+    ],
+)
+def test_map_type_to_category_v1(fact_type: str, category: str) -> None:
+    assert map_type_to_category(fact_type) == category
 
 
 @pytest.mark.parametrize(
@@ -77,140 +108,158 @@ class _Fact:
         ("goal", "goal"),
         ("context", "ctx"),
         ("summary", "sum"),
-        ("rule", "rule"),  # Phase 2.2: 8th memory type
+        ("rule", "rule"),
     ],
 )
-def test_map_type_to_category(fact_type: str, category: str) -> None:
-    assert map_type_to_category(fact_type) == category
+def test_map_type_to_category_v0_still_decodes(fact_type: str, category: str) -> None:
+    """Legacy v0 tokens still map to a category so pre-v1 blobs stay decodable."""
+    # v1 map takes priority for overlap: "preference" and "summary" are in both.
+    expected = TYPE_TO_CATEGORY_V1.get(fact_type, category)
+    assert map_type_to_category(fact_type) == expected
 
 
 def test_map_type_to_category_unknown_falls_back_to_fact() -> None:
-    # Plugin uses a strict index; Python version is defensive for LLM output.
     assert map_type_to_category("nonsense") == "fact"
 
 
 # ---------------------------------------------------------------------------
-# build_canonical_claim
+# build_canonical_claim / build_canonical_claim_v1 — v1 write path
 # ---------------------------------------------------------------------------
 
 
-def test_build_canonical_claim_byte_identical_reference() -> None:
-    """Byte-for-byte match against the plugin's claim-format.test.ts reference."""
-    fact = _Fact(
-        text="Pedro chose PostgreSQL because it is relational and needs ACID.",
-        type="decision",
-        importance=8,
-        confidence=0.92,
-        entities=[
-            _Entity(name="Pedro", type="person", role="chooser"),
-            _Entity(name="PostgreSQL", type="tool"),
-        ],
-    )
-    canonical = build_canonical_claim(
-        fact,
-        importance=8,
-        source_agent="openclaw-plugin",
-        extracted_at="2026-04-12T10:00:00Z",
-    )
-    expected = (
-        '{"t":"Pedro chose PostgreSQL because it is relational and needs ACID.",'
-        '"c":"dec","cf":0.92,"i":8,"sa":"openclaw-plugin","ea":"2026-04-12T10:00:00Z",'
-        '"e":[{"n":"Pedro","tp":"person","r":"chooser"},{"n":"PostgreSQL","tp":"tool"}]}'
-    )
-    assert canonical == expected
-
-
-def test_build_canonical_claim_round_trips_through_core() -> None:
+def test_build_canonical_claim_emits_v1_schema_version() -> None:
+    """Default path writes a v1 JSON blob with schema_version '1.0'."""
     fact = _Fact(
         text="The user lives in Lisbon.",
-        type="fact",
+        type="claim",
         importance=7,
         confidence=0.9,
+        source="user",
+        scope="personal",
     )
     canonical = build_canonical_claim(
         fact,
         importance=7,
-        source_agent="oc",
-        extracted_at="2026-04-12T10:00:00Z",
+        source_agent="python-client",  # ignored in v1
+        extracted_at="2026-04-17T10:00:00.000Z",
     )
-    parsed = json.loads(core.parse_claim_or_legacy(canonical))
-    assert parsed["t"] == fact.text
-    assert parsed["c"] == "fact"
-    assert parsed["cf"] == 0.9
-    assert parsed["i"] == 7
+    payload = json.loads(canonical)
+    assert payload["schema_version"] == V1_SCHEMA_VERSION
+    assert payload["text"] == fact.text
+    assert payload["type"] == "claim"
+    assert payload["source"] == "user"
+    assert payload["scope"] == "personal"
+    assert payload["importance"] == 7
+    assert payload["created_at"] == "2026-04-17T10:00:00.000Z"
 
 
-def test_build_canonical_claim_omits_entities_field_when_empty() -> None:
-    fact = _Fact(text="No entities here.", type="fact", importance=7)
-    canonical = build_canonical_claim(
+def test_build_canonical_claim_v1_with_reasoning() -> None:
+    fact = {
+        "text": "Chose PostgreSQL over MongoDB for data that needs ACID",
+        "type": "claim",
+        "source": "user",
+        "scope": "work",
+        "reasoning": "Transactional integrity matters more than schema flexibility",
+        "confidence": 0.95,
+    }
+    canonical = build_canonical_claim_v1(
         fact,
-        importance=7,
-        source_agent="oc",
-        extracted_at="2026-04-12T10:00:00Z",
+        importance=9,
+        created_at="2026-04-17T10:00:00.000Z",
     )
-    assert '"e":' not in canonical
-
-
-def test_build_canonical_claim_defaults_confidence_to_0_85() -> None:
-    fact = _Fact(text="No confidence supplied.", type="fact", importance=7)
-    canonical = build_canonical_claim(
-        fact,
-        importance=7,
-        source_agent="oc",
-        extracted_at="2026-04-12T10:00:00Z",
+    payload = json.loads(canonical)
+    assert payload["reasoning"] == (
+        "Transactional integrity matters more than schema flexibility"
     )
-    assert '"cf":0.85' in canonical
+    assert payload["scope"] == "work"
+    assert payload["importance"] == 9
 
 
-def test_build_canonical_claim_drops_role_when_absent() -> None:
-    fact = _Fact(
-        text="Pedro works at Acme.",
-        type="fact",
-        importance=7,
-        confidence=0.9,
-        entities=[_Entity(name="Acme", type="company")],
+def test_build_canonical_claim_v1_legacy_v0_types_coerced() -> None:
+    """Legacy v0 type tokens map to their v1 equivalent at write time."""
+    fact = {"text": "x", "type": "decision", "source": "user"}
+    payload = json.loads(
+        build_canonical_claim_v1(fact, importance=7, created_at="2026-04-17T00:00:00.000Z")
     )
-    canonical = build_canonical_claim(
-        fact,
-        importance=7,
-        source_agent="oc",
-        extracted_at="2026-04-12T10:00:00Z",
+    assert payload["type"] == "claim"  # decision → claim
+
+    fact["type"] = "rule"
+    payload = json.loads(
+        build_canonical_claim_v1(fact, importance=7, created_at="2026-04-17T00:00:00.000Z")
     )
-    assert '"e":[{"n":"Acme","tp":"company"}]' in canonical
+    assert payload["type"] == "directive"
+
+    fact["type"] = "goal"
+    payload = json.loads(
+        build_canonical_claim_v1(fact, importance=7, created_at="2026-04-17T00:00:00.000Z")
+    )
+    assert payload["type"] == "commitment"
 
 
-def test_build_canonical_claim_accepts_dict_input() -> None:
-    """Dict input must produce the same bytes as dataclass input."""
-    fact_dict = {
-        "text": "Pedro chose PostgreSQL because it is relational and needs ACID.",
-        "type": "decision",
-        "importance": 8,
-        "confidence": 0.92,
+def test_build_canonical_claim_v1_requires_source() -> None:
+    """A v1 claim without a source must raise — provenance is mandatory."""
+    fact = {"text": "x", "type": "claim"}  # no source
+    with pytest.raises(ValueError, match="source is required"):
+        build_canonical_claim_v1(fact, importance=5, created_at="2026-04-17T00:00:00.000Z")
+
+
+def test_build_canonical_claim_defaults_missing_source_to_user_inferred() -> None:
+    """The back-compat entry point supplies user-inferred when source is missing."""
+    fact_dict = {"text": "x", "type": "claim"}  # no source key
+    canonical = build_canonical_claim(fact_dict, importance=7, source_agent="whatever")
+    payload = json.loads(canonical)
+    assert payload["source"] == "user-inferred"
+
+
+def test_build_canonical_claim_v1_entities_passed_through() -> None:
+    fact = {
+        "text": "Pedro chose PostgreSQL",
+        "type": "claim",
+        "source": "user",
         "entities": [
             {"name": "Pedro", "type": "person", "role": "chooser"},
             {"name": "PostgreSQL", "type": "tool"},
         ],
     }
-    canonical = build_canonical_claim(
-        fact_dict,
-        importance=8,
-        source_agent="openclaw-plugin",
-        extracted_at="2026-04-12T10:00:00Z",
+    payload = json.loads(
+        build_canonical_claim_v1(fact, importance=8, created_at="2026-04-17T00:00:00.000Z")
     )
-    expected = (
-        '{"t":"Pedro chose PostgreSQL because it is relational and needs ACID.",'
-        '"c":"dec","cf":0.92,"i":8,"sa":"openclaw-plugin","ea":"2026-04-12T10:00:00Z",'
-        '"e":[{"n":"Pedro","tp":"person","r":"chooser"},{"n":"PostgreSQL","tp":"tool"}]}'
+    assert len(payload["entities"]) == 2
+    assert payload["entities"][0]["name"] == "Pedro"
+    assert payload["entities"][0]["role"] == "chooser"
+    assert payload["entities"][1]["name"] == "PostgreSQL"
+    assert "role" not in payload["entities"][1]
+
+
+def test_build_canonical_claim_v1_volatility_preserved() -> None:
+    fact = {
+        "text": "x",
+        "type": "claim",
+        "source": "user",
+        "volatility": "stable",
+    }
+    payload = json.loads(
+        build_canonical_claim_v1(fact, importance=7, created_at="2026-04-17T00:00:00.000Z")
     )
-    assert canonical == expected
+    assert payload["volatility"] == "stable"
+
+
+def test_build_canonical_claim_v1_rejects_invalid_source() -> None:
+    fact = {"text": "x", "type": "claim", "source": "bogus"}
+    with pytest.raises(ValueError, match="invalid source"):
+        build_canonical_claim_v1(fact, importance=5, created_at="2026-04-17T00:00:00.000Z")
+
+
+def test_protobuf_version_v4_constant_is_4() -> None:
+    assert PROTOBUF_VERSION_V4 == 4
 
 
 # ---------------------------------------------------------------------------
-# build_legacy_doc
+# Legacy doc builder — kept for back-compat, not on the default write path
 # ---------------------------------------------------------------------------
 
 
-def test_build_legacy_doc_byte_identical() -> None:
+def test_build_legacy_doc_still_works_for_back_compat() -> None:
     fact = _Fact(text="Hello world.", type="fact", importance=7)
     doc = build_legacy_doc(
         fact,
@@ -226,12 +275,10 @@ def test_build_legacy_doc_byte_identical() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Entity trapdoors
+# Entity trapdoors — byte-exact cross-client parity anchors
 # ---------------------------------------------------------------------------
 
 
-# Hardcoded expected value — computed once and pinned so this test also
-# detects any future drift in the normalization pipeline.
 POSTGRES_TRAPDOOR_HEX = hashlib.sha256(b"entity:postgresql").hexdigest()
 
 
@@ -241,7 +288,6 @@ def test_compute_entity_trapdoor_postgresql_hardcoded() -> None:
         compute_entity_trapdoor("PostgreSQL")
         == "1e364278f621eefbf64332d67597c5f2366b8527f46301dbe288b63920e89569"
     )
-    # Also exactly what the documented primitive says.
     assert compute_entity_trapdoor("PostgreSQL") == POSTGRES_TRAPDOOR_HEX
 
 
@@ -295,53 +341,15 @@ def test_compute_entity_trapdoors_skips_bad_names() -> None:
     td = compute_entity_trapdoors(
         [
             _Entity(name="", type="person"),
-            _Entity(name="   ", type="person"),  # whitespace-only → normalizes to ""
+            _Entity(name="   ", type="person"),
             _Entity(name="Real", type="person"),
         ]
     )
-    # "   " normalizes to "" at the core layer but we still hash it because
-    # we can't tell empty-after-normalize from a user who actually typed
-    # nothing meaningful. What we guarantee is that "Real" produces one
-    # entry and the result does not contain duplicates.
     assert any(t == compute_entity_trapdoor("Real") for t in td)
 
 
 # ---------------------------------------------------------------------------
-# Claim format feature flag
-# ---------------------------------------------------------------------------
-
-
-def test_resolve_claim_format_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("TOTALRECLAW_CLAIM_FORMAT", raising=False)
-    assert resolve_claim_format() == "claim"
-
-
-def test_resolve_claim_format_explicit_claim(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("TOTALRECLAW_CLAIM_FORMAT", "claim")
-    assert resolve_claim_format() == "claim"
-
-
-def test_resolve_claim_format_case_insensitive(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("TOTALRECLAW_CLAIM_FORMAT", "CLAIM")
-    assert resolve_claim_format() == "claim"
-    monkeypatch.setenv("TOTALRECLAW_CLAIM_FORMAT", "LEGACY")
-    assert resolve_claim_format() == "legacy"
-
-
-def test_resolve_claim_format_legacy(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("TOTALRECLAW_CLAIM_FORMAT", "legacy")
-    assert resolve_claim_format() == "legacy"
-
-
-def test_resolve_claim_format_unknown_falls_back_to_claim(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("TOTALRECLAW_CLAIM_FORMAT", "nonsense")
-    assert resolve_claim_format() == "claim"
-
-
-# ---------------------------------------------------------------------------
-# Digest mode flag
+# Digest mode flag (digest compilation is orthogonal to v0/v1 taxonomy)
 # ---------------------------------------------------------------------------
 
 
@@ -371,12 +379,55 @@ def test_resolve_digest_mode_values(
 
 
 # ---------------------------------------------------------------------------
-# read_claim_from_blob — decrypted blob reader
+# read_blob_unified / read_claim_from_blob — unified decrypt reader
 # ---------------------------------------------------------------------------
 
 
-def test_read_claim_from_blob_new_format() -> None:
-    out = read_claim_from_blob(
+def test_read_blob_unified_v1_payload() -> None:
+    """v1 JSON blob is decoded with all v1 metadata surfaced."""
+    v1 = json.dumps({
+        "id": "abc",
+        "text": "prefers dark mode",
+        "type": "preference",
+        "source": "user",
+        "scope": "personal",
+        "volatility": "stable",
+        "reasoning": None,
+        "importance": 8,
+        "confidence": 0.95,
+        "created_at": "2026-04-17T00:00:00.000Z",
+        "schema_version": "1.0",
+    })
+    out = read_blob_unified(v1)
+    assert out["text"] == "prefers dark mode"
+    assert out["importance"] == 8
+    assert out["category"] == "pref"
+    assert out["metadata"]["source"] == "user"
+    assert out["metadata"]["scope"] == "personal"
+    assert out["metadata"]["volatility"] == "stable"
+    assert out["metadata"]["schema_version"] == "1.0"
+
+
+def test_is_v1_blob_detects_v1() -> None:
+    v1 = json.dumps({
+        "id": "abc", "text": "x", "type": "claim", "source": "user",
+        "importance": 5, "created_at": "2026-04-17T00:00:00Z",
+        "schema_version": "1.0",
+    })
+    assert is_v1_blob(v1) is True
+
+
+def test_is_v1_blob_rejects_legacy() -> None:
+    v0 = json.dumps({"t": "x", "c": "fact", "cf": 0.9, "i": 5, "sa": "oc"})
+    assert is_v1_blob(v0) is False
+    legacy = json.dumps({"text": "x", "metadata": {}})
+    assert is_v1_blob(legacy) is False
+    assert is_v1_blob("not json") is False
+
+
+def test_read_blob_unified_v0_short_key_still_works() -> None:
+    """Pre-v1 vault entries still decode via the v0 short-key branch."""
+    out = read_blob_unified(
         json.dumps({"t": "prefers PostgreSQL", "c": "pref", "cf": 0.9, "i": 8, "sa": "oc"})
     )
     assert out["text"] == "prefers PostgreSQL"
@@ -384,8 +435,8 @@ def test_read_claim_from_blob_new_format() -> None:
     assert out["category"] == "pref"
 
 
-def test_read_claim_from_blob_new_format_with_entities() -> None:
-    out = read_claim_from_blob(
+def test_read_blob_unified_v0_with_entities() -> None:
+    out = read_blob_unified(
         json.dumps(
             {
                 "t": "lives in Lisbon",
@@ -402,22 +453,22 @@ def test_read_claim_from_blob_new_format_with_entities() -> None:
     assert out["category"] == "fact"
 
 
-def test_read_claim_from_blob_clamps_high_importance() -> None:
-    out = read_claim_from_blob(
+def test_read_blob_unified_clamps_high_importance() -> None:
+    out = read_blob_unified(
         json.dumps({"t": "x", "c": "fact", "cf": 0.9, "i": 99, "sa": "oc"})
     )
     assert out["importance"] == 10
 
 
-def test_read_claim_from_blob_clamps_low_importance() -> None:
-    out = read_claim_from_blob(
+def test_read_blob_unified_clamps_low_importance() -> None:
+    out = read_blob_unified(
         json.dumps({"t": "x", "c": "fact", "cf": 0.9, "i": 0, "sa": "oc"})
     )
     assert out["importance"] == 1
 
 
-def test_read_claim_from_blob_legacy_format() -> None:
-    out = read_claim_from_blob(
+def test_read_blob_unified_legacy_format() -> None:
+    out = read_blob_unified(
         json.dumps(
             {
                 "text": "legacy fact",
@@ -434,8 +485,8 @@ def test_read_claim_from_blob_legacy_format() -> None:
     assert out["category"] == "fact"
 
 
-def test_read_claim_from_blob_legacy_rounds_0_85_to_9() -> None:
-    out = read_claim_from_blob(
+def test_read_blob_unified_legacy_rounds_0_85_to_9() -> None:
+    out = read_blob_unified(
         json.dumps(
             {
                 "text": "prefers dark mode",
@@ -447,25 +498,25 @@ def test_read_claim_from_blob_legacy_rounds_0_85_to_9() -> None:
     assert out["category"] == "preference"
 
 
-def test_read_claim_from_blob_bare_legacy() -> None:
-    out = read_claim_from_blob(json.dumps({"text": "bare"}))
+def test_read_blob_unified_bare_legacy() -> None:
+    out = read_blob_unified(json.dumps({"text": "bare"}))
     assert out["text"] == "bare"
     assert out["importance"] == 5
 
 
-def test_read_claim_from_blob_malformed_json_falls_back() -> None:
-    out = read_claim_from_blob("not valid json")
+def test_read_blob_unified_malformed_json_falls_back() -> None:
+    out = read_blob_unified("not valid json")
     assert out["text"] == "not valid json"
     assert out["importance"] == 5
 
 
-def test_read_claim_from_blob_empty_object_falls_back() -> None:
-    out = read_claim_from_blob("{}")
+def test_read_blob_unified_empty_object_falls_back() -> None:
+    out = read_blob_unified("{}")
     assert out["text"] == "{}"
 
 
-def test_read_claim_from_blob_digest_blob_new_format() -> None:
-    out = read_claim_from_blob(
+def test_read_blob_unified_digest_blob() -> None:
+    out = read_blob_unified(
         json.dumps(
             {
                 "t": '{"prompt_text":"You are..."}',
@@ -480,8 +531,14 @@ def test_read_claim_from_blob_digest_blob_new_format() -> None:
     assert out["importance"] == 10
 
 
+def test_read_claim_from_blob_back_compat_alias() -> None:
+    """read_claim_from_blob remains a back-compat alias for read_blob_unified."""
+    v0 = json.dumps({"t": "x", "c": "fact", "cf": 0.9, "i": 5, "sa": "oc"})
+    assert read_claim_from_blob(v0) == read_blob_unified(v0)
+
+
 # ---------------------------------------------------------------------------
-# DIGEST_TRAPDOOR + constants
+# DIGEST_TRAPDOOR + constants (unchanged from v0)
 # ---------------------------------------------------------------------------
 
 
@@ -489,11 +546,9 @@ def test_digest_trapdoor_matches_documented_primitive() -> None:
     expected = hashlib.sha256(b"type:digest").hexdigest()
     assert DIGEST_TRAPDOOR == expected
     assert len(DIGEST_TRAPDOOR) == 64
-    assert all(c in "0123456789abcdef" for c in DIGEST_TRAPDOOR)
 
 
 def test_digest_trapdoor_hardcoded_value() -> None:
-    # Hardcoded so if either side (Python or plugin) drifts, this screams.
     assert DIGEST_TRAPDOOR == (
         "5e6dcf483f027cb81f78f05474a4986c236af915dcb48cd8a376485eec5598ba"
     )
@@ -502,8 +557,6 @@ def test_digest_trapdoor_hardcoded_value() -> None:
 def test_digest_constants() -> None:
     assert DIGEST_CATEGORY == "dig"
     assert DIGEST_CLAIM_CAP == 200
-    # Python side uses a distinctive marker so operators can identify
-    # Python-origin digest writes.
     assert DIGEST_SOURCE_AGENT == "hermes-agent-digest"
 
 
@@ -524,7 +577,6 @@ def test_build_digest_claim_round_trips() -> None:
     assert round_tripped["sa"] == DIGEST_SOURCE_AGENT
     assert round_tripped["ea"] == compiled_at
     assert round_tripped["t"] == digest_json
-    # Must not carry entity refs.
     assert "e" not in round_tripped or len(round_tripped["e"]) == 0
 
 
@@ -554,7 +606,6 @@ def test_extract_digest_from_claim_non_digest_returns_none() -> None:
 
 
 def test_extract_digest_from_claim_malformed_inner_json_returns_none() -> None:
-    # Hand-build a dig claim whose t field is not a valid Digest object.
     broken = json.dumps(
         {
             "t": "not a digest object",
@@ -608,7 +659,7 @@ def test_is_digest_blob_garbage_returns_false() -> None:
 
 
 def test_hours_since_zero_when_equal() -> None:
-    now_ms = 1776000000000  # 2026-04-12T13:20:00Z in ms
+    now_ms = 1776000000000
     import datetime as dt
 
     iso = dt.datetime.fromtimestamp(now_ms / 1000, tz=dt.timezone.utc).isoformat().replace("+00:00", "Z")
@@ -638,7 +689,6 @@ def test_hours_since_invalid_returns_infinity() -> None:
 
 
 def test_hours_since_future_date_clamped_to_zero() -> None:
-    # Future date → clock skew defensive, return 0
     assert hours_since("2030-01-01T00:00:00Z", 1776000000000) == 0
 
 
@@ -664,21 +714,48 @@ def test_is_digest_stale_both_zero_not_stale() -> None:
 
 
 # ---------------------------------------------------------------------------
-# should_recompile — guard conditions
+# should_recompile
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
     "count,hours,expected",
     [
-        (10, 1, True),  # exactly 10 new claims
-        (9, 1, False),  # 9 under threshold
-        (0, 24, True),  # exactly 24 hours
-        (1, 23, False),  # 23h + 1 claim → skip
-        (100, 48, True),  # both conditions
-        (0, 0, False),  # nothing
-        (0, math.inf, True),  # infinity hours → recompile
+        (10, 1, True),
+        (9, 1, False),
+        (0, 24, True),
+        (1, 23, False),
+        (100, 48, True),
+        (0, 0, False),
+        (0, math.inf, True),
     ],
 )
 def test_should_recompile(count: int, hours: float, expected: bool) -> None:
     assert should_recompile(count, hours) is expected
+
+
+# ---------------------------------------------------------------------------
+# Explicit env-var absence: v1 is the default, no gates
+# ---------------------------------------------------------------------------
+
+
+def test_no_taxonomy_version_env_var_referenced(monkeypatch: pytest.MonkeyPatch) -> None:
+    """TOTALRECLAW_TAXONOMY_VERSION should have zero effect (removed in 2.0.0)."""
+    # Set the legacy env var to a value that would have flipped to v0
+    monkeypatch.setenv("TOTALRECLAW_TAXONOMY_VERSION", "v0")
+    fact = {"text": "x", "type": "claim", "source": "user"}
+    payload = json.loads(
+        build_canonical_claim_v1(fact, importance=7, created_at="2026-04-17T00:00:00Z")
+    )
+    # Must still emit v1 (schema_version "1.0")
+    assert payload["schema_version"] == V1_SCHEMA_VERSION
+
+
+def test_no_claim_format_env_var_referenced(monkeypatch: pytest.MonkeyPatch) -> None:
+    """TOTALRECLAW_CLAIM_FORMAT=legacy should have zero effect (removed in 2.0.0)."""
+    monkeypatch.setenv("TOTALRECLAW_CLAIM_FORMAT", "legacy")
+    fact = {"text": "x", "type": "claim", "source": "user"}
+    canonical = build_canonical_claim(fact, importance=7)
+    # Even with the env var, we emit v1 — no legacy doc.
+    assert '"schema_version"' in canonical
+    assert '"text":"x"' in canonical

--- a/python/tests/test_extractor.py
+++ b/python/tests/test_extractor.py
@@ -24,6 +24,9 @@ from totalreclaw.hermes.llm_client import (
 
 class TestParseResponse:
     def test_valid_json_array(self):
+        # Input uses legacy v0 tokens ("fact", "preference") — parser coerces
+        # to the v1 equivalent ("claim", "preference"). The bare-array input
+        # is wrapped into the merged-topic shape internally.
         response = json.dumps([
             {"text": "User lives in Lisbon", "type": "fact", "importance": 8, "action": "ADD"},
             {"text": "Prefers dark mode", "type": "preference", "importance": 7, "action": "ADD"},
@@ -31,10 +34,11 @@ class TestParseResponse:
         facts = _parse_response(response)
         assert len(facts) == 2
         assert facts[0].text == "User lives in Lisbon"
-        assert facts[0].type == "fact"
+        assert facts[0].type == "claim"  # v0 "fact" → v1 "claim"
         assert facts[0].importance == 8
         assert facts[0].action == "ADD"
         assert facts[1].text == "Prefers dark mode"
+        assert facts[1].type == "preference"  # passthrough
 
     def test_empty_array(self):
         facts = _parse_response("[]")
@@ -73,13 +77,14 @@ class TestParseResponse:
         assert facts[0].action == "DELETE"
         assert facts[0].existing_fact_id == "abc-123"
 
-    def test_invalid_type_defaults_to_fact(self):
+    def test_invalid_type_defaults_to_claim(self):
         response = json.dumps([
             {"text": "Some memory with invalid type", "type": "banana", "importance": 8, "action": "ADD"},
         ])
         facts = _parse_response(response)
         assert len(facts) == 1
-        assert facts[0].type == "fact"
+        # v1 default when type is unknown is "claim" (not "fact").
+        assert facts[0].type == "claim"
 
     def test_invalid_action_defaults_to_add(self):
         response = json.dumps([
@@ -141,23 +146,40 @@ class TestParseResponse:
         assert len(facts) == 1
         assert facts[0].existing_fact_id == "def-456"
 
-    def test_all_valid_types(self):
+    def test_all_v0_types_coerce_to_v1(self):
+        """All 8 legacy v0 tokens are coerced to their v1 equivalent on parse."""
         items = []
-        # Phase 2.2: 8 memory types, including the new "rule" category.
-        for t in ["fact", "preference", "decision", "episodic", "goal", "context", "summary", "rule"]:
+        # ``summary + source:user`` is illegal in v1 (rejected by the parser).
+        # We skip "summary" + "user" here because the test input defaults
+        # source to user-inferred via the parser, which lets summary through.
+        # The type:summary+source:user check is covered separately.
+        # Exclude "summary" from this loop because the test runs without an
+        # explicit source and the parser would catch illegal combinations.
+        v0_tokens = ["fact", "preference", "decision", "episodic", "goal", "context", "rule"]
+        for t in v0_tokens:
             items.append({"text": f"Test {t} memory value", "type": t, "importance": 8, "action": "ADD"})
+        # Add summary with derived source (allowed)
+        items.append({
+            "text": "Test summary memory value",
+            "type": "summary",
+            "source": "derived",
+            "importance": 8,
+            "action": "ADD",
+        })
         response = json.dumps(items)
         facts = _parse_response(response)
         assert len(facts) == 8
         types = {f.type for f in facts}
-        assert types == {"fact", "preference", "decision", "episodic", "goal", "context", "summary", "rule"}
+        # v1 types after coercion: fact/decision/context → claim,
+        # episodic → episode, goal → commitment, rule → directive.
+        assert types == {"claim", "preference", "episode", "commitment", "directive", "summary"}
 
     def test_rule_type_round_trip(self):
-        """Phase 2.2: rule-typed facts pass parsing, retain entities, and stay above the importance floor."""
+        """Phase 2.2: v0 'rule' token coerces to v1 'directive' at parse time."""
         response = json.dumps([
             {
                 "text": "Stop the OpenClaw gateway before rm -rf ~/.totalreclaw/ — async flush can recreate stale files",
-                "type": "rule",
+                "type": "rule",  # v0 → v1 "directive"
                 "importance": 8,
                 "confidence": 1.0,
                 "action": "ADD",
@@ -166,7 +188,7 @@ class TestParseResponse:
         ])
         facts = _parse_response(response)
         assert len(facts) == 1
-        assert facts[0].type == "rule"
+        assert facts[0].type == "directive"  # v0 "rule" → v1 "directive"
         assert facts[0].importance == 8
         assert facts[0].confidence == 1.0
         assert facts[0].entities is not None
@@ -492,7 +514,8 @@ class TestExtractFactsLLM:
                 facts = await extract_facts_llm(messages, mode="turn")
                 assert len(facts) == 2
                 assert facts[0].text == "User lives in Lisbon"
-                assert facts[0].type == "fact"
+                # v0 "fact" → v1 "claim"
+                assert facts[0].type == "claim"
                 assert facts[1].text == "User prefers dark mode"
 
     @pytest.mark.asyncio
@@ -539,8 +562,8 @@ class TestExtractFactsLLM:
                 mock_chat.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_turn_mode_uses_all_unprocessed(self):
-        """Turn mode uses all provided messages — caller scopes to unprocessed."""
+    async def test_turn_mode_trims_to_last_6(self):
+        """v1 turn mode trims to the last 6 messages (matches the TS plugin)."""
         llm_response = json.dumps([])
         messages = [{"role": "user", "content": f"Message number {i} with content"} for i in range(20)]
 
@@ -550,8 +573,8 @@ class TestExtractFactsLLM:
                 await extract_facts_llm(messages, mode="turn")
                 call_args = mock_chat.call_args
                 user_prompt = call_args[0][2]
-                # All messages should be included (caller handles scoping)
-                assert "Message number 0" in user_prompt
+                # Only the tail window is sent in turn mode.
+                assert "Message number 0" not in user_prompt
                 assert "Message number 19" in user_prompt
 
     @pytest.mark.asyncio
@@ -631,10 +654,14 @@ class TestExtractFactsHeuristic:
         assert len(facts) >= 1
         f = facts[0]
         assert isinstance(f, ExtractedFact)
-        assert f.type == "fact"
+        # v1 heuristic emits "claim" for the Remember/Fact pattern.
+        assert f.type == "claim"
         assert f.importance == 7
         assert f.action == "ADD"
         assert f.existing_fact_id is None
+        # v1 heuristic tags source/scope/volatility defensively.
+        assert f.source == "user"
+        assert f.scope == "unspecified"
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_memory_types_parity.py
+++ b/python/tests/test_memory_types_parity.py
@@ -1,9 +1,9 @@
-"""Phase 2.2.6: cross-language parity test for ``VALID_MEMORY_TYPES``.
+"""Cross-language parity test for Memory Taxonomy v1 (python 2.0.0).
 
-Asserts the Python-side canonical type list matches the TypeScript plugin and
-MCP lists byte-for-byte. Drift here produces hard-to-diagnose cross-client
-divergence — a rule-typed fact stored by the plugin would deserialize as
-unknown if Python's list is missing "rule".
+Asserts the Python-side canonical v1 type list matches the TypeScript plugin
+and MCP lists byte-for-byte. Drift here produces hard-to-diagnose cross-client
+divergence — a v1 claim-typed fact stored by the plugin would deserialize as
+unknown if Python's list is missing "claim".
 
 The TypeScript-side parity check lives at
 ``tests/parity/memory-types-parity.test.ts``. These two tests together form a
@@ -18,7 +18,20 @@ from __future__ import annotations
 import pytest
 
 
-CANONICAL_TYPES = (
+# v1 canonical types — the 6 memory types the plugin's `VALID_MEMORY_TYPES`
+# exports. Order and content must match `skill/plugin/extractor.ts`.
+CANONICAL_V1_TYPES = (
+    "claim",
+    "preference",
+    "directive",
+    "commitment",
+    "episode",
+    "summary",
+)
+
+# Legacy v0 types — retained on the read-side adapter only. Order and content
+# must match `LEGACY_V0_MEMORY_TYPES` in the plugin.
+CANONICAL_V0_TYPES = (
     "fact",
     "preference",
     "decision",
@@ -30,33 +43,62 @@ CANONICAL_TYPES = (
 )
 
 
-def test_extraction_valid_memory_types_matches_canonical():
-    """``totalreclaw.agent.extraction.VALID_MEMORY_TYPES`` is the canonical 8-type list."""
+def test_extraction_valid_memory_types_is_v1():
+    """``VALID_MEMORY_TYPES`` must be the 6-item v1 list."""
     from totalreclaw.agent.extraction import VALID_MEMORY_TYPES
-    assert VALID_MEMORY_TYPES == CANONICAL_TYPES, (
-        f"VALID_MEMORY_TYPES drifted from canonical list.\n"
-        f"  expected: {CANONICAL_TYPES}\n"
+    assert VALID_MEMORY_TYPES == CANONICAL_V1_TYPES, (
+        f"VALID_MEMORY_TYPES drifted from v1 canonical.\n"
+        f"  expected: {CANONICAL_V1_TYPES}\n"
         f"  actual:   {VALID_MEMORY_TYPES}"
     )
 
 
+def test_extraction_legacy_v0_memory_types_preserved():
+    """Legacy v0 tokens are still enumerated for read-side decoding."""
+    from totalreclaw.agent.extraction import LEGACY_V0_MEMORY_TYPES
+    assert LEGACY_V0_MEMORY_TYPES == CANONICAL_V0_TYPES
+
+
 def test_extraction_valid_types_legacy_alias_matches():
-    """``VALID_TYPES`` (legacy frozenset alias) matches ``VALID_MEMORY_TYPES``."""
+    """``VALID_TYPES`` (legacy frozenset alias) matches v1 ``VALID_MEMORY_TYPES``."""
     from totalreclaw.agent.extraction import VALID_TYPES, VALID_MEMORY_TYPES
     assert VALID_TYPES == frozenset(VALID_MEMORY_TYPES)
 
 
-def test_claims_helper_type_to_category_covers_all_types():
-    """Every canonical type has a short-form mapping in ``claims_helper.TYPE_TO_CATEGORY``."""
-    from totalreclaw.claims_helper import TYPE_TO_CATEGORY
-    for t in CANONICAL_TYPES:
-        assert t in TYPE_TO_CATEGORY, f"Missing TYPE_TO_CATEGORY entry for '{t}'"
+def test_v0_to_v1_mapping_complete():
+    """Every v0 token has a v1 destination."""
+    from totalreclaw.agent.extraction import V0_TO_V1_TYPE
+    for v0 in CANONICAL_V0_TYPES:
+        assert v0 in V0_TO_V1_TYPE, f"Missing V0_TO_V1_TYPE for {v0!r}"
+        assert V0_TO_V1_TYPE[v0] in CANONICAL_V1_TYPES
 
 
-def test_claims_helper_short_form_values():
-    """The short-form mapping matches the Rust ``ClaimCategory`` serde_rename values."""
-    from totalreclaw.claims_helper import TYPE_TO_CATEGORY
-    expected = {
+def test_claims_helper_v1_category_covers_all_v1_types():
+    """Every v1 type has a display-category short key."""
+    from totalreclaw.claims_helper import TYPE_TO_CATEGORY_V1
+    for t in CANONICAL_V1_TYPES:
+        assert t in TYPE_TO_CATEGORY_V1, f"Missing TYPE_TO_CATEGORY_V1 entry for {t!r}"
+
+
+def test_claims_helper_v1_category_short_values():
+    """v1 category short-form matches the plugin's mapping exactly."""
+    from totalreclaw.claims_helper import TYPE_TO_CATEGORY_V1
+    expected_v1 = {
+        "claim": "claim",
+        "preference": "pref",
+        "directive": "rule",
+        "commitment": "goal",
+        "episode": "epi",
+        "summary": "sum",
+    }
+    for long_form, short_form in expected_v1.items():
+        assert TYPE_TO_CATEGORY_V1[long_form] == short_form
+
+
+def test_claims_helper_v0_category_short_values_preserved():
+    """v0 short-key category mapping preserved for read path."""
+    from totalreclaw.claims_helper import TYPE_TO_CATEGORY_V0
+    expected_v0 = {
         "fact": "fact",
         "preference": "pref",
         "decision": "dec",
@@ -66,36 +108,49 @@ def test_claims_helper_short_form_values():
         "summary": "sum",
         "rule": "rule",
     }
-    for long_form, short_form in expected.items():
-        assert TYPE_TO_CATEGORY[long_form] == short_form, (
-            f"TYPE_TO_CATEGORY[{long_form!r}] = {TYPE_TO_CATEGORY[long_form]!r}, "
-            f"expected {short_form!r}"
+    for long_form, short_form in expected_v0.items():
+        assert TYPE_TO_CATEGORY_V0[long_form] == short_form
+
+
+def test_rust_core_v1_types_enumerable():
+    """``totalreclaw_core`` recognizes every v1 type via ``parse_memory_type_v1``."""
+    import totalreclaw_core as core
+    for t in CANONICAL_V1_TYPES:
+        assert core.parse_memory_type_v1(t) == t, (
+            f"core.parse_memory_type_v1({t!r}) returned {core.parse_memory_type_v1(t)!r}"
         )
 
 
-def test_rust_core_category_round_trip():
-    """``totalreclaw_core.canonicalize_claim`` accepts every type and preserves short form."""
+def test_rust_core_v0_legacy_tokens_coerced():
+    """core coerces legacy v0 tokens to v1 via ``parse_memory_type_v1``."""
+    import totalreclaw_core as core
+    # Unknown / legacy tokens should fall back to "claim" (same semantics as
+    # V0_TO_V1_TYPE[fact]/[decision]/[context]). The core doesn't expose
+    # V0→V1 mapping directly — unknown tokens map to claim.
+    for t in ("fact", "decision", "context"):
+        assert core.parse_memory_type_v1(t) == "claim"
+
+
+def test_rust_core_v0_short_key_category_round_trip():
+    """v0 short-key category round-trips unchanged through the core serializer.
+
+    This ensures the on-chain storage layer can still decode pre-v1 blobs.
+    """
     import json
     import totalreclaw_core as core
 
-    for long_form in CANONICAL_TYPES:
-        short_form = {
-            "fact": "fact", "preference": "pref", "decision": "dec", "episodic": "epi",
-            "goal": "goal", "context": "ctx", "summary": "sum", "rule": "rule",
-        }[long_form]
-
-        # Build a minimal canonical Claim JSON and round-trip it through the Rust core.
-        # Short-form is what lives on-chain; this proves the Rust enum accepts it.
+    v0_short_keys = ["fact", "pref", "dec", "epi", "goal", "ctx", "sum", "rule"]
+    for short in v0_short_keys:
         claim_json = json.dumps({
-            "t": f"test {long_form}",
-            "c": short_form,
+            "t": f"test {short}",
+            "c": short,
             "cf": 0.9,
             "i": 7,
             "sa": "parity-test",
-            "ea": "2026-04-15T00:00:00Z",
+            "ea": "2026-04-17T00:00:00Z",
         })
         out = core.canonicalize_claim(claim_json)
         parsed = json.loads(out)
-        assert parsed["c"] == short_form, (
-            f"Round-trip failed for {long_form!r}: expected c={short_form!r}, got c={parsed['c']!r}"
+        assert parsed["c"] == short, (
+            f"v0 round-trip failed for {short!r}: got {parsed['c']!r}"
         )

--- a/python/tests/test_v1_hooks_integration.py
+++ b/python/tests/test_v1_hooks_integration.py
@@ -1,0 +1,184 @@
+"""Integration tests — all 3 Hermes hooks emit v1 by default.
+
+Stubs ``client.remember`` and ``client.recall`` and asserts each hook:
+
+1. ``pre_llm_call``  — passes through recall with source-weighted reranker
+   flag wired via ``search_facts``. Because the hook just calls into
+   ``client.recall()``, we only verify the call path is invoked (the
+   Tier 1 flag is asserted directly in ``test_v1_taxonomy.py``).
+2. ``post_llm_call`` — auto-extracts every N turns, forwards v1
+   ``type/source/scope`` to ``client.remember``.
+3. ``on_session_end`` — emits debrief items with ``type='summary'`` and
+   ``provenance='derived'``, matching the plugin's debrief behavior.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from totalreclaw.agent.extraction import ExtractedFact
+
+
+def _make_state(**env_overrides):
+    """Build a PluginState with a stubbed client — no real wallet derivation."""
+    from totalreclaw.hermes.state import PluginState
+    with patch.dict(os.environ, env_overrides, clear=True):
+        with patch.object(Path, "exists", return_value=False):
+            state = PluginState()
+    # Forge a fake client so is_configured() returns True.
+    fake_client = MagicMock()
+    fake_client.remember = AsyncMock(return_value="fact-uuid-abc")
+    fake_client.recall = AsyncMock(return_value=[])
+    fake_client.forget = AsyncMock(return_value=True)
+    state._client = fake_client
+    return state, fake_client
+
+
+# ---------------------------------------------------------------------------
+# post_llm_call — auto-extraction forwards v1 fields
+# ---------------------------------------------------------------------------
+
+
+def test_post_llm_call_forwards_v1_fields_to_remember() -> None:
+    """When auto_extract fires, client.remember receives v1 type/source/scope."""
+    from totalreclaw.hermes.hooks import post_llm_call
+
+    state, fake_client = _make_state()
+
+    # Seed enough turns so the extraction interval triggers.
+    # Default extraction_interval is typically 3; call post_llm_call until it hits.
+    from totalreclaw.hermes.state import DEFAULT_EXTRACTION_INTERVAL
+
+    # Mock extract_facts_llm to return a v1 fact directly. This bypasses
+    # the LLM call entirely — we're testing the wiring, not the extractor.
+    fake_fact = ExtractedFact(
+        text="User prefers PostgreSQL for OLTP",
+        type="preference",
+        importance=8,
+        action="ADD",
+        confidence=0.95,
+        source="user",
+        scope="work",
+        reasoning=None,
+        volatility="stable",
+    )
+
+    async def fake_extract(*args, **kwargs):
+        return [fake_fact]
+
+    with patch("totalreclaw.agent.lifecycle.extract_facts_llm", new=fake_extract):
+        # Inline contradiction detection (skip network).
+        async def passthrough(facts, *_args, **_kwargs):
+            return facts
+        with patch(
+            "totalreclaw.agent.lifecycle.detect_and_resolve_contradictions",
+            new=passthrough,
+        ):
+            # Mock _fetch_recent_memories to avoid calling the (stubbed) client.
+            with patch(
+                "totalreclaw.agent.lifecycle._fetch_recent_memories",
+                return_value=[],
+            ):
+                # Mock embedding so near-dup detection is a no-op.
+                with patch(
+                    "totalreclaw.agent.lifecycle._is_near_duplicate",
+                    return_value=False,
+                ):
+                    # Trigger extraction by calling post_llm_call enough times.
+                    for _ in range(DEFAULT_EXTRACTION_INTERVAL):
+                        post_llm_call(state, user_message="u", assistant_response="a")
+
+    # Assert client.remember was called with v1 kwargs.
+    assert fake_client.remember.called, "client.remember should have been called"
+    call = fake_client.remember.call_args
+    kwargs = call.kwargs
+
+    # The first positional is the text; then we check kwargs.
+    assert call.args[0] == fake_fact.text
+    assert kwargs["fact_type"] == "preference"
+    assert kwargs["provenance"] == "user"
+    assert kwargs["scope"] == "work"
+    assert kwargs["volatility"] == "stable"
+    assert kwargs["reasoning"] is None
+
+
+# ---------------------------------------------------------------------------
+# on_session_end — debrief emits v1 summaries
+# ---------------------------------------------------------------------------
+
+
+def test_on_session_end_debrief_emits_v1_summaries() -> None:
+    """Debrief path forwards type='summary' + provenance='derived' to client.remember.
+
+    We call ``session_debrief`` directly (the function the hook invokes) so
+    the test is independent of the hook's try/except wrapping.
+    """
+    from totalreclaw.agent.debrief import DebriefItem
+    from totalreclaw.agent.lifecycle import session_debrief
+
+    state, fake_client = _make_state()
+
+    # Seed enough conversation so the debrief triggers (>= 8 messages).
+    for i in range(10):
+        state.add_message("user", f"User message {i} with content words here")
+        state.add_message("assistant", f"Assistant reply {i} with different content here")
+
+    debrief_items = [
+        DebriefItem(text="Session conclusion summary here", type="summary", importance=8),
+        DebriefItem(text="Project context notes here for future", type="context", importance=7),
+    ]
+
+    async def fake_generate(*args, **kwargs):
+        return debrief_items
+
+    # Patch at the call site — lifecycle.py imports generate_debrief from
+    # totalreclaw.agent.debrief and then calls it locally.
+    with patch("totalreclaw.agent.lifecycle.generate_debrief", new=fake_generate):
+        session_debrief(state)
+
+    # Both debrief items should have been stored with v1 provenance.
+    calls = fake_client.remember.call_args_list
+    assert len(calls) == 2, f"expected 2 remember calls, got {len(calls)}"
+
+    for call in calls:
+        kwargs = call.kwargs
+        assert kwargs["fact_type"] == "summary"
+        assert kwargs["provenance"] == "derived"
+        assert kwargs["scope"] == "unspecified"
+
+
+# ---------------------------------------------------------------------------
+# pre_llm_call — recall path uses search_facts which applies Tier 1 weights
+# ---------------------------------------------------------------------------
+
+
+def test_pre_llm_call_invokes_recall_with_top_k_8() -> None:
+    """pre_llm_call runs auto-recall with top_k=8 on the first turn."""
+    from totalreclaw.hermes.hooks import pre_llm_call
+
+    state, fake_client = _make_state()
+
+    # Fake auto_recall — we just assert the hook invokes it.
+    with patch("totalreclaw.hermes.hooks.auto_recall") as fake_auto_recall:
+        fake_auto_recall.return_value = "## Memories\n- user prefers dark mode"
+        result = pre_llm_call(state, is_first_turn=True, user_message="what do i prefer?")
+
+    assert fake_auto_recall.called
+    # top_k=8 should be passed through (Hermes hook default).
+    call = fake_auto_recall.call_args
+    assert call.kwargs.get("top_k") == 8 or (len(call.args) >= 3 and call.args[2] == 8)
+
+
+def test_pre_llm_call_silently_no_op_when_not_first_turn() -> None:
+    """pre_llm_call does not auto-recall on non-first turns."""
+    from totalreclaw.hermes.hooks import pre_llm_call
+
+    state, fake_client = _make_state()
+
+    with patch("totalreclaw.hermes.hooks.auto_recall") as fake_auto_recall:
+        result = pre_llm_call(state, is_first_turn=False, user_message="follow-up?")
+
+    assert not fake_auto_recall.called

--- a/python/tests/test_v1_parity.py
+++ b/python/tests/test_v1_parity.py
@@ -1,0 +1,308 @@
+"""Cross-language v1 byte-parity tests for the Python client.
+
+Builds v1 claims in Python and verifies that core's validator (which is the
+SAME Rust code linked into the TS plugin's WASM) accepts them and round-trips
+them with the same canonical form. This is the same boundary the TS plugin's
+``v1-taxonomy.test.ts`` exercises, so a passing suite here + a passing suite
+there = byte-equivalent output across Python + TS + Rust.
+
+What it verifies:
+
+* The Python ``build_canonical_claim_v1`` produces a JSON blob that the
+  Rust core's ``validate_memory_claim_v1`` accepts without modification.
+* The v1 schema_version constant matches the Rust core.
+* The v0→v1 mapping table matches what the TS plugin + Rust core use.
+* ``source_weight`` / ``legacy_claim_fallback_weight`` return the same
+  table the Rust core exports — this is the Retrieval v2 Tier 1 anchor.
+
+Run with::
+
+    pytest python/tests/test_v1_parity.py -v
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import totalreclaw_core as core
+from totalreclaw.agent.extraction import V0_TO_V1_TYPE, VALID_MEMORY_TYPES
+from totalreclaw.claims_helper import V1_SCHEMA_VERSION, build_canonical_claim_v1
+from totalreclaw.reranker import LEGACY_CLAIM_FALLBACK_WEIGHT, source_weight
+
+
+# ---------------------------------------------------------------------------
+# Schema-version constant parity
+# ---------------------------------------------------------------------------
+
+
+def test_schema_version_is_1_0() -> None:
+    assert V1_SCHEMA_VERSION == "1.0"
+
+
+# ---------------------------------------------------------------------------
+# Python-built v1 blob ↔ Rust core validator
+# ---------------------------------------------------------------------------
+
+
+def test_python_v1_blob_validates_through_core() -> None:
+    fact = {
+        "text": "Uses PostgreSQL as primary OLTP",
+        "type": "claim",
+        "source": "user",
+        "scope": "work",
+        "reasoning": "ACID > schema flexibility",
+        "confidence": 0.95,
+    }
+    py_blob = build_canonical_claim_v1(
+        fact, importance=8, created_at="2026-04-17T00:00:00.000Z",
+        claim_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    )
+    # The Python blob carries schema_version (re-attached after core validation).
+    py_payload = json.loads(py_blob)
+    assert py_payload["schema_version"] == V1_SCHEMA_VERSION
+
+    # core.validate_memory_claim_v1 raises on any schema violation. If it
+    # accepts the Python blob, the blob is byte-acceptable core-side.
+    # Note: core strips schema_version on output (it's considered input-only).
+    validated = core.validate_memory_claim_v1(py_blob)
+    validated_payload = json.loads(validated)
+    assert validated_payload["id"] == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    assert validated_payload["text"] == fact["text"]
+    assert validated_payload["type"] == "claim"
+    assert validated_payload["source"] == "user"
+    assert validated_payload["scope"] == "work"
+    assert validated_payload["importance"] == 8
+
+
+def test_python_v1_blob_entities_survive_core_validation() -> None:
+    fact = {
+        "text": "Pedro uses PostgreSQL",
+        "type": "claim",
+        "source": "user",
+        "entities": [
+            {"name": "Pedro", "type": "person"},
+            {"name": "PostgreSQL", "type": "tool", "role": "primary_db"},
+        ],
+    }
+    py_blob = build_canonical_claim_v1(
+        fact, importance=8, created_at="2026-04-17T00:00:00.000Z"
+    )
+    validated = core.validate_memory_claim_v1(py_blob)
+    payload = json.loads(validated)
+    ents = payload.get("entities", [])
+    assert len(ents) == 2
+    names = {e["name"] for e in ents}
+    assert names == {"Pedro", "PostgreSQL"}
+
+
+def test_python_v1_blob_reasoning_truncated_to_256() -> None:
+    long_reason = "x" * 400
+    fact = {
+        "text": "Claim with long reasoning",
+        "type": "claim",
+        "source": "user",
+        "reasoning": long_reason,
+    }
+    py_blob = build_canonical_claim_v1(
+        fact, importance=8, created_at="2026-04-17T00:00:00Z"
+    )
+    validated = core.validate_memory_claim_v1(py_blob)
+    payload = json.loads(validated)
+    assert len(payload["reasoning"]) == 256
+
+
+# ---------------------------------------------------------------------------
+# v0 → v1 coercion parity (Python mapping matches the Rust core's
+# ``parse_memory_type_v1`` for at least the unknown→claim fallback)
+# ---------------------------------------------------------------------------
+
+
+def test_v0_to_v1_mapping_known_pairs() -> None:
+    """The Python V0_TO_V1_TYPE map must be internally consistent with the v1 list."""
+    for v0, v1 in V0_TO_V1_TYPE.items():
+        assert v1 in VALID_MEMORY_TYPES
+
+
+def test_core_parse_memory_type_v1_v0_unknown_returns_claim() -> None:
+    """The Rust core's parser falls back to 'claim' for unknown / v0-exclusive tokens."""
+    # v0 tokens not in the v1 enum land on "claim".
+    assert core.parse_memory_type_v1("bogus") == "claim"
+    assert core.parse_memory_type_v1("fact") == "claim"
+    assert core.parse_memory_type_v1("decision") == "claim"
+
+
+@pytest.mark.parametrize("v1_type", list(VALID_MEMORY_TYPES))
+def test_core_parse_memory_type_v1_passthrough(v1_type: str) -> None:
+    assert core.parse_memory_type_v1(v1_type) == v1_type
+
+
+# ---------------------------------------------------------------------------
+# Source-weight parity (Retrieval v2 Tier 1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        ("user", 1.0),
+        ("user-inferred", 0.9),
+        ("external", 0.7),
+        ("derived", 0.7),
+        ("assistant", 0.55),
+    ],
+)
+def test_python_source_weight_matches_core(source: str, expected: float) -> None:
+    """Python's ``source_weight`` delegates to core — values must match."""
+    assert source_weight(source) == pytest.approx(expected, abs=0.001)
+    assert core.source_weight(source) == pytest.approx(expected, abs=0.001)
+
+
+def test_legacy_claim_fallback_weight_is_0_85() -> None:
+    assert LEGACY_CLAIM_FALLBACK_WEIGHT == 0.85
+    assert core.legacy_claim_fallback_weight() == 0.85
+
+
+# ---------------------------------------------------------------------------
+# Canonical v1 fixture anchor — this JSON blob is a "golden" v1 payload
+# that both TS + Python + Rust must accept byte-for-byte.
+# ---------------------------------------------------------------------------
+
+
+CANONICAL_V1_FIXTURE = {
+    "id": "11111111-2222-3333-4444-555555555555",
+    "text": "The user prefers PostgreSQL for OLTP databases",
+    "type": "preference",
+    "source": "user",
+    "scope": "work",
+    "reasoning": None,
+    "confidence": 0.95,
+    "importance": 9,
+    "created_at": "2026-04-17T12:00:00.000Z",
+    "schema_version": "1.0",
+}
+
+
+def test_canonical_v1_fixture_validates() -> None:
+    """The golden fixture validates through the Rust core unchanged.
+
+    Note: core.validate_memory_claim_v1 strips schema_version on output —
+    the field is input-only from the core's perspective. This test asserts
+    round-trip INPUT acceptance, not byte-exact output.
+    """
+    payload = {k: v for k, v in CANONICAL_V1_FIXTURE.items() if v is not None}
+    blob = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    validated = core.validate_memory_claim_v1(blob)
+    # Core accepted the fixture; it returns a canonical subset.
+    validated_payload = json.loads(validated)
+    assert validated_payload["id"] == CANONICAL_V1_FIXTURE["id"]
+    assert validated_payload["type"] == CANONICAL_V1_FIXTURE["type"]
+
+
+# ---------------------------------------------------------------------------
+# Protobuf v4 byte-parity — Python encoder ↔ Rust core encoder
+# ---------------------------------------------------------------------------
+
+
+def test_python_rust_protobuf_v4_byte_identical() -> None:
+    """Python ``encode_fact_protobuf`` produces byte-for-byte identical output
+    to the Rust core's encoder when both are given the same FactPayload."""
+    from totalreclaw.protobuf import (
+        PROTOBUF_VERSION_V4 as PY_V4,
+        FactPayload,
+        encode_fact_protobuf,
+    )
+
+    fp = FactPayload(
+        id="test-x",
+        timestamp="2026-04-17T00:00:00Z",
+        owner="0xAB",
+        encrypted_blob="deadbeef",
+        blind_indices=[],
+        decay_score=0.8,
+        source="s",
+        content_fp="fp",
+        agent_id="a",
+        version=PY_V4,
+    )
+    py_bytes = encode_fact_protobuf(fp)
+
+    rust_bytes = core.encode_fact_protobuf(
+        json.dumps({
+            "id": "test-x",
+            "timestamp": "2026-04-17T00:00:00Z",
+            "owner": "0xAB",
+            "encrypted_blob_hex": "deadbeef",
+            "blind_indices": [],
+            "decay_score": 0.8,
+            "source": "s",
+            "content_fp": "fp",
+            "agent_id": "a",
+            "version": 4,
+        })
+    )
+
+    assert py_bytes == rust_bytes, (
+        f"Python/Rust protobuf v4 mismatch:\n"
+        f"  Python: {py_bytes.hex()}\n"
+        f"  Rust:   {rust_bytes.hex()}"
+    )
+
+
+def test_python_rust_protobuf_v3_byte_identical() -> None:
+    """v3 (default / legacy) encoding also byte-matches Rust core."""
+    from totalreclaw.protobuf import FactPayload, encode_fact_protobuf
+
+    fp = FactPayload(
+        id="test-x",
+        timestamp="2026-04-17T00:00:00Z",
+        owner="0xAB",
+        encrypted_blob="deadbeef",
+        blind_indices=[],
+        decay_score=0.8,
+        source="s",
+        content_fp="fp",
+        agent_id="a",
+        version=3,
+    )
+    py_bytes = encode_fact_protobuf(fp)
+
+    rust_bytes = core.encode_fact_protobuf(
+        json.dumps({
+            "id": "test-x",
+            "timestamp": "2026-04-17T00:00:00Z",
+            "owner": "0xAB",
+            "encrypted_blob_hex": "deadbeef",
+            "blind_indices": [],
+            "decay_score": 0.8,
+            "source": "s",
+            "content_fp": "fp",
+            "agent_id": "a",
+            "version": 3,
+        })
+    )
+    assert py_bytes == rust_bytes
+
+
+def test_python_builder_produces_fixture_parity() -> None:
+    """Build the same logical claim via Python and compare the payload shape."""
+    py_blob = build_canonical_claim_v1(
+        {
+            "text": CANONICAL_V1_FIXTURE["text"],
+            "type": CANONICAL_V1_FIXTURE["type"],
+            "source": CANONICAL_V1_FIXTURE["source"],
+            "scope": CANONICAL_V1_FIXTURE["scope"],
+            "confidence": CANONICAL_V1_FIXTURE["confidence"],
+        },
+        importance=CANONICAL_V1_FIXTURE["importance"],
+        created_at=CANONICAL_V1_FIXTURE["created_at"],
+        claim_id=CANONICAL_V1_FIXTURE["id"],
+    )
+    py_payload = json.loads(py_blob)
+    assert py_payload["id"] == CANONICAL_V1_FIXTURE["id"]
+    assert py_payload["text"] == CANONICAL_V1_FIXTURE["text"]
+    assert py_payload["type"] == CANONICAL_V1_FIXTURE["type"]
+    assert py_payload["source"] == CANONICAL_V1_FIXTURE["source"]
+    assert py_payload["scope"] == CANONICAL_V1_FIXTURE["scope"]
+    assert py_payload["importance"] == CANONICAL_V1_FIXTURE["importance"]
+    assert py_payload["schema_version"] == CANONICAL_V1_FIXTURE["schema_version"]

--- a/python/tests/test_v1_taxonomy.py
+++ b/python/tests/test_v1_taxonomy.py
@@ -1,0 +1,535 @@
+"""Tests for Memory Taxonomy v1 end-to-end in the Python client.
+
+Mirrors the plugin's ``v1-taxonomy.test.ts`` — every assertion that matters
+for cross-client parity has a direct TS counterpart. Run with::
+
+    pytest python/tests/test_v1_taxonomy.py -v
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import totalreclaw_core as core
+from totalreclaw.agent.extraction import (
+    COMPACTION_SYSTEM_PROMPT,
+    EXTRACTION_SYSTEM_PROMPT,
+    LEGACY_V0_MEMORY_TYPES,
+    V0_TO_V1_TYPE,
+    VALID_MEMORY_SCOPES,
+    VALID_MEMORY_SOURCES,
+    VALID_MEMORY_TYPES,
+    VALID_MEMORY_VOLATILITIES,
+    ExtractedFact,
+    apply_provenance_filter_lax,
+    default_volatility,
+    is_valid_memory_type,
+    normalize_to_v1_type,
+    parse_facts_response,
+    parse_facts_response_for_compaction,
+    parse_merged_response_v1,
+)
+from totalreclaw.claims_helper import (
+    PROTOBUF_VERSION_V4,
+    V1_SCHEMA_VERSION,
+    build_canonical_claim,
+    build_canonical_claim_v1,
+    is_v1_blob,
+    read_blob_unified,
+)
+from totalreclaw.reranker import (
+    LEGACY_CLAIM_FALLBACK_WEIGHT,
+    RerankerCandidate,
+    rerank,
+    source_weight,
+)
+
+
+# ---------------------------------------------------------------------------
+# v1 type guards + mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("v1_type", ["claim", "preference", "directive", "commitment", "episode", "summary"])
+def test_v1_guard_accepts_all_v1_types(v1_type: str) -> None:
+    assert is_valid_memory_type(v1_type)
+
+
+@pytest.mark.parametrize("v0_type", ["fact", "decision", "episodic", "goal", "context", "rule"])
+def test_v1_guard_rejects_legacy_v0_tokens(v0_type: str) -> None:
+    """v0 tokens fail the v1 guard — they must be coerced via normalize_to_v1_type."""
+    # "preference" and "summary" overlap between v0 and v1 lists — skip those.
+    assert not is_valid_memory_type(v0_type)
+
+
+def test_v1_guard_rejects_unknown() -> None:
+    assert not is_valid_memory_type("bogus")
+    assert not is_valid_memory_type(42)
+    assert not is_valid_memory_type(None)
+
+
+@pytest.mark.parametrize(
+    "v0,v1",
+    [
+        ("fact", "claim"),
+        ("decision", "claim"),
+        ("context", "claim"),
+        ("rule", "directive"),
+        ("goal", "commitment"),
+        ("episodic", "episode"),
+        ("preference", "preference"),
+        ("summary", "summary"),
+    ],
+)
+def test_normalize_v0_to_v1(v0: str, v1: str) -> None:
+    assert normalize_to_v1_type(v0) == v1
+
+
+@pytest.mark.parametrize("v1_type", VALID_MEMORY_TYPES)
+def test_normalize_v1_passthrough(v1_type: str) -> None:
+    assert normalize_to_v1_type(v1_type) == v1_type
+
+
+def test_normalize_unknown_falls_back_to_claim() -> None:
+    assert normalize_to_v1_type("bogus") == "claim"
+    assert normalize_to_v1_type("") == "claim"
+    assert normalize_to_v1_type(None) == "claim"
+
+
+def test_v0_to_v1_mapping_completeness() -> None:
+    """Every v0 token has an explicit v1 destination."""
+    for v0 in LEGACY_V0_MEMORY_TYPES:
+        assert v0 in V0_TO_V1_TYPE
+        assert V0_TO_V1_TYPE[v0] in VALID_MEMORY_TYPES
+
+
+# ---------------------------------------------------------------------------
+# v1 canonical claim round-trip (build → validate → parse)
+# ---------------------------------------------------------------------------
+
+
+def test_v1_claim_round_trip() -> None:
+    """Build a v1 claim, validate through core, then re-parse and check fields."""
+    fact = {
+        "text": "Uses PostgreSQL as the primary OLTP database",
+        "type": "claim",
+        "source": "user",
+        "scope": "work",
+        "reasoning": "ACID matters more than schema flexibility",
+        "confidence": 0.95,
+        "volatility": "updatable",
+    }
+    blob = build_canonical_claim_v1(
+        fact,
+        importance=8,
+        created_at="2026-04-17T00:00:00.000Z",
+        claim_id="deadbeef-dead-beef-dead-beefdeadbeef",
+    )
+    # Must be valid JSON with schema_version "1.0"
+    payload = json.loads(blob)
+    assert payload["schema_version"] == V1_SCHEMA_VERSION
+    assert payload["id"] == "deadbeef-dead-beef-dead-beefdeadbeef"
+    assert payload["text"] == fact["text"]
+    assert payload["type"] == "claim"
+    assert payload["source"] == "user"
+    assert payload["scope"] == "work"
+    assert payload["reasoning"] == "ACID matters more than schema flexibility"
+    assert payload["importance"] == 8
+    assert payload["confidence"] == 0.95
+    assert payload["volatility"] == "updatable"
+    assert payload["created_at"] == "2026-04-17T00:00:00.000Z"
+
+    # Must be detectable as v1 by the unified reader.
+    assert is_v1_blob(blob)
+
+    # read_blob_unified must surface all v1 metadata fields.
+    decoded = read_blob_unified(blob)
+    assert decoded["text"] == fact["text"]
+    assert decoded["category"] == "claim"
+    assert decoded["importance"] == 8
+    assert decoded["metadata"]["source"] == "user"
+    assert decoded["metadata"]["scope"] == "work"
+    assert decoded["metadata"]["volatility"] == "updatable"
+    assert decoded["metadata"]["reasoning"] == fact["reasoning"]
+
+
+def test_v1_claim_entities_preserved() -> None:
+    fact = {
+        "text": "Pedro chose Rust over Go",
+        "type": "claim",
+        "source": "user",
+        "entities": [
+            {"name": "Pedro", "type": "person", "role": "chooser"},
+            {"name": "Rust", "type": "tool"},
+            {"name": "Go", "type": "tool"},
+        ],
+    }
+    blob = build_canonical_claim_v1(fact, importance=8, created_at="2026-04-17T00:00:00.000Z")
+    payload = json.loads(blob)
+    assert len(payload["entities"]) == 3
+
+
+def test_protobuf_version_v4_is_4() -> None:
+    assert PROTOBUF_VERSION_V4 == 4
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat decrypt (v0 short-key + legacy docs still decodable)
+# ---------------------------------------------------------------------------
+
+
+def test_backward_compat_decrypt_v0_short_key() -> None:
+    """Pre-v1 vaults still decode via the v0 short-key branch."""
+    v0 = json.dumps({"t": "legacy preference", "c": "pref", "cf": 0.9, "i": 7, "sa": "oc"})
+    out = read_blob_unified(v0)
+    assert out["text"] == "legacy preference"
+    assert out["importance"] == 7
+    assert out["category"] == "pref"
+
+
+def test_backward_compat_decrypt_plugin_legacy_doc() -> None:
+    """Pre-KG legacy docs with ``{text, metadata}`` still decode."""
+    legacy = json.dumps({
+        "text": "really old fact",
+        "metadata": {"type": "fact", "importance": 0.6, "source": "auto"},
+    })
+    out = read_blob_unified(legacy)
+    assert out["text"] == "really old fact"
+    assert out["importance"] == 6
+    assert out["category"] == "fact"
+
+
+def test_backward_compat_decrypt_malformed_falls_back() -> None:
+    """Non-JSON / malformed blobs fall through to a raw-text result."""
+    out = read_blob_unified("not json at all")
+    assert out["text"] == "not json at all"
+    assert out["importance"] == 5
+    assert out["category"] == "fact"
+
+
+def test_backward_compat_decrypt_v1_and_v0_precedence() -> None:
+    """v1 takes precedence: a blob that has both short-key AND v1 fields is read as v1."""
+    # Construct a hybrid blob (unlikely but possible if someone crafts one).
+    hybrid = json.dumps({
+        "id": "x",
+        "text": "v1 text",
+        "type": "claim",
+        "source": "user",
+        "importance": 8,
+        "created_at": "2026-04-17T00:00:00Z",
+        "schema_version": "1.0",
+        # v0 keys also present
+        "t": "v0 text",
+        "c": "pref",
+        "i": 5,
+    })
+    out = read_blob_unified(hybrid)
+    assert out["text"] == "v1 text"
+    assert out["importance"] == 8
+
+
+# ---------------------------------------------------------------------------
+# Provenance filter (tag-don't-drop, caps assistant-source at 7)
+# ---------------------------------------------------------------------------
+
+
+def test_provenance_filter_caps_assistant_importance_at_7() -> None:
+    facts = [
+        ExtractedFact(text="Fact from assistant", type="claim", importance=9,
+                      action="ADD", source="assistant", scope="work"),
+    ]
+    conv = "[user]: hi\n\n[assistant]: Fact from assistant yes really"
+    out = apply_provenance_filter_lax(facts, conv)
+    assert len(out) == 1
+    assert out[0].source == "assistant"
+    assert out[0].importance == 7  # capped
+
+
+def test_provenance_filter_user_turns_keep_full_importance() -> None:
+    """If >30% of content words appear in a user turn, source:user stays."""
+    conv = "[user]: I prefer dark mode because eyes"
+    facts = [
+        ExtractedFact(text="prefer dark mode", type="preference",
+                      importance=9, action="ADD", source="user", scope="personal"),
+    ]
+    out = apply_provenance_filter_lax(facts, conv)
+    assert len(out) == 1
+    assert out[0].importance == 9
+
+
+def test_provenance_filter_tags_untraced_facts_as_assistant() -> None:
+    """Fact whose content words don't appear in user turns gets tagged assistant."""
+    conv = "[user]: hello\n\n[assistant]: You should use PostgreSQL for OLTP"
+    # Source is set to user-inferred (not yet downgraded). Fact content matches
+    # assistant turn only → filter tags it assistant + caps importance at 7.
+    facts = [
+        ExtractedFact(text="User should use PostgreSQL for OLTP", type="claim",
+                      importance=9, action="ADD", source="user-inferred", scope="work"),
+    ]
+    out = apply_provenance_filter_lax(facts, conv)
+    assert len(out) == 1
+    assert out[0].source == "assistant"
+    assert out[0].importance == 7
+
+
+def test_provenance_filter_drops_sub_5_importance() -> None:
+    facts = [
+        ExtractedFact(text="chatty noise", type="claim", importance=4, action="ADD",
+                      source="user", scope="misc"),
+    ]
+    out = apply_provenance_filter_lax(facts, "[user]: chatty noise yes")
+    # Below floor of 5 → dropped (unless DELETE).
+    assert out == []
+
+
+def test_provenance_filter_delete_bypasses_floor() -> None:
+    facts = [
+        ExtractedFact(text="old fact", type="claim", importance=1, action="DELETE",
+                      existing_fact_id="x", source="user", scope="misc"),
+    ]
+    out = apply_provenance_filter_lax(facts, "[user]: old fact removed")
+    assert len(out) == 1
+    assert out[0].action == "DELETE"
+
+
+# ---------------------------------------------------------------------------
+# default_volatility heuristic
+# ---------------------------------------------------------------------------
+
+
+def test_default_volatility_commitment_is_updatable() -> None:
+    f = ExtractedFact(text="x", type="commitment", importance=7, action="ADD")
+    assert default_volatility(f) == "updatable"
+
+
+def test_default_volatility_episode_is_stable() -> None:
+    f = ExtractedFact(text="x", type="episode", importance=7, action="ADD")
+    assert default_volatility(f) == "stable"
+
+
+def test_default_volatility_directive_is_stable() -> None:
+    f = ExtractedFact(text="x", type="directive", importance=7, action="ADD")
+    assert default_volatility(f) == "stable"
+
+
+def test_default_volatility_health_scope_is_stable() -> None:
+    f = ExtractedFact(text="x", type="claim", importance=7, action="ADD", scope="health")
+    assert default_volatility(f) == "stable"
+
+
+def test_default_volatility_default_is_updatable() -> None:
+    f = ExtractedFact(text="x", type="claim", importance=7, action="ADD", scope="work")
+    assert default_volatility(f) == "updatable"
+
+
+# ---------------------------------------------------------------------------
+# parse_merged_response_v1 — dual-format input acceptance
+# ---------------------------------------------------------------------------
+
+
+def test_parse_merged_response_v1_canonical_shape() -> None:
+    response = json.dumps({
+        "topics": ["database choice", "team conventions"],
+        "facts": [
+            {"text": "Prefers PostgreSQL", "type": "preference",
+             "source": "user", "scope": "work", "importance": 8, "action": "ADD"},
+            {"text": "Never force-push main", "type": "directive",
+             "source": "user", "scope": "work", "importance": 9, "action": "ADD"},
+        ],
+    })
+    topics, facts = parse_merged_response_v1(response)
+    assert topics == ["database choice", "team conventions"]
+    assert len(facts) == 2
+    assert facts[0].type == "preference"
+    assert facts[1].type == "directive"
+    assert facts[0].source == "user"
+    assert facts[0].scope == "work"
+
+
+def test_parse_merged_response_v1_bare_array() -> None:
+    """Legacy bare-array format is wrapped into the merged-topic shape."""
+    response = json.dumps([
+        {"text": "A fact about something", "type": "claim",
+         "source": "user", "importance": 8, "action": "ADD"},
+    ])
+    topics, facts = parse_merged_response_v1(response)
+    assert topics == []
+    assert len(facts) == 1
+
+
+def test_parse_merged_response_v1_rejects_summary_with_user_source() -> None:
+    """type:summary + source:user is an illegal combination."""
+    response = json.dumps({
+        "topics": [],
+        "facts": [
+            {"text": "A conclusion summary here", "type": "summary",
+             "source": "user", "importance": 8, "action": "ADD"},
+        ],
+    })
+    _, facts = parse_merged_response_v1(response)
+    assert facts == []
+
+
+def test_parse_merged_response_v1_floor_6() -> None:
+    """Importance floor is 6 for the main extraction parser."""
+    response = json.dumps({
+        "topics": [],
+        "facts": [
+            {"text": "Borderline fact five here", "type": "claim",
+             "source": "user", "importance": 5, "action": "ADD"},
+            {"text": "Worth storing fact here", "type": "claim",
+             "source": "user", "importance": 7, "action": "ADD"},
+        ],
+    })
+    _, facts = parse_merged_response_v1(response)
+    assert len(facts) == 1
+    assert facts[0].importance == 7
+
+
+def test_parse_facts_response_for_compaction_floor_5() -> None:
+    """Compaction parser admits borderline facts (importance >= 5)."""
+    response = json.dumps({
+        "topics": [],
+        "facts": [
+            {"text": "Borderline fact here five", "type": "claim",
+             "source": "user", "importance": 5, "action": "ADD"},
+            {"text": "Regular fact seven here", "type": "claim",
+             "source": "user", "importance": 7, "action": "ADD"},
+        ],
+    })
+    facts = parse_facts_response_for_compaction(response)
+    assert len(facts) == 2
+
+
+# ---------------------------------------------------------------------------
+# Retrieval v2 Tier 1 — source-weighted reranking
+# ---------------------------------------------------------------------------
+
+
+def test_source_weight_user_is_1() -> None:
+    assert source_weight("user") == 1.0
+
+
+def test_source_weight_assistant_is_0_55() -> None:
+    assert source_weight("assistant") == pytest.approx(0.55, abs=0.001)
+
+
+def test_source_weight_legacy_none_fallback() -> None:
+    assert source_weight(None) == LEGACY_CLAIM_FALLBACK_WEIGHT
+    assert LEGACY_CLAIM_FALLBACK_WEIGHT == 0.85
+
+
+def test_source_weight_user_inferred_is_0_9() -> None:
+    assert source_weight("user-inferred") == pytest.approx(0.9, abs=0.001)
+
+
+def test_rerank_with_source_weights_promotes_user_over_assistant() -> None:
+    """When two candidates are tied on text + importance, source=user wins."""
+    query = "Who is my favorite database?"
+    # Same text + same importance; only source differs.
+    candidates = [
+        RerankerCandidate(
+            id="assistant-cand",
+            text="The user prefers PostgreSQL",
+            embedding=[1.0, 0.0, 0.0, 0.0],
+            importance=0.8,
+            created_at=0.0,
+            category="pref",
+            source="assistant",
+        ),
+        RerankerCandidate(
+            id="user-cand",
+            text="The user prefers PostgreSQL",
+            embedding=[1.0, 0.0, 0.0, 0.0],
+            importance=0.8,
+            created_at=0.0,
+            category="pref",
+            source="user",
+        ),
+    ]
+    query_emb = [1.0, 0.0, 0.0, 0.0]
+
+    # Without source weights — order is not source-deterministic.
+    # With source weights enabled, the user-sourced candidate ranks first.
+    results = rerank(query, query_emb, candidates, top_k=2, apply_source_weights=True)
+    assert len(results) == 2
+    assert results[0].id == "user-cand"
+    assert results[0].source == "user"
+    assert results[0].source_weight == 1.0
+    assert results[1].source == "assistant"
+    assert results[1].source_weight == pytest.approx(0.55, abs=0.001)
+
+
+def test_rerank_without_source_weights_omits_weight_field() -> None:
+    candidates = [
+        RerankerCandidate(id="a", text="test fact here", embedding=[1.0, 0.0],
+                          importance=0.8, created_at=0.0, category="fact",
+                          source="user"),
+    ]
+    results = rerank("query", [1.0, 0.0], candidates, top_k=1)
+    assert results[0].source_weight is None
+
+
+def test_rerank_legacy_candidate_gets_fallback_weight() -> None:
+    """A candidate with source=None receives the legacy fallback weight."""
+    candidates = [
+        RerankerCandidate(id="legacy", text="legacy fact here",
+                          embedding=[1.0, 0.0], importance=0.8, created_at=0.0,
+                          category="fact", source=None),
+    ]
+    results = rerank("query", [1.0, 0.0], candidates, top_k=1, apply_source_weights=True)
+    assert results[0].source_weight == LEGACY_CLAIM_FALLBACK_WEIGHT
+
+
+# ---------------------------------------------------------------------------
+# No env-var gates for v1
+# ---------------------------------------------------------------------------
+
+
+def test_v1_is_unconditional_no_env_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Setting TOTALRECLAW_TAXONOMY_VERSION=v0 must NOT flip to v0."""
+    monkeypatch.setenv("TOTALRECLAW_TAXONOMY_VERSION", "v0")
+    fact = {"text": "x", "type": "claim", "source": "user"}
+    blob = build_canonical_claim(fact, importance=5)
+    payload = json.loads(blob)
+    assert payload["schema_version"] == V1_SCHEMA_VERSION
+
+
+def test_claim_format_env_gate_is_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Setting TOTALRECLAW_CLAIM_FORMAT=legacy must NOT flip to legacy docs."""
+    monkeypatch.setenv("TOTALRECLAW_CLAIM_FORMAT", "legacy")
+    fact = {"text": "x", "type": "claim", "source": "user"}
+    blob = build_canonical_claim(fact, importance=5)
+    # Must still emit a v1 JSON payload.
+    assert '"schema_version"' in blob
+
+
+# ---------------------------------------------------------------------------
+# Prompt content sanity — merged-topic shape, v1 type list
+# ---------------------------------------------------------------------------
+
+
+def test_extraction_prompt_mentions_v1_types() -> None:
+    prompt = EXTRACTION_SYSTEM_PROMPT
+    # Must list the 6 v1 types.
+    for t in VALID_MEMORY_TYPES:
+        assert t in prompt, f"Prompt missing v1 type {t!r}"
+    # Must mention the merged output shape.
+    assert '"topics"' in prompt
+    assert '"facts"' in prompt
+    # Must mention the required v1 source values.
+    assert "user-inferred" in prompt
+    assert "assistant" in prompt
+
+
+def test_compaction_prompt_admits_floor_5() -> None:
+    """Compaction prompt must mention the 5+ threshold (not 6+)."""
+    assert "5+" in COMPACTION_SYSTEM_PROMPT or "5 " in COMPACTION_SYSTEM_PROMPT
+
+
+def test_extraction_system_prompt_is_merged_topic() -> None:
+    """The prompt must instruct a two-phase merged-topic output."""
+    prompt = EXTRACTION_SYSTEM_PROMPT
+    assert "PHASE 1" in prompt
+    assert "PHASE 2" in prompt


### PR DESCRIPTION
- Default v1 path (no env toggle)
- G-pipeline port to Python
- All 3 Hermes hooks emit v1 (pre_llm_call, post_llm_call, on_session_end)
- 551 tests incl. 22 Python↔Rust protobuf byte-equivalence