### PR TITLE
fix(plugin): auto-detect chain 100 for Pro tier (3.0.4)

### DIFF
--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.4] — 2026-04-18
+
+### Fixed
+
+- **Pro-tier UserOp signatures now sign against chain 100 (Gnosis).** Before this
+  release, `CONFIG.chainId` was a hardcoded literal `84532`, so Pro-tier writes
+  were signed for Base Sepolia even though the relay routed them to Gnosis
+  mainnet. The bundler rejected the signature with AA23 — a silent failure
+  where every `remember()` looked OK but nothing landed on-chain. There are no
+  Pro users in production today, so this never hit a user, but any Pro upgrade
+  would have broken every subsequent write. (Hermes Gap 2 equivalent — same
+  root cause as the Python client bug fixed in `totalreclaw` 2.0.2.)
+- `CONFIG.chainId` is now a getter that reads a runtime override set from the
+  billing response. `syncChainIdFromTier(tier)` is called on every
+  `writeBillingCache` / `readBillingCache` so the chain flips to 100 for Pro
+  tier and stays at 84532 for Free. All existing `getSubgraphConfig()` call
+  sites pick up the correct chain automatically because they read
+  `CONFIG.chainId` at call time, not at module load.
+- Added 6 regression tests in `config.test.ts` covering the default, the
+  Pro-tier flip, the Free-tier default, the Pro→Free downgrade path, and the
+  test reset helper. Full config suite: 27/27 passing.
+
 ## [3.0.0] — 2026-04-18
 
 Major release adopting **Memory Taxonomy v1** and **Retrieval v2 Tier 1** source-weighted reranking — now the DEFAULT and ONLY extraction path.

--- a/skill/plugin/config.test.ts
+++ b/skill/plugin/config.test.ts
@@ -13,7 +13,13 @@
  *   npx tsx config.test.ts
  */
 
-import { resolveTuning, CONFIG, __internal } from './config.js';
+import {
+  resolveTuning,
+  CONFIG,
+  __internal,
+  setChainIdOverride,
+  __resetChainIdOverrideForTests,
+} from './config.js';
 
 let passed = 0;
 let failed = 0;
@@ -131,6 +137,36 @@ function assertEq<T>(actual: T, expected: T, name: string): void {
   );
 
   delete process.env.TOTALRECLAW_CHAIN_ID;
+}
+
+// ---------------------------------------------------------------------------
+// Chain ID auto-detect override
+//
+// Regression test for the P0 latent bug where Pro-tier users would sign
+// UserOps against chain 84532 (Base Sepolia) while the relay routed their
+// writes to chain 100 (Gnosis mainnet). The bundler would reject the sig
+// with AA23. Fix: CONFIG.chainId is a getter that reads a runtime override
+// set from the billing response. See syncChainIdFromTier in index.ts.
+// ---------------------------------------------------------------------------
+
+{
+  __resetChainIdOverrideForTests();
+  assertEq(CONFIG.chainId, 84532, 'chainId: defaults to 84532 with no override');
+
+  setChainIdOverride(100);
+  assertEq(CONFIG.chainId, 100, 'chainId: reflects Pro tier override (Gnosis)');
+
+  setChainIdOverride(84532);
+  assertEq(CONFIG.chainId, 84532, 'chainId: reflects Free tier override (Base Sepolia)');
+
+  // Pro → Free downgrade flow: override flips back correctly.
+  setChainIdOverride(100);
+  assertEq(CONFIG.chainId, 100, 'chainId: Pro override set');
+  setChainIdOverride(84532);
+  assertEq(CONFIG.chainId, 84532, 'chainId: downgrade to Free flips override back');
+
+  __resetChainIdOverrideForTests();
+  assertEq(CONFIG.chainId, 84532, 'chainId: reset returns to 84532 default');
 }
 
 // ---------------------------------------------------------------------------

--- a/skill/plugin/config.ts
+++ b/skill/plugin/config.ts
@@ -63,6 +63,28 @@ export function getRecoveryPhrase(): string {
   return _recoveryPhraseOverride ?? process.env.TOTALRECLAW_RECOVERY_PHRASE ?? '';
 }
 
+/**
+ * Runtime override for chain ID, set after the relay billing response is
+ * read. Free tier stays on 84532 (Base Sepolia); Pro tier flips to 100
+ * (Gnosis mainnet). The relay routes Pro writes to Gnosis, so Pro-tier
+ * UserOps MUST be signed against chain 100 — otherwise the bundler rejects
+ * the signature with AA23.
+ *
+ * See index.ts: after the billing fetch completes, call
+ * `setChainIdOverride(100)` for Pro users. Free users can leave the
+ * override unset.
+ */
+let _chainIdOverride: number | null = null;
+
+export function setChainIdOverride(chainId: number): void {
+  _chainIdOverride = chainId;
+}
+
+/** Reset the chain override — used by tests. */
+export function __resetChainIdOverrideForTests(): void {
+  _chainIdOverride = null;
+}
+
 export const CONFIG = {
   // Core — recoveryPhrase reads from override first, then env var.
   // Use getRecoveryPhrase() for dynamic access; this property is for
@@ -80,7 +102,14 @@ export const CONFIG = {
   // completes. Self-hosted users can still point at a custom DataEdge via
   // TOTALRECLAW_DATA_EDGE_ADDRESS / TOTALRECLAW_ENTRYPOINT_ADDRESS /
   // TOTALRECLAW_RPC_URL (undocumented; internal knobs).
-  chainId: 84532,
+  //
+  // Reads the runtime override set by the billing auto-detect in index.ts.
+  // Falls back to 84532 (free tier / pre-billing-fetch). Must be a getter,
+  // not a literal — a literal would freeze all Pro-tier UserOps to the
+  // wrong chainId and AA23 at the bundler.
+  get chainId(): number {
+    return _chainIdOverride ?? 84532;
+  },
   dataEdgeAddress: process.env.TOTALRECLAW_DATA_EDGE_ADDRESS || '',
   entryPointAddress: process.env.TOTALRECLAW_ENTRYPOINT_ADDRESS || '',
   rpcUrl: process.env.TOTALRECLAW_RPC_URL || '',

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -94,7 +94,7 @@ import {
   type PinOpDeps,
 } from './pin.js';
 import { PluginHotCache, type HotFact } from './hot-cache-wrapper.js';
-import { CONFIG, setRecoveryPhraseOverride } from './config.js';
+import { CONFIG, setRecoveryPhraseOverride, setChainIdOverride } from './config.js';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -260,11 +260,34 @@ interface BillingCache {
   checked_at: number;
 }
 
+/**
+ * Apply the billing tier to the runtime chain override.
+ *
+ * Pro tier → chain 100 (Gnosis mainnet). Free tier (or unknown) stays on
+ * 84532 (Base Sepolia). The relay routes Pro UserOps to Gnosis, so the
+ * client MUST sign them against chain 100 — otherwise the bundler returns
+ * AA23 (invalid signature). See MCP's equivalent path in mcp/src/index.ts.
+ *
+ * Called from `readBillingCache` and `writeBillingCache` so that every cache
+ * read or write keeps the chain override in sync with the cached tier.
+ * Idempotent — calling with the same tier is a no-op.
+ */
+function syncChainIdFromTier(tier: string | undefined): void {
+  if (tier === 'pro') {
+    setChainIdOverride(100);
+  } else {
+    // Free or unknown → reset to the default free-tier chain.
+    setChainIdOverride(84532);
+  }
+}
+
 function readBillingCache(): BillingCache | null {
   try {
     if (!fs.existsSync(BILLING_CACHE_PATH)) return null;
     const raw = JSON.parse(fs.readFileSync(BILLING_CACHE_PATH, 'utf-8')) as BillingCache;
     if (!raw.checked_at || Date.now() - raw.checked_at > BILLING_CACHE_TTL) return null;
+    // Keep chain override in sync with persisted tier across process restarts.
+    syncChainIdFromTier(raw.tier);
     return raw;
   } catch {
     return null;
@@ -279,6 +302,9 @@ function writeBillingCache(cache: BillingCache): void {
   } catch {
     // Best-effort — don't block on cache write failure.
   }
+  // Sync chain override AFTER the write so in-process UserOp signing picks
+  // up the correct chain immediately, even if the disk write failed.
+  syncChainIdFromTier(cache.tier);
 }
 
 /**

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. Automatic extraction, semantic search, and on-chain storage",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary

- **P0 latent bug**: `CONFIG.chainId` was a hardcoded `84532` literal, so Pro-tier users would sign UserOps against Base Sepolia while the relay routed writes to Gnosis (chain 100). The bundler would reject with **AA23** — silent failure where every `remember()` looks fine but nothing lands on-chain.
- **No active outage** — zero Pro users in production today per CLAUDE.md status. But any Pro upgrade would have broken every subsequent write.
- Same root cause as the Hermes Gap 2 bug (fixed in `totalreclaw` 2.0.2 on PyPI). MCP server does the right thing at `mcp/src/index.ts:346-374`; the plugin missed it entirely.

## Fix

- `CONFIG.chainId` → getter that reads a runtime override. Default `84532`.
- `syncChainIdFromTier(tier)` runs on every `writeBillingCache` / `readBillingCache`. Pro → 100, anything else → 84532. Idempotent.
- All `getSubgraphConfig()` consumers pick up the new chain automatically because they read `CONFIG.chainId` at call time (`subgraph-store.ts:726`).
- 6 regression tests added in `config.test.ts`. Full config suite: **27/27 passing**.

## Version

- **3.0.3 → 3.0.4.** Rebased onto main after PR #32 (scanner regression fix, 3.0.3) merged. No conflicts remain.

## Test plan

- [x] `npx tsx config.test.ts` — 27/27 passing (includes 6 new regression tests for the chainId override)
- [x] Cross-impl parity test — 13/13 passing (no crypto paths touched)
- [ ] ClawHub publish 3.0.4 after merge (CI triggers on `v3.0.4` tag push)
- [ ] Manual smoke: mock billing returning `tier: "pro"` → verify UserOp is signed for chainId 100 (deferred to first real Pro user or staging Pro-tier E2E)

## Scope

- **Touched**: `skill/plugin/config.ts`, `skill/plugin/config.test.ts`, `skill/plugin/index.ts` (3 added lines in setup flow, helper function), `skill/plugin/package.json`, `skill/plugin/CHANGELOG.md`
- **Not touched**: python/, mcp/, rust/, relay, shipped 3.0.2 lockfile fix, any crypto/signing code

🤖 Generated with [Claude Code](https://claude.com/claude-code)