### PR TITLE
fix(python/hermes): v2.0.2 — auto-detect LLM + auto-setup + dedup + spurious-extract

### DIFF
--- a/python/src/totalreclaw/agent/__init__.py
+++ b/python/src/totalreclaw/agent/__init__.py
@@ -43,6 +43,8 @@ from .extraction import (
     extract_facts_llm,
     extract_facts_heuristic,
     extract_facts_compaction,
+    deduplicate_facts_by_embedding,
+    is_product_meta_request,
     EXTRACTION_SYSTEM_PROMPT,
     COMPACTION_SYSTEM_PROMPT,
 )
@@ -74,6 +76,8 @@ __all__ = [
     "extract_facts_llm",
     "extract_facts_heuristic",
     "extract_facts_compaction",
+    "deduplicate_facts_by_embedding",
+    "is_product_meta_request",
     "EXTRACTION_SYSTEM_PROMPT",
     "COMPACTION_SYSTEM_PROMPT",
     # Recall

--- a/python/src/totalreclaw/agent/extraction.py
+++ b/python/src/totalreclaw/agent/extraction.py
@@ -164,6 +164,13 @@ class ExtractedFact:
     dataclass but required on the write path — upstream pipelines
     (:func:`apply_provenance_filter_lax`) tag it during extraction;
     defensive callers supply ``"user-inferred"`` when upstream fails.
+
+    ``_embedding`` is a transient field populated by
+    :func:`deduplicate_facts_by_embedding` and consumed by the
+    lifecycle-layer store path. It is NOT serialized to the vault —
+    embeddings are computed from ``text`` on the write side. Kept on the
+    dataclass so in-batch cross-fact dedup doesn't have to recompute the
+    vector at store time.
     """
 
     text: str
@@ -179,6 +186,9 @@ class ExtractedFact:
     scope: Optional[str] = None
     reasoning: Optional[str] = None
     volatility: Optional[str] = None
+    # Transient — set by deduplicate_facts_by_embedding, read by the
+    # lifecycle store path. Not part of the v1 wire format.
+    _embedding: Optional[List[float]] = None
 
 
 def normalize_confidence(raw: Any) -> float:
@@ -239,6 +249,13 @@ Rules:
 3. Skip generic knowledge, greetings, small talk, ephemeral task coordination
 4. Score importance 1-10 (6+ = worth storing)
 5. Every memory MUST attribute a source (provenance critical)
+6. DO NOT extract setup / configuration / installation requests ABOUT the
+   TotalReclaw product itself. Utterances like "set up TotalReclaw",
+   "I want encrypted memory across my AI tools", "install the memory plugin",
+   or "configure the vault" are META-requests about the product — they are
+   NOT user preferences or claims worth storing. Genuine preferences that
+   happen to mention encryption (e.g., "I like using Signal because it's
+   encrypted") ARE valid and should be extracted.
 
 Importance rubric (use FULL 1-10 range):
 - 10: Critical, core identity, never-forget content
@@ -326,6 +343,12 @@ Rules:
 3. Skip generic knowledge, greetings, small talk
 4. Score importance 1-10 (5+ = worth storing during compaction)
 5. Every memory MUST attribute a source (provenance critical)
+6. DO NOT extract setup / configuration / installation requests ABOUT the
+   TotalReclaw product itself. Utterances like "set up TotalReclaw",
+   "I want encrypted memory across my AI tools", or "configure the
+   memory plugin" are META-requests about the product — NOT user
+   preferences worth storing. Genuine preferences that mention encryption
+   ("I prefer Signal because it's encrypted") ARE valid.
 
 Importance rubric (full 1-10 range, NOT just 7-8):
 - 10: Core identity, never-forget ("remember this forever", name/birthday)
@@ -891,6 +914,210 @@ def compute_lexical_importance_bump(fact_text: str, conversation_text: str) -> i
 
 
 # ---------------------------------------------------------------------------
+# Bug #8 — in-batch cosine dedup (v2.0.2)
+# ---------------------------------------------------------------------------
+
+
+def _cosine_similarity(a: List[float], b: List[float]) -> float:
+    """Pure-Python cosine similarity. Falls back from Rust core."""
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = 0.0
+    norm_a = 0.0
+    norm_b = 0.0
+    for x, y in zip(a, b):
+        dot += x * y
+        norm_a += x * x
+        norm_b += y * y
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot / (math.sqrt(norm_a) * math.sqrt(norm_b))
+
+
+#: Cosine similarity threshold used by the store-time dedup. Mirrors
+#: ``agent.lifecycle.STORE_DEDUP_THRESHOLD`` but kept local so this module
+#: doesn't import from lifecycle (lifecycle imports extraction, not the
+#: other way around). Keep in sync with lifecycle.
+STORE_DEDUP_THRESHOLD = 0.85
+
+
+def deduplicate_facts_by_embedding(
+    facts: List[ExtractedFact],
+    existing_memories: List[dict],
+    threshold: float = STORE_DEDUP_THRESHOLD,
+) -> List[ExtractedFact]:
+    """Remove near-duplicate facts (cross-existing + in-batch).
+
+    Bug #8 (v2.0.2): the prior store-time dedup in ``agent.lifecycle``
+    only compared each new fact against the vault snapshot fetched ONCE
+    before the store loop. Three near-identical facts produced in the
+    same extraction batch would all persist because the loop's
+    ``existing_memories`` list was never refreshed.
+
+    This helper fixes that by running the dedup pass on the extracted
+    fact list BEFORE it reaches the store loop. Each surviving fact also
+    retains its embedding on ``fact._embedding`` so the lifecycle layer
+    doesn't have to recompute.
+
+    Rules:
+      * ``UPDATE`` / ``DELETE`` actions bypass dedup (they operate on
+        existing IDs and are intended to mutate the vault).
+      * Facts without an embedding or a computable one are kept
+        (we can't dedup without signal — be conservative).
+      * A fact is dropped if its cosine similarity to any earlier
+        surviving batch fact OR any ``existing_memories`` entry with an
+        embedding exceeds ``threshold``.
+
+    The first fact to appear wins — matches ``apply_mmr`` semantics
+    and is deterministic for a given input order.
+    """
+    if not facts:
+        return []
+
+    # Filter existing_memories to those that carry usable embeddings.
+    ex_with_emb = [
+        m for m in (existing_memories or [])
+        if isinstance(m, dict) and m.get("embedding") and len(m["embedding"]) > 0
+    ]
+
+    survivors: List[ExtractedFact] = []
+    for fact in facts:
+        # Pass-through for action types that bypass dedup.
+        if fact.action in ("UPDATE", "DELETE", "NOOP"):
+            survivors.append(fact)
+            continue
+
+        # Compute embedding lazily if not attached yet.
+        embedding = fact._embedding
+        if embedding is None:
+            try:
+                from totalreclaw.embedding import get_embedding
+                embedding = get_embedding(fact.text)
+                fact._embedding = embedding
+            except Exception as e:
+                logger.debug(
+                    "deduplicate_facts_by_embedding: embedding failed for %r: %s",
+                    fact.text[:40], e,
+                )
+                # No embedding → can't dedup → keep the fact.
+                survivors.append(fact)
+                continue
+
+        if not embedding:
+            survivors.append(fact)
+            continue
+
+        # Check against existing vault entries.
+        is_dup = False
+        for mem in ex_with_emb:
+            sim = _cosine_similarity(embedding, mem["embedding"])
+            if sim >= threshold:
+                logger.info(
+                    "deduplicate_facts_by_embedding: %r dropped (sim=%.3f to existing %s)",
+                    fact.text[:60], sim, mem.get("id", "?"),
+                )
+                is_dup = True
+                break
+        if is_dup:
+            continue
+
+        # Check against earlier surviving batch facts.
+        for earlier in survivors:
+            if earlier._embedding is None:
+                continue
+            sim = _cosine_similarity(embedding, earlier._embedding)
+            if sim >= threshold:
+                logger.info(
+                    "deduplicate_facts_by_embedding: %r dropped (sim=%.3f to batch-earlier %r)",
+                    fact.text[:60], sim, earlier.text[:40],
+                )
+                is_dup = True
+                break
+        if is_dup:
+            continue
+
+        survivors.append(fact)
+
+    return survivors
+
+
+# ---------------------------------------------------------------------------
+# Bug #9 — product-meta request filter (v2.0.2)
+# ---------------------------------------------------------------------------
+
+#: Hard-product markers: if the extracted fact text mentions setting up or
+#: installing THE PRODUCT or one of its components, it's a meta-request and
+#: should not persist as a "user preference". These are case-insensitive.
+_PRODUCT_META_NAME_PATTERNS = (
+    r"\btotalreclaw\b",
+    r"\btotal reclaw\b",
+    r"\btotal-reclaw\b",
+    r"\bhermes\s+plugin\b",
+    r"\bmemory\s+plugin\b",
+    r"\bmcp\s+memory\b",
+    r"\bopenclaw\b",
+)
+
+#: Setup-action phrases combined with meta/plugin/memory context.
+_PRODUCT_META_ACTION_PATTERNS = (
+    r"\bset(\s+)?up\b.*\b(memory|vault|plugin|totalreclaw|product)\b",
+    r"\b(install|configure)\b.*\b(memory|vault|plugin|totalreclaw)\b",
+    r"\b(the\s+)?(memory|vault)\s+plugin\b",
+    r"\bi\s+want\s+(encrypted\s+)?memory\s+across\s+my\s+(ai|agents|tools)\b",
+)
+
+
+def is_product_meta_request(text: str) -> bool:
+    """Return True if ``text`` is about setting up / asking for the product.
+
+    Used to filter spurious extractions where a setup prompt (e.g.
+    "I want encrypted memory across my AI tools") lands in the vault as
+    a "user preference". Matches the QA-reported phrase exactly while
+    letting genuine preferences ("I like encrypted tools",
+    "I prefer Signal because it's encrypted") pass through.
+
+    Heuristic:
+      1. Any mention of the product by name → meta.
+      2. Setup verbs ("set up", "install", "configure") combined with
+         "memory" / "vault" / "plugin" / "agent" targets → meta.
+      3. The specific QA-reported "I want (encrypted) memory across my
+         AI tools" idiom → meta.
+    """
+    if not isinstance(text, str) or not text:
+        return False
+    lower = text.lower().strip()
+
+    for pat in _PRODUCT_META_NAME_PATTERNS:
+        if re.search(pat, lower):
+            return True
+
+    for pat in _PRODUCT_META_ACTION_PATTERNS:
+        if re.search(pat, lower, flags=re.IGNORECASE):
+            return True
+
+    return False
+
+
+def _filter_product_meta_facts(facts: List[ExtractedFact]) -> List[ExtractedFact]:
+    """Drop facts whose text reads as a product-meta / setup request.
+
+    Bug #9 (v2.0.2). Runs as a final pass before the extracted facts are
+    returned. Meta-requests are logged at INFO so operators can verify
+    the filter isn't being over-aggressive.
+    """
+    kept: List[ExtractedFact] = []
+    for f in facts:
+        if is_product_meta_request(f.text):
+            logger.info(
+                "_filter_product_meta_facts: dropping meta-request fact: %r",
+                f.text[:80],
+            )
+            continue
+        kept.append(f)
+    return kept
+
+
+# ---------------------------------------------------------------------------
 # Main extraction entry points
 # ---------------------------------------------------------------------------
 
@@ -905,7 +1132,8 @@ async def extract_facts_llm(
 
     Pipeline: single merged-topic LLM call → ``apply_provenance_filter_lax``
     → ``comparative_rescore_v1`` (forces re-rank when >= 5 facts) →
-    ``default_volatility`` fallback → lexical importance bumps.
+    ``default_volatility`` fallback → lexical importance bumps →
+    product-meta filter (Bug #9) → in-batch embedding dedup (Bug #8).
 
     Parameters
     ----------
@@ -914,14 +1142,21 @@ async def extract_facts_llm(
     mode : {"turn", "full"}
         Only affects the user-prompt framing (turn vs full-session).
     existing_memories : list[dict], optional
-        Used for LLM-side dedup context. Caller should pre-filter.
+        Used for LLM-side dedup context AND by the new cosine dedup pass
+        (Bug #8). Entries need ``id``, ``text``, and ``embedding``.
     llm_config : LLMConfig, optional
         Pre-resolved LLM config (e.g. from Hermes). Falls back to env-var
         detection via :func:`detect_llm_config` when not provided.
     """
     config = llm_config or detect_llm_config()
     if not config:
-        logger.info("extract_facts_llm: no LLM config resolved (skipping extraction)")
+        # Bug #5: loud, actionable warning — no more silent extraction disable.
+        logger.warning(
+            "TotalReclaw extraction disabled: no LLM config resolved. "
+            "Hermes users should configure ~/.hermes/config.yaml + ~/.hermes/.env; "
+            "other agents can set OPENAI_MODEL + OPENAI_API_KEY (or an equivalent "
+            "provider pair). See docs/guides/env-vars-reference.md."
+        )
         return []
 
     if not messages:
@@ -995,6 +1230,18 @@ async def extract_facts_llm(
                 bump, f.text[:60], old, f.importance,
             )
 
+    # Bug #9: drop product-meta / setup requests before they hit the vault.
+    facts = _filter_product_meta_facts(facts)
+
+    # Bug #8: collapse near-identical facts within the batch, and against
+    # existing vault entries with embeddings. Runs last so importance
+    # bumps are already applied (the surviving fact wins with its final
+    # importance). Falls through gracefully when ``existing_memories`` is
+    # empty or facts have no computable embeddings.
+    facts = deduplicate_facts_by_embedding(
+        facts, existing_memories or [], threshold=STORE_DEDUP_THRESHOLD,
+    )
+
     return facts
 
 
@@ -1010,7 +1257,13 @@ async def extract_facts_compaction(
     """
     config = llm_config or detect_llm_config()
     if not config:
-        logger.info("extract_facts_compaction: no LLM config resolved (skipping extraction)")
+        # Bug #5: loud, actionable warning — no more silent extraction disable.
+        logger.warning(
+            "TotalReclaw compaction extraction disabled: no LLM config resolved. "
+            "Hermes users should configure ~/.hermes/config.yaml + ~/.hermes/.env; "
+            "other agents can set OPENAI_MODEL + OPENAI_API_KEY (or equivalent). "
+            "See docs/guides/env-vars-reference.md."
+        )
         return []
 
     conversation_text = _truncate_messages(messages)
@@ -1073,6 +1326,14 @@ async def extract_facts_compaction(
                 "extract_facts_compaction: lexical bump +%d for %r (%d -> %d)",
                 bump, f.text[:60], old, f.importance,
             )
+
+    # Bug #9: filter product-meta requests.
+    facts = _filter_product_meta_facts(facts)
+
+    # Bug #8: in-batch + cross-existing cosine dedup.
+    facts = deduplicate_facts_by_embedding(
+        facts, existing_memories or [], threshold=STORE_DEDUP_THRESHOLD,
+    )
 
     return facts
 

--- a/python/src/totalreclaw/hermes/__init__.py
+++ b/python/src/totalreclaw/hermes/__init__.py
@@ -21,14 +21,16 @@ def register(ctx):
     """Called by Hermes plugin system at startup."""
     state = PluginState()
 
-    # Register tools
+    # Register tools. Descriptions mirror the schemas — they are the
+    # text the Hermes agent sees when selecting a tool, so they need to
+    # clearly distinguish TotalReclaw from any built-in 'memory' tool.
     ctx.register_tool(
         name="totalreclaw_remember",
         toolset="totalreclaw",
         schema=schemas.REMEMBER,
         handler=lambda args, **kw: tools.remember(args, state, **kw),
         is_async=True,
-        description="Store a memory in TotalReclaw",
+        description=schemas.REMEMBER["description"],
     )
     ctx.register_tool(
         name="totalreclaw_recall",
@@ -36,7 +38,7 @@ def register(ctx):
         schema=schemas.RECALL,
         handler=lambda args, **kw: tools.recall(args, state, **kw),
         is_async=True,
-        description="Search memories in TotalReclaw",
+        description=schemas.RECALL["description"],
     )
     ctx.register_tool(
         name="totalreclaw_forget",
@@ -44,7 +46,7 @@ def register(ctx):
         schema=schemas.FORGET,
         handler=lambda args, **kw: tools.forget(args, state, **kw),
         is_async=True,
-        description="Delete a memory from TotalReclaw",
+        description=schemas.FORGET["description"],
     )
     ctx.register_tool(
         name="totalreclaw_export",
@@ -52,7 +54,7 @@ def register(ctx):
         schema=schemas.EXPORT,
         handler=lambda args, **kw: tools.export_all(args, state, **kw),
         is_async=True,
-        description="Export all memories from TotalReclaw",
+        description=schemas.EXPORT["description"],
     )
     ctx.register_tool(
         name="totalreclaw_status",
@@ -60,14 +62,14 @@ def register(ctx):
         schema=schemas.STATUS,
         handler=lambda args, **kw: tools.status(args, state, **kw),
         is_async=True,
-        description="Check TotalReclaw billing status",
+        description=schemas.STATUS["description"],
     )
     ctx.register_tool(
         name="totalreclaw_setup",
         toolset="totalreclaw",
         schema=schemas.SETUP,
         handler=lambda args, **kw: tools.setup(args, state, **kw),
-        description="Configure TotalReclaw credentials",
+        description=schemas.SETUP["description"],
     )
     ctx.register_tool(
         name="totalreclaw_import_from",

--- a/python/src/totalreclaw/hermes/hooks.py
+++ b/python/src/totalreclaw/hermes/hooks.py
@@ -23,6 +23,40 @@ from totalreclaw.agent.extraction import extract_facts_llm, extract_facts_heuris
 
 logger = logging.getLogger(__name__)
 
+#: Bug #6: when the user hasn't run ``totalreclaw_setup`` yet but is
+#: asking a natural memory-related question, inject a one-time context
+#: nudge telling the agent to offer setup. Otherwise Hermes's built-in
+#: ``memory`` tool absorbs the request and the user never discovers
+#: TotalReclaw is installed.
+_SETUP_NUDGE = (
+    "## TotalReclaw setup nudge (one-time)\n"
+    "TotalReclaw is installed but not yet configured. If the user is "
+    "asking about remembering things across sessions, encrypted memory, "
+    "or cross-agent persistence, call `totalreclaw_setup` to generate a "
+    "BIP-39 recovery phrase and enable the vault. After that, use "
+    "`totalreclaw_remember` / `totalreclaw_recall` — they outrank any "
+    "built-in 'memory' tool for durability + encryption."
+)
+
+#: Keywords that trigger the setup nudge when the user isn't configured.
+#: Kept intentionally broad — a missed nudge on an unrelated question is
+#: a no-op, but a missed nudge on a memory-relevant question means the
+#: user sees "memory" work only for the session (via Hermes built-in)
+#: and never learns about TotalReclaw.
+_MEMORY_INTENT_KEYWORDS = (
+    "remember", "recall", "forget", "memory", "memories", "note",
+    "save", "store", "record", "encrypted", "persistent", "across",
+    "vault", "preference", "what do you know",
+)
+
+
+def _looks_like_memory_intent(user_message: str) -> bool:
+    """Cheap heuristic: does the message reference memory semantics?"""
+    if not user_message:
+        return False
+    lower = user_message.lower()
+    return any(kw in lower for kw in _MEMORY_INTENT_KEYWORDS)
+
 
 def _get_hermes_llm_config():
     """Get LLM config from Hermes's own config files.
@@ -68,12 +102,30 @@ def on_session_start(state: "PluginState", **kwargs) -> None:
 
 
 def pre_llm_call(state: "PluginState", **kwargs) -> Optional[dict]:
-    """Auto-recall on first turn, inject memories and quota warnings into context."""
-    if not state.is_configured():
-        return None
+    """Auto-recall on first turn, inject memories, quota warnings, and the
+    unconfigured-user setup nudge (Bug #6) into context.
 
-    is_first_turn = kwargs.get("is_first_turn", False)
+    When the plugin is installed but the user hasn't run
+    ``totalreclaw_setup`` yet, a one-time nudge is injected on the first
+    turn that references any memory intent. The nudge tells the Hermes
+    agent to offer setup — preventing silent routing to Hermes's
+    built-in ``memory`` tool.
+    """
     user_message = kwargs.get("user_message", "")
+    is_first_turn = kwargs.get("is_first_turn", False)
+
+    # Bug #6 — unconfigured: one-time setup nudge, fires only when the
+    # user message looks like a memory intent. We never return None here
+    # so the Hermes agent sees the nudge as soon as memory semantics hit.
+    # The "shown once" flag lives as an ad-hoc attribute on the state
+    # instance — ``AgentState`` itself is owned by Phase 1's surface and
+    # we don't want to add state-management methods there from the plugin.
+    if not state.is_configured():
+        shown = getattr(state, "_totalreclaw_setup_nudge_shown", False)
+        if not shown and _looks_like_memory_intent(user_message):
+            state._totalreclaw_setup_nudge_shown = True
+            return {"context": _SETUP_NUDGE}
+        return None
 
     context_parts: list[str] = []
 
@@ -99,7 +151,14 @@ def pre_llm_call(state: "PluginState", **kwargs) -> Optional[dict]:
 
 
 def post_llm_call(state: "PluginState", **kwargs) -> None:
-    """Auto-extract facts every N turns."""
+    """Auto-extract facts every N turns.
+
+    Bug #5: when Hermes's LLM config can't be resolved AND no fallback
+    env-vars are set, we surface a one-time quota-channel warning so the
+    user sees the failure in their next assistant turn. Prior behavior
+    was a debug-only log; users hit 7+ natural-conversation turns and
+    watched no memories appear, with nothing to explain why.
+    """
     # Always track turns and messages (client may be configured mid-session)
     state.increment_turn()
     state.add_message("user", kwargs.get("user_message", ""))
@@ -112,9 +171,42 @@ def post_llm_call(state: "PluginState", **kwargs) -> None:
     if state.turn_count % extraction_interval != 0:
         return
 
+    # Resolve LLM config and surface a user-visible warning if it fails.
+    llm_config = _get_hermes_llm_config()
+    if llm_config is None:
+        # Also try env-var detection so non-Hermes-hosted agents work.
+        try:
+            from totalreclaw.agent.llm_client import detect_llm_config
+            llm_config = detect_llm_config()
+        except Exception:
+            llm_config = None
+
+    if llm_config is None:
+        # Surface once per session via the existing quota-warning channel
+        # so the user sees an explanation in their next assistant turn.
+        _warned_attr = "_totalreclaw_llm_missing_warned"
+        if not getattr(state, _warned_attr, False):
+            setattr(state, _warned_attr, True)
+            state.set_quota_warning(
+                "TotalReclaw: automatic memory extraction is DISABLED — no "
+                "LLM config was resolved. To enable: ensure ~/.hermes/"
+                "config.yaml has a model + provider set AND ~/.hermes/.env "
+                "contains the matching API key. (Fallback: export "
+                "OPENAI_MODEL + OPENAI_API_KEY.) Until this is fixed, "
+                "explicit `totalreclaw_remember` and `totalreclaw_recall` "
+                "still work."
+            )
+            logger.warning(
+                "TotalReclaw: no LLM config for auto-extraction; surfacing "
+                "one-time warning via quota channel"
+            )
+        # Fall through — ``_auto_extract`` will itself log the silent-skip
+        # path; it's safe to call with ``llm_config=None``. Callers that
+        # mock ``extract_facts_llm`` directly still see the wiring path.
+
     # Extract and store facts (use Hermes LLM config so model name is resolved)
     try:
-        _auto_extract(state, mode="turn", llm_config=_get_hermes_llm_config())
+        _auto_extract(state, mode="turn", llm_config=llm_config)
     except Exception as e:
         logger.warning("TotalReclaw post_llm_call extraction failed: %s", e)
 

--- a/python/src/totalreclaw/hermes/plugin.yaml
+++ b/python/src/totalreclaw/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: totalreclaw
-version: 2.0.0
+version: 2.0.2
 description: End-to-end encrypted memory vault for AI agents (Memory Taxonomy v1)
 author: TotalReclaw Team
 provides_tools:

--- a/python/src/totalreclaw/hermes/schemas.py
+++ b/python/src/totalreclaw/hermes/schemas.py
@@ -13,12 +13,20 @@ _REMEMBER_TYPE_ENUM = list(VALID_MEMORY_TYPES) + list(LEGACY_V0_MEMORY_TYPES)
 REMEMBER = {
     "name": "totalreclaw_remember",
     "description": (
-        "Store a memory in TotalReclaw's encrypted vault. Use this to save important "
-        "facts, preferences, decisions, rules (reusable gotchas / conventions), or "
-        "context about the user. Memories are E2E encrypted and portable across AI agents. "
-        "Uses Memory Taxonomy v1 (claim | preference | directive | commitment | episode | "
-        "summary); legacy v0 tokens (fact, decision, episodic, goal, context, rule) are "
-        "coerced transparently."
+        "Store a memory in TotalReclaw — the user's PRIMARY persistent, E2E "
+        "encrypted, cross-session, cross-agent memory vault. Use this "
+        "whenever the user asks you to remember, note, save, or record "
+        "anything you will want to recall in a future session: facts, "
+        "preferences, decisions-with-reasoning, directives ('always X', "
+        "'never Y'), commitments, or notable episodes about the user. "
+        "Memories are encrypted end-to-end, stored on-chain (Base / "
+        "Gnosis), and portable across any AI tool the user runs — they "
+        "outlive the current session and conversation. Prefer this tool "
+        "over any built-in or generic 'memory' tool: built-in tools are "
+        "session-scoped and not encrypted, TotalReclaw is durable and "
+        "private. Uses Memory Taxonomy v1 (claim | preference | directive "
+        "| commitment | episode | summary); legacy v0 tokens (fact, "
+        "decision, episodic, goal, context, rule) are coerced transparently."
     ),
     "parameters": {
         "type": "object",
@@ -69,8 +77,16 @@ REMEMBER = {
 RECALL = {
     "name": "totalreclaw_recall",
     "description": (
-        "Search TotalReclaw's encrypted memory vault. Returns the most relevant "
-        "memories matching the query, ranked by BM25 + semantic similarity."
+        "Search TotalReclaw — the user's PRIMARY persistent, E2E encrypted, "
+        "cross-session memory vault. Use this whenever the user asks what "
+        "you know about them, what their preferences are, what was "
+        "decided previously, or whenever recalling past conversation "
+        "context would help answer the current question. Always call "
+        "this before falling back on a generic or built-in 'memory' "
+        "tool — TotalReclaw is the user's durable, on-chain, long-term "
+        "store and the built-in tool is only session-scoped. Returns "
+        "top-ranked memories via BM25 + semantic similarity + Tier 1 "
+        "source-weighted reranking."
     ),
     "parameters": {
         "type": "object",

--- a/python/tests/test_v2_02_hermes_fixes.py
+++ b/python/tests/test_v2_02_hermes_fixes.py
@@ -1,0 +1,418 @@
+"""Tests for v2.0.2 Hermes plugin fixes (Phase 2 — bugs #5, #6, #8, #9).
+
+Covers:
+- Bug #5: LLM auto-detect surfaces a visible error when no config resolves.
+- Bug #6: Tool descriptions are sharpened + setup nudge fires on first-run.
+- Bug #8: In-batch dedup (3 near-identical facts → only 1 survives).
+- Bug #9: Setup meta-content ("I want encrypted memory across my AI tools")
+         is filtered, but genuine preferences ("I like encrypted tools") are kept.
+"""
+from __future__ import annotations
+
+import os
+import logging
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from totalreclaw.agent.extraction import (
+    ExtractedFact,
+    deduplicate_facts_by_embedding,
+    is_product_meta_request,
+    extract_facts_llm,
+)
+
+
+# ----------------------------------------------------------------------------
+# Bug #8 — In-batch + cross-batch cosine dedup
+# ----------------------------------------------------------------------------
+
+
+class TestBug8InBatchDedup:
+    """Store-time cosine dedup must collapse near-duplicates within a single
+    extraction batch. Prior code fetched ``existing_memories`` ONCE before the
+    store loop, so 3 near-identical facts in the same batch all persisted.
+    """
+
+    def test_deduplicate_collapses_near_identical_batch(self):
+        """3 near-identical facts in a batch → only 1 survives.
+
+        Uses synthetic normalized embeddings with cosine sim > 0.85.
+        """
+        # All three point in nearly the same direction.
+        e1 = [1.0, 0.0, 0.0]
+        e2 = [0.98, 0.02, 0.0]  # cosine ~ 0.9998
+        e3 = [0.99, 0.01, 0.0]  # cosine ~ 0.9999
+
+        fact1 = ExtractedFact(
+            text="User uses PyCharm with the Darcula theme.",
+            type="preference", importance=7, action="ADD",
+            _embedding=e1,
+        )
+        fact2 = ExtractedFact(
+            text="User uses PyCharm with Darcula theme for Python work.",
+            type="preference", importance=7, action="ADD",
+            _embedding=e2,
+        )
+        fact3 = ExtractedFact(
+            text="PyCharm + Darcula is the user's Python IDE setup.",
+            type="preference", importance=7, action="ADD",
+            _embedding=e3,
+        )
+
+        # No existing memories — pure in-batch dedup.
+        result = deduplicate_facts_by_embedding(
+            [fact1, fact2, fact3], existing_memories=[], threshold=0.85,
+        )
+        assert len(result) == 1, f"expected 1 survivor, got {len(result)}"
+        assert result[0] is fact1  # First one wins.
+
+    def test_deduplicate_keeps_dissimilar_facts(self):
+        """Facts with orthogonal embeddings are not deduped."""
+        f1 = ExtractedFact(
+            text="User prefers PyCharm IDE.",
+            type="preference", importance=7, action="ADD",
+            _embedding=[1.0, 0.0, 0.0],
+        )
+        f2 = ExtractedFact(
+            text="User runs on Ubuntu Linux.",
+            type="claim", importance=7, action="ADD",
+            _embedding=[0.0, 1.0, 0.0],
+        )
+        f3 = ExtractedFact(
+            text="User drinks espresso in the morning.",
+            type="preference", importance=6, action="ADD",
+            _embedding=[0.0, 0.0, 1.0],
+        )
+        result = deduplicate_facts_by_embedding([f1, f2, f3], [], 0.85)
+        assert len(result) == 3
+
+    def test_deduplicate_drops_fact_matching_existing_memory(self):
+        """A fact with embedding matching an existing vault entry is dropped."""
+        fact = ExtractedFact(
+            text="User uses dark mode.",
+            type="preference", importance=7, action="ADD",
+            _embedding=[1.0, 0.0, 0.0],
+        )
+        existing = [
+            {"id": "existing-1", "text": "dark mode", "embedding": [0.99, 0.01, 0.0]},
+        ]
+        result = deduplicate_facts_by_embedding([fact], existing, 0.85)
+        assert len(result) == 0
+
+    def test_deduplicate_bypasses_update_actions(self):
+        """UPDATE facts are not near-dup checked — they intentionally supersede."""
+        update_fact = ExtractedFact(
+            text="User uses dark mode (always).",
+            type="preference", importance=8, action="UPDATE",
+            existing_fact_id="old-1",
+            _embedding=[1.0, 0.0, 0.0],
+        )
+        existing = [
+            {"id": "old-1", "text": "dark mode", "embedding": [1.0, 0.0, 0.0]},
+        ]
+        result = deduplicate_facts_by_embedding([update_fact], existing, 0.85)
+        assert len(result) == 1
+
+    def test_deduplicate_handles_missing_embeddings(self):
+        """Facts without embeddings are kept (can't dedup without signal)."""
+        fact = ExtractedFact(
+            text="Plain fact",
+            type="claim", importance=6, action="ADD",
+            _embedding=None,
+        )
+        result = deduplicate_facts_by_embedding([fact], [], 0.85)
+        assert len(result) == 1
+
+    def test_deduplicate_delete_actions_pass_through(self):
+        """DELETE actions are tombstones — they bypass dedup."""
+        delete_fact = ExtractedFact(
+            text="obsolete fact",
+            type="claim", importance=5, action="DELETE",
+            existing_fact_id="old-1",
+            _embedding=[1.0, 0.0, 0.0],
+        )
+        existing = [
+            {"id": "old-1", "text": "old", "embedding": [1.0, 0.0, 0.0]},
+        ]
+        result = deduplicate_facts_by_embedding([delete_fact], existing, 0.85)
+        assert len(result) == 1
+
+
+# ----------------------------------------------------------------------------
+# Bug #9 — Spurious extraction of setup/meta content
+# ----------------------------------------------------------------------------
+
+
+class TestBug9MetaFilter:
+    """Product-meta-request filter drops setup utterances but keeps genuine
+    preferences that happen to mention encryption.
+    """
+
+    def test_meta_filter_catches_setup_utterance(self):
+        """QA-reported phrase is flagged as meta."""
+        assert is_product_meta_request(
+            "I want encrypted memory across my AI tools"
+        ) is True
+
+    def test_meta_filter_catches_totalreclaw_mention(self):
+        assert is_product_meta_request("Please set up TotalReclaw for me") is True
+        assert is_product_meta_request("can you configure totalreclaw") is True
+        assert is_product_meta_request(
+            "I need to install the memory plugin"
+        ) is True
+
+    def test_meta_filter_allows_genuine_preferences(self):
+        """Preferences like 'I like encrypted tools' SHOULD be extracted."""
+        assert is_product_meta_request("I like encrypted tools") is False
+        assert is_product_meta_request(
+            "I prefer PostgreSQL over MySQL for OLTP"
+        ) is False
+        assert is_product_meta_request("My favorite editor is Vim") is False
+
+    def test_meta_filter_allows_legitimate_encryption_preferences(self):
+        """'Encrypted' as an adjective in a real preference is not meta."""
+        # Borderline — but these are genuine preferences, not setup requests.
+        assert is_product_meta_request(
+            "I prefer using end-to-end encrypted messengers"
+        ) is False
+        assert is_product_meta_request(
+            "I like using Signal because it's encrypted"
+        ) is False
+
+
+# ----------------------------------------------------------------------------
+# Bug #5 — LLM auto-detect surfaces a visible error (no more silent disable)
+# ----------------------------------------------------------------------------
+
+
+class TestBug5VisibleLLMError:
+    """When no LLM config resolves, extraction must surface a loud warning
+    with actionable guidance — not a quiet INFO log line.
+    """
+
+    @pytest.mark.asyncio
+    async def test_extract_facts_llm_warns_when_no_config(self, caplog):
+        with patch.dict(os.environ, {}, clear=True):
+            with caplog.at_level(logging.WARNING, logger="totalreclaw.agent.extraction"):
+                result = await extract_facts_llm(
+                    [{"role": "user", "content": "I like coffee"}],
+                )
+        assert result == []
+        # Must log at WARNING (not INFO) with actionable guidance.
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert len(warnings) >= 1, (
+            "no WARNING logged — bug #5 says silent failure must be loud"
+        )
+        msg = warnings[0].getMessage().lower()
+        assert "llm" in msg
+        assert "extraction" in msg
+        # Actionable guidance: mention setup path or config file
+        assert any(term in msg for term in [
+            "openai_model", "config", "extraction disabled", "hermes",
+            "set up", "configure",
+        ]), f"no actionable guidance in warning: {msg!r}"
+
+    def test_post_llm_call_surfaces_quota_warning_when_no_llm_config(self):
+        """User-visible: when LLM can't be resolved, a one-time quota-channel
+        warning appears so the user sees something in their next context.
+        """
+        from totalreclaw.hermes.hooks import post_llm_call
+        from totalreclaw.hermes.state import PluginState
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(Path, "exists", return_value=False):
+                state = PluginState()
+        state._client = MagicMock()  # Configured
+
+        # Force LLM detect to return None (no env) + Hermes config absent.
+        with patch(
+            "totalreclaw.hermes.hooks._get_hermes_llm_config",
+            return_value=None,
+        ):
+            with patch(
+                "totalreclaw.agent.llm_client.detect_llm_config",
+                return_value=None,
+            ):
+                # Call enough times to hit the extraction interval.
+                from totalreclaw.hermes.state import DEFAULT_EXTRACTION_INTERVAL
+                for _ in range(DEFAULT_EXTRACTION_INTERVAL):
+                    post_llm_call(state, user_message="u", assistant_response="a")
+
+        # A quota_warning should now be queued and mention LLM.
+        warning = state.get_quota_warning()
+        assert warning is not None, "post_llm_call should surface a visible warning"
+        assert "llm" in warning.lower() or "extraction" in warning.lower()
+
+    def test_post_llm_call_quota_warning_fires_only_once(self):
+        """Multiple failed extraction attempts → still only ONE warning."""
+        from totalreclaw.hermes.hooks import post_llm_call
+        from totalreclaw.hermes.state import PluginState
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(Path, "exists", return_value=False):
+                state = PluginState()
+        state._client = MagicMock()
+
+        with patch(
+            "totalreclaw.hermes.hooks._get_hermes_llm_config",
+            return_value=None,
+        ):
+            with patch(
+                "totalreclaw.agent.llm_client.detect_llm_config",
+                return_value=None,
+            ):
+                from totalreclaw.hermes.state import DEFAULT_EXTRACTION_INTERVAL
+                # Trigger twice.
+                for _ in range(DEFAULT_EXTRACTION_INTERVAL * 2):
+                    post_llm_call(state, user_message="u", assistant_response="a")
+
+        # First consume clears the warning; second cycle shouldn't re-set it.
+        w1 = state.get_quota_warning()
+        state.clear_quota_warning()
+        with patch(
+            "totalreclaw.hermes.hooks._get_hermes_llm_config",
+            return_value=None,
+        ):
+            with patch(
+                "totalreclaw.agent.llm_client.detect_llm_config",
+                return_value=None,
+            ):
+                post_llm_call(state, user_message="u2", assistant_response="a2")
+                post_llm_call(state, user_message="u3", assistant_response="a3")
+                post_llm_call(state, user_message="u4", assistant_response="a4")
+        w2 = state.get_quota_warning()
+
+        assert w1 is not None
+        assert w2 is None, "warning should fire only once per session"
+
+
+# ----------------------------------------------------------------------------
+# Bug #6 — Tool descriptions sharpened to outrank Hermes built-in memory
+# ----------------------------------------------------------------------------
+
+
+class TestBug6ToolDescriptions:
+    """TotalReclaw tool descriptions must be distinctive/specific enough
+    that the LLM picks them over Hermes's built-in ``memory`` tool.
+
+    Heuristic: descriptions should mention encryption + cross-agent
+    portability + persistence qualities that the built-in tool lacks.
+    """
+
+    def test_remember_description_is_distinctive(self):
+        from totalreclaw.hermes.schemas import REMEMBER
+        desc = REMEMBER["description"].lower()
+        # Key differentiators vs built-in memory:
+        # Must contain at least 3 of: encrypted, persistent, cross-session,
+        # portable, onchain, vault, e2e, permanent, durable.
+        distinctive_terms = [
+            "encrypted", "persistent", "cross-session", "portable",
+            "onchain", "on-chain", "vault", "e2e", "permanent", "durable",
+            "long-term",
+        ]
+        hits = [t for t in distinctive_terms if t in desc]
+        assert len(hits) >= 3, (
+            f"remember description too generic; only {len(hits)} distinctive "
+            f"terms ({hits}). Add more to outrank built-in memory."
+        )
+
+    def test_recall_description_mentions_persistence(self):
+        from totalreclaw.hermes.schemas import RECALL
+        desc = RECALL["description"].lower()
+        # Must be clearly about cross-session/persistent memory.
+        assert any(t in desc for t in [
+            "cross-session", "persistent", "onchain", "on-chain", "vault",
+            "encrypted", "long-term",
+        ]), (
+            f"recall description should signal persistence: {desc!r}"
+        )
+
+    def test_recall_description_signals_preference_over_builtin(self):
+        """Description should include an explicit usage hint."""
+        from totalreclaw.hermes.schemas import RECALL
+        desc = RECALL["description"].lower()
+        # Either mention "use this for X" or "prefer this" or similar.
+        assert any(term in desc for term in [
+            "use this", "for any", "always", "whenever", "preferred",
+            "primary",
+        ]), f"no usage-preference hint in recall description: {desc!r}"
+
+
+# ----------------------------------------------------------------------------
+# Bug #6 continued — on_session_start nudges setup when not configured
+# ----------------------------------------------------------------------------
+
+
+class TestBug6FirstRunNudge:
+    """When the user has installed the plugin but not run totalreclaw_setup,
+    the first-turn ``pre_llm_call`` must surface a one-time nudge telling
+    the user (via the system) to run setup.
+    """
+
+    def test_pre_llm_call_nudges_unconfigured_user_on_first_turn(self):
+        from totalreclaw.hermes.hooks import pre_llm_call
+        from totalreclaw.hermes.state import PluginState
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(Path, "exists", return_value=False):
+                state = PluginState()
+
+        assert not state.is_configured()
+
+        # First turn — user asks a natural memory-related question.
+        result = pre_llm_call(
+            state,
+            is_first_turn=True,
+            user_message="Can you remember that I prefer dark mode?",
+        )
+
+        # Should return a context nudge mentioning setup.
+        assert result is not None, "expected setup nudge on first turn"
+        ctx = result.get("context", "")
+        assert "totalreclaw_setup" in ctx.lower() or "set up" in ctx.lower()
+
+    def test_pre_llm_call_nudge_only_fires_once(self):
+        """Second invocation should NOT re-inject the nudge."""
+        from totalreclaw.hermes.hooks import pre_llm_call
+        from totalreclaw.hermes.state import PluginState
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(Path, "exists", return_value=False):
+                state = PluginState()
+
+        first = pre_llm_call(
+            state, is_first_turn=True,
+            user_message="Remember I like dark mode",
+        )
+        second = pre_llm_call(
+            state, is_first_turn=True,
+            user_message="Can you remember another thing for me?",
+        )
+        assert first is not None
+        # Second call: nudge should not re-fire (no "totalreclaw_setup" in ctx).
+        if second is not None:
+            ctx = second.get("context", "").lower()
+            assert "totalreclaw_setup" not in ctx
+
+    def test_pre_llm_call_configured_user_no_nudge(self):
+        """Configured users don't see the setup nudge."""
+        from totalreclaw.hermes.hooks import pre_llm_call
+        from totalreclaw.hermes.state import PluginState
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(Path, "exists", return_value=False):
+                state = PluginState()
+        state._client = MagicMock()  # Forge configured state
+
+        with patch("totalreclaw.hermes.hooks.auto_recall", return_value=None):
+            result = pre_llm_call(
+                state,
+                is_first_turn=True,
+                user_message="Any natural question",
+            )
+        # No nudge when configured.
+        if result is not None:
+            ctx = result.get("context", "").lower()
+            assert "totalreclaw_setup" not in ctx


### PR DESCRIPTION
## Summary

- Phase 2 of the v1.0.x stabilization wave (QA-V1CLEAN-VPS-20260418 returned NO-GO). Fixes the Hermes-plugin-specific bugs (#5, #6, #8, #9) so automatic memory extraction, recall, and store-time dedup all behave for a new user on a fresh machine.
- **Bug #5** — Surface the silent "no LLM config" failure: bumped the extraction-path log from INFO to WARNING with actionable guidance, and added a one-time user-visible quota-channel warning from `post_llm_call` so the agent sees the explanation in its next turn.
- **Bug #6** — Outrank Hermes's built-in `memory` tool: sharpened `totalreclaw_remember` / `totalreclaw_recall` descriptions to position TotalReclaw as the PRIMARY, E2E encrypted, cross-session, cross-agent, on-chain memory vault (with explicit usage hints), and added a first-run setup nudge on `pre_llm_call` for unconfigured installs.
- **Bug #8** — Fix in-batch dedup: added `deduplicate_facts_by_embedding` as the final pass of `extract_facts_llm` / `extract_facts_compaction`. Collapses near-identical facts against existing vault entries AND against earlier facts in the same batch (the QA regression was 3 PyCharm/Darcula facts from a single extraction; prior lifecycle-layer dedup only checked the pre-loop vault snapshot).
- **Bug #9** — Filter product-meta extractions: added `is_product_meta_request` + `_filter_product_meta_facts`. Drops "set up TotalReclaw", "I want encrypted memory across my AI tools", "install the memory plugin", etc. Extraction prompts also get a rule-#6 addition so the LLM skips them upstream; the regex is the safety net. Genuine preferences ("I like encrypted tools", "I prefer Signal because it's encrypted") still pass through.

## Coordination

- Ships as **totalreclaw 2.0.2** — targeted to fold into Phase 1 (`phase1-py202` branch: async-lifecycle + export fixes). Files touched are disjoint from Phase 1's surface (`lifecycle.py`, `recall.py`, `relay.py`, `loop_runner.py`). No shared-infra conflicts. Did NOT bump `pyproject.toml`; rebase on Phase 1 once it lands. Plugin surface only — no relay, Rust core, or other-client changes.

## Test plan

- [x] 19 new unit tests in `python/tests/test_v2_02_hermes_fixes.py` — all passing
- [x] Full Python suite: 574 passed / 9 skipped / 1 xfailed (no regressions)
- [x] 13/13 cross-impl parity preserved (`test_v1_parity.py`, `test_memory_types_parity.py`)
- [ ] Full real-user QA on staging using the release-candidate tarballs (gate per `CLAUDE.md` — user runs this after Phase 1+2 merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)