### PR TITLE
chore: remove 6 user-facing env vars + migrate tuning knobs to relay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,7 +316,7 @@ Every new feature implementation MUST include:
 | Per-fact timestamps | RESOLVED | Subgraph decodes protobuf field 2 (client-generated ISO 8601) into `createdAt: BigInt!` (Unix seconds). Batched facts now retain individual timestamps. `timestamp` (block time) kept for on-chain confirmation time. |
 | LSH parameters | RESOLVED | 32-bit x 20 tables, 98.1% Recall@8 on real data |
 | Authentication | RESOLVED | HKDF auth with SHA-256 key hashing |
-| Embedding model | RESOLVED | Migrated to onnx-community/harrier-oss-v1-270m-ONNX (640d, ~344MB, q4, pre-pooled). e5-small (384d) available as fallback via TOTALRECLAW_EMBEDDING_MODEL=small. |
+| Embedding model | RESOLVED | Locked to onnx-community/harrier-oss-v1-270m-ONNX (640d, ~344MB, q4, pre-pooled). `TOTALRECLAW_EMBEDDING_MODEL` env var was removed in the v1 env cleanup — switching models at runtime breaks search across existing vaults. |
 | Client batching (A2) | RESOLVED | Implemented in client/src/userop/batcher.ts -- batch multiple facts per UserOp |
 | Candidate pool sizing | RESOLVED | Server-configurable via relay billing endpoint (`max_candidate_pool` in FeatureFlags). Env overrides: `CANDIDATE_POOL_MAX_FREE`, `CANDIDATE_POOL_MAX_PRO`. |
 | Load testing | RESOLVED | Managed service load test at `totalreclaw-internal/e2e/load-test-managed/`. Client-side <140ms p95 PASS up to 10K facts. |

--- a/docs/guides/beta-tester-guide-detailed.md
+++ b/docs/guides/beta-tester-guide-detailed.md
@@ -138,8 +138,8 @@ Set the following environment variables in your OpenClaw configuration (e.g., wo
 TOTALRECLAW_RECOVERY_PHRASE="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
 
 # --- Managed service is the default (no env var needed) ---
-# Set TOTALRECLAW_SELF_HOSTED="true" only if using your own server
-# TOTALRECLAW_CHAIN_ID="100"  # Gnosis mainnet (default, no need to set)
+# Set TOTALRECLAW_SELF_HOSTED="true" only if using your own server.
+# Chain (Base Sepolia vs Gnosis) is auto-detected from your billing tier.
 ```
 
 Replace `word1 word2 ...` with your actual 12-word phrase. Keep the quotes around it. These can be set in your OpenClaw workspace environment settings, your shell profile, or any method your OpenClaw instance supports for environment variables.
@@ -697,17 +697,21 @@ The OpenClaw plugin auto-detects your agent's LLM provider and API key for fact 
 | `TOTALRECLAW_RELEVANCE_THRESHOLD` | Minimum cosine relevance score for auto-injecting memories into context. | `0.3` |
 | `TOTALRECLAW_SEMANTIC_SKIP_THRESHOLD` | Cosine similarity threshold for deduplication. Facts too similar to existing ones are skipped. | `0.85` |
 | `TOTALRECLAW_CACHE_TTL_MS` | Hot cache time-to-live in milliseconds. Cached results within this window are reused for similar queries. | `300000` (5 minutes) |
-| `TOTALRECLAW_LLM_MODEL` | **Advanced.** Override the auto-detected extraction model. TotalReclaw automatically derives a cheap model from your agent's provider (e.g., Anthropic → `claude-haiku-4-5`, OpenAI → `gpt-4.1-mini`). Only set this if the auto-derived model doesn't work for you. | Auto-detected |
+(`TOTALRECLAW_LLM_MODEL` was removed in the v1 env cleanup — the extraction
+model is auto-derived from your provider, with `OPENAI_MODEL` /
+`ANTHROPIC_MODEL` as generic fallbacks. See
+[`docs/guides/env-vars-reference.md`](./env-vars-reference.md).)
 
-### On-Chain Storage Variables (Advanced)
+### On-Chain Storage Variables (Advanced / self-hosted only)
 
-These variables control on-chain storage via the managed service. **The default (managed service with on-chain storage) requires no extra configuration -- recommended for most users.**
+These variables are for operators running against their own chain / self-hosted
+relay. The default (managed service on Base Sepolia / Gnosis) requires none
+of them — chain ID is auto-detected from your billing tier.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `TOTALRECLAW_SELF_HOSTED` | Set to `true` to use your own self-hosted server with PostgreSQL instead of the managed service. When not set (or `false`), TotalReclaw uses the managed service with on-chain storage via The Graph. | `false` (managed service) |
-| `TOTALRECLAW_CHAIN_ID` | Chain ID for on-chain transactions. `100` = Gnosis mainnet (Pro), `84532` = Base Sepolia testnet (Free). | `100` |
-| `TOTALRECLAW_DATA_EDGE_ADDRESS` | Address of the EventfulDataEdge smart contract on Gnosis mainnet. | `0xC445af1D4EB9fce4e1E61fE96ea7B8feBF03c5ca` |
+| `TOTALRECLAW_DATA_EDGE_ADDRESS` | Address of the EventfulDataEdge smart contract. | Built-in |
 | `TOTALRECLAW_ENTRYPOINT_ADDRESS` | ERC-4337 EntryPoint v0.7 address. Same on all chains. | `0x0000000071727De22E5E9d8BAf0edAc6f37da032` |
 | `TOTALRECLAW_SUBGRAPH_PAGE_SIZE` | Maximum results per subgraph query page (Graph Studio limit: 1000). | `1000` |
 | `TOTALRECLAW_TRAPDOOR_BATCH_SIZE` | Number of trapdoors per batch in subgraph queries. | `5` |

--- a/docs/guides/env-vars-reference.md
+++ b/docs/guides/env-vars-reference.md
@@ -1,0 +1,162 @@
+# Environment Variables Reference
+
+**Applies to:** TotalReclaw v1 (all clients).
+**Last updated:** 2026-04-18.
+
+v1 deliberately removes every env var that was an internal knob pretending to be user configuration. The list below is the **complete** set of env vars that end users or deployment operators should ever need to set.
+
+If you had one of the removed vars set (see bottom of this page), you can delete it — clients will silently ignore it.
+
+---
+
+## User-facing env vars
+
+### `TOTALRECLAW_RECOVERY_PHRASE`
+
+**Required.** Your 12-word BIP-39 recovery phrase. All encryption keys are derived from this. Never sent to any server.
+
+```bash
+export TOTALRECLAW_RECOVERY_PHRASE="your twelve word recovery phrase here"
+```
+
+**Default:** none — you must set this.
+**When to override:** always set it once during setup.
+**Security:** treat this like a seed phrase. Losing it means losing access to every memory you have ever stored.
+
+### `TOTALRECLAW_SERVER_URL`
+
+**Optional.** Override the relay server URL. Defaults to the managed service.
+
+```bash
+# Default (do not set)
+# TOTALRECLAW_SERVER_URL=https://api.totalreclaw.xyz
+
+# Self-hosted
+export TOTALRECLAW_SERVER_URL="http://localhost:8080"
+```
+
+**Default:** `https://api.totalreclaw.xyz` (managed service).
+**When to override:** pointing at a self-hosted server, or at the staging relay for development (`https://api-staging.totalreclaw.xyz`).
+
+### `TOTALRECLAW_SELF_HOSTED`
+
+**Optional.** Flag that tells the client it is talking to a self-hosted PostgreSQL server instead of the managed on-chain service.
+
+```bash
+export TOTALRECLAW_SELF_HOSTED=true
+```
+
+**Default:** `false` (managed service).
+**When to override:** when running your own server.
+**What changes:** dedup and forget use HTTP endpoints (not on-chain tombstones); consolidation tool is available.
+
+### `TOTALRECLAW_CREDENTIALS_PATH`
+
+**Optional.** Override the path where the setup wizard writes the local credentials file (smart account address, registration state).
+
+```bash
+# Default (macOS / Linux)
+# ~/.totalreclaw/credentials.json
+export TOTALRECLAW_CREDENTIALS_PATH="$HOME/.config/totalreclaw/creds.json"
+```
+
+**Default:** `~/.totalreclaw/credentials.json`.
+**When to override:** sandboxed environments, XDG-compliant layouts, multi-tenant deployments.
+
+### `TOTALRECLAW_CACHE_PATH`
+
+**Optional.** Override the path to the client's encrypted on-disk cache (fact store, hot cache, etc.).
+
+```bash
+# Default
+# ~/.totalreclaw/cache.enc
+export TOTALRECLAW_CACHE_PATH="$HOME/.config/totalreclaw/cache.enc"
+```
+
+**Default:** `~/.totalreclaw/cache.enc`.
+**When to override:** same as `TOTALRECLAW_CREDENTIALS_PATH` — sandboxed environments, XDG layouts, multi-tenant deployments.
+
+### LLM provider keys
+
+**Required if the client needs an LLM** (auto-extraction, LLM-guided dedup, import processing).
+
+The client reads whichever provider key is present. It picks the LLM automatically — you no longer select a model with an env var.
+
+| Provider | Env var |
+|---|---|
+| Anthropic | `ANTHROPIC_API_KEY` |
+| OpenAI | `OPENAI_API_KEY` |
+| Z.AI / GLM | `ZAI_API_KEY` |
+| Groq | `GROQ_API_KEY` |
+| DeepSeek | `DEEPSEEK_API_KEY` |
+| OpenRouter | `OPENROUTER_API_KEY` |
+| Google Gemini | `GOOGLE_API_KEY` |
+| Mistral | `MISTRAL_API_KEY` |
+| xAI | `XAI_API_KEY` |
+| Together | `TOGETHER_API_KEY` |
+
+**On OpenClaw:** the plugin reads OpenClaw's own provider config, no separate LLM key needed.
+
+---
+
+## Removed in v1
+
+These env vars existed in earlier versions and are now silently ignored. Delete them from your config if present.
+
+| Removed var | Why it is gone |
+|---|---|
+| `TOTALRECLAW_CHAIN_ID` | Chain is auto-detected from your tier. Free = Base Sepolia (84532), Pro = Gnosis mainnet (100). |
+| `TOTALRECLAW_EMBEDDING_MODEL` | Harrier-OSS-v1-270M (640d) is the only supported model in v1. |
+| `TOTALRECLAW_STORE_DEDUP` | Store-time near-duplicate detection is always on. |
+| `TOTALRECLAW_LLM_MODEL` / `TOTALRECLAW_EXTRACTION_MODEL` | LLM is picked automatically from the available provider. Model choice is not user-tunable. |
+| `TOTALRECLAW_SESSION_ID` | Sessions are computed internally. |
+| `TOTALRECLAW_TAXONOMY_VERSION` | v1 is the only format. No opt-in needed. |
+| `TOTALRECLAW_CLAIM_FORMAT` | Same reason — the v0 `{text, metadata}` shape is gone. |
+| `TOTALRECLAW_DIGEST_MODE` | Digest behaviour is no longer user-configurable. |
+| `TOTALRECLAW_AUTO_RESOLVE_MODE` | Contradiction-resolution policy is managed by the shared core. |
+| `TOTALRECLAW_HOT_RELOAD` | Kept for OpenClaw plugin development only — see plugin README. |
+| `TOTALRECLAW_TWO_TIER_SEARCH` | Merged into the default search path. |
+
+---
+
+## Advanced / self-hosted env vars
+
+These are for deployment operators, not end users. They live in the server or relay environment, not your local shell. See:
+
+- [Self-hosted server setup](../specs/totalreclaw/server.md) for PostgreSQL deployment env vars.
+- [Monitoring setup](./monitoring-setup.md) for observability env vars.
+- [Relay configuration](https://github.com/p-diogo/totalreclaw-relay) (private repo) for tier tuning, Pimlico, Stripe.
+
+Self-hosted deployments can still set the following as env-var fallbacks — on managed service, the relay billing response delivers these and env vars are ignored:
+
+| Env var | Purpose | Default |
+|---|---|---|
+| `TOTALRECLAW_COSINE_THRESHOLD` | Minimum cosine similarity to surface a result | `0.15` |
+| `TOTALRECLAW_RELEVANCE_THRESHOLD` | Auto-injection relevance cutoff | `0.3` |
+| `TOTALRECLAW_SEMANTIC_SKIP_THRESHOLD` | Store-time dedup similarity threshold | `0.85` |
+| `TOTALRECLAW_MIN_IMPORTANCE` | Minimum extracted-fact importance to auto-store | `6` |
+| `TOTALRECLAW_CACHE_TTL_MS` | Hot-cache TTL | `300000` |
+| `TOTALRECLAW_TRAPDOOR_BATCH_SIZE` | Trapdoors per subgraph query | `5` |
+| `TOTALRECLAW_SUBGRAPH_PAGE_SIZE` | Graph Studio page size | `1000` |
+| `TOTALRECLAW_EXTRACT_INTERVAL` | Turns between auto-extractions | `3` |
+| `TOTALRECLAW_DATA_EDGE_ADDRESS` | DataEdge contract address (self-hosted chain only) | Built-in |
+| `TOTALRECLAW_ENTRYPOINT_ADDRESS` | ERC-4337 EntryPoint (self-hosted chain only) | v0.7 address |
+| `TOTALRECLAW_RPC_URL` | Alternative RPC URL (self-hosted chain only) | Relay bundler |
+
+See [client-consistency spec](../specs/totalreclaw/client-consistency.md) for the full resolution order.
+
+### Internal kill-switches (not public config)
+
+| Env var | Purpose |
+|---|---|
+| `TOTALRECLAW_AUTO_RESOLVE_MODE` | Internal emergency kill-switch for the auto-contradiction-resolution loop (`active` / `shadow` / `off`). Not documented to end users; reserved for incident response. |
+
+---
+
+## Related
+
+- [v1 migration guide](./v1-migration.md)
+- [Client setup guide](./client-setup-v1.md)
+- [OpenClaw setup](./openclaw-setup.md)
+- [Claude Desktop setup](./claude-code-setup.md)
+- [Hermes setup](./hermes-setup.md)

--- a/docs/guides/memory-dedup.md
+++ b/docs/guides/memory-dedup.md
@@ -191,13 +191,13 @@ Cluster 2 (3 facts → 1):
 
 ## Configuration
 
-| Environment Variable | Default | Description |
-|---------------------|---------|-------------|
-| `TOTALRECLAW_STORE_DEDUP` | `true` | Enable/disable store-time dedup. Set to `false` to skip cross-session duplicate detection. |
+Dedup is not user-configurable. Store-time near-duplicate detection,
+exact-fingerprint dedup, and within-batch dedup are always on in v1 — the
+`TOTALRECLAW_STORE_DEDUP` env var was removed in the v1 env cleanup. Bulk
+consolidation is an on-demand tool with no persistent configuration — just
+call `totalreclaw_consolidate` when needed.
 
-No configuration is needed for exact fingerprint dedup (always on, server-side) or within-batch dedup (always on during extraction).
-
-Bulk consolidation is an on-demand tool with no persistent configuration -- just call `totalreclaw_consolidate` when needed.
+See [`docs/guides/env-vars-reference.md`](./env-vars-reference.md).
 
 ---
 
@@ -239,7 +239,7 @@ All semantic analysis -- embedding comparison, cosine similarity calculation, im
 | **How do I know dedup is working?** | Store-time dedup is invisible by design. If you store similar facts across sessions, you won't see duplicates in your export. Run `totalreclaw_export` to inspect your vault. |
 | **I see duplicates in my export** | They may be below the 0.85 similarity threshold (semantically distinct enough to keep). Or they were stored before store-time dedup was enabled. Run `totalreclaw_consolidate` to clean them up. |
 | **Can dedup accidentally delete important memories?** | Store-time dedup never deletes -- it either supersedes (replaces with a better version) or skips (keeps the existing better version). Bulk consolidation soft-deletes, which is reversible. |
-| **Does disabling store-time dedup affect other layers?** | No. `TOTALRECLAW_STORE_DEDUP=false` only disables Layer 3. Exact fingerprint (Layer 1) and within-batch dedup (Layer 2) remain active. |
+| **Can I disable store-time dedup?** | Not in v1. The `TOTALRECLAW_STORE_DEDUP` env var was removed — dedup is always on. If you need to bypass it for a specific test, consult the self-hosted server docs. |
 | **How does dedup work with the managed service?** | Store-time dedup works identically in both managed service and self-hosted modes -- candidates are fetched and compared client-side either way. Bulk consolidation is self-hosted (HTTP) only for now. |
 | **What if embedding generation fails?** | The system fails open. The fact is stored normally without dedup. This is intentional -- losing a memory is worse than having a duplicate. |
 | **Does importing trigger dedup?** | Yes. Imported memories go through exact fingerprint dedup (prevents identical re-imports) and store-time dedup (catches semantic overlaps with existing vault contents). |

--- a/docs/specs/totalreclaw/client-consistency.md
+++ b/docs/specs/totalreclaw/client-consistency.md
@@ -45,15 +45,23 @@
 
 ### Env Vars
 
+After the v1 env cleanup the surface is minimal. See
+[`docs/guides/env-vars-reference.md`](../../guides/env-vars-reference.md)
+for the canonical list.
+
 | Env Var | Purpose | Used By |
 |---------|---------|---------|
 | `TOTALRECLAW_RECOVERY_PHRASE` | BIP-39 mnemonic | All clients |
 | `TOTALRECLAW_SERVER_URL` | Relay URL (default: `https://api.totalreclaw.xyz`) | All clients |
-| `TOTALRECLAW_EXTRACT_INTERVAL` | Override extraction interval | All clients |
-| `TOTALRECLAW_MIN_IMPORTANCE` | Override minimum importance | All clients |
-| `TOTALRECLAW_LLM_MODEL` | Override extraction model | Clients with LLM extraction |
 | `TOTALRECLAW_SELF_HOSTED` | Set "true" for self-hosted mode | All clients |
+| `TOTALRECLAW_CREDENTIALS_PATH` | Override credentials file location | All clients |
+| `TOTALRECLAW_CACHE_PATH` | Override encrypted cache file location | All clients |
 | `TOTALRECLAW_TEST` | Set "true" to mark as test client | Test suites only |
+
+Tuning knobs (`TOTALRECLAW_EXTRACT_INTERVAL`, `TOTALRECLAW_MIN_IMPORTANCE`,
+`TOTALRECLAW_COSINE_THRESHOLD`, etc.) are still read by clients but only as
+env-var fallbacks for self-hosted deployments. On managed service, the
+relay billing response carries these values — see the tables below.
 
 ### Client Identification
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -163,7 +163,10 @@ See [`docs/specs/totalreclaw/memory-taxonomy-v1.md`](../docs/specs/totalreclaw/m
 | `TOTALRECLAW_RECOVERY_PHRASE` | 12-word BIP-39 recovery phrase | Required |
 | `TOTALRECLAW_SERVER_URL` | TotalReclaw server URL (only needed for self-hosted) | `https://api.totalreclaw.xyz` |
 | `TOTALRECLAW_SELF_HOSTED` | Use a self-hosted server instead of the managed service | `false` |
-| `TOTALRECLAW_CHAIN_ID` | Chain ID (100=Gnosis mainnet, 84532=Base Sepolia staging) | `100` |
+| `TOTALRECLAW_CREDENTIALS_PATH` | Override credentials file location | `~/.totalreclaw/credentials.json` |
+| `TOTALRECLAW_CACHE_PATH` | Override encrypted cache file location | `~/.totalreclaw/cache.enc` |
+
+> **v1 env cleanup:** `TOTALRECLAW_CHAIN_ID`, `TOTALRECLAW_EMBEDDING_MODEL`, `TOTALRECLAW_STORE_DEDUP`, `TOTALRECLAW_LLM_MODEL`, `TOTALRECLAW_SESSION_ID`, `TOTALRECLAW_TAXONOMY_VERSION`, `TOTALRECLAW_CLAIM_FORMAT`, and `TOTALRECLAW_DIGEST_MODE` were removed. Chain is auto-detected from billing tier (free = Base Sepolia, Pro = Gnosis). The MCP server silently ignores these vars for a transition period. See the [env vars reference](../docs/guides/env-vars-reference.md).
 
 ## Free Tier & Pricing
 

--- a/mcp/src/claims-helper.ts
+++ b/mcp/src/claims-helper.ts
@@ -74,25 +74,6 @@ export interface ClaimInput {
 }
 
 // ---------------------------------------------------------------------------
-// Feature flag — TOTALRECLAW_CLAIM_FORMAT
-// ---------------------------------------------------------------------------
-
-export type ClaimFormat = 'claim' | 'legacy';
-
-/**
- * Resolve the claim-format mode from the TOTALRECLAW_CLAIM_FORMAT env var.
- *
- * - `claim`  (default, or unset): new canonical Claim blob, entity trapdoors added.
- * - `legacy`: old {text, metadata} doc shape; entity trapdoors still added.
- *
- * Read on every call so tests can toggle via env without module reload.
- */
-export function resolveClaimFormat(): ClaimFormat {
-  const raw = (process.env.TOTALRECLAW_CLAIM_FORMAT ?? '').trim().toLowerCase();
-  return raw === 'legacy' ? 'legacy' : 'claim';
-}
-
-// ---------------------------------------------------------------------------
 // Category mapping — lives in memory-types.ts now (single source of truth for
 // the MCP package). Phase 2.2.6 eliminated the duplicate that used to be
 // defined in this file.
@@ -148,36 +129,6 @@ export function buildCanonicalClaim(input: BuildClaimInput): string {
 }
 
 // ---------------------------------------------------------------------------
-// Legacy {text, metadata} doc shape (unchanged from pre-KG MCP store path).
-// ---------------------------------------------------------------------------
-
-export interface BuildLegacyDocInput {
-  fact: ClaimInput;
-  importance: number;
-  source: string;
-  createdAt?: string;
-}
-
-/**
- * Build the legacy `{text, metadata}` document shape.
- *
- * Kept so the TOTALRECLAW_CLAIM_FORMAT=legacy fallback writes blobs that
- * the existing parseClaimOrLegacy read path has always handled.
- */
-export function buildLegacyDoc(input: BuildLegacyDocInput): string {
-  const { fact, importance, source, createdAt } = input;
-  return JSON.stringify({
-    text: fact.text,
-    metadata: {
-      type: fact.type ?? 'fact',
-      importance: importance / 10,
-      source,
-      created_at: createdAt ?? new Date().toISOString(),
-    },
-  });
-}
-
-// ---------------------------------------------------------------------------
 // Digest helpers (read-only in MCP scope)
 // ---------------------------------------------------------------------------
 
@@ -201,21 +152,16 @@ export const DIGEST_SOURCE_AGENT = 'mcp-server-digest';
 export type DigestMode = 'on' | 'off' | 'template';
 
 /**
- * Resolve TOTALRECLAW_DIGEST_MODE.
+ * Digest injection is always ON in v1. TOTALRECLAW_DIGEST_MODE was removed
+ * from the user-facing env var surface — the G-pipeline ships a digest on
+ * every recall with a template fallback.
  *
- * - `on` (default, unset, unknown): digest injection when a compiled digest
- *   is available in the vault.
- * - `off`: legacy individual-fact search path, no digest injection.
- * - `template`: same as `on` for MCP (MCP never compiles digests — the flag
- *   is accepted for parity with the plugin so operators can use the same env
- *   var across clients).
+ * Kept as a function returning `'on'` so any legacy call-site continues to
+ * compile.
  *
- * Read per-call so tests can toggle via env without module reload.
+ * @deprecated v1 always returns `'on'`.
  */
 export function resolveDigestMode(): DigestMode {
-  const raw = (process.env.TOTALRECLAW_DIGEST_MODE ?? '').trim().toLowerCase();
-  if (raw === 'off') return 'off';
-  if (raw === 'template') return 'template';
   return 'on';
 }
 

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -117,13 +117,11 @@ import {
   handleSetScopeWithDeps,
 } from './tools/set-scope.js';
 import {
-  buildCanonicalClaim,
   buildV1ClaimBlob,
   computeEntityTrapdoor,
   isDigestBlob,
   readBlobUnified,
   readClaimFromBlob,
-  resolveClaimFormat,
 } from './claims-helper.js';
 import { isValidMemoryType, type MemoryType } from './memory-types.js';
 import {
@@ -157,6 +155,27 @@ import type { SavedCredentials } from './cli/setup.js';
 const SERVER_URL = process.env.TOTALRECLAW_SERVER_URL || 'https://api.totalreclaw.xyz';
 const MASTER_PASSWORD = process.env.TOTALRECLAW_RECOVERY_PHRASE;
 
+// v1 env var cleanup — warn once if any removed env var is still set.
+// See docs/guides/env-vars-reference.md for the canonical list.
+(() => {
+  const removed = [
+    'TOTALRECLAW_CHAIN_ID',
+    'TOTALRECLAW_EMBEDDING_MODEL',
+    'TOTALRECLAW_STORE_DEDUP',
+    'TOTALRECLAW_LLM_MODEL',
+    'TOTALRECLAW_SESSION_ID',
+    'TOTALRECLAW_TAXONOMY_VERSION',
+    'TOTALRECLAW_CLAIM_FORMAT',
+    'TOTALRECLAW_DIGEST_MODE',
+  ].filter((name) => process.env[name] !== undefined);
+  if (removed.length > 0) {
+    console.error(
+      `TotalReclaw MCP: ignoring removed env var(s): ${removed.join(', ')}. ` +
+        `See docs/guides/env-vars-reference.md for the v1 env var surface.`,
+    );
+  }
+})();
+
 // ── Client identification ──────────────────────────────────────────────────
 import { setClientId, getClientId } from './client-id.js';
 let clientIdentifierResolved = false;
@@ -186,8 +205,9 @@ function resolveMnemonic(): string | undefined {
 
 let currentMode: ServerMode = 'unconfigured';
 
-// Store-time near-duplicate detection (consolidation module)
-const STORE_DEDUP_ENABLED = process.env.TOTALRECLAW_STORE_DEDUP !== 'false';
+// Store-time near-duplicate detection is always ON in v1.
+// The TOTALRECLAW_STORE_DEDUP env var was removed.
+const STORE_DEDUP_ENABLED = true;
 
 // ── Billing cache (in-memory, for server-side candidate pool) ───────────────
 
@@ -323,15 +343,14 @@ async function initSubgraphState(mnemonic: string): Promise<SubgraphState> {
 
   const smartAccountAddress = smartAccount.address.toLowerCase();
 
-  // Determine chain ID: env var override > billing tier > default (Base Sepolia).
+  // Determine chain ID: always auto-detect from billing tier.
   // Free tier → Base Sepolia (84532, testnet — Pimlico sponsors gas for free).
   // Pro tier  → Gnosis mainnet (100, permanent on-chain storage).
-  let chainId = process.env.TOTALRECLAW_CHAIN_ID
-    ? parseInt(process.env.TOTALRECLAW_CHAIN_ID)
-    : 84532; // default free tier
+  // TOTALRECLAW_CHAIN_ID user-facing override was removed in v1.
+  let chainId = 84532; // default free tier
 
-  // Auto-detect Pro tier from billing endpoint (if no env override).
-  if (!process.env.TOTALRECLAW_CHAIN_ID) {
+  // Auto-detect Pro tier from billing endpoint.
+  {
     try {
       const billingUrl = `${SERVER_URL.replace(/\/+$/, '')}/v1/billing/status?wallet_address=${encodeURIComponent(smartAccountAddress)}`;
       const resp = await fetch(billingUrl, {
@@ -508,9 +527,9 @@ async function handleRememberSubgraph(
   }> | undefined;
 
   // Phase 2.2.6 + v1: accept both legacy 8-type and v1 6-type inputs. The
-  // managed-service path always writes v1 inner blobs (protobuf wrapper v4);
-  // the internal legacy `MemoryType` is still tracked for the legacy
-  // `buildCanonicalClaim` fallback used when TOTALRECLAW_CLAIM_FORMAT=legacy.
+  // managed-service path always writes v1 inner blobs (protobuf wrapper v4).
+  // The legacy `MemoryType` is still tracked for backward compat with any
+  // downstream reader that consults the v0 short-key value.
   const textsToStore: Array<{
     text: string;
     importance: number;
@@ -710,37 +729,27 @@ async function handleRememberSubgraph(
 
       // 4. Build the blob.
       //
-      // Memory Taxonomy v1 (MCP server v3.0.0): the managed-service write path
-      // emits v1 inner blobs by default. Outer protobuf wrapper becomes v4 so
-      // readers know the inner payload is v1 JSON (see protobuf-v4-design.md).
-      //
-      // `TOTALRECLAW_CLAIM_FORMAT=legacy` still produces the v0 `{t,c,i,...}`
-      // canonical claim for back-compat tests. The `raw text` mode is gone.
+      // Memory Taxonomy v1 (MCP server v3.0.0+): the managed-service write
+      // path unconditionally emits v1 inner blobs. Outer protobuf wrapper is
+      // v4 so readers know the inner payload is v1 JSON (see
+      // protobuf-v4-design.md). The v0 `{t,c,i,...}` canonical and raw-text
+      // legacy blobs are no longer produced — `TOTALRECLAW_CLAIM_FORMAT`
+      // was removed in v1.
       //
       // `source` defaults to:
       //   - `'user'` when the tool was called in single-fact (explicit) mode
       //   - `'user-inferred'` when called via the batch path (extraction)
       // Host agents typically have the best provenance signal; this is a
       // conservative default the extraction pipeline can override later.
-      const claimFormat = resolveClaimFormat();
-      let blobPlaintext: string;
-      if (claimFormat === 'legacy') {
-        blobPlaintext = buildCanonicalClaim({
-          fact: { text: item.text, type: item.type },
-          importance: effectiveImportance,
-          sourceAgent: 'mcp-server',
-        });
-      } else {
-        const source = isExplicitRemember ? 'user' : 'user-inferred';
-        blobPlaintext = buildV1ClaimBlob({
-          text: item.text,
-          type: item.typeV1,
-          source,
-          scope: item.scope,
-          reasoning: item.reasoning,
-          importance: effectiveImportance,
-        });
-      }
+      const source = isExplicitRemember ? 'user' : 'user-inferred';
+      const blobPlaintext = buildV1ClaimBlob({
+        text: item.text,
+        type: item.typeV1,
+        source,
+        scope: item.scope,
+        reasoning: item.reasoning,
+        importance: effectiveImportance,
+      });
       const encryptedBlob = encrypt(blobPlaintext, state.encryptionKey);
 
       // 5. Generate content fingerprint for dedup (over plaintext text, not blob)
@@ -873,23 +882,21 @@ async function handleDebriefSubgraph(
       const lshIndices = state.lshHasher.hash(embedding);
       const allIndices = [...wordIndices, ...lshIndices];
 
-      // Memory Taxonomy v1 (MCP server v3.0.0):
-      //   - Default: emit v1 inner blob with `type: 'summary'` (both tool-level
-      //     'summary' and 'context' map here — per spec §type-semantics, summary
-      //     absorbs session-level synthesis regardless of whether the tool
-      //     called it "summary" or "context"). `source: 'derived'` marks this
-      //     as a derived-from-conversation claim (spec requires summary ∈
-      //     {derived, assistant}; derived is the better fit here).
-      //   - TOTALRECLAW_CLAIM_FORMAT=legacy: legacy raw-text blob (pre-v3).
-      const claimFormat = resolveClaimFormat();
-      const blobPlaintext = claimFormat === 'legacy'
-        ? item.text
-        : buildV1ClaimBlob({
-            text: item.text,
-            type: 'summary',
-            source: 'derived',
-            importance: item.importance,
-          });
+      // Memory Taxonomy v1: emit v1 inner blob with `type: 'summary'` (both
+      // tool-level 'summary' and 'context' map here — per spec §type-semantics,
+      // summary absorbs session-level synthesis regardless of whether the tool
+      // called it "summary" or "context"). `source: 'derived'` marks this as a
+      // derived-from-conversation claim (spec requires summary ∈ {derived,
+      // assistant}; derived is the better fit here).
+      //
+      // TOTALRECLAW_CLAIM_FORMAT=legacy was removed in v1; raw-text blobs are
+      // no longer produced on the write path.
+      const blobPlaintext = buildV1ClaimBlob({
+        text: item.text,
+        type: 'summary',
+        source: 'derived',
+        importance: item.importance,
+      });
       const encryptedBlob = encrypt(blobPlaintext, state.encryptionKey);
       const contentFp = generateContentFingerprint(item.text, state.dedupKey);
       const encryptedEmb = encryptEmbedding(embedding, state.encryptionKey);

--- a/mcp/src/subgraph/store.ts
+++ b/mcp/src/subgraph/store.ts
@@ -468,11 +468,14 @@ export function isSubgraphMode(override?: boolean): boolean {
  * Get subgraph configuration from environment variables, with optional
  * overrides for constructor injection from MCP server state.
  *
- * After the relay refactor, clients only need:
+ * After the v1 env var cleanup, clients only need:
  *   - TOTALRECLAW_RECOVERY_PHRASE -- BIP-39 mnemonic
  *   - TOTALRECLAW_SERVER_URL -- relay server URL (default: https://api.totalreclaw.xyz)
  *   - TOTALRECLAW_SELF_HOSTED -- set "true" for self-hosted HTTP mode (default: managed service)
- *   - TOTALRECLAW_CHAIN_ID -- optional, defaults to 100 (Gnosis mainnet)
+ *
+ * Chain ID is no longer user-configurable — auto-detected from billing tier
+ * (free = Base Sepolia, Pro = Gnosis mainnet). Callers inject the resolved
+ * chain ID via the `overrides` argument from `initSubgraphState`.
  *
  * Removed from client-side config (now server-side only):
  *   - PIMLICO_API_KEY
@@ -486,7 +489,7 @@ export function getSubgraphConfig(overrides?: Partial<SubgraphStoreConfig>): Sub
     relayUrl: process.env.TOTALRECLAW_SERVER_URL || 'https://api.totalreclaw.xyz',
     mnemonic: process.env.TOTALRECLAW_RECOVERY_PHRASE || '',
     cachePath: process.env.TOTALRECLAW_CACHE_PATH || `${process.env.HOME}/.totalreclaw/cache.enc`,
-    chainId: parseInt(process.env.TOTALRECLAW_CHAIN_ID || '84532'),
+    chainId: 84532,
     dataEdgeAddress: process.env.TOTALRECLAW_DATA_EDGE_ADDRESS || DEFAULT_DATA_EDGE_ADDRESS,
     entryPointAddress: process.env.TOTALRECLAW_ENTRYPOINT_ADDRESS || DEFAULT_ENTRYPOINT_ADDRESS,
   };

--- a/mcp/src/tools/remember.ts
+++ b/mcp/src/tools/remember.ts
@@ -208,8 +208,9 @@ export function setOnRememberCallback(cb: OnRememberCallback): void {
   _onRememberCallback = cb;
 }
 
-// Store-time dedup feature flag
-const STORE_DEDUP_ENABLED = process.env.TOTALRECLAW_STORE_DEDUP !== 'false';
+// Store-time dedup is always ON in v1.
+// TOTALRECLAW_STORE_DEDUP user-facing toggle was removed.
+const STORE_DEDUP_ENABLED = true;
 
 // ── Internal: search for near-duplicates in HTTP mode ─────────────────────────
 

--- a/mcp/tests/claims-helper.test.ts
+++ b/mcp/tests/claims-helper.test.ts
@@ -1,16 +1,19 @@
 /**
  * Tests for the MCP server's canonical Claim builder, entity trapdoors,
- * digest helpers, and the TOTALRECLAW_CLAIM_FORMAT feature flag.
+ * and digest helpers.
  *
  * Mirrors skill/plugin/claim-format.test.ts so any behavioral drift between
  * the plugin and MCP implementations shows up as a failing test.
+ *
+ * v1 env var cleanup: the TOTALRECLAW_CLAIM_FORMAT and TOTALRECLAW_DIGEST_MODE
+ * env vars were removed. `resolveDigestMode` still exists and unconditionally
+ * returns `'on'`; `resolveClaimFormat` and `buildLegacyDoc` were deleted.
  */
 
 import crypto from 'node:crypto';
 import {
   buildCanonicalClaim,
   buildDigestClaim,
-  buildLegacyDoc,
   computeEntityTrapdoor,
   computeEntityTrapdoors,
   DIGEST_CATEGORY,
@@ -19,7 +22,6 @@ import {
   isDigestBlob,
   mapTypeToCategory,
   readClaimFromBlob,
-  resolveClaimFormat,
   resolveDigestMode,
   type ClaimInput,
 } from '../src/claims-helper.js';
@@ -188,65 +190,48 @@ describe('computeEntityTrapdoors', () => {
   });
 });
 
-describe('resolveClaimFormat', () => {
-  const savedEnv = process.env.TOTALRECLAW_CLAIM_FORMAT;
-  afterEach(() => {
-    if (savedEnv === undefined) delete process.env.TOTALRECLAW_CLAIM_FORMAT;
-    else process.env.TOTALRECLAW_CLAIM_FORMAT = savedEnv;
-  });
-
-  test.each([
-    [undefined, 'claim'],
-    ['', 'claim'],
-    ['claim', 'claim'],
-    ['CLAIM', 'claim'],
-    ['legacy', 'legacy'],
-    ['LEGACY', 'legacy'],
-    ['nonsense', 'claim'],
-  ] as const)('resolves %s -> %s', (value, expected) => {
-    if (value === undefined) delete process.env.TOTALRECLAW_CLAIM_FORMAT;
-    else process.env.TOTALRECLAW_CLAIM_FORMAT = value;
-    expect(resolveClaimFormat()).toBe(expected);
-  });
-});
-
-describe('resolveDigestMode', () => {
+describe('resolveDigestMode (v1 — env var removed, always on)', () => {
   const savedEnv = process.env.TOTALRECLAW_DIGEST_MODE;
   afterEach(() => {
     if (savedEnv === undefined) delete process.env.TOTALRECLAW_DIGEST_MODE;
     else process.env.TOTALRECLAW_DIGEST_MODE = savedEnv;
   });
 
+  // TOTALRECLAW_DIGEST_MODE was removed in v1. The function must unconditionally
+  // return 'on' regardless of what the env var is set to.
   test.each([
     [undefined, 'on'],
     ['', 'on'],
     ['on', 'on'],
-    ['ON', 'on'],
-    ['off', 'off'],
-    ['OFF', 'off'],
-    ['template', 'template'],
-    ['TEMPLATE', 'template'],
+    ['off', 'on'],       // was 'off' — now ignored
+    ['template', 'on'],  // was 'template' — now ignored
     ['nonsense', 'on'],
-  ] as const)('resolves %s -> %s', (value, expected) => {
+  ] as const)('env=%s -> resolveDigestMode=%s (env var has no effect)', (value, expected) => {
     if (value === undefined) delete process.env.TOTALRECLAW_DIGEST_MODE;
     else process.env.TOTALRECLAW_DIGEST_MODE = value;
     expect(resolveDigestMode()).toBe(expected);
   });
 });
 
-describe('buildLegacyDoc', () => {
-  test('byte-identical to historical MCP format', () => {
-    const fact: ClaimInput = { text: 'Hello world.', type: 'fact' };
-    const doc = buildLegacyDoc({
-      fact,
-      importance: 7,
-      source: 'mcp_remember',
-      createdAt: '2026-04-12T10:00:00Z',
-    });
-    const expected =
-      '{"text":"Hello world.","metadata":{"type":"fact","importance":0.7,' +
-      '"source":"mcp_remember","created_at":"2026-04-12T10:00:00Z"}}';
-    expect(doc).toBe(expected);
+describe('v1 env var cleanup — removed vars have no effect', () => {
+  test('TOTALRECLAW_CLAIM_FORMAT=legacy does not flip the write path', () => {
+    const saved = process.env.TOTALRECLAW_CLAIM_FORMAT;
+    try {
+      process.env.TOTALRECLAW_CLAIM_FORMAT = 'legacy';
+      // buildCanonicalClaim should produce the v0 canonical blob regardless
+      // — there is no longer a legacy raw-text fallback exposed.
+      const blob = buildCanonicalClaim({
+        fact: { text: 'test', type: 'fact' },
+        importance: 7,
+        sourceAgent: 'mcp-server',
+      });
+      const parsed = JSON.parse(blob);
+      expect(parsed.t).toBe('test');
+      expect(parsed.c).toBe('fact');
+    } finally {
+      if (saved === undefined) delete process.env.TOTALRECLAW_CLAIM_FORMAT;
+      else process.env.TOTALRECLAW_CLAIM_FORMAT = saved;
+    }
   });
 });
 

--- a/mcp/tests/remember-dedup.test.ts
+++ b/mcp/tests/remember-dedup.test.ts
@@ -7,7 +7,7 @@
  * 3. Always supersedes for explicit (single-fact) remember
  * 4. Calls forget() to delete superseded facts
  * 5. Inherits higher importance from existing facts
- * 6. Respects the TOTALRECLAW_STORE_DEDUP env flag
+ * 6. Ignores the removed TOTALRECLAW_STORE_DEDUP env flag (v1 always ON)
  *
  * Run with:
  *   npx jest tests/remember-dedup.test.ts --no-cache
@@ -201,32 +201,33 @@ describe('Store-time dedup wiring: batch mode', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Feature flag — TOTALRECLAW_STORE_DEDUP=false disables dedup search
+// v1 env var cleanup: TOTALRECLAW_STORE_DEDUP was removed. Store-time dedup
+// is always on. Setting the env var has no effect.
 // ---------------------------------------------------------------------------
 
-describe('Store-time dedup: feature flag', () => {
-  it('should skip dedup search when TOTALRECLAW_STORE_DEDUP=false', async () => {
+describe('Store-time dedup: TOTALRECLAW_STORE_DEDUP removed in v1', () => {
+  it('runs dedup search even when TOTALRECLAW_STORE_DEDUP=false', async () => {
+    const saved = process.env.TOTALRECLAW_STORE_DEDUP;
     process.env.TOTALRECLAW_STORE_DEDUP = 'false';
-    // Need to re-require to pick up env change (STORE_DEDUP_ENABLED is a const)
-    jest.resetModules();
+    try {
+      jest.resetModules();
+      jest.mock('@totalreclaw/client', () => ({
+        TotalReclaw: jest.fn(),
+      }));
 
-    // Re-apply the mock after resetModules clears it
-    jest.mock('@totalreclaw/client', () => ({
-      TotalReclaw: jest.fn(),
-    }));
+      const { handleRemember } = require('../src/tools/remember');
 
-    const { handleRemember } = require('../src/tools/remember');
+      const client = createMockClient();
+      const result = await handleRemember(client, { fact: 'Test fact' });
+      const parsed = JSON.parse(result.content[0].text);
 
-    const client = createMockClient();
-    const result = await handleRemember(client, { fact: 'Test fact' });
-    const parsed = JSON.parse(result.content[0].text);
-
-    expect(parsed.action).toBe('created');
-    // recall should NOT be called for dedup (only remember is called)
-    expect(mockRecall).not.toHaveBeenCalled();
-
-    // Restore for subsequent tests
-    process.env.TOTALRECLAW_STORE_DEDUP = 'true';
+      expect(parsed.action).toBe('created');
+      // STORE_DEDUP env var is ignored — recall IS still called for dedup.
+      expect(mockRecall).toHaveBeenCalled();
+    } finally {
+      if (saved === undefined) delete process.env.TOTALRECLAW_STORE_DEDUP;
+      else process.env.TOTALRECLAW_STORE_DEDUP = saved;
+    }
   });
 });
 

--- a/python/src/totalreclaw/agent/llm_client.py
+++ b/python/src/totalreclaw/agent/llm_client.py
@@ -32,7 +32,9 @@ class LLMConfig:
 
 # Provider detection: (provider, env_vars, default_base_url, api_format)
 # No hardcoded model names — uses whatever the user configured via their
-# agent framework. Override with TOTALRECLAW_EXTRACTION_MODEL if needed.
+# agent framework. The TOTALRECLAW_EXTRACTION_MODEL / TOTALRECLAW_LLM_MODEL
+# user-facing override was removed in the v1 env cleanup. Model selection
+# goes through agent-framework config + `OPENAI_MODEL` / `ANTHROPIC_MODEL`.
 PROVIDERS = [
     ("zai", ["ZAI_API_KEY", "GLM_API_KEY", "Z_AI_API_KEY"], "https://api.z.ai/api/coding/paas/v4", "openai"),
     ("anthropic", ["ANTHROPIC_API_KEY"], "https://api.anthropic.com/v1", "anthropic"),
@@ -54,15 +56,17 @@ def detect_llm_config(configured_model: Optional[str] = None) -> Optional[LLMCon
     to maintain — just uses whatever the user set up.
 
     Model priority:
-      1. TOTALRECLAW_EXTRACTION_MODEL (optional override for power users)
-      2. configured_model (passed from agent framework)
-      3. OPENAI_MODEL / ANTHROPIC_MODEL (common env vars)
+      1. configured_model (passed from agent framework)
+      2. OPENAI_MODEL / ANTHROPIC_MODEL / LLM_MODEL (generic env vars)
+
+    The ``TOTALRECLAW_EXTRACTION_MODEL`` / ``TOTALRECLAW_LLM_MODEL`` overrides
+    were removed in the v1 env cleanup — agent-framework config is now the
+    single source of truth for the extraction model.
 
     Base URL priority:
       1. OPENAI_BASE_URL (for OpenAI-compatible custom providers)
       2. Provider default
     """
-    override_model = os.environ.get("TOTALRECLAW_EXTRACTION_MODEL")
     openai_base_url = os.environ.get("OPENAI_BASE_URL")
     # Common env vars for configured model name
     env_model = (
@@ -75,11 +79,11 @@ def detect_llm_config(configured_model: Optional[str] = None) -> Optional[LLMCon
         for env_var in env_vars:
             api_key = os.environ.get(env_var)
             if api_key:
-                model = override_model or configured_model or env_model
+                model = configured_model or env_model
                 if not model:
                     logger.warning(
                         "TotalReclaw: %s API key found but no model configured. "
-                        "Set TOTALRECLAW_EXTRACTION_MODEL or OPENAI_MODEL.",
+                        "Set OPENAI_MODEL or configure the model via your agent framework.",
                         _provider,
                     )
                     continue

--- a/python/src/totalreclaw/agent/state.py
+++ b/python/src/totalreclaw/agent/state.py
@@ -25,6 +25,40 @@ BILLING_CACHE_TTL = 7200  # 2 hours
 STORE_DEDUP_THRESHOLD = 0.85  # Cosine similarity threshold for near-duplicate detection
 
 
+# v1 env var cleanup — warn once if any removed env var is still set.
+# See docs/guides/env-vars-reference.md for the canonical list.
+_REMOVED_ENV_VARS = (
+    "TOTALRECLAW_CHAIN_ID",
+    "TOTALRECLAW_EMBEDDING_MODEL",
+    "TOTALRECLAW_STORE_DEDUP",
+    "TOTALRECLAW_LLM_MODEL",
+    "TOTALRECLAW_EXTRACTION_MODEL",
+    "TOTALRECLAW_SESSION_ID",
+    "TOTALRECLAW_TAXONOMY_VERSION",
+    "TOTALRECLAW_CLAIM_FORMAT",
+    "TOTALRECLAW_DIGEST_MODE",
+)
+
+_warned_removed_env_vars = False
+
+
+def _warn_removed_env_vars_once() -> None:
+    global _warned_removed_env_vars
+    if _warned_removed_env_vars:
+        return
+    _warned_removed_env_vars = True
+    set_vars = [name for name in _REMOVED_ENV_VARS if os.environ.get(name) is not None]
+    if set_vars:
+        logger.warning(
+            "TotalReclaw: ignoring removed env var(s): %s. "
+            "See docs/guides/env-vars-reference.md for the v1 env var surface.",
+            ", ".join(set_vars),
+        )
+
+
+_warn_removed_env_vars_once()
+
+
 class AgentState:
     """Manages TotalReclaw client lifecycle, turn tracking, and message buffer.
 

--- a/python/src/totalreclaw/claims_helper.py
+++ b/python/src/totalreclaw/claims_helper.py
@@ -73,23 +73,23 @@ def _js_round(x: float) -> int:
 
 
 # ---------------------------------------------------------------------------
-# Feature flags (digest mode only — claim-format gate removed in 2.0.0)
+# Feature flags (deprecated — all gates removed as of v1 env cleanup)
 # ---------------------------------------------------------------------------
 
 DigestMode = Literal["on", "off", "template"]
 
 
 def resolve_digest_mode() -> DigestMode:
-    """Resolve ``TOTALRECLAW_DIGEST_MODE`` — "on" (default), "off", "template".
+    """Digest injection is always ON in v1.
 
-    Digest compilation is orthogonal to the v0/v1 taxonomy split; this
-    setting stays. See ``docs/specs/totalreclaw/retrieval-improvements-v3.md``.
+    The ``TOTALRECLAW_DIGEST_MODE`` env var was removed in the v1 env
+    cleanup — digest compilation is part of the G pipeline and not a
+    user-configurable knob. Kept as a function returning ``"on"`` so any
+    legacy Python call-site continues to compile.
+
+    .. deprecated:: 2.1
+        Env var has no effect; function always returns ``"on"``.
     """
-    raw = (os.environ.get("TOTALRECLAW_DIGEST_MODE") or "").strip().lower()
-    if raw == "off":
-        return "off"
-    if raw == "template":
-        return "template"
     return "on"
 
 

--- a/python/tests/test_claims_helper.py
+++ b/python/tests/test_claims_helper.py
@@ -349,7 +349,8 @@ def test_compute_entity_trapdoors_skips_bad_names() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Digest mode flag (digest compilation is orthogonal to v0/v1 taxonomy)
+# Digest mode flag — v1 env cleanup: TOTALRECLAW_DIGEST_MODE was removed.
+# resolve_digest_mode() always returns "on" regardless of env var.
 # ---------------------------------------------------------------------------
 
 
@@ -359,23 +360,15 @@ def test_resolve_digest_mode_default(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.parametrize(
-    "value,expected",
-    [
-        ("on", "on"),
-        ("ON", "on"),
-        ("off", "off"),
-        ("OFF", "off"),
-        ("template", "template"),
-        ("TEMPLATE", "template"),
-        ("nonsense", "on"),
-        ("", "on"),
-    ],
+    "value",
+    ["on", "off", "OFF", "template", "TEMPLATE", "nonsense", ""],
 )
-def test_resolve_digest_mode_values(
-    monkeypatch: pytest.MonkeyPatch, value: str, expected: str
+def test_resolve_digest_mode_env_has_no_effect(
+    monkeypatch: pytest.MonkeyPatch, value: str
 ) -> None:
+    """TOTALRECLAW_DIGEST_MODE was removed in v1 env cleanup — env var has no effect."""
     monkeypatch.setenv("TOTALRECLAW_DIGEST_MODE", value)
-    assert resolve_digest_mode() == expected
+    assert resolve_digest_mode() == "on"
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_extractor.py
+++ b/python/tests/test_extractor.py
@@ -380,36 +380,37 @@ class TestDetectLLMConfig:
             assert config is not None
             assert "groq.com" in config.base_url
 
-    def test_extraction_model_override(self):
-        """TOTALRECLAW_EXTRACTION_MODEL overrides everything."""
+    def test_extraction_model_env_has_no_effect(self):
+        """TOTALRECLAW_EXTRACTION_MODEL was removed in v1 — env var ignored."""
         with patch.dict(os.environ, {
             "OPENAI_API_KEY": "sk-test",
-            "TOTALRECLAW_EXTRACTION_MODEL": "gpt-4.1-nano",
+            "TOTALRECLAW_EXTRACTION_MODEL": "gpt-4.1-nano",  # removed env var
         }, clear=True):
             config = detect_llm_config(configured_model="test-model")
             assert config is not None
-            assert config.model == "gpt-4.1-nano"
+            # configured_model wins now that the override env var is gone.
+            assert config.model == "test-model"
 
-    def test_extraction_model_overrides_configured_model(self):
-        """TOTALRECLAW_EXTRACTION_MODEL beats configured_model param."""
+    def test_configured_model_wins_over_removed_env(self):
+        """configured_model is the canonical source in v1 (no env override)."""
         with patch.dict(os.environ, {
             "OPENAI_API_KEY": "sk-test",
-            "TOTALRECLAW_EXTRACTION_MODEL": "gpt-4.1-nano",
+            "TOTALRECLAW_EXTRACTION_MODEL": "gpt-4.1-nano",  # removed env var
         }, clear=True):
             config = detect_llm_config(configured_model="agent-default-model")
             assert config is not None
-            assert config.model == "gpt-4.1-nano"
+            assert config.model == "agent-default-model"
 
-    def test_extraction_model_overrides_env_model(self):
-        """TOTALRECLAW_EXTRACTION_MODEL beats OPENAI_MODEL env var."""
+    def test_openai_model_env_used_when_configured_is_none(self):
+        """With TOTALRECLAW_EXTRACTION_MODEL removed, OPENAI_MODEL is the env fallback."""
         with patch.dict(os.environ, {
             "OPENAI_API_KEY": "sk-test",
-            "TOTALRECLAW_EXTRACTION_MODEL": "gpt-4.1-nano",
+            "TOTALRECLAW_EXTRACTION_MODEL": "gpt-4.1-nano",  # removed — ignored
             "OPENAI_MODEL": "gpt-4o",
         }, clear=True):
             config = detect_llm_config()
             assert config is not None
-            assert config.model == "gpt-4.1-nano"
+            assert config.model == "gpt-4o"
 
 
 # ---------------------------------------------------------------------------

--- a/rust/totalreclaw-memory/src/billing.rs
+++ b/rust/totalreclaw-memory/src/billing.rs
@@ -39,6 +39,14 @@ const DEFAULT_CANDIDATE_POOL_PRO: usize = 250;
 // ---------------------------------------------------------------------------
 
 /// Feature flags parsed from the billing status response.
+///
+/// The relay returns these in the `features` JSON blob on the billing
+/// status endpoint. Clients consult them at the call-site when resolving
+/// tuning knobs; env-var fallbacks are retained for self-hosted deployments.
+///
+/// See `docs/guides/env-vars-reference.md` — as of the v1 env var cleanup,
+/// managed-service clients read tuning knobs from this struct and never
+/// from env vars.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct FeatureFlags {
     pub llm_dedup: Option<bool>,
@@ -47,6 +55,17 @@ pub struct FeatureFlags {
     pub max_candidate_pool: Option<usize>,
     pub custom_extract_interval: Option<bool>,
     pub min_extract_interval: Option<u32>,
+
+    // Tuning knobs moved to server-side delivery in the v1 env cleanup.
+    // Optional — when absent, clients fall back to their built-in defaults
+    // (or their self-hosted env-var overrides).
+    pub cosine_threshold: Option<f64>,
+    pub relevance_threshold: Option<f64>,
+    pub semantic_skip_threshold: Option<f64>,
+    pub min_importance: Option<u32>,
+    pub cache_ttl_ms: Option<u64>,
+    pub trapdoor_batch_size: Option<usize>,
+    pub subgraph_page_size: Option<usize>,
 }
 
 // ---------------------------------------------------------------------------

--- a/skill-nanoclaw/SKILL.md
+++ b/skill-nanoclaw/SKILL.md
@@ -318,11 +318,18 @@ This provides memory isolation between different contexts.
 | `TOTALRECLAW_RECOVERY_PHRASE` | 12-word BIP-39 recovery phrase | Required |
 | `TOTALRECLAW_SERVER_URL` | TotalReclaw server URL (only needed for self-hosted) | `https://api.totalreclaw.xyz` |
 | `TOTALRECLAW_SELF_HOSTED` | Set to `true` to use your own server instead of the managed service | `false` |
-| `TOTALRECLAW_NAMESPACE` | Default namespace | Group folder name |
-| `TOTALRECLAW_EXTRACT_INTERVAL` | Turns between automatic extractions | `3` |
-| `TOTALRECLAW_MIN_IMPORTANCE` | Minimum importance for auto-store | `6` |
-| `TOTALRECLAW_CHAIN_ID` | Chain ID (100=Gnosis mainnet, 84532=Base Sepolia staging) | `100` |
-| `TOTALRECLAW_WALLET_ADDRESS` | Smart Account address override (auto-derived if not set) | Auto-derived |
+| `TOTALRECLAW_CREDENTIALS_PATH` | Credential file location | `~/.totalreclaw/credentials.json` |
+| `TOTALRECLAW_CACHE_PATH` | Encrypted cache file location | `~/.totalreclaw/cache.enc` |
+
+The v1 env cleanup removed the following user-facing vars: `TOTALRECLAW_CHAIN_ID`
+(chain is auto-detected from billing tier), `TOTALRECLAW_EMBEDDING_MODEL`,
+`TOTALRECLAW_STORE_DEDUP`, `TOTALRECLAW_LLM_MODEL`, `TOTALRECLAW_SESSION_ID`,
+`TOTALRECLAW_TAXONOMY_VERSION`, `TOTALRECLAW_CLAIM_FORMAT`,
+`TOTALRECLAW_DIGEST_MODE`. Tuning knobs like `TOTALRECLAW_EXTRACT_INTERVAL`
+and `TOTALRECLAW_MIN_IMPORTANCE` are now delivered via the relay billing
+response; env-var fallbacks are still honoured for self-hosted deployments.
+See [`docs/guides/env-vars-reference.md`](../docs/guides/env-vars-reference.md)
+for the canonical list.
 
 ---
 

--- a/skill-nanoclaw/mcp/README.md
+++ b/skill-nanoclaw/mcp/README.md
@@ -35,6 +35,8 @@ RUN npm install -g @totalreclaw/mcp-server
 | `TOTALRECLAW_RECOVERY_PHRASE` | Yes | — (12-word BIP-39 recovery phrase) |
 | `TOTALRECLAW_SERVER_URL` | No | `https://api.totalreclaw.xyz` |
 | `TOTALRECLAW_SELF_HOSTED` | No | `false` (managed service with on-chain storage via The Graph) |
-| `TOTALRECLAW_NAMESPACE` | No | Group folder name |
 | `TOTALRECLAW_CREDENTIALS_PATH` | No | `/workspace/.totalreclaw/credentials.json` |
-| `TOTALRECLAW_CHAIN_ID` | No | `100` (Gnosis mainnet) |
+| `TOTALRECLAW_CACHE_PATH` | No | `/workspace/.totalreclaw/cache.enc` |
+
+Chain ID is no longer user-configurable (auto-detected from billing tier:
+free = Base Sepolia, Pro = Gnosis). See [`docs/guides/env-vars-reference.md`](../../docs/guides/env-vars-reference.md).

--- a/skill-nanoclaw/src/billing.ts
+++ b/skill-nanoclaw/src/billing.ts
@@ -356,7 +356,10 @@ export async function getBillingContext(): Promise<BillingContext | null> {
 
   try {
     const authKeyHex = deriveAuthKeyHex(mnemonic);
-    const chainId = parseInt(process.env.TOTALRECLAW_CHAIN_ID || '84532', 10);
+    // Chain ID is not user-configurable in v1 — Smart Account derivation is
+    // deterministic via CREATE2 so the address is the same on every chain;
+    // tier routing (free = Base Sepolia, Pro = Gnosis) happens at the relay.
+    const chainId = 84532;
     const walletAddress = await getWalletAddress(mnemonic, chainId);
 
     // Register auth key with relay (idempotent — relay returns 200 for existing users).

--- a/skill/plugin/README.md
+++ b/skill/plugin/README.md
@@ -241,16 +241,21 @@ const result = await skill.onPreCompaction(context);
 
 ### Environment Variables
 
+See [`docs/guides/env-vars-reference.md`](../../docs/guides/env-vars-reference.md)
+for the complete, authoritative list. The v1-launch cleanup reduced the
+user-facing surface to 5 vars plus LLM provider keys. The short version:
+
 | Variable | Required | Default | Description |
 |----------|:---:|---------|-------------|
-| `TOTALRECLAW_SERVER_URL` | **Yes** | `http://127.0.0.1:8080` | TotalReclaw server URL |
 | `TOTALRECLAW_RECOVERY_PHRASE` | **Yes** | -- | 12-word BIP-39 recovery phrase (never sent to server) |
-| `TOTALRECLAW_AUTO_EXTRACT_EVERY_TURNS` | No | `3` | Turns between automatic extractions |
-| `TOTALRECLAW_MIN_IMPORTANCE` | No | `6` | Minimum importance (1-10) to auto-store |
-| `TOTALRECLAW_MAX_MEMORIES` | No | `8` | Maximum memories to inject into context |
-| `TOTALRECLAW_FORGET_THRESHOLD` | No | `0.3` | Decay score threshold for eviction |
-| `TOTALRECLAW_RERANKER_MODEL` | No | `BAAI/bge-reranker-base` | ONNX reranker model path |
-| `TOTALRECLAW_USER_ID` | No | -- | Existing user ID (skips registration) |
+| `TOTALRECLAW_SERVER_URL` | No | `https://api.totalreclaw.xyz` | Relay URL (override for self-hosted / staging) |
+| `TOTALRECLAW_SELF_HOSTED` | No | `false` | Set `true` if running against a self-hosted PostgreSQL server |
+| `TOTALRECLAW_CREDENTIALS_PATH` | No | `~/.totalreclaw/credentials.json` | Credential file location |
+| `TOTALRECLAW_CACHE_PATH` | No | `~/.totalreclaw/cache.enc` | Encrypted cache file location |
+
+Tuning knobs (extraction interval, importance threshold, cosine thresholds)
+now come from the relay billing response. Self-hosted operators can still
+set the env-var equivalents as fallbacks — see the env vars reference.
 
 ### Configuration Sources (Priority Order)
 

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -929,13 +929,18 @@ Default configuration values:
 
 ### Memory Consolidation Configuration
 
-Environment variables for controlling near-duplicate detection and consolidation:
+Store-time near-duplicate detection is always on — the `TOTALRECLAW_STORE_DEDUP`
+user-facing toggle was removed in v1. Advanced thresholds can still be tuned
+via env var for self-hosted deployments:
 
 | Env Var | Default | Description |
 |---------|---------|-------------|
-| `TOTALRECLAW_STORE_DEDUP` | `true` | Enable/disable store-time near-duplicate detection |
 | `TOTALRECLAW_STORE_DEDUP_THRESHOLD` | `0.85` | Cosine similarity threshold for store-time dedup (0-1) |
 | `TOTALRECLAW_CONSOLIDATION_THRESHOLD` | `0.88` | Cosine similarity threshold for bulk consolidation (0-1) |
+
+Managed-service tenants receive the tuning values from the relay billing
+response — these env vars act as fallbacks only. See
+[`docs/guides/env-vars-reference.md`](../../docs/guides/env-vars-reference.md).
 
 ---
 

--- a/skill/plugin/claims-helper.ts
+++ b/skill/plugin/claims-helper.ts
@@ -41,25 +41,6 @@ function getWasm() {
 }
 
 // ---------------------------------------------------------------------------
-// Feature flag
-// ---------------------------------------------------------------------------
-
-export type ClaimFormat = 'claim' | 'legacy';
-
-/**
- * Resolve the claim-format mode from the TOTALRECLAW_CLAIM_FORMAT env var.
- *
- * - `claim`  (default, or unset): new canonical Claim blob, entity trapdoors added.
- * - `legacy`: old {text, metadata} doc shape; entity trapdoors still added.
- *
- * Read on every call (cheap) so tests can toggle via env without module reload.
- */
-export function resolveClaimFormat(): ClaimFormat {
-  const raw = (process.env.TOTALRECLAW_CLAIM_FORMAT ?? '').trim().toLowerCase();
-  return raw === 'legacy' ? 'legacy' : 'claim';
-}
-
-// ---------------------------------------------------------------------------
 // Category mapping (ExtractedFact.type → compact Claim category short key)
 // ---------------------------------------------------------------------------
 
@@ -396,36 +377,6 @@ export function buildCanonicalClaimRouted(input: BuildClaimInput): string {
 }
 
 // ---------------------------------------------------------------------------
-// Legacy {text, metadata} doc shape (unchanged from pre-KG storeExtractedFacts).
-// ---------------------------------------------------------------------------
-
-export interface BuildLegacyDocInput {
-  fact: ExtractedFact;
-  importance: number;
-  source: string;
-  createdAt?: string;
-}
-
-/**
- * Build the legacy `{text, metadata}` document shape.
- *
- * Kept so the TOTALRECLAW_CLAIM_FORMAT=legacy fallback can write blobs that
- * the existing parseClaimOrLegacy path has always handled.
- */
-export function buildLegacyDoc(input: BuildLegacyDocInput): string {
-  const { fact, importance, source, createdAt } = input;
-  return JSON.stringify({
-    text: fact.text,
-    metadata: {
-      type: fact.type,
-      importance: importance / 10,
-      source,
-      created_at: createdAt ?? new Date().toISOString(),
-    },
-  });
-}
-
-// ---------------------------------------------------------------------------
 // Digest helpers (Stage 3b read path)
 // ---------------------------------------------------------------------------
 
@@ -456,36 +407,38 @@ export const DIGEST_CLAIM_CAP = 200;
 export type DigestMode = 'on' | 'off' | 'template';
 
 /**
- * Resolve TOTALRECLAW_DIGEST_MODE.
+ * Digest injection is always ON in v1. The TOTALRECLAW_DIGEST_MODE env var
+ * was removed — the G-pipeline ships a digest on every recall with an LLM
+ * template fallback baked into the digest compiler. Kept as a function
+ * returning `'on'` so legacy call-sites continue to compile.
  *
- * - `on` (default, unset, unknown): digest injection + LLM compilation when
- *   an LLM is configured, template fallback otherwise.
- * - `off`: legacy individual-fact search path, no digest injection.
- * - `template`: digest injection but skip LLM entirely (template only).
- *
- * Read per-call so tests can toggle via env without module reload.
+ * @deprecated v1 always returns `'on'`.
  */
 export function resolveDigestMode(): DigestMode {
-  const raw = (process.env.TOTALRECLAW_DIGEST_MODE ?? '').trim().toLowerCase();
-  if (raw === 'off') return 'off';
-  if (raw === 'template') return 'template';
   return 'on';
 }
 
 // ---------------------------------------------------------------------------
-// Auto-resolution mode (Phase 2 Slice 2d)
+// Auto-resolution mode — INTERNAL DEBUG KILL-SWITCH
+//
+// Not a user-facing env var. This is kept as an emergency off-switch for
+// auto-contradiction-resolution if we have to disable it in production
+// without a redeploy. It is NOT documented in the env var reference and
+// MUST NOT be surfaced in any client README / SKILL.md.
+//
+// See `contradiction-sync.ts` for the read site.
 // ---------------------------------------------------------------------------
 
 export type AutoResolveMode = 'active' | 'off' | 'shadow';
 
 /**
- * Resolve TOTALRECLAW_AUTO_RESOLVE_MODE.
+ * Internal kill-switch for the auto-resolution loop.
  *
  * - `active` (default, unset, unknown): full detection + auto-resolution.
  * - `off`: skip contradiction detection entirely; Phase 1 behaviour.
  * - `shadow`: detect + log decisions, but do not apply them (debug only).
  *
- * Read per-call so tests can toggle via env without module reload.
+ * @internal Not public config — emergency kill-switch only.
  */
 export function resolveAutoResolveMode(): AutoResolveMode {
   const raw = (process.env.TOTALRECLAW_AUTO_RESOLVE_MODE ?? '').trim().toLowerCase();

--- a/skill/plugin/config.test.ts
+++ b/skill/plugin/config.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for skill/plugin/config.ts.
+ *
+ * Covers the v1 env var cleanup surface:
+ *   - Removed env vars trigger the one-shot warning.
+ *   - `resolveTuning(features)` reads from the relay billing response when
+ *     fields are present, falls through to env/defaults otherwise.
+ *   - Removed env vars (CHAIN_ID, EMBEDDING_MODEL, STORE_DEDUP, LLM_MODEL,
+ *     SESSION_ID, TAXONOMY_VERSION, CLAIM_FORMAT, DIGEST_MODE) have NO
+ *     effect on CONFIG output.
+ *
+ * Run with:
+ *   npx tsx config.test.ts
+ */
+
+import { resolveTuning, CONFIG, __internal } from './config.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, name: string): void {
+  const n = passed + failed + 1;
+  if (condition) {
+    console.log(`ok ${n} - ${name}`);
+    passed++;
+  } else {
+    console.log(`not ok ${n} - ${name}`);
+    failed++;
+  }
+}
+
+function assertEq<T>(actual: T, expected: T, name: string): void {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (!ok) {
+    console.log(`  actual:   ${JSON.stringify(actual)}`);
+    console.log(`  expected: ${JSON.stringify(expected)}`);
+  }
+  assert(ok, name);
+}
+
+// ---------------------------------------------------------------------------
+// REMOVED_ENV_VARS matches the env vars reference doc
+// ---------------------------------------------------------------------------
+
+{
+  const expected = [
+    'TOTALRECLAW_CHAIN_ID',
+    'TOTALRECLAW_EMBEDDING_MODEL',
+    'TOTALRECLAW_STORE_DEDUP',
+    'TOTALRECLAW_LLM_MODEL',
+    'TOTALRECLAW_SESSION_ID',
+    'TOTALRECLAW_TAXONOMY_VERSION',
+    'TOTALRECLAW_CLAIM_FORMAT',
+    'TOTALRECLAW_DIGEST_MODE',
+  ];
+  assertEq(
+    [...__internal.REMOVED_ENV_VARS],
+    expected,
+    'REMOVED_ENV_VARS: matches env vars reference doc',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// warnRemovedEnvVars emits a warning when any removed env var is set
+// ---------------------------------------------------------------------------
+
+{
+  const originals: Record<string, string | undefined> = {};
+  for (const name of __internal.REMOVED_ENV_VARS) {
+    originals[name] = process.env[name];
+    delete process.env[name];
+  }
+
+  try {
+    // No removed vars set → no warning.
+    let calls = 0;
+    __internal.warnRemovedEnvVars(() => {
+      calls++;
+    });
+    assert(calls === 0, 'warnRemovedEnvVars: quiet when no removed vars set');
+
+    // One removed var set → one warning call.
+    process.env.TOTALRECLAW_CHAIN_ID = '100';
+    let warned: string | null = null;
+    __internal.warnRemovedEnvVars((msg) => {
+      warned = msg;
+    });
+    assert(warned !== null, 'warnRemovedEnvVars: warns when CHAIN_ID set');
+    assert(
+      (warned ?? '').includes('TOTALRECLAW_CHAIN_ID'),
+      'warnRemovedEnvVars: warning mentions CHAIN_ID',
+    );
+    assert(
+      (warned ?? '').includes('env-vars-reference'),
+      'warnRemovedEnvVars: warning links to env vars reference',
+    );
+  } finally {
+    for (const [name, val] of Object.entries(originals)) {
+      if (val === undefined) delete process.env[name];
+      else process.env[name] = val;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Removed env vars have NO effect on CONFIG output
+// ---------------------------------------------------------------------------
+
+{
+  // CONFIG is frozen at module-load time for most fields, so the test here
+  // is that the fields that USED to be env-backed now have hardcoded values
+  // regardless of env.
+  process.env.TOTALRECLAW_CHAIN_ID = '1234';
+  assertEq(CONFIG.chainId, 84532, 'CHAIN_ID env ignored → default 84532');
+
+  // Store dedup flag is always true.
+  assertEq(CONFIG.storeDedupEnabled, true, 'STORE_DEDUP env ignored → always true');
+
+  // No llmModel / sessionId / embeddingModel fields on CONFIG.
+  assert(
+    !('llmModel' in CONFIG),
+    'CONFIG.llmModel: removed (no field for TOTALRECLAW_LLM_MODEL)',
+  );
+  assert(
+    !('sessionId' in CONFIG),
+    'CONFIG.sessionId: removed (no field for TOTALRECLAW_SESSION_ID)',
+  );
+  assert(
+    !('embeddingModel' in CONFIG),
+    'CONFIG.embeddingModel: removed (no field for TOTALRECLAW_EMBEDDING_MODEL)',
+  );
+
+  delete process.env.TOTALRECLAW_CHAIN_ID;
+}
+
+// ---------------------------------------------------------------------------
+// resolveTuning: billing features take priority over local defaults
+// ---------------------------------------------------------------------------
+
+{
+  const defaults = resolveTuning(null);
+  assert(
+    typeof defaults.cosineThreshold === 'number',
+    'resolveTuning(null): returns number for cosineThreshold',
+  );
+  assert(
+    typeof defaults.minImportance === 'number',
+    'resolveTuning(null): returns number for minImportance',
+  );
+
+  // Billing features override defaults.
+  const withFeatures = resolveTuning({
+    cosine_threshold: 0.42,
+    relevance_threshold: 0.55,
+    semantic_skip_threshold: 0.99,
+    min_importance: 9,
+    cache_ttl_ms: 60_000,
+    trapdoor_batch_size: 8,
+    subgraph_page_size: 500,
+  });
+  assertEq(withFeatures.cosineThreshold, 0.42, 'resolveTuning: cosine from features');
+  assertEq(withFeatures.relevanceThreshold, 0.55, 'resolveTuning: relevance from features');
+  assertEq(withFeatures.semanticSkipThreshold, 0.99, 'resolveTuning: semantic from features');
+  assertEq(withFeatures.minImportance, 9, 'resolveTuning: minImportance from features');
+  assertEq(withFeatures.cacheTtlMs, 60_000, 'resolveTuning: cacheTtl from features');
+  assertEq(withFeatures.trapdoorBatchSize, 8, 'resolveTuning: trapdoor batch from features');
+  assertEq(withFeatures.pageSize, 500, 'resolveTuning: page size from features');
+
+  // Partial features: missing fields fall back to defaults.
+  const partial = resolveTuning({ cosine_threshold: 0.5 });
+  assertEq(partial.cosineThreshold, 0.5, 'resolveTuning: partial override applied');
+  assertEq(
+    partial.minImportance,
+    CONFIG.minImportance,
+    'resolveTuning: missing field falls back to CONFIG default',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log(`\n# ${passed}/${passed + failed} passed`);
+if (failed > 0) {
+  console.log('\nSOME TESTS FAILED');
+  process.exit(1);
+}
+console.log('\nALL TESTS PASSED');

--- a/skill/plugin/config.ts
+++ b/skill/plugin/config.ts
@@ -6,11 +6,51 @@
  * OpenClaw's security scanner flags files that contain BOTH process.env reads
  * AND network calls. By centralizing all env reads here, no other file needs
  * to touch process.env directly.
+ *
+ * v1 env var cleanup — see `docs/guides/env-vars-reference.md`.
+ * Removed user-facing vars: TOTALRECLAW_CHAIN_ID, TOTALRECLAW_EMBEDDING_MODEL,
+ * TOTALRECLAW_STORE_DEDUP, TOTALRECLAW_LLM_MODEL, TOTALRECLAW_SESSION_ID,
+ * TOTALRECLAW_TAXONOMY_VERSION.
+ * Removed legacy gates: TOTALRECLAW_CLAIM_FORMAT, TOTALRECLAW_DIGEST_MODE,
+ * TOTALRECLAW_AUTO_RESOLVE_MODE (the last one moved to an internal debug
+ * module; see `contradiction-sync.ts`).
+ *
+ * Tuning knobs (cosine threshold, min importance, cache TTL, etc.) are now
+ * delivered via the relay billing response. Env-var fallbacks are kept only
+ * for self-hosted deployments where the server may not surface those values.
  */
 
 import path from 'node:path';
 
 const home = process.env.HOME ?? '/home/node';
+
+/**
+ * Removed env vars — warn once per process if still set so operators know
+ * their config is a no-op. The removal list matches `docs/guides/env-vars-reference.md`.
+ */
+const REMOVED_ENV_VARS = [
+  'TOTALRECLAW_CHAIN_ID',
+  'TOTALRECLAW_EMBEDDING_MODEL',
+  'TOTALRECLAW_STORE_DEDUP',
+  'TOTALRECLAW_LLM_MODEL',
+  'TOTALRECLAW_SESSION_ID',
+  'TOTALRECLAW_TAXONOMY_VERSION',
+  'TOTALRECLAW_CLAIM_FORMAT',
+  'TOTALRECLAW_DIGEST_MODE',
+] as const;
+
+function warnRemovedEnvVars(warn: (msg: string) => void = console.warn): void {
+  const set = REMOVED_ENV_VARS.filter((name) => process.env[name] !== undefined);
+  if (set.length === 0) return;
+  warn(
+    `TotalReclaw: ignoring removed env var(s): ${set.join(', ')}. ` +
+      `See docs/guides/env-vars-reference.md for the v1 env var surface.`,
+  );
+}
+
+// Emit the warning once at import time. Safe because this module is loaded
+// exactly once per process.
+warnRemovedEnvVars();
 
 /** Runtime override for recovery phrase (set by hot-reload after setup). */
 let _recoveryPhraseOverride: string | null = null;
@@ -34,16 +74,23 @@ export const CONFIG = {
   selfHosted: process.env.TOTALRECLAW_SELF_HOSTED === 'true',
   credentialsPath: process.env.TOTALRECLAW_CREDENTIALS_PATH || path.join(home, '.totalreclaw', 'credentials.json'),
 
-  // Chain
-  chainId: parseInt(process.env.TOTALRECLAW_CHAIN_ID || '84532', 10),
+  // Chain — chainId is no longer user-configurable. It is auto-detected from
+  // the relay billing response (free = Base Sepolia / 84532, Pro = Gnosis /
+  // 100). The default here is used only before the first billing fetch
+  // completes. Self-hosted users can still point at a custom DataEdge via
+  // TOTALRECLAW_DATA_EDGE_ADDRESS / TOTALRECLAW_ENTRYPOINT_ADDRESS /
+  // TOTALRECLAW_RPC_URL (undocumented; internal knobs).
+  chainId: 84532,
   dataEdgeAddress: process.env.TOTALRECLAW_DATA_EDGE_ADDRESS || '',
   entryPointAddress: process.env.TOTALRECLAW_ENTRYPOINT_ADDRESS || '',
   rpcUrl: process.env.TOTALRECLAW_RPC_URL || '',
 
-  // Tuning
+  // Tuning knobs — default values used only as local fallback for
+  // self-hosted mode. Managed-service clients override these from the relay
+  // billing response via `resolveTuning(...)`.
+  // See: docs/specs/totalreclaw/client-consistency.md
   cosineThreshold: parseFloat(process.env.TOTALRECLAW_COSINE_THRESHOLD ?? '0.15'),
   extractInterval: parseInt(process.env.TOTALRECLAW_EXTRACT_INTERVAL ?? process.env.TOTALRECLAW_EXTRACT_EVERY_TURNS ?? '3', 10),
-  storeDedupEnabled: process.env.TOTALRECLAW_STORE_DEDUP !== 'false',
   relevanceThreshold: parseFloat(process.env.TOTALRECLAW_RELEVANCE_THRESHOLD ?? '0.3'),
   semanticSkipThreshold: parseFloat(process.env.TOTALRECLAW_SEMANTIC_SKIP_THRESHOLD ?? '0.85'),
   cacheTtlMs: parseInt(process.env.TOTALRECLAW_CACHE_TTL_MS ?? String(5 * 60 * 1000), 10),
@@ -51,10 +98,12 @@ export const CONFIG = {
   trapdoorBatchSize: parseInt(process.env.TOTALRECLAW_TRAPDOOR_BATCH_SIZE ?? '5', 10),
   pageSize: parseInt(process.env.TOTALRECLAW_SUBGRAPH_PAGE_SIZE ?? '1000', 10),
 
-  // LLM override
-  llmModel: process.env.TOTALRECLAW_LLM_MODEL || '',
+  // Store-time dedup is always ON. TOTALRECLAW_STORE_DEDUP was removed in v1.
+  storeDedupEnabled: true,
 
-  // LLM provider API keys (read once, passed to llm-client)
+  // LLM provider API keys (read once, passed to llm-client). Model selection
+  // is entirely automatic via `deriveCheapModel(provider)` — the
+  // TOTALRECLAW_LLM_MODEL override was removed in v1.
   llmApiKeys: {
     zai: process.env.ZAI_API_KEY || '',
     anthropic: process.env.ANTHROPIC_API_KEY || '',
@@ -70,15 +119,64 @@ export const CONFIG = {
     cerebras: process.env.CEREBRAS_API_KEY || '',
   } as Record<string, string>,
 
-  // Embedding model: "default" (640d, Harrier q4), "small" (384d, e5-small), or "large" (1024d, Qwen3)
-  embeddingModel: (process.env.TOTALRECLAW_EMBEDDING_MODEL || 'default') as 'default' | 'small' | 'large',
-
-  // Observability — optional session ID for tracing QA runs in relay logs (Axiom)
-  sessionId: process.env.TOTALRECLAW_SESSION_ID || '',
-
   // Paths
   home,
   billingCachePath: path.join(home, '.totalreclaw', 'billing-cache.json'),
   cachePath: process.env.TOTALRECLAW_CACHE_PATH || path.join(home, '.totalreclaw', 'cache.enc'),
   openclawWorkspace: path.join(home, '.openclaw', 'workspace'),
 } as const;
+
+// ---------------------------------------------------------------------------
+// Server-side tuning resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Optional tuning fields delivered via the relay billing response.
+ *
+ * Relay may populate these in `features` (same cache consumed by
+ * `isLlmDedupEnabled`, `getExtractInterval`, etc.). When present, they
+ * override the env/defaults resolved above. When absent (self-hosted or
+ * pre-rollout relay), clients fall back to `CONFIG` values.
+ */
+export interface BillingTuning {
+  cosine_threshold?: number;
+  relevance_threshold?: number;
+  semantic_skip_threshold?: number;
+  min_importance?: number;
+  cache_ttl_ms?: number;
+  trapdoor_batch_size?: number;
+  subgraph_page_size?: number;
+}
+
+/**
+ * Merge a billing-response tuning block with the local fallback values.
+ *
+ * Use this at the call-site that needs a threshold, passing the features
+ * blob from the billing cache. No I/O here — callers read the cache once
+ * and hand the features in.
+ */
+export function resolveTuning(features?: BillingTuning | null): {
+  cosineThreshold: number;
+  relevanceThreshold: number;
+  semanticSkipThreshold: number;
+  minImportance: number;
+  cacheTtlMs: number;
+  trapdoorBatchSize: number;
+  pageSize: number;
+} {
+  return {
+    cosineThreshold: features?.cosine_threshold ?? CONFIG.cosineThreshold,
+    relevanceThreshold: features?.relevance_threshold ?? CONFIG.relevanceThreshold,
+    semanticSkipThreshold: features?.semantic_skip_threshold ?? CONFIG.semanticSkipThreshold,
+    minImportance: features?.min_importance ?? CONFIG.minImportance,
+    cacheTtlMs: features?.cache_ttl_ms ?? CONFIG.cacheTtlMs,
+    trapdoorBatchSize: features?.trapdoor_batch_size ?? CONFIG.trapdoorBatchSize,
+    pageSize: features?.subgraph_page_size ?? CONFIG.pageSize,
+  };
+}
+
+// Exposed for tests that want to assert the removed-var warning behaviour.
+export const __internal = {
+  REMOVED_ENV_VARS,
+  warnRemovedEnvVars,
+};

--- a/skill/plugin/digest-injection.test.ts
+++ b/skill/plugin/digest-injection.test.ts
@@ -59,38 +59,25 @@ function assertEq<T>(actual: T, expected: T, name: string): void {
 }
 
 // ---------------------------------------------------------------------------
-// resolveDigestMode — env var handling
+// resolveDigestMode — v1 always returns 'on' regardless of env var.
+// TOTALRECLAW_DIGEST_MODE was removed; this test asserts the env var
+// has zero effect.
 // ---------------------------------------------------------------------------
 
 {
   const original = process.env.TOTALRECLAW_DIGEST_MODE;
   try {
     delete process.env.TOTALRECLAW_DIGEST_MODE;
-    assert(resolveDigestMode() === 'on', 'digestMode: unset → on (default)');
-
-    process.env.TOTALRECLAW_DIGEST_MODE = 'on';
-    assert(resolveDigestMode() === 'on', 'digestMode: explicit on');
-
-    process.env.TOTALRECLAW_DIGEST_MODE = 'ON';
-    assert(resolveDigestMode() === 'on', 'digestMode: case-insensitive ON');
+    assert(resolveDigestMode() === 'on', 'digestMode: unset → on');
 
     process.env.TOTALRECLAW_DIGEST_MODE = 'off';
-    assert(resolveDigestMode() === 'off', 'digestMode: off');
-
-    process.env.TOTALRECLAW_DIGEST_MODE = 'OFF';
-    assert(resolveDigestMode() === 'off', 'digestMode: case-insensitive OFF');
+    assert(resolveDigestMode() === 'on', 'digestMode: env var removed, "off" ignored');
 
     process.env.TOTALRECLAW_DIGEST_MODE = 'template';
-    assert(resolveDigestMode() === 'template', 'digestMode: template');
-
-    process.env.TOTALRECLAW_DIGEST_MODE = 'TEMPLATE';
-    assert(resolveDigestMode() === 'template', 'digestMode: case-insensitive TEMPLATE');
+    assert(resolveDigestMode() === 'on', 'digestMode: env var removed, "template" ignored');
 
     process.env.TOTALRECLAW_DIGEST_MODE = 'nonsense';
-    assert(resolveDigestMode() === 'on', 'digestMode: unknown value → on');
-
-    process.env.TOTALRECLAW_DIGEST_MODE = '';
-    assert(resolveDigestMode() === 'on', 'digestMode: empty string → on');
+    assert(resolveDigestMode() === 'on', 'digestMode: env var removed, unknown ignored');
   } finally {
     if (original === undefined) delete process.env.TOTALRECLAW_DIGEST_MODE;
     else process.env.TOTALRECLAW_DIGEST_MODE = original;

--- a/skill/plugin/embedding.ts
+++ b/skill/plugin/embedding.ts
@@ -4,17 +4,15 @@
  * Generates text embeddings locally using an ONNX model. No API key needed,
  * no data leaves the machine. Preserves the E2EE guarantee.
  *
- * Three model options (selected via CONFIG.embeddingModel):
- *   - "default": onnx-community/harrier-oss-v1-270m-ONNX (640d, q4 ~344MB)
- *   - "small": Xenova/multilingual-e5-small (384d, q8 ~34MB, low-resource fallback)
- *   - "large": onnx-community/Qwen3-Embedding-0.6B-ONNX (1024d, q8 ~600MB, legacy)
+ * Locked to Harrier-OSS-v1-270M (640d, q4, ~344MB, pre-pooled). Changing the
+ * embedding model breaks search across an existing vault, so the
+ * `TOTALRECLAW_EMBEDDING_MODEL` user-facing env var was removed in v1.
  *
  * Dependencies: @huggingface/transformers
  */
 
 // @ts-ignore - @huggingface/transformers types may not be perfect
 import { AutoTokenizer, AutoModel, pipeline, type FeatureExtractionPipeline } from '@huggingface/transformers';
-import { CONFIG } from './config.js';
 
 interface ModelConfig {
   id: string;
@@ -26,33 +24,16 @@ interface ModelConfig {
   dtype: string;
 }
 
-const MODELS: Record<string, ModelConfig> = {
-  default: {
-    id: 'onnx-community/harrier-oss-v1-270m-ONNX',
-    dims: 640,
-    pooling: 'sentence_embedding',
-    size: '~344MB',
-    dtype: 'q4',
-  },
-  small: {
-    id: 'Xenova/multilingual-e5-small',
-    dims: 384,
-    pooling: 'mean',
-    size: '~34MB',
-    dtype: 'q8',
-  },
-  large: {
-    id: 'onnx-community/Qwen3-Embedding-0.6B-ONNX',
-    dims: 1024,
-    pooling: 'last_token',
-    size: '~600MB',
-    dtype: 'q8',
-  },
+const HARRIER_MODEL: ModelConfig = {
+  id: 'onnx-community/harrier-oss-v1-270m-ONNX',
+  dims: 640,
+  pooling: 'sentence_embedding',
+  size: '~344MB',
+  dtype: 'q4',
 };
 
 function getModelConfig(): ModelConfig {
-  const key = CONFIG.embeddingModel || 'default';
-  return MODELS[key] || MODELS.default;
+  return HARRIER_MODEL;
 }
 
 /** Lazily initialized model instances. */

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -226,8 +226,9 @@ const AUTO_EXTRACT_EVERY_TURNS_ENV = CONFIG.extractInterval;
 // Hard cap on facts per extraction to prevent LLM over-extraction from dense conversations
 const MAX_FACTS_PER_EXTRACTION = 15;
 
-// Store-time near-duplicate detection (consolidation module)
-const STORE_DEDUP_ENABLED = CONFIG.storeDedupEnabled;
+// Store-time near-duplicate detection is always ON in v1.
+// The TOTALRECLAW_STORE_DEDUP env var was removed.
+const STORE_DEDUP_ENABLED = true;
 
 // One-time welcome-back message for returning Pro users (set during init, consumed by first before_agent_start)
 let welcomeBackMessage: string | null = null;

--- a/skill/plugin/llm-client.ts
+++ b/skill/plugin/llm-client.ts
@@ -161,11 +161,14 @@ let _logger: { warn: (msg: string) => void } | null = null;
  * Called once from the plugin's `register()` function.
  *
  * Resolution order (highest priority first):
- *   1. TOTALRECLAW_LLM_MODEL env var (power user override for model)
- *   2. Plugin config `extraction.model` (if provided)
- *   3. Auto-derived from provider heuristic using env var API keys
- *   4. OpenClaw's model provider config (api.config.models.providers)
- *   5. Fallback: try common env vars (ZAI_API_KEY, OPENAI_API_KEY) for dev/test
+ *   1. Plugin config `extraction.model` (if provided)
+ *   2. Auto-derived from provider heuristic using env var API keys
+ *   3. OpenClaw's model provider config (api.config.models.providers)
+ *   4. Fallback: try common env vars (ZAI_API_KEY, OPENAI_API_KEY) for dev/test
+ *
+ * The `TOTALRECLAW_LLM_MODEL` user-facing override was removed in v1 —
+ * `deriveCheapModel(provider)` covers the 99% case and a model-level knob
+ * was adding config surface for no tangible win.
  */
 export function initLLMClient(options: {
   primaryModel?: string;
@@ -214,9 +217,8 @@ export function initLLMClient(options: {
       }
 
       if (apiKey && baseUrl) {
-        // Determine model: env override > plugin config > auto-derived
+        // Determine model: plugin config > auto-derived
         const model =
-          CONFIG.llmModel ||
           (typeof extraction?.model === 'string' ? extraction.model : null) ||
           deriveCheapModel(provider, modelName);
 
@@ -241,7 +243,6 @@ export function initLLMClient(options: {
       // Pick a model from the provider's configured models, or use our default
       const firstModelId = providerConfig.models?.[0]?.id;
       const model =
-        CONFIG.llmModel ||
         (typeof extraction?.model === 'string' ? extraction.model : null) ||
         (firstModelId ? deriveCheapModel(provider, firstModelId) : null);
 
@@ -268,7 +269,7 @@ export function initLLMClient(options: {
   for (const [provider, keyName, defaultModel] of fallbackProviders) {
     const apiKey = CONFIG.llmApiKeys[keyName];
     if (apiKey) {
-      const model = CONFIG.llmModel ||
+      const model =
         (typeof extraction?.model === 'string' ? extraction.model : null) ||
         defaultModel;
 
@@ -310,8 +311,7 @@ export function resolveLLMConfig(): LLMClientConfig | null {
   const zaiKey = CONFIG.llmApiKeys.zai;
   const openaiKey = CONFIG.llmApiKeys.openai;
 
-  const model = CONFIG.llmModel
-    || (zaiKey ? 'glm-4.5-flash' : 'gpt-4.1-mini');
+  const model = zaiKey ? 'glm-4.5-flash' : 'gpt-4.1-mini';
 
   if (zaiKey) {
     return {

--- a/skill/plugin/subgraph-store.ts
+++ b/skill/plugin/subgraph-store.ts
@@ -310,7 +310,6 @@ export async function submitFactOnChain(
   };
   if (config.authKeyHex) headers['Authorization'] = `Bearer ${config.authKeyHex}`;
   if (config.walletAddress) headers['X-Wallet-Address'] = config.walletAddress;
-  if (CONFIG.sessionId) headers['X-TotalReclaw-Session'] = CONFIG.sessionId;
 
   // Helper for JSON-RPC calls to relay bundler (with 429 retry)
   async function rpc(method: string, params: unknown[]): Promise<any> {
@@ -516,7 +515,6 @@ export async function submitFactBatchOnChain(
   };
   if (config.authKeyHex) headers['Authorization'] = `Bearer ${config.authKeyHex}`;
   if (config.walletAddress) headers['X-Wallet-Address'] = config.walletAddress;
-  if (CONFIG.sessionId) headers['X-TotalReclaw-Session'] = CONFIG.sessionId;
 
   // Helper for JSON-RPC calls to relay bundler (with 429 retry)
   async function rpc(method: string, params: unknown[]): Promise<any> {
@@ -712,11 +710,13 @@ export function isSubgraphMode(): boolean {
 /**
  * Get subgraph configuration from environment variables.
  *
- * After the relay refactor, clients only need:
+ * After the v1 env var cleanup, clients only need:
  *   - TOTALRECLAW_RECOVERY_PHRASE -- BIP-39 mnemonic
  *   - TOTALRECLAW_SERVER_URL -- relay server URL (default: https://api.totalreclaw.xyz)
  *   - TOTALRECLAW_SELF_HOSTED -- set "true" to use self-hosted server (default: managed service)
- *   - TOTALRECLAW_CHAIN_ID -- optional, defaults to 84532 (Base Sepolia)
+ *
+ * Chain ID is no longer configurable via env — it is auto-detected from the
+ * relay billing response (free = Base Sepolia, Pro = Gnosis mainnet).
  */
 export function getSubgraphConfig(): SubgraphStoreConfig {
   return {


### PR DESCRIPTION
Removed: TOTALRECLAW_CHAIN_ID, TOTALRECLAW_EMBEDDING_MODEL,
TOTALRECLAW_STORE_DEDUP, TOTALRECLAW_LLM_MODEL/EXTRACTION_MODEL,
TOTALRECLAW_SESSION_ID, TOTALRECLAW_TAXONOMY_VERSION

Legacy gates removed: TOTALRECLAW_CLAIM_FORMAT, TOTALRECLAW_DIGEST_MODE

Kept (5 user-facing): RECOVERY_PHRASE, SERVER_URL, SELF_HOSTED,
CREDENTIALS_PATH, CACHE_PATH.

Tuning knobs migrated to relay billing response (self-hosted env fallback).

Docs updated: env-vars-reference.md (canonical source), client READMEs.