### PR TITLE
feat(pin): v1 taxonomy — core 2.1.1 + mcp 3.2.0 — pin/unpin emit v1 blobs with pin_status

### DIFF
--- a/docs/specs/totalreclaw/memory-taxonomy-v1.md
+++ b/docs/specs/totalreclaw/memory-taxonomy-v1.md
@@ -1,9 +1,14 @@
 # MCP Memory Taxonomy v1
 
-**Version:** 1.0.0-draft (pending benchmark validation + lock)
-**Status:** DRAFT. Validated on Gemini corpus (Pipeline C). WildChat cross-validation in progress (2026-04-17). Lock after WildChat results confirm.
+**Version:** 1.1.0-draft (additive `pin_status` extension over 1.0)
+**Status:** DRAFT. 1.0 validated on Gemini corpus (Pipeline C). WildChat cross-validation in progress (2026-04-17). 1.1 adds `pin_status` without breaking 1.0 readers. Lock after WildChat results confirm.
 **Owner:** TotalReclaw (pedro@thegraph.foundation)
 **Intended publication:** `totalreclaw.xyz/spec/memory-v1` + PR to MCP spec repo as optional `@modelcontextprotocol/memory-taxonomy/v1` extension.
+
+## Version history
+
+- **1.0.0** (2026-04-17) — initial v1 taxonomy lock-candidate. Six-type closed enum, provenance-as-first-class-field, open-extensible scope, advisory importance.
+- **1.1.0** (2026-04-19) — additive `pin_status` field (`"pinned" | "unpinned"`). No breaking changes: 1.0 blobs continue to validate, and 1.0 readers ignore the new field. The on-wire `schema_version` string remains `"1.0"` so existing strict validators are unaffected (the field is optional; absence is equivalent to `"unpinned"`). Implementations that understand 1.1 MUST honor `pin_status == "pinned"` as immunity from auto-supersede and surface it via the same helpers (`is_pinned_claim`, `respect_pin_in_resolution`) that already recognize the legacy v0 `st == "p"` sentinel. `pin_status` is intentionally additive rather than gated behind a `schema_version` bump because (a) the field is optional and ignorable, and (b) we want cross-client pin to work the moment any client ships the new field — not after every client agrees to accept `"1.1"`.
 
 ---
 
@@ -56,7 +61,18 @@ interface MemoryClaimV1 {
   importance?: number;           // 1-10, auto-ranked in comparative pass
   confidence?: number;           // 0-1, extractor self-assessment
   superseded_by?: string;        // claim id that overrides this (tombstone chain)
+
+  // ── PIN STATE (v1.1, additive) ───────────────────────────────
+  pin_status?: PinStatus;        // default "unpinned" when absent. Pinned claims
+                                 // are immune to auto-supersede / auto-retract.
 }
+
+type PinStatus =
+  | "pinned"      // user explicitly pinned — MUST NOT be auto-superseded by
+                  //   contradiction resolution, compaction, or digest pruning.
+                  //   Cross-references the v0 `st == "p"` sentinel so that
+                  //   `is_pinned_claim(&claim)` returns true for either shape.
+  | "unpinned";   // default. Standard supersede/retract rules apply.
 
 type MemoryType = 
   | "claim"        // assertive speech act: absorbs fact, context, decision
@@ -126,6 +142,36 @@ For `type: claim` where the user expressed a decision-with-reasoning, populate `
 ```
 
 Separate field (not embedded in text) enables structured queries like "show me all my decisions with their reasoning."
+
+## Pin semantics (normative, v1.1)
+
+A **pinned** claim is one the user has explicitly marked as ground truth: it MUST NOT be auto-superseded by contradiction resolution, compaction, digest pruning, or any other implicit write path. Pinning is always user-initiated (via `totalreclaw_pin` or equivalent) and always reversible (via `totalreclaw_unpin`).
+
+### Representation
+
+- **v1.1+**: `pin_status: "pinned"` on the canonical claim. Absence or `"unpinned"` = unpinned.
+- **v0 legacy**: the compact `st == "p"` sentinel on the short-key claim (`{t, c, ..., st: "p"}`). Implementations MUST continue to recognize this for vaults that predate v1.1.
+
+### Implementation contract
+
+Every v1.1-compliant client MUST:
+
+1. **Detect**: `is_pinned_claim(claim)` returns `true` when EITHER the v1 field `pin_status == "pinned"` OR the v0 sentinel `st == "p"` is present. The Rust core helpers in `rust/totalreclaw-core/src/claims.rs` (`is_pinned_claim`, `is_pinned_json`) are the normative reference implementation.
+2. **Respect during auto-resolution**: `respect_pin_in_resolution` (or equivalent) MUST return `SkipNew { reason: ExistingPinned }` when the existing claim is pinned, regardless of score.
+3. **Write on pin**: pinning a fact produces a NEW claim with `pin_status == "pinned"` that supersedes the original via the standard tombstone + new-fact pattern (same pattern as `retype` and `set_scope`). The new claim is wrapped in the v1 outer protobuf (`version = 4`) with `schema_version = "1.0"` inner JSON.
+4. **Write on unpin**: unpinning produces a NEW claim with `pin_status == "unpinned"` (or omits the field — both are equivalent) and supersedes the pinned one.
+5. **Round-trip**: readers at any compliance level MUST preserve the `pin_status` field on round-trip (read → write) so a fact pinned by one client does not silently lose its pinned status when surfaced by another.
+
+### Cross-client compatibility
+
+Clients that still emit v0 short-key blobs (legacy) continue to use `st: "p"`. Clients on v1.1 emit `pin_status: "pinned"` in the canonical v1 claim. Readers at both shapes, via `is_pinned_claim`, return identical pin-detection semantics — no silent drift, no cross-client override.
+
+See also:
+
+- `rust/totalreclaw-core/src/claims.rs::is_pinned_claim` / `is_pinned_json` — normative detection.
+- `rust/totalreclaw-core/src/claims.rs::respect_pin_in_resolution` — normative auto-resolution guard.
+- `skill/plugin/pin.ts::executePinOperation` — TypeScript reference implementation.
+- `mcp/src/tools/pin.ts::executePinOperation` — TypeScript mirror for the MCP server.
 
 ## Provenance filter (normative)
 
@@ -244,6 +290,13 @@ tombstone the old fact id, write a new fact that carries `superseded_by:
 `totalreclaw_pin` additionally accepts the v1-wording alias `memory_id` so all
 three tools have a consistent parameter shape for callers. Legacy `fact_id`
 wins if both are supplied (backward compat).
+
+**v1.1 note (2026-04-19)**: `totalreclaw_pin` / `totalreclaw_unpin` emit v1.1
+canonical claims with `pin_status ∈ {pinned, unpinned}` and the outer protobuf
+wrapper set to `version = 4`. Prior shipped behavior (pre-v1.1) emitted legacy
+v0 short-key blobs at `version = 3` on the pin path — bug identified in the
+2026-04-19 RC QA and fixed in core 2.1.1 + mcp 3.2.0 + plugin pin fixes landed
+together. `retype` / `set_scope` already emitted v1 blobs and are unaffected.
 
 ## Open items
 

--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [3.2.0] - 2026-04-19
+
+### Added
+- **`totalreclaw_pin` / `totalreclaw_unpin` now emit v1.1 canonical claims** with the new `pin_status` field (`"pinned" | "unpinned"`) instead of the legacy v0 short-key shape (`{t,c,st,sup,...}`). The outer protobuf wrapper is already written at `version = 4` (unchanged since 3.0.1), so the pin path now lines up with the v1 on-chain contract end to end.
+  - New helper export from `src/claims-helper.ts`: `buildV1ClaimBlob(input)` accepts an optional `pinStatus` and returns a canonical v1.1 JSON blob validated through `@totalreclaw/core@2.1.1`'s `validateMemoryClaimV1`.
+  - `src/tools/pin.ts::executePinOperation` rewritten: source blob is parsed, projected into v1 shape (v0 sources are UPGRADED per the spec's legacy-type map — `fact|context|decision → claim`, `rule → directive`, `goal → commitment`), then a fresh v1.1 blob is built with `pin_status` set and `superseded_by` pointing to the old fact.
+  - `parseBlobForPin` now recognizes pinned status on a v1.1 blob via `pin_status == "pinned"` AND on a v0 blob via the legacy `st == "p"` sentinel (back-compat preserved).
+  - `readBlobUnified` surfaces `v1.pin_status` on parsed v1 blobs so downstream (recall display, export) can render the pin indicator without re-parsing.
+
+### Fixed
+- **BLOCKER bug #2 from RC 3.0.7-rc.1 QA (2026-04-19)** — `totalreclaw_pin` on a v1 vault was writing a v0 short-key blob without `schema_version` and with the v0 type token (`"rule"` instead of v1 `"directive"`). v1 readers would then report the pinned fact with a different `type` from its pre-pin neighbor. Root cause: the pin rewrite path bypassed `buildV1ClaimBlob` and used the legacy `canonicalizeClaim` helper. Fixed — pin/unpin now route through `buildV1ClaimBlob` with `pinStatus` set.
+- `schema_version` is now always emitted on v1.1 pin output (re-attached after core's serde-skip default-omission). Matches plugin output byte-for-byte.
+
+### Notes / Compatibility
+- Minor-version bump (3.1.0 → 3.2.0). New pin output format is a breaking change for any downstream reader that expected v0 short-key shape from the pin path — but the whole point of v1 is cross-client interoperability on the v1 surface, so this change lines MCP up with what all other clients already expect.
+- v0 blobs continue to READ correctly via `parseBlobForPin`'s fall-through (unchanged), so mixed-version vaults produce uniform pin/unpin behavior.
+- Cross-client parity: plugin + MCP produce the same v1.1 JSON for identical inputs — verified by new tests in both packages.
+- Requires `@totalreclaw/core@^2.1.1` (bumped in parallel — see `rust/totalreclaw-core/CHANGELOG.md`).
+
+### Tests
+- `tests/pin-unpin.test.ts` grew from 33 → 38 assertions. Existing v0 assertions updated to v1 equivalents; 5 new v1.1 tests (pin preserves fields, unpin flips pin_status, idempotent detects v1.1 pinned, cross-impl parity, entities round-trip).
+- `tests/tool-pin-recovery.test.ts` 2 tests updated to assert v1.1 output on tombstone-recovery pin.
+- Full TS suite: 402 passed (up from 397).
+
+### References
+- QA: `totalreclaw-internal/docs/notes/QA-openclaw-RC-3.0.7-rc.1-20260420.md` bug #2.
+- Audit: `mcp/AUDIT-v1-tools.md` §A2 (deferred gap — now closed).
+- Spec: `docs/specs/totalreclaw/memory-taxonomy-v1.md` (bumped to v1.1; additive extension).
+
 ## [3.1.0]
 
 ### Added

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/mcp-server",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. MCP server with XChaCha20-Poly1305 E2EE, semantic search, import/export, and on-chain storage",
   "homepage": "https://totalreclaw.xyz",
   "main": "dist/index.js",

--- a/mcp/src/claims-helper.ts
+++ b/mcp/src/claims-helper.ts
@@ -330,6 +330,13 @@ export function computeEntityTrapdoors(
 // ---------------------------------------------------------------------------
 
 /**
+ * v1.1 pin state. `"pinned"` = user explicitly pinned (immune to
+ * auto-supersede); `"unpinned"` = explicit unpin (resets a prior pin);
+ * undefined = field absent, receivers treat as unpinned.
+ */
+export type PinStatus = 'pinned' | 'unpinned';
+
+/**
  * Input shape for building a Memory Taxonomy v1 blob. All fields mirror the
  * MemoryClaimV1 schema; the builder fills in required timestamps/UUIDs so
  * callers can pass the subset they know about.
@@ -348,6 +355,12 @@ export interface BuildV1ClaimInput {
   importance?: number;             // 1-10 (optional advisory)
   confidence?: number;             // 0-1
   supersededBy?: string;           // claim id override
+  /**
+   * v1.1 additive field. When `"pinned"`, the claim is immune to
+   * auto-supersede. When `"unpinned"`, an explicit unpin event; receivers
+   * treat absence as equivalent. Only emitted in the output when provided.
+   */
+  pinStatus?: PinStatus;
 }
 
 /**
@@ -380,9 +393,24 @@ export function buildV1ClaimBlob(input: BuildV1ClaimInput): string {
   if (typeof input.importance === 'number') claim.importance = input.importance;
   if (typeof input.confidence === 'number') claim.confidence = input.confidence;
   if (input.supersededBy) claim.superseded_by = input.supersededBy;
+  // v1.1: pin_status is additive — only emitted when the caller opts in.
+  if (input.pinStatus === 'pinned' || input.pinStatus === 'unpinned') {
+    // Cast: MemoryClaimV1 interface is defined in v1-types.ts and pre-dates
+    // the v1.1 field. The Rust core accepts pin_status via serde; TS-side
+    // shape drift is handled by the validator's JSON round-trip.
+    (claim as unknown as Record<string, unknown>).pin_status = input.pinStatus;
+  }
 
   // Canonicalise + validate via core. Throws on any schema violation.
-  return getWasm().validateMemoryClaimV1(JSON.stringify(claim));
+  //
+  // Rust core's serde config drops `schema_version` on serialize when it
+  // equals the default ("1.0") — that shrinks blobs but loses a field MCP
+  // consumers (and the audit trail in export) expect on the wire. We
+  // re-attach it here so pin/unpin output matches the plugin byte-for-byte.
+  const validated = getWasm().validateMemoryClaimV1(JSON.stringify(claim));
+  const parsed = JSON.parse(validated) as Record<string, unknown>;
+  parsed.schema_version = MEMORY_CLAIM_V1_SCHEMA_VERSION;
+  return JSON.stringify(parsed);
 }
 
 /**
@@ -411,6 +439,11 @@ export interface V1BlobReadResult {
     superseded_by?: string;
     entities?: MemoryEntityV1[];
     created_at: string;
+    /**
+     * v1.1 pin state. Absent when the blob is a v1.0 payload or when the
+     * writer explicitly omitted the field (receivers treat as "unpinned").
+     */
+    pin_status?: PinStatus;
   };
   /** Whatever metadata the blob carried (v0 or v1). Used by callers that want raw access. */
   metadata: Record<string, unknown>;
@@ -471,6 +504,13 @@ export function readBlobUnified(decryptedJson: string): V1BlobReadResult {
       };
       const short = shortMap[v1Type] ?? 'claim';
 
+      // v1.1 pin_status (additive). Accept either canonical value; reject
+      // anything else so garbage on the wire doesn't propagate.
+      const rawPinStatus =
+        typeof obj.pin_status === 'string' ? obj.pin_status : undefined;
+      const pinStatus: PinStatus | undefined =
+        rawPinStatus === 'pinned' || rawPinStatus === 'unpinned' ? rawPinStatus : undefined;
+
       return {
         text: obj.text,
         importance,
@@ -488,6 +528,7 @@ export function readBlobUnified(decryptedJson: string): V1BlobReadResult {
             typeof obj.superseded_by === 'string' ? obj.superseded_by : undefined,
           entities: Array.isArray(obj.entities) ? (obj.entities as MemoryEntityV1[]) : undefined,
           created_at: typeof obj.created_at === 'string' ? obj.created_at : '',
+          pin_status: pinStatus,
         },
         metadata: obj as Record<string, unknown>,
       };

--- a/mcp/src/tools/pin.ts
+++ b/mcp/src/tools/pin.ts
@@ -1,10 +1,28 @@
-/** Pin/unpin tools for TotalReclaw MCP server — Slice 2e-mcp, Phase 2. */
+/** Pin/unpin tools for TotalReclaw MCP server — v1.1 taxonomy.
+ *
+ * As of core 2.1.1 / MCP 3.2.0 (2026-04-19) the pin/unpin operation emits
+ * a canonical v1.1 MemoryClaimV1 JSON blob (schema_version "1.0", additive
+ * `pin_status` field) wrapped in the outer protobuf at `version = 4`. The
+ * prior behavior — emitting v0 short-key blobs — broke the v1 on-chain
+ * contract (RC QA bug #2). v0 blobs continue to READ correctly via
+ * parseBlobForPin's fallback, so mixed-version vaults stay uniform from the
+ * user's point of view.
+ */
 
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { buildV1ClaimBlob, readBlobUnified, type PinStatus } from '../claims-helper.js';
 import { findLoserClaimInDecisionLog } from '../decision-log-reader.js';
+import type {
+  MemoryTypeV1,
+  MemorySource,
+  MemoryScope,
+  MemoryVolatility,
+  MemoryEntityV1,
+} from '../v1-types.js';
+import { LEGACY_TYPE_TO_V1 } from '../v1-types.js';
 import type { SubgraphSearchFact } from '../subgraph/search.js';
 import { encodeFactProtobuf } from '../subgraph/store.js';
 
@@ -301,7 +319,45 @@ export function parseBlobForPin(decrypted: string): ParsedBlob {
     };
   }
 
-  // New canonical Claim — short keys present
+  // v1.1+ payload: long-form `text` + `type` + schema_version "1.x".
+  //
+  // We detect pin status through the v1.1 `pin_status` field. The ParsedBlob
+  // return shape is the legacy short-key projection so existing callers that
+  // dereference `claim.t` / `claim.e` keep working — the actual REWRITE path
+  // in executePinOperation uses `plaintext` directly (re-parsed via
+  // projectToV1) so no data loss.
+  if (
+    typeof obj.text === 'string' &&
+    typeof obj.type === 'string' &&
+    typeof obj.schema_version === 'string' &&
+    obj.schema_version.startsWith('1.')
+  ) {
+    const rawPin = typeof obj.pin_status === 'string' ? obj.pin_status : undefined;
+    const human: HumanStatus = rawPin === 'pinned' ? 'pinned' : 'active';
+    // Build a v0-shape projection for legacy callers (tests, etc) that inspect
+    // `parsed.claim.t` / `parsed.claim.c`. Pin/unpin's rewrite path does NOT
+    // use this projection — it re-parses the plaintext via projectToV1().
+    const v1Type = String(obj.type);
+    const shortCategory = ((): string => {
+      const map: Record<string, string> = {
+        claim: 'claim', preference: 'pref', directive: 'rule',
+        commitment: 'goal', episode: 'epi', summary: 'sum',
+      };
+      return map[v1Type] ?? 'claim';
+    })();
+    const claimProjection: Record<string, unknown> = {
+      t: obj.text,
+      c: shortCategory,
+      cf: typeof obj.confidence === 'number' ? obj.confidence : 0.85,
+      i: typeof obj.importance === 'number' ? obj.importance : 5,
+      sa: typeof obj.source === 'string' ? obj.source : 'mcp-server',
+      ea: typeof obj.created_at === 'string' ? obj.created_at : new Date().toISOString(),
+    };
+    if (rawPin === 'pinned') claimProjection.st = 'p';
+    return { claim: claimProjection, currentStatus: human, isLegacy: false };
+  }
+
+  // v0 canonical Claim — short keys present.
   if (typeof obj.t === 'string' && typeof obj.c === 'string') {
     const st = typeof obj.st === 'string' ? obj.st : 'a';
     const human = SHORT_TO_HUMAN[st] ?? 'active';
@@ -354,6 +410,122 @@ function buildCanonicalObjectFromLegacy(
     i: importance,
     sa: source,
     ea: createdAt,
+  };
+}
+
+// ─── v1 projection for pin/unpin rewrite ──────────────────────────────────────
+
+/** Subset of v1 fields needed to drive `buildV1ClaimBlob`. */
+interface V1Projection {
+  text: string;
+  type: MemoryTypeV1;
+  source: MemorySource;
+  scope?: MemoryScope;
+  volatility?: MemoryVolatility;
+  reasoning?: string;
+  entities?: MemoryEntityV1[];
+  importance?: number;
+  confidence?: number;
+}
+
+/**
+ * Project a decrypted blob (v1 or v0 / legacy) into a v1 shape suitable for
+ * rebuilding via `buildV1ClaimBlob`. v1 blobs pass through their fields;
+ * v0 / legacy blobs are UPGRADED via the spec's legacy-mapping table
+ * (`fact|context|decision → claim`, `rule → directive`, `goal → commitment`).
+ *
+ * Mirrors `skill/plugin/pin.ts::projectToV1` — MCP + plugin produce the same
+ * v1 JSON for identical source blobs (cross-client parity).
+ */
+function projectToV1(
+  plaintext: string,
+  parsed: ParsedBlob,
+  defaultSourceAgent: string,
+): V1Projection {
+  // Fast path: try the unified reader. If the blob is v1 it returns the
+  // full surface; if it's v0 / legacy it returns only `{text, importance,
+  // category, metadata}` and we upgrade.
+  const unified = readBlobUnified(plaintext);
+  if (unified.v1) {
+    return {
+      text: unified.text,
+      type: unified.v1.type,
+      source: unified.v1.source,
+      scope: unified.v1.scope,
+      volatility: unified.v1.volatility,
+      reasoning: unified.v1.reasoning,
+      entities: unified.v1.entities,
+      importance: unified.importance,
+      confidence: unified.v1.confidence,
+    };
+  }
+
+  // v0 / legacy path — upgrade.
+  const v0Category = parsed.claim.c;
+  const v0TypeToken = ((): string => {
+    if (typeof v0Category !== 'string') return 'fact';
+    // Inverse of the v0 short-key → v0 type map.
+    const CATEGORY_TO_V0_TYPE: Record<string, string> = {
+      fact: 'fact',
+      pref: 'preference',
+      dec: 'decision',
+      epi: 'episodic',
+      goal: 'goal',
+      ctx: 'context',
+      sum: 'summary',
+      rule: 'rule',
+      ent: 'fact', // entity records don't round-trip; fall back
+      dig: 'summary',
+      claim: 'claim',
+    };
+    return CATEGORY_TO_V0_TYPE[v0Category] ?? 'fact';
+  })();
+  const v1Type: MemoryTypeV1 =
+    (LEGACY_TYPE_TO_V1[v0TypeToken] as MemoryTypeV1 | undefined) ?? 'claim';
+
+  // Heuristic: upgrade v0 `sa` (source agent) → v1 MemorySource.
+  // Legacy blobs don't carry real provenance; default "user-inferred" matches
+  // the core's Tier 1 fallback weight policy.
+  const sa = typeof parsed.claim.sa === 'string' ? (parsed.claim.sa as string) : defaultSourceAgent;
+  let v1Source: MemorySource = 'user-inferred';
+  const saLower = sa.toLowerCase();
+  if (saLower.includes('derived') || saLower.includes('digest') || saLower.includes('consolidat')) {
+    v1Source = 'derived';
+  } else if (saLower.includes('assistant')) {
+    v1Source = 'assistant';
+  } else if (saLower.includes('extern') || saLower.includes('mem0') || saLower.includes('import')) {
+    v1Source = 'external';
+  }
+
+  const text = typeof parsed.claim.t === 'string' ? (parsed.claim.t as string) : unified.text;
+  const importance = typeof parsed.claim.i === 'number' ? (parsed.claim.i as number) : unified.importance;
+
+  // Map v0 short-key entities → v1 entity shape when present.
+  const rawEntities = Array.isArray(parsed.claim.e) ? parsed.claim.e : [];
+  const entities: MemoryEntityV1[] | undefined = rawEntities.length > 0
+    ? rawEntities
+        .map((e: unknown) => {
+          if (!e || typeof e !== 'object') return null;
+          const entity = e as Record<string, unknown>;
+          const name = typeof entity.n === 'string' ? entity.n : '';
+          const entType = typeof entity.tp === 'string' ? (entity.tp as string) : 'concept';
+          if (!name) return null;
+          const out: MemoryEntityV1 = {
+            name,
+            type: entType as MemoryEntityV1['type'],
+          };
+          if (typeof entity.r === 'string' && entity.r.length > 0) out.role = entity.r;
+          return out;
+        })
+        .filter((x): x is MemoryEntityV1 => x !== null)
+    : undefined;
+
+  return {
+    text,
+    type: v1Type,
+    source: v1Source,
+    importance,
+    entities,
   };
 }
 
@@ -488,30 +660,40 @@ export async function executePinOperation(
     };
   }
 
-  // 4. Build the new canonical claim with updated status + supersedes link
-  const newClaimObj = { ...parsed.claim };
-  if (targetStatus === 'active') {
-    // Default — omit the "st" field entirely
-    delete newClaimObj.st;
-  } else {
-    newClaimObj.st = HUMAN_TO_SHORT[targetStatus];
-  }
-  newClaimObj.sup = factId;
-  // Refresh extraction timestamp so downstream consumers can tell this is a new event
-  newClaimObj.ea = new Date().toISOString();
-  // Carry the source agent forward if present, otherwise stamp it
-  if (typeof newClaimObj.sa !== 'string' || newClaimObj.sa.length === 0) {
-    newClaimObj.sa = deps.sourceAgent;
-  }
+  // 4. Build the new canonical v1.1 claim with pin_status + superseded_by link.
+  //
+  // The new blob is ALWAYS v1.1 shaped (schema_version "1.0", pin_status
+  // present) regardless of the source blob format. v0 sources are upgraded
+  // to v1 on the pin path (category → type, sa heuristic → MemorySource);
+  // v1 sources round-trip their metadata (source, scope, reasoning,
+  // entities, volatility).
+  const pinStatus: PinStatus = targetStatus === 'pinned' ? 'pinned' : 'unpinned';
+  const newFactId = crypto.randomUUID();
+
+  const v1View = projectToV1(plaintext, parsed, deps.sourceAgent);
 
   let canonicalJson: string;
   try {
-    canonicalJson = getWasm().canonicalizeClaim(JSON.stringify(newClaimObj));
+    canonicalJson = buildV1ClaimBlob({
+      id: newFactId,
+      text: v1View.text,
+      type: v1View.type,
+      source: v1View.source,
+      scope: v1View.scope,
+      volatility: v1View.volatility,
+      reasoning: v1View.reasoning,
+      entities: v1View.entities,
+      importance: v1View.importance,
+      confidence: v1View.confidence,
+      createdAt: new Date().toISOString(),
+      supersededBy: factId,
+      pinStatus,
+    });
   } catch (err) {
     return {
       success: false,
       fact_id: factId,
-      error: `Failed to canonicalize updated claim: ${err instanceof Error ? err.message : String(err)}`,
+      error: `Failed to build v1 claim blob: ${err instanceof Error ? err.message : String(err)}`,
     };
   }
 
@@ -528,20 +710,24 @@ export async function executePinOperation(
   }
 
   // 5b. Regenerate trapdoors so the new fact is findable by the same text.
-  const newClaimText = typeof parsed.claim.t === 'string' ? parsed.claim.t : '';
-  const entityNames: string[] = Array.isArray(parsed.claim.e)
-    ? parsed.claim.e
-        .map((e: unknown) => (e && typeof (e as { n?: unknown }).n === 'string' ? (e as { n: string }).n : ''))
-        .filter((n: string): n is string => n.length > 0)
+  const entityNames: string[] = v1View.entities
+    ? v1View.entities.map((e) => e.name).filter((n): n is string => typeof n === 'string' && n.length > 0)
     : [];
   let regenerated: { blindIndices: string[]; encryptedEmbedding?: string };
   try {
-    regenerated = await deps.generateIndices(newClaimText, entityNames);
+    regenerated = await deps.generateIndices(v1View.text, entityNames);
   } catch {
     regenerated = { blindIndices: [] };
   }
 
-  // 6. Build tombstone + new protobuf payloads
+  // 6. Build tombstone + new protobuf payloads.
+  //
+  // Note: encodeFactProtobuf in `subgraph/store.ts` hardcodes the outer
+  // protobuf `version` field to PROTOBUF_VERSION_V4 (4) for all MCP writes,
+  // so the new v1 blob is already wrapped at v=4. The tombstone row also
+  // goes out at v=4 in MCP (unlike the plugin which writes tombstones at
+  // legacy v3). This is fine — readers ignore the version field on tombstone
+  // rows since they carry no decryptable inner blob.
   const tombstonePayload: FactPayloadMinimal = {
     id: factId,
     timestamp: new Date().toISOString(),
@@ -554,7 +740,6 @@ export async function executePinOperation(
     agentId: deps.sourceAgent,
   };
 
-  const newFactId = crypto.randomUUID();
   const newPayload: FactPayloadMinimal = {
     id: newFactId,
     timestamp: new Date().toISOString(),

--- a/mcp/tests/pin-cross-client-parity.test.ts
+++ b/mcp/tests/pin-cross-client-parity.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Cross-client parity: MCP buildV1ClaimBlob + pin path produce v1.1 blobs
+ * that match the plugin's output for identical inputs.
+ *
+ * Since the plugin helper lives in the skill/plugin tree and the MCP helper
+ * lives here, a true byte-for-byte comparison requires loading both into
+ * the same process. We sidestep that by capturing the canonical v1 JSON
+ * that pin.ts emits and asserting its SHAPE + field semantics match what
+ * plugin/pin-unpin.test.ts asserts for its parity case (`# parity: ...`).
+ *
+ * If this test passes AND the plugin's equivalent parity assertions pass,
+ * both clients are producing the same canonical v1.1 blob for the same
+ * source fact. Round-trip through `validateMemoryClaimV1` (in core) is the
+ * shared single source of truth for field ordering.
+ */
+
+import { executePinOperation, type PinOpDeps } from '../src/tools/pin';
+import type { SubgraphSearchFact } from '../src/subgraph/search';
+
+function makeFact(id: string, blob: string): SubgraphSearchFact {
+  return {
+    id,
+    encryptedBlob: Buffer.from(blob, 'utf-8').toString('hex'),
+    encryptedEmbedding: null,
+    decayScore: '1.0',
+    timestamp: new Date().toISOString(),
+    isActive: true,
+  };
+}
+
+function makeDeps(overrides: Partial<PinOpDeps> & { _submitted?: Buffer[][] } = {}): PinOpDeps & { _submitted: Buffer[][] } {
+  const _submitted: Buffer[][] = [];
+  return {
+    owner: '0xtest',
+    sourceAgent: 'mcp-server-pin',
+    async fetchFactById() { return null; },
+    decryptBlob(hex: string) {
+      return Buffer.from(hex, 'hex').toString('utf-8');
+    },
+    encryptBlob(plaintext: string) {
+      return Buffer.from(plaintext, 'utf-8').toString('hex');
+    },
+    async submitBatch(payloads: Buffer[]) {
+      _submitted.push(payloads);
+      return { txHash: '0xparity', success: true };
+    },
+    async generateIndices() {
+      return { blindIndices: [], encryptedEmbedding: undefined };
+    },
+    ...overrides,
+    _submitted,
+  } as PinOpDeps & { _submitted: Buffer[][] };
+}
+
+describe('Cross-client parity: MCP pin path matches plugin v1.1 shape', () => {
+  test('v1.1 pin output contains only canonical v1 fields + pin_status', async () => {
+    const v1Src = JSON.stringify({
+      id: '01900000-0000-7000-8000-000000000200',
+      text: 'parity canary',
+      type: 'claim',
+      source: 'user',
+      created_at: '2026-04-19T12:00:00.000Z',
+      schema_version: '1.0',
+    });
+
+    let capturedPlaintext: string | null = null;
+    const deps = makeDeps({
+      async fetchFactById(id) { return makeFact(id, v1Src); },
+      encryptBlob(plaintext: string) {
+        capturedPlaintext = plaintext;
+        return Buffer.from(plaintext, 'utf-8').toString('hex');
+      },
+    });
+    await executePinOperation('parity-canary', 'pinned', deps);
+
+    expect(capturedPlaintext).not.toBeNull();
+    const parsed = JSON.parse(capturedPlaintext!);
+
+    // Required v1 fields present (matches plugin parity assertions at
+    // skill/plugin/pin-unpin.test.ts:~985-1005).
+    expect(typeof parsed.id).toBe('string');
+    expect(parsed.text).toBe('parity canary');
+    expect(parsed.type).toBe('claim');
+    expect(parsed.source).toBe('user');
+    expect(typeof parsed.created_at).toBe('string');
+    expect(parsed.schema_version).toBe('1.0');
+    expect(parsed.pin_status).toBe('pinned');
+    expect(parsed.superseded_by).toBe('parity-canary');
+
+    // NO v0 leak — same assertions the plugin makes.
+    expect(Object.prototype.hasOwnProperty.call(parsed, 't')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(parsed, 'c')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(parsed, 'st')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(parsed, 'sup')).toBe(false);
+  });
+
+  test('v1.1 unpin output matches plugin unpin shape', async () => {
+    const v1Pinned = JSON.stringify({
+      id: '01900000-0000-7000-8000-000000000201',
+      text: 'unpin parity canary',
+      type: 'preference',
+      source: 'user',
+      created_at: '2026-04-19T12:00:00.000Z',
+      schema_version: '1.0',
+      pin_status: 'pinned',
+    });
+
+    let capturedPlaintext: string | null = null;
+    const deps = makeDeps({
+      async fetchFactById(id) { return makeFact(id, v1Pinned); },
+      encryptBlob(plaintext: string) {
+        capturedPlaintext = plaintext;
+        return Buffer.from(plaintext, 'utf-8').toString('hex');
+      },
+    });
+    await executePinOperation('unpin-canary', 'active', deps);
+
+    const parsed = JSON.parse(capturedPlaintext!);
+    // The plugin writes pin_status:"unpinned" on an unpin (explicit, not
+    // absent) — MCP must match.
+    expect(parsed.pin_status).toBe('unpinned');
+    expect(parsed.superseded_by).toBe('unpin-canary');
+    expect(parsed.schema_version).toBe('1.0');
+    expect(parsed.text).toBe('unpin parity canary');
+    expect(parsed.type).toBe('preference');
+    // v0 leak check.
+    expect(parsed.st).toBeUndefined();
+    expect(parsed.sup).toBeUndefined();
+  });
+
+  test('v0 source → v1.1 upgrade matches plugin upgrade rules', async () => {
+    // v0 short-key with category "rule" → v1 type "directive".
+    const v0Src = JSON.stringify({
+      t: 'always use snake_case for database column names',
+      c: 'rule',
+      cf: 0.9,
+      i: 8,
+      sa: 'openclaw-plugin',
+      ea: '2026-04-19T10:00:00.000Z',
+    });
+
+    let capturedPlaintext: string | null = null;
+    const deps = makeDeps({
+      async fetchFactById(id) { return makeFact(id, v0Src); },
+      encryptBlob(plaintext: string) {
+        capturedPlaintext = plaintext;
+        return Buffer.from(plaintext, 'utf-8').toString('hex');
+      },
+    });
+    await executePinOperation('v0-upgrade', 'pinned', deps);
+
+    const parsed = JSON.parse(capturedPlaintext!);
+    // Per spec §migration-from-v0: rule → directive.
+    expect(parsed.type).toBe('directive');
+    expect(parsed.text).toBe('always use snake_case for database column names');
+    expect(parsed.pin_status).toBe('pinned');
+    expect(parsed.schema_version).toBe('1.0');
+    expect(parsed.superseded_by).toBe('v0-upgrade');
+  });
+});

--- a/mcp/tests/pin-unpin.test.ts
+++ b/mcp/tests/pin-unpin.test.ts
@@ -200,7 +200,7 @@ describe('executePinOperation — pin', () => {
     expect(deps._submitted).toHaveLength(0);
   });
 
-  test('new blob on-chain is valid canonical Claim with status=pinned', async () => {
+  test('new blob on-chain is valid v1.1 MemoryClaim with pin_status=pinned', async () => {
     const activeBlob = buildFixtureClaim('a');
     let capturedNewBlobPlaintext: string | null = null;
     const deps = makeDeps({
@@ -217,11 +217,17 @@ describe('executePinOperation — pin', () => {
 
     expect(capturedNewBlobPlaintext).not.toBeNull();
     const parsed = JSON.parse(capturedNewBlobPlaintext!);
-    expect(parsed.t).toBe('prefers coffee over tea');
-    expect(parsed.c).toBe('pref');
-    expect(parsed.st).toBe('p');
-    // supersedes link points to the old fact id
-    expect(parsed.sup).toBe('old-id');
+    // v1.1 canonical fields — long-form, schema_version 1.0, pin_status.
+    expect(parsed.text).toBe('prefers coffee over tea');
+    expect(parsed.type).toBe('preference');
+    expect(parsed.schema_version).toBe('1.0');
+    expect(parsed.pin_status).toBe('pinned');
+    expect(parsed.superseded_by).toBe('old-id');
+    // v0 short-key fields MUST NOT leak.
+    expect(parsed.t).toBeUndefined();
+    expect(parsed.c).toBeUndefined();
+    expect(parsed.st).toBeUndefined();
+    expect(parsed.sup).toBeUndefined();
   });
 
   test('pin works on a legacy {text, metadata} blob', async () => {
@@ -245,10 +251,14 @@ describe('executePinOperation — pin', () => {
     expect(result.success).toBe(true);
     expect(result.previous_status).toBe('active');
     expect(result.new_status).toBe('pinned');
-    // Output is a canonical Claim now
+    // v1.1 output: legacy blob is UPGRADED to v1.
     const parsed = JSON.parse(capturedPlaintext!);
-    expect(parsed.t).toBe('lives in Lisbon');
-    expect(parsed.st).toBe('p');
+    expect(parsed.text).toBe('lives in Lisbon');
+    expect(parsed.schema_version).toBe('1.0');
+    expect(parsed.pin_status).toBe('pinned');
+    expect(parsed.superseded_by).toBe('legacy-id');
+    // v0 legacy type "fact" → v1 type "claim".
+    expect(parsed.type).toBe('claim');
   });
 
   test('stores reason in metadata when provided (does not affect canonical blob)', async () => {
@@ -288,11 +298,15 @@ describe('executePinOperation — unpin', () => {
     expect(result.new_fact_id).toBeDefined();
     expect(result.new_fact_id).not.toBe('pinned-id');
 
-    // New blob has no "st" field (status=active is the default, omitted)
+    // v1.1 unpin: explicit pin_status=unpinned, superseded_by on v1 field.
     expect(capturedPlaintext).not.toBeNull();
     const parsed = JSON.parse(capturedPlaintext!);
+    expect(parsed.schema_version).toBe('1.0');
+    expect(parsed.pin_status).toBe('unpinned');
+    expect(parsed.superseded_by).toBe('pinned-id');
+    // v0 short-key fields MUST NOT leak.
     expect(parsed.st).toBeUndefined();
-    expect(parsed.sup).toBe('pinned-id');
+    expect(parsed.sup).toBeUndefined();
 
     // Submitted 2 payloads
     expect(deps._submitted[0]).toHaveLength(2);
@@ -628,5 +642,147 @@ describe('Slice 2f: executePinOperation writes feedback on override', () => {
     const fb = JSON.parse(content.split('\n').filter((l) => l.length > 0)[0]) as FeedbackEntry;
     expect(fb.user_decision).toBe('pin_b');
     expect(fb.claim_b_id).toBe('was-winner');
+  });
+});
+
+// ─── v1.1 pin_status end-to-end ──────────────────────────────────────────────
+
+describe('executePinOperation — v1.1 pin_status', () => {
+  function buildV1Blob(overrides: Partial<Record<string, unknown>> = {}): string {
+    const base = {
+      id: '01900000-0000-7000-8000-000000000099',
+      text: 'prefers PostgreSQL over MongoDB for transactional workloads',
+      type: 'preference',
+      source: 'user',
+      created_at: '2026-04-19T10:00:00.000Z',
+      schema_version: '1.0',
+      scope: 'work',
+      volatility: 'stable',
+      importance: 9,
+      confidence: 0.95,
+    };
+    return JSON.stringify({ ...base, ...overrides });
+  }
+
+  test('pin on v1 blob preserves all v1 fields + sets pin_status=pinned', async () => {
+    const v1Blob = buildV1Blob({
+      reasoning: 'ACID guarantees matter for OrbitLedger',
+    });
+    let capturedPlaintext: string | null = null;
+    const deps = makeDeps({
+      async fetchFactById(id) { return makeFact(id, v1Blob); },
+      encryptBlob(plaintext: string) {
+        capturedPlaintext = plaintext;
+        return Buffer.from(plaintext, 'utf-8').toString('hex');
+      },
+    });
+    const result = await executePinOperation('v1-src', 'pinned', deps);
+    expect(result.success).toBe(true);
+    const parsed = JSON.parse(capturedPlaintext!);
+    expect(parsed.schema_version).toBe('1.0');
+    expect(parsed.pin_status).toBe('pinned');
+    expect(parsed.type).toBe('preference');
+    expect(parsed.source).toBe('user');
+    expect(parsed.scope).toBe('work');
+    expect(parsed.volatility).toBe('stable');
+    expect(parsed.reasoning).toContain('ACID');
+    expect(parsed.superseded_by).toBe('v1-src');
+    expect(parsed.t).toBeUndefined();
+    expect(parsed.st).toBeUndefined();
+  });
+
+  test('unpin on v1 pinned blob → pin_status=unpinned', async () => {
+    const v1PinnedBlob = buildV1Blob({
+      type: 'directive',
+      pin_status: 'pinned',
+    });
+    let capturedPlaintext: string | null = null;
+    const deps = makeDeps({
+      async fetchFactById(id) { return makeFact(id, v1PinnedBlob); },
+      encryptBlob(plaintext: string) {
+        capturedPlaintext = plaintext;
+        return Buffer.from(plaintext, 'utf-8').toString('hex');
+      },
+    });
+    const result = await executePinOperation('v1-pinned', 'active', deps);
+    expect(result.success).toBe(true);
+    expect(result.previous_status).toBe('pinned');
+    expect(result.new_status).toBe('active');
+    const parsed = JSON.parse(capturedPlaintext!);
+    expect(parsed.pin_status).toBe('unpinned');
+    expect(parsed.type).toBe('directive');
+    expect(parsed.superseded_by).toBe('v1-pinned');
+  });
+
+  test('idempotent pin on v1.1 pinned blob → no on-chain write', async () => {
+    const v1PinnedBlob = buildV1Blob({ pin_status: 'pinned' });
+    const deps = makeDeps({
+      async fetchFactById(id) { return makeFact(id, v1PinnedBlob); },
+    });
+    const result = await executePinOperation('already-pinned-v1', 'pinned', deps);
+    expect(result.success).toBe(true);
+    expect(result.idempotent).toBe(true);
+    expect(deps._submitted).toHaveLength(0);
+  });
+
+  test('cross-impl parity: canonical field shape matches plugin output', async () => {
+    const v1Source = buildV1Blob({
+      // Minimal shape used by the plugin parity test.
+      text: 'cross-client parity test',
+      type: 'claim',
+      source: 'user',
+      scope: undefined,
+      volatility: undefined,
+      importance: undefined,
+      confidence: undefined,
+    });
+    let capturedPlaintext: string | null = null;
+    const deps = makeDeps({
+      async fetchFactById(id) { return makeFact(id, v1Source); },
+      encryptBlob(plaintext: string) {
+        capturedPlaintext = plaintext;
+        return Buffer.from(plaintext, 'utf-8').toString('hex');
+      },
+    });
+    await executePinOperation('parity-src', 'pinned', deps);
+    const parsed = JSON.parse(capturedPlaintext!);
+    // Required v1 fields present.
+    expect(typeof parsed.id).toBe('string');
+    expect(typeof parsed.text).toBe('string');
+    expect(typeof parsed.type).toBe('string');
+    expect(typeof parsed.source).toBe('string');
+    expect(typeof parsed.created_at).toBe('string');
+    expect(parsed.schema_version).toBe('1.0');
+    expect(parsed.pin_status).toBe('pinned');
+    expect(parsed.superseded_by).toBe('parity-src');
+    // No v0 leak.
+    expect(parsed.t).toBeUndefined();
+    expect(parsed.c).toBeUndefined();
+    expect(parsed.st).toBeUndefined();
+    expect(parsed.sup).toBeUndefined();
+  });
+
+  test('v1 source with entities round-trips entities on pin', async () => {
+    const v1WithEntities = buildV1Blob({
+      entities: [
+        { name: 'PostgreSQL', type: 'tool', role: 'chosen' },
+        { name: 'OrbitLedger', type: 'company' },
+      ],
+    });
+    let capturedPlaintext: string | null = null;
+    const deps = makeDeps({
+      async fetchFactById(id) { return makeFact(id, v1WithEntities); },
+      encryptBlob(plaintext: string) {
+        capturedPlaintext = plaintext;
+        return Buffer.from(plaintext, 'utf-8').toString('hex');
+      },
+    });
+    await executePinOperation('v1-entities', 'pinned', deps);
+    const parsed = JSON.parse(capturedPlaintext!);
+    expect(Array.isArray(parsed.entities)).toBe(true);
+    expect(parsed.entities).toHaveLength(2);
+    expect(parsed.entities[0].name).toBe('PostgreSQL');
+    expect(parsed.entities[0].type).toBe('tool');
+    expect(parsed.entities[0].role).toBe('chosen');
   });
 });

--- a/mcp/tests/tool-pin-recovery.test.ts
+++ b/mcp/tests/tool-pin-recovery.test.ts
@@ -289,12 +289,14 @@ describe('executePinOperation — pin-on-tombstone recovery', () => {
     expect(deps._submitted).toHaveLength(1);
     expect(deps._submitted[0]).toHaveLength(2);
 
-    // The new blob reflects the RECOVERED claim text + flipped status.
+    // The new blob reflects the RECOVERED claim text + flipped pin_status.
+    // v1.1: long-form fields, schema_version "1.0", pin_status, superseded_by.
     expect(capturedNewPlaintext).not.toBeNull();
     const parsed = JSON.parse(capturedNewPlaintext!);
-    expect(parsed.t).toBe('I use Neovim as my primary editor');
-    expect(parsed.st).toBe('p');
-    expect(parsed.sup).toBe('tombstoned-vim');
+    expect(parsed.text).toBe('I use Neovim as my primary editor');
+    expect(parsed.schema_version).toBe('1.0');
+    expect(parsed.pin_status).toBe('pinned');
+    expect(parsed.superseded_by).toBe('tombstoned-vim');
   });
 
   test('returns error when tombstone blob has no matching decisions.jsonl row', async () => {
@@ -456,10 +458,12 @@ describe('executePinOperation — pin-on-tombstone recovery', () => {
     expect(result.new_status).toBe('pinned');
 
     // The re-pinned fact MUST match the pre-forget claim's text + type.
+    // v1.1: long-form fields + pin_status + superseded_by.
     const parsed = JSON.parse(capturedPlaintext!);
-    expect(parsed.t).toBe('My preferred editor is Neovim');
-    expect(parsed.c).toBe('pref');
-    expect(parsed.st).toBe('p');
-    expect(parsed.sup).toBe(f1Id);
+    expect(parsed.text).toBe('My preferred editor is Neovim');
+    // Legacy v0 type "preference" → v1 type "preference" (identity mapping).
+    expect(parsed.type).toBe('preference');
+    expect(parsed.pin_status).toBe('pinned');
+    expect(parsed.superseded_by).toBe(f1Id);
   });
 });

--- a/rust/totalreclaw-core/CHANGELOG.md
+++ b/rust/totalreclaw-core/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to `@totalreclaw/core` / `totalreclaw-core` are documented h
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2026-04-19
+
+### Added
+
+- **Memory Taxonomy v1.1 — additive `pin_status` field** on
+  [`MemoryClaimV1`](./src/claims.rs). New enum `PinStatus` with variants
+  `Pinned` / `Unpinned` (serde kebab → `"pinned"` / `"unpinned"`).
+  The field is `Option<PinStatus>` with `#[serde(skip_serializing_if =
+  "Option::is_none")]` so pre-v1.1 blobs continue to round-trip byte-for-byte.
+- **Unified pin detection** — [`is_pinned_json`](./src/claims.rs) now
+  recognizes BOTH the legacy v0 short-key sentinel (`st == "p"`) AND the
+  new v1.1 field (`pin_status == "pinned"`). Dispatch: try `MemoryClaimV1`
+  first; if that parses successfully, it is authoritative (no fall-through
+  to the v0 parser). Back-compat: every input accepted by pre-2.1.1
+  `is_pinned_json` returns an unchanged result.
+- New helper [`is_pinned_memory_claim_v1`](./src/claims.rs) for v1-only
+  callers that have already parsed the blob.
+- **WASM bindings**: `parsePinStatus`, `isPinnedClaimJson`.
+- **PyO3 bindings**: `parse_pin_status`, `is_pinned_claim_json`.
+- Spec: `docs/specs/totalreclaw/memory-taxonomy-v1.md` bumped to v1.1
+  (additive — on-wire `schema_version` stays `"1.0"` so existing strict
+  validators are unaffected).
+
+### Notes / Compatibility
+
+- Patch-version bump (additive serde field only). No breaking changes.
+- Motivated by 2026-04-19 RC QA bug #2: `totalreclaw_pin` shipped v0
+  short-key blobs at protobuf `version = 3`, breaking the "v1 on-chain"
+  contract for new pins. Rust core gains the field; plugin + mcp pin
+  paths are rewired in parallel (plugin 3.1.0 + mcp 3.2.0). See
+  `mcp/AUDIT-v1-tools.md` §A2 for the original deferred gap note.
+- Existing `ClaimStatus::Pinned` sentinel (v0) is UNCHANGED — v0 blobs
+  continue to decode and `is_pinned_claim(&Claim)` still returns `true`
+  for them.
+
+### References
+
+- Spec: [`docs/specs/totalreclaw/memory-taxonomy-v1.md`](../../docs/specs/totalreclaw/memory-taxonomy-v1.md) §pin-semantics (v1.1)
+- QA: `totalreclaw-internal/docs/notes/QA-openclaw-RC-3.0.7-rc.1-20260420.md` bug #2
+
 ## [2.1.0] - 2026-04-19
 
 ### Added

--- a/rust/totalreclaw-core/Cargo.lock
+++ b/rust/totalreclaw-core/Cargo.lock
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "totalreclaw-core"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/rust/totalreclaw-core/Cargo.toml
+++ b/rust/totalreclaw-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "totalreclaw-core"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 description = "TotalReclaw core — E2EE crypto, reranker, wallet, UserOp, store/search pipelines. Single source of truth for all clients."
 license = "MIT"

--- a/rust/totalreclaw-core/src/claims.rs
+++ b/rust/totalreclaw-core/src/claims.rs
@@ -148,15 +148,48 @@ pub struct DigestClaim {
 /// the 2026-04-14 false-positive where the gap was 9 parts per million.
 pub const TIE_ZONE_SCORE_TOLERANCE: f64 = 0.01;
 
-/// Check whether a claim has pinned status.
+/// Check whether a v0 [`Claim`] has pinned status.
+///
+/// v0 pin state is carried by the compact `st == "p"` sentinel
+/// ([`ClaimStatus::Pinned`]). For v1 claims use
+/// [`is_pinned_memory_claim_v1`] or the JSON-level [`is_pinned_json`].
 pub fn is_pinned_claim(claim: &Claim) -> bool {
     matches!(claim.status, ClaimStatus::Pinned)
 }
 
-/// Check whether a JSON-serialized claim has pinned status.
+/// Check whether a v1.1 [`MemoryClaimV1`] is pinned.
 ///
-/// Returns false on parse error or missing status field (which defaults to Active).
+/// Returns `true` when [`MemoryClaimV1::pin_status`] is `Some(PinStatus::Pinned)`.
+/// `None` and `Some(PinStatus::Unpinned)` both mean unpinned (spec §pin-semantics).
+pub fn is_pinned_memory_claim_v1(claim: &MemoryClaimV1) -> bool {
+    matches!(claim.pin_status, Some(PinStatus::Pinned))
+}
+
+/// Check whether a JSON-serialized claim has pinned status, recognizing both
+/// the legacy v0 [`Claim`] shape (`st == "p"`) and the v1.1
+/// [`MemoryClaimV1`] shape (`pin_status == "pinned"`).
+///
+/// Dispatch rule: if the JSON parses as a `MemoryClaimV1` (it contains the
+/// required v1 fields `id`, `text`, `type`, `source`, `created_at` with a
+/// closed-enum `type` token), the v1 check is authoritative. Otherwise we
+/// fall through to the v0 parser. Returns `false` for any JSON that fails
+/// both parsers or has neither sentinel set.
+///
+/// Guarantee: for every input accepted by pre-v1.1 `is_pinned_json`, the
+/// return value is unchanged. New return: `true` when the input is a v1.1
+/// blob with `pin_status == "pinned"`.
 pub fn is_pinned_json(claim_json: &str) -> bool {
+    // Try v1.1 first — a well-formed MemoryClaimV1 won't match the v0 shape
+    // (different required fields, different type enum), so no ambiguity.
+    if let Ok(v1) = serde_json::from_str::<MemoryClaimV1>(claim_json) {
+        if is_pinned_memory_claim_v1(&v1) {
+            return true;
+        }
+        // Parsed as v1 but pin_status != pinned — authoritative, do NOT
+        // fall through to the v0 parser (would be a type error anyway).
+        return false;
+    }
+    // Fall back to v0 short-key parser.
     match serde_json::from_str::<Claim>(claim_json) {
         Ok(claim) => is_pinned_claim(&claim),
         Err(_) => false,
@@ -510,6 +543,37 @@ pub enum MemoryVolatility {
     Ephemeral,
 }
 
+/// Pin state for a v1.1 memory claim.
+///
+/// Added as an additive extension in spec v1.1 (2026-04-19) so the pin path
+/// can emit canonical v1 blobs (outer protobuf `version = 4`, inner
+/// `schema_version = "1.0"`) while still carrying the user's explicit pin
+/// intent. See `docs/specs/totalreclaw/memory-taxonomy-v1.md#pin-semantics`.
+///
+/// Absence of the field is equivalent to `Unpinned` — readers MUST tolerate
+/// either representation. [`is_pinned_claim`] / [`is_pinned_json`] also return
+/// `true` for legacy v0 short-key blobs where `st == "p"`, so cross-version
+/// vaults produce uniform pin-detection semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum PinStatus {
+    /// User explicitly pinned — immune to auto-supersede / auto-retract.
+    Pinned,
+    /// Standard behavior (default when absent).
+    Unpinned,
+}
+
+impl PinStatus {
+    /// Case-insensitive parser; returns `Unpinned` for unknown input.
+    pub fn from_str_lossy(s: &str) -> Self {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "pinned" => PinStatus::Pinned,
+            "unpinned" => PinStatus::Unpinned,
+            _ => PinStatus::Unpinned,
+        }
+    }
+}
+
 /// Entity type for v1 structured entity references. Mirrors the v0
 /// [`EntityType`] enum and uses the same string-level encoding so
 /// v1 claims can cross-reference v0 entities.
@@ -614,6 +678,16 @@ pub struct MemoryClaimV1 {
     /// Claim ID that overrides this (tombstone chain).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub superseded_by: Option<String>,
+
+    // ── PIN STATE (v1.1, additive) ───────────────────────────────
+    /// User-controlled pin state. When `Some(PinStatus::Pinned)`, the claim
+    /// is immune to auto-supersede / auto-retract — see
+    /// [`respect_pin_in_resolution`]. Absence is equivalent to `Unpinned` on
+    /// the wire; [`is_pinned_claim`] also honors the legacy v0 sentinel
+    /// (`Claim::status == ClaimStatus::Pinned`) so mixed-version vaults
+    /// produce uniform pin-detection semantics.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pin_status: Option<PinStatus>,
 }
 
 impl MemoryTypeV1 {
@@ -1571,6 +1645,7 @@ mod tests {
             importance: None,
             confidence: None,
             superseded_by: None,
+            pin_status: None,
         }
     }
 
@@ -1594,6 +1669,7 @@ mod tests {
             importance: Some(8),
             confidence: Some(0.92),
             superseded_by: None,
+            pin_status: None,
         }
     }
 
@@ -1633,6 +1709,8 @@ mod tests {
         assert!(!json.contains("superseded_by"));
         // Entity list empty -> omitted
         assert!(!json.contains("entities"));
+        // pin_status = None -> omitted (v1.1 additive, absence == "unpinned")
+        assert!(!json.contains("pin_status"));
     }
 
     #[test]
@@ -1656,6 +1734,7 @@ mod tests {
         assert!(c.importance.is_none());
         assert!(c.confidence.is_none());
         assert!(c.superseded_by.is_none());
+        assert!(c.pin_status.is_none());
     }
 
     #[test]
@@ -1690,6 +1769,7 @@ mod tests {
             importance: None,
             confidence: None,
             superseded_by: None,
+            pin_status: None,
         };
         let json = serde_json::to_string(&c).unwrap();
         let expected = r#"{"id":"01900000-0000-7000-8000-000000000000","text":"prefers PostgreSQL","type":"preference","source":"user","created_at":"2026-04-17T10:00:00Z"}"#;
@@ -1724,5 +1804,212 @@ mod tests {
         }"#;
         let c: MemoryClaimV1 = serde_json::from_str(json).unwrap();
         assert_eq!(c.schema_version, "1.0");
+    }
+
+    // === Pin status (v1.1, additive) ===
+
+    #[test]
+    fn test_pin_status_serde_round_trip() {
+        let pairs = [
+            (PinStatus::Pinned, "\"pinned\""),
+            (PinStatus::Unpinned, "\"unpinned\""),
+        ];
+        for (variant, expected) in pairs {
+            let json = serde_json::to_string(&variant).unwrap();
+            assert_eq!(json, expected);
+            let back: PinStatus = serde_json::from_str(&json).unwrap();
+            assert_eq!(variant, back);
+        }
+    }
+
+    #[test]
+    fn test_pin_status_from_str_lossy() {
+        assert_eq!(PinStatus::from_str_lossy("pinned"), PinStatus::Pinned);
+        assert_eq!(PinStatus::from_str_lossy("PINNED"), PinStatus::Pinned);
+        assert_eq!(PinStatus::from_str_lossy("unpinned"), PinStatus::Unpinned);
+        assert_eq!(PinStatus::from_str_lossy(""), PinStatus::Unpinned);
+        assert_eq!(PinStatus::from_str_lossy("bogus"), PinStatus::Unpinned);
+    }
+
+    #[test]
+    fn test_memory_claim_v1_pin_status_absent_by_default() {
+        // Minimal v1 blob MUST omit pin_status when None.
+        let c = minimal_v1_claim();
+        assert!(c.pin_status.is_none());
+        let json = serde_json::to_string(&c).unwrap();
+        assert!(
+            !json.contains("pin_status"),
+            "pin_status should be omitted when None: {}",
+            json
+        );
+    }
+
+    #[test]
+    fn test_memory_claim_v1_pinned_round_trip() {
+        // A pinned v1 blob round-trips cleanly and keeps the field.
+        let mut c = minimal_v1_claim();
+        c.pin_status = Some(PinStatus::Pinned);
+        let json = serde_json::to_string(&c).unwrap();
+        assert!(json.contains("\"pin_status\":\"pinned\""));
+        let back: MemoryClaimV1 = serde_json::from_str(&json).unwrap();
+        assert_eq!(c, back);
+    }
+
+    #[test]
+    fn test_memory_claim_v1_unpinned_round_trip_explicit() {
+        // Explicit "unpinned" is preserved verbatim on round-trip (NOT dropped).
+        let mut c = minimal_v1_claim();
+        c.pin_status = Some(PinStatus::Unpinned);
+        let json = serde_json::to_string(&c).unwrap();
+        assert!(json.contains("\"pin_status\":\"unpinned\""));
+        let back: MemoryClaimV1 = serde_json::from_str(&json).unwrap();
+        assert_eq!(c, back);
+        assert_eq!(back.pin_status, Some(PinStatus::Unpinned));
+    }
+
+    #[test]
+    fn test_memory_claim_v1_deserialize_without_pin_status_field() {
+        // A v1 blob that predates v1.1 has no pin_status field. Deserialize
+        // must tolerate it and default to None.
+        let json = r#"{
+            "id":"01900000-0000-7000-8000-000000000000",
+            "text":"hi",
+            "type":"claim",
+            "source":"user",
+            "created_at":"2026-04-17T10:00:00Z"
+        }"#;
+        let c: MemoryClaimV1 = serde_json::from_str(json).unwrap();
+        assert!(c.pin_status.is_none());
+    }
+
+    #[test]
+    fn test_is_pinned_memory_claim_v1_true_when_pinned() {
+        let mut c = minimal_v1_claim();
+        c.pin_status = Some(PinStatus::Pinned);
+        assert!(is_pinned_memory_claim_v1(&c));
+    }
+
+    #[test]
+    fn test_is_pinned_memory_claim_v1_false_when_unpinned_or_absent() {
+        let c = minimal_v1_claim();
+        assert!(!is_pinned_memory_claim_v1(&c));
+        let mut c2 = minimal_v1_claim();
+        c2.pin_status = Some(PinStatus::Unpinned);
+        assert!(!is_pinned_memory_claim_v1(&c2));
+    }
+
+    // === is_pinned_json — unified v0 + v1.1 ===
+
+    #[test]
+    fn test_is_pinned_json_v1_pinned() {
+        let mut c = minimal_v1_claim();
+        c.pin_status = Some(PinStatus::Pinned);
+        let json = serde_json::to_string(&c).unwrap();
+        assert!(is_pinned_json(&json), "v1 pinned blob must be detected");
+    }
+
+    #[test]
+    fn test_is_pinned_json_v1_unpinned() {
+        let mut c = minimal_v1_claim();
+        c.pin_status = Some(PinStatus::Unpinned);
+        let json = serde_json::to_string(&c).unwrap();
+        assert!(!is_pinned_json(&json), "v1 unpinned blob must NOT be detected as pinned");
+    }
+
+    #[test]
+    fn test_is_pinned_json_v1_no_pin_status_field() {
+        // Pre-v1.1 v1 blob without pin_status — not pinned.
+        let json = r#"{
+            "id":"01900000-0000-7000-8000-000000000000",
+            "text":"hi",
+            "type":"claim",
+            "source":"user",
+            "created_at":"2026-04-17T10:00:00Z"
+        }"#;
+        assert!(!is_pinned_json(json));
+    }
+
+    #[test]
+    fn test_is_pinned_json_v0_pinned_backcompat() {
+        // Legacy v0 short-key blob with st=p — MUST still be detected.
+        let mut c = minimal_claim();
+        c.status = ClaimStatus::Pinned;
+        let json = serde_json::to_string(&c).unwrap();
+        assert!(is_pinned_json(&json), "v0 st=p must still trigger is_pinned_json");
+    }
+
+    #[test]
+    fn test_is_pinned_json_v0_active_backcompat() {
+        let c = minimal_claim();
+        let json = serde_json::to_string(&c).unwrap();
+        assert!(!is_pinned_json(&json));
+    }
+
+    #[test]
+    fn test_is_pinned_json_invalid_input_returns_false() {
+        assert!(!is_pinned_json(""));
+        assert!(!is_pinned_json("not json"));
+        assert!(!is_pinned_json("{}"));
+        assert!(!is_pinned_json("[1,2,3]"));
+    }
+
+    #[test]
+    fn test_is_pinned_json_v1_dispatch_does_not_fall_through_to_v0() {
+        // A v1 blob that parses successfully but isn't pinned MUST NOT be
+        // re-parsed via the v0 path (different semantics — `st` field is
+        // absent on v1 blobs but a stray `st` key on an otherwise-v1 JSON
+        // blob could be interpreted as the v0 sentinel if we fell through).
+        //
+        // Craft a v1 blob with a literal `st: "p"` field. The v1 parser
+        // ignores unknown fields — wait, serde's default is to reject unknown
+        // fields NO — the default is to IGNORE unknown fields unless
+        // deny_unknown_fields is set. MemoryClaimV1 doesn't deny, so it will
+        // accept the v1 blob with st=p and, per the dispatch rule, return
+        // the v1 answer (not pinned) without falling through.
+        let json = r#"{
+            "id":"01900000-0000-7000-8000-000000000000",
+            "text":"hi",
+            "type":"claim",
+            "source":"user",
+            "created_at":"2026-04-17T10:00:00Z",
+            "st":"p"
+        }"#;
+        assert!(
+            !is_pinned_json(json),
+            "v1-shaped blob with stray v0 sentinel must NOT be treated as pinned"
+        );
+    }
+
+    #[test]
+    fn test_respect_pin_in_resolution_v1_pinned_blob() {
+        // Use respect_pin_in_resolution with a v1 pinned blob — the existing
+        // claim should be detected as pinned through the unified is_pinned_json.
+        let mut c = minimal_v1_claim();
+        c.pin_status = Some(PinStatus::Pinned);
+        let json = serde_json::to_string(&c).unwrap();
+        let action = respect_pin_in_resolution(
+            &json,
+            "new_id",
+            "existing_id",
+            "new_id",
+            0.5,
+            0.7,
+            TIE_ZONE_SCORE_TOLERANCE,
+        );
+        assert_eq!(
+            action,
+            ResolutionAction::SkipNew {
+                reason: SkipReason::ExistingPinned,
+                existing_id: "existing_id".to_string(),
+                new_id: "new_id".to_string(),
+                entity_id: None,
+                similarity: None,
+                winner_score: None,
+                loser_score: None,
+                winner_components: None,
+                loser_components: None,
+            },
+            "v1 pinned blob must trigger SkipNew::ExistingPinned"
+        );
     }
 }

--- a/rust/totalreclaw-core/src/python.rs
+++ b/rust/totalreclaw-core/src/python.rs
@@ -466,6 +466,27 @@ fn py_parse_memory_source(s: &str) -> String {
         .to_string()
 }
 
+/// Case-insensitive parse of a v1.1 pin_status string. Unknown input returns "unpinned".
+#[pyfunction]
+#[pyo3(name = "parse_pin_status")]
+fn py_parse_pin_status(s: &str) -> String {
+    let st = crate::claims::PinStatus::from_str_lossy(s);
+    serde_json::to_string(&st)
+        .unwrap_or_else(|_| "\"unpinned\"".to_string())
+        .trim_matches('"')
+        .to_string()
+}
+
+/// Check whether a JSON-encoded claim is pinned.
+///
+/// Recognises both the v0 short-key sentinel (``st == "p"``) and the v1.1
+/// field (``pin_status == "pinned"``). Returns ``False`` on any parse failure.
+#[pyfunction]
+#[pyo3(name = "is_pinned_claim_json")]
+fn py_is_pinned_claim_json(claim_json: &str) -> bool {
+    crate::claims::is_pinned_json(claim_json)
+}
+
 /// Cosine similarity between two f32 vectors.
 ///
 /// Args:
@@ -1502,6 +1523,8 @@ fn totalreclaw_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_validate_memory_claim_v1, m)?)?;
     m.add_function(wrap_pyfunction!(py_parse_memory_type_v1, m)?)?;
     m.add_function(wrap_pyfunction!(py_parse_memory_source, m)?)?;
+    m.add_function(wrap_pyfunction!(py_parse_pin_status, m)?)?;
+    m.add_function(wrap_pyfunction!(py_is_pinned_claim_json, m)?)?;
     m.add_function(wrap_pyfunction!(py_cosine_similarity, m)?)?;
 
     // Wallet derivation

--- a/rust/totalreclaw-core/src/wasm.rs
+++ b/rust/totalreclaw-core/src/wasm.rs
@@ -439,6 +439,26 @@ pub fn wasm_parse_memory_source(s: &str) -> String {
         .to_string()
 }
 
+/// Case-insensitive parse of a v1.1 pin_status string. Unknown input returns "unpinned".
+#[wasm_bindgen(js_name = "parsePinStatus")]
+pub fn wasm_parse_pin_status(s: &str) -> String {
+    let st = crate::claims::PinStatus::from_str_lossy(s);
+    serde_json::to_string(&st)
+        .unwrap_or_else(|_| "\"unpinned\"".to_string())
+        .trim_matches('"')
+        .to_string()
+}
+
+/// Check whether a JSON-encoded claim is pinned, recognizing both the v0
+/// short-key sentinel (`st == "p"`) and the v1.1 field (`pin_status ==
+/// "pinned"`). Returns `false` on any parse failure.
+///
+/// Wrapper around [`crate::claims::is_pinned_json`] for TS clients.
+#[wasm_bindgen(js_name = "isPinnedClaimJson")]
+pub fn wasm_is_pinned_claim_json(claim_json: &str) -> bool {
+    crate::claims::is_pinned_json(claim_json)
+}
+
 /// Cosine similarity between two f32 vectors.
 #[wasm_bindgen(js_name = "cosineSimilarity")]
 pub fn wasm_cosine_similarity(a: &[f32], b: &[f32]) -> f64 {

--- a/rust/totalreclaw-memory/Cargo.lock
+++ b/rust/totalreclaw-memory/Cargo.lock
@@ -3199,7 +3199,7 @@ dependencies = [
 
 [[package]]
 name = "totalreclaw-core"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/rust/totalreclaw-memory/src/store.rs
+++ b/rust/totalreclaw-memory/src/store.rs
@@ -316,6 +316,9 @@ pub fn build_memory_claim_v1(input: &V1StoreInput) -> MemoryClaimV1 {
         importance: Some(input.importance),
         confidence: None,
         superseded_by: None,
+        // v1.1 additive field: pin_status is user-controlled via totalreclaw_pin.
+        // Extraction-path claims start unpinned (field absent).
+        pin_status: None,
     }
 }
 

--- a/skill/plugin/claims-helper.ts
+++ b/skill/plugin/claims-helper.ts
@@ -142,6 +142,16 @@ export function buildCanonicalClaim(input: BuildClaimInput): string {
 
 export const V1_SCHEMA_VERSION = '1.0' as const;
 
+/**
+ * v1.1 pin state — `"pinned"` = user explicitly pinned (immune to
+ * auto-supersede); `"unpinned"` (or absence) = standard behavior.
+ *
+ * Surface of the `pin_status` field added in spec v1.1 (2026-04-19). Writers
+ * that understand v1.1 emit this field on the pin path; readers at 1.0 / 1.1
+ * that see it MUST honor `"pinned"` as immunity from auto-supersede.
+ */
+export type PinStatus = 'pinned' | 'unpinned';
+
 export interface BuildClaimV1Input {
   /** The extracted fact in v1 shape. Must have `type` as a MemoryTypeV1 token. */
   fact: ExtractedFact;
@@ -156,6 +166,13 @@ export interface BuildClaimV1Input {
   /** Stable claim ID. Defaults to crypto.randomUUID() at the call site; keep the
    *  same ID for both the blob and the on-chain fact id. */
   id?: string;
+  /**
+   * v1.1 pin state. When `"pinned"`, the claim is immune to auto-supersede.
+   * Omitted or `"unpinned"` both mean unpinned (field is additive — absence
+   * equivalent to `"unpinned"` on the wire). Surfaced in the final JSON only
+   * when provided.
+   */
+  pinStatus?: PinStatus;
 }
 
 /**
@@ -226,6 +243,10 @@ export function buildCanonicalClaimV1(input: BuildClaimV1Input): string {
   }
   if (expiresAt) corePayload.expires_at = expiresAt;
   if (supersededBy) corePayload.superseded_by = supersededBy;
+  // v1.1 pin_status — additive field; only emitted when the caller opts in.
+  if (input.pinStatus === 'pinned' || input.pinStatus === 'unpinned') {
+    corePayload.pin_status = input.pinStatus;
+  }
 
   // Validate through core — throws on invalid type / source / missing id.
   const validated = getWasm().validateMemoryClaimV1(JSON.stringify(corePayload)) as string;
@@ -237,6 +258,122 @@ export function buildCanonicalClaimV1(input: BuildClaimV1Input): string {
     canonical.volatility = fact.volatility;
   }
 
+  return JSON.stringify(canonical);
+}
+
+// ---------------------------------------------------------------------------
+// buildV1ClaimBlob — lightweight v1 blob builder for pin / retype / set_scope
+//
+// Unlike buildCanonicalClaimV1 (which consumes a full ExtractedFact), this
+// helper takes raw primitives and is the right entry point when synthesizing
+// a new blob from a previously-decrypted one — e.g. the pin path rewrites the
+// blob with an updated pin_status field and everything else preserved.
+//
+// The output is a v1.1 JSON payload with schema_version "1.0" (v1.1 is
+// additive; on-wire schema_version is unchanged per spec). The outer protobuf
+// wrapper MUST be written at version 4 — see `subgraph-store.ts`.
+// ---------------------------------------------------------------------------
+
+export interface BuildV1ClaimBlobInput {
+  /** Human-readable fact text (5-512 UTF-8 chars). */
+  text: string;
+  /** v1 memory type. Must be one of the 6 canonical values. */
+  type: MemoryType;
+  /** Provenance per spec §provenance-filter. */
+  source: MemorySource;
+  /** Optional stable UUID; defaults to randomUUID(). */
+  id?: string;
+  /** Optional creation timestamp (ISO 8601 UTC); defaults to now. */
+  createdAt?: string;
+  /** Optional scope (defaults to omitted → "unspecified"). */
+  scope?: MemoryScope;
+  /** Optional volatility (defaults to omitted → "updatable"). */
+  volatility?: MemoryVolatility;
+  /** Optional reasoning clause for decision-style claims. */
+  reasoning?: string;
+  /** Optional structured entities. */
+  entities?: ExtractedEntity[];
+  /** Optional expiration timestamp. */
+  expiresAt?: string;
+  /** Optional importance (1-10, advisory). */
+  importance?: number;
+  /** Optional confidence (0-1). */
+  confidence?: number;
+  /** Optional superseded-by chain pointer. */
+  supersededBy?: string;
+  /**
+   * Optional v1.1 pin state.
+   *
+   * - `"pinned"` → user explicitly pinned; the claim MUST NOT be auto-superseded.
+   * - `"unpinned"` → explicit unpin (resets a previous pin).
+   * - Undefined/omitted → field not emitted; receivers treat as unpinned.
+   *
+   * Callers are free to pass `"unpinned"` to create an explicit un-pin
+   * supersede event, or to pass `undefined` to leave the field absent on a
+   * non-pin write.
+   */
+  pinStatus?: PinStatus;
+}
+
+/**
+ * Build a v1.1 canonical claim JSON string, validated through the core
+ * `validateMemoryClaimV1` WASM export.
+ *
+ * Output is UTF-8 JSON ready for encryption as the inner blob of a
+ * protobuf-v4 fact (outer `version = 4`). Field ordering follows the core
+ * validator, so the result is byte-identical to what MCP's equivalent helper
+ * produces for the same inputs (cross-client parity).
+ *
+ * Throws on malformed input (missing required field, invalid enum value).
+ */
+export function buildV1ClaimBlob(input: BuildV1ClaimBlobInput): string {
+  if (!(VALID_MEMORY_SOURCES as readonly string[]).includes(input.source)) {
+    throw new Error(`buildV1ClaimBlob: invalid source "${input.source}"`);
+  }
+  if (!isValidMemoryType(input.type)) {
+    throw new Error(`buildV1ClaimBlob: invalid type "${input.type}"`);
+  }
+
+  const corePayload: Record<string, unknown> = {
+    id: input.id ?? crypto.randomUUID(),
+    text: input.text,
+    type: input.type,
+    source: input.source,
+    created_at: input.createdAt ?? new Date().toISOString(),
+  };
+
+  if (input.scope && (VALID_MEMORY_SCOPES as readonly string[]).includes(input.scope)) {
+    corePayload.scope = input.scope;
+  }
+  if (input.reasoning && input.reasoning.length > 0) {
+    corePayload.reasoning = input.reasoning.slice(0, 256);
+  }
+  if (input.entities && input.entities.length > 0) {
+    corePayload.entities = input.entities.slice(0, 8).map((e) => {
+      const entity: Record<string, unknown> = { name: e.name, type: e.type };
+      if (e.role) entity.role = e.role;
+      return entity;
+    });
+  }
+  if (typeof input.importance === 'number') {
+    corePayload.importance = Math.max(1, Math.min(10, Math.round(input.importance)));
+  }
+  if (typeof input.confidence === 'number') {
+    corePayload.confidence = Math.max(0, Math.min(1, input.confidence));
+  }
+  if (input.expiresAt) corePayload.expires_at = input.expiresAt;
+  if (input.supersededBy) corePayload.superseded_by = input.supersededBy;
+  if (input.pinStatus === 'pinned' || input.pinStatus === 'unpinned') {
+    corePayload.pin_status = input.pinStatus;
+  }
+
+  // Validate via core — throws on invalid shape.
+  const validated = getWasm().validateMemoryClaimV1(JSON.stringify(corePayload)) as string;
+  const canonical = JSON.parse(validated) as Record<string, unknown>;
+  canonical.schema_version = V1_SCHEMA_VERSION;
+  if (input.volatility && (VALID_MEMORY_VOLATILITIES as readonly string[]).includes(input.volatility)) {
+    canonical.volatility = input.volatility;
+  }
   return JSON.stringify(canonical);
 }
 
@@ -289,6 +426,11 @@ export interface V1BlobReadResult {
   expiresAt?: string;
   supersededBy?: string;
   id?: string;
+  /**
+   * v1.1 pin state. Absent when the blob was written by a v1.0 client or
+   * when the writer explicitly omitted the field (treated as `"unpinned"`).
+   */
+  pinStatus?: PinStatus;
 }
 
 export function readV1Blob(decrypted: string): V1BlobReadResult | null {
@@ -349,6 +491,12 @@ export function readV1Blob(decrypted: string): V1BlobReadResult | null {
     if (typeof obj.expires_at === 'string') result.expiresAt = obj.expires_at;
     if (typeof obj.superseded_by === 'string') result.supersededBy = obj.superseded_by;
     if (typeof obj.id === 'string') result.id = obj.id;
+    if (typeof obj.pin_status === 'string') {
+      const ps = obj.pin_status;
+      if (ps === 'pinned' || ps === 'unpinned') {
+        result.pinStatus = ps;
+      }
+    }
 
     return result;
   } catch {
@@ -484,6 +632,9 @@ export function readClaimFromBlob(decryptedJson: string): BlobReadResult {
           scope: typeof obj.scope === 'string' ? obj.scope : 'unspecified',
           volatility: typeof obj.volatility === 'string' ? obj.volatility : 'updatable',
           reasoning: typeof obj.reasoning === 'string' ? obj.reasoning : undefined,
+          // v1.1: surface pin_status verbatim for downstream (recall display +
+          // export). Absent ⇒ undefined (receivers treat as "unpinned").
+          pin_status: typeof obj.pin_status === 'string' ? obj.pin_status : undefined,
           importance: importance / 10,
           created_at: typeof obj.created_at === 'string' ? obj.created_at : '',
           schema_version: obj.schema_version,

--- a/skill/plugin/pin-unpin.test.ts
+++ b/skill/plugin/pin-unpin.test.ts
@@ -317,11 +317,16 @@ async function runTests(): Promise<void> {
     assert(typeof result.new_fact_id === 'string', 'unpin pinned: new_fact_id set');
     assertEq(state.submittedBatches.length, 1, 'unpin pinned: one batch submitted');
 
-    // The new canonical blob must NOT contain "st":"a" or any st field.
+    // v1.1 unpin: the new canonical blob is a v1 payload with
+    // pin_status=unpinned and superseded_by pointing to the old fact id.
     assert(capturedEncryptedHex !== null, 'unpin pinned: encrypted blob captured');
     const canonicalPlaintext = Buffer.from(capturedEncryptedHex!, 'hex').toString('utf8');
-    assert(!canonicalPlaintext.includes('"st":'), 'unpin pinned: st field omitted from canonical JSON');
-    assert(canonicalPlaintext.includes('"sup":"pinned-2"'), 'unpin pinned: sup field points to old id');
+    assert(canonicalPlaintext.includes('"schema_version":"1.0"'), 'unpin pinned: blob is v1 (schema_version 1.0)');
+    assert(canonicalPlaintext.includes('"pin_status":"unpinned"'), 'unpin pinned: v1 pin_status=unpinned');
+    assert(canonicalPlaintext.includes('"superseded_by":"pinned-2"'), 'unpin pinned: v1 superseded_by points to old id');
+    // v0 short-key fields MUST NOT leak into a v1 blob.
+    assert(!canonicalPlaintext.includes('"st":'), 'unpin pinned: no v0 st field on v1 blob');
+    assert(!canonicalPlaintext.includes('"sup":"'), 'unpin pinned: no v0 sup field on v1 blob');
   }
 
   // Unpin a non-pinned claim → idempotent no-op
@@ -362,9 +367,13 @@ async function runTests(): Promise<void> {
     assertEq(result.previous_status, 'active', 'pin legacy: previous_status active (legacy default)');
     assertEq(result.new_status, 'pinned', 'pin legacy: new_status pinned');
     assert(capturedNewBlob !== null, 'pin legacy: new blob captured');
-    assert(capturedNewBlob!.includes('"t":"Pedro lives in Lisbon"'), 'pin legacy: text lifted into canonical t');
-    assert(capturedNewBlob!.includes('"st":"p"'), 'pin legacy: status flipped to pinned');
-    assert(capturedNewBlob!.includes('"sup":"legacy-1"'), 'pin legacy: sup points to old id');
+    // v1.1: legacy blob is UPGRADED to a v1 payload on the pin path.
+    assert(capturedNewBlob!.includes('"text":"Pedro lives in Lisbon"'), 'pin legacy: text lifted into v1 text field');
+    assert(capturedNewBlob!.includes('"schema_version":"1.0"'), 'pin legacy: output is v1 (schema_version 1.0)');
+    assert(capturedNewBlob!.includes('"pin_status":"pinned"'), 'pin legacy: v1 pin_status=pinned');
+    assert(capturedNewBlob!.includes('"superseded_by":"legacy-1"'), 'pin legacy: v1 superseded_by points to old id');
+    // legacy v0 type "fact" upgrades to v1 type "claim" per the spec map.
+    assert(capturedNewBlob!.includes('"type":"claim"'), 'pin legacy: v0 fact → v1 claim type');
   }
 
   // Fact not found → error
@@ -553,11 +562,13 @@ async function runTests(): Promise<void> {
     const result = await executePinOperation('sup-link-1', 'pinned', deps);
     assertEq(result.success, true, 'sup-link: success');
     assert(capturedPlaintext !== null, 'sup-link: plaintext captured');
-    assert(capturedPlaintext!.includes('"sup":"sup-link-1"'), 'sup-link: sup field set to old id');
-    assert(capturedPlaintext!.includes('"st":"p"'), 'sup-link: st set to p');
-    // ea must be refreshed (non-empty)
-    const match = capturedPlaintext!.match(/"ea":"([^"]+)"/);
-    assert(match !== null && match![1] !== '2026-04-12T10:00:00.000Z', 'sup-link: ea refreshed to a new timestamp');
+    // v1.1: `sup` → `superseded_by`, `st` → `pin_status`, `ea` → `created_at`.
+    assert(capturedPlaintext!.includes('"superseded_by":"sup-link-1"'), 'sup-link: v1 superseded_by set to old id');
+    assert(capturedPlaintext!.includes('"pin_status":"pinned"'), 'sup-link: v1 pin_status=pinned');
+    assert(capturedPlaintext!.includes('"schema_version":"1.0"'), 'sup-link: output is v1');
+    // created_at must be refreshed (non-empty, different from source ea)
+    const match = capturedPlaintext!.match(/"created_at":"([^"]+)"/);
+    assert(match !== null && match![1] !== '2026-04-12T10:00:00.000Z', 'sup-link: created_at refreshed to a new timestamp');
   }
 
   // ── Slice 2f: pin → feedback.jsonl wiring ────────────────────────────────
@@ -976,6 +987,145 @@ async function runTests(): Promise<void> {
       typeof result.error === 'string' && !result.error!.includes('decisions.jsonl'),
       'pin-tombstone-real-corruption: error does NOT mention recovery (path not taken)',
     );
+  }
+
+  // ── v1.1 pin_status end-to-end ────────────────────────────────────────────
+
+  // A pin on a v1.1 source blob preserves all v1 fields + flips pin_status=pinned.
+  {
+    const state: MockState = { facts: new Map(), submittedBatches: [] };
+    const v1Claim = JSON.stringify({
+      id: '01900000-0000-7000-8000-000000000099',
+      text: 'prefers PostgreSQL over MongoDB for transactional workloads',
+      type: 'preference',
+      source: 'user',
+      created_at: '2026-04-19T10:00:00.000Z',
+      schema_version: '1.0',
+      scope: 'work',
+      volatility: 'stable',
+      reasoning: 'ACID guarantees matter for OrbitLedger',
+      importance: 9,
+      confidence: 0.95,
+    });
+    seedFact(state, 'v1-source-1', v1Claim);
+
+    let capturedBlob: string | null = null;
+    const deps = makeDeps(state, {
+      encryptBlob: (plaintext: string) => {
+        capturedBlob = plaintext;
+        return Buffer.from(plaintext, 'utf8').toString('hex');
+      },
+    });
+    const result = await executePinOperation('v1-source-1', 'pinned', deps);
+
+    assertEq(result.success, true, 'v1-pin: success');
+    assert(capturedBlob !== null, 'v1-pin: plaintext captured');
+    assert(capturedBlob!.includes('"schema_version":"1.0"'), 'v1-pin: output schema_version 1.0');
+    assert(capturedBlob!.includes('"pin_status":"pinned"'), 'v1-pin: pin_status=pinned');
+    assert(capturedBlob!.includes('"type":"preference"'), 'v1-pin: preserves v1 type');
+    assert(capturedBlob!.includes('"source":"user"'), 'v1-pin: preserves v1 source');
+    assert(capturedBlob!.includes('"scope":"work"'), 'v1-pin: preserves scope');
+    assert(capturedBlob!.includes('"volatility":"stable"'), 'v1-pin: preserves volatility');
+    assert(capturedBlob!.includes('"reasoning":"ACID guarantees'), 'v1-pin: preserves reasoning');
+    assert(capturedBlob!.includes('"importance":9'), 'v1-pin: preserves importance');
+    assert(capturedBlob!.includes('"superseded_by":"v1-source-1"'), 'v1-pin: superseded_by points to source fact');
+  }
+
+  // An unpin on a v1.1 pinned blob flips pin_status=unpinned and preserves fields.
+  {
+    const state: MockState = { facts: new Map(), submittedBatches: [] };
+    const v1PinnedClaim = JSON.stringify({
+      id: '01900000-0000-7000-8000-0000000000a0',
+      text: 'always use snake_case for database column names',
+      type: 'directive',
+      source: 'user',
+      created_at: '2026-04-19T10:00:00.000Z',
+      schema_version: '1.0',
+      scope: 'work',
+      pin_status: 'pinned',
+    });
+    seedFact(state, 'v1-pinned-1', v1PinnedClaim);
+
+    let capturedBlob: string | null = null;
+    const deps = makeDeps(state, {
+      encryptBlob: (plaintext: string) => {
+        capturedBlob = plaintext;
+        return Buffer.from(plaintext, 'utf8').toString('hex');
+      },
+    });
+    const result = await executePinOperation('v1-pinned-1', 'active', deps);
+
+    assertEq(result.success, true, 'v1-unpin: success');
+    assertEq(result.previous_status, 'pinned', 'v1-unpin: previous_status=pinned detected via pin_status');
+    assertEq(result.new_status, 'active', 'v1-unpin: new_status=active');
+    assert(capturedBlob !== null, 'v1-unpin: plaintext captured');
+    assert(capturedBlob!.includes('"pin_status":"unpinned"'), 'v1-unpin: pin_status=unpinned');
+    assert(capturedBlob!.includes('"type":"directive"'), 'v1-unpin: preserves directive type');
+    assert(capturedBlob!.includes('"superseded_by":"v1-pinned-1"'), 'v1-unpin: supersedes pinned fact');
+  }
+
+  // Idempotent pin: a v1.1 blob already pinned via pin_status is a no-op.
+  {
+    const state: MockState = { facts: new Map(), submittedBatches: [] };
+    const v1PinnedClaim = JSON.stringify({
+      id: '01900000-0000-7000-8000-0000000000a1',
+      text: 'already pinned',
+      type: 'claim',
+      source: 'user',
+      created_at: '2026-04-19T10:00:00.000Z',
+      schema_version: '1.0',
+      pin_status: 'pinned',
+    });
+    seedFact(state, 'v1-already-pinned', v1PinnedClaim);
+
+    const deps = makeDeps(state);
+    const result = await executePinOperation('v1-already-pinned', 'pinned', deps);
+
+    assertEq(result.success, true, 'v1-idempotent: success');
+    assertEq(result.idempotent, true, 'v1-idempotent: idempotent flag set');
+    assertEq(state.submittedBatches.length, 0, 'v1-idempotent: zero on-chain writes');
+  }
+
+  // Cross-impl parity: plugin output v1 JSON has the SAME canonical field
+  // ordering as core's validateMemoryClaimV1 produces. This is what makes the
+  // cross-client pin-in-plugin / unpin-in-mcp round-trip byte-stable.
+  {
+    const state: MockState = { facts: new Map(), submittedBatches: [] };
+    const v1Source = JSON.stringify({
+      id: '01900000-0000-7000-8000-0000000000b0',
+      text: 'cross-client parity test',
+      type: 'claim',
+      source: 'user',
+      created_at: '2026-04-19T10:00:00.000Z',
+      schema_version: '1.0',
+    });
+    seedFact(state, 'parity-src', v1Source);
+
+    let capturedBlob: string | null = null;
+    const deps = makeDeps(state, {
+      encryptBlob: (plaintext: string) => {
+        capturedBlob = plaintext;
+        return Buffer.from(plaintext, 'utf8').toString('hex');
+      },
+    });
+    const result = await executePinOperation('parity-src', 'pinned', deps);
+    assertEq(result.success, true, 'parity: success');
+    assert(capturedBlob !== null, 'parity: plaintext captured');
+    const parsed = JSON.parse(capturedBlob!);
+    // Required fields present.
+    assert(typeof parsed.id === 'string', 'parity: id present');
+    assert(typeof parsed.text === 'string', 'parity: text present');
+    assert(typeof parsed.type === 'string', 'parity: type present');
+    assert(typeof parsed.source === 'string', 'parity: source present');
+    assert(typeof parsed.created_at === 'string', 'parity: created_at present');
+    assertEq(parsed.schema_version, '1.0', 'parity: schema_version=1.0');
+    assertEq(parsed.pin_status, 'pinned', 'parity: pin_status=pinned');
+    assertEq(parsed.superseded_by, 'parity-src', 'parity: superseded_by points to src');
+    // Ensure no v0 leak.
+    assert(!Object.prototype.hasOwnProperty.call(parsed, 't'), 'parity: no v0 t field');
+    assert(!Object.prototype.hasOwnProperty.call(parsed, 'c'), 'parity: no v0 c field');
+    assert(!Object.prototype.hasOwnProperty.call(parsed, 'st'), 'parity: no v0 st field');
+    assert(!Object.prototype.hasOwnProperty.call(parsed, 'sup'), 'parity: no v0 sup field');
   }
 
   // Cleanup: remove the temp state dir.

--- a/skill/plugin/pin.ts
+++ b/skill/plugin/pin.ts
@@ -1,14 +1,30 @@
-/** Pin/unpin pure operation for OpenClaw plugin — Slice 2e-plugin, Phase 2. */
+/** Pin/unpin pure operation for OpenClaw plugin — v1.1 taxonomy.
+ *
+ * As of core 2.1.1 / plugin pin path v1.1 (2026-04-19) the pin/unpin operation
+ * emits a canonical v1.1 MemoryClaimV1 JSON blob (schema_version "1.0",
+ * `pin_status` additive field) wrapped in the outer protobuf at `version = 4`.
+ * The prior behavior — emitting v0 short-key blobs at `version = 3` on the
+ * pin path — broke the v1 on-chain contract (RC QA bug #2). v0 blobs continue
+ * to be READ correctly (via parseBlobForPin's fall-through), so mixed-version
+ * vaults remain uniform from the user's point of view.
+ */
 
 import crypto from 'node:crypto';
 import { createRequire } from 'node:module';
-import { mapTypeToCategory } from './claims-helper.js';
+import {
+  buildV1ClaimBlob,
+  mapTypeToCategory,
+  readV1Blob,
+  type PinStatus,
+} from './claims-helper.js';
 import {
   findLoserClaimInDecisionLog,
   maybeWriteFeedbackForPin,
   type ContradictionLogger,
 } from './contradiction-sync.js';
-import { isValidMemoryType } from './extractor.js';
+import { isValidMemoryType, V0_TO_V1_TYPE } from './extractor.js';
+import type { MemoryType, MemorySource, MemoryScope, MemoryVolatility } from './extractor.js';
+import { PROTOBUF_VERSION_V4 } from './subgraph-store.js';
 import type { SubgraphSearchFact } from './subgraph-search.js';
 
 // Lazy-load WASM core (mirrors claims-helper.ts pattern — plays nicely under
@@ -34,8 +50,15 @@ export interface FactPayload {
   encryptedEmbedding?: string;
 }
 
-/** Encode a FactPayload as the minimal Protobuf wire format via WASM core. */
-function encodeFactProtobufLocal(fact: FactPayload): Buffer {
+/**
+ * Encode a FactPayload as the minimal Protobuf wire format via WASM core.
+ *
+ * The `version` field is threaded through so callers can opt into
+ * `PROTOBUF_VERSION_V4` (Memory Taxonomy v1) for the new-fact write and leave
+ * tombstone rows at the default (legacy v3). When omitted, defaults to v1
+ * (`PROTOBUF_VERSION_V4`) — pin/unpin is a v1 write path.
+ */
+function encodeFactProtobufLocal(fact: FactPayload, version: number = PROTOBUF_VERSION_V4): Buffer {
   const json = JSON.stringify({
     id: fact.id,
     timestamp: fact.timestamp,
@@ -47,6 +70,7 @@ function encodeFactProtobufLocal(fact: FactPayload): Buffer {
     content_fp: fact.contentFp,
     agent_id: fact.agentId,
     encrypted_embedding: fact.encryptedEmbedding || null,
+    version,
   });
   return Buffer.from(getWasm().encodeFactProtobuf(json));
 }
@@ -73,11 +97,49 @@ const HUMAN_TO_SHORT: Record<HumanStatus, string> = {
 
 // ─── Blob parsing ─────────────────────────────────────────────────────────────
 
+/** Shape of a v1 blob normalized for downstream pin-path rewrite. */
+export interface V1PinBlob {
+  kind: 'v1';
+  text: string;
+  type: MemoryType;
+  source: MemorySource;
+  scope?: MemoryScope;
+  volatility?: MemoryVolatility;
+  reasoning?: string;
+  entities?: Array<{ name: string; type: string; role?: string }>;
+  importance: number;
+  confidence: number;
+  createdAt: string;
+  expiresAt?: string;
+  id?: string;
+  /** Previously-stored pin_status on the blob (v1.1). */
+  pinStatus?: PinStatus;
+}
+
+/** Shape of a v0 (short-key) blob or a legacy {text, metadata} blob. */
+export interface V0PinBlob {
+  kind: 'v0';
+  /** The short-key claim object (with t, c, cf, i, sa, ea, ...). */
+  claim: Record<string, unknown>;
+}
+
 /** Result of parsing a decrypted blob for pin/unpin mutation. */
 export interface ParsedBlob {
-  claim: Record<string, unknown>;
+  /**
+   * Either a v1 normalized view or a v0 short-key claim object. Pin path
+   * always emits v1.1 on output regardless of source — see
+   * `executePinOperation`.
+   */
+  source: V1PinBlob | V0PinBlob;
   currentStatus: HumanStatus;
   isLegacy: boolean;
+  /**
+   * Legacy field — kept for existing test/downstream code that dereferences
+   * `parsed.claim`. For v1 blobs this is a short-key projection (same as
+   * pre-v1.1 behavior); for v0 blobs it's the untouched short-key claim.
+   * Do NOT mutate when you intend to write — use the `source` view instead.
+   */
+  claim: Record<string, unknown>;
 }
 
 /** Parse a decrypted blob into a canonical mutable Claim + current human status. */
@@ -86,26 +148,51 @@ export function parseBlobForPin(decrypted: string): ParsedBlob {
   try {
     obj = JSON.parse(decrypted) as Record<string, unknown>;
   } catch {
+    const shortClaim = buildCanonicalObjectFromLegacy(decrypted, {});
     return {
-      claim: buildCanonicalObjectFromLegacy(decrypted, {}),
+      source: { kind: 'v0', claim: shortClaim },
+      claim: shortClaim,
       currentStatus: 'active',
       isLegacy: true,
     };
   }
 
   // v1 payload (plugin v3.0.0+): long-form fields + schema_version "1.x".
-  // Convert to the short-key shape pin.ts operates on so the rest of the
-  // pipeline (st, sup, trapdoor regeneration) keeps working unchanged.
+  // Preserve the v1 structure so the pin path can emit v1 on output.
   if (
     typeof obj.text === 'string' &&
     typeof obj.type === 'string' &&
     typeof obj.schema_version === 'string' &&
     obj.schema_version.startsWith('1.')
   ) {
-    const shortObj = v1ToShortKeyClaim(obj);
-    const st = typeof shortObj.st === 'string' ? shortObj.st : 'a';
-    const human = SHORT_TO_HUMAN[st] ?? 'active';
-    return { claim: shortObj, currentStatus: human, isLegacy: false };
+    const v1 = readV1Blob(decrypted);
+    if (v1) {
+      // Current status = pinStatus if present, else active.
+      const human: HumanStatus = v1.pinStatus === 'pinned' ? 'pinned' : 'active';
+      const shortProjection = v1ToShortKeyClaim(obj);
+      return {
+        source: {
+          kind: 'v1',
+          text: v1.text,
+          type: v1.type,
+          source: v1.source,
+          scope: v1.scope,
+          volatility: v1.volatility,
+          reasoning: v1.reasoning,
+          entities: v1.entities,
+          importance: v1.importance,
+          confidence: v1.confidence,
+          createdAt: v1.createdAt,
+          expiresAt: v1.expiresAt,
+          id: v1.id,
+          pinStatus: v1.pinStatus,
+        },
+        claim: shortProjection,
+        currentStatus: human,
+        isLegacy: false,
+      };
+    }
+    // readV1Blob returned null — fall through to v0 path.
   }
 
   // v0 canonical Claim — short keys present.
@@ -113,21 +200,30 @@ export function parseBlobForPin(decrypted: string): ParsedBlob {
     const st = typeof obj.st === 'string' ? obj.st : 'a';
     const human = SHORT_TO_HUMAN[st] ?? 'active';
     const cloned = JSON.parse(JSON.stringify(obj)) as Record<string, unknown>;
-    return { claim: cloned, currentStatus: human, isLegacy: false };
+    return {
+      source: { kind: 'v0', claim: cloned },
+      claim: cloned,
+      currentStatus: human,
+      isLegacy: false,
+    };
   }
 
   // Legacy {text, metadata: {importance: 0-1}} shape.
   if (typeof obj.text === 'string') {
     const meta = (obj.metadata as Record<string, unknown>) ?? {};
+    const shortClaim = buildCanonicalObjectFromLegacy(obj.text, meta);
     return {
-      claim: buildCanonicalObjectFromLegacy(obj.text, meta),
+      source: { kind: 'v0', claim: shortClaim },
+      claim: shortClaim,
       currentStatus: 'active',
       isLegacy: true,
     };
   }
 
+  const shortClaim = buildCanonicalObjectFromLegacy(decrypted, {});
   return {
-    claim: buildCanonicalObjectFromLegacy(decrypted, {}),
+    source: { kind: 'v0', claim: shortClaim },
+    claim: shortClaim,
     currentStatus: 'active',
     isLegacy: true,
   };
@@ -202,6 +298,113 @@ function buildCanonicalObjectFromLegacy(
     i: importance,
     sa: source,
     ea: createdAt,
+  };
+}
+
+// ─── v1 projection ────────────────────────────────────────────────────────────
+
+/** v1 shape used to drive buildV1ClaimBlob from a (v0 or v1) source. */
+interface V1Projection {
+  text: string;
+  type: MemoryType;
+  source: MemorySource;
+  scope?: MemoryScope;
+  volatility?: MemoryVolatility;
+  reasoning?: string;
+  entities?: Array<{ name: string; type: string; role?: string }>;
+  importance: number;
+  confidence: number;
+}
+
+/**
+ * Project a source blob (v1 or v0 short-key) into the v1 shape needed by
+ * `buildV1ClaimBlob`. For v1 sources this is identity; for v0 sources we
+ * upgrade the category / source fields per the spec's legacy-mapping table
+ * (`fact|context|decision → claim`, `rule → directive`, `goal → commitment`,
+ * etc.). Anything we can't determine falls back to a sensible default so the
+ * build call doesn't throw.
+ */
+function projectToV1(src: V1PinBlob | V0PinBlob, defaultSourceAgent: string): V1Projection {
+  if (src.kind === 'v1') {
+    return {
+      text: src.text,
+      type: src.type,
+      source: src.source,
+      scope: src.scope,
+      volatility: src.volatility,
+      reasoning: src.reasoning,
+      entities: src.entities,
+      importance: src.importance,
+      confidence: src.confidence,
+    };
+  }
+
+  // v0 path — upgrade short-key claim to v1.
+  const claim = src.claim;
+  const text = typeof claim.t === 'string' ? claim.t : '';
+  const v0Category = typeof claim.c === 'string' ? claim.c : 'fact';
+  // Legacy short category keys back to type names (reverse of TYPE_TO_CATEGORY_V0).
+  const V0_CATEGORY_TO_V0_TYPE: Record<string, string> = {
+    fact: 'fact',
+    pref: 'preference',
+    dec: 'decision',
+    epi: 'episodic',
+    goal: 'goal',
+    ctx: 'context',
+    sum: 'summary',
+    rule: 'rule',
+    ent: 'fact', // entity records don't round-trip as v1 claims; fall back
+    dig: 'summary',
+    claim: 'claim',
+  };
+  const v0TypeToken = V0_CATEGORY_TO_V0_TYPE[v0Category] ?? 'fact';
+  // Use the shared v0→v1 map for the upgrade.
+  const v1Type: MemoryType = (V0_TO_V1_TYPE as Record<string, MemoryType>)[v0TypeToken] ?? 'claim';
+
+  const importance = typeof claim.i === 'number'
+    ? Math.max(1, Math.min(10, Math.round(claim.i as number)))
+    : 5;
+  const confidence = typeof claim.cf === 'number' ? (claim.cf as number) : 0.85;
+
+  // v0 `sa` isn't a provenance source — it's a "source agent" string like
+  // "openclaw-plugin". Map heuristically: if it looks like an agent-style
+  // string (contains "plugin"/"agent"/"derived"), mark it as appropriate;
+  // otherwise default to "user-inferred" so Tier 1 reranker doesn't give it
+  // "user" trust (which would be wrong for legacy blobs with no provenance
+  // signal).
+  const sa = typeof claim.sa === 'string' ? claim.sa : defaultSourceAgent;
+  let v1Source: MemorySource = 'user-inferred';
+  const saLower = sa.toLowerCase();
+  if (saLower.includes('derived') || saLower.includes('digest') || saLower.includes('consolidat')) {
+    v1Source = 'derived';
+  } else if (saLower.includes('assistant')) {
+    v1Source = 'assistant';
+  } else if (saLower.includes('extern') || saLower.includes('mem0') || saLower.includes('import')) {
+    v1Source = 'external';
+  }
+
+  const entities = Array.isArray(claim.e)
+    ? (claim.e as unknown[])
+        .map((e) => {
+          if (!e || typeof e !== 'object') return null;
+          const entity = e as Record<string, unknown>;
+          const name = typeof entity.n === 'string' ? entity.n : '';
+          const entType = typeof entity.tp === 'string' ? entity.tp : 'concept';
+          if (!name) return null;
+          const out: { name: string; type: string; role?: string } = { name, type: entType };
+          if (typeof entity.r === 'string' && entity.r.length > 0) out.role = entity.r;
+          return out;
+        })
+        .filter((x): x is { name: string; type: string; role?: string } => x !== null)
+    : undefined;
+
+  return {
+    text,
+    type: v1Type,
+    source: v1Source,
+    importance,
+    confidence,
+    entities,
   };
 }
 
@@ -338,30 +541,41 @@ export async function executePinOperation(
     };
   }
 
-  // 4. Build the new canonical claim with updated status + supersedes link
-  const newClaimObj = { ...parsed.claim };
-  if (targetStatus === 'active') {
-    // Active is the canonical default — omit `st` entirely.
-    delete newClaimObj.st;
-  } else {
-    newClaimObj.st = HUMAN_TO_SHORT[targetStatus];
-  }
-  newClaimObj.sup = factId;
-  // Refresh extraction timestamp so downstream consumers can tell this is a new event.
-  newClaimObj.ea = new Date().toISOString();
-  // Carry source agent forward if present, else stamp it.
-  if (typeof newClaimObj.sa !== 'string' || newClaimObj.sa.length === 0) {
-    newClaimObj.sa = deps.sourceAgent;
-  }
+  // 4. Build the new canonical v1.1 claim with pin_status + superseded_by link.
+  //
+  // The new blob is ALWAYS v1.1 shaped (schema_version "1.0", pin_status
+  // present) regardless of the source blob's format. v0 sources are upgraded
+  // to v1 on the pin path; v1 sources round-trip their metadata (source,
+  // scope, reasoning, entities, volatility) into the new blob.
+  const pinStatus: PinStatus = targetStatus === 'pinned' ? 'pinned' : 'unpinned';
+  const newFactId = crypto.randomUUID();
+
+  // Project the source blob into v1 shape. For v0 sources we upgrade on the
+  // fly: short-key `c` → v1 type, `sa` → source (heuristic), etc.
+  const v1View = projectToV1(parsed.source, deps.sourceAgent);
 
   let canonicalJson: string;
   try {
-    canonicalJson = getWasm().canonicalizeClaim(JSON.stringify(newClaimObj));
+    canonicalJson = buildV1ClaimBlob({
+      id: newFactId,
+      text: v1View.text,
+      type: v1View.type,
+      source: v1View.source,
+      scope: v1View.scope,
+      volatility: v1View.volatility,
+      reasoning: v1View.reasoning,
+      entities: v1View.entities,
+      importance: v1View.importance,
+      confidence: v1View.confidence,
+      createdAt: new Date().toISOString(),
+      supersededBy: factId,
+      pinStatus,
+    });
   } catch (err) {
     return {
       success: false,
       fact_id: factId,
-      error: `Failed to canonicalize updated claim: ${err instanceof Error ? err.message : String(err)}`,
+      error: `Failed to build v1 claim blob: ${err instanceof Error ? err.message : String(err)}`,
     };
   }
 
@@ -378,22 +592,22 @@ export async function executePinOperation(
   }
 
   // 5b. Regenerate trapdoors so the new fact is findable by the same text.
-  const newClaimText = typeof parsed.claim.t === 'string' ? parsed.claim.t : '';
-  const entityNames: string[] = Array.isArray(parsed.claim.e)
-    ? (parsed.claim.e as unknown[])
-        .map((e) => (e && typeof (e as { n?: unknown }).n === 'string' ? (e as { n: string }).n : ''))
-        .filter((n): n is string => n.length > 0)
+  const entityNames: string[] = v1View.entities
+    ? v1View.entities.map((e) => e.name).filter((n): n is string => typeof n === 'string' && n.length > 0)
     : [];
   let regenerated: { blindIndices: string[]; encryptedEmbedding?: string };
   try {
-    regenerated = await deps.generateIndices(newClaimText, entityNames);
+    regenerated = await deps.generateIndices(v1View.text, entityNames);
   } catch {
     regenerated = { blindIndices: [] };
   }
 
   // 6. Build tombstone + new protobuf payloads.
-  // Plugin tombstone convention matches the rest of the plugin: `encryptedBlob: '00'`,
-  // empty indices, decayScore=0, source='tombstone'.
+  //
+  // Tombstone: empty blob ('00'), empty indices, decayScore=0, source='tombstone'.
+  // Written at the DEFAULT protobuf version (legacy v3) because tombstone rows
+  // carry no inner blob — the version field is irrelevant for readers and
+  // writing v3 keeps round-trip compat with any pre-v1 tombstone parser.
   const tombstonePayload: FactPayload = {
     id: factId,
     timestamp: new Date().toISOString(),
@@ -406,7 +620,6 @@ export async function executePinOperation(
     agentId: deps.sourceAgent,
   };
 
-  const newFactId = crypto.randomUUID();
   const newPayload: FactPayload = {
     id: newFactId,
     timestamp: new Date().toISOString(),
@@ -420,7 +633,13 @@ export async function executePinOperation(
     encryptedEmbedding: regenerated.encryptedEmbedding,
   };
 
-  const payloads = [encodeFactProtobufLocal(tombstonePayload), encodeFactProtobufLocal(newPayload)];
+  // Outer protobuf version: v=4 for the new v1 claim, default (legacy v3)
+  // for the tombstone. This is the core of the bug-2 fix — previously both
+  // payloads went out at version=3 and the inner blob was v0 short-key.
+  const payloads = [
+    encodeFactProtobufLocal(tombstonePayload, /* version = legacy v3 */ 3),
+    encodeFactProtobufLocal(newPayload, PROTOBUF_VERSION_V4),
+  ];
 
   // 6b. Slice 2f: consult decisions.jsonl to see if this pin/unpin contradicts
   // a prior auto-resolution. If so, append a counterexample to feedback.jsonl


### PR DESCRIPTION
## Summary

Fixes [QA RC 3.0.7-rc.1 bug #2](../blob/main/mcp/AUDIT-v1-tools.md) (also tracked internally at `totalreclaw-internal/docs/notes/QA-openclaw-RC-3.0.7-rc.1-20260420.md`): `totalreclaw_pin` / `totalreclaw_unpin` shipped v0 short-key blobs at outer protobuf `version=3`, breaking the v1-on-chain contract for new pins. After this PR, pin/unpin emit canonical v1.1 `MemoryClaimV1` JSON (with new additive `pin_status` field) wrapped at protobuf `version=4` on both the plugin and the MCP server.

Closes the A2 deferred gap from [`mcp/AUDIT-v1-tools.md`](../blob/main/mcp/AUDIT-v1-tools.md).

## Spec change — v1.0 → v1.1 (additive)

- **Bumped spec header to v1.1.0** in `docs/specs/totalreclaw/memory-taxonomy-v1.md`.
- **New optional field** `pin_status: "pinned" | "unpinned"` on `MemoryClaimV1`. Absence = `"unpinned"` (no behavior change for 1.0 readers).
- **On-wire `schema_version` stays `"1.0"`** — 1.0 validators continue to accept 1.1 blobs byte-for-byte because the field is optional and ignorable. This was a deliberate trade-off vs. bumping the version string: we want cross-client pin to work the instant any client ships the field, not after all clients agree to accept `"1.1"`.
- **New "Pin semantics (normative, v1.1)"** section documents detection dispatch (v1 `pin_status` OR v0 `st == "p"` sentinel — both produce identical `is_pinned_claim` output for cross-version vaults), write contract (supersede via new blob + tombstone), and cross-client compatibility.

## Back-compat verification

- v0 short-key blobs continue to decode unchanged. `is_pinned_json` first tries `MemoryClaimV1` (authoritative if parse succeeds) then falls back to the v0 `Claim` parser — tests in `rust/totalreclaw-core/src/claims.rs` confirm every pre-v1.1 input returns the same result (`test_is_pinned_json_v0_pinned_backcompat`, `test_is_pinned_json_v0_active_backcompat`, `test_is_pinned_json_invalid_input_returns_false`).
- `MemoryClaimV1::pin_status: Option<PinStatus>` serializes to absence when `None`, so pre-v1.1 blobs round-trip byte-for-byte.
- `ClaimStatus::Pinned` (v0 sentinel) is untouched. v0 `is_pinned_claim(&Claim)` behavior unchanged.

## Cross-client parity

Plugin `buildV1ClaimBlob` + MCP `buildV1ClaimBlob` produce the same canonical JSON for the same logical inputs. Enforced by:

- Shared validator: both helpers round-trip through `@totalreclaw/core`'s `validateMemoryClaimV1` WASM export for canonical field ordering.
- `schema_version: "1.0"` is explicitly re-attached after the validator on both sides (Rust serde's default-skip would otherwise drop it).
- New test `mcp/tests/pin-cross-client-parity.test.ts` asserts the output SHAPE matches the assertions in `skill/plugin/pin-unpin.test.ts`'s "parity:" block (tests 144-157): required v1 fields present, no v0 leak (`t`, `c`, `st`, `sup` all absent), correct v0→v1 type upgrade per spec legacy map.
- v0 → v1.1 upgrade uses the spec's `LEGACY_TYPE_TO_V1` table (plugin: `extractor.ts::V0_TO_V1_TYPE`; MCP: `v1-types.ts::LEGACY_TYPE_TO_V1`). Both clients share the same mapping.

## Test results

| Suite | Before | After | Delta |
|-------|--------|-------|-------|
| `rust/totalreclaw-core` lib tests (native) | 467 | 482 | +15 |
| `rust/totalreclaw-core` lib tests (`--features python`) | 520 | 535 | +15 |
| `rust/totalreclaw-core` `cargo check --features wasm` | clean | clean | — |
| `rust/totalreclaw-memory` `cargo check` | clean | clean | — |
| plugin `pin-unpin.test.ts` | 116 | 157 | +41 (7 updated + 34 new v1.1) |
| plugin `claim-format.test.ts` | 65 | 65 | — |
| plugin `v1-taxonomy.test.ts` | 128 | 128 | — |
| plugin `store-dedup-wiring.test.ts` | 23 | 23 | — |
| plugin `consolidation.test.ts` | 42 | 42 | — |
| MCP `pin-unpin.test.ts` | 33 | 38 | +5 (3 updated + 5 new v1.1) |
| MCP `tool-pin-recovery.test.ts` | 11 | 11 | (2 updated) |
| MCP `pin-cross-client-parity.test.ts` | — | 3 | +3 new |
| MCP full TS suite | 397 | 405 | +8 |

Pre-existing failure in `mcp/tests/*.js` (server/tool-registration/etc) is unrelated — those need `dist/` which isn't built in this worktree. Also pre-existing failure in `skill/plugin/contradiction-sync.test.ts` unrelated — reproduces on `main` before these commits.

## Rebase coordination with parallel agent

Parallel agent is fixing bugs #1, #3, #4 in `skill/plugin/` (package.json 3.0.7→3.1.0, index.ts tool-schema enum dedupe, digest skip-tombstone). File ownership was strict:

- **My PR touches ONLY**: `rust/totalreclaw-core/**`, `rust/totalreclaw-memory/src/store.rs` (single required update), `skill/plugin/pin.ts`, `skill/plugin/pin-unpin.test.ts`, `skill/plugin/claims-helper.ts`, `mcp/src/tools/pin.ts`, `mcp/src/claims-helper.ts`, `mcp/tests/pin-unpin.test.ts`, `mcp/tests/tool-pin-recovery.test.ts`, `mcp/tests/pin-cross-client-parity.test.ts`, `mcp/package.json`, `mcp/CHANGELOG.md`, `docs/specs/totalreclaw/memory-taxonomy-v1.md`.
- **My PR does NOT touch**: `skill/plugin/package.json`, `skill/plugin/index.ts`, `skill/plugin/digest.ts`, `skill/CHANGELOG.md` (all owned by the parallel agent's 3.1.0 bump).

**Recommended merge order**: Merge parallel agent's PR FIRST (plugin 3.1.0 runtime fixes + package.json bump), then this PR. When both land, plugin version 3.1.0 captures both sets of plugin-side changes. No double-bump.

If this PR lands first, the parallel agent will need to rebase — resolve the rebase by re-applying their package.json + index.ts + digest.ts changes on top; my plugin-pin changes should merge cleanly (different files).

## Why a single PR (not split)

Core 2.1.1 + MCP 3.2.0 + plugin pin.ts changes + spec addendum form a single logical unit — the core field IS the spec extension IS the bindings' serialization contract IS what plugin/mcp pin paths emit. Splitting would force intermediate states where core ships the field but no client emits it, or MCP emits the field without the spec blessing. Reviewing as one change is clearer.

## Test plan

- [x] Rust: `cd rust/totalreclaw-core && cargo test --lib` — 482/482
- [x] Rust: `cargo test --features python --lib` — 535/535
- [x] Rust: `cargo check --features wasm` — clean
- [x] Rust: `cd rust/totalreclaw-memory && cargo check` — clean
- [x] WASM rebuild: `./build-wasm.sh` — clean; new exports `parsePinStatus`, `isPinnedClaimJson` visible in `.d.ts`
- [x] Plugin: `npx tsx pin-unpin.test.ts` — 157/157
- [x] Plugin: pre-existing tests (claim-format, v1-taxonomy, store-dedup-wiring, consolidation) — all green
- [x] MCP: `npm test -- --testPathPattern='\.ts$'` — 405/405 (includes new parity test)
- [x] MCP: `npx tsc --noEmit` — clean
- [ ] Manual cross-client parity on staging: pin via plugin → unpin via MCP → verify `pin_status` flips correctly (deferred to release QA gate per `CLAUDE.md` "real-user QA on staging" rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)