### PR TITLE
ci: add crates.io publish workflow for totalreclaw-core + totalreclaw-memory

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,162 @@
+name: Publish to crates.io
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      crate:
+        description: 'Crate to publish'
+        required: true
+        type: choice
+        options:
+          - totalreclaw-core
+          - totalreclaw-memory
+          - all
+        default: all
+      dry-run:
+        description: 'Dry run (package only, no publish)'
+        required: false
+        type: boolean
+        default: false
+
+# Publish order matters: totalreclaw-memory depends on totalreclaw-core, so core must
+# exist on crates.io before memory is published. The two jobs below encode that ordering.
+
+jobs:
+  publish-core:
+    if: >
+      github.event_name == 'push' ||
+      inputs.crate == 'totalreclaw-core' ||
+      inputs.crate == 'all'
+    name: Publish totalreclaw-core
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            rust/totalreclaw-core/target
+          key: ${{ runner.os }}-cargo-core-${{ hashFiles('rust/totalreclaw-core/Cargo.lock') }}
+
+      - name: Report version
+        id: version
+        run: |
+          cd rust/totalreclaw-core
+          VERSION=$(cargo metadata --format-version 1 --no-deps | python3 -c "import sys,json; d=json.load(sys.stdin); print(next(p['version'] for p in d['packages'] if p['name']=='totalreclaw-core'))")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing totalreclaw-core@$VERSION"
+
+      - name: Cargo package (dry-run sanity check)
+        run: cd rust/totalreclaw-core && cargo package --allow-dirty
+
+      - name: Publish
+        if: >
+          github.event_name == 'push' ||
+          inputs.dry-run == false
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: |
+          cd rust/totalreclaw-core
+          VERSION="${{ steps.version.outputs.version }}"
+          # Tolerate "already uploaded" — publish is idempotent per version
+          set +e
+          OUT=$(cargo publish --allow-dirty 2>&1)
+          CODE=$?
+          set -e
+          echo "$OUT"
+          if [ $CODE -eq 0 ]; then
+            echo "Published totalreclaw-core@$VERSION"
+          elif echo "$OUT" | grep -qE "(already uploaded|already exists|crate version .* is already uploaded)"; then
+            echo "totalreclaw-core@$VERSION already published, continuing"
+          else
+            exit $CODE
+          fi
+
+  publish-memory:
+    needs: [publish-core]
+    if: >
+      always() &&
+      (needs.publish-core.result == 'success' || needs.publish-core.result == 'skipped') &&
+      (
+        github.event_name == 'push' ||
+        inputs.crate == 'totalreclaw-memory' ||
+        inputs.crate == 'all'
+      )
+    name: Publish totalreclaw-memory
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            rust/totalreclaw-memory/target
+          key: ${{ runner.os }}-cargo-memory-${{ hashFiles('rust/totalreclaw-memory/Cargo.lock') }}
+
+      - name: Wait for core to be queryable on crates.io
+        if: needs.publish-core.result == 'success'
+        run: |
+          # crates.io index propagation can take a few seconds after publish.
+          # Poll until the version we depend on shows up (or bail after ~2 min).
+          CORE_VERSION=$(python3 -c "import tomllib,sys; d=tomllib.load(open('rust/totalreclaw-core/Cargo.toml','rb')); print(d['package']['version'])")
+          echo "Waiting for totalreclaw-core@$CORE_VERSION on crates.io..."
+          for i in $(seq 1 24); do
+            if curl -sSf "https://crates.io/api/v1/crates/totalreclaw-core/$CORE_VERSION" >/dev/null 2>&1; then
+              echo "totalreclaw-core@$CORE_VERSION is live"
+              exit 0
+            fi
+            echo "Not yet (attempt $i/24), sleeping 5s..."
+            sleep 5
+          done
+          echo "Timed out waiting for crates.io propagation"
+          exit 1
+
+      - name: Report version
+        id: version
+        run: |
+          cd rust/totalreclaw-memory
+          VERSION=$(cargo metadata --format-version 1 --no-deps | python3 -c "import sys,json; d=json.load(sys.stdin); print(next(p['version'] for p in d['packages'] if p['name']=='totalreclaw-memory'))")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing totalreclaw-memory@$VERSION"
+
+      - name: Cargo package (dry-run sanity check)
+        run: cd rust/totalreclaw-memory && cargo package --allow-dirty
+
+      - name: Publish
+        if: >
+          github.event_name == 'push' ||
+          inputs.dry-run == false
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: |
+          cd rust/totalreclaw-memory
+          VERSION="${{ steps.version.outputs.version }}"
+          set +e
+          OUT=$(cargo publish --allow-dirty 2>&1)
+          CODE=$?
+          set -e
+          echo "$OUT"
+          if [ $CODE -eq 0 ]; then
+            echo "Published totalreclaw-memory@$VERSION"
+          elif echo "$OUT" | grep -qE "(already uploaded|already exists|crate version .* is already uploaded)"; then
+            echo "totalreclaw-memory@$VERSION already published, continuing"
+          else
+            exit $CODE
+          fi

--- a/rust/totalreclaw-core/Cargo.toml
+++ b/rust/totalreclaw-core/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 description = "TotalReclaw core — E2EE crypto, reranker, wallet, UserOp, store/search pipelines. Single source of truth for all clients."
 license = "MIT"
 repository = "https://github.com/p-diogo/totalreclaw"
+homepage = "https://totalreclaw.xyz"
+readme = "README.md"
+keywords = ["e2ee", "memory", "crypto", "erc4337", "ai"]
+categories = ["cryptography", "api-bindings"]
 
 [features]
 default = ["managed"]

--- a/rust/totalreclaw-core/README.md
+++ b/rust/totalreclaw-core/README.md
@@ -1,0 +1,40 @@
+# totalreclaw-core
+
+Shared core library powering every TotalReclaw client — a single source of truth for crypto, search, reranking, wallet derivation, UserOp construction, and store pipelines.
+
+Used natively by [`totalreclaw-memory`](https://crates.io/crates/totalreclaw-memory) (Rust / ZeroClaw), and exposed via WASM (`@totalreclaw/core` on npm) and PyO3 (`totalreclaw-core` on PyPI) bindings for TypeScript and Python clients.
+
+## What's in the box
+
+- **Crypto** — XChaCha20-Poly1305 envelope encryption, HKDF key derivation, BIP-39 mnemonic + BIP-44 wallet derivation, Keccak256.
+- **Reranker** — BM25 + cosine + RRF with intent-weighted scoring.
+- **Store / Search pipelines** — canonical claim construction, LSH blind indexing, fingerprinting.
+- **Dedup & KG** — best-match near-duplicate detection, cluster facts, contradiction detection orchestration, pin semantics, decision log.
+- **ERC-4337** — UserOp construction (feature-gated via `managed`), signing verified byte-for-byte against viem.
+- **Hot cache + consolidation + debrief + stemmer**.
+
+## Features
+
+- `managed` (default) — ERC-4337 UserOp support via `alloy-primitives` / `alloy-sol-types`.
+- `wasm` — WASM bindings via `wasm-bindgen` (consumed by `@totalreclaw/core` npm package).
+- `python` / `python-extension` — PyO3 bindings (consumed by `totalreclaw-core` PyPI package).
+
+## Usage
+
+```toml
+[dependencies]
+totalreclaw-core = "2.0"
+```
+
+Most Rust users should depend on [`totalreclaw-memory`](https://crates.io/crates/totalreclaw-memory), which bundles core into a high-level `Memory` trait.
+
+## License
+
+MIT
+
+## Links
+
+- Homepage: <https://totalreclaw.xyz>
+- Repository: <https://github.com/p-diogo/totalreclaw>
+- npm (WASM): [`@totalreclaw/core`](https://www.npmjs.com/package/@totalreclaw/core)
+- PyPI (PyO3): [`totalreclaw-core`](https://pypi.org/project/totalreclaw-core/)

--- a/rust/totalreclaw-memory/Cargo.toml
+++ b/rust/totalreclaw-memory/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 description = "TotalReclaw memory backend — E2EE crypto, LSH, embeddings, reranker (Memory Taxonomy v1)"
 license = "MIT"
 repository = "https://github.com/p-diogo/totalreclaw"
+homepage = "https://totalreclaw.xyz"
+readme = "README.md"
+keywords = ["e2ee", "memory", "ai", "embeddings", "lsh"]
+categories = ["cryptography", "api-bindings"]
 
 [features]
 default = []


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish-crates.yml` — publishes `totalreclaw-core` then `totalreclaw-memory` to crates.io.
- Triggered by `push: tags: v*` (to match the existing tagging convention — see `v3.0.1`) or manually via `workflow_dispatch` with a crate choice (`totalreclaw-core | totalreclaw-memory | all`) and a `dry-run` toggle.
- Rounds out Cargo.toml metadata on both crates (`keywords`, `categories`, `homepage`, `readme`) so crates.io renders a proper landing page.
- Adds a minimal `rust/totalreclaw-core/README.md` (the memory crate already had one).

## Audit of current state

```
$ curl -sS https://crates.io/api/v1/crates/totalreclaw-core  → NOT PUBLISHED
$ curl -sS https://crates.io/api/v1/crates/totalreclaw-memory → NOT PUBLISHED
```

Both crates are on `main` at 2.0.0 in `rust/totalreclaw-{core,memory}/Cargo.toml` but have never been published.

## Metadata before → after

**Before (both crates):** `name`, `version`, `edition`, `description`, `license`, `repository`. Required fields were all present, so publish would have worked. But the crates.io page would be bare.

**After:**
- Both crates now also have `homepage`, `readme`, `keywords`, `categories`.
- `totalreclaw-core/README.md` created (minimal, links to WASM/PyO3 siblings + memory crate).
- `totalreclaw-memory/README.md` already existed.

## Publish-order handling

`totalreclaw-memory` depends on `totalreclaw-core` via `{ path = "../totalreclaw-core", version = "2.0" }`. The memory publish job runs `needs: [publish-core]` and polls `crates.io/api/v1/crates/totalreclaw-core/<version>` for up to 2 minutes before attempting its own publish, to ride out index propagation.

## :warning: ACTION REQUIRED — CRATES_IO_TOKEN not set

`gh secret list` shows only `CLAWHUB_TOKEN` and `NPM_TOKEN` — **`CRATES_IO_TOKEN` is missing**.

Before merging and triggering this workflow:

1. Create an API token at <https://crates.io/settings/tokens> with scope `publish-new` + `publish-update` (both crates are first-time publishes).
2. Add it as a repo secret:
   ```
   gh secret set CRATES_IO_TOKEN --body '<token>'
   ```
3. Then trigger the publish manually:
   ```
   gh workflow run "Publish to crates.io" --ref main -f crate=all -f dry-run=false
   ```

I did **not** trigger the workflow myself because the secret is missing — it would fail immediately with an auth error.

## Workflow behavior

- **Idempotent**: if the current version is already on crates.io, the publish step logs `... already published, continuing` and succeeds. Safe to re-run.
- **Dry-run mode**: `workflow_dispatch` with `dry-run=true` runs `cargo package` on both crates but skips `cargo publish`. Tag-push always publishes.
- **Caches** `~/.cargo/registry` + `target/` for faster reruns.

## Test plan

- [ ] Reviewer adds `CRATES_IO_TOKEN` secret
- [ ] Merge this PR
- [ ] Trigger `gh workflow run "Publish to crates.io" --ref main -f crate=totalreclaw-core -f dry-run=true` (sanity check: package step must pass)
- [ ] Trigger `gh workflow run "Publish to crates.io" --ref main -f crate=all -f dry-run=false`
- [ ] Verify at <https://crates.io/crates/totalreclaw-core> and <https://crates.io/crates/totalreclaw-memory>

🤖 Generated with [Claude Code](https://claude.com/claude-code)