### PR TITLE
fix(ci+docs): publish @totalreclaw/totalreclaw plugin to npm + reconcile install docs

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,5 +1,14 @@
 name: Publish npm packages
 
+# The `publish-plugin` job was added 2026-04-19 to fix an install bug on
+# OpenClaw CLI 2026.4.2+: `openclaw plugins install @totalreclaw/totalreclaw`
+# fell through to npm and fetched a stale 1.6.0 tarball (last published
+# pre-centralization work), which tripped the CLI's `env-harvesting`
+# scanner and blocked install. Plugin had only ever shipped to ClawHub.
+# Publishing the current 3.0.x plugin to npm restores the documented
+# one-liner install path. See PR https://github.com/p-diogo/totalreclaw/pull/
+# (the PR that introduced this comment) for full write-up.
+
 on:
   workflow_dispatch:
     inputs:
@@ -12,6 +21,7 @@ on:
           - mcp-server
           - client
           - nanoclaw
+          - plugin
           - all
       dry-run:
         description: 'Dry run (build only, no publish)'
@@ -211,3 +221,61 @@ jobs:
       - name: Report version
         run: |
           node -e "const p = require('./skill-nanoclaw/package.json'); console.log('Published:', p.name + '@' + p.version)"
+
+  publish-plugin:
+    needs: [publish-core, publish-client]
+    if: |
+      always() &&
+      (inputs.package == 'plugin' || inputs.package == 'all') &&
+      (needs.publish-core.result != 'cancelled') &&
+      (needs.publish-client.result != 'cancelled')
+    name: Publish @totalreclaw/totalreclaw (OpenClaw plugin)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # OIDC trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: cd skill/plugin && rm -f package-lock.json && npm install --legacy-peer-deps
+
+      # Defense-in-depth: block the publish if any plugin file would trip
+      # OpenClaw's `env-harvesting` scanner rule. The same gate runs in
+      # `publish-clawhub.yml`. We don't want npm to serve a tarball that
+      # `openclaw plugins install @totalreclaw/totalreclaw` would then
+      # refuse to install. `prepublishOnly` ALSO runs this script, but we
+      # surface it explicitly here so a failure shows up as its own step.
+      - name: Scanner-sim (env-harvesting false-positive check)
+        run: cd skill/plugin && npm run check-scanner
+
+      # Tests intentionally skipped at this step: this plugin publishes
+      # `.ts` source (no build step), and `skill/plugin/package.json` has
+      # no `test` script defined. Per-file `*.test.ts` suites are run in
+      # other workflows; gating publish on them here would require wiring
+      # a runner that isn't currently present. Mirrors the nanoclaw
+      # rationale above.
+
+      - name: Publish
+        if: inputs.dry-run == false
+        run: |
+          cd skill/plugin
+          npm publish --access public 2>&1 || {
+            # Tolerate "already published" (403/409) — version already exists on registry
+            if npm view @totalreclaw/totalreclaw@$(node -e "console.log(require('./package.json').version)") version 2>/dev/null; then
+              echo "Version already published, continuing"
+            else
+              exit 1
+            fi
+          }
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Report version
+        run: |
+          node -e "const p = require('./skill/plugin/package.json'); console.log('Published:', p.name + '@' + p.version)"

--- a/docs/guides/beta-tester-guide-detailed.md
+++ b/docs/guides/beta-tester-guide-detailed.md
@@ -57,26 +57,28 @@ Before you begin, make sure you have:
 
 **For MCP users (Claude Desktop / Cursor):** Skip to [Section 11](#11-mcp-server-setup-claude-desktop--cursor) for the fastest setup path.
 
-### Install the OpenClaw Skill
+### Install the OpenClaw Plugin
 
-The easiest way is to tell your OpenClaw agent:
-
-> "Install the TotalReclaw skill from ClawHub"
-
-Or via terminal:
-
-```
-openclaw skills install totalreclaw
-```
-
-The skill registers itself with the ID `totalreclaw` and sets up automatically on first run. Verify it appears in your OpenClaw skill list -- you should see **TotalReclaw** described as "End-to-end encrypted memory vault for AI agents."
-
-<details>
-<summary>Alternative: install via npm</summary>
+The quickest path is a single command that pulls the plugin from npm:
 
 ```
 openclaw plugins install @totalreclaw/totalreclaw
 ```
+
+This registers the plugin with your gateway under the ID `totalreclaw` and sets it up automatically on first run. Verify it appears in your OpenClaw skill/plugin list -- you should see **TotalReclaw** described as "End-to-end encrypted memory vault for AI agents."
+
+<details>
+<summary>Alternative: install from source (ClawHub + local path)</summary>
+
+```
+openclaw skills install totalreclaw
+openclaw plugins install ~/.openclaw/workspace/skills/totalreclaw
+```
+
+`openclaw skills install` pulls the plugin source from ClawHub into your workspace skills directory, then `openclaw plugins install <local-path>` registers it with your gateway. Use this path if the npm install fails or if you want to pin a specific ClawHub version.
+
+You can also ask your OpenClaw agent: *"Install the TotalReclaw skill from ClawHub"*.
+
 </details>
 
 ---

--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -6,10 +6,26 @@ TotalReclaw gives your OpenClaw agent encrypted, persistent memory. Facts, prefe
 
 ## Install
 
+The quickest path -- one command, install from npm:
+
+```bash
+openclaw plugins install @totalreclaw/totalreclaw
+```
+
+<details>
+<summary>Alternative: install from source (ClawHub + local path)</summary>
+
 ```bash
 openclaw skills install totalreclaw
 openclaw plugins install ~/.openclaw/workspace/skills/totalreclaw
 ```
+
+`openclaw skills install` pulls the plugin source from ClawHub into your
+workspace skills directory, then `openclaw plugins install <local-path>`
+registers it with your gateway. Use this path if the npm install fails
+or if you want to pin a specific ClawHub version.
+
+</details>
 
 Then start a conversation and tell your agent:
 


### PR DESCRIPTION
## Summary

- Adds a `publish-plugin` job to `.github/workflows/npm-publish.yml` so the OpenClaw plugin can be published to npm via workflow_dispatch (it has only ever shipped to ClawHub until now).
- Aligns the two install guides (`docs/guides/beta-tester-guide-detailed.md` + `docs/guides/openclaw-setup.md`) so both lead with the `openclaw plugins install @totalreclaw/totalreclaw` one-liner and keep the ClawHub + local-path form as a fallback.

## Why

OpenClaw CLI (`2026.4.2`) handles `openclaw plugins install @totalreclaw/totalreclaw` in the order [ClawHub -> npm], and **both legs currently fail** for a new user:

1. **ClawHub leg**: CLI queries `clawhub:@totalreclaw/totalreclaw`; ClawHub's metadata reports `family: "skill"` so the CLI rejects with `SKILL_PACKAGE` and falls through.
2. **npm leg**: CLI fetches `totalreclaw-totalreclaw-1.6.0.tgz` — the stale, pre-centralization release from before the 3.0.x rewrite. That tarball's `index.ts`, `llm-client.ts`, `subgraph-search.ts`, and `subgraph-store.ts` all contain `process.env` reads alongside `fetch`/`post` tokens, which trips the CLI's built-in `env-harvesting` scanner rule. Install is hard-blocked.

Result: users following `docs/guides/beta-tester-guide-detailed.md` hit a wall on the documented one-liner install. `openclaw skills install totalreclaw` + `openclaw plugins install <local-path>` continues to work, but the one-liner is what the docs have been advertising.

For the full scanner investigation, see the internal note `docs/notes/INVESTIGATION-OPENCLAW-SCANNER-EXEMPTION-20260418.md` (in the `totalreclaw-internal` repo).

## What the new job does

Mirrors the `publish-nanoclaw` job pattern (same OIDC trusted publishing, same `rm -f package-lock.json && npm install --legacy-peer-deps` ceremony, same tolerate-already-published 403/409 guard):

- `cd skill/plugin`
- `rm -f package-lock.json` then `npm install --legacy-peer-deps` (no npm workspace at repo root, so each package has its own lockfile; removing it before install matches nanoclaw's rationale)
- `npm run check-scanner` as a defense-in-depth gate — the same `skill/scripts/check-scanner.mjs` script that `publish-clawhub.yml` already uses. This ensures npm never serves a tarball that would trip the CLI scanner. `prepublishOnly` in `skill/plugin/package.json` ALSO calls it, but surfacing it as its own step makes a failure clearer in the Actions log.
- `npm publish --access public` with `NODE_AUTH_TOKEN` from `NPM_TOKEN` secret + OIDC trusted publishing (`id-token: write`)
- Tolerates 403/409 via `npm view @totalreclaw/totalreclaw@<ver> version` check — matches `publish-core` and `publish-nanoclaw`
- `needs: [publish-core, publish-client]` because the plugin depends on both (`@totalreclaw/core@^2.0.0`, `@totalreclaw/client@^1.2.0`)

Also adds `plugin` to the `inputs.package` choice list and includes it in the `all` pathway via `inputs.package == 'plugin' || inputs.package == 'all'`.

**No build/test step.** The plugin ships `.ts` source directly (OpenClaw has its own `.ts` loader — see `openclaw.extensions: ["./index.ts"]` in `skill/plugin/package.json`). There is no `build` or `test` script defined; wiring a test runner here would be out of scope and not reflective of how the plugin is tested today. The nanoclaw job also skips tests, with a similar comment.

## Doc changes

Currently the two install guides contradict each other at the top-of-guide "Install" section:

- `docs/guides/openclaw-setup.md:11` leads with `openclaw plugins install ~/.openclaw/workspace/skills/totalreclaw` (local-path form).
- `docs/guides/beta-tester-guide-detailed.md:78` leads with `openclaw plugins install @totalreclaw/totalreclaw` (npm form, buried inside a `<details>` as "Alternative").

Resolution in this PR: both docs now lead with the **npm one-liner** as primary and present the **ClawHub + local-path** form as a `<details>` fallback, with a short explanation of when to use the fallback (npm install fails, or pin a specific ClawHub version). This gives new users the simplest possible install story and keeps the proven local-path form accessible for advanced cases.

**Important caveat**: the `openclaw plugins install @totalreclaw/totalreclaw` command in the docs becomes accurate only AFTER this PR merges AND the user triggers `npm-publish.yml` with `package=plugin` to publish 3.0.6 (or later) to npm. Until that first publish lands, new users who follow the primary install will continue to hit the 1.6.0 scanner block. The fallback path in both docs keeps them unblocked in the meantime.

## After this PR merges

1. User triggers `.github/workflows/npm-publish.yml` via "Run workflow" -> `package: plugin`. This publishes the current plugin version (`3.0.6` as of this PR) to npm at `@totalreclaw/totalreclaw`.
2. User runs full real-user QA on a clean machine per the internal `CLAUDE.md` real-user-QA mandate — specifically verifying that the now-documented one-liner install works end-to-end from npm, not just focused regression tests.
3. Only after that QA returns GO should this doc path be considered the "primary" user flow in comms.

## Long-term follow-up (out of scope for this PR)

Request that ClawHub re-register `totalreclaw` with `family: "code-plugin"` (currently `"skill"`) so the CLI's ClawHub leg of `openclaw plugins install clawhub:totalreclaw` resolves directly without falling through to npm. Once fixed, the npm + ClawHub publishes become truly interchangeable for users and the CLI will prefer the ClawHub source when it is more recent.

## Test plan

- [x] `action-validator` passes on `.github/workflows/npm-publish.yml` (exit 0)
- [x] Python `yaml.safe_load` parses the workflow; new job wired with correct `needs`, `permissions`, `if` condition, and `plugin` added to `inputs.package` options + the `all` pathway
- [x] `skill/plugin/package.json` `files:` array, `prepublishOnly`, and `check-scanner` script already present from PR #39 — no package.json changes needed to make the plugin npm-publishable
- [x] `node skill/scripts/check-scanner.mjs` returns exit 0 against current `skill/plugin/` tree (44 files, 0 flags)
- [ ] User triggers `npm-publish.yml` with `package=plugin` and verifies `@totalreclaw/totalreclaw@3.0.6` appears on npmjs.com
- [ ] User runs full real-user QA on a clean machine against staging with the newly-published npm tarball — natural multi-turn conversation, auto-extract, cross-session recall, import, tools via natural language, on-chain verification via subgraph
- [ ] User files a ClawHub metadata fix request to re-register `totalreclaw` as `family: code-plugin`

## Notes

- `publish-clawhub.yml` is untouched. ClawHub and npm will now be parallel publishes of the same plugin tarball.
- No crates/PyPI changes. Plugin-only fix.
- No OpenClaw CLI or `node_modules/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)