### PR TITLE
docs(guides): reconcile OpenClaw + Hermes guides with 3.1.0 install reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@
 
 <p align="center">
   <a href="https://totalreclaw.xyz">Website</a> ·
-  <a href="https://clawhub.ai/skills/totalreclaw">ClawHub</a> ·
-  <a href="https://www.npmjs.com/package/@totalreclaw/totalreclaw">npm</a> ·
+  <a href="https://www.npmjs.com/package/@totalreclaw/totalreclaw">npm (plugin)</a> ·
+  <a href="https://www.npmjs.com/package/@totalreclaw/mcp-server">npm (MCP)</a> ·
+  <a href="https://pypi.org/project/totalreclaw/">PyPI</a> ·
   <a href="docs/guides/client-setup-v1.md">Getting Started</a> ·
   <a href="docs/architecture.md">Architecture</a>
 </p>
@@ -41,7 +42,7 @@ One command per client. v1 is the default — no env toggles, no feature flags.
 
 | Client | Install |
 |---|---|
-| **OpenClaw** | `openclaw skills install totalreclaw` |
+| **OpenClaw** | `openclaw plugins install @totalreclaw/totalreclaw` |
 | **Claude Desktop / Cursor / Windsurf** | `npx @totalreclaw/mcp-server setup` |
 | **NanoClaw** | add `TOTALRECLAW_RECOVERY_PHRASE` to deployment env |
 | **Python / Hermes** | `pip install totalreclaw` |
@@ -95,7 +96,7 @@ Supported sources: **ChatGPT** (memories or conversations.json), **Claude** (mem
 
 | Package | Description | Install |
 | --- | --- | --- |
-| [@totalreclaw/totalreclaw](https://clawhub.ai/skills/totalreclaw) | OpenClaw skill — automatic encrypted memory | `openclaw skills install totalreclaw` |
+| [@totalreclaw/totalreclaw](https://www.npmjs.com/package/@totalreclaw/totalreclaw) | OpenClaw plugin — automatic encrypted memory | `openclaw plugins install @totalreclaw/totalreclaw` |
 | [@totalreclaw/mcp-server](https://www.npmjs.com/package/@totalreclaw/mcp-server) | MCP server for Claude Desktop and other MCP clients | `npx @totalreclaw/mcp-server setup` |
 | [@totalreclaw/client](https://www.npmjs.com/package/@totalreclaw/client) | Client library (encryption, indexing, search, re-ranking) | `npm install @totalreclaw/client` |
 | [totalreclaw](https://pypi.org/project/totalreclaw/) | Python client + Hermes Agent plugin | `pip install totalreclaw` |

--- a/docs/guides/beta-tester-guide-detailed.md
+++ b/docs/guides/beta-tester-guide-detailed.md
@@ -59,27 +59,44 @@ Before you begin, make sure you have:
 
 ### Install the OpenClaw Plugin
 
-The quickest path is a single command that pulls the plugin from npm:
+One command, installed from npm:
 
 ```
 openclaw plugins install @totalreclaw/totalreclaw
 ```
 
-This registers the plugin with your gateway under the ID `totalreclaw` and sets it up automatically on first run. Verify it appears in your OpenClaw skill/plugin list -- you should see **TotalReclaw** described as "End-to-end encrypted memory vault for AI agents."
+This registers the plugin with your gateway under the ID `totalreclaw` and sets it up automatically on first run. Verify it appears in your OpenClaw skill/plugin list -- you should see **TotalReclaw** described as "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime."
+
+**Scanner status (plugin 3.1.0):** `openclaw security audit --deep` reports **0 `code_safety` warnings** for totalreclaw. The install completes without any `--dangerously-force-unsafe-install` flag. Earlier 3.0.x releases could trip a false-positive `potential-exfiltration` warning -- that was resolved in 3.0.8 / 3.1.0 by consolidating filesystem helpers.
+
+> **TotalReclaw is distributed via npm.** Future CLI resolvers may surface it via additional registries.
 
 <details>
-<summary>Alternative: install from source (ClawHub + local path)</summary>
+<summary>Developer / from-source install (plugin contributors only)</summary>
+
+If you are working from a fork or want to pin a specific local source tree, clone the repo and point `openclaw plugins install` at the local path:
 
 ```
-openclaw skills install totalreclaw
-openclaw plugins install ~/.openclaw/workspace/skills/totalreclaw
+git clone https://github.com/p-diogo/totalreclaw.git
+openclaw plugins install ./totalreclaw/skill/plugin
 ```
 
-`openclaw skills install` pulls the plugin source from ClawHub into your workspace skills directory, then `openclaw plugins install <local-path>` registers it with your gateway. Use this path if the npm install fails or if you want to pin a specific ClawHub version.
-
-You can also ask your OpenClaw agent: *"Install the TotalReclaw skill from ClawHub"*.
+This is for plugin development only. Users following this guide should stick with the one-line npm install above.
 
 </details>
+
+### What you get in plugin 3.1.0 (release notes)
+
+Plugin 3.1.0 is the first v1-taxonomy-complete stable release after the 3.0.x stabilization wave. Relative to 3.0.4, it fixes the following user-visible issues:
+
+| Fix | Description |
+|-----|-------------|
+| Scanner-clean install | No `potential-exfiltration` warnings; one-line install works without any force flags. |
+| Auto-bootstrap credentials | Plugin generates a recovery phrase automatically on first load when `credentials.json` is missing -- no explicit `totalreclaw_setup` call needed. |
+| Digest stubs populated | Session digests flushed to storage carry the fields downstream consumers expect (schema fix). |
+| `pin_status` round-trips on-chain | Pinning / unpinning through the natural-language tools emits v1 protobuf blobs with `pin_status` set; cross-client verified against core 2.1.1. |
+
+Paired with `@totalreclaw/core@2.1.1`, these close out the post-v1.0.0 stabilization items tracked in the project's Wave 1 verdict.
 
 ---
 
@@ -102,7 +119,21 @@ npx @totalreclaw/mcp-server setup
 
 The wizard will ask if you already have a recovery phrase. If you are a new user, it generates one, displays it, and asks you to confirm you have saved it before proceeding. It then registers you with the relay server and saves your credentials to `~/.totalreclaw/credentials.json`. See [Section 11](#11-mcp-server-setup-claude-desktop--cursor) for the full MCP setup flow.
 
-**OpenClaw plugin users:** Open a terminal and run:
+**OpenClaw plugin users (v3.1.0+):** Auto-bootstrap handles this for you. On the first conversation turn after install, if `~/.openclaw/extensions/totalreclaw/credentials.json` does not exist, the plugin generates a 12-word phrase, writes it to that file, and continues. You do not need to run any `generate-mnemonic` command or explicitly ask the agent to set TotalReclaw up.
+
+The phrase **may** also appear in the agent's first chat reply via a one-time banner -- but this surfacing is LLM-dependent. To retrieve your phrase reliably:
+
+```bash
+cat ~/.openclaw/extensions/totalreclaw/credentials.json
+```
+
+Copy the `mnemonic` field and store it somewhere safe.
+
+> **Known UX limitation (v3.1.0):** the first-turn phrase banner goes through the LLM channel, so (a) it is visible to your LLM provider, and (b) the LLM may choose not to surface it to you. v3.2.0 ships an onboarding flow that keeps the phrase off the LLM channel. Until then, `cat ~/.openclaw/extensions/totalreclaw/credentials.json` is the source of truth.
+
+> **Do not reuse a blockchain wallet mnemonic.** TotalReclaw keys are memory-only. Using a recovery phrase that has funds or on-chain history attached increases your blast radius with no benefit.
+
+If you prefer to generate a phrase outside the plugin (e.g., to pre-provision it before first run), you can still run:
 
 ```
 npx @totalreclaw/totalreclaw generate-mnemonic

--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -28,6 +28,8 @@ mkdir -p ~/.hermes/plugins/totalreclaw
 cp -r $(python -c "import totalreclaw.hermes; print(totalreclaw.hermes.__path__[0])")/* ~/.hermes/plugins/totalreclaw/
 ```
 
+> **Current stable:** `totalreclaw==2.2.1` on PyPI. 2.2.0 added ERC-4337 `executeBatch` (up to 15 facts per UserOp) and 2.2.1 wired auto-extraction through the batched path, cutting typical extraction-to-on-chain latency from ~60s to ~8s. Older 2.0.x releases had several auto-flow regressions (`Event loop is closed` on `status` / `export`, missing session-id tracing); upgrade fixes them.
+
 > **Ubuntu/Debian/Docker note:** Add `--break-system-packages` if you see "externally-managed-environment" errors:
 > ```bash
 > pip install --break-system-packages totalreclaw
@@ -62,7 +64,7 @@ You should see:
 
 ```
 Plugins (1+):
-  ✓ totalreclaw v1.0.0 (8 tools, 4 hooks)
+  ✓ totalreclaw v2.2.1 (8 tools, 4 hooks)
 ```
 
 ## 3. Start chatting
@@ -124,6 +126,7 @@ The plugin recognizes 7 memory types:
 |----------|---------|-------------|
 | `TOTALRECLAW_RECOVERY_PHRASE` | -- | Import an existing recovery phrase. If not set, the agent generates one on first use. |
 | `TOTALRECLAW_SERVER_URL` | `https://api.totalreclaw.xyz` | Override for self-hosted deployments. Most users don't need this. |
+| `TOTALRECLAW_SESSION_ID` | auto-generated | Stable session identifier for log tracing in Axiom. Supported since Python client 2.0.2; if you're still on an older release you may see an "ignoring removed env var" log line — upgrade to clear it. |
 
 TotalReclaw automatically uses whatever LLM provider you configured for Hermes. It picks a fast/cheap model from the same provider for fact extraction -- no extra API keys or model settings needed.
 

--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -6,36 +6,65 @@ TotalReclaw gives your OpenClaw agent encrypted, persistent memory. Facts, prefe
 
 ## Install
 
-The quickest path -- one command, install from npm:
+One command -- install from npm:
 
 ```bash
 openclaw plugins install @totalreclaw/totalreclaw
 ```
 
+The OpenClaw CLI resolves `@totalreclaw/totalreclaw` from the npm registry, activates the plugin, and wires it into your gateway. On first load the plugin auto-generates a recovery phrase if one is not already configured -- you do not need to run a separate setup command.
+
+> **Note:** TotalReclaw is distributed via the npm registry. Future CLI resolvers may surface it via additional registries.
+
+> **Note:** The first interaction downloads a ~344MB embedding model. This is cached locally and only happens once.
+
 <details>
-<summary>Alternative: install from source (ClawHub + local path)</summary>
+<summary>Developer / from-source install (non-primary)</summary>
+
+If you are working from a fork or want to pin a specific local source tree, clone the repo and point `openclaw plugins install` at the local path:
 
 ```bash
-openclaw skills install totalreclaw
-openclaw plugins install ~/.openclaw/workspace/skills/totalreclaw
+git clone https://github.com/p-diogo/totalreclaw.git
+openclaw plugins install ./totalreclaw/skill/plugin
 ```
 
-`openclaw skills install` pulls the plugin source from ClawHub into your
-workspace skills directory, then `openclaw plugins install <local-path>`
-registers it with your gateway. Use this path if the npm install fails
-or if you want to pin a specific ClawHub version.
+This is for plugin development only. Users following this guide should stick with the one-line npm install above.
 
 </details>
 
-Then start a conversation and tell your agent:
+---
 
-> "Set up TotalReclaw for me. Generate a new recovery phrase."
+## Your recovery phrase
 
-Write down the 12-word phrase and store it safely. There is no password reset -- this phrase is the only key to your memories.
+TotalReclaw is keyed by a 12-word BIP-39 recovery phrase. The plugin handles generation automatically the first time it loads.
 
-**Returning user?** Say: *"I have an existing TotalReclaw recovery phrase: word1 word2 ... word12"* and your existing memories become accessible immediately.
+**Where it is stored:** `~/.openclaw/extensions/totalreclaw/credentials.json` (owner-only permissions). This file contains your recovery phrase plus derived identifiers.
 
-> **Note:** The first interaction downloads a ~344MB embedding model. This is cached locally and only happens once.
+**You must save it somewhere safe.** It is the only key to your memories and the only way to use the same vault from another agent (Claude Desktop, Cursor, Hermes, etc.). There is no password reset, no recovery email, no support ticket that can recover lost memories.
+
+> **Use a dedicated phrase.** Never reuse a recovery phrase that has been used for a blockchain wallet or any on-chain activity. TotalReclaw keys are memory-only -- they should not share entropy with funds.
+
+### How to retrieve your phrase (current behavior, v3.1.0)
+
+When the plugin generates a fresh phrase, it is written to the credentials file above. Depending on your LLM provider, the phrase may *also* appear in your first chat response via a one-time banner. **This surfacing is LLM-dependent -- it may or may not happen.** Either way, the phrase is saved on disk.
+
+To retrieve it reliably:
+
+```bash
+cat ~/.openclaw/extensions/totalreclaw/credentials.json
+```
+
+Copy the `mnemonic` field and store it somewhere safe (password manager, offline paper backup -- not a plaintext note in the cloud).
+
+> **Heads up:** v3.2.0 will improve onboarding so the phrase is surfaced outside the LLM channel. Until that ships, the `cat` command above is the source of truth.
+
+### Returning user
+
+If you already have a phrase from another client (Hermes, MCP, NanoClaw, etc.), tell the agent before the first extraction:
+
+> "I have an existing TotalReclaw recovery phrase: word1 word2 ... word12"
+
+The plugin will use it to re-derive your keys and your existing memories become accessible immediately. Alternatively, write the phrase into `credentials.json` yourself before first load.
 
 ---
 
@@ -54,15 +83,23 @@ Once set up, memory is fully automatic. You do not need to do anything.
 
 ## Explicit Tools
 
-You can also use memory directly by asking your agent:
+You can also drive memory directly by asking your agent. The v1 taxonomy adds pin / retype / set_scope for when you want to curate a memory rather than let the automatic flow decide.
 
-| Tool | Example prompt |
-|------|---------------|
-| **Remember** | "Remember that I prefer PostgreSQL over MySQL" |
-| **Recall** | "What do you remember about my database choices?" |
-| **Forget** | "Forget what you know about my old email address" |
-| **Export** | "Export all my TotalReclaw memories as plain text" |
-| **Status** | "What's my TotalReclaw subscription status?" |
+| Tool | What it does | Example prompt |
+|------|--------------|---------------|
+| **Remember** | Store a specific fact now | "Remember that I prefer PostgreSQL over MySQL" |
+| **Recall** | Search your vault | "What do you remember about my database choices?" |
+| **Forget** | Delete a memory | "Forget what you know about my old email address" |
+| **Pin** | Mark a memory as permanent (won't decay / auto-evict) | "Pin that -- it's important" |
+| **Unpin** | Remove the permanent flag | "Unpin the note about my old editor" |
+| **Retype** | Reclassify an existing memory (`claim`, `preference`, `directive`, `commitment`, `episode`, `summary`) | "That should be a preference, not a fact" |
+| **Set scope** | Reassign a memory to a scope (`work`, `personal`, `health`, `family`, `creative`, `finance`, `misc`) | "File that under work" |
+| **Export** | Download everything as text / JSON | "Export all my TotalReclaw memories as plain text" |
+| **Status** | Tier + usage | "What's my TotalReclaw status?" |
+| **Import from** | Pull memories in from Mem0 / ChatGPT / Claude / Gemini | "Import my Gemini history from ~/Downloads/..." |
+| **Setup** | Re-run setup (no-op when credentials already match) | "Set up TotalReclaw for me" |
+
+> **Note on `setup`:** since v3.1.0, a fresh vault is bootstrapped automatically on first load. The `setup` tool remains available for explicit re-setup (e.g., switching recovery phrases) but is a no-op when your credentials are already in place.
 
 ---
 
@@ -96,11 +133,13 @@ Upgrade by asking your agent: *"Upgrade my TotalReclaw subscription."*
 | Problem | Fix |
 |---------|-----|
 | Plugin not loading | Restart the gateway. On first install, npm dependencies may still be installing in the background -- restart once more after a minute. |
-| "1 suspicious code pattern" warning | Normal. The plugin reads config and makes encrypted network calls. |
+| I can't find my recovery phrase | `cat ~/.openclaw/extensions/totalreclaw/credentials.json` -- the `mnemonic` field is your phrase. The LLM banner that prints the phrase on first load is not guaranteed to surface; the file is. |
 | Tools not appearing in conversations | Ensure your gateway config includes `"tools": { "allow": ["totalreclaw", "group:plugins"] }`. Rebuild the Docker image if using Docker. |
-| "Not authenticated" / 401 | Check your recovery phrase -- exact words, exact order. |
+| "Not authenticated" / 401 | Check your recovery phrase -- exact words, exact order, all lowercase, single spaces. |
 | Memories not appearing | Try an explicit recall: *"What do you remember about X?"* |
 | Quota exceeded (403) | Upgrade to Pro for permanent mainnet storage. |
+
+> **Security scanner:** since plugin 3.1.0 (which builds on the 3.0.7 / 3.0.8 fs-helpers consolidation), `openclaw security audit --deep` reports **0 `code_safety` warnings** for totalreclaw. If you see a scanner warning on an older version, upgrade with `openclaw plugins install @totalreclaw/totalreclaw@latest`.
 
 For detailed technical reference (environment variables, configuration, architecture), see the [detailed guide](beta-tester-guide-detailed.md).
 

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,19 +1,26 @@
 {
   "name": "@totalreclaw/totalreclaw",
   "version": "3.1.0",
-  "description": "End-to-end encrypted memory for AI agents — portable, yours forever. Automatic extraction, semantic search, and on-chain storage",
+  "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [
     "totalreclaw",
     "openclaw",
     "ai-memory",
     "ai-agent",
+    "agent-memory",
+    "portable-memory",
     "e2e-encryption",
     "encryption",
     "e2ee",
+    "xchacha20-poly1305",
+    "bip39",
+    "erc-4337",
     "lsh",
     "semantic-search",
-    "memory"
+    "memory",
+    "memory-taxonomy",
+    "v1"
   ],
   "homepage": "https://totalreclaw.xyz",
   "repository": {


### PR DESCRIPTION
## Summary

Reconciles the public-facing user guides, root README, and plugin package metadata with the reality of plugin 3.1.0 (now stable on npm) and Python client 2.2.1. Five surgical commits, no source code touched.

Key shifts:
- **Install flow** — `openclaw plugins install @totalreclaw/totalreclaw` is now the single primary install path everywhere. The two-step `openclaw skills install` + `plugins install <path>` dance is demoted to a collapsed "developer / from-source" appendix. ClawHub references are removed from install paths (package is being delisted).
- **Recovery phrase UX** — documented the auto-bootstrap behavior in 3.1.0 (plugin generates the phrase to `~/.openclaw/extensions/totalreclaw/credentials.json` on first load) **and** the honest limitation that the first-turn LLM banner surfacing is not guaranteed. Users are told to `cat credentials.json` as the reliable retrieval path. Flagged that 3.2.0 will improve this.
- **Scanner status** — install is now scanner-clean on 3.1.0 (0 `code_safety` warnings); removed the misleading "1 suspicious code pattern is normal" troubleshooting row and replaced it with an upgrade hint for older versions.
- **v1 tools** — OpenClaw guide now enumerates the full v1 surface: pin / unpin / retype / set_scope / status / export / import_from / setup, with plain-language prompts.
- **Hermes** — bumped version refs to 2.2.1 (batched on-chain writes → ~60s→8s extraction latency). Documented `TOTALRECLAW_SESSION_ID` as supported since 2.0.2.
- **Plugin description** — rewrote for v1 reality (dropped "skill" framing, added protobuf v4 + v1 taxonomy language, refreshed keywords).

## Files touched

- `docs/guides/openclaw-setup.md` — npm one-liner as lead install; dedicated "Your recovery phrase" section; v1 tools table; scanner-clean note.
- `docs/guides/beta-tester-guide-detailed.md` — matching install-flow update; release-notes table for 3.1.0 (4-bug Wave 1); rewrote Step 1 of first-time setup around auto-bootstrap; LLM-channel-phrase caveat.
- `docs/guides/hermes-setup.md` — `totalreclaw==2.2.1` stable note; bumped `/plugins` verification output; documented `TOTALRECLAW_SESSION_ID`.
- `skill/plugin/package.json` — refreshed `description` and keywords for v1.
- `README.md` — removed ClawHub link + references; promoted npm plugin install everywhere.

## Test plan

- [ ] Visual diff review of each guide section changed.
- [ ] Confirm the credentials.json retrieval instruction matches plugin 3.1.0 behavior on a fresh VPS install.
- [ ] Confirm the scanner-clean claim by running `openclaw security audit --deep` against the installed plugin.
- [ ] Spot-check that all ClawHub references are removed from the install flow (leaving historical references in release-process / ironclaw docs where they describe legacy channels is fine).
- [ ] Verify the plugin `description` field lands in the npm package metadata on the next publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)