### PR TITLE
feat(python): v2.1.0 — Hermes parity Phase A (upgrade + debrief + mem0 import)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,14 @@ docker-compose.override.yml
 # Internal coordination files (not for public repo)
 TASKS.md
 CHANGELOG.md
+# Package-level CHANGELOGs ARE tracked — they ship with the package.
+!python/CHANGELOG.md
+!mcp/CHANGELOG.md
+!rust/totalreclaw-core/CHANGELOG.md
+!rust/totalreclaw-memory/CHANGELOG.md
+!skill/plugin/CHANGELOG.md
+!skill-nanoclaw/CHANGELOG.md
+!CHANGELOG-public.md
 
 # Misc
 *.tgz

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -1,0 +1,115 @@
+# Changelog
+
+All notable changes to the `totalreclaw` Python client and the `totalreclaw.hermes`
+Hermes Agent plugin are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.1.0] - 2026-04-19
+
+Phase A of the Hermes parity roadmap
+([docs/plans/2026-04-18-hermes-parity-roadmap.md][hermes-parity]). Closes the
+three lowest-effort / highest-visibility gaps between the Python client's
+Hermes plugin and the OpenClaw + MCP reference implementations. Feature
+release per semver (new public tool surface; no breaking changes).
+
+### Added
+
+- **`totalreclaw_upgrade` tool** (Hermes) — creates a Stripe Checkout
+  session via `RelayClient.create_checkout()` and returns the URL for the
+  user to complete payment for the Pro tier. Mirrors
+  `mcp/src/tools/upgrade.ts`, except the Python client already knows its
+  own wallet address so the tool schema has no required arguments. The
+  description follows the Phase 2 (v2.0.2) style with explicit
+  user-utterance hints ("upgrade to Pro", "I hit the free limit",
+  "unlimited") to help the agent invoke it correctly.
+
+- **`totalreclaw_debrief` tool** (Hermes) — explicit-invocation form of
+  the session-end debrief. Reuses
+  `totalreclaw.agent.lifecycle.session_debrief` (the same function the
+  auto `on_session_end` hook calls), so the stored summary facts are
+  indistinguishable from the auto-flow output (`type=summary`,
+  `provenance=derived`, `scope=unspecified`). The tool returns the stored
+  count + `fact_ids` so the agent can confirm. Short sessions
+  (< 4 turns) short-circuit with a clear `skipped=true` response.
+
+- **Mem0 import adapter** (`totalreclaw.import_adapters.mem0_adapter`) —
+  structural port of `skill/plugin/import-adapters/mem0-adapter.ts`.
+  Parses the three canonical Mem0 JSON shapes (dashboard export
+  `{memories: [...]}`, API response `{results: [...]}`, bare array) and
+  emits pre-structured `NormalizedFact`s that flow through the existing
+  `ImportEngine` without LLM re-extraction. Category mapping is
+  byte-identical to the TS adapter. `get_adapter('mem0')` + `list_sources()`
+  now include the new source.
+
+### Changed
+
+- `totalreclaw.agent.lifecycle.session_debrief(state, stored_fact_texts=None)`
+  now returns `list[str]` of stored debrief fact ids instead of `None` so
+  the new `totalreclaw_debrief` tool can surface them back to the user.
+  The auto `on_session_end` hook ignores the return value — this is a
+  behaviour-compatible widening.
+
+- `totalreclaw.hermes.plugin.yaml` version bumped `2.0.2` → `2.1.0` and
+  the two new tools added to `provides_tools`.
+
+- `hermes/__init__.py::register()` now registers 10 tools (was 8): the
+  existing 8 plus `totalreclaw_upgrade` + `totalreclaw_debrief`.
+
+### Tests
+
+- +33 new tests (`test_upgrade_tool.py` 7, `test_debrief_tool.py` 8,
+  `test_mem0_adapter.py` 18). Full suite now 637 passing, 4 skipped,
+  1 xfailed.
+
+### Notes
+
+- Gap 3 (`remember_batch` + Python batcher) is tracked in a parallel
+  agent worktree; those files (`userop.py`, `operations.py`, `client.py`,
+  `agent/extraction.py`) are deliberately untouched in this release.
+- The Mem0 adapter's optional live-API fetch path is intentionally
+  skipped for Phase A — users export JSON from the Mem0 dashboard and
+  paste or point-to it. Live-API ingestion is a potential Phase B
+  follow-up.
+
+[hermes-parity]: https://github.com/p-diogo/totalreclaw-internal/blob/main/docs/plans/2026-04-18-hermes-parity-roadmap.md
+
+## [2.0.2] - 2026-04-18
+
+Phase 2 of the v1.0.x stabilization wave. Plugin-layer fixes flagged by
+the v1.0.0 QA run (`docs/notes/QA-V1CLEAN-VPS-20260418.md`).
+
+### Fixed
+
+- **Event-loop lifecycle** — `RelayClient` now caches `httpx.AsyncClient`
+  per event loop so the Python client works both from Hermes's async
+  runtime AND its sync-hook sidecars (`pre_llm_call`). Previous behavior
+  raised "Event loop is closed" on the second loop.
+
+- **LLM auto-detect surfaces visible errors** — when no LLM config
+  resolves, `extract_facts_llm` / `extract_facts_compaction` now warn at
+  WARNING level with actionable guidance, and `post_llm_call` surfaces a
+  one-time quota-channel warning so the user sees an explanation in
+  their next assistant turn.
+
+- **Auto-setup detection** — rewrote `REMEMBER` / `RECALL` tool
+  descriptions so the LLM prefers TotalReclaw over Hermes's built-in
+  `memory` tool, and added a one-time setup-nudge when a memory-related
+  message arrives before `totalreclaw_setup` has run.
+
+- **In-batch cosine dedup** — `deduplicate_facts_by_embedding` now
+  collapses near-identical facts both against `existing_memories` AND
+  against earlier facts in the same extraction batch.
+
+- **Spurious extraction of setup meta-content** — `is_product_meta_request`
+  + `_filter_product_meta_facts` filter "set up TotalReclaw" / "install
+  the memory plugin" utterances before they reach the vault as "user
+  preferences". Genuine preferences still pass through.
+
+- **Export / session-id / chain-id auto-detect** — export path, session
+  header forwarding, and Pro-tier chain-100 auto-detect all stabilized.
+
+## [2.0.1] and earlier
+
+See git history — pre-v1 stabilization patches.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "totalreclaw"
-version = "2.0.2"
+version = "2.1.0"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"

--- a/python/src/totalreclaw/agent/lifecycle.py
+++ b/python/src/totalreclaw/agent/lifecycle.py
@@ -232,28 +232,40 @@ def auto_extract(state: "AgentState", mode: str = "turn", llm_config=None) -> li
     return stored_texts
 
 
-def session_debrief(state: "AgentState", stored_fact_texts: Optional[list[str]] = None) -> None:
+def session_debrief(
+    state: "AgentState",
+    stored_fact_texts: Optional[list[str]] = None,
+) -> list[str]:
     """Run session debrief: extract broader context and store it.
 
     Args:
         state: The AgentState instance (must be configured).
         stored_fact_texts: Optional list of already-stored fact texts for dedup.
             If None, an empty list is used.
+
+    Returns:
+        List of newly-stored debrief fact ids. Empty on short sessions,
+        unconfigured state, LLM unavailability, or any interior failure.
+        The return type widened from ``None`` in 2.1.0 so the explicit
+        ``totalreclaw_debrief`` tool can surface per-fact ids back to the
+        user. The auto ``on_session_end`` path ignores the return value —
+        behavior-compatible.
     """
     if not state.is_configured():
-        return
+        return []
 
     all_messages = state.get_all_messages()
     if len(all_messages) < 8:  # Minimum 4 turns
-        return
+        return []
 
     if stored_fact_texts is None:
         stored_fact_texts = []
 
     client = state.get_client()
     if not client:
-        return
+        return []
 
+    stored_fact_ids: list[str] = []
     try:
         debrief_items = run_sync(generate_debrief(all_messages, stored_fact_texts))
         if debrief_items:
@@ -263,7 +275,7 @@ def session_debrief(state: "AgentState", stored_fact_texts: Optional[list[str]] 
                     # provenance — the assistant-side debrief pipeline
                     # synthesized them from the conversation, so the
                     # v1 source is always "derived" (plugin parity).
-                    run_sync(
+                    fact_id = run_sync(
                         client.remember(
                             item.text,
                             importance=item.importance / 10.0,
@@ -273,7 +285,10 @@ def session_debrief(state: "AgentState", stored_fact_texts: Optional[list[str]] 
                             scope="unspecified",
                         )
                     )
+                    if fact_id:
+                        stored_fact_ids.append(fact_id)
                 except Exception as e:
                     logger.warning("Failed to store debrief item: %s", e)
     except Exception as e:
         logger.warning("Session debrief failed: %s", e)
+    return stored_fact_ids

--- a/python/src/totalreclaw/hermes/__init__.py
+++ b/python/src/totalreclaw/hermes/__init__.py
@@ -87,6 +87,23 @@ def register(ctx):
         is_async=True,
         description="Process one batch of a large import",
     )
+    # v2.1.0 Phase A parity additions — Stripe checkout + explicit debrief.
+    ctx.register_tool(
+        name="totalreclaw_upgrade",
+        toolset="totalreclaw",
+        schema=schemas.UPGRADE,
+        handler=lambda args, **kw: tools.upgrade(args, state, **kw),
+        is_async=True,
+        description=schemas.UPGRADE["description"],
+    )
+    ctx.register_tool(
+        name="totalreclaw_debrief",
+        toolset="totalreclaw",
+        schema=schemas.DEBRIEF,
+        handler=lambda args, **kw: tools.debrief(args, state, **kw),
+        is_async=True,
+        description=schemas.DEBRIEF["description"],
+    )
 
     # Register hooks
     ctx.register_hook("on_session_start", lambda **kw: hooks.on_session_start(state, **kw))
@@ -94,4 +111,4 @@ def register(ctx):
     ctx.register_hook("post_llm_call", lambda **kw: hooks.post_llm_call(state, **kw))
     ctx.register_hook("on_session_end", lambda **kw: hooks.on_session_end(state, **kw))
 
-    logger.info("TotalReclaw plugin registered (8 tools, 4 hooks)")
+    logger.info("TotalReclaw plugin registered (10 tools, 4 hooks)")

--- a/python/src/totalreclaw/hermes/plugin.yaml
+++ b/python/src/totalreclaw/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: totalreclaw
-version: 2.0.2
+version: 2.1.0
 description: End-to-end encrypted memory vault for AI agents (Memory Taxonomy v1)
 author: TotalReclaw Team
 provides_tools:
@@ -13,6 +13,8 @@ provides_tools:
   - totalreclaw_unpin
   - totalreclaw_import_from
   - totalreclaw_import_batch
+  - totalreclaw_upgrade
+  - totalreclaw_debrief
 provides_hooks:
   - on_session_start
   - pre_llm_call

--- a/python/src/totalreclaw/hermes/schemas.py
+++ b/python/src/totalreclaw/hermes/schemas.py
@@ -237,6 +237,55 @@ IMPORT_FROM = {
     },
 }
 
+UPGRADE = {
+    "name": "totalreclaw_upgrade",
+    "description": (
+        "Start the TotalReclaw Pro upgrade flow — creates a Stripe "
+        "Checkout session and returns the URL the user opens to pay. "
+        "\n\nINVOKE WHEN USER SAYS:\n"
+        "- 'upgrade to Pro' / 'I want Pro' / 'how do I upgrade'\n"
+        "- 'I hit the free limit' / 'pay for more memories' / 'unlimited'\n"
+        "- 'subscribe' / 'how much does Pro cost'\n"
+        "\nAfter calling this tool, read the returned ``message`` aloud — "
+        "it contains the checkout URL the user must open in their browser. "
+        "Do NOT call this tool speculatively; only when the user has "
+        "explicitly asked to upgrade, pay, or hit the quota limit. Pro "
+        "tier routes writes to Gnosis mainnet (permanent) instead of "
+        "Base Sepolia (testnet) and removes the free-write cap."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {},
+    },
+}
+
+DEBRIEF = {
+    "name": "totalreclaw_debrief",
+    "description": (
+        "Capture broader context, outcomes, and open threads that "
+        "turn-by-turn auto-extraction missed. Writes a small number of "
+        "``summary`` facts (v1 type=summary, provenance=derived) that a "
+        "future session can use to reconstruct what happened overall. "
+        "\n\nINVOKE WHEN USER SAYS:\n"
+        "- 'goodbye' / 'bye' / 'thanks' / 'that's all'\n"
+        "- 'I'm done' / 'wrapping up' / 'let's end here'\n"
+        "- after a long debug, plan, or decision session\n"
+        "- before a detected context compaction / reset\n"
+        "\nWHEN NOT TO USE:\n"
+        "- casual chat or pure Q&A — adds noise, no broader context\n"
+        "- when no memories were stored this session — nothing to synthesize\n"
+        "- if unsure → skip; debriefs are meant to be rare + high-signal.\n"
+        "\nThe tool reuses the same extraction pipeline as the automatic "
+        "``on_session_end`` hook, so the resulting facts are identical in "
+        "shape (type=summary, provenance=derived, scope=unspecified). "
+        "Returns ``stored`` count + ``fact_ids`` so the agent can confirm."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {},
+    },
+}
+
 IMPORT_BATCH = {
     "name": "totalreclaw_import_batch",
     "description": (

--- a/python/src/totalreclaw/hermes/tools.py
+++ b/python/src/totalreclaw/hermes/tools.py
@@ -290,6 +290,117 @@ def setup(args: dict, state: "PluginState", **kwargs) -> str:
         return json.dumps({"error": str(e)})
 
 
+# ── Billing Upgrade ──────────────────────────────────────────────────────────
+
+
+async def upgrade(args: dict, state: "PluginState", **kwargs) -> str:
+    """Create a Stripe Checkout session for upgrading to Pro tier.
+
+    Thin wrapper around :meth:`RelayClient.create_checkout` — the relay
+    already resolves wallet + auth headers from the client state, so the
+    tool takes no user-facing arguments. Returns the checkout URL plus a
+    user-visible ``message`` the agent should read back verbatim (the URL
+    is the whole point of calling this tool).
+    """
+    client = state.get_client()
+    if not client:
+        return json.dumps(
+            {"error": "TotalReclaw not configured. Run totalreclaw_setup first."}
+        )
+
+    try:
+        # Ensure the relay has the resolved Smart Account address before
+        # asking for a checkout — otherwise the ``wallet_address`` field
+        # in the POST body is null and the relay rejects with 400. The
+        # public client methods (remember/recall/status) all hit
+        # ``_ensure_address()`` internally; create_checkout is one of the
+        # few that doesn't need a fact write so we thread the address
+        # resolution explicitly.
+        ensure_addr = getattr(client, "_ensure_address", None)
+        if callable(ensure_addr):
+            try:
+                await ensure_addr()
+            except Exception:
+                # Non-fatal — the relay may still accept the checkout if
+                # ``self._wallet_address`` was populated elsewhere.
+                pass
+
+        checkout = await client._relay.create_checkout()
+        return json.dumps({
+            "checkout_url": checkout.checkout_url,
+            "session_id": checkout.session_id,
+            "message": (
+                f"Open this URL in your browser to complete the upgrade "
+                f"to Pro: {checkout.checkout_url}"
+            ),
+        })
+    except Exception as e:
+        logger.error("totalreclaw_upgrade failed: %s", e)
+        return json.dumps({"error": f"Failed to create checkout session: {e}"})
+
+
+# ── Debrief (explicit invocation) ────────────────────────────────────────────
+
+
+async def debrief(args: dict, state: "PluginState", **kwargs) -> str:
+    """Run the session debrief on demand.
+
+    Reuses :func:`totalreclaw.agent.lifecycle.session_debrief` — the same
+    function the automatic ``on_session_end`` hook calls — so the stored
+    summary facts are indistinguishable from the auto-flow output
+    (``type=summary``, ``provenance=derived``, ``scope=unspecified``).
+
+    Returns a JSON object with ``stored`` (count), ``fact_ids``, and
+    ``skipped=true`` when the session is too short (< 4 turns).
+    """
+    client = state.get_client()
+    if not client:
+        return json.dumps(
+            {"error": "TotalReclaw not configured. Run totalreclaw_setup first."}
+        )
+
+    # Short-circuit guard so the tool returns a clear explanation to the
+    # agent rather than an empty debrief. Mirrors the < 8-message gate in
+    # ``session_debrief`` itself.
+    all_messages = state.get_all_messages() if hasattr(state, "get_all_messages") else []
+    if len(all_messages) < 8:
+        return json.dumps({
+            "stored": 0,
+            "count": 0,
+            "fact_ids": [],
+            "skipped": True,
+            "message": (
+                "Session is too short for a debrief (need at least 4 turns). "
+                "Keep chatting, or re-invoke after a longer session."
+            ),
+        })
+
+    try:
+        # ``session_debrief`` is synchronous (drives its own ``run_sync``
+        # under the hood — see ``agent/loop_runner.py``). Call it via an
+        # executor so we do not block the Hermes async runtime loop.
+        import asyncio
+
+        loop = asyncio.get_running_loop()
+        from totalreclaw.agent.lifecycle import session_debrief
+        fact_ids: list[str] = await loop.run_in_executor(
+            None, session_debrief, state, None
+        ) or []
+        return json.dumps({
+            "stored": len(fact_ids),
+            "count": len(fact_ids),
+            "fact_ids": fact_ids,
+            "message": (
+                f"Stored {len(fact_ids)} debrief summary fact(s) on-chain."
+                if fact_ids
+                else "No debrief items were generated (conversation may not have enough signal)."
+            ),
+        })
+    except Exception as e:
+        logger.error("totalreclaw_debrief failed: %s", e)
+        return json.dumps({"error": str(e)})
+
+
 # ── Import Tools ─────────────────────────────────────────────────────────────
 
 

--- a/python/src/totalreclaw/import_adapters/__init__.py
+++ b/python/src/totalreclaw/import_adapters/__init__.py
@@ -23,12 +23,14 @@ from .base_adapter import BaseImportAdapter
 from .gemini_adapter import GeminiAdapter
 from .chatgpt_adapter import ChatGPTAdapter
 from .claude_adapter import ClaudeAdapter
+from .mem0_adapter import Mem0Adapter
 
 
 _ADAPTERS: dict[str, type[BaseImportAdapter]] = {
     'gemini': GeminiAdapter,
     'chatgpt': ChatGPTAdapter,
     'claude': ClaudeAdapter,
+    'mem0': Mem0Adapter,
 }
 
 
@@ -36,8 +38,8 @@ def get_adapter(source: str) -> BaseImportAdapter:
     """
     Get an import adapter by source name.
 
-    Currently supported: 'gemini'
-    (ChatGPT, Claude, Mem0 adapters to be ported from TypeScript)
+    Currently supported: 'gemini', 'chatgpt', 'claude', 'mem0'.
+    (MCP Memory adapter to be ported from TypeScript in Phase B.)
 
     Raises ValueError if the source is not supported.
     """
@@ -60,6 +62,7 @@ __all__ = [
     'GeminiAdapter',
     'ChatGPTAdapter',
     'ClaudeAdapter',
+    'Mem0Adapter',
     'ImportSource',
     'NormalizedFact',
     'ConversationChunk',

--- a/python/src/totalreclaw/import_adapters/mem0_adapter.py
+++ b/python/src/totalreclaw/import_adapters/mem0_adapter.py
@@ -1,0 +1,211 @@
+"""
+Mem0 import adapter — parses a Mem0 export JSON or API response.
+
+Mem0 is a pre-structured source: each memory in the export is already
+an atomic fact, so the adapter emits :class:`NormalizedFact` objects
+directly rather than :class:`ConversationChunk` chunks. The
+``ImportEngine`` then stores them via ``client.remember`` without any
+LLM re-extraction.
+
+Ported from ``skill/plugin/import-adapters/mem0-adapter.ts`` (233 LOC).
+The structural parts — shape detection, category mapping, validation —
+are preserved 1:1 so the Python adapter behaves identically to the TS
+adapter for the same export file. The TS adapter also has an optional
+API-fetch path (``fetchFromApi``); that is intentionally *omitted* here
+for Phase A — users export JSON from Mem0 and paste or point-to it,
+which is the 95% case. If a user ever needs live API ingestion we can
+add it in a follow-up (TODO flagged in README).
+"""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Callable, Dict, List, Optional
+
+from .base_adapter import BaseImportAdapter
+from .types import AdapterParseResult
+
+
+# Map Mem0 category strings to TotalReclaw v0 fact types (the BaseImportAdapter
+# v0 → v1 coercion happens downstream in client.remember). Parity with the TS
+# ``CATEGORY_MAP`` constant in mem0-adapter.ts.
+CATEGORY_MAP: Dict[str, str] = {
+    'preference': 'preference',
+    'preferences': 'preference',
+    'like': 'preference',
+    'dislike': 'preference',
+    'fact': 'fact',
+    'personal': 'fact',
+    'biographical': 'fact',
+    'decision': 'decision',
+    'goal': 'goal',
+    'objective': 'goal',
+    'experience': 'episodic',
+    'event': 'episodic',
+    'memory': 'episodic',
+}
+
+
+class Mem0Adapter(BaseImportAdapter):
+    """Adapter for Mem0 (mem0.ai) export JSON."""
+
+    source = 'mem0'
+    display_name = 'Mem0'
+
+    def parse(
+        self,
+        *,
+        content: Optional[str] = None,
+        file_path: Optional[str] = None,
+        on_progress: Optional[Callable] = None,
+    ) -> AdapterParseResult:
+        warnings: List[str] = []
+        errors: List[str] = []
+
+        # Resolve input: content > file_path > error.
+        raw: Optional[str] = None
+        if content:
+            raw = content
+        elif file_path:
+            try:
+                resolved = os.path.expanduser(file_path)
+                with open(resolved, 'r', encoding='utf-8') as f:
+                    raw = f.read()
+            except Exception as e:
+                errors.append(f'Failed to read file: {e}')
+                return AdapterParseResult(
+                    facts=[], chunks=[], total_messages=0,
+                    warnings=warnings, errors=errors,
+                )
+        else:
+            errors.append(
+                'Mem0 import requires either content (pasted export JSON) '
+                'or file_path. Export from Mem0: dashboard → Settings → '
+                'Export Memories, or paste an API response.',
+            )
+            return AdapterParseResult(
+                facts=[], chunks=[], total_messages=0,
+                warnings=warnings, errors=errors,
+            )
+
+        memories = self._parse_export_content(raw, errors)
+
+        if on_progress:
+            on_progress({
+                'current': 0,
+                'total': len(memories),
+                'phase': 'parsing',
+                'message': f'Parsing {len(memories)} Mem0 memories...',
+            })
+
+        # Convert to partial fact dicts for BaseImportAdapter.validate_facts.
+        raw_facts: List[dict] = []
+        for mem in memories:
+            if not isinstance(mem, dict):
+                continue
+            text = mem.get('memory', '')
+            categories = mem.get('categories') or []
+            # Older Mem0 exports stored the category under metadata.category
+            # instead of the top-level categories array. Support both.
+            md = mem.get('metadata') or {}
+            md_category = md.get('category') if isinstance(md, dict) else None
+            fact_type = self._map_category(categories, md_category)
+
+            # Timestamp: prefer updated_at, fall back to created_at.
+            ts: Optional[str] = None
+            if isinstance(md, dict):
+                ts = md.get('updated_at') or md.get('created_at')
+
+            # Tag list mirrors what the TS adapter emits (categories array).
+            tags = [c for c in categories if isinstance(c, str)]
+
+            raw_facts.append({
+                'text': text,
+                'type': fact_type,
+                # Mem0 does not provide an importance score — default to 6 so
+                # the fact passes the importance >= 6 downstream filter. Parity
+                # with the TS adapter.
+                'importance': 6,
+                'source_id': mem.get('id'),
+                'source_timestamp': ts,
+                'tags': tags,
+            })
+
+        facts, invalid_count = self.validate_facts(raw_facts)
+
+        if invalid_count > 0:
+            warnings.append(
+                f'{invalid_count} memories had invalid/empty text and were skipped'
+            )
+
+        return AdapterParseResult(
+            facts=facts,
+            chunks=[],
+            total_messages=0,
+            warnings=warnings,
+            errors=errors,
+            source_metadata={
+                'total_from_source': len(memories),
+                'format': 'mem0-json',
+            },
+        )
+
+    # ── Internal ─────────────────────────────────────────────────────────
+
+    def _parse_export_content(
+        self,
+        content: str,
+        errors: List[str],
+    ) -> List[dict]:
+        """Parse a Mem0 export string into a list of memory dicts.
+
+        Accepts three shapes (parity with the TS adapter):
+          1. Export file format ``{memories: [...]}`` (the dashboard export).
+          2. API response format ``{results: [...]}`` (live API call).
+          3. Bare JSON array of memories.
+        """
+        try:
+            data: Any = json.loads(content.strip())
+        except json.JSONDecodeError as e:
+            errors.append(f'Failed to parse Mem0 JSON: {e}')
+            return []
+
+        # Dashboard export.
+        if isinstance(data, dict) and isinstance(data.get('memories'), list):
+            return data['memories']
+        # API response.
+        if isinstance(data, dict) and isinstance(data.get('results'), list):
+            return data['results']
+        # Bare array.
+        if isinstance(data, list):
+            return data
+
+        errors.append(
+            'Unrecognized Mem0 format. Expected {memories: [...]}, '
+            '{results: [...]}, or a bare array.',
+        )
+        return []
+
+    def _map_category(
+        self,
+        categories: List[str],
+        single_category: Optional[str],
+    ) -> str:
+        """Resolve a Mem0 category → TotalReclaw v0 fact type.
+
+        Checks the ``categories`` array first, then the ``metadata.category``
+        fallback. Unknown categories default to ``fact`` (the safest, most
+        neutral type — v0 ``fact`` coerces to v1 ``claim`` downstream).
+        """
+        all_categories: List[str] = list(categories) if categories else []
+        if single_category:
+            all_categories.append(single_category)
+
+        for cat in all_categories:
+            if not isinstance(cat, str):
+                continue
+            mapped = CATEGORY_MAP.get(cat.lower())
+            if mapped:
+                return mapped
+
+        return 'fact'

--- a/python/tests/test_debrief_tool.py
+++ b/python/tests/test_debrief_tool.py
@@ -1,0 +1,163 @@
+"""Tests for the ``totalreclaw_debrief`` Hermes tool (Phase A).
+
+The explicit-invocation form of the debrief flow. The tool reuses the
+same ``session_debrief`` pipeline as the auto ``on_session_end`` hook,
+so the resulting summary facts are indistinguishable from the auto-flow
+output (same ``type=summary``, ``provenance=derived``, ``scope=unspecified``).
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from totalreclaw.agent.debrief import DebriefItem
+from totalreclaw.hermes import schemas
+from totalreclaw.hermes.state import PluginState
+
+
+def _make_state_with_client():
+    """Return a configured PluginState + fake remember-capturing client."""
+    with patch.dict(os.environ, {}, clear=True):
+        with patch.object(Path, "exists", return_value=False):
+            state = PluginState()
+
+    fake_client = MagicMock()
+    # The agent pipeline calls ``client.remember`` via ``run_sync``; return
+    # a synthetic fact id so we can assert the tool threads it back.
+    remember_return = iter(["fact-id-1", "fact-id-2", "fact-id-3"])
+
+    async def _remember(*args, **kwargs):
+        return next(remember_return)
+
+    fake_client.remember = AsyncMock(side_effect=_remember)
+    fake_client.recall = AsyncMock(return_value=[])  # empty vault, no dedup noise
+    state._client = fake_client
+    return state, fake_client
+
+
+class TestDebriefSchema:
+    def test_schema_exists(self) -> None:
+        assert hasattr(schemas, "DEBRIEF")
+        assert schemas.DEBRIEF["name"] == "totalreclaw_debrief"
+
+    def test_schema_description_has_utterance_mapping(self) -> None:
+        """Follow the Phase 2 style — spell out INVOKE WHEN / WHEN NOT TO USE."""
+        desc = schemas.DEBRIEF["description"]
+        lowered = desc.lower()
+        # Must advertise the conclusion-capturing intent.
+        assert "summary" in lowered or "debrief" in lowered
+        # Explicit utterance hints (parity with mcp/src/tools/debrief.ts).
+        assert "goodbye" in lowered or "wrap" in lowered or "done" in lowered
+
+    def test_schema_parameters_empty(self) -> None:
+        """No args required — the tool reuses the buffered session."""
+        params = schemas.DEBRIEF["parameters"]
+        assert params["type"] == "object"
+        assert params.get("required", []) == []
+
+
+class TestDebriefTool:
+    @pytest.mark.asyncio
+    async def test_not_configured_returns_error(self) -> None:
+        from totalreclaw.hermes.tools import debrief
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(Path, "exists", return_value=False):
+                state = PluginState()
+        result = json.loads(await debrief({}, state))
+        assert "error" in result
+        assert "totalreclaw_setup" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_too_short_session_returns_skipped(self) -> None:
+        """Fewer than 4 turns (8 messages) → skip, no debrief generated."""
+        from totalreclaw.hermes.tools import debrief
+
+        state, _client = _make_state_with_client()
+        # Only 3 messages — below the 8-message threshold.
+        for i in range(3):
+            state.add_message("user", f"hi {i}")
+        result = json.loads(await debrief({}, state))
+        assert result.get("stored") == 0
+        # Skipped field signals the shortcut.
+        assert result.get("skipped") is True
+
+    @pytest.mark.asyncio
+    async def test_explicit_invocation_produces_summary_facts(self) -> None:
+        """The tool must call the SAME code path as the auto-flow.
+
+        We fake ``generate_debrief`` so the test is LLM-free and assert:
+        1. The stored facts have ``type=summary``, ``provenance=derived``
+           (the v1 contract the auto-flow commits).
+        2. The tool's response surfaces the stored count + fact ids.
+        """
+        from totalreclaw.hermes.tools import debrief
+
+        state, fake_client = _make_state_with_client()
+
+        # Seed a long-enough session (>= 8 messages).
+        for i in range(8):
+            state.add_message("user", f"A meaningful user message about project X turn {i}")
+            state.add_message("assistant", f"A long assistant response covering topic Y turn {i}")
+
+        fake_items = [
+            DebriefItem(text="Session concluded refactor of the auth module.", type="summary", importance=8),
+            DebriefItem(text="API migration still pending for billing module.", type="context", importance=7),
+        ]
+
+        async def fake_generate(*args, **kwargs):
+            return fake_items
+
+        with patch("totalreclaw.agent.lifecycle.generate_debrief", new=fake_generate):
+            result = json.loads(await debrief({}, state))
+
+        # Verify the v1 contract — parity with ``on_session_end`` hook.
+        calls = fake_client.remember.call_args_list
+        assert len(calls) == 2
+        for call in calls:
+            kwargs = call.kwargs
+            assert kwargs["fact_type"] == "summary"
+            assert kwargs["provenance"] == "derived"
+            assert kwargs["scope"] == "unspecified"
+
+        # Tool response surfaces the count + fact ids for the user.
+        assert result.get("stored") == 2
+        assert result.get("count") == 2
+        assert isinstance(result.get("fact_ids"), list)
+        assert len(result["fact_ids"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_debrief_returns_zero_when_llm_yields_empty(self) -> None:
+        """LLM returns no items → tool reports stored=0 without erroring."""
+        from totalreclaw.hermes.tools import debrief
+
+        state, _client = _make_state_with_client()
+        for i in range(8):
+            state.add_message("user", f"turn {i}")
+            state.add_message("assistant", f"reply {i}")
+
+        async def fake_generate(*args, **kwargs):
+            return []
+
+        with patch("totalreclaw.agent.lifecycle.generate_debrief", new=fake_generate):
+            result = json.loads(await debrief({}, state))
+
+        assert result.get("stored") == 0
+        assert "error" not in result
+
+
+class TestDebriefRegistration:
+    def test_register_wires_debrief_tool(self) -> None:
+        from totalreclaw.hermes import register
+
+        ctx = MagicMock()
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(Path, "exists", return_value=False):
+                register(ctx)
+
+        tool_names = [call.kwargs["name"] for call in ctx.register_tool.call_args_list]
+        assert "totalreclaw_debrief" in tool_names

--- a/python/tests/test_hermes_plugin.py
+++ b/python/tests/test_hermes_plugin.py
@@ -490,8 +490,8 @@ class TestRegister:
         with patch.dict(os.environ, {}, clear=True):
             with patch.object(Path, "exists", return_value=False):
                 register(ctx)
-        # Should register 8 tools and 4 hooks
-        assert ctx.register_tool.call_count == 8
+        # v2.1.0 — 10 tools (+ totalreclaw_upgrade, totalreclaw_debrief).
+        assert ctx.register_tool.call_count == 10
         assert ctx.register_hook.call_count == 4
 
         # Check tool names
@@ -504,6 +504,8 @@ class TestRegister:
         assert "totalreclaw_setup" in tool_names
         assert "totalreclaw_import_from" in tool_names
         assert "totalreclaw_import_batch" in tool_names
+        assert "totalreclaw_upgrade" in tool_names
+        assert "totalreclaw_debrief" in tool_names
 
         # Check hook names
         hook_names = [call.args[0] for call in ctx.register_hook.call_args_list]

--- a/python/tests/test_mem0_adapter.py
+++ b/python/tests/test_mem0_adapter.py
@@ -1,0 +1,311 @@
+"""Tests for the Mem0 import adapter.
+
+Mirrors the TypeScript reference test cases in
+``skill/plugin/import-adapters/import-adapters.test.ts`` (Mem0Adapter
+section) so Python and TS adapters stay feature-identical.
+
+Mem0 is a pre-structured source: the export JSON is a list of already-
+atomic memories, so the adapter emits ``facts`` (not ``chunks``) and
+the ``ImportEngine`` stores them directly without LLM re-extraction.
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Happy-path parsing across the three accepted Mem0 shapes
+# ---------------------------------------------------------------------------
+
+
+class TestMem0ParseShapes:
+    def test_api_response_format_results_key(self) -> None:
+        from totalreclaw.import_adapters.mem0_adapter import Mem0Adapter
+
+        content = json.dumps({
+            "results": [
+                {"id": "mem-1", "memory": "User prefers dark mode", "categories": ["preference"]},
+                {"id": "mem-2", "memory": "User works at Acme Corp", "categories": ["fact"]},
+            ]
+        })
+        result = Mem0Adapter().parse(content=content)
+        assert len(result.facts) == 2
+        assert result.facts[0].text == "User prefers dark mode"
+        assert result.facts[0].type == "preference"
+        assert result.facts[0].source == "mem0"
+        assert result.facts[1].type == "fact"
+        assert result.facts[1].source_id == "mem-2"
+        # Pre-structured source → no chunks.
+        assert len(result.chunks) == 0
+
+    def test_export_file_format_memories_key(self) -> None:
+        from totalreclaw.import_adapters.mem0_adapter import Mem0Adapter
+
+        content = json.dumps({
+            "export_date": "2026-03-10",
+            "memories": [{"id": "mem-1", "memory": "User likes TypeScript"}],
+        })
+        result = Mem0Adapter().parse(content=content)
+        assert len(result.facts) == 1
+        assert result.facts[0].text == "User likes TypeScript"
+
+    def test_bare_array_format(self) -> None:
+        from totalreclaw.import_adapters.mem0_adapter import Mem0Adapter
+
+        content = json.dumps([
+            {"id": "mem-1", "memory": "User prefers Python"},
+            {"id": "mem-2", "memory": "User dislikes Java"},
+        ])
+        result = Mem0Adapter().parse(content=content)
+        assert len(result.facts) == 2
+        assert result.facts[0].text == "User prefers Python"
+
+
+# ---------------------------------------------------------------------------
+# Validation: empty/short memories dropped, warning surfaced
+# ---------------------------------------------------------------------------
+
+
+class TestMem0Validation:
+    def test_skips_empty_and_short_memories(self) -> None:
+        from totalreclaw.import_adapters.mem0_adapter import Mem0Adapter
+
+        content = json.dumps({
+            "results": [
+                {"id": "mem-1", "memory": ""},
+                {"id": "mem-2", "memory": "Valid fact here"},
+                {"id": "mem-3", "memory": "ab"},  # < 3 chars
+            ]
+        })
+        result = Mem0Adapter().parse(content=content)
+        assert len(result.facts) == 1
+        assert result.facts[0].text == "Valid fact here"
+        # Should warn about the 2 skipped entries.
+        assert any("2 memories had invalid" in w for w in result.warnings)
+
+    def test_invalid_json_returns_error_not_raises(self) -> None:
+        from totalreclaw.import_adapters.mem0_adapter import Mem0Adapter
+
+        result = Mem0Adapter().parse(content="not json {{{")
+        assert len(result.facts) == 0
+        assert len(result.errors) > 0
+        assert "Failed to parse Mem0 JSON" in result.errors[0]
+
+    def test_missing_content_returns_error(self) -> None:
+        from totalreclaw.import_adapters.mem0_adapter import Mem0Adapter
+
+        result = Mem0Adapter().parse()
+        assert len(result.facts) == 0
+        assert len(result.errors) > 0
+        assert "content" in result.errors[0].lower()
+
+    def test_unrecognized_shape_returns_error(self) -> None:
+        from totalreclaw.import_adapters.mem0_adapter import Mem0Adapter
+
+        content = json.dumps({"some_key": "some_value"})
+        result = Mem0Adapter().parse(content=content)
+        assert len(result.facts) == 0
+        assert any("Unrecognized Mem0 format" in e for e in result.errors)
+
+
+# ---------------------------------------------------------------------------
+# Category mapping — parity with the TS CATEGORY_MAP
+# ---------------------------------------------------------------------------
+
+
+class TestMem0CategoryMapping:
+    def test_category_mapping_matches_ts(self) -> None:
+        from totalreclaw.import_adapters.mem0_adapter import Mem0Adapter
+
+        content = json.dumps({
+            "results": [
+                {"id": "1", "memory": "User likes hiking outdoors a lot", "categories": ["like"]},
+                {"id": "2", "memory": "User dislikes rainy days", "categories": ["dislike"]},
+                {"id": "3", "memory": "Graduated in 2020 with honors", "categories": ["biographical"]},
+                {"id": "4", "memory": "Wants to learn Rust next year", "categories": ["objective"]},
+                {"id": "5", "memory": "Visited Paris in 2023 on vacation", "categories": ["event"]},
+                {"id": "6", "memory": "Chose React over Vue for frontend", "categories": ["decision"]},
+                {"id": "7", "memory": "Some item with an unknown category", "categories": ["zzz_unknown"]},
+            ]
+        })
+        result = Mem0Adapter().parse(content=content)
+        assert result.facts[0].type == "preference"   # like
+        assert result.facts[1].type == "preference"   # dislike
+        assert result.facts[2].type == "fact"         # biographical
+        assert result.facts[3].type == "goal"         # objective
+        assert result.facts[4].type == "episodic"     # event
+        assert result.facts[5].type == "decision"     # decision
+        assert result.facts[6].type == "fact"         # unknown → default
+
+    def test_metadata_category_fallback(self) -> None:
+        """Older Mem0 exports use ``metadata.category`` (singular) instead of
+        the top-level ``categories`` array; the adapter must honor both.
+        """
+        from totalreclaw.import_adapters.mem0_adapter import Mem0Adapter
+
+        content = json.dumps({
+            "results": [
+                {
+                    "id": "m1",
+                    "memory": "User prefers vanilla ice cream always",
+                    "metadata": {"category": "preference"},
+                },
+            ]
+        })
+        result = Mem0Adapter().parse(content=content)
+        assert result.facts[0].type == "preference"
+
+
+# ---------------------------------------------------------------------------
+# Importance default + source_id preservation
+# ---------------------------------------------------------------------------
+
+
+class TestMem0FieldDefaults:
+    def test_default_importance_is_6(self) -> None:
+        """Mem0 has no importance field → adapter must default to 6 so the
+        fact clears the ImportEngine's importance >= 6 filter.
+        """
+        from totalreclaw.import_adapters.mem0_adapter import Mem0Adapter
+
+        content = json.dumps({"results": [{"id": "m1", "memory": "User prefers dark mode everywhere"}]})
+        result = Mem0Adapter().parse(content=content)
+        assert result.facts[0].importance == 6
+
+    def test_source_timestamp_preserved(self) -> None:
+        from totalreclaw.import_adapters.mem0_adapter import Mem0Adapter
+
+        content = json.dumps({
+            "results": [{
+                "id": "m1",
+                "memory": "User visited Berlin last month on a trip",
+                "metadata": {"updated_at": "2026-03-01T10:00:00Z"},
+            }]
+        })
+        result = Mem0Adapter().parse(content=content)
+        assert result.facts[0].source_timestamp == "2026-03-01T10:00:00Z"
+
+    def test_tags_from_categories(self) -> None:
+        from totalreclaw.import_adapters.mem0_adapter import Mem0Adapter
+
+        content = json.dumps({
+            "results": [
+                {"id": "m1", "memory": "User prefers tea over coffee", "categories": ["preference", "beverage"]},
+            ]
+        })
+        result = Mem0Adapter().parse(content=content)
+        assert "preference" in result.facts[0].tags
+        assert "beverage" in result.facts[0].tags
+
+
+# ---------------------------------------------------------------------------
+# File-based parsing (the import_engine hits this path via file_path)
+# ---------------------------------------------------------------------------
+
+
+class TestMem0FileInput:
+    def test_file_path_reads_disk(self) -> None:
+        from totalreclaw.import_adapters.mem0_adapter import Mem0Adapter
+
+        content = json.dumps({"memories": [{"id": "m1", "memory": "User likes mountain hiking"}]})
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, encoding="utf-8"
+        ) as f:
+            f.write(content)
+            tmp_path = f.name
+        try:
+            result = Mem0Adapter().parse(file_path=tmp_path)
+            assert len(result.facts) == 1
+            assert result.facts[0].text == "User likes mountain hiking"
+        finally:
+            os.unlink(tmp_path)
+
+    def test_missing_file_returns_error(self) -> None:
+        from totalreclaw.import_adapters.mem0_adapter import Mem0Adapter
+
+        result = Mem0Adapter().parse(file_path="/nonexistent/path/to/mem0.json")
+        assert len(result.facts) == 0
+        assert len(result.errors) > 0
+
+
+# ---------------------------------------------------------------------------
+# Adapter registry wiring
+# ---------------------------------------------------------------------------
+
+
+class TestMem0RegistryWiring:
+    def test_get_adapter_mem0_returns_mem0_adapter(self) -> None:
+        from totalreclaw.import_adapters import get_adapter
+        from totalreclaw.import_adapters.mem0_adapter import Mem0Adapter
+
+        adapter = get_adapter("mem0")
+        assert isinstance(adapter, Mem0Adapter)
+
+    def test_list_sources_includes_mem0(self) -> None:
+        from totalreclaw.import_adapters import list_sources
+
+        assert "mem0" in list_sources()
+
+    def test_unknown_source_error_lists_mem0(self) -> None:
+        from totalreclaw.import_adapters import get_adapter
+
+        with pytest.raises(ValueError) as excinfo:
+            get_adapter("bogus")
+        assert "mem0" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through ImportEngine — golden-file round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestMem0ImportEngineIntegration:
+    def test_import_engine_processes_mem0_facts_as_batch(self) -> None:
+        """Mem0 adapter + ImportEngine round-trip: 3 facts in → 3 stored.
+
+        Uses a fake client that captures ``remember`` calls; verifies the
+        engine routes through the pre-structured-fact path (not LLM
+        extraction) and preserves source=import.
+        """
+        from unittest.mock import AsyncMock, MagicMock
+        import asyncio
+
+        from totalreclaw.import_engine import ImportEngine
+
+        fixture = json.dumps({
+            "memories": [
+                {"id": "m1", "memory": "User prefers dark mode always", "categories": ["preference"]},
+                {"id": "m2", "memory": "User works on the TotalReclaw project", "categories": ["fact"]},
+                {"id": "m3", "memory": "Decided to use PostgreSQL for the DB", "categories": ["decision"]},
+            ]
+        })
+
+        fake_client = MagicMock()
+
+        async def _remember(text, **kwargs):
+            return f"fact-{text[:20]}"
+
+        fake_client.remember = AsyncMock(side_effect=_remember)
+
+        engine = ImportEngine(client=fake_client, llm_extract=None)
+
+        # Estimate first (matches the tool workflow).
+        est = engine.estimate(source="mem0", content=fixture)
+        assert est["total_facts"] == 3
+        assert est["total_chunks"] == 0
+        assert est["has_facts"] is True
+
+        # Process the batch.
+        result = asyncio.run(engine.process_batch(
+            source="mem0", content=fixture, offset=0, batch_size=25,
+        ))
+        assert result.success is True
+        assert result.facts_stored == 3
+        assert result.is_complete is True
+        # All three stored with the import engine's source tag.
+        assert fake_client.remember.await_count == 3

--- a/python/tests/test_upgrade_tool.py
+++ b/python/tests/test_upgrade_tool.py
@@ -1,0 +1,121 @@
+"""Tests for the ``totalreclaw_upgrade`` Hermes tool (Phase A).
+
+The tool wraps :meth:`RelayClient.create_checkout` and returns a Stripe
+checkout URL plus a user-visible message. No on-chain writes, no LLM
+calls — it is a pure relay round-trip.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from totalreclaw.hermes import schemas
+from totalreclaw.hermes.state import PluginState
+from totalreclaw.relay import CheckoutResponse
+
+
+def _make_state():
+    """Return an unconfigured PluginState with isolated env."""
+    with patch.dict(os.environ, {}, clear=True):
+        with patch.object(Path, "exists", return_value=False):
+            return PluginState()
+
+
+class TestUpgradeSchema:
+    def test_schema_exists(self) -> None:
+        assert hasattr(schemas, "UPGRADE")
+        assert schemas.UPGRADE["name"] == "totalreclaw_upgrade"
+
+    def test_schema_description_is_user_utterance_mapped(self) -> None:
+        """Description should follow the Phase 2 style: explicit utterance hints
+        telling the LLM when to invoke.
+        """
+        desc = schemas.UPGRADE["description"]
+        # Must mention the payment/checkout outcome.
+        assert "Pro" in desc
+        assert "checkout" in desc.lower()
+        # Must include the "when user says X" pattern (Phase 2 style).
+        lowered = desc.lower()
+        assert "upgrade" in lowered
+        # Either upgrade-mention or Pro-mention is the utterance hook.
+        assert any(
+            phrase in lowered
+            for phrase in ("upgrade to pro", "unlimited", "limit", "pay")
+        )
+
+    def test_schema_parameters_empty(self) -> None:
+        """Python client already knows its wallet — no args required from the LLM."""
+        params = schemas.UPGRADE["parameters"]
+        assert params["type"] == "object"
+        # No required args — the checkout pulls wallet_address from the client.
+        assert params.get("required", []) == []
+
+
+class TestUpgradeTool:
+    @pytest.mark.asyncio
+    async def test_not_configured_returns_error(self) -> None:
+        from totalreclaw.hermes.tools import upgrade
+
+        state = _make_state()
+        result = json.loads(await upgrade({}, state))
+        assert "error" in result
+        assert "totalreclaw_setup" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_url_and_message(self) -> None:
+        """Mock relay → assert tool returns the checkout URL + a user-visible message."""
+        from totalreclaw.hermes.tools import upgrade
+
+        state = _make_state()
+        mock_client = MagicMock()
+        # The handler reaches into the client to call the relay.
+        mock_client._relay = MagicMock()
+        mock_client._relay.create_checkout = AsyncMock(
+            return_value=CheckoutResponse(
+                checkout_url="https://checkout.stripe.com/c/pay/cs_test_abc123",
+                session_id="cs_test_abc123",
+            )
+        )
+        state._client = mock_client
+
+        result = json.loads(await upgrade({}, state))
+        assert result.get("checkout_url") == "https://checkout.stripe.com/c/pay/cs_test_abc123"
+        assert "session_id" in result
+        # User-visible message includes the URL (so the LLM reads it back).
+        assert "https://checkout.stripe.com/c/pay/cs_test_abc123" in result.get("message", "")
+        assert mock_client._relay.create_checkout.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_relay_error_surfaces_as_error_field(self) -> None:
+        """Relay failure → tool returns ``{"error": "..."}`` (no exception)."""
+        from totalreclaw.hermes.tools import upgrade
+
+        state = _make_state()
+        mock_client = MagicMock()
+        mock_client._relay = MagicMock()
+        mock_client._relay.create_checkout = AsyncMock(
+            side_effect=RuntimeError("relay down")
+        )
+        state._client = mock_client
+
+        result = json.loads(await upgrade({}, state))
+        assert "error" in result
+        assert "relay down" in result["error"]
+
+
+class TestUpgradeRegistration:
+    def test_register_wires_upgrade_tool(self) -> None:
+        """``register()`` must include ``totalreclaw_upgrade`` in the tool set."""
+        from totalreclaw.hermes import register
+
+        ctx = MagicMock()
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(Path, "exists", return_value=False):
+                register(ctx)
+
+        tool_names = [call.kwargs["name"] for call in ctx.register_tool.call_args_list]
+        assert "totalreclaw_upgrade" in tool_names


### PR DESCRIPTION
## Summary

Phase A of the [Hermes parity roadmap](https://github.com/p-diogo/totalreclaw-internal/blob/main/docs/plans/2026-04-18-hermes-parity-roadmap.md) — three low-effort, high-visibility additions for the Python client + Hermes plugin. Post-v1-stabilization feature wave, semver minor bump (new public tool surface, no breaking changes).

- **`totalreclaw_upgrade` tool** — wraps `RelayClient.create_checkout()` and returns a Stripe checkout URL. Mirrors `mcp/src/tools/upgrade.ts`; schema has no required args (the Python client already knows its own wallet).
- **`totalreclaw_debrief` tool** — explicit-invocation form of the session-end debrief. Reuses `agent/lifecycle.py::session_debrief` (the same function the auto `on_session_end` hook calls), so stored summary facts are indistinguishable from the auto flow (`type=summary`, `provenance=derived`, `scope=unspecified`). Returns `stored` count + `fact_ids`.
- **Mem0 import adapter** — port of `skill/plugin/import-adapters/mem0-adapter.ts` (~190 prod LOC). Pre-structured source: emits `NormalizedFact`s that flow through the existing `ImportEngine` without LLM re-extraction. Wires `mem0` into `get_adapter()` / `list_sources()`; the `IMPORT_FROM` schema enum already listed it.

## Commits

1. `f2d63db` feat(python/hermes): totalreclaw_upgrade + totalreclaw_debrief tools
2. `bc3c719` feat(python/import): mem0 adapter + register 'mem0' source
3. `1d87b55` chore(python): bump 2.0.2 -> 2.1.0 + seed CHANGELOG

## Scope guarantees

- Python + Hermes only. No changes to TS (`skill/`, `mcp/`, `client/`), Rust (`rust/`, `core/`, `memory/`), or relay (`server/`).
- Gap 3's file-set left untouched: `python/src/totalreclaw/userop.py`, `python/src/totalreclaw/operations.py`, `python/src/totalreclaw/client.py`, `python/src/totalreclaw/agent/extraction.py`.
- `session_debrief` in `agent/lifecycle.py` widens its return type from `None` to `list[str]` — behavior-compatible (the auto hook ignores the return value).

## Test plan

- [x] 33 new tests (`test_upgrade_tool.py` 7, `test_debrief_tool.py` 8, `test_mem0_adapter.py` 18)
- [x] Full suite: **637 passing**, 4 skipped, 1 xfailed (baseline was 604)
- [x] Cross-impl parity: `test_v1_parity.py` + `test_memory_types_parity.py` 32/32 green
- [ ] Staging QA — real-user conversation exercising all three tools (required before v2.1.0 publish per CLAUDE.md)
- [ ] Manual test: upgrade tool returns valid Stripe URL against staging relay
- [ ] Manual test: mem0 import against a real Mem0 dashboard export file

## Release gate

Per roadmap constraint: **do NOT publish to PyPI from this PR**. Version bumped in `pyproject.toml` + `plugin.yaml`, CHANGELOG seeded. User reviews, runs real-user QA against staging with the release-candidate artifact, then dispatches the publish workflow manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)