### PR TITLE
feat(zeroclaw): totalreclaw-memory@2.0.0 — v1 store_v1 + Tier 1 recall

### DIFF
--- a/rust/totalreclaw-memory/CHANGELOG.md
+++ b/rust/totalreclaw-memory/CHANGELOG.md
@@ -1,0 +1,134 @@
+# Changelog — totalreclaw-memory (ZeroClaw)
+
+## 2.0.0 — 2026-04-18
+
+Memory Taxonomy v1 lands in the ZeroClaw Rust backend. The legacy v0
+envelope + v3 outer protobuf remain the default for the existing
+`Memory` trait API so pre-2.0 vaults keep round-tripping, but the new
+`store_v1()` entry point plus the read-side v1 envelope parser put the
+crate on feature parity with plugin v3.0.0 / mcp 3.0.0 / python 2.0.0.
+
+### v1 write path
+
+- **New** `store::V1StoreInput` struct carrying text + v1 type + source
+  + scope + volatility + importance (+ optional reasoning).
+- **New** `store::build_memory_claim_v1(input)` — constructs a canonical
+  `MemoryClaimV1` with UUIDv7 id + RFC 3339 `created_at` + `schema_version`
+  ("1.0") per the v1 spec.
+- **New** `store::store_fact_v1()` — full v1 pipeline (exact-dedup via
+  content fingerprint, best-match near-duplicate supersede, v4 protobuf
+  submission). Emits `zeroclaw_v1_{source-token}` as the on-chain source
+  tag (e.g. `zeroclaw_v1_user-inferred`) for analytics.
+- **New** `TotalReclawMemory::store_v1(input)` trait method — thin
+  wrapper around `store_fact_v1` that threads the memory's pre-derived
+  keys / embedding provider / relay client and invalidates the hot cache
+  after the store.
+- **New** `core::store::prepare_fact_v1()` — the pure-computation half:
+  encrypts the v1 JSON envelope (no `{t,a,s}` wrapper — the envelope IS
+  the ClaimPayload), builds blind indices from the same text, encrypts
+  the embedding, emits the protobuf with `version = 4`.
+
+### v4 outer protobuf
+
+- Core `FactPayload` gains a `version: u32` field.
+- Core `encode_fact_protobuf` / `encode_tombstone_protobuf` now thread
+  `version` onto field 8. `0` is normalized to `DEFAULT_PROTOBUF_VERSION`
+  (`3`) for back-compat callers.
+- New constants `DEFAULT_PROTOBUF_VERSION = 3` and
+  `PROTOBUF_VERSION_V4 = 4` exported from core's `protobuf` module.
+- ZeroClaw's `forget()` / `store_tombstone_v1()` use the v4 path;
+  legacy `store_tombstone()` stays on v3 for the non-v1 code path.
+- WASM + PyO3 bindings: optional `version` field on the JSON /
+  kwarg input; v0 callers who omit it still get a valid v3 blob.
+
+### Read path — v1 envelope parsing
+
+- `backend::parse_decrypted_envelope()` now tries v1 ClaimPayload
+  (top-level `text` + `type` fields) first, then falls back to the
+  legacy v0 `{t, a, s}` short-key envelope.
+- v1 `source` field is parsed (kebab-case literals: `user`,
+  `user-inferred`, `assistant`, `external`, `derived`) and attached to
+  each `reranker::Candidate` so Retrieval v2 Tier 1 source weights
+  apply. v0 envelopes leave `source: None`; the reranker applies the
+  legacy-claim fallback weight for them.
+- v1 type → ZeroClaw `MemoryCategory` mapping:
+  - `episode` → Conversation (7-day decay)
+  - `claim | preference | directive | commitment | summary` → Core
+  - anything else → Core (safe default)
+
+### Retrieval v2 Tier 1 — source-weighted reranking
+
+- `TotalReclawMemory::recall()` now calls
+  `reranker::rerank_with_config(apply_source_weights: true, ...)`.
+- v1 blobs carry provenance into the reranker; v0 blobs use
+  `LEGACY_CLAIM_FALLBACK_WEIGHT` so pre-2.0 vault entries aren't
+  penalized during the migration window.
+
+### Deferred operations — pin / retype / set_scope
+
+The new MCP v1 tools (`totalreclaw_pin`, `totalreclaw_retype`,
+`totalreclaw_set_scope`) are not yet wired into the ZeroClaw `Memory`
+trait. `pin()` / `retype()` / `set_scope()` stubs exist on
+`TotalReclawMemory` but currently return an error telling callers to
+use the MCP server's equivalent tools from their NEAR AI agent.
+Tracked as a Known Gap in CLAUDE.md.
+
+Rationale: ZeroClaw 2.0 ships the storage-layer v1 support; the
+supersede-chain semantics for pin/retype/set_scope are defined in the
+v1 spec addendum but are best exercised once the MCP v1 tools are
+published and validated end-to-end. Doing them in Rust without that
+validation ladder would mean shipping untested pin-chain behaviour
+that diverges from the TS / Python implementations.
+
+### Bumps
+
+- `totalreclaw-memory` crate version: **0.1.0 → 2.0.0**
+- `totalreclaw-core` dependency: **pinned to "2.0"** (already the case
+  as of Agent F's core-v2.0.0 branch).
+
+### Testing
+
+- **51 library unit tests pass** (existing behaviour: crypto, LSH,
+  blind index, fingerprint, stemmer, hot cache, reranker, wallet,
+  userop, store).
+- **15 new v1 integration tests** in `tests/v1_taxonomy.rs` covering:
+  - `V1StoreInput` + `build_memory_claim_v1` (UUIDv7, RFC3339, scope /
+    volatility / reasoning threading)
+  - v1 `MemoryClaimV1` JSON round-trip (spec field names, not v0
+    short-keys)
+  - v4 protobuf encoding (version tag on field 8, v3 vs v4 distinct)
+  - tombstone v4 encoding
+  - `MemorySource` kebab-case ser/de (for Tier 1 reranker wiring)
+  - `MemoryTypeV1::from_str_lossy` case-insensitivity
+  - Enum cardinality (6 types, 5 sources, 8 scopes, 3 volatilities)
+- **24 spec-compliance tests pass** (updated one `Candidate` literal
+  to include the new `source: None` field).
+- **Cross-client E2E tests** (3-way, native UserOp, staging) updated
+  to set `version: DEFAULT_PROTOBUF_VERSION` on `FactPayload`
+  literals. These tests are `#[ignore]`-gated on network availability
+  so they compile but only run when the staging relay / local Anvil
+  is up.
+
+### Not done (deferred)
+
+- v1 extraction pipeline in ZeroClaw. The current ZeroClaw usage
+  pattern is the NEAR AI agent calling `store_v1()` with already-built
+  `V1StoreInput` (the agent runs its own extractor). No LLM extraction
+  happens inside this crate — that's in the NEAR AI routines engine
+  or in the MCP server. If ZeroClaw ever grows a local extractor
+  (analogous to plugin's `extractor.ts`), the G-pipeline (merged-topic
+  prompt + `apply_provenance_filter_lax` + `comparative_rescore_v1`
+  + `default_volatility`) will need porting — at that point core's
+  `smart_import` / `digest` modules are the natural reuse points.
+- Native pin / retype / set_scope in the Rust trait. Scheduled for
+  ZeroClaw 2.1 once MCP 3.0.0 is published and the v1 supersede-chain
+  behaviour is validated end-to-end against the staging subgraph.
+- Staging E2E smoke test for the v1 write path specifically. The
+  `test_three_way_cross_client` integration test still writes v3
+  blobs; a v1 variant will land with the ZeroClaw 2.1 pin/retype work.
+
+## 0.1.0 — pre-2.0
+
+Initial ZeroClaw Rust backend — v0 taxonomy, v3 outer protobuf,
+Phase 2 KG contradiction detection, hot cache, dynamic candidate pool,
+client batching, debrief. See git history.

--- a/rust/totalreclaw-memory/Cargo.lock
+++ b/rust/totalreclaw-memory/Cargo.lock
@@ -3225,7 +3225,7 @@ dependencies = [
 
 [[package]]
 name = "totalreclaw-memory"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "base64 0.22.1",
  "bip39",

--- a/rust/totalreclaw-memory/Cargo.toml
+++ b/rust/totalreclaw-memory/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "totalreclaw-memory"
-version = "0.1.0"
+version = "2.0.0"
 edition = "2021"
-description = "TotalReclaw memory backend — E2EE crypto, LSH, embeddings, reranker"
+description = "TotalReclaw memory backend — E2EE crypto, LSH, embeddings, reranker (Memory Taxonomy v1)"
 license = "MIT"
 repository = "https://github.com/p-diogo/totalreclaw"
 

--- a/rust/totalreclaw-memory/src/backend.rs
+++ b/rust/totalreclaw-memory/src/backend.rs
@@ -50,53 +50,115 @@ use crate::crypto::{self, DerivedKeys};
 use crate::embedding::{self, EmbeddingMode, EmbeddingProvider};
 use crate::hotcache::HotCache;
 use crate::lsh::LshHasher;
-use crate::reranker::{self, Candidate};
+use crate::reranker::{self, Candidate, RerankerConfig};
 use crate::relay::{RelayClient, RelayConfig};
 use crate::search;
 use crate::store;
 use crate::wallet;
 use crate::Result;
+use totalreclaw_core::claims::MemorySource;
 
 /// Default relay URL.
 const DEFAULT_RELAY_URL: &str = "https://api.totalreclaw.xyz";
 
-/// Result of parsing the decrypted fact envelope (`{"t":..,"a":..,"s":..}`).
+/// Result of parsing the decrypted fact envelope.
+///
+/// ZeroClaw reads both envelope shapes:
+///  * **v0 (pre-2.0)**: `{"t": text, "a": agent_id, "s": source_tag}`
+///    (source_tag is `zeroclaw_{category}` or `openclaw_extraction` etc.)
+///  * **v1 (Memory Taxonomy v1)**: full v1 `ClaimPayload` with `text`,
+///    `type`, `source` (one of `user|user-inferred|assistant|external|derived`),
+///    `scope`, optional `reasoning`, `volatility`, `entities`, `importance`.
 struct DecryptedEnvelope {
     text: String,
     category: MemoryCategory,
+    /// Memory Taxonomy v1 provenance source if the envelope is v1; `None`
+    /// for v0 envelopes (read-side back-compat). Used by `rerank_with_config`
+    /// to apply Retrieval v2 Tier 1 source weights.
+    v1_source: Option<MemorySource>,
 }
 
-/// Parse the decrypted JSON envelope and extract text + category.
+/// Parse the decrypted fact envelope.
 ///
-/// The encrypted blob stores `{"t": text, "a": agent_id, "s": source}`.
-/// ZeroClaw stores source as `zeroclaw_{category}` (e.g. `zeroclaw_core`).
-/// Other clients use different source formats (e.g. `openclaw_extraction`).
-///
-/// Category mapping:
-///   - source contains "core"         -> Core
-///   - source contains "conversation" -> Conversation
-///   - source contains "daily"        -> Daily
-///   - source contains "debrief"      -> Core (debriefs are high-value)
-///   - anything else                  -> Core (safe default)
+/// Tries v1 first (ClaimPayload JSON), falls back to v0 (`{t,a,s}` envelope)
+/// on parse failure so pre-2.0 vault entries still decode.
 fn parse_decrypted_envelope(decrypted: &str) -> DecryptedEnvelope {
-    // Try to parse as JSON envelope
+    // Try v1 ClaimPayload JSON first. A v1 envelope has `text` and `type`
+    // fields at top level; v0 envelopes use `t`/`a`/`s` short keys.
     if let Ok(obj) = serde_json::from_str::<serde_json::Value>(decrypted) {
+        let is_v1 = obj.get("text").is_some() && obj.get("type").is_some();
+        if is_v1 {
+            let text = obj
+                .get("text")
+                .and_then(|v| v.as_str())
+                .unwrap_or(decrypted)
+                .to_string();
+            // v1 source field: literal enum string
+            let v1_source = obj
+                .get("source")
+                .and_then(|v| v.as_str())
+                .and_then(parse_v1_source);
+            // v1 "type" → ZeroClaw category mapping
+            let v1_type = obj
+                .get("type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("claim");
+            let category = v1_type_to_category(v1_type);
+            return DecryptedEnvelope {
+                text,
+                category,
+                v1_source,
+            };
+        }
+
+        // v0 envelope path (pre-2.0)
         let text = obj
             .get("t")
             .and_then(|v| v.as_str())
             .unwrap_or(decrypted)
             .to_string();
-        let source = obj
-            .get("s")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
+        let source = obj.get("s").and_then(|v| v.as_str()).unwrap_or("");
         let category = category_from_source(source);
-        return DecryptedEnvelope { text, category };
+        return DecryptedEnvelope {
+            text,
+            category,
+            v1_source: None,
+        };
     }
     // Fallback: treat entire decrypted content as text
     DecryptedEnvelope {
         text: decrypted.to_string(),
         category: MemoryCategory::Core,
+        v1_source: None,
+    }
+}
+
+/// Parse a v1 memory source literal to the core `MemorySource` enum.
+fn parse_v1_source(raw: &str) -> Option<MemorySource> {
+    match raw {
+        "user" => Some(MemorySource::User),
+        "user-inferred" => Some(MemorySource::UserInferred),
+        "assistant" => Some(MemorySource::Assistant),
+        "external" => Some(MemorySource::External),
+        "derived" => Some(MemorySource::Derived),
+        _ => None,
+    }
+}
+
+/// Map a v1 memory type to a ZeroClaw memory category.
+///
+/// Category rules:
+///  * claim, preference, directive, commitment → Core (durable)
+///  * episode → Conversation (7-day decay)
+///  * summary → Core (synthesis is high-value)
+///  * anything else → Core (safe default)
+fn v1_type_to_category(v1_type: &str) -> MemoryCategory {
+    match v1_type {
+        "episode" => MemoryCategory::Conversation,
+        "claim" | "preference" | "directive" | "commitment" | "summary" => {
+            MemoryCategory::Core
+        }
+        _ => MemoryCategory::Core,
     }
 }
 
@@ -429,7 +491,7 @@ impl TotalReclawMemory {
             }
         }
 
-        // 8. Decrypt candidates and build reranker input
+        // 8. Decrypt candidates and build reranker input (with v1 provenance)
         let mut rerank_candidates = Vec::new();
         for fact in &candidates {
             // Decrypt content
@@ -437,10 +499,16 @@ impl TotalReclawMemory {
                 Some(b) => b,
                 None => continue,
             };
-            let text = match crypto::decrypt(&blob_b64, &self.keys.encryption_key) {
+            let decrypted = match crypto::decrypt(&blob_b64, &self.keys.encryption_key) {
                 Ok(t) => t,
                 Err(_) => continue,
             };
+
+            // Parse the envelope to extract the display text + v1 source.
+            // v1 blobs carry `source` (Retrieval v2 Tier 1 weighting signal);
+            // v0 blobs don't — reranker falls back to the legacy claim weight.
+            let envelope = parse_decrypted_envelope(&decrypted);
+            let text = envelope.text;
 
             // Decrypt embedding (if available)
             let mut emb = fact
@@ -474,11 +542,22 @@ impl TotalReclawMemory {
                 text: text.clone(),
                 embedding: emb,
                 timestamp: fact.timestamp.clone().unwrap_or_default(),
+                source: envelope.v1_source,
             });
         }
 
-        // 9. Rerank
-        let ranked = reranker::rerank(query, &query_embedding, &rerank_candidates, limit)?;
+        // 9. Rerank with Retrieval v2 Tier 1 source weights enabled.
+        // v1 blobs carry a MemorySource; v0 blobs fall through to the legacy
+        // claim weight so pre-2.0 vaults aren't penalized.
+        let ranked = reranker::rerank_with_config(
+            query,
+            &query_embedding,
+            &rerank_candidates,
+            limit,
+            RerankerConfig {
+                apply_source_weights: true,
+            },
+        )?;
 
         // 10. Convert to MemoryEntry
         let results: Vec<MemoryEntry> = ranked
@@ -555,9 +634,97 @@ impl TotalReclawMemory {
     }
 
     /// Forget (soft-delete) a memory entry using native UserOp.
+    ///
+    /// Emits a Memory Taxonomy v1 tombstone (outer protobuf `version = 4`)
+    /// so the subgraph can distinguish v1 deletes from legacy v3 deletes.
     pub async fn forget(&self, key: &str) -> Result<bool> {
-        store::store_tombstone(key, &self.relay, Some(&self.private_key)).await?;
+        store::store_tombstone_v1(key, &self.relay, Some(&self.private_key)).await?;
         Ok(true)
+    }
+
+    // -----------------------------------------------------------------------
+    // Memory Taxonomy v1 extensions
+    // -----------------------------------------------------------------------
+
+    /// Store a Memory Taxonomy v1 claim (explicit v1 write path).
+    ///
+    /// Use this when the caller has full v1 context (type, source, scope,
+    /// volatility, optional reasoning). Produces a v4 protobuf envelope
+    /// with the canonical `MemoryClaimV1` JSON inner blob.
+    ///
+    /// For the ZeroClaw `Memory` trait's simpler `(key, content, category)`
+    /// shape, `store_with_importance()` remains the primary entry point
+    /// and continues to emit v3 envelopes during the v0→v1 migration
+    /// window. Switch your agent to `store_v1()` when you want v1
+    /// provenance-weighted reranking at recall time.
+    pub async fn store_v1(&self, input: &store::V1StoreInput) -> Result<String> {
+        let fact_id = store::store_fact_v1(
+            input,
+            &self.keys,
+            &self.lsh_hasher,
+            self.embedding_provider.as_ref(),
+            &self.relay,
+            Some(&self.private_key),
+        )
+        .await?;
+
+        // Invalidate hot cache after v1 store
+        if let Ok(mut cache) = self.hot_cache.lock() {
+            cache.clear();
+        }
+        Ok(fact_id)
+    }
+
+    /// Pin a memory claim — supersede it with a new v1 blob whose
+    /// `volatility: stable` signals "never auto-supersede".
+    ///
+    /// ZeroClaw implements pin as a supersede operation: fetch the fact,
+    /// re-store it as a v1 claim with `volatility: stable`, then tombstone
+    /// the prior version. The new claim's `superseded_by` field tracks the
+    /// previous id so a future unpin can reverse the chain.
+    ///
+    /// Not-yet-implemented: this method returns an error advising the
+    /// caller to run the MCP server's `totalreclaw_pin` tool instead.
+    /// See ZeroClaw 2.0 Known Gaps in CLAUDE.md.
+    pub async fn pin(&self, _memory_id: &str) -> Result<()> {
+        Err(crate::Error::Crypto(
+            "pin: not yet implemented in ZeroClaw — use the MCP totalreclaw_pin tool \
+             from your agent. See CLAUDE.md Known Gaps."
+                .into(),
+        ))
+    }
+
+    /// Retype a memory claim — change its v1 `type` (claim → directive, etc.)
+    /// via supersede.
+    ///
+    /// Not-yet-implemented in ZeroClaw's native trait. The MCP server's
+    /// `totalreclaw_retype` tool is the canonical path.
+    pub async fn retype(
+        &self,
+        _memory_id: &str,
+        _new_type: MemorySource,
+    ) -> Result<()> {
+        Err(crate::Error::Crypto(
+            "retype: not yet implemented in ZeroClaw — use the MCP \
+             totalreclaw_retype tool. See CLAUDE.md Known Gaps."
+                .into(),
+        ))
+    }
+
+    /// Set or change the v1 `scope` of a memory claim via supersede.
+    ///
+    /// Not-yet-implemented in ZeroClaw's native trait. The MCP server's
+    /// `totalreclaw_set_scope` tool is the canonical path.
+    pub async fn set_scope(
+        &self,
+        _memory_id: &str,
+        _new_scope: totalreclaw_core::claims::MemoryScope,
+    ) -> Result<()> {
+        Err(crate::Error::Crypto(
+            "set_scope: not yet implemented in ZeroClaw — use the MCP \
+             totalreclaw_set_scope tool. See CLAUDE.md Known Gaps."
+                .into(),
+        ))
     }
 
     /// Count active memories.

--- a/rust/totalreclaw-memory/src/lib.rs
+++ b/rust/totalreclaw-memory/src/lib.rs
@@ -44,6 +44,12 @@ pub use totalreclaw_core::claims::{
     Claim, ClaimCategory, ClaimStatus, EntityRef, EntityType, ResolutionAction, SkipReason,
     TIE_ZONE_SCORE_TOLERANCE, is_pinned_claim, is_pinned_json, respect_pin_in_resolution,
 };
+// Memory Taxonomy v1 types. As of totalreclaw-memory 2.0 these are the
+// canonical taxonomy; v0 categories remain for pre-2.0 vault back-compat.
+pub use totalreclaw_core::claims::{
+    MemoryClaimV1, MemoryEntityV1, MemorySource, MemoryScope, MemoryTypeV1,
+    MemoryVolatility, MEMORY_CLAIM_V1_SCHEMA_VERSION,
+};
 pub use totalreclaw_core::contradiction::{
     Contradiction, ResolutionOutcome, ResolutionWeights, ScoreComponents,
     resolve_with_candidates, resolve_pair, detect_contradictions, default_weights,

--- a/rust/totalreclaw-memory/src/protobuf.rs
+++ b/rust/totalreclaw-memory/src/protobuf.rs
@@ -22,9 +22,39 @@ mod tests {
             content_fp: "fp123".into(),
             agent_id: "zeroclaw".into(),
             encrypted_embedding: None,
+            version: DEFAULT_PROTOBUF_VERSION,
         };
         let encoded = encode_fact_protobuf(&payload);
         assert!(!encoded.is_empty());
         assert!(encoded.windows(7).any(|w| w == b"test-id"));
+    }
+
+    #[test]
+    fn test_encode_fact_protobuf_v4() {
+        // v1 blobs use version = 4
+        let payload = FactPayload {
+            id: "v1-test".into(),
+            timestamp: "2026-04-18T12:00:00Z".into(),
+            owner: "0xABCD".into(),
+            encrypted_blob_hex: "cafe".into(),
+            blind_indices: vec![],
+            decay_score: 0.9,
+            source: "zeroclaw_v1_user".into(),
+            content_fp: "fp_v1".into(),
+            agent_id: "zeroclaw".into(),
+            encrypted_embedding: None,
+            version: PROTOBUF_VERSION_V4,
+        };
+        let encoded = encode_fact_protobuf(&payload);
+        // Field 8 (version) tag byte = (8<<3)|0 = 0x40, value = 4
+        assert!(encoded.windows(2).any(|w| w == [0x40, 4]));
+    }
+
+    #[test]
+    fn test_encode_tombstone_v4() {
+        let v3 = encode_tombstone_protobuf("t", "0xABCD", DEFAULT_PROTOBUF_VERSION);
+        let v4 = encode_tombstone_protobuf("t", "0xABCD", PROTOBUF_VERSION_V4);
+        assert!(v3.windows(2).any(|w| w == [0x40, 3]));
+        assert!(v4.windows(2).any(|w| w == [0x40, 4]));
     }
 }

--- a/rust/totalreclaw-memory/src/store.rs
+++ b/rust/totalreclaw-memory/src/store.rs
@@ -17,7 +17,10 @@
 use base64::Engine;
 
 use totalreclaw_core::blind;
-use totalreclaw_core::claims::{Claim, ResolutionAction};
+use totalreclaw_core::claims::{
+    Claim, MemoryClaimV1, MemoryScope, MemorySource, MemoryTypeV1, MemoryVolatility,
+    ResolutionAction, MEMORY_CLAIM_V1_SCHEMA_VERSION,
+};
 use totalreclaw_core::consolidation;
 use totalreclaw_core::contradiction;
 use totalreclaw_core::crypto;
@@ -209,6 +212,9 @@ pub async fn store_fact_batch(
 }
 
 /// Store a tombstone on-chain (soft-delete a fact).
+///
+/// Legacy (v3 outer protobuf). For Memory Taxonomy v1 vaults, prefer
+/// `store_tombstone_v1()` so the tombstone protobuf carries `version = 4`.
 pub async fn store_tombstone(
     fact_id: &str,
     relay: &RelayClient,
@@ -222,6 +228,179 @@ pub async fn store_tombstone(
         relay.submit_protobuf(&protobuf).await?;
     }
     Ok(())
+}
+
+/// Store a Memory Taxonomy v1 tombstone on-chain.
+///
+/// Emits `version = 4` on the outer protobuf so the subgraph indexes this
+/// tombstone under the v1 taxonomy. Semantically identical to
+/// `store_tombstone()`.
+pub async fn store_tombstone_v1(
+    fact_id: &str,
+    relay: &RelayClient,
+    private_key: Option<&[u8; 32]>,
+) -> Result<()> {
+    let protobuf = core_store::prepare_tombstone_v1(fact_id, relay.wallet_address());
+
+    if let Some(pk) = private_key {
+        relay.submit_fact_native(&protobuf, pk).await?;
+    } else {
+        relay.submit_protobuf(&protobuf).await?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Memory Taxonomy v1 store path
+// ---------------------------------------------------------------------------
+
+/// Input for building a v1 memory claim from ZeroClaw's high-level API.
+///
+/// The ZeroClaw Memory trait deals in `(key, content, category, session_id)`.
+/// `V1StoreInput` is the adapter shape that maps those plus explicit v1
+/// provenance (`source`, `scope`, `volatility`) onto the canonical
+/// `MemoryClaimV1` the core write path expects.
+#[derive(Debug, Clone)]
+pub struct V1StoreInput {
+    /// Plaintext body of the claim (5-512 UTF-8 chars).
+    pub text: String,
+    /// v1 memory type (claim | preference | directive | commitment |
+    /// episode | summary).
+    pub memory_type: MemoryTypeV1,
+    /// v1 provenance source.
+    pub source: MemorySource,
+    /// Importance on the 1-10 scale. Normalized to 0.0-1.0 on-chain.
+    pub importance: u8,
+    /// Life-domain scope. Defaults to `Unspecified`.
+    pub scope: MemoryScope,
+    /// Stability signal. Defaults to `Updatable`.
+    pub volatility: MemoryVolatility,
+    /// Decision-with-reasoning clause (only meaningful for `type: claim`).
+    pub reasoning: Option<String>,
+}
+
+impl V1StoreInput {
+    /// Convenience constructor for a plain claim with default scope + volatility.
+    pub fn new_claim(text: impl Into<String>, importance: u8) -> Self {
+        Self {
+            text: text.into(),
+            memory_type: MemoryTypeV1::Claim,
+            source: MemorySource::UserInferred,
+            importance,
+            scope: MemoryScope::Unspecified,
+            volatility: MemoryVolatility::Updatable,
+            reasoning: None,
+        }
+    }
+}
+
+/// Build a canonical `MemoryClaimV1` from a `V1StoreInput`.
+///
+/// Populates `id` (UUIDv7) and `created_at` (RFC 3339 UTC) and threads the
+/// rest through verbatim. The resulting claim is the JSON envelope that
+/// `prepare_fact_v1()` encrypts into the outer v4 protobuf.
+pub fn build_memory_claim_v1(input: &V1StoreInput) -> MemoryClaimV1 {
+    MemoryClaimV1 {
+        id: uuid::Uuid::now_v7().to_string(),
+        text: input.text.clone(),
+        memory_type: input.memory_type,
+        source: input.source,
+        created_at: chrono::Utc::now()
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        schema_version: MEMORY_CLAIM_V1_SCHEMA_VERSION.to_string(),
+        scope: input.scope,
+        volatility: input.volatility,
+        entities: Vec::new(),
+        reasoning: input.reasoning.clone(),
+        expires_at: None,
+        importance: Some(input.importance),
+        confidence: None,
+        superseded_by: None,
+    }
+}
+
+/// Store a Memory Taxonomy v1 claim on-chain.
+///
+/// Full v1 pipeline:
+///  1. Build canonical `MemoryClaimV1`
+///  2. Serialize to JSON envelope (the inner blob)
+///  3. Content fingerprint exact-dedup check (tombstone v4 if match)
+///  4. Generate embedding
+///  5. Best-match near-duplicate dedup (tombstone v4 if match, cosine ≥ 0.85)
+///  6. `core::prepare_fact_v1()` — encrypt envelope, build blind indices,
+///     encrypt embedding, emit v4 protobuf
+///  7. Submit via native UserOp (or legacy if no private key)
+///
+/// Returns the fact_id of the stored claim.
+pub async fn store_fact_v1(
+    input: &V1StoreInput,
+    keys: &crypto::DerivedKeys,
+    lsh_hasher: &LshHasher,
+    embedding_provider: &dyn EmbeddingProvider,
+    relay: &RelayClient,
+    private_key: Option<&[u8; 32]>,
+) -> Result<String> {
+    // 1. Build canonical v1 claim
+    let claim = build_memory_claim_v1(input);
+
+    // 2. Serialize envelope
+    let envelope_json = serde_json::to_string(&claim)
+        .map_err(|e| crate::Error::Crypto(format!("v1 envelope serialize: {e}")))?;
+
+    // 3. Exact-dedup via content fingerprint
+    let content_fp = fingerprint::generate_content_fingerprint(&claim.text, &keys.dedup_key);
+    if let Ok(Some(dup)) =
+        search::search_by_fingerprint(relay, relay.wallet_address(), &content_fp).await
+    {
+        // v1 vaults emit v4 tombstones
+        let _ = store_tombstone_v1(&dup.id, relay, private_key).await;
+    }
+
+    // 4. Generate embedding
+    let embedding = embedding_provider.embed(&claim.text).await?;
+
+    // 5. Best-match near-duplicate supersede
+    if let Some(dup) = find_best_duplicate(&claim.text, &embedding, keys, relay).await {
+        let _ = store_tombstone_v1(&dup.fact_id, relay, private_key).await;
+    }
+
+    // 6. Prepare v1 fact (encrypt envelope + v4 protobuf)
+    //    Source tag for on-chain analytics uses the v1 provenance token
+    //    (e.g. `zeroclaw_v1_user-inferred`).
+    let source_tag = format!("zeroclaw_v1_{}", v1_source_to_str(input.source));
+    let prepared = core_store::prepare_fact_v1(
+        &envelope_json,
+        &claim.text,
+        &keys.encryption_key,
+        &keys.dedup_key,
+        lsh_hasher,
+        &embedding,
+        input.importance as f64,
+        &source_tag,
+        relay.wallet_address(),
+        "zeroclaw",
+    )
+    .map_err(|e| crate::Error::Crypto(e.to_string()))?;
+
+    // 7. Submit
+    if let Some(pk) = private_key {
+        relay.submit_fact_native(&prepared.protobuf_bytes, pk).await?;
+    } else {
+        relay.submit_protobuf(&prepared.protobuf_bytes).await?;
+    }
+
+    Ok(prepared.fact_id)
+}
+
+/// Render a `MemorySource` enum value to its kebab-case wire token.
+fn v1_source_to_str(src: MemorySource) -> &'static str {
+    match src {
+        MemorySource::User => "user",
+        MemorySource::UserInferred => "user-inferred",
+        MemorySource::Assistant => "assistant",
+        MemorySource::External => "external",
+        MemorySource::Derived => "derived",
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/rust/totalreclaw-memory/tests/e2e_spec_validation.rs
+++ b/rust/totalreclaw-memory/tests/e2e_spec_validation.rs
@@ -156,6 +156,7 @@ async fn test_e2e_store_recall_with_dedup() {
         content_fp,
         agent_id: "e2e-spec-validation".to_string(),
         encrypted_embedding: None,
+        version: totalreclaw_memory::protobuf::DEFAULT_PROTOBUF_VERSION,
     };
 
     let protobuf = totalreclaw_memory::protobuf::encode_fact_protobuf(&payload);

--- a/rust/totalreclaw-memory/tests/native_userop_e2e.rs
+++ b/rust/totalreclaw-memory/tests/native_userop_e2e.rs
@@ -87,6 +87,7 @@ async fn test_native_store_and_recall() {
         content_fp,
         agent_id: "native-userop-e2e".to_string(),
         encrypted_embedding: None,
+        version: totalreclaw_memory::protobuf::DEFAULT_PROTOBUF_VERSION,
     };
 
     let protobuf = totalreclaw_memory::protobuf::encode_fact_protobuf(&payload);
@@ -227,6 +228,7 @@ async fn test_batch_store_and_recall() {
             content_fp,
             agent_id: "batch-e2e".to_string(),
             encrypted_embedding: None,
+            version: totalreclaw_memory::protobuf::DEFAULT_PROTOBUF_VERSION,
         };
 
         protobuf_payloads.push(totalreclaw_memory::protobuf::encode_fact_protobuf(&payload));

--- a/rust/totalreclaw-memory/tests/spec_compliance.rs
+++ b/rust/totalreclaw-memory/tests/spec_compliance.rs
@@ -332,6 +332,7 @@ fn test_auto_recall_top_k_is_8() {
             text: format!("test fact about dark mode preference number {}", i),
             embedding: vec![i as f32 / 20.0; 4],
             timestamp: String::new(),
+            source: None,
         })
         .collect();
 

--- a/rust/totalreclaw-memory/tests/three_way_cross_client.rs
+++ b/rust/totalreclaw-memory/tests/three_way_cross_client.rs
@@ -345,6 +345,7 @@ async fn store_via_rust(mnemonic: &str, fact_text: &str) -> bool {
         content_fp,
         agent_id: "cross-client-e2e".to_string(),
         encrypted_embedding: None,
+        version: totalreclaw_memory::protobuf::DEFAULT_PROTOBUF_VERSION,
     };
 
     let protobuf = totalreclaw_memory::protobuf::encode_fact_protobuf(&payload);

--- a/rust/totalreclaw-memory/tests/v1_taxonomy.rs
+++ b/rust/totalreclaw-memory/tests/v1_taxonomy.rs
@@ -1,0 +1,307 @@
+//! ZeroClaw Memory Taxonomy v1 tests.
+//!
+//! Covers the v1 write path (`store_fact_v1` / `V1StoreInput` /
+//! `build_memory_claim_v1`), v4 protobuf encoding, and v1 blob envelope
+//! parsing on the recall side. Crypto-heavy end-to-end flows (real
+//! relay + subgraph) are exercised by the separate
+//! `tests/e2e_spec_validation.rs` suite.
+
+use totalreclaw_core::claims::{
+    MemoryClaimV1, MemoryScope, MemorySource, MemoryTypeV1, MemoryVolatility,
+    MEMORY_CLAIM_V1_SCHEMA_VERSION,
+};
+use totalreclaw_core::protobuf::{
+    encode_fact_protobuf, encode_tombstone_protobuf, FactPayload, DEFAULT_PROTOBUF_VERSION,
+    PROTOBUF_VERSION_V4,
+};
+use totalreclaw_memory::store::{build_memory_claim_v1, V1StoreInput};
+
+// ---------------------------------------------------------------------------
+// V1StoreInput + build_memory_claim_v1
+// ---------------------------------------------------------------------------
+
+#[test]
+fn v1_store_input_new_claim_populates_sensible_defaults() {
+    let input = V1StoreInput::new_claim("User prefers PostgreSQL", 8);
+    assert_eq!(input.text, "User prefers PostgreSQL");
+    assert_eq!(input.memory_type, MemoryTypeV1::Claim);
+    assert_eq!(input.source, MemorySource::UserInferred);
+    assert_eq!(input.importance, 8);
+    assert_eq!(input.scope, MemoryScope::Unspecified);
+    assert_eq!(input.volatility, MemoryVolatility::Updatable);
+    assert!(input.reasoning.is_none());
+}
+
+#[test]
+fn build_memory_claim_v1_uuid_v7_and_iso8601() {
+    let input = V1StoreInput {
+        text: "x".into(),
+        memory_type: MemoryTypeV1::Directive,
+        source: MemorySource::User,
+        importance: 9,
+        scope: MemoryScope::Work,
+        volatility: MemoryVolatility::Stable,
+        reasoning: None,
+    };
+    let claim = build_memory_claim_v1(&input);
+
+    // UUID v7 is 36 chars long with the standard dash layout
+    assert_eq!(claim.id.len(), 36);
+    assert_eq!(claim.id.chars().filter(|c| *c == '-').count(), 4);
+    // version nibble is the 15th character (index 14) — should be '7' for v7
+    assert_eq!(claim.id.chars().nth(14), Some('7'));
+
+    // ISO8601 UTC with millisecond precision (ends in `Z` or has a `+` offset)
+    assert!(claim.created_at.contains('T'));
+    assert!(
+        claim.created_at.ends_with('Z') || claim.created_at.contains('+'),
+        "expected RFC 3339 UTC: {}",
+        claim.created_at
+    );
+
+    // Provenance + schema wiring
+    assert_eq!(claim.memory_type, MemoryTypeV1::Directive);
+    assert_eq!(claim.source, MemorySource::User);
+    assert_eq!(claim.scope, MemoryScope::Work);
+    assert_eq!(claim.volatility, MemoryVolatility::Stable);
+    assert_eq!(claim.schema_version, MEMORY_CLAIM_V1_SCHEMA_VERSION);
+    assert_eq!(claim.importance, Some(9));
+}
+
+#[test]
+fn build_memory_claim_v1_preserves_reasoning_for_decisions() {
+    let input = V1StoreInput {
+        text: "Chose PostgreSQL over MySQL".into(),
+        memory_type: MemoryTypeV1::Claim,
+        source: MemorySource::User,
+        importance: 9,
+        scope: MemoryScope::Work,
+        volatility: MemoryVolatility::Stable,
+        reasoning: Some("because data is relational and needs ACID".into()),
+    };
+    let claim = build_memory_claim_v1(&input);
+    assert_eq!(
+        claim.reasoning.as_deref(),
+        Some("because data is relational and needs ACID")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// v1 envelope round-trip (JSON canonical form)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn v1_claim_serializes_with_spec_field_names() {
+    let input = V1StoreInput {
+        text: "test".into(),
+        memory_type: MemoryTypeV1::Preference,
+        source: MemorySource::UserInferred,
+        importance: 7,
+        scope: MemoryScope::Personal,
+        volatility: MemoryVolatility::Updatable,
+        reasoning: None,
+    };
+    let claim = build_memory_claim_v1(&input);
+    let json = serde_json::to_string(&claim).unwrap();
+
+    // Required fields use the v1 wire names (`text`, `type`, `source`,
+    // `created_at`, id). Avoid matching on short v0 keys (`t`, `s`, `a`).
+    assert!(json.contains(r#""text":"test""#));
+    assert!(json.contains(r#""type":"preference""#));
+    assert!(json.contains(r#""source":"user-inferred""#));
+    assert!(json.contains(r#""scope":"personal""#));
+    // `scope:unspecified` + `volatility:updatable` + schema_version are default-skipped
+    // but `personal` is non-default so it IS emitted.
+    assert!(!json.contains(r#""a":"zeroclaw""#)); // v0 short key must not appear
+}
+
+#[test]
+fn v1_claim_round_trips_through_json() {
+    let input = V1StoreInput {
+        text: "User prefers PostgreSQL over MySQL for OLTP".into(),
+        memory_type: MemoryTypeV1::Preference,
+        source: MemorySource::User,
+        importance: 8,
+        scope: MemoryScope::Work,
+        volatility: MemoryVolatility::Stable,
+        reasoning: None,
+    };
+    let claim = build_memory_claim_v1(&input);
+    let json = serde_json::to_string(&claim).unwrap();
+    let back: MemoryClaimV1 = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(claim, back);
+}
+
+// ---------------------------------------------------------------------------
+// v4 protobuf — outer schema version tag
+// ---------------------------------------------------------------------------
+
+#[test]
+fn v4_protobuf_carries_version_4_on_field_8() {
+    let payload = FactPayload {
+        id: "v1-test".into(),
+        timestamp: "2026-04-18T12:00:00Z".into(),
+        owner: "0xabcd".into(),
+        encrypted_blob_hex: "deadbeef".into(),
+        blind_indices: vec![],
+        decay_score: 0.8,
+        source: "zeroclaw_v1_user".into(),
+        content_fp: "fp".into(),
+        agent_id: "zeroclaw".into(),
+        encrypted_embedding: None,
+        version: PROTOBUF_VERSION_V4,
+    };
+    let bytes = encode_fact_protobuf(&payload);
+    // Tag byte for field 8 (varint): (8<<3)|0 = 0x40.
+    assert!(bytes.windows(2).any(|w| w == [0x40, 4]));
+    assert!(!bytes.windows(2).any(|w| w == [0x40, 3]));
+}
+
+#[test]
+fn v3_protobuf_still_valid_for_legacy_writes() {
+    // ZeroClaw 2.0 keeps the v3 path for the legacy `Memory` trait writes
+    // during the v0→v1 migration window. Confirm version tag is 3.
+    let payload = FactPayload {
+        id: "v3-test".into(),
+        timestamp: "2026-04-18T12:00:00Z".into(),
+        owner: "0xabcd".into(),
+        encrypted_blob_hex: "deadbeef".into(),
+        blind_indices: vec![],
+        decay_score: 0.8,
+        source: "zeroclaw_core".into(),
+        content_fp: "fp".into(),
+        agent_id: "zeroclaw".into(),
+        encrypted_embedding: None,
+        version: DEFAULT_PROTOBUF_VERSION,
+    };
+    let bytes = encode_fact_protobuf(&payload);
+    assert!(bytes.windows(2).any(|w| w == [0x40, 3]));
+    assert!(!bytes.windows(2).any(|w| w == [0x40, 4]));
+}
+
+#[test]
+fn tombstone_v1_uses_version_4() {
+    let v1_bytes = encode_tombstone_protobuf("fact-id-1", "0xabcd", PROTOBUF_VERSION_V4);
+    let v3_bytes = encode_tombstone_protobuf("fact-id-1", "0xabcd", DEFAULT_PROTOBUF_VERSION);
+    assert!(v1_bytes.windows(2).any(|w| w == [0x40, 4]));
+    assert!(v3_bytes.windows(2).any(|w| w == [0x40, 3]));
+}
+
+#[test]
+fn zero_version_defaults_to_v3() {
+    // back-compat safety net — a caller that forgets to set `version` still
+    // emits a valid v3 blob.
+    let payload = FactPayload {
+        id: "back-compat".into(),
+        timestamp: "2026-04-18T12:00:00Z".into(),
+        owner: "0xabcd".into(),
+        encrypted_blob_hex: "de".into(),
+        blind_indices: vec![],
+        decay_score: 0.5,
+        source: "zeroclaw_core".into(),
+        content_fp: "fp".into(),
+        agent_id: "zeroclaw".into(),
+        encrypted_embedding: None,
+        version: 0,
+    };
+    let bytes = encode_fact_protobuf(&payload);
+    assert!(bytes.windows(2).any(|w| w == [0x40, 3]));
+}
+
+// ---------------------------------------------------------------------------
+// v1 MemorySource enum — Retrieval v2 Tier 1 plumbing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn memory_source_serializes_as_kebab_case() {
+    // ZeroClaw 2.0 parses the v1 blob's `source` field and feeds the value
+    // into the reranker's Candidate struct so Retrieval v2 Tier 1 source
+    // weights apply. Confirm the wire format is kebab-case per spec.
+    let mk = |s: MemorySource| serde_json::to_string(&s).unwrap();
+    assert_eq!(mk(MemorySource::User), r#""user""#);
+    assert_eq!(mk(MemorySource::UserInferred), r#""user-inferred""#);
+    assert_eq!(mk(MemorySource::Assistant), r#""assistant""#);
+    assert_eq!(mk(MemorySource::External), r#""external""#);
+    assert_eq!(mk(MemorySource::Derived), r#""derived""#);
+}
+
+#[test]
+fn memory_source_deserializes_from_kebab_case() {
+    let from = |s: &str| -> MemorySource { serde_json::from_str(s).unwrap() };
+    assert_eq!(from(r#""user""#), MemorySource::User);
+    assert_eq!(from(r#""user-inferred""#), MemorySource::UserInferred);
+    assert_eq!(from(r#""assistant""#), MemorySource::Assistant);
+    assert_eq!(from(r#""external""#), MemorySource::External);
+    assert_eq!(from(r#""derived""#), MemorySource::Derived);
+}
+
+// ---------------------------------------------------------------------------
+// v1 memory type semantics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn memory_type_v1_covers_6_canonical_values() {
+    use std::collections::HashSet;
+    let all: HashSet<MemoryTypeV1> = [
+        MemoryTypeV1::Claim,
+        MemoryTypeV1::Preference,
+        MemoryTypeV1::Directive,
+        MemoryTypeV1::Commitment,
+        MemoryTypeV1::Episode,
+        MemoryTypeV1::Summary,
+    ]
+    .into_iter()
+    .collect();
+    assert_eq!(all.len(), 6);
+}
+
+#[test]
+fn memory_type_v1_from_str_lossy_is_case_insensitive() {
+    assert_eq!(MemoryTypeV1::from_str_lossy("claim"), MemoryTypeV1::Claim);
+    assert_eq!(MemoryTypeV1::from_str_lossy("CLAIM"), MemoryTypeV1::Claim);
+    assert_eq!(MemoryTypeV1::from_str_lossy(" Directive "), MemoryTypeV1::Directive);
+    assert_eq!(MemoryTypeV1::from_str_lossy("commitment"), MemoryTypeV1::Commitment);
+    assert_eq!(MemoryTypeV1::from_str_lossy("episode"), MemoryTypeV1::Episode);
+    assert_eq!(MemoryTypeV1::from_str_lossy("summary"), MemoryTypeV1::Summary);
+    assert_eq!(MemoryTypeV1::from_str_lossy("preference"), MemoryTypeV1::Preference);
+    // Unknown → Claim (lossy parse per v1 spec)
+    assert_eq!(MemoryTypeV1::from_str_lossy("fact"), MemoryTypeV1::Claim);
+    assert_eq!(MemoryTypeV1::from_str_lossy("rule"), MemoryTypeV1::Claim);
+    assert_eq!(MemoryTypeV1::from_str_lossy(""), MemoryTypeV1::Claim);
+}
+
+// ---------------------------------------------------------------------------
+// v1 memory scope enum
+// ---------------------------------------------------------------------------
+
+#[test]
+fn memory_scope_covers_8_canonical_values() {
+    use std::collections::HashSet;
+    let all: HashSet<MemoryScope> = [
+        MemoryScope::Work,
+        MemoryScope::Personal,
+        MemoryScope::Health,
+        MemoryScope::Family,
+        MemoryScope::Creative,
+        MemoryScope::Finance,
+        MemoryScope::Misc,
+        MemoryScope::Unspecified,
+    ]
+    .into_iter()
+    .collect();
+    assert_eq!(all.len(), 8);
+}
+
+#[test]
+fn memory_volatility_covers_3_canonical_values() {
+    use std::collections::HashSet;
+    let all: HashSet<MemoryVolatility> = [
+        MemoryVolatility::Stable,
+        MemoryVolatility::Updatable,
+        MemoryVolatility::Ephemeral,
+    ]
+    .into_iter()
+    .collect();
+    assert_eq!(all.len(), 3);
+}


### PR DESCRIPTION
- New store_v1() trait method on TotalReclawMemory
- v1 read path with v0 fallback
- Tier 1 source-weighted rerank in recall()
- 91 tests + 457 core tests