### PR TITLE
fix(python): wallet_address no longer returns stale EOA placeholder

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -142,6 +142,23 @@ Memories stored by the Python client can be recalled by the MCP server, and vice
 - [Hermes setup guide](https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md)
 - [Feature comparison](https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/feature-comparison.md)
 
+## Recent changes
+
+### 2.0.1 — 2026-04-18
+
+- Fixed `wallet_address` property returning the EOA placeholder before
+  `resolve_address()` ran. The property now raises `RuntimeError` if read
+  before resolution; accessing it after `await client.resolve_address()` or
+  after the first `remember/recall/forget/export` call works as before.
+- Added `await client.get_wallet_address()` async getter that resolves
+  lazily and returns the Smart Account address in one call — preferred for
+  introspection code that doesn't want to sequence a separate
+  `resolve_address()` step.
+- **Not a data-loss bug.** UserOps mined correctly in 2.0.0; facts land
+  on-chain under the correct Smart Account. Only the introspection API
+  was wrong, which misled QA tooling into querying the subgraph with the
+  EOA.
+
 ## License
 
 MIT

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "totalreclaw"
-version = "2.0.0"
+version = "2.0.1"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"

--- a/python/src/totalreclaw/agent/state.py
+++ b/python/src/totalreclaw/agent/state.py
@@ -154,7 +154,11 @@ class AgentState:
         creds_path.write_text(json.dumps({"recovery_phrase": mnemonic}))
         creds_path.chmod(0o600)
 
-        logger.info("TotalReclaw configured: wallet=%s", self._client.wallet_address)
+        # Do NOT read `self._client.wallet_address` here — it raises until
+        # `resolve_address()` has run, and `configure()` is synchronous. The
+        # EOA is what we have at this point; the Smart Account address is
+        # resolved lazily on the first remember/recall call.
+        logger.info("TotalReclaw configured: eoa=%s", self._client._eoa_address)
 
     def is_configured(self) -> bool:
         """Return True if the client is configured and ready."""

--- a/python/src/totalreclaw/client.py
+++ b/python/src/totalreclaw/client.py
@@ -153,9 +153,19 @@ class TotalReclaw:
         self._eoa_address: str = eoa_acct.address
         self._eoa_private_key: bytes = bytes(eoa_acct.key)
 
-        # Use provided address, or fall back to EOA (resolve_address fixes it later)
-        self._wallet_address = (wallet_address or self._eoa_address).lower()
-        self._address_resolved = wallet_address is not None
+        # Store Smart Account address. If provided at construction time, mark as
+        # resolved. Otherwise, leave as None — callers MUST call
+        # ``await client.resolve_address()`` (or any remember/recall/forget/export,
+        # which lazily triggers resolution) before reading ``.wallet_address``.
+        # We intentionally do NOT fall back to the EOA placeholder here: silently
+        # exposing the EOA misled QA tooling in v2.0.0 into querying the subgraph
+        # with the wrong address. See DIAG-PYTHON-V2-20260418.md.
+        if wallet_address is not None:
+            self._wallet_address: Optional[str] = wallet_address.lower()
+            self._address_resolved = True
+        else:
+            self._wallet_address = None
+            self._address_resolved = False
         self._relay = RelayClient(
             relay_url=resolved_url,
             auth_key_hex=self._auth_key_hex,
@@ -168,9 +178,10 @@ class TotalReclaw:
         """Resolve the CREATE2 Smart Account address via RPC.
 
         Must be called before remember/recall/forget/export if wallet_address
-        was not provided at construction time.
+        was not provided at construction time. Also called automatically by
+        remember/recall/forget/export via ``_ensure_address``.
         """
-        if self._address_resolved:
+        if self._address_resolved and self._wallet_address is not None:
             return self._wallet_address
 
         self._wallet_address = await _derive_smart_account_address(self._mnemonic)
@@ -205,6 +216,51 @@ class TotalReclaw:
 
     @property
     def wallet_address(self) -> str:
+        """Return the CREATE2 Smart Account (SA) address.
+
+        **Contract:** this property is only valid once the SA has been
+        resolved. Resolution happens either:
+
+        * at construction time (if ``wallet_address=`` was passed in),
+        * explicitly via ``await client.resolve_address()``, or
+        * implicitly on the first ``remember/recall/forget/export`` call,
+          which internally calls ``_ensure_address``.
+
+        If you read this property before any of the above has happened it
+        will raise ``RuntimeError``. Historically (<=2.0.0) it silently
+        returned the EOA placeholder, which led QA tooling to query the
+        subgraph with the wrong address and report false negatives. See
+        DIAG-PYTHON-V2-20260418.md.
+
+        Returns
+        -------
+        str
+            The lowercase 0x-prefixed Smart Account address.
+
+        Raises
+        ------
+        RuntimeError
+            If called before the address has been resolved.
+        """
+        if not self._address_resolved or self._wallet_address is None:
+            raise RuntimeError(
+                "Smart Account address not yet resolved. Call "
+                "`await client.resolve_address()` before reading "
+                "`wallet_address`, or simply call `remember`/`recall`/"
+                "`forget`/`export` first (they resolve lazily). "
+                "See DIAG-PYTHON-V2-20260418.md for background."
+            )
+        return self._wallet_address
+
+    async def get_wallet_address(self) -> str:
+        """Async-safe getter that resolves the SA address if needed.
+
+        Prefer this in code that may run before any remember/recall call —
+        it guarantees you get the Smart Account address without needing
+        to sequence a separate ``await client.resolve_address()`` first.
+        """
+        await self._ensure_address()
+        assert self._wallet_address is not None  # _ensure_address guarantees this
         return self._wallet_address
 
     @property

--- a/python/src/totalreclaw/hermes/tools.py
+++ b/python/src/totalreclaw/hermes/tools.py
@@ -267,9 +267,19 @@ def setup(args: dict, state: "PluginState", **kwargs) -> str:
 
     try:
         state.configure(recovery_phrase)
+        client = state.get_client()
+        # The Smart Account address is resolved lazily on the first
+        # remember/recall call (requires async RPC). At setup time we only
+        # have the EOA — surface it as ``eoa_address`` and mark the SA as
+        # pending so callers don't confuse the two. See DIAG-PYTHON-V2.
         result = {
             "configured": True,
-            "wallet_address": state.get_client().wallet_address,
+            "eoa_address": client._eoa_address,
+            "wallet_address_pending": True,
+            "note": (
+                "Smart Account address will be resolved on the first "
+                "remember/recall call. Until then `wallet_address` is unset."
+            ),
         }
         if generated:
             result["recovery_phrase"] = recovery_phrase

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -96,3 +96,79 @@ class TestTotalReclawClient:
         addr = await client.resolve_address()
         assert addr == "0x2c0cf74b2b76110708ca431796367779e3738250"
         await client.close()
+
+
+class TestWalletAddressContract:
+    """Regression tests for DIAG-PYTHON-V2-20260418.md.
+
+    Pre-2.0.1 the `wallet_address` property silently returned the EOA placeholder
+    until `resolve_address()` ran. That misled QA tooling into querying the
+    subgraph with the EOA and seeing "0 facts" — but the facts were written
+    under the correct Smart Account address all along.
+
+    The fix: `wallet_address` raises `RuntimeError` if accessed before the
+    Smart Account address is resolved. The new async `get_wallet_address()`
+    resolves-then-returns for callers that want the lazy behaviour.
+    """
+
+    def test_wallet_address_raises_before_resolve(self):
+        """Accessing `wallet_address` pre-resolve must fail loud, not return EOA."""
+        client = TotalReclaw(recovery_phrase=TEST_MNEMONIC)
+        # No async calls here — the relay http client is lazy and is never
+        # instantiated just by reading `.wallet_address`.
+        with pytest.raises(RuntimeError, match="not yet resolved"):
+            _ = client.wallet_address
+
+    def test_wallet_address_works_when_provided_at_construction(self):
+        """If `wallet_address=` is passed, the property returns it immediately."""
+        sa = "0x2c0cf74b2b76110708ca431796367779e3738250"
+        client = TotalReclaw(recovery_phrase=TEST_MNEMONIC, wallet_address=sa)
+        assert client.wallet_address == sa.lower()
+
+    def test_wallet_address_does_not_leak_eoa(self):
+        """The EOA must never be returned by `.wallet_address` as a placeholder.
+
+        Historical bug: constructor stored EOA in `_wallet_address` and the
+        property returned it until `resolve_address` ran. That leaked the wrong
+        address to introspection callers.
+        """
+        client = TotalReclaw(recovery_phrase=TEST_MNEMONIC)
+        eoa = client._eoa_address
+        # `_wallet_address` must NOT be initialized to the EOA. It must be None
+        # so any accidental direct read fails rather than silently pointing at
+        # the wrong address.
+        assert client._wallet_address is None
+        assert client._address_resolved is False
+        # And the property must refuse to return anything.
+        with pytest.raises(RuntimeError):
+            _ = client.wallet_address
+        # Sanity: we still have access to the EOA via the private attribute,
+        # just not via the public `wallet_address` property.
+        assert eoa.startswith("0x")
+
+    @pytest.mark.asyncio
+    async def test_wallet_address_after_resolve(self):
+        """After `resolve_address()`, the property returns the SA address."""
+        client = TotalReclaw(recovery_phrase=TEST_MNEMONIC)
+        try:
+            sa = await client.resolve_address()
+            assert client.wallet_address == sa
+            # SA differs from EOA (this is the whole point of a Smart Account).
+            assert client.wallet_address != client._eoa_address.lower()
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_get_wallet_address_resolves_lazily(self):
+        """`await client.get_wallet_address()` resolves if not yet resolved."""
+        client = TotalReclaw(recovery_phrase=TEST_MNEMONIC)
+        try:
+            assert client._address_resolved is False
+            sa = await client.get_wallet_address()
+            assert sa.startswith("0x") and len(sa) == 42
+            assert client._address_resolved is True
+            # Second call is cached.
+            sa2 = await client.get_wallet_address()
+            assert sa2 == sa
+        finally:
+            await client.close()

--- a/python/tests/test_hermes_plugin.py
+++ b/python/tests/test_hermes_plugin.py
@@ -214,7 +214,9 @@ class TestTools:
         assert result["configured"] is True
         assert result["generated"] is True
         assert len(result["recovery_phrase"].split()) == 12
-        assert result["wallet_address"].startswith("0x")
+        # SA is resolved lazily; setup returns the EOA.
+        assert result["eoa_address"].startswith("0x")
+        assert result["wallet_address_pending"] is True
 
     def test_setup_success(self):
         from totalreclaw.hermes.tools import setup
@@ -226,7 +228,8 @@ class TestTools:
              patch.object(Path, "mkdir", return_value=None):
             result = json.loads(setup({"recovery_phrase": mnemonic}, state))
         assert result["configured"] is True
-        assert result["wallet_address"].startswith("0x")
+        assert result["eoa_address"].startswith("0x")
+        assert result["wallet_address_pending"] is True
 
 
 class TestHooks:


### PR DESCRIPTION
## Summary

Fixes a misleading introspection API in `totalreclaw` Python client 2.0.0 that caused QA tooling to query the subgraph with the wrong address and report "0 facts on-chain" for mnemonics whose facts were correctly indexed under the Smart Account.

**This is NOT a data-loss bug.** UserOps mined correctly in 2.0.0. Facts land on-chain under the correct SA. The `remember/recall/forget/export` happy path worked end-to-end. Only `client.wallet_address` was wrong when read before any of those methods triggered lazy resolution.

## Background

See `totalreclaw-internal/docs/notes/DIAG-PYTHON-V2-20260418.md` for full diagnostic and `QA-V1-VPS-20260418.md` Bugs #11 and #12 for the original reports. Both reported bugs share a single root cause:

- `client.py:157` (pre-fix): `self._wallet_address = (wallet_address or self._eoa_address).lower()` — the constructor stored the EOA as a placeholder.
- `client.py:207-208` (pre-fix): the `wallet_address` property returned that placeholder until `resolve_address()` ran via RPC.

QA tooling read `client.wallet_address` right after construction, got the EOA, queried the subgraph with the EOA owner filter, and saw 0 facts — but the facts were under the SA all along. Cross-impl parity (13/13) confirmed the crypto is fine; the address shown was just wrong.

## Fix

- `_wallet_address` initializes to `None` (not the EOA) so direct reads fail loud.
- `wallet_address` property raises `RuntimeError("Smart Account address not yet resolved...")` if read pre-resolution. No silent placeholder.
- New async getter `await client.get_wallet_address()` resolves lazily and returns the SA — preferred for introspection callers.
- `remember/recall/forget/export` still resolve lazily via `_ensure_address()`, same as before — happy path unchanged.
- `hermes/tools.py::setup` now returns `eoa_address` + `wallet_address_pending: true` instead of returning the EOA labeled as `wallet_address`.
- `agent/state.py` configure-time log shows `eoa=<addr>` (not `wallet=<addr>`), since the SA is resolved lazily on the first async call.

5 regression tests added in `tests/test_client.py::TestWalletAddressContract`.

## Test results

- `pytest tests/ --ignore=tests/test_staging_integration.py --ignore=tests/cross_client_e2e.py --ignore=tests/test_cross_client.py`: **555 passed, 1 xfailed** (the xfail predates this PR).
- `tests/parity/cross-impl-test.ts`: **13 passed, 0 failed** — confirms no crypto regression.

## Test plan

- [x] Unit tests cover: pre-resolve access raises, construction with explicit `wallet_address` works immediately, `_wallet_address` is `None` by default, post-resolve access returns SA, `get_wallet_address()` resolves lazily.
- [x] Existing `test_client`/`test_hermes_plugin`/`test_pin_unpin` tests adjusted where they asserted the old leaky shape.
- [ ] Staging smoke test after publish: `TotalReclaw(recovery_phrase=...)` → `wallet_address` raises → `await resolve_address()` → `remember()` → subgraph query against SA returns the fact.

## Version bump

`python/pyproject.toml`: `2.0.0` → `2.0.1`. README notes the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)