### PR TITLE
docs(v1): launch docs — migration guide, user guides, v1 specs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,8 +160,15 @@ Features across OpenClaw plugin (`skill/plugin/`), MCP server (`mcp/`), NanoClaw
 | Decay handling | -- | -- | -- | -- | -- | Yes (via ZeroClaw) | ZeroClaw applies 7-day half-life at retrieval time |
 | Conflict resolution | -- | -- | -- | -- | -- | Yes (via ZeroClaw) | ZeroClaw checks semantic similarity before storing Core |
 | **Extraction** | | | | | | | |
-| Expanded memory types (8 categories) | Yes | Yes (via prompt) | Yes | Yes (LLM or heuristic) | Yes (via prompt) | Yes (category mapping) | fact, preference, decision, episodic, goal, context, summary, rule (Phase 2.2) |
+| Expanded memory types (8 categories, v0 legacy) | Read-only | Read-only | Read-only | Read-only | Read-only | Read-only | fact, preference, decision, episodic, goal, context, summary, rule — reads only, coerced to v1 on recall |
+| **Memory Taxonomy v1 (6 types)** | Yes (write default) | Yes (write default) | Yes (write default, via MCP) | Yes (write default) | Yes (via MCP) | Yes (write via `store_v1`) | `claim / preference / directive / commitment / episode / summary`. v1 is the only write path. |
+| `source` field (provenance) | Yes | Yes | Yes (via MCP) | Yes | Yes (via MCP) | Yes | user / user-inferred / assistant / external / derived |
+| `scope` field (life domain) | Yes | Yes | Yes (via MCP) | Yes | Yes (via MCP) | Yes | work/personal/health/family/creative/finance/misc/unspecified |
+| `volatility` field | Yes | Yes | Yes (via MCP) | Yes | Yes (via MCP) | Yes | stable / updatable / ephemeral |
+| `reasoning` field (decision-style claims) | Yes | Yes | Yes (via MCP) | Yes | Yes (via MCP) | Yes | Separate field; `claim` type with `reasoning` replaces v0 `decision` |
 | Decision reasoning extraction | Yes | Yes (via prompt) | Yes | Yes (LLM or heuristic) | Yes (via prompt) | Yes (via ZeroClaw) | Extraction prompts require "chose X because Y" |
+| Protobuf v4 outer wrapper | Yes | Yes | Yes (via MCP) | Yes | Yes (via MCP) | Yes | `version = 4` signals v1 inner JSON blob; subgraph schema unchanged |
+| G-pipeline extraction | Yes | -- | Yes (hook) | Yes | -- | Yes (store pipeline) | Merged-topic prompt + provenance filter lax + comparative rescore + volatility heuristic |
 | **Knowledge Graph (Core Hoist Tier 1)** | | | | | | | All via `@totalreclaw/core` 1.5.0 WASM/PyO3 with local fallbacks |
 | Store-time dedup (best-match) | Yes (core) | Yes (core) | Yes (via MCP) | Yes (core) | Yes (via MCP) | Yes (core) | `find_best_near_duplicate` — returns highest-similarity match, not first |
 | Bulk clustering | Yes (core) | Yes (core) | Yes (via MCP) | -- | Yes (via MCP) | -- | `cluster_facts` — greedy single-pass for consolidation tool |
@@ -174,6 +181,11 @@ Features across OpenClaw plugin (`skill/plugin/`), MCP server (`mcp/`), NanoClaw
 | Bump cap (≥8 → max +1) | Yes | -- | -- | Yes | -- | -- | Phase 2.2.7 — prevents over-scoring already-high facts |
 | Type in recall results | Yes | Yes | Yes (via MCP) | Yes | Yes (via MCP) | -- | `[rule]` `[fact]` `[decision]` prefix tags in recall output |
 | Remember type+importance params | Yes | Yes | Yes (via MCP) | Yes | Yes (via MCP) | -- | Phase 2.2.6 — `type` and `importance` in totalreclaw_remember tool |
+| **Retrieval v2 — Tier 1 source-weighted rerank** | Yes (core) | Yes (core) | Yes (via MCP) | Yes (core) | Yes (via MCP) | Yes (core) | All via `@totalreclaw/core@2.0.0` `rerankWithConfig` — user=1.0, user-inferred=0.9, derived/external=0.7, assistant=0.55, legacy=0.85 |
+| `totalreclaw_pin` tool | -- | Yes | Yes (via MCP) | -- | Yes (via MCP) | -- | New in v1 — locks memory against auto-supersession |
+| `totalreclaw_unpin` tool | -- | Yes | Yes (via MCP) | -- | Yes (via MCP) | -- | New in v1 |
+| `totalreclaw_retype` tool | -- | Yes | Yes (via MCP) | -- | Yes (via MCP) | -- | New in v1 — change memory type (e.g. preference → directive) |
+| `totalreclaw_set_scope` tool | -- | Yes | Yes (via MCP) | -- | Yes (via MCP) | -- | New in v1 — assign memory to a scope |
 | **Dedup** | | | | | | |
 | Content fingerprint (exact) | Yes | Yes | Yes | Yes | Yes (via MCP) | Yes | Server-side HMAC-SHA256 |
 | Within-batch semantic dedup | Yes | -- | -- | -- | -- | -- | Cosine >= 0.9, during extraction |
@@ -249,6 +261,9 @@ Managed Service two-tier chain model: **Free** = Base Sepolia testnet (unlimited
 | KG features MCP/NanoClaw-only dedup | LOW | MCP and NanoClaw have core-backed store-time dedup but not contradiction detection or pin semantics (no auto-extraction pipeline to wire them into). OpenClaw, Hermes, and ZeroClaw have full KG wiring. |
 | Lexical importance bump not in MCP/NanoClaw | LOW | `computeLexicalImportanceBump` only runs in OpenClaw plugin and Python Hermes. MCP and NanoClaw don't have auto-extraction, so this is by-design for now. |
 | ZeroClaw no type in recall | RESOLVED | ZeroClaw now parses category from decrypted envelope and surfaces it in recall results. |
+| v1 taxonomy adoption | RESOLVED (2026-04-18) | All 5 clients ship v1 (core 2.0.0, plugin 3.0.0, mcp-server 3.0.0, nanoclaw 3.0.0, python 2.0.0, totalreclaw-memory 2.0.0). No env-var gating. Legacy v0 writes are no longer possible. |
+| v1 VPS QA | PENDING | End-to-end validation on VPS per `totalreclaw-internal/docs/plans/2026-04-18-v1-vps-qa-plan.md`. 8 scenarios + cross-client interop + Bangkok recall test. Gates production promotion. |
+| Cross-client parity tests | PENDING | `tests/parity/` cross-language v1 round-trip tests pass in isolation; `totalreclaw-internal/e2e/cross-client/` multi-client parity bed still queued. |
 
 ---
 
@@ -441,15 +456,18 @@ git checkout main
 
 ## Current Status
 
-- **Version**: v1.0-beta
-- **Phase**: Private Beta
+- **Version**: v1 (taxonomy v1 + Retrieval v2 Tier 1) — shipped April 2026
+- **Phase**: Private Beta; v1 is the default extraction + write path across every client with zero env-var toggles
 - **Default mode**: Managed Service with dual-chain (free=Base Sepolia testnet, pro=Gnosis mainnet)
-- **Default chain ID**: 84532 (Base Sepolia) -- all clients default to free tier, auto-detect Pro (chain 100/Gnosis) from billing
-- **Embedding model**: onnx-community/harrier-oss-v1-270m-ONNX (640d, ~344MB, q4, pre-pooled). e5-small (384d, ~34MB) available as fallback via TOTALRECLAW_EMBEDDING_MODEL=small.
-- **Crypto core**: `@totalreclaw/core` v1.5.0 (Rust WASM for npm, PyO3 for PyPI) -- 16 modules (crypto, reranker, wallet, userop, store, search, blind, lsh, fingerprint, hotcache, consolidation, debrief, stemmer, claims/pin, decision_log, contradiction orchestration). 423 tests. Single source of truth for all clients. Core Hoist Tier 1 complete: store-time dedup best-match, pin semantics, decision log types, contradiction orchestration loop.
-- **Packages**: `@totalreclaw/core@1.5.0`, `@totalreclaw/client@1.1.0`, `@totalreclaw/mcp-server@2.7.0`, `@totalreclaw/totalreclaw@2.11.2` (OpenClaw plugin, ClawHub); `totalreclaw-core@1.5.0`, `totalreclaw@1.9.0` (PyPI)
+- **Default chain ID**: auto-detected from billing tier. Free = 84532 (Base Sepolia), Pro = 100 (Gnosis). `TOTALRECLAW_CHAIN_ID` env var removed in v1.
+- **Embedding model**: onnx-community/harrier-oss-v1-270m-ONNX (640d, ~344MB, q4, pre-pooled). Only supported model in v1; `TOTALRECLAW_EMBEDDING_MODEL` env var removed.
+- **Memory taxonomy**: v1 (6 types: claim / preference / directive / commitment / episode / summary + 3 axes: source / scope / volatility). See `docs/specs/totalreclaw/memory-taxonomy-v1.md`.
+- **Outer protobuf**: v4 (inner blob now v1 JSON; subgraph schema unchanged). See `totalreclaw-internal/docs/plans/2026-04-18-protobuf-v4-design.md`.
+- **Crypto core**: `@totalreclaw/core@2.0.0` (Rust WASM for npm, PyO3 for PyPI) — adds `MemoryClaimV1` types, `validateMemoryClaimV1`, `rerankWithConfig` (Tier 1 source-weighted reranker), `parseMemoryTypeV1` / `parseMemorySource`. 455 native + 498 WASM + 508 PyO3 tests pass. Legacy v0 `rerank()` preserved for back-compat.
+- **Packages (v1)**: `@totalreclaw/core@2.0.0`, `@totalreclaw/totalreclaw@3.0.0` (OpenClaw plugin, ClawHub), `@totalreclaw/mcp-server@3.0.0` (with 19 tools including `pin`/`unpin`/`retype`/`set_scope`), `@totalreclaw/skill-nanoclaw@3.0.0`; `totalreclaw-core@2.0.0`, `totalreclaw@2.0.0` (PyPI); `totalreclaw-memory@2.0.0` (crates.io)
 - **OpenClaw integration**: Plugin installs without force flags (`openclaw plugins install`), hot-reload setup via `TOTALRECLAW_HOT_RELOAD=true`, auto-recall on `before_agent_start`, auto-extraction on `agent_end`, LLM config sourced from OpenClaw providers, plaintext fallback prevention
 - **Relay**: Billing, Pimlico sponsorship, dual-chain routing, and query proxying extracted to private `totalreclaw-relay` TypeScript repo (p-diogo/totalreclaw-relay). Public server retains only self-hosted functionality (storage, search, auth).
+- **Server-side tuning**: Relay billing response carries `extraction_interval`, `max_facts_per_extraction`, `max_candidate_pool`, and (planned) `ephemeral_ttl_days`. Clients read these from the billing cache — no npm/PyPI publish required to retune.
 - **Staging**: Base Sepolia (chain 84532) -- free testnet, no gas costs
 - **Production**: Gnosis mainnet (chain 100) -- Pro tier only
 - **All releases via CI**: GitHub Actions workflows for npm, PyPI, and ClawHub. Never publish manually.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,11 @@ Specs are organized by product area under `docs/specs/`:
 | Spec | File | Status |
 |------|------|--------|
 | E2EE Architecture (LSH + Blind Buckets) | `architecture.md` | Implemented, validated |
+| **Memory Taxonomy v1** | `memory-taxonomy-v1.md` | **Shipped 2026-04-18 across 5 clients + core 2.0.0** |
+| **Retrieval v2 (Tier 1 source-weighted)** | `retrieval-v2.md` | **Tier 1 shipped in core 2.0.0; Tier 2-4 designed** |
+| **Tiered Retrieval (impl deep dive)** | `tiered-retrieval.md` | Shipped |
 | Server PoC v0.3.1b (Auth + Dedup) | `server.md` | Partially implemented |
+| Client Consistency | `client-consistency.md` | Canonical reference for all 5 clients |
 | OpenClaw Skill | `skill-openclaw.md` | Implemented |
 | NanoClaw Skill | `skill-nanoclaw.md` | Implemented |
 | MCP Server | `mcp-server.md` | Implemented |
@@ -111,7 +115,7 @@ Specs are organized by product area under `docs/specs/`:
 | Benchmark Harness (OMBH) | `benchmark.md` | Implemented |
 | LSH Tuning (Multi-Tenant SaaS) | `lsh-tuning.md` | Complete |
 | Conflict Resolution v0.3.2 | `conflict-resolution.md` | Design complete, not implemented |
-| Retrieval Improvements v3 | `retrieval-improvements-v3.md` | Implemented |
+| Retrieval Improvements v3 | `retrieval-improvements-v3.md` | Implemented (superseded by retrieval-v2 in v1) |
 
 ### Subgraph (Decentralized) -- `docs/specs/subgraph/`
 | Spec | File | Status |

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@
 <h1 align="center">TotalReclaw</h1>
 
 <p align="center">
-  <strong>End-to-end encrypted memory for AI agents — portable, yours forever</strong>
+  <strong>End-to-end encrypted memory + knowledge graph for AI agents — portable, yours forever</strong>
 </p>
 
 <p align="center">
   <a href="https://totalreclaw.xyz">Website</a> ·
   <a href="https://clawhub.ai/skills/totalreclaw">ClawHub</a> ·
   <a href="https://www.npmjs.com/package/@totalreclaw/totalreclaw">npm</a> ·
-  <a href="docs/guides/openclaw-setup.md">Getting Started</a> ·
+  <a href="docs/guides/client-setup-v1.md">Getting Started</a> ·
   <a href="docs/architecture.md">Architecture</a>
 </p>
 
@@ -24,53 +24,62 @@
 
 ---
 
-Your AI remembers everything — without remembering it for Big Tech.
+Your AI remembers everything — without remembering it for Big Tech. And starting with v1, every memory is structured: 6 speech-act types, provenance, scope, and volatility on every entry.
 
 - **Private** — XChaCha20-Poly1305 encryption happens on-device. The server never sees plaintext, even if fully compromised.
+- **Structured** — v1 taxonomy: `claim`, `preference`, `directive`, `commitment`, `episode`, `summary`, each with source / scope / volatility. [Learn more →](docs/guides/memory-types-guide.md)
 - **Portable** — one 12-word recovery phrase works across every supported agent. Switch platforms without losing a single memory. [Compare integrations →](docs/guides/feature-comparison.md)
 - **Yours forever** — memories are anchored to Gnosis Chain and indexed by The Graph. No vendor lock-in, no data hostage.
 
 Other AI memory tools ([Mem0](https://mem0.ai), [Zep](https://getzep.com)) store your data in plaintext on their servers. TotalReclaw can't read your data by design — that's the difference between a privacy promise and a structural guarantee.
 
+> **New in v1 (April 2026):** memory taxonomy, source-weighted reranking, 3 new MCP tools (`totalreclaw_pin` / `totalreclaw_retype` / `totalreclaw_set_scope`), protobuf v4 wire format. v1 is the default on every client. Existing vaults decrypt transparently. See the [v1 migration guide](docs/guides/v1-migration.md).
+
 ## Quick Start
 
-### OpenClaw
+One command per client. v1 is the default — no env toggles, no feature flags.
 
-Tell your agent: *"Install the TotalReclaw skill from ClawHub"*
+| Client | Install |
+|---|---|
+| **OpenClaw** | `openclaw skills install totalreclaw` |
+| **Claude Desktop / Cursor / Windsurf** | `npx @totalreclaw/mcp-server setup` |
+| **NanoClaw** | add `TOTALRECLAW_RECOVERY_PHRASE` to deployment env |
+| **Python / Hermes** | `pip install totalreclaw` |
+| **Rust / ZeroClaw** | `cargo add totalreclaw-memory` |
+| **IronClaw** | via MCP server — see [IronClaw setup](docs/guides/ironclaw-setup.md) |
 
-Or via terminal:
+Then set one env var on your host:
 
 ```bash
-openclaw skills install totalreclaw
+export TOTALRECLAW_RECOVERY_PHRASE="your twelve word recovery phrase here"
 ```
 
-The agent handles everything: generates encryption keys, registers, and sets up automatic memory. See the [OpenClaw setup guide](docs/guides/openclaw-setup.md).
-
-### Claude Desktop / Cursor / Windsurf
-
-```bash
-npx @totalreclaw/mcp-server setup
-```
-
-The wizard generates your recovery phrase, registers you, and prints a config snippet. See the [MCP setup guide](docs/guides/claude-code-setup.md).
-
-### NanoClaw / IronClaw / Hermes
-
-Each platform has its own setup guide:
-
-- **[NanoClaw](docs/guides/nanoclaw-getting-started.md)** — automatic memory via agent-runner MCP bridge
-- **[IronClaw](docs/guides/ironclaw-setup.md)** — NEAR AI TEE + TotalReclaw E2EE
-- **[Hermes](docs/guides/hermes-setup.md)** — Python agent plugin
+If you don't have a phrase yet, the setup wizard generates one. See the [client setup guide](docs/guides/client-setup-v1.md) for per-platform details.
 
 ## How It Works
 
-1. **Your agent extracts facts** from conversations — preferences, decisions, context
-2. **Everything is encrypted on-device** — keys derived from your recovery phrase, never sent anywhere
-3. **Encrypted data is stored on-chain** — the server only sees ciphertext and hashed search tokens
-4. **Search works over encrypted data** — blind indices and LSH let the server find relevant memories without reading them
-5. **Results are decrypted and ranked locally** — BM25 + cosine similarity + importance scoring
+1. **Your agent extracts facts** from conversations — typed by speech act (claim, preference, directive, commitment, episode, summary) and tagged with source, scope, volatility.
+2. **Everything is encrypted on-device** — keys derived from your recovery phrase, never sent anywhere.
+3. **Encrypted data is stored on-chain** — the server only sees ciphertext and hashed search tokens.
+4. **Search works over encrypted data** — blind indices and LSH let the server find relevant memories without reading them.
+5. **Results are decrypted and ranked locally** — BM25 + cosine + RRF with source-weighted reranking (v1 Tier 1).
 
-> Full technical deep dive: [Architecture](docs/architecture.md)
+> Full technical deep dives: [Architecture](docs/architecture.md), [Memory Taxonomy v1](docs/specs/totalreclaw/memory-taxonomy-v1.md), [Tiered Retrieval](docs/specs/totalreclaw/tiered-retrieval.md).
+
+## What's new in v1
+
+v1 shipped across every client in April 2026. Highlights:
+
+- **6-type speech-act taxonomy** — `claim / preference / directive / commitment / episode / summary`. Replaces the ambiguous 8-type v0 list.
+- **3 orthogonal axes** — `source` (user / user-inferred / assistant / external / derived), `scope` (work / personal / health / family / creative / finance / misc / unspecified), `volatility` (stable / updatable / ephemeral).
+- **Source-weighted reranking** — user-authored claims consistently rank above assistant-regurgitated noise. Structurally fixes the [97.8% junk problem](https://github.com/mem0ai/mem0/issues/4573) documented in other memory systems.
+- **3 new MCP tools** — `totalreclaw_pin`, `totalreclaw_retype`, `totalreclaw_set_scope`. Invoked by natural language ("pin that", "file that under work").
+- **Protobuf v4 wire format** — outer wrapper bump; subgraph schema unchanged.
+- **Env var cleanup** — 6 experimental env vars removed. 5 user-facing env vars remain. See the [env vars reference](docs/guides/env-vars-reference.md).
+
+> Benchmark headline: *(placeholder — filled in once phase 2 500-conv run lands 2026-04-18)* — v1's source-weighted reranker preserves recall quality while breaking the importance-clustering pathology.
+
+Full details: [v1 migration guide](docs/guides/v1-migration.md) and [memory types guide](docs/guides/memory-types-guide.md).
 
 ## Import from Other AI Tools
 
@@ -126,12 +135,35 @@ totalreclaw/
 
 ## Documentation
 
-- [OpenClaw Setup](docs/guides/openclaw-setup.md) — install, configure, start using memory
-- [Claude Desktop / Cursor / Windsurf](docs/guides/claude-code-setup.md) — MCP server setup
-- [Feature Comparison](docs/guides/feature-comparison.md) — what works on each platform
-- [Architecture](docs/architecture.md) — encryption, LSH, search, deduplication, network layer
-- [Importing Memories](docs/guides/importing-memories.md) — ChatGPT, Claude, Gemini, Mem0
-- [totalreclaw.xyz](https://totalreclaw.xyz) — project homepage
+### Start here
+
+- [Client setup — v1](docs/guides/client-setup-v1.md) — one install command per client.
+- [Memory types guide](docs/guides/memory-types-guide.md) — what gets stored and how to override it via natural language.
+- [v1 migration guide](docs/guides/v1-migration.md) — if you're upgrading from v0.
+- [Environment variables](docs/guides/env-vars-reference.md) — the 5 env vars that matter.
+- [Feature comparison](docs/guides/feature-comparison.md) — which features work on which client.
+
+### Per-client setup
+
+- [OpenClaw](docs/guides/openclaw-setup.md)
+- [Claude Desktop / Cursor / Windsurf](docs/guides/claude-code-setup.md)
+- [NanoClaw](docs/guides/nanoclaw-getting-started.md)
+- [Hermes (Python)](docs/guides/hermes-setup.md)
+- [IronClaw (NEAR AI)](docs/guides/ironclaw-setup.md)
+- [ZeroClaw (Rust)](docs/guides/zeroclaw-setup.md)
+
+### Specs + architecture
+
+- [Architecture](docs/architecture.md) — encryption, LSH, search, deduplication, network layer.
+- [Memory Taxonomy v1](docs/specs/totalreclaw/memory-taxonomy-v1.md) — normative cross-client spec.
+- [Retrieval v2](docs/specs/totalreclaw/retrieval-v2.md) — source-weighted reranking + future tiers.
+- [Tiered Retrieval](docs/specs/totalreclaw/tiered-retrieval.md) — implementation-focused retrieval deep dive.
+- [Client Consistency](docs/specs/totalreclaw/client-consistency.md) — cross-client contracts.
+
+### Other
+
+- [Importing memories](docs/guides/importing-memories.md) — ChatGPT, Claude, Gemini, Mem0.
+- [totalreclaw.xyz](https://totalreclaw.xyz) — project homepage.
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,10 @@
 # Architecture
 
-A technical deep dive into how TotalReclaw provides semantic search over fully encrypted memories — without ever seeing the data.
+A technical deep dive into how TotalReclaw provides semantic search + knowledge-graph memory over fully encrypted storage — without ever seeing the data.
 
 > This document covers the full system design. For a high-level overview, see the [README](../README.md).
+>
+> **v1 additions** (April 2026): the encrypted blob now contains a [v1 taxonomy claim](specs/totalreclaw/memory-taxonomy-v1.md) (6 speech-act types + source / scope / volatility axes). The reranker applies [Tier 1 source-weighted scoring](specs/totalreclaw/tiered-retrieval.md). Outer protobuf bumped to v4 — subgraph schema unchanged.
 
 <p align="center">
   <img src="assets/architecture.svg" alt="TotalReclaw Architecture" />

--- a/docs/guides/blog-draft-v1-launch.md
+++ b/docs/guides/blog-draft-v1-launch.md
@@ -1,0 +1,66 @@
+# TotalReclaw v1 — Better Memory for AI Agents
+
+**Status:** DRAFT. Do not publish until the phase 2 benchmark number lands (see `[BENCHMARK PLACEHOLDER]` below).
+**Target:** <https://totalreclaw.xyz/blog/v1-launch>
+**Word count target:** ~800.
+
+---
+
+## v1 is live
+
+TotalReclaw v1 ships today across every supported client: OpenClaw, Claude Desktop (via MCP), Cursor, Windsurf, NanoClaw, IronClaw, Hermes, and ZeroClaw. If your client updates automatically, you already have it. If it pins a version, bump the package — the new versions are plugin 3.0.0, mcp-server 3.0.0, nanoclaw 3.0.0, python 2.0.0, and ZeroClaw 2.0.0.
+
+v1 is the first release where a memory written by one client can be read by any other client with identical semantics. Same claim, same type, same source, same scope. That sounds obvious; in practice the memory systems we studied (Mem0, Zep, Mastra, Supermemory, Letta) each define their own schema and none of them interoperate.
+
+We shipped v1 because the MCP protocol itself deliberately leaves memory semantics undefined, and someone had to write a cross-client spec. We are uniquely positioned to do it: we ship in five clients, our server is end-to-end encrypted (so we cannot unilaterally normalize memory server-side — the spec has to be client-enforced), and we have no commercial reason to diverge from a standard.
+
+## What is new in v1
+
+**Six memory types, grounded in speech acts.** Instead of the 8 overlapping categories we had before (`fact`, `context`, `decision`, `preference`, `rule`, `goal`, `episodic`, `summary`), v1 uses a closed set of six:
+
+- `claim` — assertive: "X is the case."
+- `preference` — expressive: "I like X."
+- `directive` — imperative: "always do X."
+- `commitment` — commissive: "I will do X."
+- `episode` — narrative: "X happened at time T."
+- `summary` — derived: session syntheses only.
+
+Each type corresponds to one of John Searle's illocutionary classes. The mapping is intentional — it forces extractors to think "what kind of *act* is the user performing" instead of "what kind of object is this." That one change broke the importance-clustering pathology where every memory was pinned at importance 7 or 8.
+
+**Three orthogonal axes on every memory.** `source` (user / user-inferred / assistant / external / derived), `scope` (work / personal / health / family / creative / finance / misc / unspecified), and `volatility` (stable / updatable / ephemeral). These ride alongside the type instead of being jammed into it.
+
+**Source-weighted reranking.** The biggest lever v1 pulls on recall quality. Every memory now carries who wrote it, and the ranker penalizes assistant-authored content by default. Mem0's own team documented a case where 97.8% of their memory entries were junk because the assistant was authoring "facts" about the user that then ranked equal to things the user actually said. v1 tags and down-weights those (weight 0.55) instead of dropping them — so genuine content the assistant summarised (like a receipt you shared) is still recoverable, but opinion drift from the assistant never outranks what you said directly.
+
+**Three new tools for overrides.** `totalreclaw_pin`, `totalreclaw_retype`, and `totalreclaw_set_scope`. You invoke them via natural language — say "pin that" or "that was actually a rule, not a preference" and the agent calls the right tool. No JSON editing.
+
+## Why E2EE matters here
+
+The hard design constraint on v1 was: we cannot normalize memory server-side, because we never see plaintext. So everything — type inference, source attribution, scope detection, volatility assignment, provenance filtering — happens client-side, inside the encrypted envelope.
+
+This is the difference between a privacy promise and a structural guarantee. Mem0 and Zep store your memories in plaintext on their servers: they promise they won't read them, but they can. TotalReclaw can't, by design.
+
+E2EE also forces a different product shape. We cannot auto-tune your retrieval from your behaviour (we can't see your behaviour). We cannot A/B-test ranker weights on your data. Every setting has to be either a universal default (same for everyone) or a natural-language override you explicitly ask for. v1 is designed around that constraint.
+
+## Benchmarks
+
+[BENCHMARK PLACEHOLDER — will fill in once the 500-conversation phase 2 run completes. Expected to cover Gemini Takeout + WildChat corpora. Metrics: clustering ratio, normalized type entropy, recall@8, precision@1, token-cost delta. Target headline: "v1 breaks the 51% importance clustering, keeps recall quality at baseline."]
+
+The short version, pending final numbers: v1's source-weighted reranker preserves the recall quality of our v0.3 pipeline while the taxonomy change restructures the vault to spread memories across types instead of collapsing to 70%-clustering-on-fact.
+
+## What does not change
+
+Your recovery phrase, your wallet address, your memories, your ability to export plain-text JSON, and the free tier on Base Sepolia all stay the same. Upgrade the package and everything keeps working. Pre-v1 memories are read transparently — the client maps old types onto the new ones on the fly.
+
+If you self-host, no schema migration. The inner blob format changes inside the ciphertext, which your PostgreSQL never saw anyway.
+
+## No action required
+
+For users: just upgrade. The full migration guide lives at [docs/guides/v1-migration.md](./v1-migration.md).
+
+For developers using the libraries directly: core 2.0.0 ships new strict validators and a new `rerankWithConfig` entry point. The v0 paths are preserved where practical (reads are back-compat, writes are v1-only). Per-package CHANGELOGs have the details.
+
+## What is next
+
+Retrieval Tier 2-4 (scope pre-filter, volatility-aware decay, type boost) are designed and will ship post-v1, gated on real recall-quality data. A native web app at `app.totalreclaw.xyz` lets you inspect and bulk-edit memories out of band. And we are taking the v1 spec to the MCP spec repo as a proposed optional extension — once other memory systems align on it, your TotalReclaw memories become truly portable across the whole AI tool ecosystem.
+
+Try it. If something is wrong, file an issue: <https://github.com/p-diogo/totalreclaw/issues>.

--- a/docs/guides/client-setup-v1.md
+++ b/docs/guides/client-setup-v1.md
@@ -1,0 +1,231 @@
+# Client Setup — v1
+
+**Applies to:** TotalReclaw v1 (core 2.0.0, plugin 3.0.0, mcp-server 3.0.0, nanoclaw 3.0.0, python 2.0.0, ZeroClaw 2.0.0).
+
+One setup page per client. v1 is the default on every client — no env toggles, no feature flags to flip. Pick your platform.
+
+---
+
+## Which one do I want?
+
+| You are using... | Install |
+|---|---|
+| OpenClaw | [OpenClaw plugin](#openclaw-plugin) |
+| Claude Desktop, Cursor, Windsurf, or any MCP-compatible agent | [MCP server](#mcp-server) |
+| NanoClaw (OpenClaw's lightweight variant) | [NanoClaw skill](#nanoclaw-skill) |
+| Python / Hermes Agent | [Python client](#python-client) |
+| Native Rust app / ZeroClaw (NEAR AI) | [ZeroClaw](#zeroclaw-rust-crate) |
+| IronClaw (NEAR AI) | [MCP server via IronClaw](#mcp-server) |
+
+All clients write to the same vault. If you use multiple clients, use the same 12-word recovery phrase everywhere.
+
+---
+
+## OpenClaw plugin
+
+**Package:** `@totalreclaw/totalreclaw@^3.0.0` (ClawHub).
+**Features:** fully automatic — auto-recall on every message, auto-extract every 3 turns, pre-compaction flush, session debrief.
+
+### Install
+
+Tell your OpenClaw agent:
+
+> "Install the TotalReclaw skill from ClawHub"
+
+Or via terminal:
+
+```bash
+openclaw skills install totalreclaw
+```
+
+### Configure
+
+Set one env var:
+
+```bash
+export TOTALRECLAW_RECOVERY_PHRASE="your twelve word recovery phrase here"
+```
+
+If you don't already have a recovery phrase, the plugin will generate one on first run and print it once.
+
+That's it. v1 taxonomy, source-weighted reranking, and the new pin / retype / set_scope tools are all on by default.
+
+**Full guide:** [openclaw-setup.md](./openclaw-setup.md)
+
+---
+
+## MCP server
+
+**Package:** `@totalreclaw/mcp-server@^3.0.0` (npm).
+**Features:** 19 MCP tools (including 4 new v1 tools: pin, unpin, retype, set_scope). No lifecycle hooks — the host agent invokes tools from context.
+
+### Install + setup
+
+```bash
+npx @totalreclaw/mcp-server setup
+```
+
+The wizard generates a 12-word recovery phrase, registers you with the relay, and prints a config snippet.
+
+### Claude Desktop
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "totalreclaw": {
+      "command": "npx",
+      "args": ["-y", "@totalreclaw/mcp-server"],
+      "env": {
+        "TOTALRECLAW_RECOVERY_PHRASE": "your twelve word recovery phrase here"
+      }
+    }
+  }
+}
+```
+
+### Cursor / Windsurf
+
+Settings > MCP Servers — use the same block as above.
+
+### IronClaw (NEAR AI)
+
+The IronClaw agent config references the MCP server via the same JSON shape. See [ironclaw-setup.md](./ironclaw-setup.md).
+
+### Verify
+
+Ask the agent: *"What TotalReclaw tools do you have?"* — you should see 19 tools including `totalreclaw_pin`, `totalreclaw_retype`, `totalreclaw_set_scope`.
+
+**Full guide:** [claude-code-setup.md](./claude-code-setup.md)
+
+---
+
+## NanoClaw skill
+
+**Package:** `@totalreclaw/skill-nanoclaw@^3.0.0` (npm, via NanoClaw).
+**Features:** automatic memory, same hooks as OpenClaw. Shares the MCP server as a background agent-runner.
+
+### Install
+
+```bash
+TOTALRECLAW_RECOVERY_PHRASE="your twelve word recovery phrase here"
+```
+
+Add this to your NanoClaw deployment (Docker env, `.env`, or platform config). The NanoClaw agent-runner auto-spawns `@totalreclaw/mcp-server` with this env.
+
+If you need to generate a recovery phrase first, run `npx @totalreclaw/mcp-server setup` on any machine with Node 18+.
+
+**Full guide:** [nanoclaw-getting-started.md](./nanoclaw-getting-started.md)
+
+---
+
+## Python client
+
+**Package:** `totalreclaw==2.0.0` (PyPI).
+**Features:** Hermes Agent plugin with pre_llm_call auto-recall + post_llm_call auto-extract + on_session_end debrief. Core remember/recall/forget/export/status tools.
+
+### Install
+
+```bash
+pip install totalreclaw
+```
+
+**Docker slim images:** install a C compiler first (required by PyStemmer):
+
+```bash
+apt-get update && apt-get install -y gcc g++
+```
+
+### Use
+
+```python
+import asyncio
+from totalreclaw import TotalReclaw
+
+async def main():
+    client = TotalReclaw(
+        recovery_phrase="your twelve word recovery phrase here",
+    )
+    await client.resolve_address()
+    await client.register()
+
+    # v1 fields supported end-to-end
+    await client.remember(
+        "Pedro prefers dark mode for all editors",
+        fact_type="preference",
+        importance=0.8,
+    )
+
+    results = await client.recall("What does Pedro prefer?")
+    for r in results:
+        print(f"  [{r.rrf_score:.3f}] {r.text}")
+
+    await client.close()
+
+asyncio.run(main())
+```
+
+### Hermes Agent
+
+```bash
+pip install totalreclaw[hermes]
+```
+
+The plugin registers automatically with Hermes Agent v0.5.0+.
+
+**Full guide:** [hermes-setup.md](./hermes-setup.md)
+
+---
+
+## ZeroClaw (Rust crate)
+
+**Crate:** `totalreclaw-memory = "2.0.0"` (crates.io).
+**Features:** native Rust Memory trait with v1 write path (`store_v1`), cosine + fingerprint dedup, v4 outer protobuf. Designed for ZeroClaw (NEAR AI agent framework) but usable in any Rust app.
+
+### Add dependency
+
+```toml
+[dependencies]
+totalreclaw-memory = "2.0.0"
+```
+
+### Use
+
+```rust
+use totalreclaw_memory::{Memory, TotalReclawMemory, V1StoreInput};
+
+let memory = TotalReclawMemory::new(recovery_phrase).await?;
+memory.store_v1(V1StoreInput {
+    text: "Pedro prefers dark mode for all editors".into(),
+    type_: "preference".into(),
+    source: "user".into(),
+    scope: Some("personal".into()),
+    volatility: Some("stable".into()),
+    importance: 0.8,
+    reasoning: None,
+}).await?;
+```
+
+**Full guide:** [zeroclaw-setup.md](./zeroclaw-setup.md)
+
+---
+
+## After setup
+
+- [Memory types guide](./memory-types-guide.md) — what the agent stores and how to override it via natural language.
+- [v1 migration guide](./v1-migration.md) — if you already have memories on an earlier version.
+- [Environment variables](./env-vars-reference.md) — short list of actual env vars.
+- [Feature comparison](./feature-comparison.md) — which features work on which client.
+
+---
+
+## Troubleshooting
+
+**The setup wizard prints no phrase.** — You already have credentials at the default path (`~/.totalreclaw/credentials.json`). Either set `TOTALRECLAW_CREDENTIALS_PATH` to a new path or remove the existing file.
+
+**The agent says "I don't have memory tools."** — Check the MCP server config path and JSON syntax. On Claude Desktop, restart after editing the config file.
+
+**Pro-tier features are gated.** — Clients auto-detect your tier from the relay's billing response. If you just upgraded, wait up to 2 hours for the billing cache to refresh, or delete `~/.totalreclaw/billing-cache.json` to force a refresh.
+
+**I still see old env vars in my shell.** — Env vars from the v0 era (see [env-vars-reference.md](./env-vars-reference.md#removed-in-v1)) are silently ignored in v1. Safe to delete.

--- a/docs/guides/feature-comparison.md
+++ b/docs/guides/feature-comparison.md
@@ -1,6 +1,8 @@
 # Feature Comparison -- TotalReclaw Integrations
 
-TotalReclaw works across multiple AI agent platforms. The core encryption, storage, and search pipeline is identical everywhere -- the differences are in automation (lifecycle hooks) and available tools. This table shows what each platform supports.
+TotalReclaw works across multiple AI agent platforms. The core encryption, storage, search pipeline, and v1 taxonomy are identical everywhere -- the differences are in automation (lifecycle hooks) and available tools. This table shows what each platform supports.
+
+All clients below ship v1 (core 2.0.0, plugin 3.0.0, mcp-server 3.0.0, nanoclaw 3.0.0, python 2.0.0, ZeroClaw 2.0.0).
 
 ---
 
@@ -8,14 +10,23 @@ TotalReclaw works across multiple AI agent platforms. The core encryption, stora
 
 | Feature | OpenClaw | MCP (Claude Desktop, Cursor, Windsurf) | NanoClaw | Hermes (Python) | IronClaw (NEAR AI) | ZeroClaw (Rust) |
 |---------|:-:|:-:|:-:|:-:|:-:|:-:|
+| **Memory Taxonomy v1** | | | | | | |
+| 6-type taxonomy (claim/preference/directive/commitment/episode/summary) | Yes (default) | Yes | Yes (via MCP) | Yes | Yes (via MCP) | Yes |
+| source / scope / volatility axes | Yes | Yes | Yes (via MCP) | Yes | Yes (via MCP) | Yes |
+| reasoning field for decision-style claims | Yes | Yes | Yes (via MCP) | Yes | Yes (via MCP) | Yes |
+| Retrieval v2 Tier 1 (source-weighted rerank) | Yes | Yes | Yes (via MCP) | Yes | Yes (via MCP) | Yes |
+| Protobuf v4 outer wrapper | Yes | Yes | Yes (via MCP) | Yes | Yes (via MCP) | Yes |
 | **Automatic Memory** | | | | | | |
 | Auto-recall (every message) | Yes | -- | Yes | Yes | -- | Yes |
-| Auto-extract (every 3 turns) | Yes | -- | Yes | Yes | -- | Yes |
+| Auto-extract (G-pipeline, every 3 turns) | Yes | -- | Yes | Yes | -- | Yes |
 | Pre-compaction flush | Yes | -- | Yes | -- | -- | -- |
-| Session debrief | Yes | Yes (tool) | Yes | Yes | Yes (tool) | Yes |
+| Session debrief (v1 `summary`, source=derived) | Yes | Yes (tool) | Yes | Yes | Yes (tool) | Yes |
 | **Explicit Tools** | | | | | | |
 | Remember / Recall / Forget / Export | Yes | Yes | Yes | Yes | Yes | Yes |
 | Status (billing & usage) | Yes | Yes | Yes | Yes | Yes | Yes |
+| Pin / Unpin (v1) | -- | Yes | Yes (via MCP) | -- | Yes (via MCP) | -- |
+| Retype (v1) | -- | Yes | Yes (via MCP) | -- | Yes (via MCP) | -- |
+| Set scope (v1) | -- | Yes | Yes (via MCP) | -- | Yes (via MCP) | -- |
 | Import from Mem0 / ChatGPT / Claude | Yes | Yes | Yes | -- | Yes | -- |
 | Upgrade to Pro | Yes | Yes | Yes | -- | Yes | -- |
 | Migrate (testnet to mainnet) | Yes | Yes | Yes | -- | Yes | -- |
@@ -26,6 +37,7 @@ TotalReclaw works across multiple AI agent platforms. The core encryption, stora
 | Content fingerprint (exact match) | Yes | Yes | Yes | Yes | Yes | Yes |
 | **Search** | | | | | | |
 | BM25 + Cosine + RRF reranking | Yes | Yes | Yes | Yes | Yes | Yes |
+| Source-weighted final score (v1 Tier 1) | Yes | Yes | Yes | Yes | Yes | Yes |
 | Broadened search fallback | Yes | Yes | Yes | Yes | Yes | Yes |
 | Hot cache (skip remote on repeat) | Yes | -- | -- | -- | -- | Yes |
 

--- a/docs/guides/memory-types-guide.md
+++ b/docs/guides/memory-types-guide.md
@@ -1,0 +1,196 @@
+# Understanding Memory Types
+
+**Target audience:** end users who want to know what is being stored and how to influence it.
+**Applies to:** TotalReclaw v1 (all clients).
+
+This guide explains the v1 memory model in plain English. You do not need to think about any of this to use TotalReclaw — the agent picks the right type automatically. Read this when you want to understand what is being stored, or when you want to override the agent's choice.
+
+---
+
+## The big picture
+
+Every memory TotalReclaw keeps has four pieces of information attached:
+
+1. **Type** — what kind of statement it is (6 options).
+2. **Source** — who wrote it (user, user-inferred, assistant, external, derived).
+3. **Scope** — what area of your life it belongs to (work, personal, health, ...).
+4. **Volatility** — how long it is likely to stay true (stable, updatable, ephemeral).
+
+You never set these manually. The agent infers them from context during extraction. You only override them when you notice the agent got something wrong — and you override by speaking naturally, not by editing JSON.
+
+---
+
+## The six memory types
+
+Each type maps to a different kind of statement you make in conversation. The examples below use natural phrasing you might actually say to an agent.
+
+### `claim`
+
+A descriptive statement about yourself or the world.
+
+- "I live in Lisbon."
+- "The database runs on Postgres 16."
+- "My daughter's name is Maya."
+- "I chose Postgres for the analytics store because the data is relational."  ← stored as `claim` with a `reasoning` field.
+
+Use `claim` when something just *is*. If the statement changes (job, city, relationship status), that is fine — `claim` can be superseded by a later `claim`.
+
+### `preference`
+
+An expression of taste, like/dislike, or style.
+
+- "I prefer dark mode in all my editors."
+- "I don't like cilantro."
+- "I like my coffee black."
+- "Sci-fi over fantasy, always."
+
+`preference` is about taste. If you want the agent to follow a rule, use `directive` (below). If you want to record a fact about yourself, use `claim`.
+
+### `directive`
+
+A rule the agent should follow going forward.
+
+- "Always cite a source when you make a factual claim."
+- "Never auto-commit to my git repo."
+- "When writing SQL, prefer CTEs over subqueries."
+- "Don't use dark UI for data-dense screens."
+
+`directive` is imperative: you are telling the agent how to behave. This is different from `preference` (which is just taste — "I like dark mode" does not mean "always produce dark UI").
+
+### `commitment`
+
+A future-facing intent — something you are going to do.
+
+- "I'll ship v2 on Friday."
+- "I'm going to start training for a marathon next month."
+- "I'll call the dentist tomorrow."
+
+A `commitment` about an event that already happened becomes an `episode` (see below).
+
+### `episode`
+
+A notable event that happened at a specific time.
+
+- "Deployed v1.0 on March 15."
+- "We flew to Bangkok in November."
+- "Had a great meeting with Maya's teacher on Tuesday."
+
+An `episode` is a `narrative` speech act — it tells the story of something that occurred. When you recall by time ("what happened last March?") you are searching episodes.
+
+### `summary`
+
+A derived synthesis, not a single-turn extraction. The agent creates these automatically at session end or before compaction. You do not usually author `summary` memories yourself — they are computed from longer conversation threads.
+
+---
+
+## Boundary cases
+
+The agent picks the right type by asking a structural question, not by matching keywords. Here are the tests:
+
+- **claim vs preference:** "I live in Lisbon" = claim. "I prefer Portuguese over Spanish" = preference. *Test: would replacing this affect a decision, or just taste?*
+- **claim vs directive:** "Postgres handles my analytics workload" = claim. "Always use Postgres for analytics" = directive. *Test: is this descriptive, or commanding future behavior?*
+- **directive vs preference:** "I prefer dark mode" = preference. "Never use dark UI for data-dense screens" = directive. *Test: do you want this enforced, or just considered?*
+- **commitment vs claim:** "Shipping v2 Friday" = commitment. "v2 shipped Friday" = episode.
+- **episode vs claim:** "Deployed v1.0 on March 15" = episode (event). "v1.0 is deployed" = claim (state).
+
+---
+
+## Source — who wrote it
+
+Every memory is tagged with who authored the content. This matters for recall: user-authored claims rank higher than anything else.
+
+| Source | What it means | Recall weight |
+|---|---|:-:|
+| `user` | You said it directly | 1.00 |
+| `user-inferred` | Extracted from your signals (but not a direct quote) | 0.90 |
+| `derived` | Computed (debrief, digest, summary) | 0.70 |
+| `external` | Imported from another tool (ChatGPT export, Mem0, etc.) | 0.70 |
+| `assistant` | The assistant said it and you didn't affirm it | 0.55 |
+
+The `assistant` weight is deliberately low. It prevents a failure mode documented in other memory systems: the assistant makes an inference in its response, that inference gets extracted as a "fact", and then it ranks the same as things you actually said. TotalReclaw tags it but down-weights it instead of dropping it entirely, so genuine content you shared (e.g. a receipt the assistant summarised) is still recoverable.
+
+---
+
+## Scope — what area of your life
+
+Memories are grouped into 8 scopes:
+
+- `work` — your job, colleagues, projects, tools.
+- `personal` — things about you that are not work-related.
+- `health` — medical, fitness, diet, allergies.
+- `family` — partner, kids, parents, relatives.
+- `creative` — writing, music, art, side projects.
+- `finance` — money, budgets, taxes, investments.
+- `misc` — doesn't fit elsewhere.
+- `unspecified` — the agent didn't identify a clear scope.
+
+The agent picks the scope automatically from conversation context. You can override: "that's actually a work thing" or "file that under health".
+
+---
+
+## Volatility — how long it stays true
+
+- `stable` — unlikely to change for years (your name, allergies, birthplace, unchanging preferences).
+- `updatable` — changes occasionally (job, active project, partner's name, current city).
+- `ephemeral` — short-lived (today's task, this week's itinerary, a specific question you had yesterday).
+
+Volatility is assigned by the agent during extraction. Ephemeral memories can auto-expire (14 or 30 days depending on type); stable and updatable do not expire.
+
+You can pin any memory regardless of volatility. Pinning overrides auto-expiry.
+
+---
+
+## Overriding the agent — natural language
+
+You never edit memories by hand. You talk to the agent and it picks the right tool.
+
+### Pin a memory ("never forget this")
+
+Say: *"pin that last thing"* or *"remember this forever"* or *"never forget I'm allergic to shellfish"*.
+
+The agent calls `totalreclaw_pin` behind the scenes. Pinned memories cannot be auto-superseded and do not expire.
+
+### Unpin
+
+Say: *"unpin the shellfish allergy"* or *"it's fine to update that if things change"*.
+
+### Re-type a memory
+
+Say: *"that was actually a rule, not a preference"* or *"file that as a commitment, not a claim"*.
+
+The agent calls `totalreclaw_retype`.
+
+### Re-scope a memory
+
+Say: *"that's a work thing, not personal"* or *"file that under health"*.
+
+The agent calls `totalreclaw_set_scope`.
+
+### Forget a memory
+
+Say: *"forget what I said about the old project"* or *"delete my diet notes from last week"*.
+
+The agent calls `totalreclaw_forget`. On the managed service this writes a tombstone on-chain; on self-hosted it deletes the row.
+
+---
+
+## Explicit remember — optional
+
+If you want to write something into memory without a natural conversation, you can ask directly: *"remember that I prefer PostgreSQL for analytics"*. The agent calls `totalreclaw_remember` with type + importance + scope set from your statement. This works the same way as auto-extraction but skips the conversation-extraction step.
+
+---
+
+## Where the settings live
+
+Every one of these fields lives **inside the encrypted memory blob**. The server sees only ciphertext; the type, source, scope, and volatility are all readable to you (locally, after decryption) but invisible to the server.
+
+This is the same privacy model TotalReclaw has always had — v1 adds more fields but keeps them all end-to-end encrypted.
+
+---
+
+## Related
+
+- [v1 migration guide](./v1-migration.md) — what changed from v0.
+- [Memory types spec](../specs/totalreclaw/memory-taxonomy-v1.md) — full normative spec (for implementers).
+- [Tiered retrieval](../specs/totalreclaw/tiered-retrieval.md) — how `source` affects recall.
+- [Feature comparison](./feature-comparison.md) — which clients support which features.

--- a/docs/guides/v1-migration.md
+++ b/docs/guides/v1-migration.md
@@ -1,0 +1,164 @@
+# Upgrading to TotalReclaw v1
+
+**Target audience:** existing TotalReclaw users on any client (OpenClaw, MCP, NanoClaw, Hermes, ZeroClaw).
+**Version landing in:** core 2.0.0, plugin 3.0.0, mcp-server 3.0.0, nanoclaw 3.0.0, python 2.0.0, ZeroClaw (`totalreclaw-memory`) 2.0.0.
+**TL;DR:** v1 is a bigger + cleaner memory model. Your wallet, recovery phrase, memories, and privacy model do not change. Upgrade the package and you are done.
+
+---
+
+## What is v1?
+
+v1 is the first cross-client memory taxonomy shipped by TotalReclaw: **six speech-act-grounded memory types** plus **three orthogonal axes** (source, scope, volatility) that fix the "everything is just a fact" pathology in every prior memory system.
+
+The short version:
+
+- Memory types collapse from 8 ambiguous categories to **6 clean ones**: `claim`, `preference`, `directive`, `commitment`, `episode`, `summary`.
+- Every memory now carries **provenance** (who said it: user, user-inferred, assistant, external, derived).
+- Every memory now carries **scope** (work, personal, health, family, creative, finance, misc, unspecified).
+- Every memory now carries **volatility** (stable, updatable, ephemeral).
+- Retrieval uses `source` to rank results so user-authored claims consistently win over assistant-regurgitated noise.
+
+See the full spec in [`docs/specs/totalreclaw/memory-taxonomy-v1.md`](../specs/totalreclaw/memory-taxonomy-v1.md) and the retrieval change in [`docs/specs/totalreclaw/retrieval-v2.md`](../specs/totalreclaw/retrieval-v2.md).
+
+---
+
+## What stays the same
+
+Nothing about TotalReclaw's security or portability model changes.
+
+- **E2E encryption** — XChaCha20-Poly1305, keys derived from your 12-word recovery phrase. Server-blind.
+- **Recovery phrase** — same phrase keeps working. No re-registration, no re-derivation.
+- **Wallet / Smart Account address** — same deterministic address across chains.
+- **Storage** — same DataEdge contract, same subgraph, same chains (Base Sepolia free, Gnosis Pro).
+- **Plain-text export** — same one-click JSON/Markdown export tools.
+- **Import adapters** — ChatGPT, Claude, Gemini, Mem0, MCP Memory all continue to work.
+
+---
+
+## What changed
+
+### 1. Memory types — from 8 to 6
+
+The old 8-type list (`fact`, `preference`, `decision`, `episodic`, `goal`, `context`, `summary`, `rule`) mixed three different things together (content class, temporal scope, and operation). v1 splits them cleanly.
+
+| v0 type | v1 equivalent | Notes |
+|---|---|---|
+| `fact` | `claim` | descriptive statements ("I live in Lisbon") |
+| `context` | `claim` with `volatility: ephemeral` | short-lived context now expressed via volatility axis |
+| `decision` | `claim` with `reasoning` populated | reasoning moves to its own field |
+| `preference` | `preference` | unchanged (expressive speech act) |
+| `rule` | `directive` | renamed (imperative: "always do X") |
+| `goal` | `commitment` | renamed (commissive: "I will do X") |
+| `episodic` | `episode` | renamed |
+| `summary` | `summary` | unchanged — restricted to source in `{derived, assistant}` |
+
+All clients do the v0 → v1 mapping automatically when reading existing memories. You do not need to rewrite anything.
+
+### 2. Three new axes every memory carries
+
+- **source** — who authored the memory
+  - `user` — user explicitly said it (highest recall weight)
+  - `user-inferred` — extractor inferred it from user signals
+  - `assistant` — assistant authored it (heavily down-weighted at recall)
+  - `external` — imported from another system
+  - `derived` — computed (digests, debrief, consolidation)
+- **scope** — life domain the memory belongs to (work, personal, health, family, creative, finance, misc, unspecified)
+- **volatility** — how long the memory is expected to stay true (stable, updatable, ephemeral)
+
+### 3. New MCP tools
+
+Three new tools (on `@totalreclaw/mcp-server@3.0.0` + inherited by NanoClaw + IronClaw):
+
+- `totalreclaw_pin` — lock a memory against auto-supersession.
+- `totalreclaw_retype` — change a memory's type (e.g. "that is actually a directive, not a preference").
+- `totalreclaw_set_scope` — assign a memory to a scope (work, personal, health, ...).
+
+These are invoked via natural language: "pin that", "that was actually a rule, not a preference", "file that under work". The host LLM picks the right tool.
+
+See the [memory types guide](./memory-types-guide.md) for examples.
+
+### 4. Source-weighted reranking (Retrieval v2 Tier 1)
+
+Recalls now respect `source` when ranking. User-authored claims consistently beat assistant-regurgitated restatements, which structurally solves the "97.8% junk" problem reported in other memory systems.
+
+Full detail in [`docs/specs/totalreclaw/tiered-retrieval.md`](../specs/totalreclaw/tiered-retrieval.md).
+
+### 5. Protobuf v4 outer wrapper
+
+The on-chain wire format bumps from v3 to v4 to signal that the encrypted blob now contains v1 JSON (not v0 binary). Subgraph schema is unchanged — no re-indexing required.
+
+Details: [`totalreclaw-internal/docs/plans/2026-04-18-protobuf-v4-design.md`](https://github.com/p-diogo/totalreclaw-internal/) (internal).
+
+### 6. Environment variables removed
+
+Six env vars that were internal/experimental knobs are gone. If you had them set they are now silently ignored:
+
+- `TOTALRECLAW_CHAIN_ID` — chain is auto-detected from billing tier.
+- `TOTALRECLAW_EMBEDDING_MODEL` — Harrier 640d is the default, no alternatives shipped.
+- `TOTALRECLAW_STORE_DEDUP` — always on (best-match near-duplicate detection at core).
+- `TOTALRECLAW_LLM_MODEL` — LLM picked automatically from your provider's default.
+- `TOTALRECLAW_SESSION_ID` — computed internally.
+- `TOTALRECLAW_TAXONOMY_VERSION` — v1 is the only format.
+- `TOTALRECLAW_CLAIM_FORMAT` — same reason.
+- `TOTALRECLAW_DIGEST_MODE` / `TOTALRECLAW_AUTO_RESOLVE_MODE` — internal behaviour no longer user-configurable.
+
+See the [env vars reference](./env-vars-reference.md) for the current short list.
+
+---
+
+## Breaking changes summary
+
+For application developers using the libraries directly (not via a host agent):
+
+- `@totalreclaw/core@2.0.0` — `rerank()` preserved for back-compat; new `rerankWithConfig()` is the v1 entry point (source-weighted).
+- `@totalreclaw/totalreclaw@3.0.0` (plugin) — `buildCanonicalClaim` always emits v1 JSON. No legacy fallback.
+- `@totalreclaw/mcp-server@3.0.0` — tool schemas gain v1 fields; 4 new tools (pin / unpin / retype / set_scope).
+- `totalreclaw@2.0.0` (Python) — `VALID_MEMORY_TYPES` is now the 6-item v1 list; `ExtractedFact` carries `source`, `scope`, `volatility`, `reasoning`.
+- `totalreclaw-memory@2.0.0` (Rust/ZeroClaw) — new `store_v1(V1StoreInput)` method and `Memory::store_v1()` trait method.
+
+If you write code against these APIs, review the per-package CHANGELOG. If you use TotalReclaw via a host agent (OpenClaw, Claude Desktop, Cursor, etc.) — no code change on your side.
+
+---
+
+## Action required
+
+**For users on managed service (default):** nothing. Upgrade your client package, continue using memory.
+
+```bash
+# OpenClaw
+openclaw skills update totalreclaw
+
+# Claude Desktop / Cursor / Windsurf (MCP)
+# The npx invocation pulls the latest automatically
+
+# NanoClaw
+# Your deployment pins @totalreclaw/skill-nanoclaw — bump to ^3.0.0
+
+# Python / Hermes
+pip install -U totalreclaw
+
+# Rust / ZeroClaw
+# Bump `totalreclaw-memory = "2.0.0"` in your Cargo.toml
+```
+
+**For self-hosted users:** no schema migration needed. Your PostgreSQL keeps working — the inner blob format changes inside the ciphertext (server never reads plaintext, so it never noticed).
+
+**Pre-v1 vaults:** reads continue working. Old memories are automatically mapped into v1 types when returned. New writes are v1.
+
+---
+
+## Cross-client guarantee
+
+v1 is designed so the same memory written by any client can be read by any other client with identical semantics. If you store a `directive` from OpenClaw, recall from Claude Desktop + MCP returns the same memory with the same type, source, scope, and reasoning.
+
+This is the first release where cross-client parity is specified and tested — not just inherited from shared crypto.
+
+---
+
+## Getting help
+
+- [Memory types guide](./memory-types-guide.md) — user-facing explanation of types, scopes, and volatility.
+- [Environment variables reference](./env-vars-reference.md) — current env vars after cleanup.
+- [Client setup guide](./client-setup-v1.md) — install instructions per client at v1.
+- [Feature comparison](./feature-comparison.md) — what works on each client.
+- GitHub: <https://github.com/p-diogo/totalreclaw/issues>

--- a/docs/specs/totalreclaw/tiered-retrieval.md
+++ b/docs/specs/totalreclaw/tiered-retrieval.md
@@ -1,0 +1,233 @@
+# Tiered Retrieval — source-aware ranking
+
+**Status:** Tier 1 shipped in `@totalreclaw/core@2.0.0` and every v1 client. Tiers 2-4 designed, not yet implemented.
+**Related specs:** [memory-taxonomy-v1.md](./memory-taxonomy-v1.md), [retrieval-v2.md](./retrieval-v2.md).
+**Audience:** implementers, performance engineers, and anyone tuning recall quality.
+
+---
+
+## Why tiered retrieval
+
+v1 taxonomy introduces three new axes on every memory (`source`, `scope`, `volatility`) plus a closed 6-type enum. The retrieval pipeline in `@totalreclaw/core` has to respect these fields — otherwise the taxonomy work is cosmetic and recall quality does not move.
+
+Four discrete tiers of retrieval improvement were designed. Tier 1 ships with v1 because it is load-bearing for the taxonomy (without it, assistant-regurgitated "facts" score equal to user-authored ones). Tiers 2-4 are optional post-v1 work gated on real-user recall quality data.
+
+---
+
+## Pipeline diagram (v1, Tier 1 active)
+
+```
+                                     CLIENT
+  query text
+      │
+      ├── tokenize → blind trapdoors (HMAC-SHA256 word hashes)
+      ├── compute query embedding (Harrier-OSS 640d, local)
+      ├── compute LSH bucket hashes
+      │
+      ▼
+     HTTP request (blind trapdoors + LSH buckets only — no plaintext)
+      │
+      ▼
+                                   RELAY + SUBGRAPH
+  GraphQL query over indexed blind_indices + bucket tables
+  returns ~30-200 encrypted candidates (ciphertext + metadata)
+      │
+      ▼
+                                     CLIENT
+  decrypt candidates (XChaCha20-Poly1305)
+  parse v1 claim payload (text, type, source, scope, volatility, reasoning)
+      │
+      ├── BM25 over decrypted text (intent-weighted)
+      ├── Cosine similarity over decrypted embeddings
+      ├── RRF fusion (k=60)
+      │
+      ▼
+  ┌─────────────────────────────────┐
+  │  TIER 1: source-weighted rerank │   ← NEW in v1
+  │  final_score *= source_weight   │
+  │   user        = 1.00            │
+  │   user-inf.   = 0.90            │
+  │   derived     = 0.70            │
+  │   external    = 0.70            │
+  │   assistant   = 0.55            │
+  │   legacy/null = 0.85            │
+  └─────────────────────────────────┘
+      │
+      ▼
+  top-k (default 8) returned to host agent
+```
+
+Every step that touches plaintext runs on the client. The relay and subgraph only ever see blind trapdoors, ciphertext, and LSH bucket hashes.
+
+---
+
+## Tier 1 — source-weighted final score (SHIPPED)
+
+**Required for v1 launch.** Without it, the `source` field on every claim is metadata the ranker ignores, and assistant-tagged memories score equal to user-authored ones.
+
+### Scoring formula
+
+After BM25 + cosine + RRF fusion produces a base score per candidate, multiply by source weight:
+
+```
+final_score = rrf_score * source_weight(claim.source)
+```
+
+Source weights (locked in core 2.0.0):
+
+| Source | Weight | Rationale |
+|---|:-:|---|
+| `user` | 1.00 | Anchor — user explicitly said it |
+| `user-inferred` | 0.90 | Extracted from user signals (high confidence) |
+| `derived` | 0.70 | Digests, summaries, consolidation output |
+| `external` | 0.70 | Imported from another system |
+| `assistant` | 0.55 | Assistant-authored, heavy penalty |
+| `legacy` / null | 0.85 | Pre-v1 vault entries (back-compat default) |
+
+### Why these numbers
+
+Calibrated during the v1 development run:
+
+- `user = 1.0` anchors everything else. You never penalize direct user statements.
+- Distances between tiers are small enough that a high-BM25 assistant claim can still beat a low-BM25 user claim if the content match is overwhelming (e.g. a specific Marriott number appearing verbatim in the query). This preserves the "Bangkok test": shared content (receipts, screenshots) extracted by the assistant remains recoverable.
+- `assistant = 0.55` is aggressive enough to break the Mem0 97.8%-junk failure mode documented in [mem0 Issue #4573](https://github.com/mem0ai/mem0/issues/4573), where assistant-regurgitated inferences polluted recall.
+- Never drop to zero — all candidates remain eligible for top-k.
+- `0.85 legacy fallback` lets mixed v0/v1 vaults rerank cleanly during migration without silently biasing against pre-v1 data.
+
+### Source code
+
+- Rust core: `rust/totalreclaw-core/src/reranker.rs` — `rerank_with_config`, `source_weight`.
+- WASM binding: `@totalreclaw/core` exports `rerankWithConfig`, `sourceWeight`, `legacyClaimFallbackWeight`.
+- PyO3 binding: `totalreclaw-core` Python package exposes identical functions.
+
+All 5 clients (OpenClaw plugin, MCP, NanoClaw, Hermes, ZeroClaw) reach Tier 1 via the shared core. No client implements reranking locally.
+
+### Test coverage
+
+- 42 tests on the Tier 1 path in core.
+- Cross-language parity: TS plugin + Python + Rust all produce identical top-8 given identical input.
+- Scenario tests include the "Bangkok test" (assistant-extracted specific-entity claim wins on high content match) and the "tea vs coffee" test (user-authored claim beats equal-base-score assistant claim).
+
+---
+
+## Tier 2 — scope pre-filter (DESIGNED, NOT SHIPPED)
+
+**Post-v1.** Ship only if recall data shows scope-unaware ranking missing obvious targets.
+
+When the query carries a scope hint ("at work...", "for my health..."), pre-filter candidates to matching scope OR `unspecified`. Keep `unspecified` as escape hatch so legacy data without a scope does not disappear.
+
+```rust
+pub struct QueryIntent {
+    pub scope_hints: Vec<MemoryScope>,
+    pub type_hints: Vec<MemoryType>,
+    pub temporal_hint: Option<TemporalHint>,
+}
+```
+
+Intent extraction is keyword-based at first. Can be upgraded to an LLM call later (at ~1 extra API call per query).
+
+**Risk:** imperfect intent extraction could exclude valid candidates. Mitigation: only pre-filter when confidence is high (multiple keyword matches).
+
+**Effort:** ~1 day.
+
+---
+
+## Tier 3 — volatility-aware decay (DESIGNED, NOT SHIPPED)
+
+**Post-v1.** Ship when user feedback indicates stale facts surfacing in recall ("agent keeps reminding me of the trip I took 2 years ago").
+
+Today's `decay_score` on-chain applies uniformly to every claim. v1 adds `volatility` — some memories should never decay (your name, allergies), others should decay fast (today's task list).
+
+Proposed:
+
+```rust
+fn effective_recency(claim: &Claim, now: u64) -> f64 {
+    let age_days = (now - claim.created_at) / 86400;
+    match claim.volatility {
+        Volatility::Stable => 1.0,                                // no decay
+        Volatility::Updatable => 0.95_f64.powf(age_days as f64 / 30.0),  // ~5% per month
+        Volatility::Ephemeral => {
+            if let Some(expires) = claim.expires_at {
+                if now > expires { 0.0 }
+                else { (expires - now) as f64 / (expires - claim.created_at) as f64 }
+            } else {
+                0.9_f64.powf(age_days as f64 / 7.0)               // fast decay
+            }
+        },
+    }
+}
+```
+
+Multiply `final_score` by `effective_recency`.
+
+Interaction with on-chain decay: the on-chain `decay_score` stays (used for storage-level eviction on free tier). Tier 3 is a retrieval-time recency multiplier for ranking only.
+
+**Effort:** ~0.5 day.
+
+---
+
+## Tier 4 — type boost via query intent (DESIGNED, NOT SHIPPED)
+
+**Post-v1.** Lowest priority — add only if retrieval benchmark shows type-mismatch as a significant error class.
+
+When the query signals a desired type ("what rule...", "what do I prefer..."), multiply score by 1.2 for matching-type candidates. Soft boost, not a filter.
+
+Heuristic mapping:
+
+- "what rule" / "best practice" / "gotcha" → `directive`
+- "what do I prefer" / "my taste" → `preference`
+- "what did I decide" / "why did I choose" → `claim` with `reasoning` present
+- "when did I" / "last time" → `episode`
+- "what am I working on" → `claim` with `volatility: ephemeral`
+- "what will I do" / "plan" → `commitment`
+
+**Effort:** ~0.5 day.
+
+---
+
+## Why tiered (not "ship everything")
+
+Each tier adds complexity; each tier has a calibration cost (wrong weights make recall worse, not better). Shipping in tiers lets us:
+
+1. Lock in the biggest win (Tier 1, source-weighted) with v1.
+2. Measure real recall quality for a period of weeks.
+3. Add Tier 2-4 only when data shows they would help.
+
+Per the internal roadmap: after 2-4 weeks of production use, revisit Tier 2-4 based on (a) opt-in telemetry of recall quality and (b) specific user feedback. Until then, Tier 1 is the full retrieval change for v1.
+
+---
+
+## Cross-client consistency requirement
+
+All 5 clients share `@totalreclaw/core` — change once, ships everywhere. The taxonomy v1 spec §cross-client-guarantees requires that identical queries against identical vaults return identical top-k ordering regardless of which client is doing the reranking.
+
+Invariants that must hold:
+
+- Source weights: constant across all clients (locked in core).
+- Scope filter (Tier 2, future): deterministic extraction rules.
+- Volatility decay (Tier 3, future): time-dependent but deterministic given same `now`.
+- Type boost (Tier 4, future): constant keyword → type mapping.
+
+No randomness. No per-client config that diverges.
+
+---
+
+## Observable impact
+
+Phase 2 benchmark data (placeholder — will fill in once 500-conv benchmark run completes on 2026-04-18):
+
+- **Baseline (pre-v1):** TBD — clustering ratio, recall@8, precision@1 on Gemini + WildChat corpora.
+- **v1 + Tier 1:** TBD — same metrics with source-weighted reranker.
+- **v1 Bangkok test:** TBD — user-authored vs assistant-extracted specific-entity claims.
+
+Once the number lands, this section will include the concrete delta. Until then, the qualitative claim is: Tier 1 structurally prevents the Mem0 97.8%-junk failure mode without dropping useful assistant-extracted content (like shared receipts or screenshots).
+
+---
+
+## References
+
+- Full retrieval design: [retrieval-v2.md](./retrieval-v2.md)
+- Taxonomy depending on this: [memory-taxonomy-v1.md](./memory-taxonomy-v1.md)
+- Reranker implementation: `rust/totalreclaw-core/src/reranker.rs`
+- Mem0 audit motivating Tier 1: <https://github.com/mem0ai/mem0/issues/4573>
+- Core 2.0.0 CHANGELOG: `rust/totalreclaw-core/CHANGELOG.md`

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -24,6 +24,8 @@
 
 End-to-end encrypted memory vault as an MCP server. Your memories are encrypted on your device before leaving -- no one can read them, not even us.
 
+**v3.0.0 ships Memory Taxonomy v1** — 6 speech-act types + source / scope / volatility axes on every memory. Four new tools (`totalreclaw_pin`, `totalreclaw_unpin`, `totalreclaw_retype`, `totalreclaw_set_scope`) let agents override categorization via natural language. Source-weighted reranking ranks user-authored claims above assistant-regurgitated noise. See [memory types guide](../docs/guides/memory-types-guide.md).
+
 **Requirements:** Node.js 18+
 
 ## Quick Start
@@ -117,6 +119,8 @@ The server only ever sees ciphertext and hashed tokens.
 
 ## Available Tools
 
+All 19 tools are invoked by the host agent from natural language context. Tool schemas include v1 taxonomy fields (`type`, `source`, `scope`, `reasoning`).
+
 | Tool | Description |
 |------|-------------|
 | `totalreclaw_remember` | Store a fact in encrypted memory. Supports v1 taxonomy (`type`, `scope`, `reasoning`) + legacy types for migration |
@@ -130,6 +134,7 @@ The server only ever sees ciphertext and hashed tokens.
 | `totalreclaw_status` | Check billing status and quota usage |
 | `totalreclaw_import` | Re-import previously exported memories |
 | `totalreclaw_import_from` | Import from Mem0, MCP Memory Server, ChatGPT, Claude, or generic JSON/CSV |
+| `totalreclaw_import_batch` | Batch import with background polling |
 | `totalreclaw_consolidate` | Merge duplicate and related memories |
 | `totalreclaw_debrief` | End-of-conversation summary to capture broader context |
 | `totalreclaw_upgrade` | Get a link to upgrade to Pro |
@@ -137,6 +142,8 @@ The server only ever sees ciphertext and hashed tokens.
 | `totalreclaw_account` | View account details (wallet, tier, quota, phrase hint) |
 | `totalreclaw_support` | Troubleshooting help + contact links |
 | `totalreclaw_setup` | Generate or import a recovery phrase (first-run flow) |
+
+Users invoke the new v1 tools naturally: *"pin that"*, *"that was actually a rule, not a preference"*, *"file that under work"*. Tool descriptions teach the host LLM to match utterances to tools.
 
 ### Memory Taxonomy v1 (`@totalreclaw/core 2.0`)
 
@@ -187,10 +194,14 @@ npm run lint     # Lint
 
 ## Learn More
 
-- [Getting Started Guide](../docs/guides/beta-tester-guide.md)
-- [IronClaw Setup Guide](../docs/guides/ironclaw-setup.md) -- full walkthrough for IronClaw (NEAR AI) agents
+- [Client setup guide (v1)](../docs/guides/client-setup-v1.md) — one install command per client
+- [Memory types guide](../docs/guides/memory-types-guide.md) — what gets stored and natural-language overrides
+- [v1 migration guide](../docs/guides/v1-migration.md) — upgrading from v0
+- [Environment variables](../docs/guides/env-vars-reference.md) — the 5 env vars that matter
+- [Feature comparison](../docs/guides/feature-comparison.md) — what works on each client
+- [IronClaw setup guide](../docs/guides/ironclaw-setup.md) — full walkthrough for IronClaw (NEAR AI) agents
 - [totalreclaw.xyz](https://totalreclaw.xyz)
-- [Main Repository](https://github.com/p-diogo/totalreclaw)
+- [Main repository](https://github.com/p-diogo/totalreclaw)
 
 ## License
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,21 +1,22 @@
 # totalreclaw
 
-End-to-end encrypted memory for AI agents -- the "password manager for AI memory."
+End-to-end encrypted memory + knowledge graph for AI agents.
 
 Store, search, and recall memories across any AI agent with zero-knowledge encryption. Your data is encrypted on-device before it leaves -- the server never sees plaintext.
 
-As of **2.0.0**, the client uses **Memory Taxonomy v1** (6 canonical types: `claim | preference | directive | commitment | episode | summary`) and **Retrieval v2 Tier 1** source-weighted reranking (user-sourced facts rank higher than assistant-sourced facts on tied BM25 + cosine scores). See the [TS plugin 3.0.0 migration notes](https://github.com/p-diogo/totalreclaw/blob/main/skill/plugin/CHANGELOG.md) — the Python client follows the same pattern. Existing pre-v1 vault entries decrypt transparently.
+As of **2.0.0**, the client uses **Memory Taxonomy v1** (6 canonical types: `claim | preference | directive | commitment | episode | summary`) and **Retrieval v2 Tier 1** source-weighted reranking (user-sourced facts rank higher than assistant-sourced facts on tied BM25 + cosine scores). See the [memory types guide](https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/memory-types-guide.md) and [TS plugin 3.0.0 migration notes](https://github.com/p-diogo/totalreclaw/blob/main/skill/plugin/CHANGELOG.md) — the Python client follows the same pattern. Existing pre-v1 vault entries decrypt transparently.
 
 ## Features
 
 - **End-to-end encrypted** -- XChaCha20-Poly1305 encryption, HKDF key derivation from BIP-39 mnemonic
-- **Portable** -- Same recovery phrase works across Hermes, OpenClaw, Claude Desktop, IronClaw
-- **Memory Taxonomy v1** -- 6-type schema with required provenance (`user | user-inferred | assistant | external | derived`) and 8 life-domain scopes
-- **Tier 1 source-weighted reranking** -- user-sourced facts rank higher than assistant-sourced facts on tied scores
+- **Portable** -- Same recovery phrase works across Hermes, OpenClaw, Claude Desktop, IronClaw, ZeroClaw
+- **Memory Taxonomy v1** -- 6 speech-act types + required provenance (`user | user-inferred | assistant | external | derived`) and 8 life-domain scopes. v1 is the only write path (no env-var gating).
+- **Retrieval v2 Tier 1** -- source-weighted reranking via `totalreclaw-core@2.0.0` PyO3 bindings (user-sourced facts rank higher on tied scores)
+- **G-pipeline extraction** -- merged-topic prompt, provenance filter (lax), comparative rescoring, volatility heuristic
 - **Local embeddings** -- Harrier-OSS-v1-270M runs on-device (no API calls)
 - **Hybrid search** -- BM25 + cosine similarity + RRF reranking
 - **LSH bucketing** -- Locality-sensitive hashing for encrypted search
-- **On-chain storage** -- Managed service stores on Gnosis/Base Sepolia via ERC-4337
+- **On-chain storage** -- Managed service stores on Gnosis/Base Sepolia via ERC-4337; outer protobuf v4
 
 ## Quick Start
 
@@ -44,6 +45,8 @@ async def main():
 
     # Store a memory — v1 taxonomy defaults: type="claim", source="user", scope="unspecified".
     # Importance is 1-10 (int) or 0-1 (float, auto-normalized).
+    # v1 types: claim | preference | directive | commitment | episode | summary
+    # scope, volatility, reasoning also accepted.
     fact_id = await client.remember(
         "Pedro prefers dark mode for all editors",
         fact_type="preference",
@@ -129,6 +132,15 @@ This Python client produces byte-for-byte identical outputs to the TypeScript im
 - LSH bucket hashes (32-bit x 20 tables)
 
 Memories stored by the Python client can be recalled by the MCP server, and vice versa.
+
+## Learn More
+
+- [Client setup guide (v1)](https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/client-setup-v1.md)
+- [Memory types guide](https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/memory-types-guide.md)
+- [v1 migration guide](https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/v1-migration.md)
+- [Environment variables](https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/env-vars-reference.md)
+- [Hermes setup guide](https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md)
+- [Feature comparison](https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/feature-comparison.md)
 
 ## License
 

--- a/rust/totalreclaw-memory/README.md
+++ b/rust/totalreclaw-memory/README.md
@@ -1,0 +1,81 @@
+# totalreclaw-memory
+
+End-to-end encrypted memory backend for Rust. Native `Memory` trait implementation that powers [ZeroClaw](https://near.ai/zeroclaw) and any other Rust agent or app that wants the TotalReclaw memory model.
+
+**v2.0.0 ships Memory Taxonomy v1** — every memory is typed (`claim` / `preference` / `directive` / `commitment` / `episode` / `summary`) and tagged with `source`, `scope`, and `volatility`. Retrieval uses source-weighted reranking via the shared `totalreclaw-core` crate. See the [memory types guide](../../docs/guides/memory-types-guide.md).
+
+## Features
+
+- **Memory trait** — implements the canonical async `store` / `recall` / `forget` / `export` / `status` / `debrief` contract.
+- **Memory Taxonomy v1** — new `store_v1()` method + `V1StoreInput` struct with type / source / scope / volatility / reasoning.
+- **Native ERC-4337** — UserOp construction via `alloy-primitives` / `alloy-sol-types`, verified byte-for-byte against viem.
+- **Batching** — up to 15 facts per UserOp via `executeBatch()`.
+- **Cosine + fingerprint dedup** — near-duplicate prevention at store time (via shared core).
+- **Contradiction detection + pin semantics** — via shared core.
+- **Hot cache** — 30-entry local query cache with cosine similarity matching.
+- **Billing cache** — 2-hour TTL with quota warnings (>80%) and 403 invalidation.
+- **Chain ID auto-detect** — free tier on Base Sepolia, Pro on Gnosis. No env var.
+- **Protobuf v4 outer wrapper** — inner blob is v1 JSON.
+
+## Quick Start
+
+```toml
+[dependencies]
+totalreclaw-memory = "2.0"
+```
+
+```rust
+use totalreclaw_memory::{Memory, TotalReclawMemory, V1StoreInput};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let memory = TotalReclawMemory::new(
+        "your twelve word recovery phrase here",
+    ).await?;
+
+    // Store a memory with v1 taxonomy
+    memory.store_v1(V1StoreInput {
+        text: "Pedro prefers dark mode for all editors".into(),
+        type_: "preference".into(),
+        source: "user".into(),
+        scope: Some("personal".into()),
+        volatility: Some("stable".into()),
+        importance: 0.8,
+        reasoning: None,
+    }).await?;
+
+    // Recall — source-weighted reranking applied automatically
+    let results = memory.recall("What does Pedro prefer?", 8).await?;
+    for r in results {
+        println!("[{:.3}] {}", r.score, r.text);
+    }
+
+    Ok(())
+}
+```
+
+## Cross-client parity
+
+All encryption, fingerprinting, LSH, reranking, and v1 taxonomy validation is handled by the shared [`totalreclaw-core`](../totalreclaw-core) crate — the same Rust core compiled to WASM for the TypeScript clients and PyO3 for the Python client. Memories written by this crate are byte-equivalent to memories written by `@totalreclaw/client`, `totalreclaw` (Python), or `@totalreclaw/mcp-server`.
+
+## Environment Variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `TOTALRECLAW_RECOVERY_PHRASE` | 12-word recovery phrase | Required |
+| `TOTALRECLAW_SERVER_URL` | Relay URL | `https://api.totalreclaw.xyz` |
+| `TOTALRECLAW_SELF_HOSTED` | Use self-hosted server | `false` |
+
+See the [env vars reference](../../docs/guides/env-vars-reference.md) for the canonical list (5 user-facing vars after the v1 cleanup).
+
+## Learn More
+
+- [ZeroClaw setup guide](../../docs/guides/zeroclaw-setup.md)
+- [Client setup guide (v1)](../../docs/guides/client-setup-v1.md)
+- [Memory types guide](../../docs/guides/memory-types-guide.md)
+- [Feature comparison](../../docs/guides/feature-comparison.md)
+- [Architecture](../../docs/architecture.md)
+
+## License
+
+MIT

--- a/skill-nanoclaw/README.md
+++ b/skill-nanoclaw/README.md
@@ -21,9 +21,11 @@
 
 ---
 
-Automatic encrypted memory for NanoClaw agents, powered by the `@totalreclaw/mcp-server`. Memories are encrypted inside the container before leaving -- no server, service, or third party can read them.
+Automatic encrypted memory + knowledge graph for NanoClaw agents, powered by the `@totalreclaw/mcp-server`. Memories are encrypted inside the container before leaving -- no server, service, or third party can read them.
 
 Once configured, your NanoClaw agent automatically extracts facts from conversations, recalls relevant memories at the start of each session, and preserves context before compaction. No manual action needed from end users.
+
+**v3.0.0 ships Memory Taxonomy v1** — every memory is typed (`claim` / `preference` / `directive` / `commitment` / `episode` / `summary`) and tagged with source, scope, and volatility. Inherits the four new MCP tools (`totalreclaw_pin`, `totalreclaw_unpin`, `totalreclaw_retype`, `totalreclaw_set_scope`) from the underlying MCP server. See the [memory types guide](../docs/guides/memory-types-guide.md).
 
 ## Quick Start
 
@@ -116,20 +118,24 @@ This provides memory isolation between different NanoClaw groups. Memories store
 | `TOTALRECLAW_SELF_HOSTED` | Set to `true` for self-hosted mode | `false` |
 | `TOTALRECLAW_NAMESPACE` | Default namespace | Group folder name |
 | `TOTALRECLAW_AUTO_EXTRACT` | Enable automatic fact extraction | `true` |
-| `TOTALRECLAW_EXTRACT_INTERVAL` | Turns between extractions | `3` |
-| `TOTALRECLAW_CHAIN_ID` | Chain ID (100=Gnosis mainnet, 84532=Base Sepolia staging) | `100` |
+
+> **v3.0.0 env cleanup:** `TOTALRECLAW_CHAIN_ID` and `TOTALRECLAW_EXTRACT_INTERVAL` were removed. Chain is auto-detected from billing tier; extraction interval is server-tuned via the relay billing response. See the [env vars reference](../docs/guides/env-vars-reference.md).
 
 ## Available Tools
 
-The MCP server provides these tools to the NanoClaw agent:
+The MCP server provides 19 tools to the NanoClaw agent (v3.0.0 adds v1 taxonomy tools):
 
 | Tool | Description |
 |------|-------------|
-| `totalreclaw_remember` | Store a fact in encrypted memory |
-| `totalreclaw_recall` | Search memories by natural language query |
-| `totalreclaw_forget` | Delete a specific memory by ID |
+| `totalreclaw_remember` | Store a memory with v1 taxonomy (type, source, scope, reasoning) |
+| `totalreclaw_recall` | Search memories; results reranked by source weight (v1 Tier 1) |
+| `totalreclaw_forget` | Delete a specific memory by ID or query |
 | `totalreclaw_export` | Export all memories decrypted as Markdown or JSON |
 | `totalreclaw_status` | Check billing status and quota usage |
+| `totalreclaw_pin` | **New in v1** — lock a memory against auto-supersession |
+| `totalreclaw_unpin` | **New in v1** — remove pin lock |
+| `totalreclaw_retype` | **New in v1** — change memory type |
+| `totalreclaw_set_scope` | **New in v1** — assign memory to a scope |
 | `totalreclaw_import` | Re-import previously exported memories |
 | `totalreclaw_import_from` | Import from Mem0 or MCP Memory Server |
 | `totalreclaw_upgrade` | Get a link to upgrade to Pro |

--- a/skill/plugin/README.md
+++ b/skill/plugin/README.md
@@ -1,10 +1,12 @@
 # TotalReclaw Skill for OpenClaw
 
-> **End-to-end encrypted memory for AI agents -- portable, yours forever.**
+> **End-to-end encrypted memory + knowledge graph for AI agents -- portable, yours forever.**
 >
 > Your AI remembers everything. Your server sees nothing.
 
-TotalReclaw gives any [OpenClaw](https://github.com/openclaw/openclaw) agent persistent, encrypted long-term memory. Preferences, decisions, and context carry across every conversation -- fully end-to-end encrypted so the server **never** sees plaintext.
+TotalReclaw gives any [OpenClaw](https://github.com/openclaw/openclaw) agent persistent, encrypted long-term memory. Preferences, decisions, commitments, rules, and context carry across every conversation -- fully end-to-end encrypted so the server **never** sees plaintext.
+
+**v3.0.0 ships Memory Taxonomy v1**: every memory is typed (`claim` / `preference` / `directive` / `commitment` / `episode` / `summary`) and tagged with source, scope, and volatility. Recall uses source-weighted reranking so user-authored claims consistently rank above assistant-regurgitated noise. See [`docs/guides/memory-types-guide.md`](../../docs/guides/memory-types-guide.md).
 
 ## Installation
 
@@ -20,14 +22,13 @@ Or via terminal:
 openclaw skills install totalreclaw
 ```
 
-Then set your environment variables:
+Then set one environment variable:
 
 ```bash
-export TOTALRECLAW_SERVER_URL="http://your-totalreclaw-server:8080"
 export TOTALRECLAW_RECOVERY_PHRASE="your twelve word recovery phrase here"
 ```
 
-That's it. TotalReclaw hooks into your agent automatically.
+That's it. TotalReclaw hooks into your agent automatically. The server URL defaults to `https://api.totalreclaw.xyz` (managed service) -- only set `TOTALRECLAW_SERVER_URL` if you are self-hosting. See the [env vars reference](../../docs/guides/env-vars-reference.md) for the full (short) list.
 
 ### Alternative: npm
 
@@ -62,9 +63,12 @@ Most AI memory solutions force a tradeoff: **good recall OR privacy**. TotalRecl
 ## Features
 
 - **End-to-End Encryption**: XChaCha20-Poly1305 ensures the server never sees plaintext memories
-- **Intelligent Extraction**: Automatically extracts facts, preferences, and decisions from conversations
+- **Memory Taxonomy v1**: 6 speech-act types + source / scope / volatility axes on every memory. [Learn more](../../docs/guides/memory-types-guide.md)
+- **Intelligent Extraction**: G-pipeline — single merged-topic LLM call, provenance filter, comparative rescoring, volatility heuristic. v1 is the only write path.
 - **Semantic Search**: LSH blind indices with client-side BM25 + cosine + RRF fusion reranking
-- **Lifecycle Hooks**: Seamlessly integrates with OpenClaw's agent lifecycle
+- **Retrieval v2 Tier 1**: Source-weighted reranking — user=1.0, user-inferred=0.9, derived/external=0.7, assistant=0.55
+- **Lifecycle Hooks**: Seamlessly integrates with OpenClaw's agent lifecycle (before_agent_start, agent_end, pre_compaction, before_reset)
+- **Natural-language overrides**: "pin that", "that was actually a rule, not a preference", "file that under work" — agent calls the right tool automatically
 - **Portable Export**: One-click plaintext export -- no vendor lock-in
 - **Decay Management**: Automatic memory decay with configurable thresholds
 
@@ -92,20 +96,19 @@ openclaw plugins install @totalreclaw/totalreclaw
 
 ### 2. Configure
 
-Set the required environment variables:
+Set one environment variable:
 
 ```bash
-# Required
-export TOTALRECLAW_SERVER_URL="http://your-totalreclaw-server:8080"
 export TOTALRECLAW_RECOVERY_PHRASE="your twelve word recovery phrase here"
+```
 
-# Optional
-export TOTALRECLAW_AUTO_EXTRACT_EVERY_TURNS=3
-export TOTALRECLAW_MIN_IMPORTANCE=6
-export TOTALRECLAW_MAX_MEMORIES=8
-export TOTALRECLAW_FORGET_THRESHOLD=0.3
-export TOTALRECLAW_RERANKER_MODEL="BAAI/bge-reranker-base"
-export TOTALRECLAW_USER_ID="user-123"
+**That's it.** v1 is the default extraction and write path. Extraction cadence, importance floor, candidate pool size, and dedup thresholds are all server-tuned via the relay's billing response -- no client env vars to set. See [env vars reference](../../docs/guides/env-vars-reference.md).
+
+For self-hosted deployments:
+
+```bash
+export TOTALRECLAW_SERVER_URL="http://your-totalreclaw-server:8080"
+export TOTALRECLAW_SELF_HOSTED=true
 ```
 
 ### 3. Use
@@ -130,17 +133,19 @@ You can also use the tools directly in conversation:
 
 ## Tools
 
-TotalReclaw provides four tools:
+The plugin exposes these tools to your OpenClaw agent. Most invocations happen via natural language -- the agent picks the right tool from context.
 
 ### totalreclaw_remember
 
-Explicitly store a memory.
+Explicitly store a memory. Accepts v1 taxonomy fields.
 
 ```typescript
 const result = await skill.remember({
   text: 'User prefers dark mode',
-  type: 'preference',  // optional: fact, preference, decision, episodic, goal
-  importance: 7,       // optional: 1-10, default is minImportanceForAutoStore
+  type: 'preference',  // v1 types: claim, preference, directive, commitment, episode, summary
+  source: 'user',      // v1 sources: user, user-inferred, assistant, external, derived
+  scope: 'personal',   // v1 scopes: work, personal, health, family, creative, finance, misc, unspecified
+  importance: 7,       // 1-10 (see importance rubric)
 });
 
 console.log(result); // "Memory stored successfully with ID: fact-123"


### PR DESCRIPTION
Added:
- docs/guides/v1-migration.md
- docs/guides/memory-types-guide.md
- docs/guides/env-vars-reference.md
- docs/guides/client-setup-v1.md
- docs/guides/blog-draft-v1-launch.md
- docs/specs/totalreclaw/tiered-retrieval.md

Updated: top-level README, CLAUDE.md, architecture.md,
feature-comparison.md, all 5 client READMEs.