### PR TITLE
fix(mcp): resolve ERESOLVE conflict permissionless/ox

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -45,6 +45,11 @@
     "tslib": "^2.8.1",
     "viem": "^2.47.0"
   },
+  "overrides": {
+    "permissionless": {
+      "ox": "^0.14.17"
+    }
+  },
   "devDependencies": {
     "@types/jest": "^29.5.0",
     "@types/node": "^20.11.0",

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. Automatic extraction, semantic search, and on-chain storage",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary

Fixes VPS QA Blocker B4: fresh `npm install` in `mcp/` fails with ERESOLVE.

**Root cause:** `permissionless@0.3.5` peer-deps `ox@^0.11.3`; `viem^2.47` pulls `ox@0.14.17`. Mismatch.

**Fix:** add `overrides.permissionless.ox: ^0.14.17` to `mcp/package.json`. Safe because ox is optional peer, only used in permissionless WebAuthn path that MCP doesn't touch (grep verified zero `ox`/WebAuthn imports in MCP src).

## Test results

- `rm -rf node_modules package-lock.json && npm install` → 593 packages, exit 0
- `npm install --strict-peer-deps` → exit 0
- `npm ci` → exit 0
- `npm run build` → tsc clean
- `npm test` → 22 suites, 524 tests pass

## Side-note (not in this PR)

`client/` has same condition. If `@totalreclaw/client@1.3+` republishes, mirror this override.

🤖 Agent-authored per autonomous v1 rollout