### PR TITLE
feat(python): v2.2.1 — wire auto_extract to remember_batch

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,38 @@ Hermes Agent plugin are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2026-04-19
+
+Wire `auto_extract` to `remember_batch`; realizes the ~8x extraction latency win
+from 2.2.0. No new public API — internal call-site change only.
+
+### Changed
+
+- `agent/lifecycle.py::auto_extract` now submits ADD/UPDATE facts via
+  `client.remember_batch()` in chunks of 15 instead of looping
+  `client.remember()` per fact. DELETE and NOOP actions are unaffected.
+  For a 15-fact extraction cycle this drops relay round-trips from 15
+  separate UserOperations to 1, matching the ~60s → ~8s latency projection
+  from the Gap 3 notes in 2.2.0.
+- Per-fact error granularity is preserved: if `remember_batch` returns
+  fewer IDs than facts, the missing ones are logged at WARNING level so
+  the caller can diagnose. If the whole batch fails, each fact is logged
+  individually.
+- UPDATE tombstones (`client.forget(existing_fact_id)`) are still issued
+  individually after the batch that stored the replacement, preserving the
+  same ordering guarantee as the old loop.
+
+### Tests
+
+- +3 new tests (`tests/test_auto_extract_uses_batch.py`):
+  `test_auto_extract_5_facts_calls_remember_batch_once`,
+  `test_auto_extract_20_facts_calls_remember_batch_twice`,
+  `test_auto_extract_partial_failure_logs_failed_facts`.
+- Updated `tests/test_v1_hooks_integration.py` and
+  `tests/test_hermes_plugin.py` to assert on `remember_batch` instead of
+  `remember` for the auto-extraction path.
+- Full suite: 640 passing, 9 skipped, 1 xfailed.
+
 ## [2.2.0] - 2026-04-19
 
 Hermes parity Gap 3: client-side batching. Drops 15-fact extraction

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "totalreclaw"
-version = "2.2.0"
+version = "2.2.1"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"

--- a/python/src/totalreclaw/agent/lifecycle.py
+++ b/python/src/totalreclaw/agent/lifecycle.py
@@ -29,6 +29,11 @@ logger = logging.getLogger(__name__)
 
 STORE_DEDUP_THRESHOLD = 0.85  # Cosine similarity for near-duplicate detection
 
+# Maximum facts per batched UserOperation — mirrors userop.MAX_BATCH_SIZE so
+# we don't need to import from userop here (avoids a circular-import risk).
+# If the userop constant ever changes, update both.
+_LIFECYCLE_MAX_BATCH = 15
+
 
 def _fetch_recent_memories(state: "AgentState") -> list[dict]:
     """Fetch recent memories from the vault for dedup context.
@@ -174,18 +179,30 @@ def auto_extract(state: "AgentState", mode: str = "turn", llm_config=None) -> li
     except Exception as exc:
         logger.debug("Contradiction detection failed (proceeding with all facts): %s", exc)
 
+    # -----------------------------------------------------------------------
+    # Two-pass approach:
+    #   Pass 1 — handle NOOP / DELETE actions individually (no batch needed).
+    #   Pass 2 — collect ADD / UPDATE facts that survive dedup into a pending
+    #            list, then submit in chunks of _LIFECYCLE_MAX_BATCH via
+    #            client.remember_batch().  UPDATE tombstones (forget old id)
+    #            are issued after the batch that stored the replacement.
+    # -----------------------------------------------------------------------
+
+    # pending_store: list of (fact, embedding, fact_dict) for batch submission
+    pending_store: list[tuple[ExtractedFact, Optional[list[float]], dict]] = []
+
     for fact in facts:
         try:
             if fact.action == "NOOP":
                 continue
 
             if fact.action == "DELETE":
-                # Tombstone the old fact
+                # Tombstone the old fact — one-at-a-time, no batch needed.
                 if fact.existing_fact_id:
                     run_sync(client.forget(fact.existing_fact_id))
                 continue
 
-            # For ADD and UPDATE: store the new fact
+            # For ADD and UPDATE: resolve embedding + run dedup, then enqueue.
             embedding = None
             try:
                 from totalreclaw.embedding import get_embedding
@@ -200,33 +217,75 @@ def auto_extract(state: "AgentState", mode: str = "turn", llm_config=None) -> li
                     logger.debug("Skipping near-duplicate fact: %s", fact.text[:80])
                     continue
 
+            # Build the fact dict — mirrors the kwargs passed to remember() so
+            # remember_batch() sees an identical payload.
+            fact_dict: dict = {
+                "text": fact.text,
+                "embedding": embedding,
+                "importance": fact.importance / 10.0,  # Normalize 1-10 to 0.0-1.0
+                "fact_type": fact.type,
+                "entities": fact.entities,
+                "confidence": fact.confidence,
+                "provenance": fact.source or "user-inferred",
+                "scope": fact.scope or "unspecified",
+                "reasoning": fact.reasoning,
+                "volatility": fact.volatility,
+            }
+            pending_store.append((fact, embedding, fact_dict))
+
+        except Exception as e:
+            logger.warning("Failed to prepare extracted fact for batch: %s", e)
+
+    # Submit pending ADD/UPDATE facts in chunks of _LIFECYCLE_MAX_BATCH.
+    for chunk_start in range(0, len(pending_store), _LIFECYCLE_MAX_BATCH):
+        chunk = pending_store[chunk_start : chunk_start + _LIFECYCLE_MAX_BATCH]
+        chunk_dicts = [fd for (_, _, fd) in chunk]
+
+        try:
             # v1 write path — forward the taxonomy fields the extractor
             # populated (source/scope/reasoning/volatility). Defensive
             # fallback for source matches the plugin's
             # ``storeExtractedFacts`` handling.
-            run_sync(
-                client.remember(
-                    fact.text,
-                    embedding=embedding,
-                    importance=fact.importance / 10.0,  # Normalize 1-10 to 0.0-1.0
-                    source="hermes-auto",
-                    fact_type=fact.type,
-                    entities=fact.entities,
-                    confidence=fact.confidence,
-                    provenance=fact.source or "user-inferred",
-                    scope=fact.scope or "unspecified",
-                    reasoning=fact.reasoning,
-                    volatility=fact.volatility,
-                )
+            fact_ids = run_sync(
+                client.remember_batch(chunk_dicts, source="hermes-auto")
             )
-            stored_texts.append(fact.text)
-
-            # For UPDATE: also tombstone the old fact after storing the new one
-            if fact.action == "UPDATE" and fact.existing_fact_id:
-                run_sync(client.forget(fact.existing_fact_id))
-
         except Exception as e:
-            logger.warning("Failed to store/process extracted fact: %s", e)
+            logger.warning(
+                "remember_batch failed for chunk of %d facts: %s", len(chunk), e
+            )
+            # On a total batch failure, none of the facts in this chunk landed.
+            # Log each one individually so the caller can diagnose.
+            for fact, _, _ in chunk:
+                logger.warning(
+                    "Fact not stored (batch failure): %s", fact.text[:80]
+                )
+            continue
+
+        # fact_ids is a list[str] in the same order as chunk_dicts.
+        # Process per-fact results: log stored facts and issue UPDATE tombstones.
+        for i, (fact, _, _) in enumerate(chunk):
+            try:
+                fact_id = fact_ids[i] if i < len(fact_ids) else None
+                if fact_id:
+                    stored_texts.append(fact.text)
+                    # For UPDATE: tombstone the old fact after the replacement
+                    # has been successfully stored.
+                    if fact.action == "UPDATE" and fact.existing_fact_id:
+                        try:
+                            run_sync(client.forget(fact.existing_fact_id))
+                        except Exception as fe:
+                            logger.warning(
+                                "Failed to tombstone old fact %s after UPDATE: %s",
+                                fact.existing_fact_id, fe,
+                            )
+                else:
+                    # remember_batch returned a short list — treat as failure.
+                    logger.warning(
+                        "Fact not stored (no id returned by batch): %s",
+                        fact.text[:80],
+                    )
+            except Exception as e:
+                logger.warning("Failed to process batch result for fact: %s", e)
 
     state.mark_messages_processed()
     return stored_texts

--- a/python/src/totalreclaw/hermes/plugin.yaml
+++ b/python/src/totalreclaw/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: totalreclaw
-version: 2.2.0
+version: 2.2.1
 description: End-to-end encrypted memory vault for AI agents (Memory Taxonomy v1)
 author: TotalReclaw Team
 provides_tools:

--- a/python/tests/test_auto_extract_uses_batch.py
+++ b/python/tests/test_auto_extract_uses_batch.py
@@ -1,0 +1,217 @@
+"""Tests for v2.2.1 batch wiring: auto_extract calls remember_batch.
+
+Verifies:
+1. With 5 extracted facts, remember_batch is called once (not 5 remember calls).
+2. With 20 extracted facts, remember_batch is called twice (chunked at 15).
+3. Partial-failure path: batch returns a shorter id list; surviving facts are
+   logged to stored_texts and failed ones are reported via logger.warning.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+import pytest
+
+from totalreclaw.agent.extraction import ExtractedFact
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_state_and_client():
+    """Build a minimal PluginState with a stubbed client.
+
+    remember_batch is configured with a side_effect that returns one UUID
+    per fact in the batch — so any call with N facts returns N IDs.
+    """
+    from totalreclaw.hermes.state import PluginState
+
+    with patch.dict(os.environ, {}, clear=True):
+        with patch.object(Path, "exists", return_value=False):
+            state = PluginState()
+
+    fake_client = MagicMock()
+    fake_client.recall = AsyncMock(return_value=[])
+    fake_client.forget = AsyncMock(return_value=True)
+    fake_client.remember = AsyncMock(return_value="should-not-be-called")
+
+    # Default remember_batch: return one UUID per fact so stored_texts is populated.
+    call_count = [0]
+
+    async def _batch_side_effect(facts, source="python-client"):
+        n = len(facts)
+        ids = [f"fact-id-{call_count[0]}-{i}" for i in range(n)]
+        call_count[0] += 1
+        return ids
+
+    fake_client.remember_batch = AsyncMock(side_effect=_batch_side_effect)
+    state._client = fake_client
+    return state, fake_client
+
+
+def _make_facts(n: int, action: str = "ADD") -> list[ExtractedFact]:
+    """Create n distinct ExtractedFact instances."""
+    return [
+        ExtractedFact(
+            text=f"Fact number {i}: user detail here",
+            type="claim",
+            importance=7,
+            action=action,
+            confidence=0.9,
+            source="user",
+            scope="unspecified",
+        )
+        for i in range(n)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Test 1: 5 facts → 1 remember_batch call, 0 remember calls
+# ---------------------------------------------------------------------------
+
+
+def test_auto_extract_5_facts_calls_remember_batch_once() -> None:
+    """Given 5 extracted facts, remember_batch is called exactly once."""
+    from totalreclaw.agent.lifecycle import auto_extract
+
+    state, fake_client = _make_state_and_client()
+    facts = _make_facts(5)
+
+    async def fake_extract(*args, **kwargs):
+        return facts
+
+    async def passthrough(fs, *args, **kwargs):
+        return fs
+
+    with patch("totalreclaw.agent.lifecycle.extract_facts_llm", new=fake_extract), \
+         patch("totalreclaw.agent.lifecycle.detect_and_resolve_contradictions", new=passthrough), \
+         patch("totalreclaw.agent.lifecycle._fetch_recent_memories", return_value=[]), \
+         patch("totalreclaw.agent.lifecycle._is_near_duplicate", return_value=False), \
+         patch("totalreclaw.embedding.get_embedding", return_value=None):
+
+        # Add a message so get_unprocessed_messages() returns something.
+        state.add_message("user", "I like fact number 0")
+        state.add_message("assistant", "Got it")
+        stored = auto_extract(state)
+
+    # remember_batch called exactly once with all 5 facts
+    assert isinstance(fake_client.remember_batch, AsyncMock)
+    assert fake_client.remember_batch.call_count == 1, (
+        f"expected 1 remember_batch call, got {fake_client.remember_batch.call_count}"
+    )
+    # remember must NOT have been called (auto_extract now uses batch path)
+    assert fake_client.remember.call_count == 0, (
+        "client.remember should not be called — auto_extract uses remember_batch"
+    )
+    # The batch should contain all 5 facts
+    batch_args = fake_client.remember_batch.call_args
+    fact_dicts = batch_args.args[0]
+    assert len(fact_dicts) == 5, f"expected 5 fact dicts, got {len(fact_dicts)}"
+    # source kwarg is shared
+    assert batch_args.kwargs.get("source") == "hermes-auto"
+    # All 5 texts stored
+    assert len(stored) == 5
+
+
+# ---------------------------------------------------------------------------
+# Test 2: 20 facts → 2 remember_batch calls (chunked at 15)
+# ---------------------------------------------------------------------------
+
+
+def test_auto_extract_20_facts_calls_remember_batch_twice() -> None:
+    """Given 20 extracted facts, remember_batch is called twice (chunks of 15+5)."""
+    from totalreclaw.agent.lifecycle import auto_extract
+
+    # Track batch sizes to verify chunking
+    batch_sizes: list[int] = []
+
+    async def _tracking_side_effect(facts, source="python-client"):
+        batch_sizes.append(len(facts))
+        return [f"id-{i}" for i in range(len(facts))]
+
+    state, fake_client = _make_state_and_client()
+    fake_client.remember_batch = AsyncMock(side_effect=_tracking_side_effect)
+    facts = _make_facts(20)
+
+    async def fake_extract(*args, **kwargs):
+        return facts
+
+    async def passthrough(fs, *args, **kwargs):
+        return fs
+
+    with patch("totalreclaw.agent.lifecycle.extract_facts_llm", new=fake_extract), \
+         patch("totalreclaw.agent.lifecycle.detect_and_resolve_contradictions", new=passthrough), \
+         patch("totalreclaw.agent.lifecycle._fetch_recent_memories", return_value=[]), \
+         patch("totalreclaw.agent.lifecycle._is_near_duplicate", return_value=False), \
+         patch("totalreclaw.embedding.get_embedding", return_value=None):
+
+        state.add_message("user", "Tell me facts")
+        state.add_message("assistant", "Here they are")
+        # Override max_facts so the 20-fact cap doesn't truncate before chunking.
+        with patch.object(state, "get_max_facts_per_extraction", return_value=20):
+            stored = auto_extract(state)
+
+    # Must be called twice (15 + 5)
+    assert len(batch_sizes) == 2, (
+        f"expected 2 remember_batch calls for 20 facts, got {len(batch_sizes)}"
+    )
+    assert batch_sizes[0] == 15, f"first chunk should be 15, got {batch_sizes[0]}"
+    assert batch_sizes[1] == 5, f"second chunk should be 5, got {batch_sizes[1]}"
+    # All 20 texts stored
+    assert len(stored) == 20
+
+
+# ---------------------------------------------------------------------------
+# Test 3: partial-failure — batch returns shorter id list
+# ---------------------------------------------------------------------------
+
+
+def test_auto_extract_partial_failure_logs_failed_facts(caplog) -> None:
+    """When remember_batch returns fewer IDs than facts, surviving facts are
+    stored and failed ones are logged via logger.warning.
+
+    Simulates the case where 3 facts are batched but only 2 IDs come back
+    (the third fact's id is missing → treat as failure).
+    """
+    from totalreclaw.agent.lifecycle import auto_extract
+
+    state, fake_client = _make_state_and_client()
+    # Override remember_batch to return only 2 IDs for a batch of 3.
+    fake_client.remember_batch = AsyncMock(return_value=["id-0", "id-1"])
+    facts = _make_facts(3)
+
+    async def fake_extract(*args, **kwargs):
+        return facts
+
+    async def passthrough(fs, *args, **kwargs):
+        return fs
+
+    with caplog.at_level(logging.WARNING, logger="totalreclaw.agent.lifecycle"):
+        with patch("totalreclaw.agent.lifecycle.extract_facts_llm", new=fake_extract), \
+             patch("totalreclaw.agent.lifecycle.detect_and_resolve_contradictions", new=passthrough), \
+             patch("totalreclaw.agent.lifecycle._fetch_recent_memories", return_value=[]), \
+             patch("totalreclaw.agent.lifecycle._is_near_duplicate", return_value=False), \
+             patch("totalreclaw.embedding.get_embedding", return_value=None):
+
+            state.add_message("user", "Three facts please")
+            state.add_message("assistant", "OK")
+            stored = auto_extract(state)
+
+    # Only 2 facts successfully stored (the ones with returned IDs)
+    assert len(stored) == 2, f"expected 2 stored facts, got {len(stored)}"
+    assert facts[0].text in stored
+    assert facts[1].text in stored
+    assert facts[2].text not in stored
+
+    # A warning must have been logged for the missing-id case
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("no id" in r.getMessage().lower() or "not stored" in r.getMessage().lower()
+               for r in warnings), (
+        f"expected a warning for the unidded fact, got: {[r.getMessage() for r in warnings]}"
+    )

--- a/python/tests/test_hermes_plugin.py
+++ b/python/tests/test_hermes_plugin.py
@@ -434,14 +434,10 @@ class TestStoreTimeDedup:
         async def mock_recall(query, top_k=50):
             return [mock_recall_result]
 
-        async def mock_remember(*args, **kwargs):
-            return "new-id"
-
         async def mock_forget(fact_id):
             return True
 
         mock_client.recall = mock_recall
-        mock_client.remember = mock_remember
         mock_client.forget = mock_forget
 
         state.add_message("user", "I like dark mode")
@@ -456,14 +452,14 @@ class TestStoreTimeDedup:
             importance=9, action="UPDATE", existing_fact_id="existing-1"
         )
 
-        remember_calls = []
-        original_remember = mock_client.remember
+        # As of v2.2.1 auto_extract uses remember_batch instead of remember.
+        batch_calls = []
 
-        async def tracking_remember(*args, **kwargs):
-            remember_calls.append((args, kwargs))
-            return "new-id"
+        async def tracking_remember_batch(facts, source="python-client"):
+            batch_calls.append((facts, source))
+            return ["new-id"] * len(facts)
 
-        mock_client.remember = tracking_remember
+        mock_client.remember_batch = tracking_remember_batch
 
         with patch("totalreclaw.agent.lifecycle.extract_facts_llm") as mock_llm, \
              patch("totalreclaw.agent.lifecycle.extract_facts_heuristic"), \
@@ -478,9 +474,15 @@ class TestStoreTimeDedup:
 
             # ADD should be skipped (near-duplicate of existing [1,0,0])
             # UPDATE should go through (bypasses dedup)
-            # So we expect exactly 1 remember call (for the UPDATE)
-            assert len(remember_calls) == 1
-            assert remember_calls[0][1].get("source") == "hermes-auto"
+            # So we expect exactly 1 batch call with 1 fact dict (the UPDATE)
+            assert len(batch_calls) == 1, (
+                f"expected 1 remember_batch call, got {len(batch_calls)}"
+            )
+            facts_in_batch, source = batch_calls[0]
+            assert len(facts_in_batch) == 1, (
+                f"expected 1 fact in batch (UPDATE only), got {len(facts_in_batch)}"
+            )
+            assert source == "hermes-auto"
 
 
 class TestRegister:

--- a/python/tests/test_v1_hooks_integration.py
+++ b/python/tests/test_v1_hooks_integration.py
@@ -31,6 +31,8 @@ def _make_state(**env_overrides):
     # Forge a fake client so is_configured() returns True.
     fake_client = MagicMock()
     fake_client.remember = AsyncMock(return_value="fact-uuid-abc")
+    # remember_batch returns a list of fact IDs (one per fact in the batch).
+    fake_client.remember_batch = AsyncMock(return_value=["fact-uuid-abc"])
     fake_client.recall = AsyncMock(return_value=[])
     fake_client.forget = AsyncMock(return_value=True)
     state._client = fake_client
@@ -42,8 +44,12 @@ def _make_state(**env_overrides):
 # ---------------------------------------------------------------------------
 
 
-def test_post_llm_call_forwards_v1_fields_to_remember() -> None:
-    """When auto_extract fires, client.remember receives v1 type/source/scope."""
+def test_post_llm_call_forwards_v1_fields_to_remember_batch() -> None:
+    """When auto_extract fires, client.remember_batch receives v1 type/source/scope.
+
+    As of v2.2.1 auto_extract calls remember_batch instead of remember per-fact.
+    We verify the batch dict payload carries all the v1 taxonomy fields.
+    """
     from totalreclaw.hermes.hooks import post_llm_call
 
     state, fake_client = _make_state()
@@ -91,18 +97,27 @@ def test_post_llm_call_forwards_v1_fields_to_remember() -> None:
                     for _ in range(DEFAULT_EXTRACTION_INTERVAL):
                         post_llm_call(state, user_message="u", assistant_response="a")
 
-    # Assert client.remember was called with v1 kwargs.
-    assert fake_client.remember.called, "client.remember should have been called"
-    call = fake_client.remember.call_args
-    kwargs = call.kwargs
+    # As of v2.2.1 auto_extract uses remember_batch (not remember per-fact).
+    assert fake_client.remember_batch.called, "client.remember_batch should have been called"
+    assert not fake_client.remember.called, (
+        "client.remember should NOT be called — auto_extract now uses remember_batch"
+    )
 
-    # The first positional is the text; then we check kwargs.
-    assert call.args[0] == fake_fact.text
-    assert kwargs["fact_type"] == "preference"
-    assert kwargs["provenance"] == "user"
-    assert kwargs["scope"] == "work"
-    assert kwargs["volatility"] == "stable"
-    assert kwargs["reasoning"] is None
+    # Inspect the batch dict payload for v1 taxonomy fields.
+    batch_call = fake_client.remember_batch.call_args
+    # First arg is the list of fact dicts.
+    fact_dicts = batch_call.args[0]
+    assert len(fact_dicts) == 1, f"expected 1 fact dict in batch, got {len(fact_dicts)}"
+    fd = fact_dicts[0]
+
+    assert fd["text"] == fake_fact.text
+    assert fd["fact_type"] == "preference"
+    assert fd["provenance"] == "user"
+    assert fd["scope"] == "work"
+    assert fd["volatility"] == "stable"
+    assert fd["reasoning"] is None
+    # source is passed as the shared kwarg, not per-dict
+    assert batch_call.kwargs.get("source") == "hermes-auto"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Wires `agent/lifecycle.py::auto_extract` to call `client.remember_batch()` instead of looping `client.remember()` per fact, realizing the ~8x latency win shipped in 2.2.0 (Gap 3).
- Facts are submitted in chunks of 15 (matching `MAX_BATCH_SIZE`); 20-fact extraction → 2 UserOperations instead of 20.
- DELETE/NOOP actions remain per-fact; UPDATE tombstones (`client.forget(existing_fact_id)`) are still issued individually after the batch storing the replacement, preserving observable ordering.
- Per-fact error granularity is preserved: if `remember_batch` returns fewer IDs than facts, missing ones are logged at `WARNING`; total batch failure logs each fact individually.

## Test plan

- [ ] `python -m pytest python/tests/test_auto_extract_uses_batch.py` — 3 new tests green:
  - 5 facts → 1 `remember_batch` call (not 5 `remember`)
  - 20 facts → 2 `remember_batch` calls (chunks of 15 + 5)
  - Partial-failure (batch returns 2 IDs for 3 facts): 2 stored, 1 logged at WARNING
- [ ] `python -m pytest python/tests/ --ignore=python/tests/test_userop_batch.py` — 640 passing, 9 skipped, 1 xfailed (baseline was 637; +3 new tests)
- [ ] Confirm `test_v1_hooks_integration.py::test_post_llm_call_forwards_v1_fields_to_remember_batch` passes (now asserts on `remember_batch`, not `remember`)
- [ ] Confirm `test_hermes_plugin.py::test_dedup_skips_add_but_allows_update` passes (tracks `remember_batch` calls)
- [ ] **Real-user QA on staging required before publish** (per CLAUDE.md gate)

## Notes

- No new public API. `client.remember_batch()` and all batch infrastructure are unchanged from 2.2.0.
- The `_LIFECYCLE_MAX_BATCH = 15` constant in `lifecycle.py` mirrors `userop.MAX_BATCH_SIZE` without importing from `userop` (avoids a potential circular-import path).
- Staging reachability not verified (agent is offline-only) — latency assumption is based on the Gap 3 design doc and 2.2.0 CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)