### PR TITLE
refactor(plugin): v3.0.6 — delegate consolidation to Rust core via WASM

### DIFF
--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.6] — 2026-04-19
+
+### Changed
+
+- **Internal refactor — memory consolidation now delegates to `@totalreclaw/core`
+  WASM.** `findNearDuplicate`, `shouldSupersede`, and `clusterFacts` in
+  `consolidation.ts` previously ran pure-TypeScript implementations of
+  cosine-similarity dedup, greedy single-pass clustering, and representative
+  selection. They now call the Rust core's WASM exports
+  (`findBestNearDuplicate`, `shouldSupersede`, `clusterFacts`) — the same
+  single source of truth already used by the MCP server
+  (`mcp/src/consolidation.ts:128-233`) and the Python client
+  (`python/src/totalreclaw/agent/lifecycle.py:73-94`). Public API, types,
+  thresholds, and return shapes are unchanged; no behavior change for callers.
+- **Dedup parity across clients.** OpenClaw plugin, MCP, and Python now all
+  emit byte-identical dedup decisions for the same inputs — previously plugin
+  had its own TS loop that was functionally equivalent but duplicated the
+  work. Cross-impl drift risk eliminated.
+- **Removed stale TODO.** The "hoist findNearDuplicate / clusterFacts /
+  pickRepresentative to @totalreclaw/core WASM once bindings are published"
+  comment at the top of `consolidation.ts` was shipped-ready — the core
+  WASM bindings have been live since `@totalreclaw/core` 1.5.0 (currently
+  2.0.0). Delivered.
+- **New parity tests.** `consolidation.test.ts` adds 6 tests that re-execute
+  representative inputs against the raw WASM API and assert the plugin
+  wrapper returns byte-identical results, so future drift between plugin
+  and core is caught at test time.
+
+### Fixed
+
+- Nothing. Pure internal refactor — no user-visible bug fixes.
+
 ## [3.0.5] — 2026-04-19
 
 ### Fixed

--- a/skill/plugin/consolidation.test.ts
+++ b/skill/plugin/consolidation.test.ts
@@ -340,6 +340,120 @@ console.log('# clusterFacts');
 }
 
 // ---------------------------------------------------------------------------
+// Cross-impl parity: plugin wrappers delegate to the exact same WASM functions
+// that MCP (`mcp/src/consolidation.ts`) delegates to. This block re-executes
+// the same inputs against the raw WASM API and asserts the plugin wrapper
+// returns the same result, so any future drift between plugin and core is
+// caught at test time.
+// ---------------------------------------------------------------------------
+
+console.log('# cross-impl parity (raw WASM vs plugin wrapper)');
+
+{
+  // Use createRequire from node:module so this works under ESM (plugin's
+  // runtime mode). Mirrors the pattern the module under test uses.
+  const { createRequire } = await import('node:module');
+  const requireWasm = createRequire(import.meta.url);
+  const wasm = requireWasm('@totalreclaw/core') as typeof import('@totalreclaw/core');
+
+  // findNearDuplicate parity
+  const newEmb = [1, 0, 0, 0];
+  const candidates = [
+    makeCandidate({ id: 'low', embedding: [0.86, Math.sqrt(1 - 0.86 * 0.86), 0, 0] }),
+    makeCandidate({ id: 'high', embedding: [0.99, Math.sqrt(1 - 0.99 * 0.99), 0, 0] }),
+    makeCandidate({ id: 'mid', embedding: [0.90, Math.sqrt(1 - 0.90 * 0.90), 0, 0] }),
+  ];
+
+  const pluginMatch = findNearDuplicate(newEmb, candidates, 0.85);
+  const rawExisting = candidates
+    .filter((c) => c.embedding && c.embedding.length > 0)
+    .map((c) => ({ id: c.id, embedding: c.embedding! }));
+  const rawResultJs = (wasm as any).findBestNearDuplicate(
+    JSON.stringify(newEmb),
+    JSON.stringify(rawExisting),
+    0.85,
+  );
+  const rawMatch: { fact_id: string; similarity: number } | null =
+    rawResultJs == null
+      ? null
+      : typeof rawResultJs === 'string'
+      ? JSON.parse(rawResultJs)
+      : rawResultJs;
+
+  assert(
+    pluginMatch !== null && rawMatch !== null && pluginMatch.existingFact.id === rawMatch.fact_id,
+    'parity: findNearDuplicate picks same fact_id as raw WASM findBestNearDuplicate',
+  );
+  assert(
+    pluginMatch !== null && rawMatch !== null &&
+      Math.abs(pluginMatch.similarity - rawMatch.similarity) < 1e-9,
+    'parity: findNearDuplicate similarity equals raw WASM similarity',
+  );
+}
+
+{
+  // shouldSupersede parity — plugin wrapper is a thin pass-through. Test
+  // that equal importance returns 'supersede' from BOTH plugin and raw WASM.
+  const { createRequire } = await import('node:module');
+  const requireWasm = createRequire(import.meta.url);
+  const wasm = requireWasm('@totalreclaw/core') as typeof import('@totalreclaw/core');
+
+  const existing = makeCandidate({ id: 'e', importance: 5 });
+  for (const [newImp, label] of [[8, 'higher'], [3, 'lower'], [5, 'equal']] as const) {
+    const pluginAns = shouldSupersede(newImp, existing);
+    const rawAns = wasm.shouldSupersede(newImp, existing.importance) ? 'supersede' : 'skip';
+    assert(pluginAns === rawAns, `parity: shouldSupersede agrees with raw WASM (${label} importance)`);
+  }
+}
+
+{
+  // clusterFacts parity — compare plugin-wrapper output (IDs only) against a
+  // raw WASM call with the same JSON payload. The plugin filters singleton
+  // clusters; apply the same filter to the raw output before comparing.
+  const { createRequire } = await import('node:module');
+  const requireWasm = createRequire(import.meta.url);
+  const wasm = requireWasm('@totalreclaw/core') as typeof import('@totalreclaw/core');
+
+  const facts = [
+    makeCandidate({ id: 'a1', embedding: [1, 0, 0] }),
+    makeCandidate({ id: 'a2', embedding: [1, 0, 0] }),
+    makeCandidate({ id: 'b1', embedding: [0, 1, 0] }),
+    makeCandidate({ id: 'b2', embedding: [0, 1, 0] }),
+    makeCandidate({ id: 'c1', embedding: [0, 0, 1] }), // singleton
+  ];
+
+  const pluginClusters = clusterFacts(facts, 0.88).map((c) => ({
+    representative: c.representative.id,
+    duplicates: [...c.duplicates.map((d) => d.id)].sort(),
+  }));
+
+  const wasmCandidates = facts.map((f) => ({
+    id: f.id,
+    text: f.text,
+    embedding: f.embedding!,
+    importance: f.importance,
+    decay_score: f.decayScore,
+    created_at: f.createdAt,
+    version: f.version,
+  }));
+  const rawJs = (wasm as any).clusterFacts(JSON.stringify(wasmCandidates), 0.88);
+  const rawClusters: { representative: string; duplicates: string[] }[] =
+    typeof rawJs === 'string' ? JSON.parse(rawJs) : rawJs;
+  const rawFiltered = rawClusters
+    .filter((c) => c.duplicates.length > 0)
+    .map((c) => ({ representative: c.representative, duplicates: [...c.duplicates].sort() }));
+
+  // Sort both by representative for stable comparison.
+  const norm = (arr: { representative: string; duplicates: string[] }[]) =>
+    [...arr].sort((x, y) => x.representative.localeCompare(y.representative));
+
+  assert(
+    JSON.stringify(norm(pluginClusters)) === JSON.stringify(norm(rawFiltered)),
+    'parity: clusterFacts output (sans singletons) equals raw WASM clusterFacts output',
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
 

--- a/skill/plugin/consolidation.ts
+++ b/skill/plugin/consolidation.ts
@@ -12,16 +12,29 @@
  *   3. Bulk consolidation — cluster all facts in the vault and identify
  *      groups of near-duplicates for cleanup (clusterFacts).
  *
- * This module intentionally has minimal dependencies (only reranker for
- * cosineSimilarity) so it can be tested without pulling in the full
- * plugin dependency graph.
+ * Delegates core computation to `@totalreclaw/core` Rust WASM module where
+ * bindings are available. `shouldSupersede` uses the core directly.
+ * `findNearDuplicate` and `clusterFacts` use the core's `findBestNearDuplicate`
+ * and `clusterFacts` WASM functions when available, falling back to local
+ * implementations that use WASM-backed `cosineSimilarity`.
+ *
+ * Threshold helpers remain local (they read process.env).
  */
 
+import { createRequire } from 'node:module';
 import { cosineSimilarity } from './reranker.js';
 
-// TODO: hoist findNearDuplicate, clusterFacts, pickRepresentative to
-// @totalreclaw/core WASM once findBestNearDuplicate / clusterFacts / pickRepresentative
-// bindings are published (pending core 1.5.0+ WASM bindings).
+// ---------------------------------------------------------------------------
+// Lazy-load WASM core (mirrors claims-helper.ts / contradiction-sync.ts
+// pattern — plays nicely under both the OpenClaw runtime (CJS-ish tsx) and
+// bare Node ESM used by tests).
+// ---------------------------------------------------------------------------
+const requireWasm = createRequire(import.meta.url);
+let _wasm: typeof import('@totalreclaw/core') | null = null;
+function getWasm(): typeof import('@totalreclaw/core') {
+  if (!_wasm) _wasm = requireWasm('@totalreclaw/core');
+  return _wasm!;
+}
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -110,6 +123,36 @@ export function findNearDuplicate(
   candidates: DecryptedCandidate[],
   threshold: number,
 ): NearDuplicateMatch | null {
+  const wasm = getWasm();
+
+  // Use core's findBestNearDuplicate if available (added in core >=1.5.0;
+  // guaranteed present in core >=2.0.0 which this plugin depends on).
+  if (typeof (wasm as any).findBestNearDuplicate === 'function') {
+    const existing = candidates
+      .filter((c) => c.embedding && c.embedding.length > 0)
+      .map((c) => ({ id: c.id, embedding: c.embedding! }));
+
+    if (existing.length === 0) return null;
+
+    const resultJs = (wasm as any).findBestNearDuplicate(
+      JSON.stringify(newFactEmbedding),
+      JSON.stringify(existing),
+      threshold,
+    );
+
+    if (resultJs == null) return null;
+
+    const result: { fact_id: string; similarity: number } =
+      typeof resultJs === 'string' ? JSON.parse(resultJs) : resultJs;
+
+    const matched = candidates.find((c) => c.id === result.fact_id);
+    if (!matched) return null;
+
+    return { existingFact: matched, similarity: result.similarity };
+  }
+
+  // Fallback: local loop using WASM-backed cosineSimilarity. Defensive only
+  // — core >=2.0.0 always exposes findBestNearDuplicate.
   let bestMatch: NearDuplicateMatch | null = null;
 
   for (const candidate of candidates) {
@@ -136,6 +179,8 @@ export function findNearDuplicate(
  * - Higher importance wins.
  * - Equal importance: new fact supersedes (newer is preferred).
  *
+ * Delegates to `@totalreclaw/core` WASM `shouldSupersede`.
+ *
  * @param newImportance - Importance score of the new fact
  * @param existingFact  - The existing near-duplicate candidate
  * @returns             - 'supersede' if new fact should replace, 'skip' otherwise
@@ -144,12 +189,126 @@ export function shouldSupersede(
   newImportance: number,
   existingFact: DecryptedCandidate,
 ): 'supersede' | 'skip' {
-  if (newImportance >= existingFact.importance) return 'supersede';
-  return 'skip';
+  const wasm = getWasm();
+  return wasm.shouldSupersede(newImportance, existingFact.importance) ? 'supersede' : 'skip';
 }
 
 // ---------------------------------------------------------------------------
 // Bulk consolidation
+// ---------------------------------------------------------------------------
+
+/**
+ * Cluster facts by semantic similarity using greedy single-pass clustering.
+ *
+ * Delegates to `@totalreclaw/core` WASM `clusterFacts` which performs the
+ * same greedy single-pass algorithm and representative selection. The WASM
+ * function returns ID-only clusters; this wrapper maps IDs back to full
+ * `DecryptedCandidate` objects for callers.
+ *
+ * Only returns clusters that have duplicates (i.e. more than one member).
+ * Facts without embeddings are not clustered.
+ *
+ * @param facts     - All facts to cluster
+ * @param threshold - Cosine similarity threshold (e.g. 0.88)
+ * @returns         - Clusters with duplicates (representative + duplicates)
+ */
+export function clusterFacts(
+  facts: DecryptedCandidate[],
+  threshold: number,
+): ConsolidationCluster[] {
+  const wasm = getWasm();
+
+  // Use core's clusterFacts if available (added in core >=1.5.0;
+  // guaranteed present in core >=2.0.0 which this plugin depends on).
+  if (typeof (wasm as any).clusterFacts === 'function') {
+    // Build ConsolidationCandidate JSON for WASM (snake_case fields).
+    const wasmCandidates = facts
+      .filter((f) => f.embedding && f.embedding.length > 0)
+      .map((f) => ({
+        id: f.id,
+        text: f.text,
+        embedding: f.embedding!,
+        importance: f.importance,
+        decay_score: f.decayScore,
+        created_at: f.createdAt,
+        version: f.version,
+      }));
+
+    if (wasmCandidates.length === 0) return [];
+
+    const resultJs = (wasm as any).clusterFacts(
+      JSON.stringify(wasmCandidates),
+      threshold,
+    );
+
+    // WASM returns a JSON string: [{ representative: string, duplicates: string[] }]
+    const wasmClusters: { representative: string; duplicates: string[] }[] =
+      typeof resultJs === 'string' ? JSON.parse(resultJs) : resultJs;
+
+    // Build a lookup map for fast ID -> DecryptedCandidate resolution.
+    const byId = new Map<string, DecryptedCandidate>();
+    for (const f of facts) byId.set(f.id, f);
+
+    // Map ID-only clusters back to full DecryptedCandidate objects.
+    // Filter out singleton clusters (no duplicates) to match the pre-WASM
+    // plugin contract — callers rely on `clusters.length === 0` when nothing
+    // duplicates anything.
+    const result: ConsolidationCluster[] = [];
+    for (const wc of wasmClusters) {
+      const rep = byId.get(wc.representative);
+      if (!rep) continue;
+
+      const dups = wc.duplicates
+        .map((id) => byId.get(id))
+        .filter((d): d is DecryptedCandidate => d !== undefined);
+
+      if (dups.length > 0) {
+        result.push({ representative: rep, duplicates: dups });
+      }
+    }
+
+    return result;
+  }
+
+  // Fallback: local greedy single-pass clustering using WASM-backed
+  // cosineSimilarity. Defensive only — core >=2.0.0 always exposes clusterFacts.
+  const clusters: { members: DecryptedCandidate[] }[] = [];
+
+  for (const fact of facts) {
+    if (!fact.embedding || fact.embedding.length === 0) continue;
+
+    let assigned = false;
+    for (const cluster of clusters) {
+      const seed = cluster.members[0];
+      if (!seed.embedding) continue;
+
+      const similarity = cosineSimilarity(fact.embedding, seed.embedding);
+      if (similarity >= threshold) {
+        cluster.members.push(fact);
+        assigned = true;
+        break;
+      }
+    }
+
+    if (!assigned) {
+      clusters.push({ members: [fact] });
+    }
+  }
+
+  const result: ConsolidationCluster[] = [];
+  for (const cluster of clusters) {
+    if (cluster.members.length < 2) continue;
+
+    const representative = pickRepresentative(cluster.members);
+    const duplicates = cluster.members.filter((m) => m !== representative);
+    result.push({ representative, duplicates });
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Local helpers (used only in fallback paths)
 // ---------------------------------------------------------------------------
 
 /**
@@ -173,59 +332,4 @@ function pickRepresentative(facts: DecryptedCandidate[]): DecryptedCandidate {
     }
   }
   return best;
-}
-
-/**
- * Cluster facts by semantic similarity using greedy single-pass clustering.
- *
- * For each fact (in order), assigns it to the first existing cluster whose
- * representative has cosine similarity >= threshold. If no cluster matches,
- * a new cluster is started.
- *
- * Only returns clusters that have duplicates (i.e. more than one member).
- * Facts without embeddings are not clustered.
- *
- * @param facts     - All facts to cluster
- * @param threshold - Cosine similarity threshold (e.g. 0.88)
- * @returns         - Clusters with duplicates (representative + duplicates)
- */
-export function clusterFacts(
-  facts: DecryptedCandidate[],
-  threshold: number,
-): ConsolidationCluster[] {
-  const clusters: { members: DecryptedCandidate[] }[] = [];
-
-  for (const fact of facts) {
-    if (!fact.embedding || fact.embedding.length === 0) continue;
-
-    let assigned = false;
-    for (const cluster of clusters) {
-      // Compare against the first member's embedding (cluster seed)
-      const seed = cluster.members[0];
-      if (!seed.embedding) continue;
-
-      const similarity = cosineSimilarity(fact.embedding, seed.embedding);
-      if (similarity >= threshold) {
-        cluster.members.push(fact);
-        assigned = true;
-        break;
-      }
-    }
-
-    if (!assigned) {
-      clusters.push({ members: [fact] });
-    }
-  }
-
-  // Only return clusters with duplicates, pick representative for each
-  const result: ConsolidationCluster[] = [];
-  for (const cluster of clusters) {
-    if (cluster.members.length < 2) continue;
-
-    const representative = pickRepresentative(cluster.members);
-    const duplicates = cluster.members.filter((m) => m !== representative);
-    result.push({ representative, duplicates });
-  }
-
-  return result;
 }

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. Automatic extraction, semantic search, and on-chain storage",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary

- Rewrites `skill/plugin/consolidation.ts` as thin wrappers around `@totalreclaw/core` WASM, matching the pattern MCP already uses at `mcp/src/consolidation.ts:128-233` and Python uses at `python/src/totalreclaw/agent/lifecycle.py:73-94`. Plugin was the last client still running pure-TS dedup — now every client delegates to the same Rust source of truth.
- Deletes the stale TODO at `consolidation.ts:22-24` (the core WASM exports it was waiting on have been live since core 1.5.0; the plugin peer-dep range `^2.0.0` guarantees them).
- Public API, exported types, thresholds, and return shapes are unchanged; `index.ts` and `store-dedup-wiring.test.ts` call sites required no modification.
- Adds 6 cross-impl parity tests to `consolidation.test.ts` that re-execute representative inputs against the raw WASM API and assert the plugin wrapper returns byte-identical results. Baseline 36 preserved; suite is now 42/42 green.
- Version bump `3.0.5` → `3.0.6` (patch — internal refactor, no behavior change). Changelog entry added.

Identified by `docs/notes/ROADMAP-AUDIT-20260419.md` §2 item #4 + §7.2 Agent E.

## Test plan

- [x] `npx tsx skill/plugin/consolidation.test.ts` — 42/42 pass (baseline 36 + 6 new parity tests against raw WASM)
- [x] `npx tsx skill/plugin/store-dedup-wiring.test.ts` — 23/23 pass (no callers needed adaptation)
- [x] Confirmed public API of `consolidation.ts` is byte-identical (same exports, signatures, thresholds, return shapes)
- [x] Confirmed `@totalreclaw/core@2.0.0` on npm exports all three WASM functions used: `findBestNearDuplicate`, `clusterFacts`, `shouldSupersede`
- [x] Confirmed no behavioral drift vs pre-change TS impl — representative tiebreak (decayScore → createdAt → text length), clusterFacts seed-comparison, and shouldSupersede equal-importance-wins all match between Rust core and old TS impl
- [ ] Full real-user QA on staging per CLAUDE.md hard rule before ClawHub publish (user gates publish workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)