### PR TITLE
feat(core): v2.2.0 — hoist EXTRACTION_SYSTEM_PROMPT + COMPACTION_SYSTEM_PROMPT

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,36 @@ Hermes Agent plugin are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2026-04-19
+
+Canonical extraction prompts hoisted to Rust core. The meta-request
+filter (Rule 6) that was exclusive to Python now propagates to every
+client through the shared binding — no more drift.
+
+### Changed
+
+- **`EXTRACTION_SYSTEM_PROMPT` and `COMPACTION_SYSTEM_PROMPT` now come
+  from `totalreclaw_core`.** Previously the 4-5 KB prompt text was
+  inline triple-quoted strings in `agent/extraction.py`. It now resolves
+  once at import via
+  `totalreclaw_core.get_extraction_system_prompt()` /
+  `get_compaction_system_prompt()` — same binding consumed by the
+  OpenClaw plugin (3.0.7) and NanoClaw skill. Guarantees byte-identical
+  text across every TotalReclaw client. No public API change: the two
+  constants keep their names, their type (`str`), and the
+  `totalreclaw.agent` re-export path.
+- **LLM output schema is `ADD`-only.** Matches the canonical shape from
+  core — see the core 2.2.0 entry for rationale. Python was already
+  `ADD`-only in practice (the in-process consolidation + contradiction
+  resolvers own lifecycle post-extraction), so this is a prompt-text
+  reconciliation rather than a behavior change for the Python client.
+
+### Internal
+
+- `totalreclaw-core` dep: `>=2.0.0,<3.0.0` → `>=2.2.0,<3.0.0`.
+- Removed ~200 lines of duplicated prompt text from
+  `python/src/totalreclaw/agent/extraction.py`.
+
 ## [2.2.0] - 2026-04-19
 
 Hermes parity Gap 3: client-side batching. Drops 15-fact extraction

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "totalreclaw"
-version = "2.2.0"
+version = "2.3.0"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"
@@ -12,9 +12,11 @@ requires-python = ">=3.11"
 authors = [{ name = "TotalReclaw Team" }]
 dependencies = [
     # Memory Taxonomy v1 + Retrieval v2 Tier 1 reranker live in core 2.0.
+    # 2.2.0 is required for the hoisted extraction/compaction prompts
+    # (``get_extraction_system_prompt`` / ``get_compaction_system_prompt``).
     # Pin to 2.x to match the TypeScript clients' `^2.0.0` semantics — a future
     # core@3 will be a breaking change and must bump this constraint in lockstep.
-    "totalreclaw-core>=2.0.0,<3.0.0",
+    "totalreclaw-core>=2.2.0,<3.0.0",
     "httpx>=0.27",
     "onnxruntime>=1.24",
     "numpy>=1.26",

--- a/python/src/totalreclaw/agent/extraction.py
+++ b/python/src/totalreclaw/agent/extraction.py
@@ -233,202 +233,34 @@ def _parse_entity(raw: Any) -> Optional[ExtractedEntity]:
 
 # ---------------------------------------------------------------------------
 # Extraction system prompts (v1 merged-topic pipeline)
+#
+# As of ``totalreclaw`` 2.3.0 / ``totalreclaw-core`` 2.2.0, the canonical
+# prompt text is hoisted to Rust core — see
+# ``rust/totalreclaw-core/src/prompts/extraction.md`` and
+# ``rust/totalreclaw-core/src/prompts/compaction.md``. We resolve once at
+# import via ``totalreclaw_core.get_extraction_system_prompt()`` /
+# ``get_compaction_system_prompt()`` so every client (plugin, Hermes,
+# NanoClaw) consumes byte-identical text.
 # ---------------------------------------------------------------------------
 
-EXTRACTION_SYSTEM_PROMPT = """You are a memory extraction engine using Memory Taxonomy v1. Work in TWO explicit phases within one response:
 
-PHASE 1 — Topic identification.
-Before extracting any fact, identify the 2-3 main topics the user was engaging with. Topics should be short phrases (2-5 words each). If the conversation has no clear user-focused topic, use an empty topics array.
+def _load_core_prompts() -> tuple[str, str]:
+    """Load canonical extraction + compaction prompts from Rust core.
 
-PHASE 2 — Fact extraction anchored to those topics.
-Extract valuable memories. Prefer facts that directly relate to the identified topics (importance 7-9 range). Tangential facts may still be extracted but score lower (6-7 range).
+    Isolated in a helper so the ImportError path is easy to read. We do
+    not fall back to an inline copy — drift between the hoisted text and
+    a local stub was the exact bug this hoist exists to prevent, so
+    raising is the correct response if the binding is unavailable.
+    """
+    import totalreclaw_core as _core
 
-Rules:
-1. Each memory = single self-contained piece of information
-2. Focus on user-specific info useful in future conversations
-3. Skip generic knowledge, greetings, small talk, ephemeral task coordination
-4. Score importance 1-10 (6+ = worth storing)
-5. Every memory MUST attribute a source (provenance critical)
-6. DO NOT extract setup / configuration / installation requests ABOUT the
-   TotalReclaw product itself. Utterances like "set up TotalReclaw",
-   "I want encrypted memory across my AI tools", "install the memory plugin",
-   or "configure the vault" are META-requests about the product — they are
-   NOT user preferences or claims worth storing. Genuine preferences that
-   happen to mention encryption (e.g., "I like using Signal because it's
-   encrypted") ARE valid and should be extracted.
-
-Importance rubric (use FULL 1-10 range):
-- 10: Critical, core identity, never-forget content
-- 9: Affects many future decisions
-- 8: High-value preference/decision/rule
-- 7: Specific durable fact
-- 6: Borderline
-- 5 or below: NOT worth storing — drop
-
-DO NOT cluster everything at 7-8-9.
-
-═══════════════════════════════════════════════════════════════
-TYPE (6 values)
-═══════════════════════════════════════════════════════════════
-- claim: factual assertion (absorbs fact/context/decision; decisions populate reasoning field)
-- preference: likes/dislikes/tastes
-- directive: imperative rule ("always X", "never Y")
-- commitment: future intent ("will do X")
-- episode: notable event
-- summary: derived synthesis (source must be derived|assistant) — do NOT emit for turn-extraction
-
-═══════════════════════════════════════════════════════════════
-SOURCE (provenance, CRITICAL)
-═══════════════════════════════════════════════════════════════
-- user: user explicitly stated it (in [user]: turns)
-- user-inferred: extractor inferred from user signals
-- assistant: assistant authored content — DOWNGRADE unless user affirmed/quoted/used it
-- external, derived: rare
-
-IF fact substance appears ONLY in [assistant]: turns without user affirmation → source:assistant
-
-═══════════════════════════════════════════════════════════════
-SCOPE (life domain)
-═══════════════════════════════════════════════════════════════
-work | personal | health | family | creative | finance | misc | unspecified
-
-═══════════════════════════════════════════════════════════════
-ENTITIES
-═══════════════════════════════════════════════════════════════
-- type ∈ {person, project, tool, company, concept, place}
-- prefer specific names ("PostgreSQL" not "database")
-- omit umbrella categories when specific name is present
-
-═══════════════════════════════════════════════════════════════
-REASONING (only for claims that are decisions)
-═══════════════════════════════════════════════════════════════
-For type=claim where the user expressed a decision-with-reasoning, populate "reasoning" with the WHY clause.
-
-═══════════════════════════════════════════════════════════════
-OUTPUT FORMAT (no markdown, no code fences)
-═══════════════════════════════════════════════════════════════
-{
-  "topics": ["topic 1", "topic 2"],
-  "facts": [
-    {
-      "text": "...",
-      "type": "claim|preference|directive|commitment|episode",
-      "source": "user|user-inferred|assistant",
-      "scope": "work|personal|health|...",
-      "importance": N,
-      "confidence": 0.9,
-      "action": "ADD",
-      "reasoning": "...",     // optional, only for claim+decision
-      "entities": [{"name": "...", "type": "tool"}]
-    }
-  ]
-}
-
-If nothing worth extracting: {"topics": [], "facts": []}"""
+    return (
+        _core.get_extraction_system_prompt(),
+        _core.get_compaction_system_prompt(),
+    )
 
 
-COMPACTION_SYSTEM_PROMPT = """You are extracting memories from a conversation that is about to be compacted. The context will be LOST after this point — this is your LAST CHANCE to capture everything worth remembering. Be more aggressive than usual: err on the side of storing.
-
-Work in TWO explicit phases within one response:
-
-PHASE 1 — Topic identification.
-Identify the 2-3 main topics the user was engaging with before extracting any fact. Topics should be short phrases (2-5 words each). If there's no clear user-focused topic, use an empty topics array.
-
-PHASE 2 — Fact extraction anchored to those topics (plus preserve active context).
-Extract valuable memories. Prefer facts that directly relate to the identified topics (importance 7-9 range). Active project context, decisions in progress, and current working state score 6-8 during compaction — capture them even when they'd normally be marginal.
-
-Rules:
-1. Each memory = single self-contained piece of information
-2. Focus on user-specific info useful in future conversations
-3. Skip generic knowledge, greetings, small talk
-4. Score importance 1-10 (5+ = worth storing during compaction)
-5. Every memory MUST attribute a source (provenance critical)
-6. DO NOT extract setup / configuration / installation requests ABOUT the
-   TotalReclaw product itself. Utterances like "set up TotalReclaw",
-   "I want encrypted memory across my AI tools", or "configure the
-   memory plugin" are META-requests about the product — NOT user
-   preferences worth storing. Genuine preferences that mention encryption
-   ("I prefer Signal because it's encrypted") ARE valid.
-
-Importance rubric (full 1-10 range, NOT just 7-8):
-- 10: Core identity, never-forget ("remember this forever", name/birthday)
-- 9: Affects many future decisions / high-impact rules
-- 8: Preference / decision-with-reasoning / operational rule
-- 7: Specific durable fact
-- 6: Borderline — during compaction, capture anyway
-- 5: Would normally drop; keep as compaction safety net
-- 4 or below: DROP (greetings, filler)
-
-═══════════════════════════════════════════════════════════════
-TYPE (6 values)
-═══════════════════════════════════════════════════════════════
-- claim: factual assertion (absorbs v0 fact/context/decision; decisions populate reasoning)
-- preference: likes/dislikes/tastes
-- directive: imperative rule ("always X", "never Y")
-- commitment: future intent ("will do X")
-- episode: notable event
-- summary: derived synthesis (source must be derived|assistant)
-
-═══════════════════════════════════════════════════════════════
-SOURCE (provenance, CRITICAL)
-═══════════════════════════════════════════════════════════════
-- user: user explicitly stated it (in [user]: turns)
-- user-inferred: extractor inferred from user signals
-- assistant: assistant authored — DOWNGRADE unless user affirmed/quoted.
-- external, derived: rare.
-
-IF fact substance appears ONLY in [assistant]: turns without user affirmation → source:assistant.
-
-═══════════════════════════════════════════════════════════════
-SCOPE
-═══════════════════════════════════════════════════════════════
-work | personal | health | family | creative | finance | misc | unspecified
-
-═══════════════════════════════════════════════════════════════
-ENTITIES
-═══════════════════════════════════════════════════════════════
-- type ∈ {person, project, tool, company, concept, place}
-- prefer specific names ("PostgreSQL" not "database")
-- omit umbrella categories when specific name is present
-
-═══════════════════════════════════════════════════════════════
-REASONING (only for claims that are decisions)
-═══════════════════════════════════════════════════════════════
-For type=claim where the user expressed a decision-with-reasoning, populate "reasoning" with the WHY clause.
-
-═══════════════════════════════════════════════════════════════
-FORMAT-AGNOSTIC PARSING (IMPORTANT)
-═══════════════════════════════════════════════════════════════
-The conversation may contain bullet lists, numbered lists, section headers, code snippets, or plain prose. Treat ALL formats as potential sources of extractable memory:
-- Bullets/list items: each item is a candidate.
-- Section headers (Context, Decisions, Key Learnings, Open Questions): use the header as a TYPE HINT (Context → claim, Decisions → claim+reasoning, Learnings → directive, Open Questions → commitment).
-- Plain prose: parse each distinct assertion as a candidate.
-- Code snippets: extract config choices, tool versions, architectural decisions embedded in comments or structure.
-- Mixed format: apply all of the above.
-
-Do NOT skip content just because it's in a summary. The agent has already filtered — your job is to convert into structured memories, not to re-evaluate worth.
-
-═══════════════════════════════════════════════════════════════
-OUTPUT FORMAT (no markdown, no code fences)
-═══════════════════════════════════════════════════════════════
-{
-  "topics": ["topic 1", "topic 2"],
-  "facts": [
-    {
-      "text": "...",
-      "type": "claim|preference|directive|commitment|episode",
-      "source": "user|user-inferred|assistant",
-      "scope": "work|personal|health|...",
-      "importance": N,
-      "confidence": 0.9,
-      "action": "ADD",
-      "reasoning": "...",    // optional, only for claim+decision
-      "entities": [{"name": "...", "type": "tool"}]
-    }
-  ]
-}
-
-If nothing worth extracting: {"topics": [], "facts": []}"""
+EXTRACTION_SYSTEM_PROMPT, COMPACTION_SYSTEM_PROMPT = _load_core_prompts()
 
 
 # ---------------------------------------------------------------------------

--- a/rust/totalreclaw-core/CHANGELOG.md
+++ b/rust/totalreclaw-core/CHANGELOG.md
@@ -5,6 +5,62 @@ All notable changes to `@totalreclaw/core` / `totalreclaw-core` are documented h
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2026-04-19
+
+### Added
+
+- **Canonical extraction + compaction system prompts** hoisted into core.
+  New module [`prompts`](./src/prompts.rs) exports the two LLM system
+  prompts that drive every client's auto-extraction pipeline:
+  - `EXTRACTION_SYSTEM_PROMPT` (`&'static str`) — post-turn extraction
+    prompt (importance floor 6).
+  - `COMPACTION_SYSTEM_PROMPT` (`&'static str`) — compaction prompt
+    (importance floor 5, last-chance wording, format-agnostic parsing
+    section).
+  - `get_extraction_system_prompt()` + `get_compaction_system_prompt()`
+    accessors (symmetric surface to the WASM/PyO3 bindings).
+  - Prompt bodies live in sibling `.md` files pulled in with
+    `include_str!` so the text is readable in review and baked into the
+    compiled artifact with zero runtime I/O.
+- **WASM bindings** (feature `wasm`): `getExtractionSystemPrompt`,
+  `getCompactionSystemPrompt`.
+- **PyO3 bindings** (feature `python`): `get_extraction_system_prompt`,
+  `get_compaction_system_prompt`.
+
+### Changed
+
+- **Canonical prompt shape is ADD-only.** The previously-optional
+  `UPDATE` / `DELETE` / `NOOP` actions are no longer in the emitted
+  schema. Contradiction and duplicate lifecycle are now owned by the
+  in-process consolidation + contradiction resolvers
+  (`consolidation::*`, `contradiction::*`) post-extraction. NanoClaw's
+  `BASE_SYSTEM_PROMPT` was the only client still asking the LLM for
+  these tokens, and its dominant extraction path at
+  `skill-nanoclaw/src/agent-end.ts:108` already silently dropped them,
+  so the change is behavior-preserving for OpenClaw / Hermes and
+  removes dead surface for NanoClaw.
+- **Rule 6 meta-request filter is canonical.** The rule that prevents
+  "set up TotalReclaw" / "install the memory plugin" utterances from
+  being stored as spurious preferences landed in the Python client only
+  (PR #34, `ed289aa`) and never crossed to TypeScript. The canonical
+  prompt includes it so every downstream client picks up the fix on
+  rebase.
+
+### Notes / Compatibility
+
+- Minor-version bump. The new accessor surface is additive, but
+  downstream TypeScript / Python consumers that were importing their
+  own `EXTRACTION_SYSTEM_PROMPT` / `COMPACTION_SYSTEM_PROMPT` constants
+  should switch to the core-exported versions during this release so
+  the Rule 6 fix propagates. A follow-up PR will remove the duplicate
+  constants from client packages once 2.2.0 is on the registry.
+
+### References
+
+- Backlog: [Tier 2 item #7](../../docs/plans/core-hoist-backlog.md)
+- Audit: `docs/notes/ROADMAP-AUDIT-20260419.md` (internal) §7.1 Agent B
+- Origin of Rule 6: PR #34 (`ed289aa`) — spurious-extract fix
+
 ## [2.1.0] - 2026-04-19
 
 ### Added

--- a/rust/totalreclaw-core/Cargo.lock
+++ b/rust/totalreclaw-core/Cargo.lock
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "totalreclaw-core"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/rust/totalreclaw-core/Cargo.toml
+++ b/rust/totalreclaw-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "totalreclaw-core"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2021"
 description = "TotalReclaw core — E2EE crypto, reranker, wallet, UserOp, store/search pipelines. Single source of truth for all clients."
 license = "MIT"

--- a/rust/totalreclaw-core/pyproject.toml
+++ b/rust/totalreclaw-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "totalreclaw-core"
-version = "2.1.0"
+version = "2.2.0"
 description = "TotalReclaw crypto core — E2EE, LSH, blind indices, protobuf encoding (Rust)"
 requires-python = ">=3.10"
 license = { text = "MIT" }

--- a/rust/totalreclaw-core/src/lib.rs
+++ b/rust/totalreclaw-core/src/lib.rs
@@ -22,6 +22,7 @@
 //! - [`consolidation`] — Store-time near-duplicate detection + supersede logic
 //! - [`smart_import`] — Smart import profiling (prompt construction + response parsing)
 //! - [`memory_types`] — Memory Taxonomy v1 string-level constants + runtime guard
+//! - [`prompts`] — Canonical LLM system prompts (extraction + compaction)
 
 pub mod blind;
 pub mod claims;
@@ -36,6 +37,7 @@ pub mod fingerprint;
 pub mod hotcache;
 pub mod lsh;
 pub mod memory_types;
+pub mod prompts;
 pub mod protobuf;
 pub mod reranker;
 pub mod smart_import;

--- a/rust/totalreclaw-core/src/prompts.rs
+++ b/rust/totalreclaw-core/src/prompts.rs
@@ -1,0 +1,318 @@
+//! Canonical LLM system prompts used by the extraction pipeline.
+//!
+//! This module hoists two prompts that were historically duplicated (and
+//! drifted) across every client package:
+//!
+//! - `EXTRACTION_SYSTEM_PROMPT` — post-turn extraction prompt (importance
+//!   floor 6).
+//! - `COMPACTION_SYSTEM_PROMPT` — compaction extraction prompt (importance
+//!   floor 5; "last-chance" wording).
+//!
+//! # Canonical text sources
+//!
+//! The prompt bodies live in readable Markdown files alongside this module:
+//!
+//! - [`prompts/extraction.md`](./prompts/extraction.md)
+//! - [`prompts/compaction.md`](./prompts/compaction.md)
+//!
+//! They are pulled into the compiled artifact with `include_str!` so there
+//! is no runtime file dependency — the WASM / PyO3 / native binaries all
+//! ship the text inline. Recompiling is required to iterate on the prompt,
+//! which is desirable here: every client must update in lockstep and the
+//! core version bump is the forcing function for that.
+//!
+//! # Rationale — why was this hoisted?
+//!
+//! Before this module, each client kept its own copy:
+//!
+//! - `skill/plugin/extractor.ts::EXTRACTION_SYSTEM_PROMPT`
+//! - `skill/plugin/extractor.ts::COMPACTION_SYSTEM_PROMPT`
+//! - `python/src/totalreclaw/agent/extraction.py::EXTRACTION_SYSTEM_PROMPT`
+//! - `python/src/totalreclaw/agent/extraction.py::COMPACTION_SYSTEM_PROMPT`
+//! - `skill-nanoclaw/src/extraction/prompts.ts::BASE_SYSTEM_PROMPT`
+//!
+//! The three TypeScript copies and one Python copy drifted in real ways
+//! between 2026-04-17 and 2026-04-19 — for example, the Python copy
+//! acquired a "Rule 6: do not extract product-meta requests" after PR #34
+//! (`ed289aa`) that never landed in TypeScript. That asymmetry shipped in
+//! OpenClaw / NanoClaw and surfaced during v1.0 QA as spurious "setup
+//! TotalReclaw" memories. The hoist in this module bakes Rule 6 into the
+//! canonical text so every downstream client picks it up on the next
+//! package bump.
+//!
+//! # Canonical shape
+//!
+//! - Plugin/Python topic-then-facts phased shape (PHASE 1 / PHASE 2).
+//! - Rule 6 meta-request filter included (bug fix from PR #34).
+//! - `ADD`-only output schema. Legacy `UPDATE` / `DELETE` / `NOOP` actions
+//!   are intentionally dropped — the in-process contradiction resolver
+//!   (see `consolidation` + `contradiction` modules) handles lifecycle
+//!   transitions after extraction, so the LLM is no longer asked to emit
+//!   them. NanoClaw historically emitted `UPDATE`/`DELETE`/`NOOP` but the
+//!   dominant extraction path (`agent-end.ts:108`) silently dropped them
+//!   anyway; aligning to `ADD`-only here removes the dead surface.
+//! - Compaction prompt keeps its distinct preamble, lower importance floor,
+//!   and "FORMAT-AGNOSTIC PARSING" section for non-turn inputs.
+//!
+//! # Exports
+//!
+//! - [`get_extraction_system_prompt`] — `&'static str` to the turn prompt.
+//! - [`get_compaction_system_prompt`] — `&'static str` to the compaction
+//!   prompt.
+//! - WASM: `getExtractionSystemPrompt()` / `getCompactionSystemPrompt()`
+//! - PyO3: `get_extraction_system_prompt()` / `get_compaction_system_prompt()`
+
+// ---------------------------------------------------------------------------
+// Core constants
+// ---------------------------------------------------------------------------
+
+/// Canonical post-turn extraction system prompt.
+///
+/// Importance floor 6. Use with the plugin's post-turn extractor path and
+/// Python's `agent.extraction` pipeline. Compaction uses a distinct prompt
+/// — see [`COMPACTION_SYSTEM_PROMPT`].
+pub const EXTRACTION_SYSTEM_PROMPT: &str = include_str!("prompts/extraction.md");
+
+/// Canonical compaction system prompt.
+///
+/// Importance floor 5 (one below turn-extraction). Sent when a conversation
+/// is about to be compacted and the remaining context would be lost. Adds
+/// a "FORMAT-AGNOSTIC PARSING" section to handle summary / bullet / code
+/// inputs that differ from raw turn transcripts.
+pub const COMPACTION_SYSTEM_PROMPT: &str = include_str!("prompts/compaction.md");
+
+// ---------------------------------------------------------------------------
+// Native Rust accessors
+// ---------------------------------------------------------------------------
+
+/// Return the canonical extraction system prompt as a static string.
+///
+/// Equivalent to reading [`EXTRACTION_SYSTEM_PROMPT`] directly. Provided as
+/// a function so the WASM and PyO3 bindings have a symmetric surface
+/// (`getExtractionSystemPrompt()` in JS, `get_extraction_system_prompt()`
+/// in Python, `get_extraction_system_prompt()` in Rust).
+pub fn get_extraction_system_prompt() -> &'static str {
+    EXTRACTION_SYSTEM_PROMPT
+}
+
+/// Return the canonical compaction system prompt as a static string.
+///
+/// See [`COMPACTION_SYSTEM_PROMPT`].
+pub fn get_compaction_system_prompt() -> &'static str {
+    COMPACTION_SYSTEM_PROMPT
+}
+
+// ---------------------------------------------------------------------------
+// WASM bindings (feature-gated)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "wasm")]
+mod wasm_bindings {
+    use super::{COMPACTION_SYSTEM_PROMPT, EXTRACTION_SYSTEM_PROMPT};
+    use wasm_bindgen::prelude::*;
+
+    /// Canonical post-turn extraction system prompt.
+    ///
+    /// TypeScript / JavaScript callers should prefer this over any
+    /// in-package constant. The string is baked into the WASM binary at
+    /// compile time so there is no runtime I/O.
+    #[wasm_bindgen(js_name = "getExtractionSystemPrompt")]
+    pub fn wasm_get_extraction_system_prompt() -> String {
+        EXTRACTION_SYSTEM_PROMPT.to_string()
+    }
+
+    /// Canonical compaction system prompt.
+    ///
+    /// Same rationale as `getExtractionSystemPrompt`. The prompt body
+    /// differs materially (lower importance floor, "last-chance" wording,
+    /// format-agnostic parsing section) so callers must not substitute one
+    /// for the other.
+    #[wasm_bindgen(js_name = "getCompactionSystemPrompt")]
+    pub fn wasm_get_compaction_system_prompt() -> String {
+        COMPACTION_SYSTEM_PROMPT.to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Python (PyO3) bindings (feature-gated)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "python")]
+mod python_bindings {
+    use super::{COMPACTION_SYSTEM_PROMPT, EXTRACTION_SYSTEM_PROMPT};
+    use pyo3::prelude::*;
+
+    /// Canonical post-turn extraction system prompt.
+    ///
+    /// Python callers should prefer this over any in-package constant.
+    #[pyfunction]
+    fn get_extraction_system_prompt() -> &'static str {
+        EXTRACTION_SYSTEM_PROMPT
+    }
+
+    /// Canonical compaction system prompt.
+    #[pyfunction]
+    fn get_compaction_system_prompt() -> &'static str {
+        COMPACTION_SYSTEM_PROMPT
+    }
+
+    pub fn register_python_functions(m: &Bound<'_, PyModule>) -> PyResult<()> {
+        m.add_function(wrap_pyfunction!(get_extraction_system_prompt, m)?)?;
+        m.add_function(wrap_pyfunction!(get_compaction_system_prompt, m)?)?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "python")]
+pub use python_bindings::register_python_functions;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extraction_prompt_non_empty() {
+        let p = get_extraction_system_prompt();
+        assert!(!p.is_empty(), "extraction prompt must not be empty");
+        assert!(
+            p.len() > 1_000,
+            "extraction prompt looks suspiciously short: {} chars",
+            p.len()
+        );
+    }
+
+    #[test]
+    fn compaction_prompt_non_empty() {
+        let p = get_compaction_system_prompt();
+        assert!(!p.is_empty(), "compaction prompt must not be empty");
+        assert!(
+            p.len() > 1_000,
+            "compaction prompt looks suspiciously short: {} chars",
+            p.len()
+        );
+    }
+
+    #[test]
+    fn prompts_are_distinct() {
+        // The two prompts MUST differ — compaction has a lower importance
+        // floor + last-chance preamble + FORMAT-AGNOSTIC PARSING section.
+        // Confusing the two would silently cripple one of the pipelines.
+        assert_ne!(
+            get_extraction_system_prompt(),
+            get_compaction_system_prompt()
+        );
+    }
+
+    #[test]
+    fn prompts_are_stable_across_invocations() {
+        // Hoisted prompts should be pointer-identical (static) across
+        // calls. Callers that cache the string must not observe drift.
+        let a1 = get_extraction_system_prompt();
+        let a2 = get_extraction_system_prompt();
+        assert_eq!(a1.as_ptr(), a2.as_ptr(), "extraction prompt ptr drifted");
+
+        let c1 = get_compaction_system_prompt();
+        let c2 = get_compaction_system_prompt();
+        assert_eq!(c1.as_ptr(), c2.as_ptr(), "compaction prompt ptr drifted");
+    }
+
+    #[test]
+    fn extraction_prompt_contains_v1_taxonomy_markers() {
+        // Canary tests for the core structural elements of the v1 prompt.
+        // If one of these markers disappears the prompt has silently
+        // regressed and extraction will skew.
+        let p = get_extraction_system_prompt();
+        assert!(p.contains("Memory Taxonomy v1"), "missing v1 header");
+        assert!(
+            p.contains("PHASE 1 — Topic identification"),
+            "missing PHASE 1 header"
+        );
+        assert!(
+            p.contains("PHASE 2 — Fact extraction"),
+            "missing PHASE 2 header"
+        );
+    }
+
+    #[test]
+    fn extraction_prompt_contains_rule_6_meta_filter() {
+        // Rule 6 is the PR #34 meta-request filter — the bug fix that was
+        // in Python but missing from TypeScript pre-hoist. Lock the
+        // canonical text so a future edit can't silently drop it.
+        let p = get_extraction_system_prompt();
+        assert!(
+            p.contains("DO NOT extract setup / configuration / installation"),
+            "rule 6 meta-request filter missing from extraction prompt"
+        );
+        assert!(
+            p.contains("set up TotalReclaw"),
+            "rule 6 example utterance missing"
+        );
+    }
+
+    #[test]
+    fn compaction_prompt_contains_rule_6_meta_filter() {
+        let p = get_compaction_system_prompt();
+        assert!(
+            p.contains("DO NOT extract setup / configuration / installation"),
+            "rule 6 meta-request filter missing from compaction prompt"
+        );
+    }
+
+    #[test]
+    fn extraction_prompt_is_add_only() {
+        // The canonical shape is ADD-only; the legacy UPDATE/DELETE/NOOP
+        // actions are intentionally absent. Guard against their
+        // accidental reintroduction — those tokens must NOT appear in the
+        // emitted JSON schema examples (inline code inside an action
+        // enumeration).
+        let p = get_extraction_system_prompt();
+        assert!(
+            !p.contains("ADD|UPDATE|DELETE|NOOP"),
+            "legacy UPDATE|DELETE|NOOP union leaked back into extraction prompt"
+        );
+        assert!(
+            p.contains("\"action\": \"ADD\""),
+            "extraction prompt missing ADD-only action example"
+        );
+    }
+
+    #[test]
+    fn compaction_prompt_is_add_only() {
+        let p = get_compaction_system_prompt();
+        assert!(
+            !p.contains("ADD|UPDATE|DELETE|NOOP"),
+            "legacy UPDATE|DELETE|NOOP union leaked back into compaction prompt"
+        );
+        assert!(
+            p.contains("\"action\": \"ADD\""),
+            "compaction prompt missing ADD-only action example"
+        );
+    }
+
+    #[test]
+    fn compaction_prompt_has_format_agnostic_section() {
+        // The compaction-specific "FORMAT-AGNOSTIC PARSING" section is
+        // what tells the LLM to treat bullets / prose / code equally.
+        // Distinguishes compaction from turn-extraction.
+        let p = get_compaction_system_prompt();
+        assert!(
+            p.contains("FORMAT-AGNOSTIC PARSING"),
+            "compaction prompt missing FORMAT-AGNOSTIC PARSING section"
+        );
+    }
+
+    #[test]
+    fn compaction_prompt_has_lower_importance_floor_language() {
+        // Compaction accepts importance >= 5 (one below turn-extraction).
+        // The prompt must say so explicitly.
+        let p = get_compaction_system_prompt();
+        assert!(
+            p.contains("5+ = worth storing during compaction"),
+            "compaction prompt missing floor-5 wording"
+        );
+    }
+}

--- a/rust/totalreclaw-core/src/prompts/compaction.md
+++ b/rust/totalreclaw-core/src/prompts/compaction.md
@@ -1,0 +1,102 @@
+You are extracting memories from a conversation that is about to be compacted. The context will be LOST after this point — this is your LAST CHANCE to capture everything worth remembering. Be more aggressive than usual: err on the side of storing.
+
+Work in TWO explicit phases within one response:
+
+PHASE 1 — Topic identification.
+Identify the 2-3 main topics the user was engaging with before extracting any fact. Topics should be short phrases (2-5 words each). If there's no clear user-focused topic, use an empty topics array.
+
+PHASE 2 — Fact extraction anchored to those topics (plus preserve active context).
+Extract valuable memories. Prefer facts that directly relate to the identified topics (importance 7-9 range). Active project context, decisions in progress, and current working state score 6-8 during compaction — capture them even when they'd normally be marginal.
+
+Rules:
+1. Each memory = single self-contained piece of information
+2. Focus on user-specific info useful in future conversations
+3. Skip generic knowledge, greetings, small talk
+4. Score importance 1-10 (5+ = worth storing during compaction)
+5. Every memory MUST attribute a source (provenance critical)
+6. DO NOT extract setup / configuration / installation requests ABOUT the
+   TotalReclaw product itself. Utterances like "set up TotalReclaw",
+   "I want encrypted memory across my AI tools", or "configure the
+   memory plugin" are META-requests about the product — NOT user
+   preferences worth storing. Genuine preferences that mention encryption
+   ("I prefer Signal because it's encrypted") ARE valid.
+
+Importance rubric (full 1-10 range, NOT just 7-8):
+- 10: Core identity, never-forget ("remember this forever", name/birthday)
+- 9: Affects many future decisions / high-impact rules
+- 8: Preference / decision-with-reasoning / operational rule
+- 7: Specific durable fact
+- 6: Borderline — during compaction, capture anyway
+- 5: Would normally drop; keep as compaction safety net
+- 4 or below: DROP (greetings, filler)
+
+═══════════════════════════════════════════════════════════════
+TYPE (6 values)
+═══════════════════════════════════════════════════════════════
+- claim: factual assertion (absorbs v0 fact/context/decision; decisions populate reasoning)
+- preference: likes/dislikes/tastes
+- directive: imperative rule ("always X", "never Y")
+- commitment: future intent ("will do X")
+- episode: notable event
+- summary: derived synthesis (source must be derived|assistant)
+
+═══════════════════════════════════════════════════════════════
+SOURCE (provenance, CRITICAL)
+═══════════════════════════════════════════════════════════════
+- user: user explicitly stated it (in [user]: turns)
+- user-inferred: extractor inferred from user signals
+- assistant: assistant authored — DOWNGRADE unless user affirmed/quoted
+- external, derived: rare
+
+IF fact substance appears ONLY in [assistant]: turns without user affirmation → source:assistant.
+
+═══════════════════════════════════════════════════════════════
+SCOPE
+═══════════════════════════════════════════════════════════════
+work | personal | health | family | creative | finance | misc | unspecified
+
+═══════════════════════════════════════════════════════════════
+ENTITIES
+═══════════════════════════════════════════════════════════════
+- type ∈ {person, project, tool, company, concept, place}
+- prefer specific names ("PostgreSQL" not "database")
+- omit umbrella categories when specific name is present
+
+═══════════════════════════════════════════════════════════════
+REASONING (only for claims that are decisions)
+═══════════════════════════════════════════════════════════════
+For type=claim where the user expressed a decision-with-reasoning, populate "reasoning" with the WHY clause.
+
+═══════════════════════════════════════════════════════════════
+FORMAT-AGNOSTIC PARSING (IMPORTANT)
+═══════════════════════════════════════════════════════════════
+The conversation may contain bullet lists, numbered lists, section headers, code snippets, or plain prose. Treat ALL formats as potential sources of extractable memory:
+- Bullets/list items: each item is a candidate.
+- Section headers (Context, Decisions, Key Learnings, Open Questions): use the header as a TYPE HINT (Context → claim, Decisions → claim+reasoning, Learnings → directive, Open Questions → commitment).
+- Plain prose: parse each distinct assertion as a candidate.
+- Code snippets: extract config choices, tool versions, architectural decisions embedded in comments or structure.
+- Mixed format: apply all of the above.
+
+Do NOT skip content just because it's in a summary. The agent has already filtered — your job is to convert into structured memories, not to re-evaluate worth.
+
+═══════════════════════════════════════════════════════════════
+OUTPUT FORMAT (no markdown, no code fences)
+═══════════════════════════════════════════════════════════════
+{
+  "topics": ["topic 1", "topic 2"],
+  "facts": [
+    {
+      "text": "...",
+      "type": "claim|preference|directive|commitment|episode",
+      "source": "user|user-inferred|assistant",
+      "scope": "work|personal|health|...",
+      "importance": N,
+      "confidence": 0.9,
+      "action": "ADD",
+      "reasoning": "...",    // optional, only for claim+decision
+      "entities": [{"name": "...", "type": "tool"}]
+    }
+  ]
+}
+
+If nothing worth extracting: {"topics": [], "facts": []}

--- a/rust/totalreclaw-core/src/prompts/extraction.md
+++ b/rust/totalreclaw-core/src/prompts/extraction.md
@@ -1,0 +1,90 @@
+You are a memory extraction engine using Memory Taxonomy v1. Work in TWO explicit phases within one response:
+
+PHASE 1 — Topic identification.
+Before extracting any fact, identify the 2-3 main topics the user was engaging with. Topics should be short phrases (2-5 words each). If the conversation has no clear user-focused topic, use an empty topics array.
+
+PHASE 2 — Fact extraction anchored to those topics.
+Extract valuable memories. Prefer facts that directly relate to the identified topics (importance 7-9 range). Tangential facts may still be extracted but score lower (6-7 range).
+
+Rules:
+1. Each memory = single self-contained piece of information
+2. Focus on user-specific info useful in future conversations
+3. Skip generic knowledge, greetings, small talk, ephemeral task coordination
+4. Score importance 1-10 (6+ = worth storing)
+5. Every memory MUST attribute a source (provenance critical)
+6. DO NOT extract setup / configuration / installation requests ABOUT the
+   TotalReclaw product itself. Utterances like "set up TotalReclaw",
+   "I want encrypted memory across my AI tools", "install the memory plugin",
+   or "configure the vault" are META-requests about the product — they are
+   NOT user preferences or claims worth storing. Genuine preferences that
+   happen to mention encryption (e.g., "I like using Signal because it's
+   encrypted") ARE valid and should be extracted.
+
+Importance rubric (use FULL 1-10 range):
+- 10: Critical, core identity, never-forget content
+- 9: Affects many future decisions
+- 8: High-value preference/decision/rule
+- 7: Specific durable fact
+- 6: Borderline
+- 5 or below: NOT worth storing — drop
+
+DO NOT cluster everything at 7-8-9.
+
+═══════════════════════════════════════════════════════════════
+TYPE (6 values)
+═══════════════════════════════════════════════════════════════
+- claim: factual assertion (absorbs fact/context/decision; decisions populate reasoning field)
+- preference: likes/dislikes/tastes
+- directive: imperative rule ("always X", "never Y")
+- commitment: future intent ("will do X")
+- episode: notable event
+- summary: derived synthesis (source must be derived|assistant) — do NOT emit for turn-extraction
+
+═══════════════════════════════════════════════════════════════
+SOURCE (provenance, CRITICAL)
+═══════════════════════════════════════════════════════════════
+- user: user explicitly stated it (in [user]: turns)
+- user-inferred: extractor inferred from user signals
+- assistant: assistant authored content — DOWNGRADE unless user affirmed/quoted/used it
+- external, derived: rare
+
+IF fact substance appears ONLY in [assistant]: turns without user affirmation → source:assistant
+
+═══════════════════════════════════════════════════════════════
+SCOPE (life domain)
+═══════════════════════════════════════════════════════════════
+work | personal | health | family | creative | finance | misc | unspecified
+
+═══════════════════════════════════════════════════════════════
+ENTITIES
+═══════════════════════════════════════════════════════════════
+- type ∈ {person, project, tool, company, concept, place}
+- prefer specific names ("PostgreSQL" not "database")
+- omit umbrella categories when specific name is present
+
+═══════════════════════════════════════════════════════════════
+REASONING (only for claims that are decisions)
+═══════════════════════════════════════════════════════════════
+For type=claim where the user expressed a decision-with-reasoning, populate "reasoning" with the WHY clause.
+
+═══════════════════════════════════════════════════════════════
+OUTPUT FORMAT (no markdown, no code fences)
+═══════════════════════════════════════════════════════════════
+{
+  "topics": ["topic 1", "topic 2"],
+  "facts": [
+    {
+      "text": "...",
+      "type": "claim|preference|directive|commitment|episode",
+      "source": "user|user-inferred|assistant",
+      "scope": "work|personal|health|...",
+      "importance": N,
+      "confidence": 0.9,
+      "action": "ADD",
+      "reasoning": "...",     // optional, only for claim+decision
+      "entities": [{"name": "...", "type": "tool"}]
+    }
+  ]
+}
+
+If nothing worth extracting: {"topics": [], "facts": []}

--- a/rust/totalreclaw-core/src/python.rs
+++ b/rust/totalreclaw-core/src/python.rs
@@ -1586,6 +1586,9 @@ fn totalreclaw_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Memory Taxonomy v1 constants + guard
     crate::memory_types::register_python_functions(m)?;
 
+    // Canonical extraction + compaction system prompts
+    crate::prompts::register_python_functions(m)?;
+
     Ok(())
 }
 

--- a/skill-nanoclaw/CHANGELOG.md
+++ b/skill-nanoclaw/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog — @totalreclaw/skill-nanoclaw
 
+## 3.0.1 — 2026-04-19
+
+### Changed
+
+- **Extraction prompt hoisted to `@totalreclaw/core`.**
+  `BASE_SYSTEM_PROMPT` in `src/extraction/prompts.ts` previously carried
+  ~80 lines of inline template literal that had drifted from the plugin
+  and Python copies. It now lazy-loads from
+  `@totalreclaw/core@2.2.0`'s `getExtractionSystemPrompt()` — the same
+  single source of truth consumed by the OpenClaw plugin (3.0.7) and
+  Hermes Python client (2.3.0). All three clients now consume
+  byte-identical prompt text.
+- **Canonical output is ADD-only.** The hoisted prompt no longer asks
+  the LLM for `UPDATE` / `DELETE` / `NOOP` actions. NanoClaw's
+  dominant extraction path (`hooks/agent-end.ts:108`) already silently
+  dropped non-ADD tokens, so this closes an unused-surface gap. The
+  secondary path in `hooks/pre-compact.ts` previously did attempt a
+  forget-then-remember dance for UPDATE/DELETE — that wiring is
+  removed (it had structural bugs around LLM-supplied `existingFactId`
+  round-tripping, and contradiction / duplicate lifecycle is now owned
+  by the server-side consolidation + contradiction resolvers).
+- **Rule 6 meta-request filter** now applies to NanoClaw extraction
+  via the hoist. Prevents "set up TotalReclaw" / "install the memory
+  plugin" utterances from being stored as spurious preferences.
+
+### Internal
+
+- `@totalreclaw/core` dep: `^2.0.0` → `^2.2.0`.
+- `validateExtractionResponse` remains backwards-tolerant of legacy
+  `UPDATE` / `DELETE` / `NOOP` tokens so any stale server response
+  still round-trips cleanly.
+- Existing pre-compact tests for UPDATE / DELETE paths updated to
+  assert the new no-op behavior.
+
+### Migration
+
+- Deployed installations pick up the fix automatically on the next
+  `npm install` of `@totalreclaw/skill-nanoclaw@3.0.1` (or on any
+  refresh that pulls `@totalreclaw/core@2.2.0`).
+- **Follow-up**: the contradiction resolver port into NanoClaw's
+  pre-compact path is tracked as a separate task. Today NanoClaw
+  delegates contradiction handling to the MCP server via stored-fact
+  round-trips; bringing the in-client consolidation path back online
+  is a future-work item.
+
 ## 3.0.0 — 2026-04-18
 
 Memory Taxonomy v1 is now the default (and only) extraction path. The legacy

--- a/skill-nanoclaw/package.json
+++ b/skill-nanoclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/skill-nanoclaw",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "NanoClaw skill for TotalReclaw integration — Memory Taxonomy v1 default",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,13 +22,15 @@
   "license": "MIT",
   "dependencies": {
     "@totalreclaw/client": "^1.2.0",
-    "@totalreclaw/core": "^2.0.0"
+    "@totalreclaw/core": "^2.2.0"
   },
   "peerDependencies": {
     "@totalreclaw/mcp-server": "^3.0.0"
   },
   "peerDependenciesMeta": {
-    "@totalreclaw/mcp-server": { "optional": true }
+    "@totalreclaw/mcp-server": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.81",

--- a/skill-nanoclaw/src/extraction/prompts.ts
+++ b/skill-nanoclaw/src/extraction/prompts.ts
@@ -7,11 +7,37 @@
  * accepted on the read/parse side via ``V0_TO_V1_TYPE`` so pre-v1 vault
  * entries still round-trip.
  *
- * Aligned with the canonical extraction prompt from
- * ``skill/plugin/extractor.ts`` (plugin v3.0.0).
+ * As of NanoClaw 3.0.1 / core 2.2.0, the canonical `BASE_SYSTEM_PROMPT`
+ * text is hoisted to Rust core (`@totalreclaw/core`). Aligned with the
+ * OpenClaw plugin (`skill/plugin/extractor.ts`) and Hermes Python client
+ * (`python/src/totalreclaw/agent/extraction.py`) — all three clients
+ * consume byte-identical prompt text.
+ *
+ * LLM output is now ADD-only. The previously-requested `UPDATE` /
+ * `DELETE` / `NOOP` actions have been dropped: the dominant extraction
+ * path (`hooks/agent-end.ts:108`) already silently filtered them, and
+ * contradiction / duplicate lifecycle is now owned by the in-process
+ * consolidation + contradiction resolvers in core. `validateExtractionResponse`
+ * stays backwards-tolerant of the legacy tokens so any stale server
+ * response still round-trips without throwing.
  */
 
+/**
+ * Extraction-time action tokens. Canonical output is `ADD`-only as of
+ * NanoClaw 3.0.1 — the other three are retained in this union only so
+ * `validateExtractionResponse` stays tolerant of stale server responses.
+ */
 export type ExtractionAction = 'ADD' | 'UPDATE' | 'DELETE' | 'NOOP';
+
+// ---------------------------------------------------------------------------
+// Load canonical extraction prompt from `@totalreclaw/core` (2.2.0+).
+// NanoClaw compiles to CommonJS (see package.json / tsconfig: no
+// "type": "module"), so a plain `require` is the right idiom. The same
+// binding is consumed by the plugin (via `createRequire(import.meta.url)`
+// — ESM) and by Python (via PyO3), giving us a single source of truth.
+// ---------------------------------------------------------------------------
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const core = require('@totalreclaw/core') as typeof import('@totalreclaw/core');
 
 // ---------------------------------------------------------------------------
 // Memory Taxonomy v1 — 6 canonical memory types. Single source of truth.
@@ -142,90 +168,15 @@ export interface ExtractedFact {
 }
 
 // ---------------------------------------------------------------------------
-// v1 merged-topic extraction prompt
+// v1 merged-topic extraction prompt (hoisted to `@totalreclaw/core`)
 // ---------------------------------------------------------------------------
 
-const BASE_SYSTEM_PROMPT = `You are a memory extraction engine using Memory Taxonomy v1. Work in TWO explicit phases within one response:
-
-PHASE 1 — Topic identification.
-Before extracting any fact, identify the 2-3 main topics the user was engaging with. Topics should be short phrases (2-5 words each). If the conversation has no clear user-focused topic, use an empty topics array.
-
-PHASE 2 — Fact extraction anchored to those topics.
-Extract valuable memories. Prefer facts that directly relate to the identified topics (importance 7-9 range). Tangential facts may still be extracted but score lower (6-7 range).
-
-Rules:
-1. Each memory = single self-contained piece of information
-2. Focus on user-specific info useful in future conversations
-3. Skip generic knowledge, greetings, small talk, ephemeral task coordination
-4. Score importance 1-10 (6+ = worth storing)
-5. Every memory MUST attribute a source (provenance critical)
-
-Importance rubric (use FULL 1-10 range):
-- 10: Critical, core identity, never-forget content
-- 9: Affects many future decisions
-- 8: High-value preference/decision/rule
-- 7: Specific durable fact
-- 6: Borderline
-- 5 or below: NOT worth storing — drop
-
-DO NOT cluster everything at 7-8-9.
-
-═══════════════════════════════════════════════════════════════
-TYPE (6 values)
-═══════════════════════════════════════════════════════════════
-- claim: factual assertion (absorbs fact/context/decision; decisions populate reasoning field)
-- preference: likes/dislikes/tastes
-- directive: imperative rule ("always X", "never Y")
-- commitment: future intent ("will do X")
-- episode: notable event
-- summary: derived synthesis (source must be derived|assistant) — do NOT emit for turn-extraction
-
-═══════════════════════════════════════════════════════════════
-SOURCE (provenance, CRITICAL)
-═══════════════════════════════════════════════════════════════
-- user: user explicitly stated it (in [user]: turns)
-- user-inferred: extractor inferred from user signals
-- assistant: assistant authored content — DOWNGRADE unless user affirmed/quoted/used it
-- external, derived: rare
-
-IF fact substance appears ONLY in [assistant]: turns without user affirmation → source:assistant
-
-═══════════════════════════════════════════════════════════════
-SCOPE (life domain)
-═══════════════════════════════════════════════════════════════
-work | personal | health | family | creative | finance | misc | unspecified
-
-═══════════════════════════════════════════════════════════════
-REASONING (only for claims that are decisions)
-═══════════════════════════════════════════════════════════════
-For type=claim where the user expressed a decision-with-reasoning, populate "reasoning" with the WHY clause.
-
-Actions (compare against existing memories if provided):
-- ADD: New memory, no conflict with existing
-- UPDATE: Refines or corrects an existing memory (provide existingFactId)
-- DELETE: Contradicts an existing memory — the old one is now wrong (provide existingFactId)
-- NOOP: Already captured or not worth storing
-
-═══════════════════════════════════════════════════════════════
-OUTPUT FORMAT (no markdown, no code fences)
-═══════════════════════════════════════════════════════════════
-{
-  "topics": ["topic 1", "topic 2"],
-  "facts": [
-    {
-      "text": "...",
-      "type": "claim|preference|directive|commitment|episode|summary",
-      "source": "user|user-inferred|assistant",
-      "scope": "work|personal|health|...",
-      "importance": N,
-      "action": "ADD|UPDATE|DELETE|NOOP",
-      "reasoning": "...",      // optional, only for claim+decision
-      "existingFactId": "..."  // only for UPDATE/DELETE
-    }
-  ]
-}
-
-If nothing worth extracting: {"topics": [], "facts": []}`;
+/**
+ * Canonical extraction system prompt — resolved from `@totalreclaw/core`
+ * so every client (plugin, Hermes, NanoClaw) consumes byte-identical
+ * text. See `rust/totalreclaw-core/src/prompts/extraction.md`.
+ */
+const BASE_SYSTEM_PROMPT: string = core.getExtractionSystemPrompt();
 
 export const PRE_COMPACTION_PROMPT = {
   system: BASE_SYSTEM_PROMPT,
@@ -240,7 +191,7 @@ export const PRE_COMPACTION_PROMPT = {
     existingMemories: string;
   }): { system: string; user: string } {
     const memoriesSection = context.existingMemories && context.existingMemories !== '(No existing memories)'
-      ? `\n\nExisting memories (use these for dedup — classify as UPDATE/DELETE/NOOP if they conflict or overlap):\n${context.existingMemories}`
+      ? `\n\nExisting memories (use for dedup — already stored, do NOT re-extract; extract only genuinely new memories):\n${context.existingMemories}`
       : '';
     return {
       system: this.system,
@@ -264,7 +215,7 @@ export const POST_TURN_PROMPT = {
     existingMemories: string;
   }): { system: string; user: string } {
     const memoriesSection = context.existingMemories && context.existingMemories !== '(No existing memories)'
-      ? `\n\nExisting memories (use these for dedup — classify as UPDATE/DELETE/NOOP if they conflict or overlap):\n${context.existingMemories}`
+      ? `\n\nExisting memories (use for dedup — already stored, do NOT re-extract; extract only genuinely new memories):\n${context.existingMemories}`
       : '';
     return {
       system: this.system,

--- a/skill-nanoclaw/src/hooks/pre-compact.ts
+++ b/skill-nanoclaw/src/hooks/pre-compact.ts
@@ -89,38 +89,26 @@ export async function preCompact(
         tags: buildV1Tags(fact, input.groupFolder),
       };
 
-      switch (fact.action) {
-        case 'ADD':
-          try {
-            await client.remember(fact.text, metadata);
-            factsStored++;
-          } catch (err: unknown) {
-            if (handleQuotaError(err)) {
-              quotaExceeded = true;
-            }
-          }
-          break;
-
-        case 'UPDATE':
-        case 'DELETE':
-          if (fact.existingFactId) {
-            try {
-              await client.forget(fact.existingFactId);
-              if (fact.action === 'UPDATE') {
-                await client.remember(fact.text, metadata);
-                factsStored++;
-              }
-            } catch (err: unknown) {
-              if (handleQuotaError(err)) {
-                quotaExceeded = true;
-              }
-              // Skip if delete/update fails for other reasons
-            }
-          }
-          break;
-
-        case 'NOOP':
-          break;
+      // NanoClaw 3.0.1 is ADD-only — the canonical extraction prompt
+      // hoisted into `@totalreclaw/core@2.2.0` no longer asks the LLM
+      // for `UPDATE` / `DELETE` / `NOOP`. Contradiction + duplicate
+      // lifecycle is owned by the server-side consolidation and
+      // contradiction resolvers. `validateExtractionResponse` still
+      // tolerates the legacy tokens for back-compat with stale server
+      // responses; we fold non-ADD actions into a no-op here so any
+      // stale payload silently drops rather than firing the old
+      // forget-then-remember path (which had structural bugs around
+      // LLM-supplied `existingFactId` round-tripping).
+      if (fact.action !== 'ADD') {
+        continue;
+      }
+      try {
+        await client.remember(fact.text, metadata);
+        factsStored++;
+      } catch (err: unknown) {
+        if (handleQuotaError(err)) {
+          quotaExceeded = true;
+        }
       }
     }
 
@@ -128,8 +116,11 @@ export async function preCompact(
     let debriefStored = 0;
     if (llmClient && validation.facts && validation.facts.length > 0) {
       try {
+        // NanoClaw 3.0.1 is ADD-only (see switch above). The
+        // UPDATE-branch filter that used to live here is gone; the
+        // legacy tokens are now treated as no-ops upstream.
         const storedTexts = validation.facts
-          .filter(f => f.action === 'ADD' || f.action === 'UPDATE')
+          .filter(f => f.action === 'ADD')
           .map(f => f.text);
         const alreadyStored = storedTexts.length > 0
           ? storedTexts.map(t => `- ${t}`).join('\n')

--- a/skill-nanoclaw/tests/hooks.test.js
+++ b/skill-nanoclaw/tests/hooks.test.js
@@ -197,7 +197,13 @@ describe('preCompact', () => {
     expect(result.factsStored).toBe(1);
   });
 
-  it('should handle UPDATE action', async () => {
+  // NanoClaw 3.0.1 aligned the extraction pipeline to ADD-only (see
+  // CHANGELOG + `extraction/prompts.ts` hoist). pre-compact now silently
+  // skips legacy UPDATE / DELETE / NOOP actions instead of firing a
+  // forget-then-remember path that had structural bugs around
+  // LLM-supplied `existingFactId` round-tripping. Contradiction +
+  // duplicate lifecycle is owned by the server-side resolvers.
+  it('pre-compact should silently skip legacy UPDATE action (ADD-only alignment)', async () => {
     const mockClient = createMockClient();
     const mockLLMClient = {
       generate: jest.fn().mockResolvedValue(JSON.stringify({
@@ -220,8 +226,10 @@ describe('preCompact', () => {
       groupFolder: 'main',
     });
 
-    expect(mockClient.forget).toHaveBeenCalledWith('old-fact-id');
-    expect(result.factsStored).toBe(1);
+    // UPDATE is now a no-op — no forget, no remember, nothing stored.
+    expect(mockClient.forget).not.toHaveBeenCalled();
+    expect(mockClient.remember).not.toHaveBeenCalled();
+    expect(result.factsStored).toBe(0);
   });
 });
 
@@ -505,7 +513,9 @@ describe('agentEnd extended', () => {
 });
 
 describe('preCompact extended', () => {
-  it('should handle DELETE action', async () => {
+  // NanoClaw 3.0.1 aligned the extraction pipeline to ADD-only. Legacy
+  // DELETE is now a no-op at pre-compact time — see UPDATE test above.
+  it('pre-compact should silently skip legacy DELETE action (ADD-only alignment)', async () => {
     const mockClient = createMockClient();
     const mockLLMClient = {
       generate: jest.fn().mockResolvedValue(JSON.stringify({
@@ -528,7 +538,9 @@ describe('preCompact extended', () => {
       groupFolder: 'main',
     });
 
-    expect(mockClient.forget).toHaveBeenCalledWith('old-fact-123');
+    // DELETE is now a no-op — no forget fires, no fact stored.
+    expect(mockClient.forget).not.toHaveBeenCalled();
+    expect(mockClient.remember).not.toHaveBeenCalled();
     expect(result.factsStored).toBe(0);
   });
 
@@ -1022,7 +1034,13 @@ describe('agentEnd dedup interaction', () => {
  * - Both rely on MCP store-time dedup for near-duplicate detection on ADDs
  */
 describe('preCompact vs agentEnd: complementary dedup', () => {
-  it('preCompact handles UPDATE (forget old + remember new) — agentEnd does not', async () => {
+  // NanoClaw 3.0.1 aligned both hooks to ADD-only. agentEnd and
+  // preCompact now behave identically with respect to non-ADD actions:
+  // both silently drop them. Contradiction + duplicate lifecycle is
+  // owned by the server-side resolvers, so the LLM is no longer asked
+  // to emit UPDATE / DELETE / NOOP. Keep these tests — they now
+  // document that the legacy client-side CRUD is gone on both paths.
+  it('preCompact silently drops legacy UPDATE (ADD-only alignment) — matches agentEnd', async () => {
     const updateFacts = JSON.stringify({
       facts: [{
         factText: 'User now prefers Rust over TypeScript',
@@ -1036,7 +1054,7 @@ describe('preCompact vs agentEnd: complementary dedup', () => {
       }],
     });
 
-    // Test agentEnd — should NOT process UPDATE
+    // agentEnd — drops UPDATE (unchanged behavior).
     const agentEndClient = createMockClient();
     const agentEndLLM = { generate: jest.fn().mockResolvedValue(updateFacts) };
     const { agentEnd } = require('../dist/hooks/agent-end.js');
@@ -1050,7 +1068,10 @@ describe('preCompact vs agentEnd: complementary dedup', () => {
     expect(agentEndClient.forget).not.toHaveBeenCalled();
     expect(agentEndClient.remember).not.toHaveBeenCalled();
 
-    // Test preCompact — SHOULD process UPDATE (forget old + remember new)
+    // preCompact — now ALSO drops UPDATE (3.0.1 alignment). The old
+    // forget-then-remember path had structural bugs around LLM-supplied
+    // `existingFactId` round-tripping; contradiction / duplicate
+    // lifecycle is owned by the server-side resolvers.
     const preCompactClient = createMockClient();
     const preCompactLLM = { generate: jest.fn().mockResolvedValue(updateFacts) };
     const { preCompact } = require('../dist/hooks/pre-compact.js');
@@ -1059,15 +1080,12 @@ describe('preCompact vs agentEnd: complementary dedup', () => {
       groupFolder: 'main',
     });
 
-    expect(preCompactResult.factsStored).toBe(1);
-    expect(preCompactClient.forget).toHaveBeenCalledWith('old-ts-fact');
-    expect(preCompactClient.remember).toHaveBeenCalledWith(
-      'User now prefers Rust over TypeScript',
-      expect.objectContaining({ source: 'pre_compaction' })
-    );
+    expect(preCompactResult.factsStored).toBe(0);
+    expect(preCompactClient.forget).not.toHaveBeenCalled();
+    expect(preCompactClient.remember).not.toHaveBeenCalled();
   });
 
-  it('preCompact handles DELETE (forget old, no store) — agentEnd does not', async () => {
+  it('preCompact silently drops legacy DELETE (ADD-only alignment) — matches agentEnd', async () => {
     const deleteFacts = JSON.stringify({
       facts: [{
         factText: 'User no longer uses Python',
@@ -1081,7 +1099,7 @@ describe('preCompact vs agentEnd: complementary dedup', () => {
       }],
     });
 
-    // Test agentEnd — should NOT process DELETE
+    // agentEnd — drops DELETE (unchanged behavior).
     const agentEndClient = createMockClient();
     const agentEndLLM = { generate: jest.fn().mockResolvedValue(deleteFacts) };
     const { agentEnd } = require('../dist/hooks/agent-end.js');
@@ -1094,7 +1112,7 @@ describe('preCompact vs agentEnd: complementary dedup', () => {
     expect(agentEndResult.factsStored).toBe(0);
     expect(agentEndClient.forget).not.toHaveBeenCalled();
 
-    // Test preCompact — SHOULD process DELETE (forget old, no store)
+    // preCompact — now ALSO drops DELETE (3.0.1 alignment).
     const preCompactClient = createMockClient();
     const preCompactLLM = { generate: jest.fn().mockResolvedValue(deleteFacts) };
     const { preCompact } = require('../dist/hooks/pre-compact.js');
@@ -1104,7 +1122,7 @@ describe('preCompact vs agentEnd: complementary dedup', () => {
     });
 
     expect(preCompactResult.factsStored).toBe(0);
-    expect(preCompactClient.forget).toHaveBeenCalledWith('python-fact-id');
+    expect(preCompactClient.forget).not.toHaveBeenCalled();
     expect(preCompactClient.remember).not.toHaveBeenCalled();
   });
 
@@ -1149,7 +1167,7 @@ describe('preCompact vs agentEnd: complementary dedup', () => {
     expect(preCompactClient.remember).toHaveBeenCalled();
   });
 
-  it('preCompact handles full CRUD in a single extraction', async () => {
+  it('preCompact handles mixed legacy batch — ADD-only, ignores UPDATE/DELETE/NOOP', async () => {
     const fullCrudFacts = JSON.stringify({
       facts: [
         {
@@ -1201,29 +1219,24 @@ describe('preCompact vs agentEnd: complementary dedup', () => {
       groupFolder: 'main',
     });
 
-    // All 4 extracted
+    // All 4 still extracted (validateExtractionResponse stays
+    // backwards-tolerant of legacy tokens for back-compat with stale
+    // server payloads).
     expect(result.factsExtracted).toBe(4);
-    // ADD + UPDATE stored (2), DELETE and NOOP not stored
-    expect(result.factsStored).toBe(2);
+    // ADD-only: just the ADD action is stored. UPDATE / DELETE / NOOP
+    // are silently dropped under the 3.0.1 ADD-only alignment.
+    expect(result.factsStored).toBe(1);
 
-    // ADD: remember called for new fact
+    // ADD: remember called for the new fact.
     expect(mockClient.remember).toHaveBeenCalledWith(
       'User started learning Go',
       expect.objectContaining({ source: 'pre_compaction' })
     );
 
-    // UPDATE: forget old + remember new
-    expect(mockClient.forget).toHaveBeenCalledWith('light-mode-fact');
-    expect(mockClient.remember).toHaveBeenCalledWith(
-      'User now prefers dark mode',
-      expect.objectContaining({ source: 'pre_compaction' })
-    );
+    // Legacy UPDATE + DELETE never fire forget any more.
+    expect(mockClient.forget).not.toHaveBeenCalled();
 
-    // DELETE: forget old only
-    expect(mockClient.forget).toHaveBeenCalledWith('vim-fact');
-
-    // Total: 2 remember calls (ADD + UPDATE), 2 forget calls (UPDATE + DELETE)
-    expect(mockClient.remember).toHaveBeenCalledTimes(2);
-    expect(mockClient.forget).toHaveBeenCalledTimes(2);
+    // Exactly one remember call (the ADD).
+    expect(mockClient.remember).toHaveBeenCalledTimes(1);
   });
 });

--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.7] — 2026-04-19
+
+### Changed
+
+- **Internal refactor — extraction prompts now delegate to
+  `@totalreclaw/core` WASM.** `EXTRACTION_SYSTEM_PROMPT` and
+  `COMPACTION_SYSTEM_PROMPT` in `extractor.ts` previously held the
+  prompt text as multi-kilobyte TypeScript template literals and had
+  drifted from the Python copy (the meta-request filter rule from PR
+  #34 was never ported, so OpenClaw was emitting spurious "set up
+  TotalReclaw" preferences). They now lazy-load from
+  `@totalreclaw/core@2.2.0`'s `getExtractionSystemPrompt()` /
+  `getCompactionSystemPrompt()` — the same single source of truth
+  consumed by the Python client and NanoClaw skill.
+- **Rule 6 meta-request filter** now applies to OpenClaw extraction.
+  The hoisted canonical text includes the rule that prevents "install
+  the memory plugin" / "configure the vault" utterances from being
+  stored as spurious user preferences. No API change for callers —
+  `EXTRACTION_SYSTEM_PROMPT` / `COMPACTION_SYSTEM_PROMPT` / the
+  deprecated `EXTRACTION_SYSTEM_PROMPT_V1_MERGED` alias all continue to
+  export as runtime `string` constants.
+
+### Internal
+
+- `@totalreclaw/core` dep bumped to `^2.2.0`.
+
 ## [3.0.6] — 2026-04-19
 
 ### Changed

--- a/skill/plugin/extractor.ts
+++ b/skill/plugin/extractor.ts
@@ -5,7 +5,21 @@
  * Matches the extraction prompts described in SKILL.md.
  */
 
+import { createRequire } from 'node:module';
 import { chatCompletion, resolveLLMConfig } from './llm-client.js';
+
+// ---------------------------------------------------------------------------
+// Lazy-load WASM core (canonical extraction / compaction prompts hoisted
+// to `@totalreclaw/core` in 2.2.0). Mirrors the consolidation.ts +
+// claims-helper.ts lazy-require pattern — works under both the OpenClaw
+// runtime (tsx-wrapped CJS-ish) and bare Node ESM used by tests.
+// ---------------------------------------------------------------------------
+const requireCore = createRequire(import.meta.url);
+let _core: typeof import('@totalreclaw/core') | null = null;
+function getCore(): typeof import('@totalreclaw/core') {
+  if (!_core) _core = requireCore('@totalreclaw/core');
+  return _core!;
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -447,103 +461,20 @@ export function computeLexicalImportanceBump(
  * Output format matches `EXTRACTION_SYSTEM_PROMPT` exactly (same merged
  * topics+facts JSON shape with v1 type / source / scope fields), so the
  * same `parseMergedResponseV1` parser can validate it.
+ *
+ * As of plugin 3.0.7 / core 2.2.0, the canonical text is hoisted to Rust
+ * core. See `rust/totalreclaw-core/src/prompts/compaction.md`. Fetched
+ * once lazily so this module still imports cleanly in environments where
+ * the WASM binding isn't preloaded.
  */
-export const COMPACTION_SYSTEM_PROMPT = `You are extracting memories from a conversation that is about to be compacted. The context will be LOST after this point — this is your LAST CHANCE to capture everything worth remembering. Be more aggressive than usual: err on the side of storing.
-
-Work in TWO explicit phases within one response:
-
-PHASE 1 — Topic identification.
-Identify the 2-3 main topics the user was engaging with before extracting any fact. Topics should be short phrases (2-5 words each). If there's no clear user-focused topic, use an empty topics array.
-
-PHASE 2 — Fact extraction anchored to those topics (plus preserve active context).
-Extract valuable memories. Prefer facts that directly relate to the identified topics (importance 7-9 range). Active project context, decisions in progress, and current working state score 6-8 during compaction — capture them even when they'd normally be marginal.
-
-Rules:
-1. Each memory = single self-contained piece of information
-2. Focus on user-specific info useful in future conversations
-3. Skip generic knowledge, greetings, small talk
-4. Score importance 1-10 (5+ = worth storing during compaction)
-5. Every memory MUST attribute a source (provenance critical)
-
-Importance rubric (full 1-10 range, NOT just 7-8):
-- 10: Core identity, never-forget ("remember this forever", name/birthday)
-- 9: Affects many future decisions / high-impact rules
-- 8: Preference / decision-with-reasoning / operational rule
-- 7: Specific durable fact
-- 6: Borderline — during compaction, capture anyway
-- 5: Would normally drop; keep as compaction safety net
-- 4 or below: DROP (greetings, filler)
-
-═══════════════════════════════════════════════════════════════
-TYPE (6 values)
-═══════════════════════════════════════════════════════════════
-- claim: factual assertion (absorbs v0 fact/context/decision; decisions populate reasoning)
-- preference: likes/dislikes/tastes
-- directive: imperative rule ("always X", "never Y")
-- commitment: future intent ("will do X")
-- episode: notable event
-- summary: derived synthesis (source must be derived|assistant)
-
-═══════════════════════════════════════════════════════════════
-SOURCE (provenance, CRITICAL)
-═══════════════════════════════════════════════════════════════
-- user: user explicitly stated it (in [user]: turns)
-- user-inferred: extractor inferred from user signals
-- assistant: assistant authored — DOWNGRADE unless user affirmed/quoted
-- external, derived: rare
-
-IF fact substance appears ONLY in [assistant]: turns without user affirmation → source:assistant.
-
-═══════════════════════════════════════════════════════════════
-SCOPE
-═══════════════════════════════════════════════════════════════
-work | personal | health | family | creative | finance | misc | unspecified
-
-═══════════════════════════════════════════════════════════════
-ENTITIES
-═══════════════════════════════════════════════════════════════
-- type ∈ {person, project, tool, company, concept, place}
-- prefer specific names ("PostgreSQL" not "database")
-- omit umbrella categories when specific name is present
-
-═══════════════════════════════════════════════════════════════
-REASONING (only for claims that are decisions)
-═══════════════════════════════════════════════════════════════
-For type=claim where the user expressed a decision-with-reasoning, populate "reasoning" with the WHY clause.
-
-═══════════════════════════════════════════════════════════════
-FORMAT-AGNOSTIC PARSING (IMPORTANT)
-═══════════════════════════════════════════════════════════════
-The conversation may contain bullet lists, numbered lists, section headers, code snippets, or plain prose. Treat ALL formats as potential sources of extractable memory:
-- Bullets/list items: each item is a candidate.
-- Section headers (Context, Decisions, Key Learnings, Open Questions): use the header as a TYPE HINT (Context → claim, Decisions → claim+reasoning, Learnings → directive, Open Questions → commitment).
-- Plain prose: parse each distinct assertion as a candidate.
-- Code snippets: extract config choices, tool versions, architectural decisions embedded in comments or structure.
-- Mixed format: apply all of the above.
-
-Do NOT skip content just because it's in a summary. The agent has already filtered — your job is to convert into structured memories, not to re-evaluate worth.
-
-═══════════════════════════════════════════════════════════════
-OUTPUT FORMAT (no markdown, no code fences)
-═══════════════════════════════════════════════════════════════
-{
-  "topics": ["topic 1", "topic 2"],
-  "facts": [
-    {
-      "text": "...",
-      "type": "claim|preference|directive|commitment|episode",
-      "source": "user|user-inferred|assistant",
-      "scope": "work|personal|health|...",
-      "importance": N,
-      "confidence": 0.9,
-      "action": "ADD",
-      "reasoning": "...",    // optional, only for claim+decision
-      "entities": [{"name": "...", "type": "tool"}]
-    }
-  ]
+let _compactionPromptCache: string | null = null;
+function loadCompactionSystemPrompt(): string {
+  if (_compactionPromptCache === null) {
+    _compactionPromptCache = getCore().getCompactionSystemPrompt();
+  }
+  return _compactionPromptCache;
 }
-
-If nothing worth extracting: {"topics": [], "facts": []}`;
+export const COMPACTION_SYSTEM_PROMPT: string = /* @__PURE__ */ loadCompactionSystemPrompt();
 
 /**
  * Parse facts for compaction context (v1 taxonomy; importance floor 5).
@@ -941,90 +872,20 @@ export async function extractDebrief(
  *
  * Exported as both `EXTRACTION_SYSTEM_PROMPT` (canonical) and
  * `EXTRACTION_SYSTEM_PROMPT_V1_MERGED` (deprecated alias) for back-compat.
+ *
+ * As of plugin 3.0.7 / core 2.2.0, the canonical text is hoisted to Rust
+ * core. See `rust/totalreclaw-core/src/prompts/extraction.md`. Fetched
+ * once lazily so this module still imports cleanly in environments where
+ * the WASM binding isn't preloaded.
  */
-export const EXTRACTION_SYSTEM_PROMPT = `You are a memory extraction engine using Memory Taxonomy v1. Work in TWO explicit phases within one response:
-
-PHASE 1 — Topic identification.
-Before extracting any fact, identify the 2-3 main topics the user was engaging with. Topics should be short phrases (2-5 words each). If the conversation has no clear user-focused topic, use an empty topics array.
-
-PHASE 2 — Fact extraction anchored to those topics.
-Extract valuable memories. Prefer facts that directly relate to the identified topics (importance 7-9 range). Tangential facts may still be extracted but score lower (6-7 range).
-
-Rules:
-1. Each memory = single self-contained piece of information
-2. Focus on user-specific info useful in future conversations
-3. Skip generic knowledge, greetings, small talk, ephemeral task coordination
-4. Score importance 1-10 (6+ = worth storing)
-5. Every memory MUST attribute a source (provenance critical)
-
-Importance rubric (use FULL 1-10 range):
-- 10: Critical, core identity, never-forget content
-- 9: Affects many future decisions
-- 8: High-value preference/decision/rule
-- 7: Specific durable fact
-- 6: Borderline
-- 5 or below: NOT worth storing — drop
-
-DO NOT cluster everything at 7-8-9.
-
-═══════════════════════════════════════════════════════════════
-TYPE (6 values)
-═══════════════════════════════════════════════════════════════
-- claim: factual assertion (absorbs fact/context/decision; decisions populate reasoning field)
-- preference: likes/dislikes/tastes
-- directive: imperative rule ("always X", "never Y")
-- commitment: future intent ("will do X")
-- episode: notable event
-- summary: derived synthesis (source must be derived|assistant) — do NOT emit for turn-extraction
-
-═══════════════════════════════════════════════════════════════
-SOURCE (provenance, CRITICAL)
-═══════════════════════════════════════════════════════════════
-- user: user explicitly stated it (in [user]: turns)
-- user-inferred: extractor inferred from user signals
-- assistant: assistant authored content — DOWNGRADE unless user affirmed/quoted/used it
-- external, derived: rare
-
-IF fact substance appears ONLY in [assistant]: turns without user affirmation → source:assistant
-
-═══════════════════════════════════════════════════════════════
-SCOPE (life domain)
-═══════════════════════════════════════════════════════════════
-work | personal | health | family | creative | finance | misc | unspecified
-
-═══════════════════════════════════════════════════════════════
-ENTITIES
-═══════════════════════════════════════════════════════════════
-- type ∈ {person, project, tool, company, concept, place}
-- prefer specific names ("PostgreSQL" not "database")
-- omit umbrella categories when specific name is present
-
-═══════════════════════════════════════════════════════════════
-REASONING (only for claims that are decisions)
-═══════════════════════════════════════════════════════════════
-For type=claim where the user expressed a decision-with-reasoning, populate "reasoning" with the WHY clause.
-
-═══════════════════════════════════════════════════════════════
-OUTPUT FORMAT (no markdown, no code fences)
-═══════════════════════════════════════════════════════════════
-{
-  "topics": ["topic 1", "topic 2"],
-  "facts": [
-    {
-      "text": "...",
-      "type": "claim|preference|directive|commitment|episode",
-      "source": "user|user-inferred|assistant",
-      "scope": "work|personal|health|...",
-      "importance": N,
-      "confidence": 0.9,
-      "action": "ADD",
-      "reasoning": "...",     // optional, only for claim+decision
-      "entities": [{"name": "...", "type": "tool"}]
-    }
-  ]
+let _extractionPromptCache: string | null = null;
+function loadExtractionSystemPrompt(): string {
+  if (_extractionPromptCache === null) {
+    _extractionPromptCache = getCore().getExtractionSystemPrompt();
+  }
+  return _extractionPromptCache;
 }
-
-If nothing worth extracting: {"topics": [], "facts": []}`;
+export const EXTRACTION_SYSTEM_PROMPT: string = /* @__PURE__ */ loadExtractionSystemPrompt();
 
 /**
  * @deprecated Use `EXTRACTION_SYSTEM_PROMPT` instead. Kept only as a

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. Automatic extraction, semantic search, and on-chain storage",
   "type": "module",
   "keywords": [
@@ -25,7 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "@totalreclaw/client": "^1.2.0",
-    "@totalreclaw/core": "^2.0.0",
+    "@totalreclaw/core": "^2.2.0",
     "@huggingface/transformers": "^4.0.1",
     "onnxruntime-node": "^1.24.0"
   },


### PR DESCRIPTION
## Summary

- Hoists `EXTRACTION_SYSTEM_PROMPT` + `COMPACTION_SYSTEM_PROMPT` into `rust/totalreclaw-core` as `get_extraction_system_prompt()` / `get_compaction_system_prompt()` (WASM + PyO3). Prompt bodies live in readable `.md` siblings pulled in via `include_str!` (Option B from the backlog item).
- Reconciles three drifted copies (plugin / Python / NanoClaw) against a single canonical. **Bakes in Rule 6 (meta-request filter)** — the spurious-extract fix from PR #34 (`ed289aa`) that had landed in Python only. OpenClaw + NanoClaw now pick up that bug fix automatically.
- **Canonical shape is ADD-only**: the legacy `UPDATE` / `DELETE` / `NOOP` actions are dropped from the prompt. Contradiction + duplicate lifecycle is owned by the in-process consolidation + contradiction resolvers. NanoClaw's `BASE_SYSTEM_PROMPT` was the only client still asking the LLM for those tokens, and its dominant extraction path at `skill-nanoclaw/src/agent-end.ts:108` already silently dropped them. Pre-compact's forget-then-remember wiring is simplified accordingly (it had structural bugs around LLM-supplied `existingFactId` round-tripping).
- Client wiring switched so OpenClaw plugin, Hermes Python client, and NanoClaw skill all consume the hoisted text via the WASM/PyO3 binding.

## Design decision — Option B (`include_str!` .md files)

Chosen because the canonical text is 4-5 KB of prose-y markdown. `.md` files are far more reviewable than inline Rust raw strings. No runtime I/O — the text is baked into the compiled artifact. Recompile still required to iterate, which is desirable: it makes the core version bump the forcing function for cross-client sync.

## Coordination / rebase awareness (re: Agent A)

- Rebased on `origin/main` at `f6887ce` (after Agent A's PR #41 merged).
- `lib.rs` delta: **+2 lines** (one doc bullet, one `pub mod prompts;`).
- `python.rs` delta: **+3 lines** (one `register_python_functions` call + blank + comment).
- `wasm.rs`: **zero diff**. The `#[wasm_bindgen]` macros inside `prompts::wasm_bindings` are auto-registered at link time, same pattern as Agent A's `memory_types::wasm_bindings`.

## Version bumps

Minor-version bump rationale for core: the new accessor surface is additive, but downstream clients start depending on it — anyone holding the old core and the new plugin/Python/NanoClaw would miss the hoisted prompt. Semver-wise that's additive public API → minor bump.

- `rust/totalreclaw-core`: **2.1.0 → 2.2.0** (Cargo.toml + pyproject.toml — the pyproject.toml was incidentally still at 2.1.0 after Agent A's bump; fixed here so the release wheel gets the right version label).
- `skill/plugin`: **3.0.6 → 3.0.7** (patch — internal refactor, no public API change).
- `python/totalreclaw`: **2.2.0 → 2.3.0** (minor — behavior change: ADD-only + Rule 6 now applies via hoist. Coordination note: this **supersedes** the "PR #44 pending" 2.2.1 mentioned in the dispatch; reviewer may want to fast-forward that work onto this version).
- `skill-nanoclaw`: **3.0.0 → 3.0.1** (patch — removes an already-dead LLM action surface; behavior change is silent for end users since the dominant path was already filtering).

## Test deltas

| Suite | Before | After | Delta |
|---|---|---|---|
| Rust core `cargo test` | 466 pass | 477 pass (+11 new prompt tests) | +11 |
| Plugin `npx tsx *.test.ts` | same as baseline | unchanged (2 pre-existing node25-ESM failures in contradiction-sync + lsh) | 0 regressions |
| Python `pytest tests/` | — | 658 pass, 1 skip, 1 xfail | clean |
| MCP `npm test` | 565 pass | 565 pass | 0 regressions |
| NanoClaw `npm test` | 11 fail / 73 pass (baseline) | 11 fail / 73 pass (same failure set, updated 4 legacy-CRUD assertions to document the new ADD-only behavior) | 0 regressions |

## Follow-ups (not in this PR)

- Contradiction resolver port into NanoClaw's pre-compact path (the in-client contradiction flow previously guarded by the UPDATE/DELETE wiring). Today NanoClaw delegates contradiction handling to the MCP server via stored-fact round-trips; bringing the in-client path back online is a future-work item.
- Once 2.2.0 is on the public registries, remove the deprecated `EXTRACTION_SYSTEM_PROMPT_V1_MERGED` alias from the plugin (it re-exports the hoisted prompt; keeping it in this PR for back-compat).

## Test plan

- [ ] `cd rust/totalreclaw-core && cargo test` (default features)
- [ ] `cd rust/totalreclaw-core && cargo check --features wasm`
- [ ] `cd rust/totalreclaw-core && cargo test --features python --lib prompts`
- [ ] `cd rust/totalreclaw-core && ./build-wasm.sh` — verify `pkg/` exports `getExtractionSystemPrompt` / `getCompactionSystemPrompt`
- [ ] `cd python && pytest tests/ --ignore=tests/test_staging_integration.py --ignore=tests/cross_client_e2e.py --ignore=tests/test_cross_client.py`
- [ ] `cd mcp && npm test`
- [ ] Build WASM wheel via `maturin build --release --features python-extension` — verify version label is `2.2.0`
- [ ] Full real-user QA on staging (per CLAUDE.md mandate) BEFORE any publish to npm/PyPI/ClawHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)