### PR TITLE
fix: flip file: deps to @totalreclaw/core@^2.0.0 (v1 publish unblocker)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,18 +36,32 @@ jobs:
         with:
           node-version: '20'
 
-      # Plugin has no test script yet — just verify deps install cleanly
+      # Plugin has no test script yet — just verify deps install cleanly.
+      # We delete the lockfile because it was last regenerated against a local
+      # `file:` dep for `@totalreclaw/core`; the current `package.json` uses
+      # `^2.0.0` from npm and a fresh install resolves against the registry.
+      # Once the lockfile is regenerated after `@totalreclaw/core@2.x` is
+      # published, this can switch back to `npm ci`.
       - name: Install dependencies
-        run: cd skill/plugin && npm ci --legacy-peer-deps
+        run: cd skill/plugin && rm -f package-lock.json && npm install --legacy-peer-deps
 
   mcp-tests:
     name: MCP Server Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # NOTE: The `mcp` package now depends on `@totalreclaw/core@^2.0.0` from
+      # npm (previously a `file:` dep against the local wasm-pack output). The
+      # local WASM build below is now dead code — `npm install` resolves core
+      # from the registry, never from the local `pkg/` directory. It is kept
+      # transitionally so this job continues to green out on branches that
+      # still carry the old `file:` dep. Once `@totalreclaw/core@2.x` is live
+      # on npm AND no branch references the `file:` dep, the
+      # `dtolnay/rust-toolchain`, `wasm-pack-action`, and
+      # `Build @totalreclaw/core (WASM)` steps can be removed in a cleanup PR.
       - uses: dtolnay/rust-toolchain@stable
       - uses: jetli/wasm-pack-action@v0.4.0
-      - name: Build @totalreclaw/core (WASM)
+      - name: Build @totalreclaw/core (WASM) [transitional — safe to drop once core@2.x is on npm]
         run: |
           cd rust/totalreclaw-core
           wasm-pack build --target nodejs --out-dir pkg --features wasm

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -125,11 +125,17 @@ jobs:
 
       - uses: jetli/wasm-pack-action@v0.4.0
 
-      - name: "Build @totalreclaw/core (WASM) for file: dep"
+      # NOTE: `mcp/package.json` used to depend on `@totalreclaw/core` via a
+      # `file:` dep, which required building the WASM pkg locally. It now
+      # depends on `@totalreclaw/core@^2.0.0` from npm, which the
+      # `publish-core` job above already published. This step is therefore
+      # dead code and can be removed in a cleanup PR once no branch carries
+      # the old `file:` dep.
+      - name: "Build @totalreclaw/core (WASM) [transitional — safe to drop]"
         run: |
           cd rust/totalreclaw-core
           wasm-pack build --target nodejs --out-dir pkg --features wasm
-          # wasm-pack emits package name "totalreclaw-core"; mcp consumes it as "@totalreclaw/core" via file: dep
+          # wasm-pack emits package name "totalreclaw-core"; historically mcp consumed it as "@totalreclaw/core" via file: dep
           node -e "const p=require('./pkg/package.json'); p.name='@totalreclaw/core'; require('fs').writeFileSync('./pkg/package.json', JSON.stringify(p,null,2)+'\n')"
 
       - uses: actions/setup-node@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,42 @@ cd skill/plugin && npm install
 pip install -r requirements.txt -r server/requirements.txt
 ```
 
+### Developing against a local `@totalreclaw/core`
+
+All TypeScript client packages (`skill/plugin`, `mcp`, `skill-nanoclaw`) depend on the published `@totalreclaw/core` from npm (currently `^2.0.0`). For day-to-day contribution work this is what you want — `npm install` will pull the released build.
+
+If you are changing Rust code in `rust/totalreclaw-core/` and need to test the resulting WASM bindings in a TypeScript client **before** publishing to npm, use [`npm link`](https://docs.npmjs.com/cli/v10/commands/npm-link) to override the published dep with your local wasm-pack output:
+
+```bash
+# 1. Build the WASM package locally
+cd rust/totalreclaw-core
+./build-wasm.sh
+
+# 2. Register it as a linkable package
+cd pkg
+npm link
+
+# 3. In each consuming package, override the npm dep with your local link
+cd ../../../skill/plugin   # or `mcp/`, or `skill-nanoclaw/`
+npm link @totalreclaw/core
+
+# 4. When you're done, restore the published version
+npm unlink @totalreclaw/core --no-save
+npm install
+```
+
+Never commit a `file:` reference to `rust/totalreclaw-core/pkg` in `package.json` or `package-lock.json` — the `pkg/` directory is a build artifact (not checked in), and a `file:` dep inside a published tarball dangles on end-user machines. Prefer the `npm link` workflow above for any local override.
+
+Python contributors can use the equivalent editable install when hacking on PyO3 bindings:
+
+```bash
+# From the repo root
+cd rust/totalreclaw-core
+maturin develop --features python-extension --release
+```
+
+This builds the PyO3 extension and installs it into the active virtualenv, shadowing the `totalreclaw-core` package that `pip install totalreclaw` would pull from PyPI.
+
 ## Development
 
 ### Project Structure

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -39,7 +39,7 @@
     "@noble/hashes": "^2.0.1",
     "@scure/bip39": "^2.0.1",
     "@totalreclaw/client": "^1.2.0",
-    "@totalreclaw/core": "file:../rust/totalreclaw-core/pkg",
+    "@totalreclaw/core": "^2.0.0",
     "permissionless": "^0.3.4",
     "porter-stemmer": "^0.9.1",
     "tslib": "^2.8.1",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -12,7 +12,9 @@ requires-python = ">=3.11"
 authors = [{ name = "TotalReclaw Team" }]
 dependencies = [
     # Memory Taxonomy v1 + Retrieval v2 Tier 1 reranker live in core 2.0.
-    "totalreclaw-core>=2.0.0",
+    # Pin to 2.x to match the TypeScript clients' `^2.0.0` semantics — a future
+    # core@3 will be a breaking change and must bump this constraint in lockstep.
+    "totalreclaw-core>=2.0.0,<3.0.0",
     "httpx>=0.27",
     "onnxruntime>=1.24",
     "numpy>=1.26",

--- a/skill-nanoclaw/package.json
+++ b/skill-nanoclaw/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "@totalreclaw/client": "^1.2.0",
-    "@totalreclaw/core": "file:../rust/totalreclaw-core/pkg"
+    "@totalreclaw/core": "^2.0.0"
   },
   "peerDependencies": {
     "@totalreclaw/mcp-server": "^3.0.0"

--- a/skill/package.json
+++ b/skill/package.json
@@ -23,7 +23,7 @@
   "author": "TotalReclaw Team",
   "license": "MIT",
   "dependencies": {
-    "@totalreclaw/client": "file:../client",
+    "@totalreclaw/client": "^1.2.0",
     "onnxruntime-node": "^1.24.0",
     "uuid": "^9.0.0"
   },

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "@totalreclaw/client": "^1.2.0",
-    "@totalreclaw/core": "file:../../rust/totalreclaw-core/pkg",
+    "@totalreclaw/core": "^2.0.0",
     "@huggingface/transformers": "^4.0.1",
     "onnxruntime-node": "^1.24.0"
   },


### PR DESCRIPTION
## Summary

Unblocks downstream v1 publishes by flipping all `file:` deps to published npm version ranges (`@totalreclaw/core@^2.0.0`).

**Resolves VPS QA Blocker B1** (`skill/plugin/package.json` had `file:../../rust/totalreclaw-core/pkg` which dangling-symlinks on user machines) and **subsumes B2** (OpenClaw security scanner flagged the `file:` dep itself as supply-chain risk).

## Changes

- `skill/plugin/package.json`: `@totalreclaw/core` → `^2.0.0`
- `mcp/package.json`: same
- `skill-nanoclaw/package.json`: same
- `python/pyproject.toml`: `totalreclaw-core >= 2.0.0, < 3.0.0`
- `skill/package.json`: legacy wrapper flip (cosmetic)
- `CONTRIBUTING.md`: local-dev `npm link` override docs
- CI workflows: transitional notes for post-publish cleanup

## Publish ordering

CI will FAIL on this branch until `@totalreclaw/core@2.0.0` is live on npm. **Status: live as of this PR creation.**

## Test plan

- [x] `@totalreclaw/core@2.0.0` published to npm (verified via `npm view @totalreclaw/core versions`)
- [ ] CI green on this branch after merge
- [ ] Downstream clients publish in order (plugin → mcp → nanoclaw → python)
- [ ] Re-run VPS QA with published artifacts

Agent-authored per v1 launch merge train autonomous execution.

🤖 Generated with Claude Code