### PR TITLE
fix(mcp): write protobuf wrapper version=4 to match v1 contract

### DIFF
--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.0.1]
+
+### Fixed
+- Outer protobuf wrapper `version` field was hardcoded to `2` in `encodeFactProtobuf`, while all other v1 clients (OpenClaw plugin, Python, Rust `totalreclaw-memory`) write `4` per the Memory Taxonomy v1 contract. MCP now writes `PROTOBUF_VERSION_V4 = 4`. Matches VPS QA Bug #10 in `QA-V1-VPS-20260418.md`.
+
 ## [3.0.0]
 
 ### Changed

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/mcp-server",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. MCP server with XChaCha20-Poly1305 E2EE, semantic search, import/export, and on-chain storage",
   "homepage": "https://totalreclaw.xyz",
   "main": "dist/index.js",

--- a/mcp/src/subgraph/store.ts
+++ b/mcp/src/subgraph/store.ts
@@ -58,8 +58,24 @@ export interface FactPayload {
 }
 
 // ---------------------------------------------------------------------------
-// Protobuf encoding (unchanged)
+// Protobuf encoding
 // ---------------------------------------------------------------------------
+
+/**
+ * Memory Taxonomy v1 outer protobuf wrapper version.
+ *
+ * The v1 contract (shipped 2026-04-18) mandates that all clients write
+ * `version = 4` on the outer protobuf so the subgraph + cross-client
+ * readers can recognize the inner blob as a v1 JSON `MemoryClaim`.
+ *
+ * Canonical source: `rust/totalreclaw-core/src/protobuf.rs`
+ * (`PROTOBUF_VERSION_V4 = 4`). The WASM/PyO3 bindings do not re-export
+ * this constant to TS today — when they do, replace this literal with
+ * an import from `@totalreclaw/core`.
+ *
+ * TODO: import from @totalreclaw/core once the constant is re-exported.
+ */
+export const PROTOBUF_VERSION_V4 = 4;
 
 /**
  * Encode a fact payload as a minimal Protobuf wire format.
@@ -70,6 +86,11 @@ export interface FactPayload {
  *   6: decay_score (double), 7: is_active (bool), 8: version (int32),
  *   9: source (string), 10: content_fp (string), 11: agent_id (string),
  *   12: sequence_id (int64), 13: encrypted_embedding (string)
+ *
+ * Field 8 (`version`) is written as `PROTOBUF_VERSION_V4` (4) to match
+ * the Memory Taxonomy v1 contract. All other v1 clients (plugin, python,
+ * rust/totalreclaw-memory) write 4 here — writing anything else breaks
+ * cross-client uniformity.
  */
 export function encodeFactProtobuf(fact: FactPayload): Buffer {
   const parts: Buffer[] = [];
@@ -120,7 +141,7 @@ export function encodeFactProtobuf(fact: FactPayload): Buffer {
 
   writeDouble(6, fact.decayScore);
   writeVarintField(7, 1); // is_active = true
-  writeVarintField(8, 2); // version = 2
+  writeVarintField(8, PROTOBUF_VERSION_V4); // version = 4 (Memory Taxonomy v1)
   writeString(9, fact.source);
   writeString(10, fact.contentFp);
   writeString(11, fact.agentId);

--- a/mcp/tests/protobuf-version.test.ts
+++ b/mcp/tests/protobuf-version.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Regression test for QA-V1-VPS-20260418.md Bug #10.
+ *
+ * `encodeFactProtobuf` must stamp the outer protobuf wrapper field 8
+ * (`version`, wire type 0) as `4` (PROTOBUF_VERSION_V4). Shipping `2`
+ * or `3` silently breaks the Memory Taxonomy v1 cross-client contract —
+ * the subgraph and peer clients (plugin, python, rust) all expect the
+ * v4 sentinel when the inner blob is a v1 JSON claim.
+ */
+
+import {
+  encodeFactProtobuf,
+  encodeVarint,
+  PROTOBUF_VERSION_V4,
+  type FactPayload,
+} from '../src/subgraph/store.js';
+
+/**
+ * Read a protobuf varint starting at `offset`. Returns [value, bytesConsumed].
+ */
+function readVarint(buf: Buffer, offset: number): [number, number] {
+  let value = 0;
+  let shift = 0;
+  let i = offset;
+  while (i < buf.length) {
+    const byte = buf[i];
+    value |= (byte & 0x7f) << shift;
+    i += 1;
+    if ((byte & 0x80) === 0) {
+      return [value >>> 0, i - offset];
+    }
+    shift += 7;
+  }
+  throw new Error('truncated varint');
+}
+
+/**
+ * Walk the protobuf wire format and return the varint value for a given
+ * (fieldNumber, wireType=0) pair, or `undefined` if the field is absent.
+ */
+function readVarintField(buf: Buffer, fieldNumber: number): number | undefined {
+  const wantKey = (fieldNumber << 3) | 0;
+  let i = 0;
+  while (i < buf.length) {
+    const [key, keyLen] = readVarint(buf, i);
+    i += keyLen;
+    const wireType = key & 0x07;
+    if (key === wantKey) {
+      const [value] = readVarint(buf, i);
+      return value;
+    }
+    // Skip this field based on wire type.
+    if (wireType === 0) {
+      const [, len] = readVarint(buf, i);
+      i += len;
+    } else if (wireType === 1) {
+      i += 8; // fixed64
+    } else if (wireType === 2) {
+      const [len, lenLen] = readVarint(buf, i);
+      i += lenLen + len; // length-delimited
+    } else if (wireType === 5) {
+      i += 4; // fixed32
+    } else {
+      throw new Error(`unsupported wire type ${wireType}`);
+    }
+  }
+  return undefined;
+}
+
+function makeFact(overrides: Partial<FactPayload> = {}): FactPayload {
+  return {
+    id: 'test-id-00000000',
+    timestamp: '2026-04-18T00:00:00Z',
+    owner: '0x2c0CF74B2b76110708CA431796367779e3738250',
+    encryptedBlob: '00ff11ee',
+    blindIndices: ['deadbeef', 'cafef00d'],
+    decayScore: 0.9,
+    source: 'mcp_test',
+    contentFp: 'abcd',
+    agentId: 'test',
+    ...overrides,
+  };
+}
+
+describe('encodeFactProtobuf — outer wrapper version', () => {
+  it('exposes PROTOBUF_VERSION_V4 === 4', () => {
+    expect(PROTOBUF_VERSION_V4).toBe(4);
+  });
+
+  it('writes field 8 (version) as 4 for a standard fact payload', () => {
+    const buf = encodeFactProtobuf(makeFact());
+    const version = readVarintField(buf, 8);
+    expect(version).toBe(4);
+  });
+
+  it('writes field 8 (version) as 4 for a tombstone payload', () => {
+    const tombstone = makeFact({
+      encryptedBlob: Buffer.from('tombstone').toString('hex'),
+      blindIndices: [],
+      decayScore: 0,
+      source: 'mcp_dedup',
+      contentFp: '',
+    });
+    const buf = encodeFactProtobuf(tombstone);
+    const version = readVarintField(buf, 8);
+    expect(version).toBe(4);
+  });
+
+  it('writes field 8 (version) as 4 when encrypted_embedding is present', () => {
+    const buf = encodeFactProtobuf(
+      makeFact({ encryptedEmbedding: 'aa'.repeat(16) }),
+    );
+    const version = readVarintField(buf, 8);
+    expect(version).toBe(4);
+  });
+
+  it('also writes is_active (field 7) as 1', () => {
+    const buf = encodeFactProtobuf(makeFact());
+    const isActive = readVarintField(buf, 7);
+    expect(isActive).toBe(1);
+  });
+
+  // Sanity check: our varint reader actually works.
+  it('varint helper roundtrips', () => {
+    const buf = Buffer.concat([encodeVarint(4)]);
+    const [v, n] = readVarint(buf, 0);
+    expect(v).toBe(4);
+    expect(n).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

`encodeFactProtobuf` in `mcp/src/subgraph/store.ts` was hardcoded to write the outer protobuf wrapper `version` field (tag 8, varint) as **`2`**. Every other v1 client — OpenClaw plugin, Python, Rust `totalreclaw-memory` — writes **`4`** per the Memory Taxonomy v1 contract shipped 2026-04-18. This silently broke cross-client uniformity: peer clients expect `version = 4` to signal a v1 JSON inner blob.

Caught during VPS QA — **Bug #10 in `QA-V1-VPS-20260418.md`** (also surfaces through `QA-NANOCLAW-20260418.md`, since NanoClaw spawns the ` @totalreclaw/mcp-server` agent-runner, inheriting the bad wrapper).

## Changes

- `mcp/src/subgraph/store.ts` — declare `PROTOBUF_VERSION_V4 = 4` (exported), replace hardcoded `writeVarintField(8, 2)` with `writeVarintField(8, PROTOBUF_VERSION_V4)`. Docstring explains the cross-client invariant. `TODO` comment notes the constant should eventually be re-exported from `@totalreclaw/core` (today it lives only in the Rust source).
- `mcp/tests/protobuf-version.test.ts` — new. Parses the encoded bytes with a minimal varint walker and asserts field 8 is exactly `4` for plain, tombstone, and embedding-bearing payloads. 6 test cases.
- `mcp/package.json` — bump `3.0.0 → 3.0.1`.
- `mcp/CHANGELOG.md` — document the fix under `[3.0.1]`.

## Scope verified

- No other hardcoded `version = 2`, `version = 3`, or `writeVarintField(8, ...)` patterns found in `mcp/src`. All callers (`remember`, `pin`, `retype`, `consolidate`, `migrate`, tombstones in `index.ts`) funnel through the single `encodeFactProtobuf` helper.
- `version: 1` / `version: '0.7'` / `version: '1.0'` / `schema_version` occurrences are unrelated fields (DecryptedCandidate, EntryPoint version string, MemoryClaimV1 schema version, export format).

## Test plan

- [x] `cd mcp && npm install && npm run build && npm test` — 23 suites, **530 tests pass** (includes new `tests/protobuf-version.test.ts`).
- [ ] CI: Client Tests, Plugin Build, MCP Server Tests, Rust Core Tests, Python Client Tests.
- [ ] Post-merge publish via `gh workflow run "Publish npm packages" --ref main -f package=mcp-server` → verify `@totalreclaw/mcp-server@3.0.1` on npm.

Generated with [Claude Code](https://claude.com/claude-code)