### PR TITLE
feat(mcp): v3.1.0 — wire Phase 2 contradiction detection

### DIFF
--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [3.1.0]
+
+### Added
+- **Phase 2 contradiction detection + auto-resolution** wired into the subgraph write path (`handleRememberSubgraph`). Mirrors the OpenClaw plugin's `skill/plugin/contradiction-sync.ts` pattern so a fact pinned via OpenClaw and later re-asserted via MCP (or vice versa) produces the same outcome. Closes the cross-client consistency gap called out in Roadmap Audit 2026-04-19 §2 item #1 and §7.2 Agent C.
+  - New module `src/contradiction-sync.ts` — candidate fetch + decrypt, pure resolver delegating to `core.resolveWithCandidates`, decision-log writer (format byte-for-byte compatible with the plugin's `~/.totalreclaw/decisions.jsonl`).
+  - Pin respect is enforced by the Rust core via `respect_pin_in_resolution` inside `resolve_with_candidates`. When an existing claim is pinned, a contradicting new write is skipped with reason `existing_pinned`. Pinned facts are never silently overridden.
+  - Tie-zone guard (`TIE_ZONE_SCORE_TOLERANCE = 0.01`) calibrated against the 2026-04-14 Postgres/DuckDB false-positive; same threshold as the plugin.
+  - Env var `TOTALRECLAW_AUTO_RESOLVE_MODE` (values: `active` default | `off` | `shadow`) — INTERNAL kill-switch. Not user-facing, not documented in README or SKILL.md.
+- Tests at `tests/contradiction-sync.test.ts` covering non-contradicting writes, contradicting writes (new wins → supersede), and pinned existing (new skipped).
+
 ## [3.0.1]
 
 ### Fixed

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/mcp-server",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. MCP server with XChaCha20-Poly1305 E2EE, semantic search, import/export, and on-chain storage",
   "homepage": "https://totalreclaw.xyz",
   "main": "dist/index.js",

--- a/mcp/src/contradiction-sync.ts
+++ b/mcp/src/contradiction-sync.ts
@@ -1,0 +1,823 @@
+/**
+ * TotalReclaw MCP — contradiction detection + auto-resolution (Phase 2 Slice 2d).
+ *
+ * This is the MCP mirror of `skill/plugin/contradiction-sync.ts` — same
+ * pipeline, same decision semantics, same decision-log format. Keeps the MCP
+ * write path consistent with the plugin so a fact pinned via OpenClaw and
+ * later re-asserted via MCP (or vice versa) produces the same outcome.
+ *
+ * Runs after store-time dedup and before the canonical v1 claim blob is
+ * encrypted + submitted on-chain. For every entity on the new claim, fetches
+ * existing active claims that share the same entity trapdoor, decrypts them,
+ * and asks the WASM core to detect contradictions in the [0.3, 0.85) band.
+ * Each contradicting pair is then resolved via the P2-3 formula; the winner
+ * is kept on-chain, the loser is queued for tombstoning.
+ *
+ * Pinned claims are never touched — a contradiction against a pinned claim
+ * always causes the new write to be skipped with reason `existing_pinned`.
+ * Pin respect is enforced by the Rust core via `respect_pin_in_resolution`
+ * inside `resolve_with_candidates`; the TypeScript side does not need to
+ * re-check.
+ *
+ * Pure functions at the core, I/O behind dependency injection so tests can
+ * run the real WASM while stubbing the subgraph + filesystem. The WASM core
+ * is NOT mocked in tests — we run against the live @totalreclaw/core bindings
+ * so decision-log formats stay byte-for-byte compatible with the plugin.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { computeEntityTrapdoor, isDigestBlob } from './claims-helper.js';
+
+// MCP uses require('@totalreclaw/core') directly (see consolidation.ts,
+// claims-helper.ts) instead of createRequire — match that pattern.
+let _wasm: typeof import('@totalreclaw/core') | null = null;
+function getWasm(): typeof import('@totalreclaw/core') {
+  if (!_wasm) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    _wasm = require('@totalreclaw/core');
+  }
+  return _wasm!;
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Internal kill-switch for auto-resolution. Mirrors the plugin's
+ * `AutoResolveMode` (see `skill/plugin/claims-helper.ts:432`). Kept local to
+ * this module to avoid dragging plugin-specific context into MCP's
+ * `claims-helper.ts`.
+ *
+ * - `active` (default): full detection + auto-resolution
+ * - `off`: skip contradiction detection entirely; legacy behaviour
+ * - `shadow`: detect + log but do not apply decisions
+ *
+ * Read per-call from `TOTALRECLAW_AUTO_RESOLVE_MODE` — this is an INTERNAL
+ * debug kill-switch, not a user-facing env var. Not documented in the MCP
+ * README or SKILL.md.
+ */
+export type AutoResolveMode = 'active' | 'off' | 'shadow';
+
+export interface ContradictionLogger {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type CanonicalClaim = Record<string, any>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type WeightsFile = Record<string, any>;
+
+/** Per-component score breakdown, mirroring Rust `ScoreComponents`. */
+export interface ScoreComponents {
+  confidence: number;
+  corroboration: number;
+  recency: number;
+  validation: number;
+  weighted_total: number;
+}
+
+/**
+ * What action the write path should take for a given candidate existing claim.
+ *
+ * - `no_contradiction`: nothing to do, proceed with the normal write.
+ * - `supersede_existing`: the new claim wins, tombstone the named existing fact.
+ * - `skip_new`: an existing claim wins (or is pinned) — skip the new write entirely.
+ * - `tie_leave_both`: the formula scores are within TIE_ZONE_SCORE_TOLERANCE;
+ *   treat the "contradiction" as rounding noise and leave both claims active.
+ *   The write path ignores this variant.
+ */
+export type ResolutionDecision =
+  | { action: 'no_contradiction' }
+  | {
+      action: 'supersede_existing';
+      existingFactId: string;
+      existingClaim: CanonicalClaim;
+      entityId: string;
+      similarity: number;
+      winnerScore: number;
+      loserScore: number;
+      winnerComponents: ScoreComponents;
+      loserComponents: ScoreComponents;
+    }
+  | {
+      action: 'skip_new';
+      reason: 'existing_pinned' | 'existing_wins';
+      existingFactId: string;
+      entityId: string;
+      similarity: number;
+      winnerScore?: number;
+      loserScore?: number;
+      winnerComponents?: ScoreComponents;
+      loserComponents?: ScoreComponents;
+    }
+  | {
+      action: 'tie_leave_both';
+      existingFactId: string;
+      entityId: string;
+      similarity: number;
+      winnerScore: number;
+      loserScore: number;
+      winnerComponents: ScoreComponents;
+      loserComponents: ScoreComponents;
+    };
+
+/** Row format for `decisions.jsonl`. Byte-for-byte identical to plugin's. */
+export interface DecisionLogEntry {
+  ts: number;
+  entity_id: string;
+  new_claim_id: string;
+  existing_claim_id: string;
+  similarity: number;
+  action: 'supersede_existing' | 'skip_new' | 'shadow' | 'tie_leave_both';
+  reason?: 'existing_pinned' | 'existing_wins' | 'new_wins' | 'tie_below_tolerance';
+  winner_score?: number;
+  loser_score?: number;
+  winner_components?: ScoreComponents;
+  loser_components?: ScoreComponents;
+  /**
+   * Full canonical Claim JSON for the formula loser (the existing claim that
+   * got tombstoned by `supersede_existing`). Required by the pin-on-tombstone
+   * recovery path — see the plugin's `contradiction-sync.ts` for rationale.
+   */
+  loser_claim_json?: string;
+  mode: AutoResolveMode;
+}
+
+// ---------------------------------------------------------------------------
+// Paths + file I/O — identical file layout as plugin so the same decisions.jsonl
+// is compatible across clients.
+// ---------------------------------------------------------------------------
+
+function resolveStateDir(): string {
+  const override = process.env.TOTALRECLAW_STATE_DIR;
+  if (override && override.length > 0) return override;
+  return path.join(os.homedir(), '.totalreclaw');
+}
+
+function ensureStateDir(): string {
+  const dir = resolveStateDir();
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+  } catch {
+    // Caller handles downstream read/write failures.
+  }
+  return dir;
+}
+
+export function decisionsLogPath(): string {
+  return path.join(resolveStateDir(), 'decisions.jsonl');
+}
+
+export function weightsFilePath(): string {
+  return path.join(resolveStateDir(), 'weights.json');
+}
+
+/** Cap on the decisions.jsonl log — oldest lines are dropped above this. */
+export const DECISION_LOG_MAX_LINES = 10_000;
+
+/** Soft cap on candidates fetched per entity during contradiction detection. */
+export const CONTRADICTION_CANDIDATE_CAP = 20;
+
+/**
+ * Minimum score gap required to auto-resolve a `supersede_existing` decision.
+ * Calibrated against the 2026-04-14 Postgres/DuckDB false-positive (gap 9 ppm).
+ * See plugin's `contradiction-sync.ts` for full rationale.
+ */
+export const TIE_ZONE_SCORE_TOLERANCE = 0.01;
+
+/**
+ * Append one entry to the decision log, rotating if it grows past the cap.
+ * Never throws — logging is best-effort.
+ */
+export async function appendDecisionLog(entry: DecisionLogEntry): Promise<void> {
+  try {
+    const dir = ensureStateDir();
+    const p = path.join(dir, 'decisions.jsonl');
+    let existing = '';
+    try {
+      existing = fs.readFileSync(p, 'utf-8');
+    } catch {
+      existing = '';
+    }
+    const line = JSON.stringify(entry);
+    let next = existing;
+    if (next.length === 0) {
+      next = line + '\n';
+    } else if (next.endsWith('\n')) {
+      next = next + line + '\n';
+    } else {
+      next = next + '\n' + line + '\n';
+    }
+    const rotated = getWasm().rotateFeedbackLog(next, BigInt(DECISION_LOG_MAX_LINES));
+    fs.writeFileSync(p, rotated, 'utf-8');
+  } catch {
+    // Logging failures are never fatal.
+  }
+}
+
+/**
+ * Load the per-user weights file, falling back to defaults when the file
+ * does not exist or is malformed. Never throws.
+ */
+export async function loadWeightsFile(nowUnixSeconds: number): Promise<WeightsFile> {
+  const core = getWasm();
+  const p = weightsFilePath();
+  try {
+    const raw = fs.readFileSync(p, 'utf-8');
+    const parsedJson = core.parseWeightsFile(raw);
+    return JSON.parse(parsedJson) as WeightsFile;
+  } catch {
+    const freshJson = core.defaultWeightsFile(BigInt(Math.floor(nowUnixSeconds)));
+    return JSON.parse(freshJson) as WeightsFile;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Candidate fetching (subgraph + decrypt)
+// ---------------------------------------------------------------------------
+
+export interface SubgraphSearchFn {
+  (
+    owner: string,
+    trapdoors: string[],
+    maxCandidates: number,
+    authKeyHex?: string,
+  ): Promise<Array<{
+    id: string;
+    encryptedBlob: string;
+    encryptedEmbedding?: string | null;
+    timestamp?: string;
+    isActive?: boolean;
+  }>>;
+}
+
+export interface DecryptFn {
+  (hexBlob: string, key: Buffer): string;
+}
+
+export interface CandidateClaim {
+  claim: CanonicalClaim;
+  id: string;
+  embedding: number[];
+}
+
+/**
+ * Parse a decrypted Claim blob into a canonical claim object.
+ *
+ * Accepts the canonical short-key Claim shape (`{t, c, cf, i, sa, ea, ...}`).
+ * Returns null for legacy docs, digest blobs, entity-infrastructure claims,
+ * or anything that fails to parse — excluded from contradiction detection.
+ *
+ * Mirrors the plugin's `parseCandidateClaim` byte-for-byte. v1 long-form
+ * blobs (`{text, type, entities, ...}`) do not have `t`/`c` and therefore
+ * return null here. The Rust core's `Claim` struct only accepts the short-key
+ * shape, so v1 blobs are not in-band for contradiction detection in either
+ * client. This matches plugin's current behavior — cross-client parity.
+ */
+export function parseCandidateClaim(decryptedJson: string): CanonicalClaim | null {
+  if (isDigestBlob(decryptedJson)) return null;
+  let obj: Record<string, unknown>;
+  try {
+    obj = JSON.parse(decryptedJson) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  if (typeof obj.t !== 'string' || typeof obj.c !== 'string') return null;
+  if (obj.c === 'dig' || obj.c === 'ent') return null;
+  return obj as CanonicalClaim;
+}
+
+/** Is this candidate claim pinned (status `p`)? Delegates to WASM core. */
+export function isPinnedClaim(claim: CanonicalClaim): boolean {
+  try {
+    return getWasm().isPinnedClaim(JSON.stringify(claim));
+  } catch {
+    return typeof claim.st === 'string' && claim.st === 'p';
+  }
+}
+
+/**
+ * Shape of the `existing_json` expected by WASM `detectContradictions` /
+ * `resolveWithCandidates`. Matches `DetectContradictionsItem` in
+ * `rust/totalreclaw-core/src/wasm.rs`.
+ */
+interface WasmExistingItem {
+  claim: CanonicalClaim;
+  id: string;
+  embedding: number[];
+}
+
+/**
+ * Collect active claim candidates for every entity on the new claim.
+ *
+ * For each entity:
+ *   1. Compute its trapdoor (same primitive as the write path).
+ *   2. Query the subgraph for facts matching that single-element trapdoor.
+ *   3. Decrypt + parse each row, filtering infra claims and bad blobs.
+ *   4. Recover the embedding (reusing the stored one when possible).
+ *
+ * Deduplicates by subgraph fact id across entities. Caps total per entity at
+ * `CONTRADICTION_CANDIDATE_CAP` to keep the write-path cost bounded.
+ */
+export async function collectCandidatesForEntities(
+  newClaim: CanonicalClaim,
+  newClaimId: string,
+  subgraphOwner: string,
+  authKeyHex: string,
+  encryptionKey: Buffer,
+  deps: {
+    searchSubgraph: SubgraphSearchFn;
+    decryptFromHex: DecryptFn;
+  },
+  logger: ContradictionLogger,
+): Promise<CandidateClaim[]> {
+  const entities = Array.isArray(newClaim.e) ? newClaim.e : [];
+  if (entities.length === 0) return [];
+
+  const seenIds = new Set<string>();
+  const out: CandidateClaim[] = [];
+
+  for (const entity of entities) {
+    const name = typeof entity?.n === 'string' ? entity.n : null;
+    if (!name) continue;
+    const trapdoor = computeEntityTrapdoor(name);
+    let rows: Awaited<ReturnType<SubgraphSearchFn>> = [];
+    try {
+      rows = await deps.searchSubgraph(
+        subgraphOwner,
+        [trapdoor],
+        CONTRADICTION_CANDIDATE_CAP,
+        authKeyHex,
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.warn(`Contradiction: subgraph query failed for entity "${name}": ${msg}`);
+      continue;
+    }
+
+    for (const row of rows) {
+      if (!row || !row.id || row.id === newClaimId) continue;
+      if (row.isActive === false) continue;
+      if (seenIds.has(row.id)) continue;
+      seenIds.add(row.id);
+
+      let decrypted: string;
+      try {
+        decrypted = deps.decryptFromHex(row.encryptedBlob, encryptionKey);
+      } catch {
+        continue;
+      }
+      const parsed = parseCandidateClaim(decrypted);
+      if (!parsed) continue;
+
+      let embedding: number[] = [];
+      if (row.encryptedEmbedding) {
+        try {
+          const emb = JSON.parse(deps.decryptFromHex(row.encryptedEmbedding, encryptionKey));
+          if (Array.isArray(emb) && emb.every((x) => typeof x === 'number')) {
+            embedding = emb;
+          }
+        } catch {
+          embedding = [];
+        }
+      }
+
+      out.push({ claim: parsed, id: row.id, embedding });
+    }
+  }
+
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Pure resolver: given new claim + candidates + weights, return decisions
+// ---------------------------------------------------------------------------
+
+export interface ResolveWithCoreInput {
+  newClaim: CanonicalClaim;
+  newClaimId: string;
+  newEmbedding: number[];
+  candidates: CandidateClaim[];
+  weightsJson: string;
+  thresholdLower: number;
+  thresholdUpper: number;
+  nowUnixSeconds: number;
+  mode: AutoResolveMode;
+  logger: ContradictionLogger;
+}
+
+/**
+ * Run WASM contradiction detection + resolution on in-memory data only.
+ *
+ * Uses `core.resolveWithCandidates()` (the full pipeline in one call: detect
+ * contradictions + resolve pairs + pin check + tie-zone guard) — introduced in
+ * core 1.5.0, shipped live in MCP's `@totalreclaw/core@2.0.0` dependency.
+ *
+ * If the WASM export is not available (core < 1.5.0) or fails, returns `[]`
+ * and the write path falls back to the pre-Phase-2 behaviour. We do NOT ship
+ * a legacy `detectContradictions + resolvePair` path — MCP 3.1.0 pins
+ * `@totalreclaw/core ^2.0.0` which guarantees the unified export.
+ *
+ * Split out from `detectAndResolveContradictions` so the write path can test
+ * the decision logic without mocking file I/O or the subgraph.
+ */
+export function resolveWithCore(input: ResolveWithCoreInput): ResolutionDecision[] {
+  const {
+    newClaim,
+    newClaimId,
+    newEmbedding,
+    candidates,
+    weightsJson,
+    thresholdLower,
+    thresholdUpper,
+    nowUnixSeconds,
+    mode,
+    logger,
+  } = input;
+
+  if (mode === 'off') return [];
+  if (candidates.length === 0) return [];
+  if (newEmbedding.length === 0) {
+    logger.warn('Contradiction: new claim has no embedding; skipping detection');
+    return [];
+  }
+
+  const core = getWasm();
+
+  // Build the WASM candidates payload. Drop any candidate whose embedding
+  // is missing — the core short-circuits on empty vectors but we also drop
+  // them from the lookup map so we don't waste a reference.
+  const items: WasmExistingItem[] = candidates
+    .filter((c) => c.embedding.length > 0)
+    .map((c) => ({ claim: c.claim, id: c.id, embedding: c.embedding }));
+
+  if (items.length === 0) return [];
+
+  const byId = new Map<string, CandidateClaim>();
+  for (const c of items) byId.set(c.id, { claim: c.claim, id: c.id, embedding: c.embedding });
+
+  if (typeof core.resolveWithCandidates !== 'function') {
+    // Unexpected: MCP 3.1.0 depends on core ^2.0.0 which ships this export.
+    // If this branch triggers, something is materially wrong with the core
+    // package — log and fall back to Phase-1 behaviour (no detection).
+    logger.warn('Contradiction: core.resolveWithCandidates missing (core < 1.5.0?) — skipping detection');
+    return [];
+  }
+
+  let actionsJson: string;
+  try {
+    actionsJson = core.resolveWithCandidates(
+      JSON.stringify(newClaim),
+      newClaimId,
+      JSON.stringify(newEmbedding),
+      JSON.stringify(items),
+      weightsJson,
+      thresholdLower,
+      thresholdUpper,
+      BigInt(Math.floor(nowUnixSeconds)),
+      TIE_ZONE_SCORE_TOLERANCE,
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn(`Contradiction: resolveWithCandidates failed: ${msg}`);
+    return [];
+  }
+
+  let actions: Array<Record<string, unknown>>;
+  try {
+    actions = JSON.parse(actionsJson);
+  } catch {
+    return [];
+  }
+  if (actions.length === 0) return [];
+
+  // Map core ResolutionAction (tagged enum) → local ResolutionDecision.
+  const decisions: ResolutionDecision[] = [];
+  for (const action of actions) {
+    const type = action.type as string;
+    if (type === 'supersede_existing') {
+      const existing = byId.get(action.existing_id as string);
+      decisions.push({
+        action: 'supersede_existing',
+        existingFactId: action.existing_id as string,
+        existingClaim: existing?.claim ?? {},
+        entityId: (action.entity_id as string) ?? '',
+        similarity: (action.similarity as number) ?? 0,
+        winnerScore: (action.winner_score as number) ?? 0,
+        loserScore: (action.loser_score as number) ?? 0,
+        winnerComponents: action.winner_components as ScoreComponents,
+        loserComponents: action.loser_components as ScoreComponents,
+      });
+    } else if (type === 'skip_new') {
+      const reason = action.reason as string;
+      decisions.push({
+        action: 'skip_new',
+        reason: reason === 'existing_pinned' ? 'existing_pinned' : 'existing_wins',
+        existingFactId: action.existing_id as string,
+        entityId: (action.entity_id as string) ?? '',
+        similarity: (action.similarity as number) ?? 0,
+        winnerScore: action.winner_score as number | undefined,
+        loserScore: action.loser_score as number | undefined,
+        winnerComponents: action.winner_components as ScoreComponents | undefined,
+        loserComponents: action.loser_components as ScoreComponents | undefined,
+      });
+    } else if (type === 'tie_leave_both') {
+      decisions.push({
+        action: 'tie_leave_both',
+        existingFactId: action.existing_id as string,
+        entityId: (action.entity_id as string) ?? '',
+        similarity: (action.similarity as number) ?? 0,
+        winnerScore: (action.winner_score as number) ?? 0,
+        loserScore: (action.loser_score as number) ?? 0,
+        winnerComponents: action.winner_components as ScoreComponents,
+        loserComponents: action.loser_components as ScoreComponents,
+      });
+    }
+    // no_contradiction actions are ignored.
+  }
+
+  return decisions;
+}
+
+// ---------------------------------------------------------------------------
+// Top-level entry point for the write path
+// ---------------------------------------------------------------------------
+
+export interface DetectAndResolveDeps {
+  searchSubgraph: SubgraphSearchFn;
+  decryptFromHex: DecryptFn;
+  /** Now in Unix seconds — overridable for deterministic tests. */
+  nowUnixSeconds?: number;
+}
+
+export interface DetectAndResolveInput {
+  newClaim: CanonicalClaim;
+  newClaimId: string;
+  newEmbedding: number[];
+  subgraphOwner: string;
+  authKeyHex: string;
+  encryptionKey: Buffer;
+  deps: DetectAndResolveDeps;
+  logger: ContradictionLogger;
+}
+
+/**
+ * Write-path entry point. See Slice 2d of the Phase 2 design doc.
+ *
+ * Returns a list of `ResolutionDecision`s:
+ *   - `supersede_existing`: caller queues a tombstone for `existingFactId`
+ *   - `skip_new`: caller skips the new write (existing wins or is pinned)
+ *   - empty list: no contradiction, proceed unchanged
+ *
+ * Never throws. On any failure (subgraph, decrypt, WASM), returns `[]` so the
+ * write path falls back to pre-Phase-2 behaviour.
+ *
+ * Pin respect is handled inside WASM `resolve_with_candidates` via the core's
+ * `respect_pin_in_resolution` — the TypeScript side does not need to re-check.
+ */
+export async function detectAndResolveContradictions(
+  input: DetectAndResolveInput,
+): Promise<ResolutionDecision[]> {
+  const {
+    newClaim,
+    newClaimId,
+    newEmbedding,
+    subgraphOwner,
+    authKeyHex,
+    encryptionKey,
+    deps,
+    logger,
+  } = input;
+
+  // Read env per-call so tests can toggle without module reload.
+  const raw = (process.env.TOTALRECLAW_AUTO_RESOLVE_MODE ?? '').trim().toLowerCase();
+  const mode: AutoResolveMode =
+    raw === 'off' ? 'off' : raw === 'shadow' ? 'shadow' : 'active';
+
+  if (mode === 'off') return [];
+
+  // No entities → nothing to check.
+  const entities = Array.isArray(newClaim.e) ? newClaim.e : [];
+  if (entities.length === 0) return [];
+
+  const nowUnixSeconds =
+    typeof deps.nowUnixSeconds === 'number'
+      ? deps.nowUnixSeconds
+      : Math.floor(Date.now() / 1000);
+
+  const weightsFile = await loadWeightsFile(nowUnixSeconds);
+  const weightsJson = JSON.stringify(weightsFile.weights ?? {});
+  const thresholdLower =
+    typeof weightsFile.threshold_lower === 'number' ? weightsFile.threshold_lower : 0.3;
+  const thresholdUpper =
+    typeof weightsFile.threshold_upper === 'number' ? weightsFile.threshold_upper : 0.85;
+
+  let candidates: CandidateClaim[];
+  try {
+    candidates = await collectCandidatesForEntities(
+      newClaim,
+      newClaimId,
+      subgraphOwner,
+      authKeyHex,
+      encryptionKey,
+      deps,
+      logger,
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn(`Contradiction: candidate retrieval failed: ${msg}`);
+    return [];
+  }
+  if (candidates.length === 0) return [];
+
+  const rawDecisions = resolveWithCore({
+    newClaim,
+    newClaimId,
+    newEmbedding,
+    candidates,
+    weightsJson,
+    thresholdLower,
+    thresholdUpper,
+    nowUnixSeconds,
+    mode,
+    logger,
+  });
+
+  // Tie-zone guard: when the formula winner beats the loser by less than
+  // TIE_ZONE_SCORE_TOLERANCE, the "contradiction" is rounding noise.
+  // Core >= 1.5.0 already applies this inside resolveWithCandidates so this
+  // map is typically a no-op; kept defensively in case the core path is
+  // bypassed.
+  const decisions = rawDecisions.map((d): ResolutionDecision => {
+    if (
+      d.action === 'supersede_existing' &&
+      Math.abs(d.winnerScore - d.loserScore) < TIE_ZONE_SCORE_TOLERANCE
+    ) {
+      return {
+        action: 'tie_leave_both',
+        existingFactId: d.existingFactId,
+        entityId: d.entityId,
+        similarity: d.similarity,
+        winnerScore: d.winnerScore,
+        loserScore: d.loserScore,
+        winnerComponents: d.winnerComponents,
+        loserComponents: d.loserComponents,
+      };
+    }
+    return d;
+  });
+
+  // Build decision-log entries. Prefer core.buildDecisionLogEntries (>= 1.5.0)
+  // so the log format stays byte-for-byte compatible with the plugin.
+  const core = getWasm();
+  const useCoreDecisionLog = typeof core.buildDecisionLogEntries === 'function';
+
+  if (useCoreDecisionLog) {
+    try {
+      const coreActions = _decisionsToCoreActions(decisions, newClaimId);
+      const existingClaimsMap: Record<string, string> = {};
+      for (const d of decisions) {
+        if (d.action === 'supersede_existing') {
+          try { existingClaimsMap[d.existingFactId] = JSON.stringify(d.existingClaim); } catch { /* skip */ }
+        }
+      }
+      const entriesJson = core.buildDecisionLogEntries(
+        JSON.stringify(coreActions),
+        JSON.stringify(newClaim),
+        JSON.stringify(existingClaimsMap),
+        mode === 'shadow' ? 'shadow' : mode,
+        BigInt(Math.floor(nowUnixSeconds)),
+      );
+      const entries: DecisionLogEntry[] = JSON.parse(entriesJson);
+      for (const entry of entries) {
+        await appendDecisionLog(entry);
+        if (entry.action === 'tie_leave_both') {
+          logger.info(
+            `Contradiction: tie (gap=${Math.abs((entry.winner_score ?? 0) - (entry.loser_score ?? 0)).toFixed(6)} < ${TIE_ZONE_SCORE_TOLERANCE}, sim=${entry.similarity.toFixed(3)}, entity=${entry.entity_id}) — leaving both active`,
+          );
+        }
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.warn(`Contradiction: buildDecisionLogEntries failed, falling back to inline: ${msg}`);
+      await _appendDecisionLogInline(decisions, newClaimId, nowUnixSeconds, mode, logger);
+    }
+  } else {
+    await _appendDecisionLogInline(decisions, newClaimId, nowUnixSeconds, mode, logger);
+  }
+
+  // Shadow-mode filtering via core.filterShadowMode (>= 1.5.0).
+  if (typeof core.filterShadowMode === 'function') {
+    try {
+      const coreActions = _decisionsToCoreActions(decisions, newClaimId);
+      const filteredJson = core.filterShadowMode(JSON.stringify(coreActions), mode);
+      const filteredActions: Array<Record<string, unknown>> = JSON.parse(filteredJson);
+
+      const byExistingId = new Map<string, ResolutionDecision>();
+      for (const d of decisions) {
+        if (d.action === 'supersede_existing' || d.action === 'skip_new' || d.action === 'tie_leave_both') {
+          byExistingId.set(d.existingFactId, d);
+        }
+      }
+      return filteredActions
+        .map((a) => byExistingId.get(a.existing_id as string))
+        .filter((d): d is ResolutionDecision => d !== undefined);
+    } catch {
+      // Fall through to local filtering.
+    }
+  }
+
+  // Local fallback: shadow → empty, active → filter out ties.
+  if (mode === 'shadow') return [];
+  return decisions.filter((d) => d.action !== 'tie_leave_both');
+}
+
+/** Convert ResolutionDecision[] to core ResolutionAction JSON format. */
+function _decisionsToCoreActions(
+  decisions: ResolutionDecision[],
+  newClaimId: string,
+): Array<Record<string, unknown>> {
+  return decisions.map((d) => {
+    if (d.action === 'supersede_existing') {
+      return {
+        type: 'supersede_existing',
+        existing_id: d.existingFactId, new_id: newClaimId,
+        similarity: d.similarity, score_gap: Math.abs(d.winnerScore - d.loserScore),
+        entity_id: d.entityId, winner_score: d.winnerScore, loser_score: d.loserScore,
+        winner_components: d.winnerComponents, loser_components: d.loserComponents,
+      };
+    } else if (d.action === 'skip_new') {
+      return {
+        type: 'skip_new', reason: d.reason,
+        existing_id: d.existingFactId, new_id: newClaimId,
+        entity_id: d.entityId, similarity: d.similarity,
+        winner_score: d.winnerScore, loser_score: d.loserScore,
+        winner_components: d.winnerComponents, loser_components: d.loserComponents,
+      };
+    } else if (d.action === 'tie_leave_both') {
+      return {
+        type: 'tie_leave_both',
+        existing_id: d.existingFactId, new_id: newClaimId,
+        similarity: d.similarity, score_gap: Math.abs(d.winnerScore - d.loserScore),
+        entity_id: d.entityId, winner_score: d.winnerScore, loser_score: d.loserScore,
+        winner_components: d.winnerComponents, loser_components: d.loserComponents,
+      };
+    }
+    return { type: 'no_contradiction' };
+  });
+}
+
+/** Inline decision-log fallback (used when core.buildDecisionLogEntries unavailable). */
+async function _appendDecisionLogInline(
+  decisions: ResolutionDecision[],
+  newClaimId: string,
+  nowUnixSeconds: number,
+  mode: AutoResolveMode,
+  logger: ContradictionLogger,
+): Promise<void> {
+  for (const d of decisions) {
+    if (d.action === 'supersede_existing') {
+      let loserClaimJson: string | undefined;
+      try { loserClaimJson = JSON.stringify(d.existingClaim); } catch { loserClaimJson = undefined; }
+      await appendDecisionLog({
+        ts: nowUnixSeconds, entity_id: d.entityId,
+        new_claim_id: newClaimId, existing_claim_id: d.existingFactId,
+        similarity: d.similarity,
+        action: mode === 'shadow' ? 'shadow' : 'supersede_existing',
+        reason: 'new_wins',
+        winner_score: d.winnerScore, loser_score: d.loserScore,
+        winner_components: d.winnerComponents, loser_components: d.loserComponents,
+        loser_claim_json: loserClaimJson, mode,
+      });
+    } else if (d.action === 'skip_new') {
+      await appendDecisionLog({
+        ts: nowUnixSeconds, entity_id: d.entityId,
+        new_claim_id: newClaimId, existing_claim_id: d.existingFactId,
+        similarity: d.similarity,
+        action: mode === 'shadow' ? 'shadow' : 'skip_new',
+        reason: d.reason,
+        winner_score: d.winnerScore, loser_score: d.loserScore,
+        winner_components: d.winnerComponents, loser_components: d.loserComponents,
+        mode,
+      });
+    } else if (d.action === 'tie_leave_both') {
+      await appendDecisionLog({
+        ts: nowUnixSeconds, entity_id: d.entityId,
+        new_claim_id: newClaimId, existing_claim_id: d.existingFactId,
+        similarity: d.similarity,
+        action: 'tie_leave_both', reason: 'tie_below_tolerance',
+        winner_score: d.winnerScore, loser_score: d.loserScore,
+        winner_components: d.winnerComponents, loser_components: d.loserComponents,
+        mode,
+      });
+      logger.info(
+        `Contradiction: tie (gap=${Math.abs(d.winnerScore - d.loserScore).toFixed(6)} < ${TIE_ZONE_SCORE_TOLERANCE}, sim=${d.similarity.toFixed(3)}, entity=${d.entityId}) — leaving both active`,
+      );
+    }
+  }
+}

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -97,6 +97,10 @@ import {
 } from './subgraph/store.js';
 import { searchSubgraph, searchSubgraphBroadened, getOwnerFactCount, fetchFactById } from './subgraph/search.js';
 import {
+  detectAndResolveContradictions,
+  type ResolutionDecision,
+} from './contradiction-sync.js';
+import {
   pinToolDefinition,
   unpinToolDefinition,
   handlePin,
@@ -750,6 +754,109 @@ async function handleRememberSubgraph(
         reasoning: item.reasoning,
         importance: effectiveImportance,
       });
+
+      // Build the fact id up-front so contradiction detection can reference it.
+      const factId = crypto.randomUUID();
+
+      // Phase 2 Slice 2d: contradiction detection + auto-resolution.
+      //
+      // Mirrors the plugin's pattern at `skill/plugin/index.ts:1661-1754`. Runs
+      // only when the new claim has entities (the core contradiction primitive
+      // is entity-anchored), and only emits decisions when Rust core's
+      // `resolve_with_candidates` identifies a contradiction in the
+      // [threshold_lower, threshold_upper) similarity band.
+      //
+      // Pin respect is handled inside the Rust core via
+      // `respect_pin_in_resolution` — when an existing claim's status is
+      // pinned, the action emitted is `skip_new` with reason `existing_pinned`
+      // and the new write is dropped.
+      //
+      // Returns one decision per candidate contradicting claim:
+      //   - supersede_existing → queue a tombstone + proceed with the new write
+      //   - skip_new → do not write the new fact; record the skip reason
+      //   - empty list → no contradiction, proceed unchanged
+      //
+      // Never throws: on any error (subgraph, decrypt, WASM), returns [] and
+      // falls back to pre-Phase-2 behaviour.
+      let contradictionSkipNew = false;
+      try {
+        const newClaimObj = JSON.parse(blobPlaintext) as Record<string, unknown>;
+        const authKeyHex = Buffer.from(state.authKey).toString('hex');
+        const decisions: ResolutionDecision[] = await detectAndResolveContradictions({
+          newClaim: newClaimObj,
+          newClaimId: factId,
+          newEmbedding: embedding,
+          subgraphOwner: state.smartAccountAddress,
+          authKeyHex,
+          encryptionKey: state.encryptionKey,
+          deps: {
+            searchSubgraph: (owner, trapdoors, maxCandidates, authKey) =>
+              searchSubgraph(owner, trapdoors, maxCandidates, state.serverUrl, authKey).then((rows) =>
+                rows.map((r) => ({
+                  id: r.id,
+                  encryptedBlob: r.encryptedBlob,
+                  encryptedEmbedding: r.encryptedEmbedding ?? null,
+                  timestamp: r.timestamp,
+                  isActive: r.isActive,
+                })),
+              ),
+            decryptFromHex: (hex, key) => {
+              const clean = hex.startsWith('0x') ? hex.slice(2) : hex;
+              const base64 = Buffer.from(clean, 'hex').toString('base64');
+              return decrypt(base64, key);
+            },
+          },
+          logger: {
+            info: (m) => console.error(m),
+            warn: (m) => console.error(m),
+          },
+        });
+
+        for (const decision of decisions) {
+          if (decision.action === 'supersede_existing') {
+            const tombstonePayload: FactPayload = {
+              id: decision.existingFactId,
+              timestamp: new Date().toISOString(),
+              owner: state.smartAccountAddress,
+              encryptedBlob: Buffer.from('tombstone').toString('hex'),
+              blindIndices: [],
+              decayScore: 0,
+              source: 'mcp_contradiction',
+              contentFp: '',
+              agentId: 'mcp-server',
+            };
+            pendingPayloads.push(encodeFactProtobuf(tombstonePayload));
+            console.error(
+              `Auto-resolve: queued supersede for ${decision.existingFactId.slice(0, 10)}… ` +
+                `(sim=${decision.similarity.toFixed(3)}, entity=${decision.entityId})`,
+            );
+          } else if (decision.action === 'skip_new') {
+            if (decision.reason === 'existing_pinned') {
+              console.error(
+                `Auto-resolve: skipped new write — existing claim ${decision.existingFactId.slice(0, 10)}… is pinned ` +
+                  `(sim=${decision.similarity.toFixed(3)}, entity=${decision.entityId})`,
+              );
+            } else {
+              console.error(
+                `Auto-resolve: skipped new write — existing ${decision.existingFactId.slice(0, 10)}… wins ` +
+                  `(sim=${decision.similarity.toFixed(3)}, entity=${decision.entityId})`,
+              );
+            }
+            contradictionSkipNew = true;
+          }
+        }
+      } catch (crErr) {
+        // detectAndResolveContradictions is supposed to never throw — if it
+        // does, we log and continue with pre-Phase-2 behaviour.
+        const msg = crErr instanceof Error ? crErr.message : String(crErr);
+        console.error(`Contradiction detection failed (proceeding with store): ${msg}`);
+      }
+
+      if (contradictionSkipNew) {
+        results.push({ success: true, fact_id: factId, action: 'skipped_contradiction' });
+        continue;
+      }
+
       const encryptedBlob = encrypt(blobPlaintext, state.encryptionKey);
 
       // 5. Generate content fingerprint for dedup (over plaintext text, not blob)
@@ -759,7 +866,6 @@ async function handleRememberSubgraph(
       const encryptedEmb = encryptEmbedding(embedding, state.encryptionKey);
 
       // 7. Build fact payload
-      const factId = crypto.randomUUID();
       const factPayload: FactPayload = {
         id: factId,
         timestamp: new Date().toISOString(),

--- a/mcp/tests/contradiction-sync.test.ts
+++ b/mcp/tests/contradiction-sync.test.ts
@@ -1,0 +1,583 @@
+/**
+ * Tests for Phase 2 Slice 2d: contradiction detection + auto-resolution in
+ * the MCP server write path.
+ *
+ * Ported from `skill/plugin/contradiction-sync.test.ts` — same v0 short-key
+ * claim shape, same fake encrypt/decrypt, same WASM core. Cross-client parity
+ * means MCP and plugin produce identical outcomes given identical inputs.
+ *
+ * The WASM core (@totalreclaw/core) is NOT mocked. Tests run against the live
+ * bindings shipped with the MCP package — same @totalreclaw/core ^2.0.0 that
+ * ships in production. The subgraph + decisions.jsonl I/O are stubbed.
+ *
+ * Run with:
+ *   npx jest tests/contradiction-sync.test.ts --no-cache
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const {
+  appendDecisionLog,
+  CONTRADICTION_CANDIDATE_CAP,
+  decisionsLogPath,
+  detectAndResolveContradictions,
+  parseCandidateClaim,
+  resolveWithCore,
+  TIE_ZONE_SCORE_TOLERANCE,
+  isPinnedClaim,
+} = require('../src/contradiction-sync') as typeof import('../src/contradiction-sync');
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { computeEntityTrapdoor } = require('../src/claims-helper') as typeof import('../src/claims-helper');
+
+import type {
+  CandidateClaim,
+  CanonicalClaim,
+  DecisionLogEntry,
+  ResolutionDecision,
+} from '../src/contradiction-sync';
+
+// ---------------------------------------------------------------------------
+// Shared helpers — mirror plugin's test harness exactly so diffs are easy to
+// diagnose across packages.
+// ---------------------------------------------------------------------------
+
+function setupTempStateDir(label: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `mcp-contradiction-${label}-`));
+  process.env.TOTALRECLAW_STATE_DIR = dir;
+  return dir;
+}
+
+function cleanupTempStateDir(dir: string): void {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+  delete process.env.TOTALRECLAW_STATE_DIR;
+}
+
+const silentLogger = {
+  info: () => undefined,
+  warn: () => undefined,
+};
+
+function makeClaim(fields: Partial<CanonicalClaim> & { t: string; c?: string }): CanonicalClaim {
+  return {
+    t: fields.t,
+    c: fields.c ?? 'pref',
+    cf: 0.9,
+    i: 7,
+    sa: 'auto-extraction',
+    ea: '2026-04-01T00:00:00Z',
+    e: [{ n: 'editor', tp: 'concept' }],
+    ...fields,
+  };
+}
+
+function embed(values: number[], dims = 8): number[] {
+  const out = new Array<number>(dims).fill(0);
+  for (let i = 0; i < values.length && i < dims; i++) out[i] = values[i];
+  return out;
+}
+
+function fakeEncrypt(jsonString: string): string {
+  return Buffer.from(jsonString, 'utf-8').toString('hex');
+}
+
+function fakeDecrypt(hex: string, _key: Buffer): string {
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex;
+  return Buffer.from(clean, 'hex').toString('utf-8');
+}
+
+type FakeRow = {
+  id: string;
+  encryptedBlob: string;
+  encryptedEmbedding?: string | null;
+  isActive?: boolean;
+};
+
+function fakeSubgraph(byTrapdoor: Record<string, FakeRow[]>) {
+  return async (
+    _owner: string,
+    trapdoors: string[],
+    maxCandidates: number,
+    _authKeyHex?: string,
+  ): Promise<FakeRow[]> => {
+    const seen = new Set<string>();
+    const out: FakeRow[] = [];
+    for (const t of trapdoors) {
+      const rows = byTrapdoor[t] ?? [];
+      for (const r of rows) {
+        if (seen.has(r.id)) continue;
+        seen.add(r.id);
+        out.push(r);
+        if (out.length >= maxCandidates) return out;
+      }
+    }
+    return out;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// parseCandidateClaim — same surface as plugin, v0 short-key only
+// ---------------------------------------------------------------------------
+
+describe('parseCandidateClaim', () => {
+  it('accepts canonical v0 claim shape', () => {
+    const claim = makeClaim({ t: 'hello' });
+    const parsed = parseCandidateClaim(JSON.stringify(claim));
+    expect(parsed).not.toBeNull();
+    expect(parsed?.t).toBe('hello');
+  });
+
+  it('rejects v1 long-form claims (they lack short-key `t`/`c`)', () => {
+    const v1 = {
+      id: 'abc',
+      text: 'I use Vim',
+      type: 'preference',
+      source: 'user',
+      created_at: '2026-04-10T00:00:00Z',
+      schema_version: '1.0',
+    };
+    // v1 blobs are not in-band for core's Claim deserializer — the plugin
+    // filters them the same way. Cross-client parity: MCP must mirror.
+    expect(parseCandidateClaim(JSON.stringify(v1))).toBeNull();
+  });
+
+  it('rejects digest infra claims (category `dig`)', () => {
+    const digest = { ...makeClaim({ t: 'digest', c: 'dig' }) };
+    expect(parseCandidateClaim(JSON.stringify(digest))).toBeNull();
+  });
+
+  it('rejects entity-rollup claims (category `ent`)', () => {
+    const ent = { ...makeClaim({ t: 'ent', c: 'ent' }) };
+    expect(parseCandidateClaim(JSON.stringify(ent))).toBeNull();
+  });
+
+  it('rejects malformed JSON', () => {
+    expect(parseCandidateClaim('not json')).toBeNull();
+  });
+
+  it('rejects empty blob (digest tombstone)', () => {
+    // Digest tombstones round-trip as empty strings; make sure we skip them.
+    expect(parseCandidateClaim('')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isPinnedClaim — MCP delegates to core WASM
+// ---------------------------------------------------------------------------
+
+describe('isPinnedClaim', () => {
+  it('returns true for claim with st=p', () => {
+    const pinned = { ...makeClaim({ t: 'pinned' }), st: 'p' };
+    expect(isPinnedClaim(pinned)).toBe(true);
+  });
+
+  it('returns false for active claim (no st field)', () => {
+    expect(isPinnedClaim(makeClaim({ t: 'active' }))).toBe(false);
+  });
+
+  it('returns false for explicitly active claim (st=a)', () => {
+    const active = { ...makeClaim({ t: 'active' }), st: 'a' };
+    expect(isPinnedClaim(active)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// appendDecisionLog — roundtrips the jsonl format the plugin + MCP share
+// ---------------------------------------------------------------------------
+
+describe('appendDecisionLog', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = setupTempStateDir('append');
+  });
+  afterEach(() => {
+    cleanupTempStateDir(tmp);
+  });
+
+  it('writes a single jsonl line and round-trips it', async () => {
+    const entry: DecisionLogEntry = {
+      ts: 1_777_000_000,
+      entity_id: 'deadbeef12345678',
+      new_claim_id: 'new-1',
+      existing_claim_id: '0xold',
+      similarity: 0.7,
+      action: 'supersede_existing',
+      reason: 'new_wins',
+      winner_score: 0.85,
+      loser_score: 0.55,
+      mode: 'active',
+    };
+    await appendDecisionLog(entry);
+    const content = fs.readFileSync(decisionsLogPath(), 'utf-8');
+    const lines = content.split('\n').filter((l: string) => l.length > 0);
+    expect(lines.length).toBe(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.entity_id).toBe('deadbeef12345678');
+    expect(parsed.action).toBe('supersede_existing');
+    expect(parsed.reason).toBe('new_wins');
+    expect(parsed.mode).toBe('active');
+  });
+
+  it('appends a second line without overwriting the first', async () => {
+    const entry: DecisionLogEntry = {
+      ts: 1_777_000_000,
+      entity_id: 'a',
+      new_claim_id: 'n1',
+      existing_claim_id: 'e1',
+      similarity: 0.5,
+      action: 'skip_new',
+      reason: 'existing_wins',
+      mode: 'active',
+    };
+    await appendDecisionLog(entry);
+    await appendDecisionLog({ ...entry, existing_claim_id: 'e2' });
+    const content = fs.readFileSync(decisionsLogPath(), 'utf-8');
+    const lines = content.split('\n').filter((l: string) => l.length > 0);
+    expect(lines.length).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveWithCore — pure resolver, no file I/O
+// ---------------------------------------------------------------------------
+
+describe('resolveWithCore', () => {
+  it('mode=off returns [] immediately', () => {
+    const decisions = resolveWithCore({
+      newClaim: makeClaim({ t: 'new' }),
+      newClaimId: 'n1',
+      newEmbedding: embed([1, 0, 0], 8),
+      candidates: [
+        {
+          claim: makeClaim({ t: 'old' }),
+          id: 'e1',
+          embedding: embed([1, 0, 0], 8),
+        },
+      ],
+      weightsJson: '{}',
+      thresholdLower: 0.3,
+      thresholdUpper: 0.85,
+      nowUnixSeconds: 1_777_000_000,
+      mode: 'off',
+      logger: silentLogger,
+    });
+    expect(decisions).toEqual([]);
+  });
+
+  it('empty candidates returns []', () => {
+    const decisions = resolveWithCore({
+      newClaim: makeClaim({ t: 'new' }),
+      newClaimId: 'n1',
+      newEmbedding: embed([1, 0, 0], 8),
+      candidates: [],
+      weightsJson: '{}',
+      thresholdLower: 0.3,
+      thresholdUpper: 0.85,
+      nowUnixSeconds: 1_777_000_000,
+      mode: 'active',
+      logger: silentLogger,
+    });
+    expect(decisions).toEqual([]);
+  });
+
+  it('empty new embedding returns []', () => {
+    const decisions = resolveWithCore({
+      newClaim: makeClaim({ t: 'new' }),
+      newClaimId: 'n1',
+      newEmbedding: [],
+      candidates: [
+        {
+          claim: makeClaim({ t: 'old' }),
+          id: 'e1',
+          embedding: embed([1, 0, 0], 8),
+        },
+      ],
+      weightsJson: '{}',
+      thresholdLower: 0.3,
+      thresholdUpper: 0.85,
+      nowUnixSeconds: 1_777_000_000,
+      mode: 'active',
+      logger: silentLogger,
+    });
+    expect(decisions).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectAndResolveContradictions — end-to-end with real WASM
+//
+// These exercise the full pipeline: fetch candidates via fake subgraph,
+// decrypt, parse, run core.resolveWithCandidates, write decision log.
+// ---------------------------------------------------------------------------
+
+describe('detectAndResolveContradictions (E2E)', () => {
+  let tmp: string;
+  const origEnv = process.env.TOTALRECLAW_AUTO_RESOLVE_MODE;
+
+  beforeEach(() => {
+    tmp = setupTempStateDir('e2e');
+    delete process.env.TOTALRECLAW_AUTO_RESOLVE_MODE;
+  });
+
+  afterEach(() => {
+    cleanupTempStateDir(tmp);
+    if (origEnv !== undefined) {
+      process.env.TOTALRECLAW_AUTO_RESOLVE_MODE = origEnv;
+    } else {
+      delete process.env.TOTALRECLAW_AUTO_RESOLVE_MODE;
+    }
+  });
+
+  it('non-contradicting write: no decisions, proceed unchanged', async () => {
+    // No candidates returned by subgraph — pristine write path.
+    const search = fakeSubgraph({});
+    const decisions = await detectAndResolveContradictions({
+      newClaim: makeClaim({ t: 'I use VS Code' }),
+      newClaimId: 'new-vscode',
+      newEmbedding: embed([1, 0, 0, 0], 8),
+      subgraphOwner: '0xowner',
+      authKeyHex: 'authKey',
+      encryptionKey: Buffer.alloc(32),
+      deps: {
+        searchSubgraph: search,
+        decryptFromHex: fakeDecrypt,
+        nowUnixSeconds: 1_777_000_000,
+      },
+      logger: silentLogger,
+    });
+    expect(decisions).toEqual([]);
+    // No log written when no decisions fired.
+    expect(fs.existsSync(decisionsLogPath())).toBe(false);
+  });
+
+  it('contradicting write: new wins → supersede_existing decision', async () => {
+    // Stale existing claim that the new claim should beat on recency +
+    // validation (new carries sa='totalreclaw_remember' = user-validated).
+    const existingClaim = makeClaim({
+      t: 'I use Vim as my primary editor',
+      c: 'pref',
+      ea: '2025-06-01T00:00:00Z',
+      sa: 'auto-extraction',
+    });
+    const existingEmb = embed([Math.cos(Math.PI / 4), Math.sin(Math.PI / 4), 0, 0], 8);
+    const trapdoor = computeEntityTrapdoor('editor');
+    const search = fakeSubgraph({
+      [trapdoor]: [
+        {
+          id: 'existing-vim',
+          encryptedBlob: fakeEncrypt(JSON.stringify(existingClaim)),
+          encryptedEmbedding: fakeEncrypt(JSON.stringify(existingEmb)),
+          isActive: true,
+        },
+      ],
+    });
+    const newClaim = makeClaim({
+      t: 'I have switched to VS Code full-time',
+      c: 'pref',
+      ea: '2026-04-10T00:00:00Z',
+      sa: 'totalreclaw_remember',
+    });
+    const decisions = await detectAndResolveContradictions({
+      newClaim,
+      newClaimId: 'new-vscode',
+      newEmbedding: embed([1, 0, 0, 0], 8),
+      subgraphOwner: '0xowner',
+      authKeyHex: 'authKey',
+      encryptionKey: Buffer.alloc(32),
+      deps: {
+        searchSubgraph: search,
+        decryptFromHex: fakeDecrypt,
+        nowUnixSeconds: 1_777_000_000,
+      },
+      logger: silentLogger,
+    });
+
+    expect(decisions.length).toBe(1);
+    expect(decisions[0].action).toBe('supersede_existing');
+    if (decisions[0].action === 'supersede_existing') {
+      expect(decisions[0].existingFactId).toBe('existing-vim');
+    }
+
+    const log = fs.readFileSync(decisionsLogPath(), 'utf-8');
+    expect(log).toContain('supersede_existing');
+    expect(log).toContain('new_wins');
+  });
+
+  it('pinned existing: skip_new with reason=existing_pinned (new never overrides pin)', async () => {
+    const pinnedClaim = { ...makeClaim({ t: 'I use Vim' }), st: 'p' };
+    const existingEmb = embed([Math.cos(Math.PI / 4), Math.sin(Math.PI / 4), 0, 0], 8);
+    const trapdoor = computeEntityTrapdoor('editor');
+    const search = fakeSubgraph({
+      [trapdoor]: [
+        {
+          id: 'pinned-vim',
+          encryptedBlob: fakeEncrypt(JSON.stringify(pinnedClaim)),
+          encryptedEmbedding: fakeEncrypt(JSON.stringify(existingEmb)),
+          isActive: true,
+        },
+      ],
+    });
+    const decisions = await detectAndResolveContradictions({
+      newClaim: makeClaim({ t: 'I use VS Code now', ea: '2026-04-10T00:00:00Z' }),
+      newClaimId: 'new-vscode',
+      newEmbedding: embed([1, 0, 0, 0], 8),
+      subgraphOwner: '0xowner',
+      authKeyHex: 'authKey',
+      encryptionKey: Buffer.alloc(32),
+      deps: {
+        searchSubgraph: search,
+        decryptFromHex: fakeDecrypt,
+        nowUnixSeconds: 1_777_000_000,
+      },
+      logger: silentLogger,
+    });
+
+    expect(decisions.length).toBe(1);
+    expect(decisions[0].action).toBe('skip_new');
+    if (decisions[0].action === 'skip_new') {
+      expect(decisions[0].reason).toBe('existing_pinned');
+      expect(decisions[0].existingFactId).toBe('pinned-vim');
+    }
+
+    // Log row reflects the pin-respecting skip.
+    const log = fs.readFileSync(decisionsLogPath(), 'utf-8');
+    expect(log).toContain('existing_pinned');
+  });
+
+  it('mode=off: short-circuits before any subgraph query', async () => {
+    process.env.TOTALRECLAW_AUTO_RESOLVE_MODE = 'off';
+    let searchCalls = 0;
+    const search = (async () => {
+      searchCalls++;
+      return [];
+    }) as unknown as Parameters<typeof detectAndResolveContradictions>[0]['deps']['searchSubgraph'];
+    const decisions = await detectAndResolveContradictions({
+      newClaim: makeClaim({ t: 'I use VS Code now' }),
+      newClaimId: 'new-1',
+      newEmbedding: embed([1, 0, 0, 0], 8),
+      subgraphOwner: '0xowner',
+      authKeyHex: 'authKey',
+      encryptionKey: Buffer.alloc(32),
+      deps: { searchSubgraph: search, decryptFromHex: fakeDecrypt, nowUnixSeconds: 1_777_000_000 },
+      logger: silentLogger,
+    });
+    expect(decisions).toEqual([]);
+    expect(searchCalls).toBe(0);
+    expect(fs.existsSync(decisionsLogPath())).toBe(false);
+  });
+
+  it('no entities on new claim: returns [] without querying subgraph', async () => {
+    let searchCalls = 0;
+    const search = (async () => {
+      searchCalls++;
+      return [];
+    }) as unknown as Parameters<typeof detectAndResolveContradictions>[0]['deps']['searchSubgraph'];
+    const noEntityClaim = { ...makeClaim({ t: 'lone fact' }), e: [] };
+    const decisions = await detectAndResolveContradictions({
+      newClaim: noEntityClaim,
+      newClaimId: 'new-lone',
+      newEmbedding: embed([1, 0, 0, 0], 8),
+      subgraphOwner: '0xowner',
+      authKeyHex: 'authKey',
+      encryptionKey: Buffer.alloc(32),
+      deps: { searchSubgraph: search, decryptFromHex: fakeDecrypt, nowUnixSeconds: 1_777_000_000 },
+      logger: silentLogger,
+    });
+    expect(decisions).toEqual([]);
+    expect(searchCalls).toBe(0);
+  });
+
+  it('subgraph failure: swallows error, returns []', async () => {
+    const search = (async () => {
+      throw new Error('network boom');
+    }) as unknown as Parameters<typeof detectAndResolveContradictions>[0]['deps']['searchSubgraph'];
+    const decisions = await detectAndResolveContradictions({
+      newClaim: makeClaim({ t: 'new' }),
+      newClaimId: 'n1',
+      newEmbedding: embed([1, 0, 0, 0], 8),
+      subgraphOwner: '0xowner',
+      authKeyHex: 'authKey',
+      encryptionKey: Buffer.alloc(32),
+      deps: { searchSubgraph: search, decryptFromHex: fakeDecrypt, nowUnixSeconds: 1_777_000_000 },
+      logger: silentLogger,
+    });
+    expect(decisions).toEqual([]);
+  });
+
+  it('candidate with missing embedding: still processed but drops from WASM call', async () => {
+    // Candidate missing encryptedEmbedding should be decrypted + parsed but
+    // dropped in resolveWithCore before reaching WASM. No crash.
+    const existingClaim = makeClaim({ t: 'existing' });
+    const trapdoor = computeEntityTrapdoor('editor');
+    const search = fakeSubgraph({
+      [trapdoor]: [
+        {
+          id: 'no-embed',
+          encryptedBlob: fakeEncrypt(JSON.stringify(existingClaim)),
+          encryptedEmbedding: null,
+          isActive: true,
+        },
+      ],
+    });
+    const decisions = await detectAndResolveContradictions({
+      newClaim: makeClaim({ t: 'new' }),
+      newClaimId: 'n1',
+      newEmbedding: embed([1, 0, 0, 0], 8),
+      subgraphOwner: '0xowner',
+      authKeyHex: 'authKey',
+      encryptionKey: Buffer.alloc(32),
+      deps: { searchSubgraph: search, decryptFromHex: fakeDecrypt, nowUnixSeconds: 1_777_000_000 },
+      logger: silentLogger,
+    });
+    // No embedding → dropped from WASM call → no candidates → no decisions.
+    expect(decisions).toEqual([]);
+  });
+
+  it('inactive candidate: excluded from detection', async () => {
+    const existingClaim = makeClaim({ t: 'inactive existing' });
+    const existingEmb = embed([Math.cos(Math.PI / 4), Math.sin(Math.PI / 4), 0, 0], 8);
+    const trapdoor = computeEntityTrapdoor('editor');
+    const search = fakeSubgraph({
+      [trapdoor]: [
+        {
+          id: 'inactive-row',
+          encryptedBlob: fakeEncrypt(JSON.stringify(existingClaim)),
+          encryptedEmbedding: fakeEncrypt(JSON.stringify(existingEmb)),
+          isActive: false,
+        },
+      ],
+    });
+    const decisions = await detectAndResolveContradictions({
+      newClaim: makeClaim({ t: 'new' }),
+      newClaimId: 'n1',
+      newEmbedding: embed([1, 0, 0, 0], 8),
+      subgraphOwner: '0xowner',
+      authKeyHex: 'authKey',
+      encryptionKey: Buffer.alloc(32),
+      deps: { searchSubgraph: search, decryptFromHex: fakeDecrypt, nowUnixSeconds: 1_777_000_000 },
+      logger: silentLogger,
+    });
+    expect(decisions).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+describe('module constants', () => {
+  it('TIE_ZONE_SCORE_TOLERANCE is 0.01 (matches plugin)', () => {
+    expect(TIE_ZONE_SCORE_TOLERANCE).toBe(0.01);
+  });
+
+  it('CONTRADICTION_CANDIDATE_CAP is 20 (matches plugin)', () => {
+    expect(CONTRADICTION_CANDIDATE_CAP).toBe(20);
+  });
+});


### PR DESCRIPTION
## Summary

Wires Phase 2 contradiction detection + auto-resolution into the MCP server's subgraph write path. Closes the cross-client consistency gap called out in Roadmap Audit 2026-04-19 §2 item #1 and §7.2 Agent C: a fact pinned via OpenClaw and re-asserted via MCP (or vice versa) now produces the same outcome on both clients.

- New module `mcp/src/contradiction-sync.ts` mirrors `skill/plugin/contradiction-sync.ts`. Same decision semantics, same `decisions.jsonl` format — state directory is cross-client compatible.
- `handleRememberSubgraph` in `mcp/src/index.ts` runs `detectAndResolveContradictions` after store-time dedup, before protobuf encode. Mirrors the plugin pattern at `skill/plugin/index.ts:1661-1754`.
- Pin respect is enforced inside the Rust core via `respect_pin_in_resolution` (already shipped in `@totalreclaw/core@2.0.0`). Pinned facts are never silently overridden — a contradicting new write is skipped with reason `existing_pinned`.
- Fail-open: any subgraph / decrypt / WASM error returns `[]` and the write path falls back to pre-Phase-2 behaviour.

## Version + changelog

- `mcp/package.json`: `3.0.1` → `3.1.0` (minor — new behaviour, not a patch).
- Changelog entry added under `[3.1.0]`.

## Tests

New file `mcp/tests/contradiction-sync.test.ts` — 24 tests, all passing against the real `@totalreclaw/core` WASM:

| Case | Assertion |
|---|---|
| Non-contradicting write | no decisions, no log row, proceed unchanged |
| Contradicting write | one `supersede_existing` decision, log row with `new_wins` |
| Pinned existing | one `skip_new` with `reason='existing_pinned'`, pin never overridden |
| `mode=off` | short-circuit, no subgraph query, no log |
| No entities on new claim | early return, no subgraph query |
| Subgraph failure | swallowed, returns `[]` |
| Missing embedding | dropped from WASM call, no crash |
| Inactive candidate | excluded from detection |
| + `parseCandidateClaim`, `isPinnedClaim`, `appendDecisionLog`, `resolveWithCore`, constants | various shape/format parity checks |

### Full suite

Before: 530/530.
After: 554/554 (24 new, 0 regressions). Ran via `npm test`.

## Coordination with Agent D (mcp/src/tools/pin.ts — pin-on-tombstone recovery)

Agent D is running in parallel in a sibling worktree, writing only to `mcp/src/tools/pin.ts`. Scope is disjoint from this PR.

Both agents bump `mcp/package.json` — **this PR owns the 3.0.1 → 3.1.0 bump.** Agent D should skip the version bump on rebase and fold into 3.1.0. Changelog entry in this PR covers the contradiction-sync addition; Agent D to append their entry under the same `[3.1.0]` header.

## Scope guardrails

- MCP only. Did not touch `skill/plugin/*`, `python/`, `client/`, or `rust/`.
- Did not touch `mcp/src/tools/pin.ts` (Agent D's scope).
- Did not regenerate WASM binaries. Verified `resolveWithCandidates`, `buildDecisionLogEntries`, `filterShadowMode`, `respectPinInResolution`, `findLoserClaimInDecisionLog`, `isPinnedClaim`, `rotateFeedbackLog`, `defaultWeightsFile`, `parseWeightsFile` are all exported by the installed `@totalreclaw/core` package (`node_modules/@totalreclaw/core/totalreclaw_core.d.ts`).
- Did not publish.

## Test plan

- [ ] CI `npm test` green
- [ ] `npm run build` clean (verified locally)
- [ ] Real-user QA against staging before publish (per CLAUDE.md hard rule) — NOT yet run; this PR is code-only

## Known limitation

The plugin's `parseCandidateClaim` rejects v1 long-form blobs because the Rust core's `Claim` struct only deserializes the v0 short-key shape. MCP mirrors this exactly for cross-client parity. The practical impact: cross-client contradiction detection fires only when both sides emit claims with `t`/`c`/`e` short-key entity refs. A follow-up core change (hoisting v1-native contradiction detection into Rust) is tracked separately in the roadmap audit §2 — out of scope for Agent C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)