### PR TITLE
fix(python): v2.0.2 — Event loop lifecycle + export + session id + chain id autodetect

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -144,6 +144,37 @@ Memories stored by the Python client can be recalled by the MCP server, and vice
 
 ## Recent changes
 
+### 2.0.2 — 2026-04-19
+
+Real-user QA on a clean VPS install of 2.0.1 flagged four bugs that made
+the Python client effectively unusable for new users. All four are fixed
+in 2.0.2:
+
+- **`Event loop is closed`** across `totalreclaw_status`, `totalreclaw_export`,
+  and the `pre_llm_call` auto-recall hook. Root cause: sync hook callbacks
+  created a fresh `asyncio.new_event_loop()` per call, caching an
+  `httpx.AsyncClient` that got orphaned across loop boundaries. Fix:
+  process-wide background event loop (`totalreclaw.agent.loop_runner`) that
+  owns every async call from sync code, plus per-loop caching of the
+  internal `httpx.AsyncClient`.
+- **`totalreclaw_export` returning `count=0`** despite facts on-chain.
+  Same root cause as above — the subgraph query silently failed with
+  `Event loop is closed` and the outer `except` returned an empty list.
+  Fixed by the same per-loop httpx cache.
+- **`TOTALRECLAW_SESSION_ID` rejected as a removed env var** by 2.0.1's
+  v1 cleanup. Broke Axiom session-scoped log queries. Restored: the
+  `RelayClient` now accepts `session_id=` (or picks it up from the env
+  var) and forwards it as `X-TotalReclaw-Session` on every HTTP call.
+- **No chain-id auto-detect for Pro-tier users.** 2.0.1 hardcoded chain
+  `84532` (Base Sepolia), so Pro Python users had writes signed for the
+  wrong chain and the relay silently returned AA23. `resolve_chain_id()`
+  now reads `/v1/billing/status` once and switches to chain `100` (Gnosis)
+  for Pro accounts, matching MCP. Best-effort: network errors fall back
+  to free-tier chain so offline users keep working.
+
+No data-loss: existing facts on-chain remain intact; only the Python
+client's user-experience layer changed.
+
 ### 2.0.1 — 2026-04-18
 
 - Fixed `wallet_address` property returning the EOA placeholder before

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "totalreclaw"
-version = "2.0.1"
+version = "2.0.2"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"

--- a/python/src/totalreclaw/agent/lifecycle.py
+++ b/python/src/totalreclaw/agent/lifecycle.py
@@ -6,10 +6,14 @@ called from any agent framework's lifecycle hooks.
 
 This module is framework-agnostic and can be used by any Python agent
 integration (Hermes, LangChain, CrewAI, or custom agents).
+
+All sync work is driven through ``totalreclaw.agent.loop_runner.run_sync``
+rather than per-call ``asyncio.new_event_loop`` pairs — see the module
+docstring there for the rationale (QA-V1CLEAN-VPS-20260418 "Event loop is
+closed" bug).
 """
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import Optional, TYPE_CHECKING
 
@@ -19,13 +23,14 @@ if TYPE_CHECKING:
 from .extraction import ExtractedFact, extract_facts_llm, extract_facts_heuristic
 from .contradiction import detect_and_resolve_contradictions
 from .debrief import generate_debrief
+from .loop_runner import run_sync
 
 logger = logging.getLogger(__name__)
 
 STORE_DEDUP_THRESHOLD = 0.85  # Cosine similarity for near-duplicate detection
 
 
-def _fetch_recent_memories(state: "AgentState", loop: asyncio.AbstractEventLoop) -> list[dict]:
+def _fetch_recent_memories(state: "AgentState") -> list[dict]:
     """Fetch recent memories from the vault for dedup context.
 
     Returns dicts with id, text, and embedding for both LLM dedup context and
@@ -36,9 +41,7 @@ def _fetch_recent_memories(state: "AgentState", loop: asyncio.AbstractEventLoop)
         return []
     try:
         # Use a generic query to get recent memories for dedup
-        results = loop.run_until_complete(
-            client.recall("recent context", top_k=50)
-        )
+        results = run_sync(client.recall("recent context", top_k=50))
         return [{"id": r.id, "text": r.text, "embedding": r.embedding} for r in results]
     except Exception as e:
         logger.debug("Failed to fetch recent memories for dedup: %s", e)
@@ -141,97 +144,89 @@ def auto_extract(state: "AgentState", mode: str = "turn", llm_config=None) -> li
         return []
 
     stored_texts: list[str] = []
-    loop = asyncio.new_event_loop()
+
+    # Fetch existing memories for both LLM dedup context and cosine dedup
+    existing_memories = _fetch_recent_memories(state)
+
+    # Try LLM extraction first
+    facts: list[ExtractedFact] = []
     try:
-        # Fetch existing memories for both LLM dedup context and cosine dedup
-        existing_memories = _fetch_recent_memories(state, loop)
+        facts = run_sync(
+            extract_facts_llm(messages, mode=mode, existing_memories=existing_memories, llm_config=llm_config)
+        )
+    except Exception as e:
+        logger.debug("LLM extraction failed, falling back to heuristic: %s", e)
 
-        # Try LLM extraction first
-        facts: list[ExtractedFact] = []
+    # Fall back to heuristic if LLM returned nothing
+    if not facts:
+        facts = extract_facts_heuristic(messages, max_facts)
+
+    if not facts:
+        state.mark_messages_processed()
+        return []
+
+    # Cap to max_facts
+    facts = facts[:max_facts]
+
+    # Contradiction detection: filter out facts that lose to existing vault claims
+    try:
+        facts = run_sync(detect_and_resolve_contradictions(facts, client, logger))
+    except Exception as exc:
+        logger.debug("Contradiction detection failed (proceeding with all facts): %s", exc)
+
+    for fact in facts:
         try:
-            facts = loop.run_until_complete(
-                extract_facts_llm(messages, mode=mode, existing_memories=existing_memories, llm_config=llm_config)
-            )
-        except Exception as e:
-            logger.debug("LLM extraction failed, falling back to heuristic: %s", e)
+            if fact.action == "NOOP":
+                continue
 
-        # Fall back to heuristic if LLM returned nothing
-        if not facts:
-            facts = extract_facts_heuristic(messages, max_facts)
+            if fact.action == "DELETE":
+                # Tombstone the old fact
+                if fact.existing_fact_id:
+                    run_sync(client.forget(fact.existing_fact_id))
+                continue
 
-        if not facts:
-            return []
-
-        # Cap to max_facts
-        facts = facts[:max_facts]
-
-        # Contradiction detection: filter out facts that lose to existing vault claims
-        try:
-            facts = loop.run_until_complete(
-                detect_and_resolve_contradictions(facts, client, logger)
-            )
-        except Exception as exc:
-            logger.debug("Contradiction detection failed (proceeding with all facts): %s", exc)
-
-        for fact in facts:
+            # For ADD and UPDATE: store the new fact
+            embedding = None
             try:
-                if fact.action == "NOOP":
+                from totalreclaw.embedding import get_embedding
+                embedding = get_embedding(fact.text)
+            except Exception:
+                pass
+
+            # Store-time near-duplicate detection (skip if cosine sim >= threshold)
+            # UPDATE actions always store (they supersede the old fact)
+            if fact.action != "UPDATE" and embedding and existing_memories:
+                if _is_near_duplicate(embedding, existing_memories):
+                    logger.debug("Skipping near-duplicate fact: %s", fact.text[:80])
                     continue
 
-                if fact.action == "DELETE":
-                    # Tombstone the old fact
-                    if fact.existing_fact_id:
-                        loop.run_until_complete(
-                            client.forget(fact.existing_fact_id)
-                        )
-                    continue
-
-                # For ADD and UPDATE: store the new fact
-                embedding = None
-                try:
-                    from totalreclaw.embedding import get_embedding
-                    embedding = get_embedding(fact.text)
-                except Exception:
-                    pass
-
-                # Store-time near-duplicate detection (skip if cosine sim >= threshold)
-                # UPDATE actions always store (they supersede the old fact)
-                if fact.action != "UPDATE" and embedding and existing_memories:
-                    if _is_near_duplicate(embedding, existing_memories):
-                        logger.debug("Skipping near-duplicate fact: %s", fact.text[:80])
-                        continue
-
-                # v1 write path — forward the taxonomy fields the extractor
-                # populated (source/scope/reasoning/volatility). Defensive
-                # fallback for source matches the plugin's
-                # ``storeExtractedFacts`` handling.
-                loop.run_until_complete(
-                    client.remember(
-                        fact.text,
-                        embedding=embedding,
-                        importance=fact.importance / 10.0,  # Normalize 1-10 to 0.0-1.0
-                        source="hermes-auto",
-                        fact_type=fact.type,
-                        entities=fact.entities,
-                        confidence=fact.confidence,
-                        provenance=fact.source or "user-inferred",
-                        scope=fact.scope or "unspecified",
-                        reasoning=fact.reasoning,
-                        volatility=fact.volatility,
-                    )
+            # v1 write path — forward the taxonomy fields the extractor
+            # populated (source/scope/reasoning/volatility). Defensive
+            # fallback for source matches the plugin's
+            # ``storeExtractedFacts`` handling.
+            run_sync(
+                client.remember(
+                    fact.text,
+                    embedding=embedding,
+                    importance=fact.importance / 10.0,  # Normalize 1-10 to 0.0-1.0
+                    source="hermes-auto",
+                    fact_type=fact.type,
+                    entities=fact.entities,
+                    confidence=fact.confidence,
+                    provenance=fact.source or "user-inferred",
+                    scope=fact.scope or "unspecified",
+                    reasoning=fact.reasoning,
+                    volatility=fact.volatility,
                 )
-                stored_texts.append(fact.text)
+            )
+            stored_texts.append(fact.text)
 
-                # For UPDATE: also tombstone the old fact after storing the new one
-                if fact.action == "UPDATE" and fact.existing_fact_id:
-                    loop.run_until_complete(
-                        client.forget(fact.existing_fact_id)
-                    )
+            # For UPDATE: also tombstone the old fact after storing the new one
+            if fact.action == "UPDATE" and fact.existing_fact_id:
+                run_sync(client.forget(fact.existing_fact_id))
 
-            except Exception as e:
-                logger.warning("Failed to store/process extracted fact: %s", e)
-    finally:
-        loop.close()
+        except Exception as e:
+            logger.warning("Failed to store/process extracted fact: %s", e)
 
     state.mark_messages_processed()
     return stored_texts
@@ -260,31 +255,25 @@ def session_debrief(state: "AgentState", stored_fact_texts: Optional[list[str]] 
         return
 
     try:
-        loop = asyncio.new_event_loop()
-        try:
-            debrief_items = loop.run_until_complete(
-                generate_debrief(all_messages, stored_fact_texts)
-            )
-            if debrief_items:
-                for item in debrief_items:
-                    try:
-                        # v1 debrief items are summaries with derived
-                        # provenance — the assistant-side debrief pipeline
-                        # synthesized them from the conversation, so the
-                        # v1 source is always "derived" (plugin parity).
-                        loop.run_until_complete(
-                            client.remember(
-                                item.text,
-                                importance=item.importance / 10.0,
-                                source="hermes_debrief",
-                                fact_type="summary",
-                                provenance="derived",
-                                scope="unspecified",
-                            )
+        debrief_items = run_sync(generate_debrief(all_messages, stored_fact_texts))
+        if debrief_items:
+            for item in debrief_items:
+                try:
+                    # v1 debrief items are summaries with derived
+                    # provenance — the assistant-side debrief pipeline
+                    # synthesized them from the conversation, so the
+                    # v1 source is always "derived" (plugin parity).
+                    run_sync(
+                        client.remember(
+                            item.text,
+                            importance=item.importance / 10.0,
+                            source="hermes_debrief",
+                            fact_type="summary",
+                            provenance="derived",
+                            scope="unspecified",
                         )
-                    except Exception as e:
-                        logger.warning("Failed to store debrief item: %s", e)
-        finally:
-            loop.close()
+                    )
+                except Exception as e:
+                    logger.warning("Failed to store debrief item: %s", e)
     except Exception as e:
         logger.warning("Session debrief failed: %s", e)

--- a/python/src/totalreclaw/agent/loop_runner.py
+++ b/python/src/totalreclaw/agent/loop_runner.py
@@ -1,0 +1,196 @@
+"""Process-wide background event loop for sync hook callers.
+
+QA reference: ``docs/notes/QA-V1CLEAN-VPS-20260418.md``. v2.0.1 had three
+user-visible "Event loop is closed" failures:
+
+* ``totalreclaw_status`` (every call)
+* ``totalreclaw_export`` (every call)
+* ``pre_llm_call`` auto-recall hook (every first turn)
+
+Root cause
+----------
+Every sync hook and sync tool wrapper built a fresh ``asyncio.new_event_loop()``
+for a single ``run_until_complete`` and then closed it. That worked for the
+*first* call, but inside ``client.recall`` / ``client.status`` an
+``httpx.AsyncClient`` gets cached on the RelayClient for reuse. ``httpx``
+binds to whichever loop was running when it was constructed. The second sync
+call spun up a *new* loop, reused the cached httpx client, and blew up with
+``RuntimeError: Event loop is closed`` the moment the anyio/httpcore pool
+tried to schedule anything on the now-dead loop.
+
+Fix
+---
+One loop, one thread, for the entire process lifetime. All sync callers go
+through ``get_sync_loop_runner().run(coro)`` which schedules the coroutine
+on the persistent loop via ``asyncio.run_coroutine_threadsafe``. The httpx
+client is thus always constructed on (and reused from) the same loop, so
+nothing can ever get orphaned.
+
+The loop is lazily created on first use. The thread is a daemon, so it
+shuts down when the host process exits. Explicit shutdown is available via
+``shutdown_sync_loop_runner`` for tests that want to assert deterministic
+teardown.
+
+Thread-safety
+-------------
+``get_sync_loop_runner`` is protected by a module lock so concurrent
+importers can't race on the first call. Once installed, the runner itself
+is read-only state; ``run`` is safe from any thread because
+``asyncio.run_coroutine_threadsafe`` handles the cross-thread hand-off.
+
+Not a general-purpose asyncio host
+----------------------------------
+This module is intentionally narrow. It exists so that sync hook callbacks
+(Hermes ``pre_llm_call``, ``post_llm_call``, etc.) and sync tool shims can
+drive async code without the event-loop-is-closed trap. If you are already
+inside an event loop, don't use this — just ``await`` directly.
+"""
+from __future__ import annotations
+
+import asyncio
+import atexit
+import logging
+import threading
+from typing import Any, Awaitable, Coroutine, Optional, TypeVar
+
+logger = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
+
+
+class _SyncLoopRunner:
+    """One-loop, one-thread runner for sync-calls-async bridging.
+
+    Use via :func:`get_sync_loop_runner`.
+    """
+
+    def __init__(self) -> None:
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._thread: Optional[threading.Thread] = None
+        self._ready = threading.Event()
+        self._start()
+
+    def _start(self) -> None:
+        def _loop_thread_main() -> None:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            self._loop = loop
+            self._ready.set()
+            try:
+                loop.run_forever()
+            finally:
+                # Drain any pending tasks so we don't leak warnings on shutdown.
+                try:
+                    pending = asyncio.all_tasks(loop)
+                    for task in pending:
+                        task.cancel()
+                    if pending:
+                        loop.run_until_complete(
+                            asyncio.gather(*pending, return_exceptions=True)
+                        )
+                except Exception:  # pragma: no cover — best-effort drain
+                    pass
+                loop.close()
+
+        t = threading.Thread(
+            target=_loop_thread_main,
+            name="totalreclaw-sync-loop",
+            daemon=True,
+        )
+        t.start()
+        # Block until the loop is actually running — otherwise .run() races.
+        self._ready.wait(timeout=5.0)
+        if self._loop is None:  # pragma: no cover — sanity
+            raise RuntimeError("TotalReclaw sync loop failed to start within 5s")
+        self._thread = t
+
+    def run(self, coro: Coroutine[Any, Any, _T]) -> _T:
+        """Run a coroutine on the persistent loop and return its result.
+
+        Blocks the calling thread until the coroutine completes. Propagates
+        exceptions from the coroutine synchronously.
+
+        Must not be called from inside the loop's own thread.
+        """
+        if self._loop is None:  # pragma: no cover — sanity, _start blocks
+            raise RuntimeError("sync loop runner is not started")
+
+        # Guard against accidental self-scheduling (would deadlock).
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+        if running is self._loop:  # pragma: no cover
+            raise RuntimeError(
+                "_SyncLoopRunner.run called from inside its own loop; "
+                "use await directly instead."
+            )
+
+        fut = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        return fut.result()
+
+    def shutdown(self, timeout: float = 5.0) -> None:
+        """Stop the loop and join the thread.
+
+        Idempotent. Safe to call multiple times. Not usually needed — the
+        thread is a daemon and goes away with the process.
+        """
+        loop = self._loop
+        thread = self._thread
+        if loop is None or thread is None:
+            return
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=timeout)
+        self._loop = None
+        self._thread = None
+
+
+_singleton: Optional[_SyncLoopRunner] = None
+_singleton_lock = threading.Lock()
+
+
+def get_sync_loop_runner() -> _SyncLoopRunner:
+    """Return the process-wide :class:`_SyncLoopRunner`, creating it once.
+
+    The runner is lazily started on first call. All subsequent calls from
+    any thread return the same instance.
+    """
+    global _singleton
+    if _singleton is not None:
+        return _singleton
+    with _singleton_lock:
+        if _singleton is None:
+            _singleton = _SyncLoopRunner()
+            # Clean shutdown on interpreter exit. This is best-effort — the
+            # thread is a daemon so it'll die with the process anyway, but
+            # the explicit stop avoids "event loop is running during shutdown"
+            # warnings on some platforms.
+            atexit.register(_atexit_shutdown)
+    return _singleton
+
+
+def _atexit_shutdown() -> None:  # pragma: no cover — exit path
+    global _singleton
+    if _singleton is not None:
+        try:
+            _singleton.shutdown(timeout=1.0)
+        except Exception:
+            pass
+        _singleton = None
+
+
+def shutdown_sync_loop_runner() -> None:
+    """Test-visible shutdown for deterministic teardown."""
+    global _singleton
+    if _singleton is not None:
+        _singleton.shutdown()
+        _singleton = None
+
+
+def run_sync(coro: Coroutine[Any, Any, _T]) -> _T:
+    """Convenience wrapper: run a coroutine on the persistent loop.
+
+    Short alias for ``get_sync_loop_runner().run(coro)``. Preferred by
+    sync callers that want a one-liner.
+    """
+    return get_sync_loop_runner().run(coro)

--- a/python/src/totalreclaw/agent/recall.py
+++ b/python/src/totalreclaw/agent/recall.py
@@ -9,9 +9,10 @@ integration (Hermes, LangChain, CrewAI, or custom agents).
 """
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import Optional, TYPE_CHECKING
+
+from .loop_runner import run_sync
 
 if TYPE_CHECKING:
     from .state import AgentState
@@ -26,8 +27,11 @@ def auto_recall(
 ) -> Optional[str]:
     """Search the vault and return formatted context string, or None.
 
-    This is a synchronous wrapper that creates an event loop internally,
-    suitable for use in agent hooks that may not be async.
+    This is a synchronous wrapper suitable for use in agent hooks that may
+    not be async. Uses the process-wide sync loop runner so that the
+    underlying ``httpx.AsyncClient`` (cached on the RelayClient) is never
+    orphaned across short-lived loops — historically the cause of
+    ``RuntimeError: Event loop is closed`` in v2.0.1 (QA-V1CLEAN-VPS-20260418).
 
     Args:
         query: The user's message or search query.
@@ -45,13 +49,7 @@ def auto_recall(
         return None
 
     try:
-        loop = asyncio.new_event_loop()
-        try:
-            results = loop.run_until_complete(
-                client.recall(query, top_k=top_k)
-            )
-        finally:
-            loop.close()
+        results = run_sync(client.recall(query, top_k=top_k))
 
         if results:
             memories = "\n".join(f"- [{r.category}] {r.text}" for r in results)

--- a/python/src/totalreclaw/agent/state.py
+++ b/python/src/totalreclaw/agent/state.py
@@ -27,13 +27,19 @@ STORE_DEDUP_THRESHOLD = 0.85  # Cosine similarity threshold for near-duplicate d
 
 # v1 env var cleanup — warn once if any removed env var is still set.
 # See docs/guides/env-vars-reference.md for the canonical list.
+#
+# NOTE: ``TOTALRECLAW_SESSION_ID`` was in this list in v2.0.1 and silently
+# rejected with a cryptic warning, which broke Axiom log tracing — QA
+# skill and internal docs rely on it (see
+# docs/notes/QA-V1CLEAN-VPS-20260418.md Bug #1). Restored in v2.0.2: the
+# RelayClient now reads it (or the equivalent constructor arg) and
+# forwards it to the relay as ``X-TotalReclaw-Session`` on every request.
 _REMOVED_ENV_VARS = (
     "TOTALRECLAW_CHAIN_ID",
     "TOTALRECLAW_EMBEDDING_MODEL",
     "TOTALRECLAW_STORE_DEDUP",
     "TOTALRECLAW_LLM_MODEL",
     "TOTALRECLAW_EXTRACTION_MODEL",
-    "TOTALRECLAW_SESSION_ID",
     "TOTALRECLAW_TAXONOMY_VERSION",
     "TOTALRECLAW_CLAIM_FORMAT",
     "TOTALRECLAW_DIGEST_MODE",

--- a/python/src/totalreclaw/client.py
+++ b/python/src/totalreclaw/client.py
@@ -18,6 +18,8 @@ backwards compatibility but are deprecated.
 from __future__ import annotations
 from typing import Optional
 
+import httpx as _httpx
+
 from .crypto import (
     derive_keys_from_mnemonic,
     derive_lsh_seed,
@@ -41,6 +43,19 @@ from .operations import (
 # SimpleSmartAccount in the permissionless library
 SIMPLE_ACCOUNT_FACTORY = "0x91E60e0613810449d098b0b5Ec8b51A0FE8c8985"
 ENTRYPOINT_V07 = "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
+
+# Default chain IDs for the two supported tiers.
+#
+# Free tier -> Base Sepolia (testnet, Pimlico sponsors gas).
+# Pro tier  -> Gnosis mainnet (permanent on-chain storage).
+#
+# The user-facing ``TOTALRECLAW_CHAIN_ID`` override was removed in the v1
+# env cleanup; chain selection is now derived from billing tier. See
+# :func:`TotalReclaw.resolve_chain_id` and the MCP equivalent at
+# ``mcp/src/index.ts`` line ~346 for the cross-implementation contract.
+DEFAULT_CHAIN_ID_FREE: int = 84532
+DEFAULT_CHAIN_ID_PRO: int = 100
+CHAIN_ID_AUTODETECT_TIMEOUT_SECONDS: float = 5.0
 
 
 def _get_eoa_account(mnemonic: str):
@@ -180,6 +195,13 @@ class TotalReclaw:
             session_id=session_id,
         )
         self._registered = False
+        # Chain ID is auto-detected from billing tier on first write. Pro
+        # tier -> Gnosis (100); otherwise free-tier Base Sepolia (84532).
+        # Matches the MCP behavior (mcp/src/index.ts ~346). The former
+        # TOTALRECLAW_CHAIN_ID env var was removed in the v1 cleanup; no
+        # user override is exposed here.
+        self._chain_id: int = DEFAULT_CHAIN_ID_FREE
+        self._chain_id_resolved: bool = False
 
     async def resolve_address(self) -> str:
         """Resolve the CREATE2 Smart Account address via RPC.
@@ -215,6 +237,92 @@ class TotalReclaw:
         except Exception:
             # Best-effort — relay may be unreachable; will retry on next call.
             pass
+
+    async def resolve_chain_id(self) -> int:
+        """Auto-detect target chain ID from billing tier.
+
+        Mirrors the MCP behavior (``mcp/src/index.ts`` ~346). Makes a
+        best-effort ``GET /v1/billing/status?wallet_address=<sa>`` call and
+        returns:
+
+        * :data:`DEFAULT_CHAIN_ID_PRO` (100, Gnosis mainnet) if the
+          response's ``tier == "pro"``.
+        * :data:`DEFAULT_CHAIN_ID_FREE` (84532, Base Sepolia) otherwise.
+
+        Errors from the billing endpoint (network, auth, malformed JSON)
+        are swallowed — we fall back to the free-tier chain so the client
+        is usable offline. The result is cached on the client for the
+        lifetime of the instance.
+
+        Without this, Pro users' Python writes were signed for Base
+        Sepolia but the relay routed them to Gnosis, producing silent AA23
+        failures (QA-V1CLEAN-VPS-20260418 Bug #11).
+        """
+        if self._chain_id_resolved:
+            return self._chain_id
+        await self._ensure_address()
+        sa = self._wallet_address
+        assert sa is not None
+
+        # Use a short-lived httpx client — don't touch the RelayClient's
+        # per-loop cache since this runs very early (before register).
+        relay_url = self._relay._relay_url.rstrip("/")
+        billing_url = f"{relay_url}/v1/billing/status"
+        headers: dict[str, str] = {
+            "Authorization": f"Bearer {self._auth_key_hex}",
+            "X-TotalReclaw-Client": self._relay._client_id,
+        }
+        session_id = getattr(self._relay, "_session_id", None)
+        if session_id:
+            headers["X-TotalReclaw-Session"] = session_id
+
+        try:
+            async with _httpx.AsyncClient(
+                timeout=CHAIN_ID_AUTODETECT_TIMEOUT_SECONDS,
+            ) as http:
+                resp = await http.get(
+                    billing_url,
+                    params={"wallet_address": sa},
+                    headers=headers,
+                )
+            if resp.status_code == 200:
+                payload = resp.json()
+                if isinstance(payload, dict) and payload.get("tier") == "pro":
+                    self._chain_id = DEFAULT_CHAIN_ID_PRO
+                else:
+                    self._chain_id = DEFAULT_CHAIN_ID_FREE
+            else:
+                self._chain_id = DEFAULT_CHAIN_ID_FREE
+        except Exception:
+            # Best-effort — network, timeout, or auth issues all fall back
+            # to the free-tier chain. Matches the MCP "silently default"
+            # contract (mcp/src/index.ts line ~371).
+            self._chain_id = DEFAULT_CHAIN_ID_FREE
+
+        self._chain_id_resolved = True
+        return self._chain_id
+
+    async def _ensure_chain_id(self) -> int:
+        """Lazily resolve chain_id if not yet done."""
+        if not self._chain_id_resolved:
+            await self.resolve_chain_id()
+        return self._chain_id
+
+    @property
+    def chain_id(self) -> int:
+        """Return the resolved chain ID.
+
+        Raises ``RuntimeError`` if called before the chain has been
+        resolved (i.e. before any ``remember``/``forget``/``pin``/``unpin``
+        call, or an explicit ``await client.resolve_chain_id()``).
+        """
+        if not self._chain_id_resolved:
+            raise RuntimeError(
+                "Chain ID not yet resolved. Call `await client.resolve_chain_id()` "
+                "first, or just call `remember`/`forget`/`pin_fact`/`unpin_fact` "
+                "(they resolve lazily)."
+            )
+        return self._chain_id
 
     def _get_lsh_hasher(self, dims: int = 640) -> LSHHasher:
         if self._lsh_hasher is None:
@@ -336,6 +444,7 @@ class TotalReclaw:
         """
         await self._ensure_address()
         await self._ensure_registered()
+        chain_id = await self._ensure_chain_id()
         lsh = self._get_lsh_hasher() if embedding else None
         return await store_fact(
             text=text,
@@ -356,6 +465,7 @@ class TotalReclaw:
             eoa_private_key=self._eoa_private_key,
             eoa_address=self._eoa_address,
             sender=self._wallet_address,
+            chain_id=chain_id,
         )
 
     async def recall(
@@ -384,6 +494,7 @@ class TotalReclaw:
         """Soft-delete a fact by writing a tombstone."""
         await self._ensure_address()
         await self._ensure_registered()
+        chain_id = await self._ensure_chain_id()
         return await forget_fact(
             fact_id,
             self._wallet_address,
@@ -391,6 +502,7 @@ class TotalReclaw:
             eoa_private_key=self._eoa_private_key,
             eoa_address=self._eoa_address,
             sender=self._wallet_address,
+            chain_id=chain_id,
         )
 
     async def pin_fact(self, fact_id: str) -> dict:
@@ -409,6 +521,7 @@ class TotalReclaw:
         """
         await self._ensure_address()
         await self._ensure_registered()
+        chain_id = await self._ensure_chain_id()
         return await pin_fact(
             fact_id=fact_id,
             keys=self._keys,
@@ -417,6 +530,7 @@ class TotalReclaw:
             eoa_private_key=self._eoa_private_key,
             eoa_address=self._eoa_address,
             sender=self._wallet_address,
+            chain_id=chain_id,
         )
 
     async def unpin_fact(self, fact_id: str) -> dict:
@@ -427,6 +541,7 @@ class TotalReclaw:
         """
         await self._ensure_address()
         await self._ensure_registered()
+        chain_id = await self._ensure_chain_id()
         return await unpin_fact(
             fact_id=fact_id,
             keys=self._keys,
@@ -435,6 +550,7 @@ class TotalReclaw:
             eoa_private_key=self._eoa_private_key,
             eoa_address=self._eoa_address,
             sender=self._wallet_address,
+            chain_id=chain_id,
         )
 
     async def export_all(self) -> list[dict]:

--- a/python/src/totalreclaw/client.py
+++ b/python/src/totalreclaw/client.py
@@ -125,6 +125,11 @@ class TotalReclaw:
         Pre-resolved Smart Account address.
     is_test : bool
         Send ``X-TotalReclaw-Test: true`` header.
+    session_id : str, optional
+        Session tag forwarded to the relay as ``X-TotalReclaw-Session`` for
+        Axiom log tracing. If not provided, falls back to the
+        ``TOTALRECLAW_SESSION_ID`` env var. Useful for QA runs that want
+        session-scoped relay logs.
     """
 
     def __init__(
@@ -136,6 +141,7 @@ class TotalReclaw:
         *,
         mnemonic: Optional[str] = None,
         relay_url: Optional[str] = None,
+        session_id: Optional[str] = None,
     ):
         resolved_mnemonic = recovery_phrase or mnemonic
         if not resolved_mnemonic:
@@ -171,6 +177,7 @@ class TotalReclaw:
             auth_key_hex=self._auth_key_hex,
             wallet_address=self._wallet_address,
             is_test=is_test,
+            session_id=session_id,
         )
         self._registered = False
 

--- a/python/src/totalreclaw/operations.py
+++ b/python/src/totalreclaw/operations.py
@@ -280,6 +280,7 @@ async def store_fact(
         wallet_address=smart_account,
         chain_id=chain_id,
         client_id=relay._client_id,
+        session_id=getattr(relay, "_session_id", None),
     )
 
     return fact_id
@@ -497,6 +498,7 @@ async def forget_fact(
             wallet_address=smart_account,
             chain_id=chain_id,
             client_id=relay._client_id,
+            session_id=getattr(relay, "_session_id", None),
         )
         return True
     except Exception:
@@ -748,6 +750,7 @@ async def _change_claim_status(
         wallet_address=smart_account,
         chain_id=chain_id,
         client_id=relay._client_id,
+        session_id=getattr(relay, "_session_id", None),
     )
 
     new_protobuf = encode_fact_protobuf(payload)
@@ -761,6 +764,7 @@ async def _change_claim_status(
         wallet_address=smart_account,
         chain_id=chain_id,
         client_id=relay._client_id,
+        session_id=getattr(relay, "_session_id", None),
     )
 
     return {

--- a/python/src/totalreclaw/relay.py
+++ b/python/src/totalreclaw/relay.py
@@ -2,13 +2,41 @@
 TotalReclaw Relay Client.
 
 Async HTTP client for the TotalReclaw relay service.
+
+Event-loop binding
+------------------
+``httpx.AsyncClient`` binds to the event loop that was running when it was
+constructed (via anyio / httpcore primitives). Sharing one instance across
+two different loops raises ``RuntimeError: Event loop is closed`` the
+moment any I/O is attempted on the "wrong" loop — see
+``python/src/totalreclaw/agent/loop_runner.py`` for the root-cause writeup.
+
+The Python client has at least two loop contexts in production:
+
+* The process-wide :class:`_SyncLoopRunner` loop, used by sync Hermes hook
+  callbacks (e.g. ``pre_llm_call`` auto-recall).
+* Hermes's own async runtime loop, used when it invokes async tool handlers
+  like ``totalreclaw_status``.
+
+Historically v2.0.1 cached a single ``httpx.AsyncClient`` on the RelayClient
+and returned it from ``_get_http`` regardless of which loop was calling.
+That tripped "Event loop is closed" as soon as the second loop tried to
+use the client (QA-V1CLEAN-VPS-20260418).
+
+The fix below keeps the convenience of a cached client but keys the cache
+by the currently-running event loop, so each loop gets its own, correctly
+loop-bound client. Old clients from orphaned loops are dropped.
 """
 from __future__ import annotations
+import asyncio
+import logging
 import os
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
 import httpx
+
+logger = logging.getLogger(__name__)
 
 _HARDCODED_PRODUCTION_URL = "https://api.totalreclaw.xyz"
 
@@ -75,12 +103,74 @@ class RelayClient:
         self._wallet_address = wallet_address
         self._client_id = _detect_client_id()
         self._is_test = is_test or os.environ.get("TOTALRECLAW_TEST", "").lower() == "true"
-        self._http: Optional[httpx.AsyncClient] = None
+        # Cache httpx.AsyncClient per event loop. Sharing one client across
+        # loops is the root cause of "Event loop is closed" in v2.0.1 — see
+        # the module docstring. Keying by ``id(loop)`` means each loop gets
+        # its own client, correctly bound, and orphaned clients (from
+        # short-lived sync loops) are dropped transparently.
+        self._http_per_loop: dict[int, httpx.AsyncClient] = {}
 
     async def _get_http(self) -> httpx.AsyncClient:
-        if self._http is None or self._http.is_closed:
-            self._http = httpx.AsyncClient(timeout=30.0)
-        return self._http
+        """Return an ``httpx.AsyncClient`` bound to the current event loop.
+
+        If the loop we're running on already has a cached client, reuse it
+        (connection pooling is preserved within a loop). Otherwise build a
+        fresh one. We never try to carry an httpx client across loops —
+        that's the bug we're fixing.
+        """
+        loop = asyncio.get_running_loop()
+        loop_id = id(loop)
+        cached = self._http_per_loop.get(loop_id)
+        if cached is not None and not cached.is_closed:
+            return cached
+        if cached is not None and cached.is_closed:
+            # Best-effort cleanup of the stale entry — the client already
+            # released its own sockets when it closed, but we still want
+            # the dict key gone so it doesn't grow unbounded.
+            self._http_per_loop.pop(loop_id, None)
+        client = httpx.AsyncClient(timeout=30.0)
+        self._http_per_loop[loop_id] = client
+        return client
+
+    # Backward-compat shim: some legacy callers and tests read / write
+    # ``self._http`` directly (particularly tests that monkeypatch the
+    # transport). Expose it as a property mapped to the current loop's
+    # cached client so the old API keeps working.
+    @property
+    def _http(self) -> Optional[httpx.AsyncClient]:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # No running loop — return whichever entry exists (usually a
+            # test setting up state before a call). ``None`` if empty.
+            if self._http_per_loop:
+                return next(iter(self._http_per_loop.values()))
+            return None
+        return self._http_per_loop.get(id(loop))
+
+    @_http.setter
+    def _http(self, value: Optional[httpx.AsyncClient]) -> None:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # Outside any loop — apply to all cache entries so tests that
+            # assign a mock transport before making an async call see the
+            # replacement from whichever loop their call runs on.
+            if value is None:
+                self._http_per_loop.clear()
+            else:
+                # Can't bind without a loop, but the caller explicitly set
+                # a value — trust it for the next .get on any loop.
+                # This path is only really used by tests that assign a
+                # MockTransport-backed client; using ``0`` as a sentinel
+                # key means ``_get_http`` will find+reuse it on first call
+                # inside a loop as long as it isn't closed.
+                self._http_per_loop[0] = value
+            return
+        if value is None:
+            self._http_per_loop.pop(id(loop), None)
+        else:
+            self._http_per_loop[id(loop)] = value
 
     def _base_headers(self) -> dict[str, str]:
         headers = {
@@ -181,5 +271,23 @@ class RelayClient:
         return CheckoutResponse(checkout_url=data["checkout_url"], session_id=data["session_id"])
 
     async def close(self):
-        if self._http and not self._http.is_closed:
-            await self._http.aclose()
+        """Close any cached httpx clients across all loops we've touched.
+
+        Best-effort: clients from other loops cannot be closed from here
+        (aclose is loop-bound), so we only close the one for the
+        currently-running loop and drop references to the rest so they
+        get garbage-collected. In practice tests call ``close()`` on the
+        same loop they used to create the client, so this works.
+        """
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        current_id = id(loop) if loop is not None else None
+        for loop_id, client in list(self._http_per_loop.items()):
+            if loop_id == current_id and not client.is_closed:
+                try:
+                    await client.aclose()
+                except Exception:  # pragma: no cover — best-effort teardown
+                    pass
+            self._http_per_loop.pop(loop_id, None)

--- a/python/src/totalreclaw/relay.py
+++ b/python/src/totalreclaw/relay.py
@@ -97,12 +97,28 @@ class RelayClient:
         auth_key_hex: Optional[str] = None,
         wallet_address: Optional[str] = None,
         is_test: bool = False,
+        session_id: Optional[str] = None,
     ):
         self._relay_url = relay_url.rstrip("/")
         self._auth_key_hex = auth_key_hex
         self._wallet_address = wallet_address
         self._client_id = _detect_client_id()
         self._is_test = is_test or os.environ.get("TOTALRECLAW_TEST", "").lower() == "true"
+        # Optional session tag forwarded to the relay as ``X-TotalReclaw-Session``
+        # for Axiom log tracing. Resolves at construction in this priority:
+        #
+        #   1. Explicit ``session_id=`` constructor argument.
+        #   2. ``TOTALRECLAW_SESSION_ID`` env var.
+        #   3. None (header omitted).
+        #
+        # The v1 env cleanup accidentally removed this in v2.0.1 and broke
+        # Axiom session-scoped log queries — QA-V1CLEAN-VPS-20260418 Bug #1.
+        # Restored in v2.0.2.
+        resolved_session = session_id
+        if resolved_session is None:
+            env_session = os.environ.get("TOTALRECLAW_SESSION_ID")
+            resolved_session = env_session if env_session else None
+        self._session_id: Optional[str] = resolved_session or None
         # Cache httpx.AsyncClient per event loop. Sharing one client across
         # loops is the root cause of "Event loop is closed" in v2.0.1 — see
         # the module docstring. Keying by ``id(loop)`` means each loop gets
@@ -181,6 +197,11 @@ class RelayClient:
             headers["X-TotalReclaw-Test"] = "true"
         if self._auth_key_hex:
             headers["Authorization"] = f"Bearer {self._auth_key_hex}"
+        # Forward QA-scoped session tag for Axiom log tracing (if set).
+        # Matches the relay's expected header name and the semantic the
+        # plugin used before the v1 env cleanup.
+        if self._session_id:
+            headers["X-TotalReclaw-Session"] = self._session_id
         return headers
 
     async def register(self, auth_key_hash: str, salt_hex: str) -> str:
@@ -191,6 +212,8 @@ class RelayClient:
         }
         if self._is_test:
             headers["X-TotalReclaw-Test"] = "true"
+        if self._session_id:
+            headers["X-TotalReclaw-Session"] = self._session_id
         resp = await http.post(
             f"{self._relay_url}/v1/register",
             headers=headers,

--- a/python/src/totalreclaw/userop.py
+++ b/python/src/totalreclaw/userop.py
@@ -233,6 +233,7 @@ async def build_and_send_userop(
     wallet_address: str,
     chain_id: int = 84532,
     client_id: str = "python-client",
+    session_id: Optional[str] = None,
 ) -> str:
     """Build, sign, and submit a UserOperation through the relay.
 
@@ -256,6 +257,11 @@ async def build_and_send_userop(
         Target chain (84532 = Base Sepolia, 100 = Gnosis).
     client_id : str
         Client identifier for X-TotalReclaw-Client header.
+    session_id : str, optional
+        QA-scoped session tag forwarded as ``X-TotalReclaw-Session`` for
+        Axiom log tracing. Typically populated from
+        ``TOTALRECLAW_SESSION_ID`` at client construction time; see
+        :class:`totalreclaw.relay.RelayClient`.
 
     Returns
     -------
@@ -271,6 +277,8 @@ async def build_and_send_userop(
         "X-TotalReclaw-Client": client_id,
         "X-Wallet-Address": wallet_address,
     }
+    if session_id:
+        headers["X-TotalReclaw-Session"] = session_id
 
     _MAX_NONCE_RETRIES = 3
 

--- a/python/tests/test_chain_id_autodetect.py
+++ b/python/tests/test_chain_id_autodetect.py
@@ -1,0 +1,231 @@
+"""Bug #11 regression tests — chain_id auto-detect from billing tier.
+
+QA-V1CLEAN-VPS-20260418 called this out as KNOWN: the Python client
+hardcoded chain_id = 84532 (Base Sepolia) for every write, but the relay
+routes Pro-tier users to chain 100 (Gnosis mainnet). A Pro user on the
+Python client therefore had all writes signed for Base Sepolia while the
+relay expected Gnosis — producing silent AA23 signature failures.
+
+The MCP server implements auto-detect at ``mcp/src/index.ts`` ~line 346:
+read ``/v1/billing/status?wallet_address=<sa>`` once, and if
+``tier === 'pro'`` use chain 100; otherwise default to 84532. Best-effort:
+any error falls back to free-tier chain so offline / misconfigured users
+still work.
+
+Cross-implementation contract (keep these parity invariants green):
+
+* Free tier / no tier field / error -> chain 84532.
+* ``tier == "pro"`` -> chain 100.
+* The auto-detect is triggered lazily on first write.
+* The user-facing ``TOTALRECLAW_CHAIN_ID`` override was removed in the v1
+  env cleanup and must not be respected by this client.
+"""
+from __future__ import annotations
+
+import json as _json
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+
+TEST_MNEMONIC = (
+    "abandon abandon abandon abandon abandon abandon "
+    "abandon abandon abandon abandon abandon about"
+)
+TEST_SA = "0x2c0cf74b2b76110708ca431796367779e3738250"
+
+
+def _make_client(**kwargs):
+    """Factory for a TotalReclaw with a preset SA so no RPC call is needed."""
+    from totalreclaw.client import TotalReclaw
+
+    c = TotalReclaw(
+        recovery_phrase=TEST_MNEMONIC,
+        wallet_address=TEST_SA,
+        **kwargs,
+    )
+    c._registered = True
+    return c
+
+
+def _patch_billing(response_body: dict | None, status_code: int = 200, raise_exc: Exception | None = None):
+    """Patch httpx.AsyncClient globally for the billing endpoint.
+
+    Returns the captured request list so tests can assert the URL + headers.
+    """
+
+    captured: list[httpx.Request] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        if raise_exc is not None:
+            raise raise_exc
+        if response_body is None:
+            return httpx.Response(status_code, text="")
+        return httpx.Response(status_code, json=response_body)
+
+    transport = httpx.MockTransport(_handler)
+
+    class _PatchedAsyncClient(httpx.AsyncClient):
+        def __init__(self, *args, **kw):
+            kw.pop("transport", None)
+            super().__init__(*args, transport=transport, **kw)
+
+    return patch("totalreclaw.client._httpx.AsyncClient", _PatchedAsyncClient), captured
+
+
+# ---------------------------------------------------------------------------
+# Basic resolve
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_chain_id_free_tier_defaults_to_base_sepolia() -> None:
+    client = _make_client()
+    patch_ctx, captured = _patch_billing({"tier": "free", "free_writes_used": 2, "free_writes_limit": 500})
+    with patch_ctx:
+        chain_id = await client.resolve_chain_id()
+    assert chain_id == 84532
+    assert client._chain_id_resolved is True
+    # Confirm the URL was the billing endpoint with wallet_address param.
+    assert len(captured) == 1
+    req = captured[0]
+    assert "/v1/billing/status" in str(req.url)
+    assert TEST_SA in str(req.url)
+
+
+@pytest.mark.asyncio
+async def test_resolve_chain_id_pro_tier_returns_gnosis() -> None:
+    """``tier == 'pro'`` switches the client to chain 100 (Gnosis)."""
+    client = _make_client()
+    patch_ctx, _ = _patch_billing({"tier": "pro", "free_writes_used": 0, "free_writes_limit": 0})
+    with patch_ctx:
+        chain_id = await client.resolve_chain_id()
+    assert chain_id == 100
+
+
+@pytest.mark.asyncio
+async def test_resolve_chain_id_falls_back_to_free_on_network_error() -> None:
+    """Any httpx error -> default to 84532 (matches MCP 'best-effort')."""
+    client = _make_client()
+    patch_ctx, _ = _patch_billing(None, raise_exc=httpx.ConnectError("DNS down"))
+    with patch_ctx:
+        chain_id = await client.resolve_chain_id()
+    assert chain_id == 84532
+
+
+@pytest.mark.asyncio
+async def test_resolve_chain_id_falls_back_on_non_200_response() -> None:
+    """HTTP 500 from billing -> default to free-tier chain."""
+    client = _make_client()
+    patch_ctx, _ = _patch_billing({"error": "internal"}, status_code=500)
+    with patch_ctx:
+        chain_id = await client.resolve_chain_id()
+    assert chain_id == 84532
+
+
+@pytest.mark.asyncio
+async def test_resolve_chain_id_is_cached_after_first_call() -> None:
+    """Second ``resolve_chain_id`` must not re-hit the network."""
+    client = _make_client()
+    patch_ctx, captured = _patch_billing({"tier": "pro"})
+    with patch_ctx:
+        await client.resolve_chain_id()
+        await client.resolve_chain_id()
+        await client.resolve_chain_id()
+    assert len(captured) == 1, (
+        "resolve_chain_id should cache — second calls must not re-hit billing."
+    )
+
+
+@pytest.mark.asyncio
+async def test_chain_id_property_raises_before_resolve() -> None:
+    """``.chain_id`` must fail loud pre-resolve so callers can't silently
+    use the uninitialized default."""
+    client = _make_client()
+    with pytest.raises(RuntimeError, match="not yet resolved"):
+        _ = client.chain_id
+
+
+# ---------------------------------------------------------------------------
+# Lazy resolution on write paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remember_resolves_chain_id_then_signs_for_pro() -> None:
+    """A Pro user's ``remember`` must sign for Gnosis (chain 100).
+
+    Before Bug #11 was fixed, the Python client silently signed for 84532
+    regardless of tier and the relay routed to Gnosis, producing AA23 on
+    every write. This test pins the contract: after auto-detect fires,
+    ``build_and_send_userop`` sees chain_id=100.
+    """
+    from totalreclaw.client import TotalReclaw
+
+    client = _make_client()
+
+    # Patch the internal httpx call for billing detection.
+    billing_patch, _ = _patch_billing({"tier": "pro"})
+    # Capture the chain_id that flows into the userop builder.
+    mock_userop = AsyncMock(return_value="0xabc123")
+
+    with billing_patch, patch(
+        "totalreclaw.operations.build_and_send_userop", new=mock_userop,
+    ):
+        await client.remember("Pro user fact")
+
+    # build_and_send_userop should have been invoked with chain_id=100.
+    kwargs = mock_userop.await_args.kwargs
+    assert kwargs["chain_id"] == 100, (
+        f"Expected chain_id=100 for Pro tier; got {kwargs['chain_id']}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_remember_defaults_to_base_sepolia_for_free_tier() -> None:
+    client = _make_client()
+    billing_patch, _ = _patch_billing({"tier": "free"})
+    mock_userop = AsyncMock(return_value="0xabc123")
+
+    with billing_patch, patch(
+        "totalreclaw.operations.build_and_send_userop", new=mock_userop,
+    ):
+        await client.remember("Free user fact")
+
+    assert mock_userop.await_args.kwargs["chain_id"] == 84532
+
+
+@pytest.mark.asyncio
+async def test_forget_uses_detected_chain_id() -> None:
+    client = _make_client()
+    billing_patch, _ = _patch_billing({"tier": "pro"})
+    mock_userop = AsyncMock(return_value="0xabc123")
+
+    with billing_patch, patch(
+        "totalreclaw.operations.build_and_send_userop", new=mock_userop,
+    ):
+        await client.forget("fact-uuid")
+
+    assert mock_userop.await_args.kwargs["chain_id"] == 100
+
+
+# ---------------------------------------------------------------------------
+# v1 env cleanup: TOTALRECLAW_CHAIN_ID override is NOT respected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_chain_id_env_is_ignored() -> None:
+    """The removed ``TOTALRECLAW_CHAIN_ID`` env var must not influence
+    chain selection — auto-detect is authoritative, matching the MCP
+    behavior where the env var was also removed."""
+    with patch.dict(os.environ, {"TOTALRECLAW_CHAIN_ID": "9999"}):
+        client = _make_client()
+        billing_patch, _ = _patch_billing({"tier": "free"})
+        with billing_patch:
+            chain_id = await client.resolve_chain_id()
+    assert chain_id == 84532  # free-tier default, NOT 9999

--- a/python/tests/test_event_loop_lifecycle.py
+++ b/python/tests/test_event_loop_lifecycle.py
@@ -1,0 +1,269 @@
+"""Regression tests for Bug #2 — "Event loop is closed" across sync agent hooks.
+
+QA reference: `docs/notes/QA-V1CLEAN-VPS-20260418.md`. On a fresh VPS install
+of ``totalreclaw==2.0.1``, every call to ``totalreclaw_status`` and
+``totalreclaw_export`` — and every first-turn ``pre_llm_call`` auto-recall —
+returned ``RuntimeError: Event loop is closed``.
+
+Root cause
+----------
+``totalreclaw.agent.recall.auto_recall`` and
+``totalreclaw.agent.lifecycle.auto_extract`` each run synchronously from
+Hermes's sync hook callbacks. Historically they used::
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(client.recall(...))
+    finally:
+        loop.close()
+
+``client.recall`` eventually calls ``RelayClient._get_http()``, which caches
+an ``httpx.AsyncClient`` on the RelayClient instance. ``httpx.AsyncClient``
+binds to whichever event loop was running when it was constructed. After
+the *first* hook call finished and its loop was closed, the cached
+``httpx.AsyncClient`` was still held by the RelayClient — and on the *next*
+hook call we created a fresh loop but reused the stale client, which still
+had its underlying socket / connection pool referencing the closed loop.
+That raises ``RuntimeError: Event loop is closed`` from inside anyio/httpx
+on the first request attempted from the new loop.
+
+Fix
+---
+Instead of per-call loops, run all per-instance async work through a single
+long-lived background thread that owns one persistent event loop. The
+httpx client is created on (and only used from) that one loop, so it is
+never orphaned by a short-lived per-call loop. See
+``totalreclaw.agent.loop_runner``.
+
+These tests pin the invariant:
+
+* ``_SyncLoopRunner`` survives repeated ``.run`` calls from different
+  calling threads without raising.
+* A ``RelayClient`` driven via ``_SyncLoopRunner`` can issue two HTTP
+  requests (mocked transport) in sequence without tripping
+  ``Event loop is closed``.
+* Calling ``auto_recall(...)`` twice in a row against the same RelayClient
+  does not raise.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Low-level: the loop runner itself must survive re-entry
+# ---------------------------------------------------------------------------
+
+
+def test_sync_loop_runner_survives_sequential_calls() -> None:
+    """``_SyncLoopRunner.run`` must accept sequential awaitables.
+
+    Before the fix, callers used a fresh ``asyncio.new_event_loop()`` each
+    time and closed it at the end. That worked for single-call work but
+    leaked any cached ``httpx.AsyncClient`` across loops. The new runner
+    owns ONE loop in a background thread and runs every coroutine on it.
+    """
+    from totalreclaw.agent.loop_runner import get_sync_loop_runner
+
+    runner = get_sync_loop_runner()
+
+    async def _trivial(i: int) -> int:
+        return i * 2
+
+    assert runner.run(_trivial(3)) == 6
+    assert runner.run(_trivial(5)) == 10
+    assert runner.run(_trivial(7)) == 14
+
+
+def test_sync_loop_runner_is_process_wide_singleton() -> None:
+    """Multiple calls return the same runner — one loop for the process."""
+    from totalreclaw.agent.loop_runner import get_sync_loop_runner
+
+    a = get_sync_loop_runner()
+    b = get_sync_loop_runner()
+    assert a is b
+
+
+# ---------------------------------------------------------------------------
+# Mid-level: RelayClient re-entry must not blow up across sync calls
+# ---------------------------------------------------------------------------
+
+
+def test_relay_client_survives_sequential_sync_calls() -> None:
+    """Two sequential calls to a RelayClient method from sync code must work.
+
+    This is the exact pattern that broke in v2.0.1: ``totalreclaw_status``
+    was called twice in a row by a user, and the second call returned
+    ``Event loop is closed``. We mock the httpx transport so we don't
+    actually hit a relay.
+    """
+    from totalreclaw.agent.loop_runner import get_sync_loop_runner
+    from totalreclaw.relay import RelayClient
+
+    # Mock httpx.AsyncClient so each .post() returns a canned billing response.
+    # Importantly, the mock honors the httpx_mock.Response contract so that
+    # the code path exercises the same async execution flow as production.
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "tier": "free",
+                "free_writes_used": 3,
+                "free_writes_limit": 500,
+                "expires_at": None,
+            },
+        )
+
+    transport = httpx.MockTransport(_handler)
+
+    # Patch the RelayClient's _get_http so it returns a mock-transport client
+    # on the long-lived loop.
+    rc = RelayClient(
+        relay_url="https://api-staging.totalreclaw.xyz",
+        auth_key_hex="00" * 32,
+        wallet_address="0x" + "ab" * 20,
+    )
+
+    runner = get_sync_loop_runner()
+
+    # Replace the lazy async-client constructor with one bound to the runner's
+    # loop (this is how the production fix wires things up).
+    async def _mock_get_http() -> httpx.AsyncClient:
+        if rc._http is None or rc._http.is_closed:
+            rc._http = httpx.AsyncClient(transport=transport, timeout=10.0)
+        return rc._http
+
+    rc._get_http = _mock_get_http  # type: ignore[assignment]
+
+    # Call twice — the regression is that the second call raises
+    # "Event loop is closed".
+    status1 = runner.run(rc.get_billing_status())
+    status2 = runner.run(rc.get_billing_status())
+
+    assert status1.tier == "free"
+    assert status2.tier == "free"
+
+    runner.run(rc.close())
+
+
+# ---------------------------------------------------------------------------
+# High-level: lifecycle functions must not create and tear down loops
+# ---------------------------------------------------------------------------
+
+
+def _make_state_with_fake_client():
+    """Build a PluginState with a fake client. Mirrors _make_state from
+    test_v1_hooks_integration.py but keeps the imports local so failure of
+    the loop-runner module doesn't break test collection."""
+    from totalreclaw.hermes.state import PluginState
+
+    with patch.dict(os.environ, {}, clear=True):
+        with patch.object(Path, "exists", return_value=False):
+            state = PluginState()
+
+    fake_client = MagicMock()
+    fake_client.remember = AsyncMock(return_value="fact-uuid-abc")
+    fake_client.recall = AsyncMock(return_value=[])
+    fake_client.forget = AsyncMock(return_value=True)
+    state._client = fake_client
+    return state, fake_client
+
+
+def _build_real_client_with_mock_transport(transport: httpx.MockTransport):
+    """Build a real TotalReclaw client whose RelayClient uses a mock transport.
+
+    Using a real RelayClient + real httpx.AsyncClient (not an AsyncMock) is
+    essential to reproduce the ``Event loop is closed`` bug: the bug only
+    surfaces when the same httpx client is carried across two different
+    event loops, which MagicMock does not simulate.
+    """
+    from totalreclaw.client import TotalReclaw
+
+    test_mnemonic = (
+        "abandon abandon abandon abandon abandon abandon "
+        "abandon abandon abandon abandon abandon about"
+    )
+    client = TotalReclaw(
+        recovery_phrase=test_mnemonic,
+        wallet_address="0x2c0cf74b2b76110708ca431796367779e3738250",
+    )
+    client._registered = True
+
+    # Monkeypatch _get_http so it returns a real httpx.AsyncClient with the
+    # mock transport. The RelayClient still owns the reference, so if the
+    # code creates a loop, tears it down, and then reuses the cached
+    # AsyncClient from a new loop, we will hit "Event loop is closed".
+    rc = client._relay
+    original_get_http = rc._get_http
+
+    async def _patched() -> httpx.AsyncClient:
+        if rc._http is None or rc._http.is_closed:
+            rc._http = httpx.AsyncClient(transport=transport, timeout=10.0)
+        return rc._http
+
+    rc._get_http = _patched  # type: ignore[assignment]
+    return client
+
+
+def test_sync_auto_recall_does_not_hit_event_loop_is_closed() -> None:
+    """Reproduces the QA bug: two sync calls to auto_recall against the
+    same TotalReclaw instance used to raise ``Event loop is closed`` on the
+    second call. Must not raise any more.
+    """
+    from totalreclaw.agent.recall import auto_recall
+    from totalreclaw.hermes.state import PluginState
+
+    # Minimal empty-search response: no facts found.
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"data": {"blindIndexes": [], "facts": []}},
+        )
+
+    transport = httpx.MockTransport(_handler)
+    client = _build_real_client_with_mock_transport(transport)
+
+    with patch.dict(os.environ, {}, clear=True):
+        with patch.object(Path, "exists", return_value=False):
+            state = PluginState()
+    state._client = client
+
+    out1 = auto_recall("hello", state)
+    out2 = auto_recall("world", state)
+    assert out1 is None
+    assert out2 is None
+
+
+def test_sync_client_status_does_not_hit_event_loop_is_closed() -> None:
+    """Reproduces the QA bug: calling client.status() from two different
+    short-lived loops used to raise ``Event loop is closed`` on the second.
+
+    This is the ``totalreclaw_status`` path — the single most visible break
+    for users in the v2.0.1 QA because it's the first sanity tool a user
+    reaches for.
+    """
+    from totalreclaw.agent.loop_runner import get_sync_loop_runner
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "tier": "free",
+                "free_writes_used": 2,
+                "free_writes_limit": 500,
+            },
+        )
+
+    transport = httpx.MockTransport(_handler)
+    client = _build_real_client_with_mock_transport(transport)
+
+    runner = get_sync_loop_runner()
+    s1 = runner.run(client.status())
+    s2 = runner.run(client.status())
+    assert s1.tier == "free"
+    assert s2.tier == "free"

--- a/python/tests/test_event_loop_lifecycle.py
+++ b/python/tests/test_event_loop_lifecycle.py
@@ -267,3 +267,226 @@ def test_sync_client_status_does_not_hit_event_loop_is_closed() -> None:
     s2 = runner.run(client.status())
     assert s1.tier == "free"
     assert s2.tier == "free"
+
+
+# ---------------------------------------------------------------------------
+# Cross-loop RelayClient regression
+# ---------------------------------------------------------------------------
+
+
+def test_relay_client_per_loop_caching() -> None:
+    """``RelayClient._get_http`` must return different clients on different loops.
+
+    This pins the core invariant behind the fix for Bug #2 and Bug #3:
+    each event loop gets its own ``httpx.AsyncClient`` so nothing is ever
+    orphaned across loop boundaries. Before this fix, a single cached
+    client on ``RelayClient._http`` was shared across loops and blew up
+    the moment a different loop tried to use it.
+    """
+    import asyncio
+    from totalreclaw.relay import RelayClient
+
+    rc = RelayClient(
+        relay_url="https://api-staging.totalreclaw.xyz",
+        auth_key_hex="00" * 32,
+        wallet_address="0x" + "ab" * 20,
+    )
+
+    async def _grab_client():
+        return await rc._get_http()
+
+    # Loop A.
+    loop_a = asyncio.new_event_loop()
+    try:
+        client_a = loop_a.run_until_complete(_grab_client())
+    finally:
+        # Drop the reference to the client bound to loop_a and don't close
+        # loop_a yet, so the test mirrors reality: the loop stays alive
+        # until something closes it, and we never touch client_a again
+        # from loop_b.
+        loop_a.close()
+
+    # Loop B. This MUST get a fresh client, not the orphaned one from A.
+    loop_b = asyncio.new_event_loop()
+    try:
+        client_b = loop_b.run_until_complete(_grab_client())
+    finally:
+        loop_b.run_until_complete(rc.close())
+        loop_b.close()
+
+    assert client_a is not client_b, (
+        "RelayClient._get_http returned the same client across two distinct "
+        "event loops — this is the Bug #2/#3 regression. Each loop must get "
+        "its own httpx.AsyncClient."
+    )
+
+
+def test_hermes_sync_hook_then_async_tool_does_not_orphan_httpx() -> None:
+    """Full QA scenario: sync hook runs first, async tool runs after.
+
+    In v2.0.1, a single httpx client got cached on the RelayClient during
+    the sync hook's short-lived loop, then Hermes reused it on its own
+    async loop when invoking the async ``totalreclaw_export`` tool —
+    which failed with ``RuntimeError: Event loop is closed``.
+
+    With the per-loop cache this no longer happens. We prove it by:
+
+    1. Running ``auto_recall`` through the sync loop runner (hook path).
+    2. Running ``client.export_all`` / ``client.status`` through an
+       independent asyncio.run call (tool path).
+
+    Both must succeed without "Event loop is closed".
+    """
+    import asyncio
+    from totalreclaw.agent.recall import auto_recall
+    from totalreclaw.hermes.state import PluginState
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        # Handle both subgraph queries (GraphQL POST) and billing (GET).
+        if request.url.path.endswith("/v1/billing/status"):
+            return httpx.Response(
+                200,
+                json={
+                    "tier": "free",
+                    "free_writes_used": 3,
+                    "free_writes_limit": 500,
+                },
+            )
+        if request.url.path.endswith("/v1/register"):
+            return httpx.Response(200, json={"user_id": "test-user"})
+        # Default: subgraph query, no facts.
+        return httpx.Response(
+            200,
+            json={"data": {"blindIndexes": [], "facts": []}},
+        )
+
+    transport = httpx.MockTransport(_handler)
+    client = _build_real_client_with_mock_transport(transport)
+
+    with patch.dict(os.environ, {}, clear=True):
+        with patch.object(Path, "exists", return_value=False):
+            state = PluginState()
+    state._client = client
+
+    # Step 1: sync hook path (auto_recall) runs on the loop runner.
+    out = auto_recall("what do i prefer?", state)
+    assert out is None  # No results, no error.
+
+    # Step 2: async tool path (status + export) runs on a fresh
+    # asyncio.run call — exactly what Hermes does when it invokes an
+    # ``is_async=True`` tool handler.
+    async def _invoke_tools():
+        s = await client.status()
+        facts = await client.export_all()
+        return s, facts
+
+    s, facts = asyncio.run(_invoke_tools())
+    assert s.tier == "free"
+    assert facts == []  # 0 on-chain in our mock, not an error state.
+
+
+def test_export_returns_decrypted_facts_after_sync_hook_ran() -> None:
+    """QA Bug #3: export returned count=0 despite 7 facts on-chain.
+
+    Root cause was the same cross-loop httpx caching that caused Bug #2 —
+    the subgraph GraphQL query in ``export_facts`` hit "Event loop is
+    closed" and the outer ``except Exception: break`` silently returned
+    an empty list.
+
+    This test simulates the full scenario:
+
+    1. Sync hook (``auto_recall``) runs on the sync loop runner — primes
+       any cached httpx client.
+    2. Hermes invokes ``totalreclaw_export`` on its own async loop, which
+       triggers a subgraph ``EXPORT_QUERY`` returning 2 mock-encrypted
+       facts (mocked so we don't need real crypto).
+    3. Decryption is mocked so we only exercise the transport + pagination
+       path. The result MUST contain 2 entries.
+    """
+    import asyncio
+    from totalreclaw.agent.recall import auto_recall
+    from totalreclaw.hermes.state import PluginState
+
+    # Route by GraphQL query shape so the auto_recall "prime" doesn't
+    # exhaust the export facts. The auto_recall path sends
+    # ``SearchByBlindIndex`` and ``BroadenedSearch`` queries; the export
+    # path sends ``ExportFacts``. Only the last returns real fact rows
+    # here.
+    import json as _json
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/v1/register"):
+            return httpx.Response(200, json={"user_id": "test-user"})
+        if request.url.path.endswith("/v1/subgraph"):
+            payload = _json.loads(request.content.decode("utf-8"))
+            query = payload.get("query", "")
+            if "ExportFacts" in query:
+                skip = payload.get("variables", {}).get("skip", 0)
+                if skip == 0:
+                    return httpx.Response(
+                        200,
+                        json={
+                            "data": {
+                                "facts": [
+                                    {
+                                        "id": "fact-1",
+                                        "encryptedBlob": "0x" + "ab" * 32,
+                                        "encryptedEmbedding": None,
+                                        "decayScore": "0.8",
+                                        "timestamp": "1713456789",
+                                        "createdAt": "1713456800",
+                                        "isActive": True,
+                                        "contentFp": "fp1",
+                                    },
+                                    {
+                                        "id": "fact-2",
+                                        "encryptedBlob": "0x" + "cd" * 32,
+                                        "encryptedEmbedding": None,
+                                        "decayScore": "0.6",
+                                        "timestamp": "1713456790",
+                                        "createdAt": "1713456801",
+                                        "isActive": True,
+                                        "contentFp": "fp2",
+                                    },
+                                ]
+                            }
+                        },
+                    )
+                return httpx.Response(200, json={"data": {"facts": []}})
+            # Any other subgraph query (search, broadened search, by id):
+            # return an empty shell so auto_recall completes cleanly.
+            if "BroadenedSearch" in query:
+                return httpx.Response(200, json={"data": {"facts": []}})
+            return httpx.Response(200, json={"data": {"blindIndexes": []}})
+        return httpx.Response(200, json={"data": {"facts": []}})
+
+    transport = httpx.MockTransport(_handler)
+    client = _build_real_client_with_mock_transport(transport)
+
+    # Prime the RelayClient via the sync hook path.
+    with patch.dict(os.environ, {}, clear=True):
+        with patch.object(Path, "exists", return_value=False):
+            state = PluginState()
+    state._client = client
+
+    # Fake decrypt + blob parser so we don't need real crypto.
+    with patch(
+        "totalreclaw.operations.decrypt",
+        side_effect=lambda b, k: '{"text":"mocked","type":"claim","schema_version":"1.0","importance":8,"source":"user","scope":"unspecified","confidence":0.9}',
+    ), patch(
+        "totalreclaw.operations.is_digest_blob",
+        return_value=False,
+    ):
+        # Step 1: sync hook (sync loop runner).
+        auto_recall("prime", state)
+
+        # Step 2: async tool path (Hermes-style) — MUST get 2 results.
+        facts = asyncio.run(client.export_all())
+
+    assert len(facts) == 2, (
+        f"export_all returned {len(facts)} facts; expected 2. Bug #3 regression — "
+        "the cross-loop httpx issue is silently returning empty."
+    )
+    assert {f["id"] for f in facts} == {"fact-1", "fact-2"}
+    # Timestamps should be formatted strings, not raw.
+    assert all(isinstance(f["timestamp"], str) for f in facts)

--- a/python/tests/test_session_id_forwarding.py
+++ b/python/tests/test_session_id_forwarding.py
@@ -1,0 +1,229 @@
+"""Bug #4 regression tests — TOTALRECLAW_SESSION_ID is honored again.
+
+v2.0.1 accidentally rejected ``TOTALRECLAW_SESSION_ID`` as a "removed env
+var" and emitted a cryptic warning line, breaking Axiom session-scoped log
+queries (QA-V1CLEAN-VPS-20260418 Bug #1). The Python client needs to:
+
+1. NOT warn on ``TOTALRECLAW_SESSION_ID`` (it is a SUPPORTED env var
+   again in v2.0.2).
+2. Forward the value to the relay as the ``X-TotalReclaw-Session`` header
+   on every HTTP call — subgraph queries, bundler submissions, billing
+   status, and the ``/v1/register`` handshake.
+3. Also accept an explicit ``session_id=`` constructor arg as a
+   programmatic override (takes precedence over the env var).
+
+The relay (``totalreclaw-relay/src/routes/proxy.ts``) reads the header
+and emits it as the ``sessionId`` field on Axiom log lines.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# RelayClient — accepts env + constructor override, forwards header
+# ---------------------------------------------------------------------------
+
+
+def test_relay_client_picks_up_env_session_id() -> None:
+    """``TOTALRECLAW_SESSION_ID`` env var is read at construction."""
+    from totalreclaw.relay import RelayClient
+
+    with patch.dict(os.environ, {"TOTALRECLAW_SESSION_ID": "qa-py202-1"}):
+        rc = RelayClient(auth_key_hex="00" * 32)
+    assert rc._session_id == "qa-py202-1"
+
+
+def test_relay_client_constructor_arg_overrides_env() -> None:
+    """Explicit ``session_id=`` kwarg wins over the env var."""
+    from totalreclaw.relay import RelayClient
+
+    with patch.dict(os.environ, {"TOTALRECLAW_SESSION_ID": "env-value"}):
+        rc = RelayClient(auth_key_hex="00" * 32, session_id="override-value")
+    assert rc._session_id == "override-value"
+
+
+def test_relay_client_no_session_id_omits_header() -> None:
+    """No env, no kwarg → no ``X-TotalReclaw-Session`` header."""
+    from totalreclaw.relay import RelayClient
+
+    with patch.dict(os.environ, {}, clear=True):
+        rc = RelayClient(auth_key_hex="00" * 32)
+    assert rc._session_id is None
+    headers = rc._base_headers()
+    assert "X-TotalReclaw-Session" not in headers
+
+
+def test_relay_client_base_headers_include_session() -> None:
+    """With a session set, the base headers include it."""
+    from totalreclaw.relay import RelayClient
+
+    rc = RelayClient(auth_key_hex="00" * 32, session_id="qa-py202-2")
+    headers = rc._base_headers()
+    assert headers["X-TotalReclaw-Session"] == "qa-py202-2"
+
+
+def test_relay_client_empty_env_is_treated_as_unset() -> None:
+    """Empty string in env must not set a header with an empty value."""
+    from totalreclaw.relay import RelayClient
+
+    with patch.dict(os.environ, {"TOTALRECLAW_SESSION_ID": ""}):
+        rc = RelayClient(auth_key_hex="00" * 32)
+    assert rc._session_id is None
+    assert "X-TotalReclaw-Session" not in rc._base_headers()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the header actually makes it on the wire on subgraph + register
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_subgraph_query_sends_session_header() -> None:
+    """A subgraph call from RelayClient carries the session header."""
+    from totalreclaw.relay import RelayClient
+
+    observed: dict[str, str] = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        observed.update(dict(request.headers))
+        return httpx.Response(200, json={"data": {"facts": []}})
+
+    transport = httpx.MockTransport(_handler)
+    rc = RelayClient(
+        relay_url="https://api-staging.totalreclaw.xyz",
+        auth_key_hex="00" * 32,
+        session_id="qa-subgraph-1",
+    )
+
+    # Install mock transport on the current loop.
+    async def _get_http():
+        return httpx.AsyncClient(transport=transport, timeout=10.0)
+
+    rc._get_http = _get_http  # type: ignore[assignment]
+
+    await rc.query_subgraph("{ facts { id } }", {})
+    assert observed.get("x-totalreclaw-session") == "qa-subgraph-1"
+
+
+@pytest.mark.asyncio
+async def test_register_sends_session_header() -> None:
+    """The ``/v1/register`` call (which uses its own headers dict, not
+    ``_base_headers``) must still include the session header."""
+    from totalreclaw.relay import RelayClient
+
+    observed: dict[str, str] = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        observed.update(dict(request.headers))
+        return httpx.Response(200, json={"user_id": "abc"})
+
+    transport = httpx.MockTransport(_handler)
+    rc = RelayClient(
+        relay_url="https://api-staging.totalreclaw.xyz",
+        auth_key_hex="00" * 32,
+        session_id="qa-register-1",
+    )
+
+    async def _get_http():
+        return httpx.AsyncClient(transport=transport, timeout=10.0)
+
+    rc._get_http = _get_http  # type: ignore[assignment]
+
+    uid = await rc.register("hash" * 8, "salt" * 8)
+    assert uid == "abc"
+    assert observed.get("x-totalreclaw-session") == "qa-register-1"
+
+
+# ---------------------------------------------------------------------------
+# TotalReclaw client threads it through to the RelayClient
+# ---------------------------------------------------------------------------
+
+
+TEST_MNEMONIC = (
+    "abandon abandon abandon abandon abandon abandon "
+    "abandon abandon abandon abandon abandon about"
+)
+
+
+def test_client_forwards_session_id_to_relay() -> None:
+    """Passing ``session_id=`` on ``TotalReclaw(...)`` sets the header."""
+    from totalreclaw.client import TotalReclaw
+
+    with patch.dict(os.environ, {}, clear=True):
+        c = TotalReclaw(recovery_phrase=TEST_MNEMONIC, session_id="qa-tr-1")
+    assert c._relay._session_id == "qa-tr-1"
+
+
+def test_client_reads_env_session_id_when_no_override() -> None:
+    """Without ``session_id=``, ``TOTALRECLAW_SESSION_ID`` is used."""
+    from totalreclaw.client import TotalReclaw
+
+    with patch.dict(os.environ, {"TOTALRECLAW_SESSION_ID": "qa-env-1"}):
+        c = TotalReclaw(recovery_phrase=TEST_MNEMONIC)
+    assert c._relay._session_id == "qa-env-1"
+
+
+# ---------------------------------------------------------------------------
+# Agent state: the "removed env var" warning no longer fires on SESSION_ID.
+# ---------------------------------------------------------------------------
+
+
+def test_session_id_is_not_in_removed_env_vars_list() -> None:
+    """``TOTALRECLAW_SESSION_ID`` must NOT be in the removed-env list.
+
+    The state module logs a warning at import time for any of these env
+    vars when set; including SESSION_ID emitted a confusing "ignoring
+    removed env var" line and caused Bug #1 in the v2.0.1 QA.
+    """
+    from totalreclaw.agent import state
+
+    assert "TOTALRECLAW_SESSION_ID" not in state._REMOVED_ENV_VARS, (
+        "TOTALRECLAW_SESSION_ID was restored in v2.0.2; keep it OUT of "
+        "_REMOVED_ENV_VARS so the agent state module does not warn about it."
+    )
+
+
+def test_session_id_env_does_not_trigger_removed_warning(caplog) -> None:
+    """Setting the env var must not produce a 'removed env var' warning."""
+    from totalreclaw.agent.state import (
+        _REMOVED_ENV_VARS,
+        _warn_removed_env_vars_once,
+    )
+    import totalreclaw.agent.state as state_mod
+
+    # Reset the module's once-flag so the warning path runs again.
+    state_mod._warned_removed_env_vars = False
+    with patch.dict(os.environ, {"TOTALRECLAW_SESSION_ID": "qa-state-1"}, clear=True):
+        with caplog.at_level("WARNING", logger="totalreclaw.agent.state"):
+            _warn_removed_env_vars_once()
+    joined = "\n".join(r.getMessage() for r in caplog.records)
+    assert "TOTALRECLAW_SESSION_ID" not in joined, (
+        "Setting TOTALRECLAW_SESSION_ID now-supported env var must not "
+        "produce the 'ignoring removed env var' warning."
+    )
+
+
+# ---------------------------------------------------------------------------
+# UserOp path — session_id threads through build_and_send_userop
+# ---------------------------------------------------------------------------
+
+
+def test_build_and_send_userop_accepts_session_id_kwarg() -> None:
+    """The userop helper must accept ``session_id=`` — no TypeError.
+
+    We don't actually send — just verify the signature accepts the kwarg,
+    so that the calls from ``operations.py`` don't throw.
+    """
+    import inspect
+    from totalreclaw.userop import build_and_send_userop
+
+    sig = inspect.signature(build_and_send_userop)
+    assert "session_id" in sig.parameters
+    # Default must be None so existing callers keep working.
+    assert sig.parameters["session_id"].default is None


### PR DESCRIPTION
## Summary

Fixes the four bugs in `totalreclaw==2.0.1` that made the Python client effectively unusable for new users, per the real-user QA on a clean VPS install (`docs/notes/QA-V1CLEAN-VPS-20260418.md` in the internal repo, summarized inline below).

All four fixes land behind Python-only surface changes — no `mcp/`, `client/`, `contracts/`, or Rust work. Cross-implementation parity (13/13) is preserved; the chain-id autodetect explicitly mirrors the MCP behavior (`mcp/src/index.ts` line ~346).

### Bugs fixed

| # | Severity | Bug | Commit |
|---|----------|-----|--------|
| 2 | BLOCKER | `totalreclaw_status`, `totalreclaw_export`, and `pre_llm_call` auto-recall hook every raised `RuntimeError: Event loop is closed` | `c5b5d2f` |
| 3 | BLOCKER | `totalreclaw_export` returned `{count: 0, facts: []}` despite 7 facts on-chain | `4861a96` |
| 4 | HIGH    | `TOTALRECLAW_SESSION_ID` rejected as "removed env var", breaking Axiom log tracing | `e827a7b` |
| 11 | KNOWN  | No chain_id auto-detect for Pro tier — writes silently signed for Base Sepolia while relay routed to Gnosis | `e8edb39` |

### Root causes and fixes

**Bug #2 / #3 share a root cause.** Sync Hermes hook callbacks (`pre_llm_call`, `post_llm_call`, `on_session_end`) used `loop = asyncio.new_event_loop()` per call and closed the loop at the end. Inside `client.recall` / `client.status`, the `RelayClient` cached an `httpx.AsyncClient` for reuse. `httpx` binds to whichever event loop is running when constructed; the second sync call created a new loop, reused the stale cached client, and anyio/httpcore blew up from inside the connection pool. On the export path, the outer `except Exception: break` silently returned `[]` — users saw 0 facts.

Fix layered in two parts:
1. New `totalreclaw.agent.loop_runner` — one persistent event loop in a daemon background thread, owning every coroutine scheduled from sync code. `auto_recall` and every `run_until_complete` site in `lifecycle.py` now go through `run_sync`.
2. `RelayClient._http` is now keyed per event loop (`_http_per_loop: dict[int, AsyncClient]`). Each loop gets its own correctly-bound client; orphaned clients from dead loops are dropped transparently.

**Bug #4.** The v1 env cleanup removed `TOTALRECLAW_SESSION_ID` and emitted a cryptic "ignoring removed env var" warning. The QA skill at `~/.claude/skills/qa-totalreclaw.md` depends on this var for Axiom session-scoped log queries, and the relay (`totalreclaw-relay/src/routes/proxy.ts:102`) still reads the `X-TotalReclaw-Session` header. Restored: `RelayClient` accepts `session_id=` (or picks up the env var) and forwards `X-TotalReclaw-Session` on every HTTP call — subgraph, register, billing, bundler.

**Bug #11.** Ported the MCP auto-detect: `GET /v1/billing/status?wallet_address=<sa>` with 5s timeout; if `tier == "pro"` use chain 100 (Gnosis), else 84532 (Base Sepolia). Best-effort — any error falls back to free-tier chain so offline users keep working. Lazy-resolved on first write, cached per client.

### Parity

* Python chain selection now matches MCP (`mcp/src/index.ts`). No drift from `client/`.
* Session-id header matches the plugin's pre-v1-cleanup behavior and the relay's existing expectations.
* Per-loop httpx cache is an internal implementation detail — the public RelayClient API is unchanged. A `_http` property shim preserves back-compat for any tests / callers that read / write the attribute directly.

### Tests

Three new test modules, 29 new tests total:

* `tests/test_event_loop_lifecycle.py` — 8 tests. Pins `_SyncLoopRunner` singleton, sequential-call survival, per-loop httpx caching, the full Hermes hook→tool scenario, and the export path specifically (regression for `count=0` silent failure).
* `tests/test_session_id_forwarding.py` — 12 tests. Env pickup, kwarg override, empty-env handling, base-headers contents, wire verification on subgraph + register, client threading, agent-state no-warn invariant.
* `tests/test_chain_id_autodetect.py` — 10 tests. Free/pro/error paths, caching, property guard, `remember`/`forget` threading chain_id to `build_and_send_userop`, TOTALRECLAW_CHAIN_ID ignore.

Minus one unrelated test-fixture fix in `test_relay.py`/`test_operations.py`/`test_pin_unpin.py`: the new `_session_id` attribute broke `AsyncMock(spec=RelayClient)` — resolved by `getattr(relay, "_session_id", None)` in `operations.py` (no prod behavior change).

**Full suite**: 585 passed, 1 xfailed (pre-existing).

### QA references

* Full QA report: `docs/notes/QA-V1CLEAN-VPS-20260418.md` + `QA-HERMES-V1CLEAN-20260418.md` in the internal repo.
* Stabilization plan: `docs/plans/2026-04-18-v1-stabilization.md` (internal).

### Test plan

- [ ] Publish workflow builds and uploads `totalreclaw==2.0.2` to PyPI.
- [ ] Fresh-VPS QA: `pip install --upgrade totalreclaw`; run the Hermes guide end-to-end.
  - [ ] `totalreclaw_status` returns tier + counts (no "Event loop is closed").
  - [ ] `totalreclaw_export` returns the expected facts (non-zero).
  - [ ] `pre_llm_call` auto-recall hook runs clean in the session log.
  - [ ] `TOTALRECLAW_SESSION_ID=qa-<id>` makes calls queryable by `sessionId` in Axiom.
- [ ] Pro-account smoke: set up a Pro wallet, call `remember`, verify the userOp landed on Gnosis (chain 100) via the subgraph.
- [ ] Free-account smoke: `remember` lands on Base Sepolia (chain 84532) — regression check for the default path.

### Do not merge until

- [ ] Phase 2 PR (owns `hermes/*` + `agent/extraction.py`) lands first or in parallel; verify no import / lifecycle conflicts.
- [ ] Full real-user QA passes on a clean VPS against the release-candidate tarball (per `CLAUDE.md` "Real-user QA on staging before ANY release" rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)