### PR TITLE
fix(wave2a): python 2.2.2 + plugin 3.2.1 + spec — Hermes #4/#7/#8

### DIFF
--- a/docs/specs/totalreclaw/flows/01-identity-setup.md
+++ b/docs/specs/totalreclaw/flows/01-identity-setup.md
@@ -75,7 +75,46 @@ sequenceDiagram
 
 **What the relay actually stores.** After registration, the relay database has roughly: `{ auth_key_hash: hex, eoa_address: 0x..., smart_account_address: 0x..., tier: free, created_at: ... }`. It has no copy of the mnemonic, no encryption key, no dedup key, no LSH seed, and no plaintext. A full database dump gives an attacker nothing except the list of which users exist.
 
-**What the client stores locally.** `~/.totalreclaw/credentials.json` holds the auth-key hash (for bearer-token auth), the Smart Account address (cached so we do not re-resolve it), the chain ID, and the tier. The mnemonic itself is NOT persisted — it is only ever held in memory during key derivation. Re-deriving from the phrase on every startup would be slow (PBKDF2 is deliberately heavy), so the plugin caches the derived keys in memory for the session and stores only the hash on disk.
+**What the client stores locally.** `~/.totalreclaw/credentials.json` holds the auth-key hash (for bearer-token auth), the Smart Account address (cached so we do not re-resolve it), the chain ID, and the tier. The mnemonic itself IS persisted to the same file (mode `0600`) because re-requesting it from the user on every session would be poor UX; the containing directory's permissions are the only defense. Re-deriving from the phrase on every startup would be slow (PBKDF2 is deliberately heavy), so the plugin caches the derived keys in memory for the session and stores only the mnemonic + hash on disk.
+
+### `credentials.json` schema (v2026-04-20 — canonical)
+
+> Spec addendum shipped alongside `totalreclaw==2.2.2` + `@totalreclaw/totalreclaw@3.2.1` as part of Wave 2a of the Hermes QA fix-up. Prior to this addendum, Python and the OpenClaw plugin disagreed on the field name for the mnemonic — a ship-stopper for the "same recovery phrase works across all clients" portability story. See `docs/notes/QA-hermes-RC-2.2.1-20260420.md` Finding #7.
+
+**Path:** `~/.totalreclaw/credentials.json` (POSIX) — written with mode `0600`. Windows clients SHOULD emit to the equivalent user profile dir (`%USERPROFILE%\.totalreclaw\credentials.json`) at the same ACL tightness.
+
+**Canonical shape (write path):**
+
+```json
+{
+  "mnemonic": "letter sugar brave morning absurd pattern advice flight few pledge chef leisure"
+}
+```
+
+**Read path MUST accept BOTH:**
+
+- **`mnemonic`** — canonical key. Matches BIP-39 / industry convention. Emitted by plugin ≥ 3.2.0, MCP ≥ 3.2.0, Python ≥ 2.2.2 on fresh writes.
+- **`recovery_phrase`** — legacy alias. Written by Python 2.0.0–2.2.1. Accepted for back-compat so pre-2.2.2 vaults keep working without manual migration. Hand-edited files and older CLIs may also carry this key.
+
+**Priority when both keys are present:** `mnemonic` wins. Plugin-native files are authoritative because they reflect the canonical decision.
+
+**Migration policy:** implementations MUST NOT silently rewrite a legacy `recovery_phrase` file to the canonical `mnemonic` key on mere "touch" (e.g. re-opening an existing session). The file is 0600 and the user may have external tooling that reads a specific key name. Migration happens when the user explicitly re-onboards (e.g. imports a mnemonic via a fresh `totalreclaw_setup` call), at which point the write path emits canonical `mnemonic`.
+
+**Additional fields** (client-specific; both clients tolerate unknown keys):
+
+| Field | Written by | Purpose |
+|---|---|---|
+| `firstRunAnnouncementShown: bool` | Plugin 3.1.x (pre-3.2.0) | Flag for the one-time "phrase backup" banner. 3.2.0 moved phrase display to the CLI wizard, so this field is no longer set on fresh writes but preserved when reading legacy files. |
+| `userId: string` | Plugin | Server-side user id (uuid). Cached to avoid re-querying on every startup. |
+| `salt: string` | Plugin | Not used — vestige of an older derivation scheme. Tolerated on read. |
+
+**Reference implementations:**
+
+- Python: `python/src/totalreclaw/agent/state.py::_extract_mnemonic_from_creds` (2.2.2+)
+- OpenClaw plugin: `skill/plugin/fs-helpers.ts::extractBootstrapMnemonic` (3.2.0+)
+- MCP: `mcp/src/onboarding/cli.ts` (3.2.0+) — emits canonical `mnemonic` on write
+
+Cross-client parity test: writing via one implementation and reading via another MUST derive the same EOA + Smart Account address for the same mnemonic. See `python/tests/test_wave2a_hermes_fixes.py::TestBug7CrossClientParity` for the reference assertion.
 
 ---
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,83 @@ Hermes Agent plugin are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2] - 2026-04-20
+
+Wave 2a Hermes fix-up. Three bugs from the 2.2.1 VPS QA
+([internal#14](https://github.com/p-diogo/totalreclaw-internal/pull/14),
+`docs/notes/QA-hermes-RC-2.2.1-20260420.md`) — each would have been a
+ship-stopper if left in a public release:
+
+### Fixed
+
+- **Bug #4 (HIGH) — `auto_extract` reads Hermes `config.yaml`.**
+  Pre-2.2.2's `auto_extract` + post-extraction pipeline required
+  `OPENAI_MODEL` to be set as an env var even when
+  `~/.hermes/config.yaml` already carried `provider: zai` +
+  `model: glm-5-turbo`. The 2.0.2 "fix" only wired the Hermes
+  reader into the hooks layer; the generic `detect_llm_config` still
+  read env vars exclusively, and the YAML reader expected a NESTED
+  `model: {provider, model}` shape while Hermes actually writes
+  top-level `provider:` + `model:` keys. 2.2.2:
+  - `agent/llm_client.py::read_hermes_llm_config` handles BOTH YAML
+    shapes and scans `$HERMES_CONFIG` → XDG → `~/.config/hermes/` →
+    legacy `~/.hermes/`. Emits a WARN-level log line identifying the
+    config path the model came from.
+  - `detect_llm_config()` falls through to the Hermes reader when no
+    env vars resolve. This is the path `extract_facts_llm` hits when
+    no explicit `llm_config` is passed.
+- **Bug #7 (SHIP-STOPPER) — `credentials.json` key parity with plugin 3.2.0.**
+  Python pre-2.2.2 wrote `{"recovery_phrase": ...}` at
+  `~/.totalreclaw/credentials.json`; plugin 3.2.0 writes
+  `{"mnemonic": ...}` on the same canonical path. Cross-agent
+  portability — a user switching from Hermes to OpenClaw without
+  re-onboarding — was silently broken. 2.2.2:
+  - `agent/state.py::_extract_mnemonic_from_creds` helper accepts
+    BOTH keys on read, prefers canonical `mnemonic` when both present.
+  - `configure()` write path now emits canonical `mnemonic` for
+    fresh writes. Preserves legacy `recovery_phrase` shape when an
+    existing file carries ONLY that key for the same mnemonic — no
+    silent migration on touch.
+  - Canonical decision documented in
+    `docs/specs/totalreclaw/flows/01-identity-setup.md`.
+- **Bug #8 (MEDIUM) — `pin_fact` emits v=4 `MemoryClaimV1` with `pin_status`.**
+  Pre-2.2.2's `pin_fact()` wrote a v=3 tombstone but no companion v=4
+  pinned claim — a pinned fact was invisible on the subgraph, so
+  cross-client pin awareness was broken (other clients couldn't see
+  the pin and the Tier-1 reranker's pin-aware ranking never fired).
+  2.2.2 ports `skill/plugin/pin.ts::executePinOperation`:
+  - `claims_helper.py::build_canonical_claim_v1` gains a
+    `pin_status` parameter (validated against
+    `VALID_PIN_STATUSES = ("pinned", "unpinned")`).
+  - `operations.py::_change_claim_status` now always emits a fresh
+    v1.1 blob (long-form `text`/`type`/`pin_status`/`superseded_by`)
+    regardless of whether the source fact was v0 short-key or v1.
+    New `FactPayload.version` is set to `PROTOBUF_VERSION_V4` so the
+    outer protobuf tags the write as v1 taxonomy. Tombstone stays at
+    v=3 (matches plugin behavior).
+  - New `_project_source_to_v1` helper mirrors the plugin's
+    `projectToV1` function-for-function — v0 sources upgrade on the
+    fly (short-key `c` → v1 `type`, `sa` heuristics → v1 `source`).
+
+### Tests
+
+- `tests/test_wave2a_hermes_fixes.py`: 19 new tests — 7 Bug #4, 7 Bug #7
+  (5 parity + 2 cross-client), 3 Bug #8, 2 cross-client portability.
+- `tests/test_pin_unpin.py`: 2 tests updated to assert on the new v1.1
+  long-form shape (prior assertions encoded the buggy pre-2.2.2
+  short-key contract).
+- Full Python suite: 678 passing, 10 skipped, 1 xfailed — no regressions.
+
+### Known limitations
+
+- The installed `totalreclaw-core==2.1.0` PyPI wheel doesn't round-trip
+  the v1.1 `pin_status` field through `validate_memory_claim_v1` (the
+  Rust struct has it; the serde emit drops it). 2.2.2 reattaches
+  `pin_status` after validation — same pattern as `schema_version` and
+  `volatility` — so the fix ships independently of core. A future
+  `totalreclaw-core` release (2.1.1 on npm already; PyPI pending) will
+  round-trip the field natively and the reattach becomes a no-op.
+
 ## [2.2.1] - 2026-04-19
 
 Wire `auto_extract` to `remember_batch`; realizes the ~8x extraction latency win

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "totalreclaw"
-version = "2.2.1"
+version = "2.2.2"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"

--- a/python/src/totalreclaw/agent/llm_client.py
+++ b/python/src/totalreclaw/agent/llm_client.py
@@ -1,9 +1,13 @@
 """
 LLM client for TotalReclaw fact extraction.
 
-Auto-detects the user's LLM provider from environment variables.
-Supports OpenAI-compatible APIs and Anthropic Messages API.
-Uses a cheap/fast model for extraction to minimize cost.
+Auto-detects the user's LLM provider from environment variables
+AND — since 2.2.2 — from ``~/.hermes/config.yaml`` + ``~/.hermes/.env``
+so Hermes plugin users don't have to duplicate their model choice as
+an ``OPENAI_MODEL`` env var (Bug #4, QA 2026-04-20).
+
+Supports OpenAI-compatible APIs and Anthropic Messages API. Uses a
+cheap/fast model for extraction to minimize cost.
 
 This module is framework-agnostic and can be used by any Python agent
 integration (Hermes, LangChain, CrewAI, or custom agents).
@@ -15,6 +19,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
 
 import httpx
@@ -49,15 +54,212 @@ PROVIDERS = [
 ]
 
 
+# Map Hermes provider names to (API key candidates, default base URL).
+# Kept aligned with ``PROVIDERS`` above — if you add a provider there,
+# add it here too.
+_HERMES_PROVIDER_KEY_MAP = {
+    "zai": (["ZAI_API_KEY", "GLM_API_KEY", "Z_AI_API_KEY"], "https://api.z.ai/api/coding/paas/v4"),
+    "openai": (["OPENAI_API_KEY"], "https://api.openai.com/v1"),
+    "anthropic": (["ANTHROPIC_API_KEY"], "https://api.anthropic.com/v1"),
+    "openrouter": (["OPENROUTER_API_KEY"], "https://openrouter.ai/api/v1"),
+    "groq": (["GROQ_API_KEY"], "https://api.groq.com/openai/v1"),
+    "deepseek": (["DEEPSEEK_API_KEY"], "https://api.deepseek.com/v1"),
+    "mistral": (["MISTRAL_API_KEY"], "https://api.mistral.ai/v1"),
+    "gemini": (["GEMINI_API_KEY", "GOOGLE_API_KEY"], "https://generativelanguage.googleapis.com/v1beta/openai"),
+    "xai": (["XAI_API_KEY"], "https://api.x.ai/v1"),
+    "together": (["TOGETHER_API_KEY"], "https://api.together.xyz/v1"),
+}
+
+
+def _candidate_hermes_config_paths() -> list[Path]:
+    """Return the ordered candidate paths for the Hermes config file.
+
+    ``$HERMES_CONFIG`` (full file path) wins, then the XDG location,
+    then the legacy ``~/.hermes/`` dir. We return all that exist and
+    let the caller try each in order — the first parseable one with a
+    model + provider wins.
+    """
+    paths: list[Path] = []
+    env_override = os.environ.get("HERMES_CONFIG")
+    if env_override:
+        paths.append(Path(env_override).expanduser())
+
+    xdg_home = os.environ.get("XDG_CONFIG_HOME")
+    if xdg_home:
+        paths.append(Path(xdg_home).expanduser() / "hermes" / "config.yaml")
+    paths.append(Path.home() / ".config" / "hermes" / "config.yaml")
+    paths.append(Path.home() / ".hermes" / "config.yaml")
+    return paths
+
+
+def _read_hermes_env_file(env_path: Path) -> dict[str, str]:
+    """Parse a ``~/.hermes/.env`` style file into a dict.
+
+    Minimal KEY=VALUE parser — does not handle quoting or multi-line
+    values. Good enough for the Hermes-shaped ``.env`` file.
+    """
+    env_vars: dict[str, str] = {}
+    if not env_path.exists():
+        return env_vars
+    try:
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            # Strip surrounding quotes if present.
+            v = v.strip()
+            if (v.startswith('"') and v.endswith('"')) or (v.startswith("'") and v.endswith("'")):
+                v = v[1:-1]
+            env_vars[k.strip()] = v
+    except OSError:
+        return {}
+    return env_vars
+
+
+def _extract_provider_and_model(cfg: dict) -> tuple[str, str]:
+    """Accept BOTH top-level and nested shapes.
+
+    Hermes writes ``provider: zai`` + ``model: glm-5-turbo`` as top-level
+    keys in ``~/.hermes/config.yaml``. Prior to 2.2.2 this helper only
+    read the nested ``model: { provider, model }`` shape, so every Hermes
+    user had to keep an ``OPENAI_MODEL`` env var around — see the QA
+    report at ``docs/notes/QA-hermes-RC-2.2.1-20260420.md`` Finding #4.
+    Accepting both shapes lets users configure it once in ``config.yaml``.
+    """
+    # Try top-level first (the actual Hermes shape).
+    provider = cfg.get("provider") if isinstance(cfg.get("provider"), str) else ""
+    model = cfg.get("model") if isinstance(cfg.get("model"), str) else ""
+    if provider and model:
+        return provider, model
+
+    # Fall back to nested ``model: { provider, model }`` (defensive —
+    # future-proofs against Hermes reorganizing its schema).
+    model_cfg = cfg.get("model") if isinstance(cfg.get("model"), dict) else {}
+    provider_nested = model_cfg.get("provider", "") if isinstance(model_cfg.get("provider"), str) else ""
+    model_nested = model_cfg.get("model", "") if isinstance(model_cfg.get("model"), str) else ""
+    if provider_nested and model_nested:
+        return provider_nested, model_nested
+
+    return "", ""
+
+
+def read_hermes_llm_config() -> Optional[LLMConfig]:
+    """Read the LLM provider config from Hermes's own config files.
+
+    Hermes stores its config in ``~/.hermes/config.yaml`` (provider +
+    model) and ``~/.hermes/.env`` (API keys). This reads both to build an
+    LLM config that matches what Hermes itself uses — no separate env
+    vars needed.
+
+    Resolution order:
+      1. ``$HERMES_CONFIG`` (full file path)
+      2. ``$XDG_CONFIG_HOME/hermes/config.yaml``
+      3. ``~/.config/hermes/config.yaml``
+      4. ``~/.hermes/config.yaml`` (legacy)
+
+    Accepts the YAML shape BOTH as top-level
+    ``{provider: zai, model: glm-5-turbo}`` AND nested
+    ``{model: {provider: zai, model: glm-5-turbo}}``.
+
+    Returns ``None`` if no config is found, if it can't be parsed, or
+    if the required provider/model fields are missing. Logs a WARNING
+    at the resolution point so operators can tell WHERE the model came
+    from (or why it failed).
+    """
+    try:
+        import yaml
+    except ImportError:
+        # PyYAML is a dep via setuptools; if it's not installed we simply
+        # cannot read YAML. Don't blow up — just skip Hermes detection.
+        logger.debug("read_hermes_llm_config: PyYAML not installed; skipping")
+        return None
+
+    for config_path in _candidate_hermes_config_paths():
+        if not config_path.exists():
+            continue
+
+        try:
+            with open(config_path) as f:
+                cfg = yaml.safe_load(f) or {}
+        except (yaml.YAMLError, OSError) as e:
+            logger.debug(
+                "read_hermes_llm_config: %s unparseable (%s); trying next candidate",
+                config_path, e,
+            )
+            continue
+
+        if not isinstance(cfg, dict):
+            continue
+
+        provider, model = _extract_provider_and_model(cfg)
+        if not provider or not model:
+            logger.debug(
+                "read_hermes_llm_config: %s missing provider/model keys",
+                config_path,
+            )
+            continue
+
+        provider_lower = provider.lower()
+        key_names, default_base_url = _HERMES_PROVIDER_KEY_MAP.get(provider_lower, ([], ""))
+        if not key_names:
+            logger.debug(
+                "read_hermes_llm_config: unknown provider %r in %s",
+                provider, config_path,
+            )
+            continue
+
+        # Read adjacent .env for API keys. Candidate .env paths live in
+        # the same directory as the config (so ~/.hermes/.env pairs
+        # with ~/.hermes/config.yaml, etc.).
+        env_vars = _read_hermes_env_file(config_path.parent / ".env")
+
+        api_key: Optional[str] = None
+        for kn in key_names:
+            api_key = env_vars.get(kn) or os.environ.get(kn)
+            if api_key:
+                break
+
+        if not api_key:
+            logger.debug(
+                "read_hermes_llm_config: no API key found for provider %r "
+                "in %s or env (tried %s)",
+                provider, config_path.parent / ".env", ", ".join(key_names),
+            )
+            continue
+
+        base_url = (
+            env_vars.get("GLM_BASE_URL")
+            or env_vars.get("OPENAI_BASE_URL")
+            or os.environ.get("OPENAI_BASE_URL")
+            or default_base_url
+        )
+        api_format = "anthropic" if provider_lower == "anthropic" else "openai"
+
+        logger.info(
+            "TotalReclaw LLM config resolved from Hermes config: %s (provider=%s, model=%s)",
+            config_path, provider, model,
+        )
+        return LLMConfig(api_key=api_key, base_url=base_url, model=model, api_format=api_format)
+
+    return None
+
+
 def detect_llm_config(configured_model: Optional[str] = None) -> Optional[LLMConfig]:
-    """Auto-detect LLM provider and model from environment variables.
+    """Auto-detect LLM provider and model from environment variables
+    and (for Hermes users) from ``~/.hermes/config.yaml`` + ``.env``.
 
     Uses the agent's configured model by default. No hardcoded model lists
     to maintain — just uses whatever the user set up.
 
-    Model priority:
-      1. configured_model (passed from agent framework)
-      2. OPENAI_MODEL / ANTHROPIC_MODEL / LLM_MODEL (generic env vars)
+    Resolution order (first hit wins):
+      1. ``configured_model`` + env-var API key (e.g. plugin-passed model).
+      2. ``OPENAI_MODEL`` / ``ANTHROPIC_MODEL`` / ``LLM_MODEL`` env vars
+         paired with any matching provider API key.
+      3. ``~/.hermes/config.yaml`` + ``~/.hermes/.env`` (Bug #4 fix —
+         Hermes users don't need to duplicate the model as an env var).
 
     The ``TOTALRECLAW_EXTRACTION_MODEL`` / ``TOTALRECLAW_LLM_MODEL`` overrides
     were removed in the v1 env cleanup — agent-framework config is now the
@@ -81,9 +283,14 @@ def detect_llm_config(configured_model: Optional[str] = None) -> Optional[LLMCon
             if api_key:
                 model = configured_model or env_model
                 if not model:
-                    logger.warning(
-                        "TotalReclaw: %s API key found but no model configured. "
-                        "Set OPENAI_MODEL or configure the model via your agent framework.",
+                    # No model configured via env — skip this provider so
+                    # we fall through to the Hermes-config fallback below.
+                    # Previously logged a WARNING per provider, which was
+                    # noisy when the user had keys for several providers
+                    # but hadn't set OPENAI_MODEL. Debug-log instead.
+                    logger.debug(
+                        "detect_llm_config: %s API key found but no model "
+                        "configured via env; continuing",
                         _provider,
                     )
                     continue
@@ -94,12 +301,27 @@ def detect_llm_config(configured_model: Optional[str] = None) -> Optional[LLMCon
                 else:
                     resolved_base_url = default_base_url
 
+                logger.info(
+                    "TotalReclaw LLM config resolved from env vars "
+                    "(provider=%s, model=%s)",
+                    _provider, model,
+                )
                 return LLMConfig(
                     api_key=api_key,
                     base_url=resolved_base_url,
                     model=model,
                     api_format=api_format,
                 )
+
+    # Last resort: try the Hermes config.yaml + .env pair. This is the
+    # path that was broken until 2.2.2 — Hermes users with a valid
+    # config.yaml but no OPENAI_MODEL env var ended up here with None
+    # and saw silent extraction failures (QA Finding #4, 2026-04-20).
+    hermes_config = read_hermes_llm_config()
+    if hermes_config is not None:
+        return hermes_config
+
+    logger.debug("detect_llm_config: no LLM config resolved from env or Hermes")
     return None
 
 

--- a/python/src/totalreclaw/agent/state.py
+++ b/python/src/totalreclaw/agent/state.py
@@ -65,6 +65,40 @@ def _warn_removed_env_vars_once() -> None:
 _warn_removed_env_vars_once()
 
 
+# ---------------------------------------------------------------------------
+# Bug #7 (Wave 2a, 2026-04-20) — credentials.json key parity.
+#
+# Plugin 3.2.0 writes ``{"mnemonic": "..."}`` at
+# ``~/.totalreclaw/credentials.json``. Python pre-2.2.2 wrote
+# ``{"recovery_phrase": "..."}``. Both claim to use the same canonical
+# path — so a Hermes user couldn't open OpenClaw with the same vault,
+# and vice versa. We now accept BOTH keys on read and emit the canonical
+# ``mnemonic`` key on write (matching plugin + MCP). See
+# ``docs/specs/totalreclaw/flows/01-identity-setup.md`` for the schema
+# addendum.
+# ---------------------------------------------------------------------------
+
+
+def _extract_mnemonic_from_creds(creds: dict) -> str:
+    """Pull a plausible mnemonic out of a parsed credentials.json blob.
+
+    Accepts both ``mnemonic`` (canonical, plugin 3.2.0 + Python 2.2.2+)
+    and ``recovery_phrase`` (legacy Python) spellings. When both are
+    present, ``mnemonic`` wins — matches the plugin-side
+    ``extractBootstrapMnemonic`` in ``skill/plugin/fs-helpers.ts``.
+
+    Returns an empty string if neither key carries a non-empty string.
+    Never raises — defensive for partial file writes.
+    """
+    primary = creds.get("mnemonic") if isinstance(creds.get("mnemonic"), str) else ""
+    primary = primary.strip() if primary else ""
+    if primary:
+        return primary
+    alias = creds.get("recovery_phrase") if isinstance(creds.get("recovery_phrase"), str) else ""
+    alias = alias.strip() if alias else ""
+    return alias
+
+
 class AgentState:
     """Manages TotalReclaw client lifecycle, turn tracking, and message buffer.
 
@@ -126,26 +160,47 @@ class AgentState:
         self._env_importance_override = importance_env is not None
 
     def _try_auto_configure(self) -> None:
-        """Try to configure from env vars or config file."""
+        """Try to configure from env vars or config file.
+
+        Accepts the credentials.json blob keyed as EITHER ``mnemonic``
+        (canonical as of plugin 3.2.0 + Python 2.2.2) OR
+        ``recovery_phrase`` (legacy Python) — Bug #7, QA 2026-04-20.
+        Preference order on read: ``mnemonic`` wins when both are
+        present so plugin-native files are authoritative.
+        """
         # Check env var
         mnemonic = os.environ.get("TOTALRECLAW_RECOVERY_PHRASE", "")
         if mnemonic:
             self.configure(mnemonic)
             return
 
-        # Check credentials file
+        # Check credentials file — accept both canonical ``mnemonic`` and
+        # legacy ``recovery_phrase`` spellings.
         creds_path = Path.home() / ".totalreclaw" / "credentials.json"
         if creds_path.exists():
             try:
                 creds = json.loads(creds_path.read_text())
-                mnemonic = creds.get("recovery_phrase", "")
-                if mnemonic:
-                    self.configure(mnemonic)
             except Exception:
-                pass
+                return
+            if not isinstance(creds, dict):
+                return
+            mnemonic = _extract_mnemonic_from_creds(creds)
+            if mnemonic:
+                self.configure(mnemonic)
 
     def configure(self, mnemonic: str) -> None:
-        """Configure the TotalReclaw client with a mnemonic."""
+        """Configure the TotalReclaw client with a mnemonic.
+
+        Write policy (Bug #7 / Wave 2a):
+          * If the credentials file already exists with ONLY the legacy
+            ``recovery_phrase`` key, leave the legacy format in place —
+            don't silently migrate on touch. The user may have external
+            tooling reading that key. A full migration happens when the
+            user re-onboards (explicit ``totalreclaw_setup`` call).
+          * Otherwise (file missing, or already has ``mnemonic``), emit
+            the canonical ``{"mnemonic": ...}`` shape. Matches what
+            plugin 3.2.0 writes, giving cross-client portability.
+        """
         from totalreclaw.client import TotalReclaw
 
         relay_url = (
@@ -154,11 +209,32 @@ class AgentState:
         )
         self._client = TotalReclaw(mnemonic=mnemonic, relay_url=relay_url)
 
-        # Save credentials
+        # Save credentials — preserve legacy shape when present, write
+        # canonical shape otherwise.
         creds_path = Path.home() / ".totalreclaw" / "credentials.json"
         creds_path.parent.mkdir(parents=True, exist_ok=True)
-        creds_path.write_text(json.dumps({"recovery_phrase": mnemonic}))
-        creds_path.chmod(0o600)
+
+        should_preserve_legacy = False
+        if creds_path.exists():
+            try:
+                existing = json.loads(creds_path.read_text())
+                if (
+                    isinstance(existing, dict)
+                    and "mnemonic" not in existing
+                    and isinstance(existing.get("recovery_phrase"), str)
+                    and existing.get("recovery_phrase", "").strip() == mnemonic.strip()
+                ):
+                    should_preserve_legacy = True
+            except Exception:
+                pass
+
+        if should_preserve_legacy:
+            # Leave the file untouched. Same mnemonic, same content —
+            # no reason to rewrite and risk a partial update.
+            pass
+        else:
+            creds_path.write_text(json.dumps({"mnemonic": mnemonic}))
+            creds_path.chmod(0o600)
 
         # Do NOT read `self._client.wallet_address` here — it raises until
         # `resolve_address()` has run, and `configure()` is synchronous. The

--- a/python/src/totalreclaw/claims_helper.py
+++ b/python/src/totalreclaw/claims_helper.py
@@ -152,6 +152,12 @@ def _now_iso() -> str:
     return now.strftime("%Y-%m-%dT%H:%M:%S.") + f"{now.microsecond // 1000:03d}Z"
 
 
+#: Valid values for the v1.1 ``pin_status`` additive field. Kept here rather
+#: than in ``agent/extraction`` because it is a write-path concern, not a
+#: taxonomy concern — ``pin_status`` is user-controlled state, not provenance.
+VALID_PIN_STATUSES: tuple[str, ...] = ("pinned", "unpinned")
+
+
 def build_canonical_claim_v1(
     fact: Any,
     importance: int,
@@ -159,6 +165,7 @@ def build_canonical_claim_v1(
     superseded_by: Optional[str] = None,
     expires_at: Optional[str] = None,
     claim_id: Optional[str] = None,
+    pin_status: Optional[str] = None,
 ) -> str:
     """Build a v1 ``MemoryClaimV1`` JSON blob.
 
@@ -177,11 +184,22 @@ def build_canonical_claim_v1(
     The outer protobuf wrapper's ``version`` field must be set to
     :data:`PROTOBUF_VERSION_V4` (4) when storing the returned payload.
 
+    Parameters
+    ----------
+    pin_status : {"pinned", "unpinned"}, optional
+        The v1.1 additive ``pin_status`` field. Used exclusively on the
+        pin/unpin write path — ``"pinned"`` marks the claim as
+        user-pinned so auto-resolution won't supersede it; ``"unpinned"``
+        marks an explicit user un-pin. ``None`` omits the field entirely
+        (wire-equivalent to "unpinned" per spec §pin-semantics). Bug #8
+        (Wave 2a, QA 2026-04-20).
+
     Raises
     ------
     ValueError
         If the fact does not have a valid v1 ``source`` set — v1 requires
-        every claim to carry provenance.
+        every claim to carry provenance. Also raised when ``pin_status``
+        is a string outside :data:`VALID_PIN_STATUSES`.
     """
     text = _attr(fact, "text")
     fact_type = normalize_to_v1_type(_attr(fact, "type", "claim"))
@@ -198,6 +216,12 @@ def build_canonical_claim_v1(
         )
     if source not in VALID_MEMORY_SOURCES:
         raise ValueError(f"build_canonical_claim_v1: invalid source {source!r}")
+
+    if pin_status is not None and pin_status not in VALID_PIN_STATUSES:
+        raise ValueError(
+            f"build_canonical_claim_v1: invalid pin_status {pin_status!r}; "
+            f"must be one of {VALID_PIN_STATUSES} or None"
+        )
 
     resolved_id = claim_id or str(uuid.uuid4())
     resolved_created_at = created_at or _now_iso()
@@ -238,6 +262,10 @@ def build_canonical_claim_v1(
         core_payload["expires_at"] = expires_at
     if superseded_by:
         core_payload["superseded_by"] = superseded_by
+    if pin_status is not None:
+        # Additive v1.1 field — absence == "unpinned" on the wire,
+        # so we only emit the field when the caller explicitly sets it.
+        core_payload["pin_status"] = pin_status
 
     # Attach schema_version BEFORE validation — core's v1 struct requires it.
     core_payload["schema_version"] = V1_SCHEMA_VERSION
@@ -253,6 +281,14 @@ def build_canonical_claim_v1(
     canonical["schema_version"] = V1_SCHEMA_VERSION
     if volatility and volatility in VALID_MEMORY_VOLATILITIES:
         canonical["volatility"] = volatility
+    # Bug #8 (Wave 2a): the installed ``totalreclaw_core==2.1.0`` PyPI
+    # wheel doesn't round-trip the v1.1 ``pin_status`` field through
+    # ``validate_memory_claim_v1`` even though the Rust struct has it.
+    # Re-attach it here so the pin/unpin write path emits a readable
+    # pinned claim on-chain. Once core 2.1.1 (with the serde round-trip
+    # fix) is on PyPI, this becomes a no-op but remains safe.
+    if pin_status is not None:
+        canonical["pin_status"] = pin_status
 
     return json.dumps(canonical, ensure_ascii=False, separators=(",", ":"))
 

--- a/python/src/totalreclaw/claims_helper.py
+++ b/python/src/totalreclaw/claims_helper.py
@@ -277,18 +277,23 @@ def build_canonical_claim_v1(
     if not isinstance(canonical, dict):
         raise RuntimeError("validate_memory_claim_v1 did not return an object")
 
+    # Bug #8 (Wave 2a): the installed ``totalreclaw_core==2.1.0`` PyPI
+    # wheel doesn't round-trip the v1.1 ``pin_status`` field through
+    # ``validate_memory_claim_v1`` even though the Rust struct has it.
+    # Re-attach it IMMEDIATELY after validation (before schema_version +
+    # volatility). Order matters for byte-identical cross-impl parity
+    # with the plugin — core 2.1.1 on npm preserves the field in this
+    # position naturally, so inserting it here produces the same JSON
+    # key order as the plugin's output.
+    # Once core 2.1.1 (with the serde round-trip fix) lands on PyPI,
+    # this reattach becomes a no-op but remains safe.
+    if pin_status is not None and "pin_status" not in canonical:
+        canonical["pin_status"] = pin_status
+
     # Re-attach plugin-only extras not round-tripped by core's validator.
     canonical["schema_version"] = V1_SCHEMA_VERSION
     if volatility and volatility in VALID_MEMORY_VOLATILITIES:
         canonical["volatility"] = volatility
-    # Bug #8 (Wave 2a): the installed ``totalreclaw_core==2.1.0`` PyPI
-    # wheel doesn't round-trip the v1.1 ``pin_status`` field through
-    # ``validate_memory_claim_v1`` even though the Rust struct has it.
-    # Re-attach it here so the pin/unpin write path emits a readable
-    # pinned claim on-chain. Once core 2.1.1 (with the serde round-trip
-    # fix) is on PyPI, this becomes a no-op but remains safe.
-    if pin_status is not None:
-        canonical["pin_status"] = pin_status
 
     return json.dumps(canonical, ensure_ascii=False, separators=(",", ":"))
 

--- a/python/src/totalreclaw/hermes/tools.py
+++ b/python/src/totalreclaw/hermes/tools.py
@@ -405,72 +405,17 @@ async def debrief(args: dict, state: "PluginState", **kwargs) -> str:
 
 
 def _read_hermes_llm_config():
-    """Read the LLM provider config from Hermes's own config files.
+    """Back-compat thin wrapper — delegates to the agent-package helper.
 
-    Hermes stores its config in ~/.hermes/config.yaml (provider + model)
-    and ~/.hermes/.env (API keys). This reads both to build an LLM config
-    that matches what Hermes itself uses — no separate env vars needed.
+    Historically lived on the Hermes tools layer; moved to
+    :func:`totalreclaw.agent.llm_client.read_hermes_llm_config` in
+    ``totalreclaw`` 2.2.2 so the generic env-var fallback in
+    :func:`detect_llm_config` can reuse the Hermes YAML + .env resolution
+    without a circular plugin-layer import (Bug #4).
     """
-    import yaml
-    from pathlib import Path
-    from totalreclaw.agent.llm_client import LLMConfig
+    from totalreclaw.agent.llm_client import read_hermes_llm_config
 
-    hermes_dir = Path.home() / ".hermes"
-    config_path = hermes_dir / "config.yaml"
-    env_path = hermes_dir / ".env"
-
-    if not config_path.exists():
-        return None
-
-    # Read config.yaml for provider + model
-    with open(config_path) as f:
-        cfg = yaml.safe_load(f) or {}
-
-    model_cfg = cfg.get("model", {})
-    provider = model_cfg.get("provider", "")
-    model = model_cfg.get("model", "")
-
-    if not provider or not model:
-        return None
-
-    # Read .env for API keys
-    env_vars = {}
-    if env_path.exists():
-        with open(env_path) as f:
-            for line in f:
-                line = line.strip()
-                if not line or line.startswith("#"):
-                    continue
-                if "=" in line:
-                    k, v = line.split("=", 1)
-                    env_vars[k.strip()] = v.strip()
-
-    # Map Hermes provider names to API keys and base URLs
-    provider_key_map = {
-        "zai": (["ZAI_API_KEY", "GLM_API_KEY"], "https://api.z.ai/api/coding/paas/v4"),
-        "openai": (["OPENAI_API_KEY"], "https://api.openai.com/v1"),
-        "anthropic": (["ANTHROPIC_API_KEY"], "https://api.anthropic.com/v1"),
-        "openrouter": (["OPENROUTER_API_KEY"], "https://openrouter.ai/api/v1"),
-        "groq": (["GROQ_API_KEY"], "https://api.groq.com/openai/v1"),
-        "deepseek": (["DEEPSEEK_API_KEY"], "https://api.deepseek.com/v1"),
-        "mistral": (["MISTRAL_API_KEY"], "https://api.mistral.ai/v1"),
-    }
-
-    key_names, default_base_url = provider_key_map.get(provider.lower(), ([], ""))
-    api_key = None
-    for kn in key_names:
-        api_key = env_vars.get(kn) or os.environ.get(kn)
-        if api_key:
-            break
-
-    if not api_key:
-        return None
-
-    # Respect custom base URL from .env
-    base_url = env_vars.get("GLM_BASE_URL") or env_vars.get("OPENAI_BASE_URL") or default_base_url
-    api_format = "anthropic" if provider.lower() == "anthropic" else "openai"
-
-    return LLMConfig(api_key=api_key, base_url=base_url, model=model, api_format=api_format)
+    return read_hermes_llm_config()
 
 
 def _make_extractor(state: "PluginState"):

--- a/python/src/totalreclaw/operations.py
+++ b/python/src/totalreclaw/operations.py
@@ -783,6 +783,171 @@ def _decrypt_and_parse_claim(
     return claim
 
 
+# v0 short-key category → v0 memory-type token. Inverse of
+# ``TYPE_TO_CATEGORY_V0`` in ``claims_helper.py``. Used by the pin/unpin
+# path to upgrade a legacy short-key source blob into a v1 ``type`` field
+# on the fly — mirrors ``skill/plugin/pin.ts::projectToV1``.
+_V0_CATEGORY_TO_V0_TYPE: dict[str, str] = {
+    "fact": "fact",
+    "pref": "preference",
+    "dec": "decision",
+    "epi": "episodic",
+    "goal": "goal",
+    "ctx": "context",
+    "sum": "summary",
+    "rule": "rule",
+    "ent": "fact",   # entity records fall back to "fact" on round-trip
+    "dig": "summary",
+    "claim": "claim",
+}
+
+
+def _project_source_to_v1(
+    source_claim: dict, default_source_agent: str,
+) -> dict:
+    """Project a decrypted claim (v0 short-key OR v1 long-form) into the
+    v1-shape dict needed to drive :func:`build_canonical_claim_v1`.
+
+    Mirrors ``skill/plugin/pin.ts::projectToV1`` function-for-function so
+    a Python-produced pinned blob is byte-equivalent to a plugin-produced
+    pinned blob for the same input fact. The pin path in 2.2.2 always
+    emits a v1.1 blob regardless of what the existing fact's blob shape
+    was; v0 sources are upgraded on the fly per the legacy-mapping table.
+
+    Unknown or missing fields fall back to defensible defaults:
+      * ``source`` → ``"user-inferred"`` (Tier 1 reranker doesn't grant
+        these the "user" trust boost; correct for legacy blobs with no
+        explicit provenance signal)
+      * ``type`` → ``"claim"``
+      * ``importance`` → 5
+      * ``confidence`` → 0.85
+
+    Returns a dict with keys matching the :func:`build_canonical_claim_v1`
+    attribute names.
+    """
+    from .agent.extraction import V0_TO_V1_TYPE, VALID_MEMORY_TYPES
+
+    # v1 source: schema_version "1.x" + long-form fields.
+    schema_version = source_claim.get("schema_version")
+    if (
+        isinstance(source_claim.get("text"), str)
+        and isinstance(source_claim.get("type"), str)
+        and isinstance(schema_version, str)
+        and schema_version.startswith("1.")
+    ):
+        v1_type = source_claim["type"]
+        if v1_type not in VALID_MEMORY_TYPES:
+            v1_type = "claim"
+        imp_raw = source_claim.get("importance")
+        try:
+            importance = int(imp_raw) if isinstance(imp_raw, (int, float)) else 5
+        except (ValueError, TypeError):
+            importance = 5
+        importance = max(1, min(10, importance))
+        conf_raw = source_claim.get("confidence")
+        try:
+            confidence = float(conf_raw) if isinstance(conf_raw, (int, float)) else 0.85
+        except (ValueError, TypeError):
+            confidence = 0.85
+        raw_source = source_claim.get("source")
+        v1_source = raw_source if isinstance(raw_source, str) and raw_source else "user-inferred"
+        raw_scope = source_claim.get("scope")
+        v1_scope = raw_scope if isinstance(raw_scope, str) and raw_scope else None
+        raw_volatility = source_claim.get("volatility")
+        v1_volatility = raw_volatility if isinstance(raw_volatility, str) and raw_volatility else None
+        raw_reasoning = source_claim.get("reasoning")
+        v1_reasoning = raw_reasoning if isinstance(raw_reasoning, str) and raw_reasoning else None
+        v1_entities = source_claim.get("entities") if isinstance(source_claim.get("entities"), list) else None
+        return {
+            "text": source_claim["text"],
+            "type": v1_type,
+            "source": v1_source,
+            "scope": v1_scope,
+            "volatility": v1_volatility,
+            "reasoning": v1_reasoning,
+            "entities": v1_entities,
+            "importance": importance,
+            "confidence": confidence,
+        }
+
+    # v0 short-key source: {t, c, cf, i, sa, ea, ...} → upgrade to v1.
+    text = source_claim.get("t") if isinstance(source_claim.get("t"), str) else ""
+    v0_category = source_claim.get("c") if isinstance(source_claim.get("c"), str) else "fact"
+    v0_type_token = _V0_CATEGORY_TO_V0_TYPE.get(v0_category, "fact")
+    v1_type = V0_TO_V1_TYPE.get(v0_type_token, "claim")
+    imp_raw = source_claim.get("i")
+    try:
+        importance = int(imp_raw) if isinstance(imp_raw, (int, float)) else 5
+    except (ValueError, TypeError):
+        importance = 5
+    importance = max(1, min(10, importance))
+    cf_raw = source_claim.get("cf")
+    try:
+        confidence = float(cf_raw) if isinstance(cf_raw, (int, float)) else 0.85
+    except (ValueError, TypeError):
+        confidence = 0.85
+
+    # v0 `sa` was "source agent" (e.g. "openclaw-plugin"), not v1 provenance.
+    # Heuristic upgrade — matches ``projectToV1`` in the TS plugin.
+    sa = source_claim.get("sa") if isinstance(source_claim.get("sa"), str) else default_source_agent
+    sa_lower = sa.lower() if isinstance(sa, str) else ""
+    if "derived" in sa_lower or "digest" in sa_lower or "consolidat" in sa_lower:
+        v1_source = "derived"
+    elif "assistant" in sa_lower:
+        v1_source = "assistant"
+    elif "extern" in sa_lower or "mem0" in sa_lower or "import" in sa_lower:
+        v1_source = "external"
+    else:
+        v1_source = "user-inferred"
+
+    # v0 entities → v1 entity shape (short keys n/tp/r → long name/type/role).
+    raw_entities = source_claim.get("e") if isinstance(source_claim.get("e"), list) else []
+    v1_entities: list[dict] = []
+    for e in raw_entities:
+        if not isinstance(e, dict):
+            continue
+        name = e.get("n") if isinstance(e.get("n"), str) else ""
+        ent_type = e.get("tp") if isinstance(e.get("tp"), str) else "concept"
+        if not name:
+            continue
+        entity: dict = {"name": name, "type": ent_type}
+        role = e.get("r") if isinstance(e.get("r"), str) else None
+        if role:
+            entity["role"] = role
+        v1_entities.append(entity)
+
+    return {
+        "text": text,
+        "type": v1_type,
+        "source": v1_source,
+        "scope": None,
+        "volatility": None,
+        "reasoning": None,
+        "entities": v1_entities or None,
+        "importance": importance,
+        "confidence": confidence,
+    }
+
+
+class _ProjectedFact:
+    """Lightweight attribute-carrier used to feed ``build_canonical_claim_v1``.
+
+    That builder accepts either dicts or attribute-based objects (see
+    ``claims_helper._attr``). Keeping this as a tiny local class avoids
+    having to hand-craft a dict with every taxonomy field the builder
+    reads — the builder silently falls back on missing attributes.
+    """
+
+    __slots__ = (
+        "text", "type", "importance", "confidence", "source",
+        "scope", "reasoning", "entities", "volatility",
+    )
+
+    def __init__(self, **kwargs):
+        for k in self.__slots__:
+            setattr(self, k, kwargs.get(k))
+
+
 async def _change_claim_status(
     fact_id: str,
     target_status: str,
@@ -797,24 +962,32 @@ async def _change_claim_status(
 ) -> dict:
     """Shared implementation for ``pin_fact`` / ``unpin_fact``.
 
-    Semantics (Phase 2 Slice 2e-python — mirrors the MCP slice-2e tool at
-    ``mcp/src/tools/pin.ts``):
+    Semantics (Wave 2a, 2026-04-20 — see also Bug #8 in
+    ``docs/notes/QA-hermes-RC-2.2.1-20260420.md``):
 
     1. Fetch the existing fact by id via the subgraph.
-    2. Decrypt + parse as a canonical Claim.
-    3. If ``claim["st"]`` already matches ``target_status`` — return a
-       ``{idempotent: True}`` result with no on-chain write.
-    4. Otherwise, clone the claim, mutate ``st`` (omitting it when the
-       target is the default ``"a"`` so the canonical serializer drops
-       it), set ``sup`` to the previous fact id, refresh ``ea``, and
-       re-canonicalize via ``totalreclaw_core.canonicalize_claim``.
-    5. Encrypt, build a new ``FactPayload`` with a fresh UUID. Blind
-       indices on the new fact are intentionally **empty** — retrieval
-       follows the supersession chain from the old fact's search hits.
-       Re-indexing is deferred to a later slice (matches MCP).
-    6. Tombstone the old fact and submit the new fact as two sequential
-       UserOps. (Matches MCP's batch, but Python's ``build_and_send_userop``
-       doesn't currently expose a multi-call shim, so we do two calls.)
+    2. Decrypt + parse. Detect whether the source blob is v1 (long-form
+       fields + ``schema_version``) or v0 (short-key).
+    3. Idempotency guard — if the parsed status already matches
+       ``target_status``, return a no-op result with no on-chain write.
+       For v1 sources the status comes from ``pin_status``; for v0
+       sources it comes from the short-key ``st`` sentinel.
+    4. **New in 2.2.2** — project the source blob into v1 shape via
+       :func:`_project_source_to_v1` (upgrading v0 → v1 on the fly when
+       necessary), then build a fresh v1.1 ``MemoryClaimV1`` JSON blob
+       with ``pin_status`` set ("pinned" for pin; "unpinned" for
+       explicit unpin), ``superseded_by`` pointing at the old fact id,
+       and a fresh claim id. Matches ``skill/plugin/pin.ts`` byte-for-byte.
+    5. Encrypt the new blob and build a ``FactPayload`` carrying it,
+       with ``version=PROTOBUF_VERSION_V4`` so the outer protobuf wrapper
+       tags the write as v1 taxonomy.
+    6. Submit tombstone (at default v=3; matches plugin behavior) + new
+       fact (at v=4) as two sequential UserOps.
+
+    Prior to 2.2.2 this helper emitted a short-key blob at the default
+    protobuf v=3 for the new fact, which violated the v1 on-chain
+    contract: the subgraph showed a v=3 tombstone with no companion v=4
+    pinned claim. That was the QA Finding #8 ship-stopper.
 
     Returns ``{success, fact_id, new_fact_id, previous_status, new_status}``
     plus ``idempotent: True`` on no-op.
@@ -822,7 +995,9 @@ async def _change_claim_status(
     Parameters
     ----------
     target_status : {"p", "a"}
-        Compact short-key for the target ``ClaimStatus``.
+        Compact short-key for the target ``ClaimStatus``. ``"p"`` means
+        pin (emit ``pin_status: "pinned"``); ``"a"`` means unpin (emit
+        ``pin_status: "unpinned"`` on the new v1 blob).
     """
     if not isinstance(fact_id, str) or not fact_id.strip():
         raise ValueError("fact_id must be a non-empty string")
@@ -842,10 +1017,54 @@ async def _change_claim_status(
     if not fact:
         raise ValueError(f"fact {fact_id} not found")
 
-    # 2. Decrypt + parse
-    claim = _decrypt_and_parse_claim(fact, keys)
-    current_short = claim.get("st")  # may be None for default Active
-    current_long = _status_long_name(current_short)
+    # 2. Decrypt + parse. We need the raw decrypted blob (not the
+    # normalized-to-short-key output of ``_decrypt_and_parse_claim``) so
+    # v1 sources can round-trip their long-form fields into the new v1
+    # blob. Parse twice on the v0 path: once to get the short-key dict
+    # for idempotency + projection, once through the raw plaintext so
+    # v1 blobs preserve their long-form metadata.
+    encrypted_hex_src = fact.get("encryptedBlob", "") or ""
+    if encrypted_hex_src.startswith("0x"):
+        encrypted_hex_src = encrypted_hex_src[2:]
+    if not encrypted_hex_src:
+        raise ValueError("fact has empty encryptedBlob")
+    encrypted_b64_src = base64.b64encode(bytes.fromhex(encrypted_hex_src)).decode("ascii")
+    try:
+        decrypted_plaintext = decrypt(encrypted_b64_src, keys.encryption_key)
+    except Exception as e:
+        raise ValueError(f"failed to decrypt fact blob: {e}") from e
+
+    # Try to parse the raw plaintext. v1 blobs come out as long-form
+    # dicts with schema_version; v0 blobs come out as short-key dicts.
+    try:
+        raw_claim_obj = _json.loads(decrypted_plaintext)
+    except (ValueError, TypeError):
+        raw_claim_obj = None
+
+    is_v1_source = (
+        isinstance(raw_claim_obj, dict)
+        and isinstance(raw_claim_obj.get("text"), str)
+        and isinstance(raw_claim_obj.get("type"), str)
+        and isinstance(raw_claim_obj.get("schema_version"), str)
+        and raw_claim_obj["schema_version"].startswith("1.")
+    )
+
+    # Derive ``current_status`` + short-key projection for idempotency.
+    if is_v1_source:
+        source_claim_for_projection = raw_claim_obj
+        current_pin_status = raw_claim_obj.get("pin_status")
+        if current_pin_status == "pinned":
+            current_short = "p"
+            current_long = "pinned"
+        else:
+            current_short = None
+            current_long = "active"
+    else:
+        # v0 short-key path — delegate to the existing normalizer so
+        # legacy {text, metadata} blobs coerce into {t, c, ...}.
+        source_claim_for_projection = _decrypt_and_parse_claim(fact, keys)
+        current_short = source_claim_for_projection.get("st")
+        current_long = _status_long_name(current_short)
 
     # 3. Idempotency guard
     current_is_target = (
@@ -861,41 +1080,48 @@ async def _change_claim_status(
             "idempotent": True,
         }
 
-    # 4. Build the new canonical claim
-    new_claim = dict(claim)  # shallow clone
-    if target_status == "a":
-        # Active is the canonical default — omit the short key so the
-        # serializer produces exactly the same bytes as an "untouched" claim.
-        new_claim.pop("st", None)
-    else:
-        new_claim["st"] = target_status
-    new_claim["sup"] = fact_id
-    # Refresh the extraction timestamp so downstream consumers can tell
-    # this is a new event (matches MCP pin.ts behavior).
-    new_claim["ea"] = datetime.now(timezone.utc).strftime(
-        "%Y-%m-%dT%H:%M:%S.000Z"
+    # 4. Build the new v1.1 canonical claim. ALWAYS v1 on the pin path —
+    # matches ``skill/plugin/pin.ts::executePinOperation`` step 4.
+    v1_view = _project_source_to_v1(
+        source_claim_for_projection,
+        default_source_agent="python-client",
     )
-
-    new_blob_plaintext = _core.canonicalize_claim(
-        _json.dumps(new_claim, ensure_ascii=False, separators=(",", ":"))
-    )
-
-    # 5. Encrypt + build FactPayload
-    encrypted_blob = encrypt(new_blob_plaintext, keys.encryption_key)
-    encrypted_hex = base64.b64decode(encrypted_blob).hex()
 
     new_fact_id = str(uuid.uuid4())
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    pin_status_wire = "pinned" if target_status == "p" else "unpinned"
+
+    projected_fact = _ProjectedFact(
+        text=v1_view["text"],
+        type=v1_view["type"],
+        importance=v1_view["importance"],
+        confidence=v1_view["confidence"],
+        source=v1_view["source"],
+        scope=v1_view["scope"],
+        reasoning=v1_view["reasoning"],
+        entities=v1_view["entities"],
+        volatility=v1_view["volatility"],
+    )
+
+    new_blob_plaintext = build_canonical_claim_v1(
+        projected_fact,
+        importance=v1_view["importance"],
+        created_at=timestamp,
+        superseded_by=fact_id,
+        claim_id=new_fact_id,
+        pin_status=pin_status_wire,
+    )
+
+    # 5. Encrypt + build FactPayload at protobuf v=4.
+    encrypted_blob = encrypt(new_blob_plaintext, keys.encryption_key)
+    encrypted_hex = base64.b64decode(encrypted_blob).hex()
+
     source_tag = "python_pin" if target_status == "p" else "python_unpin"
 
-    # Regenerate trapdoors for the new pinned fact so trapdoor-based recall
-    # still surfaces it after the old fact is tombstoned.
-    new_claim_text = claim.get("t") if isinstance(claim.get("t"), str) else ""
-    new_entities_raw = claim.get("e") if isinstance(claim.get("e"), list) else []
-    new_entity_objs: list = []
-    for e in new_entities_raw:
-        if isinstance(e, dict) and isinstance(e.get("n"), str):
-            new_entity_objs.append({"name": e["n"], "type": e.get("tp", "concept")})
+    # Regenerate trapdoors for the new pinned fact so trapdoor-based
+    # recall still surfaces it after the old fact is tombstoned.
+    new_claim_text = v1_view["text"]
+    new_entity_objs = v1_view["entities"] or []
 
     new_word_indices: list[str] = generate_blind_indices(new_claim_text) if new_claim_text else []
     new_lsh_indices: list[str] = []
@@ -925,6 +1151,12 @@ async def _change_claim_status(
         content_fp="",
         agent_id="python-client",
         encrypted_embedding=new_encrypted_emb,
+        # Bug #8 (Wave 2a): the new v1.1 blob MUST ride a v=4 outer
+        # protobuf. Pre-2.2.2 this fell through to DEFAULT_PROTOBUF_VERSION
+        # (v=3), leaving the on-chain fact with an inner v0 short-key
+        # blob and a v=3 wrapper — unreadable by decoders that gate on
+        # the v=4 flag.
+        version=PROTOBUF_VERSION_V4,
     )
 
     # 5b. Slice 2f: if this pin/unpin overrides a prior auto-resolution,
@@ -941,8 +1173,9 @@ async def _change_claim_status(
         # Feedback wiring is best-effort — never block the pin operation.
         pass
 
-    # 6. Tombstone old, then write new. Order matters: if the new write
-    # fails after a successful tombstone, the caller will see the fact as
+    # 6. Tombstone old (at v=3, legacy; matches plugin ``pin.ts``), then
+    # write new fact (at v=4). Order matters: if the new write fails
+    # after a successful tombstone, the caller will see the fact as
     # deleted — acceptable trade-off vs. duplicating the fact live then
     # tombstoning (which would surface both in recall on failure).
     tombstone_bytes = encode_tombstone_protobuf(fact_id, owner)

--- a/python/tests/test_pin_unpin.py
+++ b/python/tests/test_pin_unpin.py
@@ -213,8 +213,15 @@ class TestPinFact:
     @pytest.mark.asyncio
     @patch("totalreclaw.operations.build_and_send_userop", new_callable=AsyncMock)
     async def test_pin_new_blob_parses_back_as_pinned(self, mock_send, keys):
-        """Capture the ciphertext passed to the second UserOp call, decrypt, and
-        verify the canonical claim has st='p' and sup=<old_fact_id>."""
+        """Capture the ciphertext of the new fact (second UserOp), decrypt,
+        and verify the canonical claim is a v1.1 MemoryClaimV1 JSON with
+        ``pin_status: "pinned"`` and ``superseded_by: <old_fact_id>``.
+
+        Wave 2a (Bug #8, 2026-04-20) flipped the write path from v0
+        short-key blobs (``t``, ``c``, ``st``) to v1.1 long-form
+        (``text``, ``type``, ``pin_status``) so Python-pinned facts are
+        indistinguishable from plugin-pinned facts on the subgraph.
+        """
         mock_send.return_value = "0xabc"
         relay = _build_relay_mock(
             keys, fact_id="old-fact-id", text="Sarah loves Django", status=None
@@ -242,25 +249,23 @@ class TestPinFact:
         assert len(captured_payloads) == 2
         new_payload = captured_payloads[1]
 
-        # Pull out field 4 (encrypted_blob) by scanning for the tag (0x22 = field 4, wire 2).
-        # The simpler path: re-derive via operations.py isn't easy, so decode minimally.
-        # Tag 4<<3|2 = 0x22. Since field 1 is 'id' (variable length), we must parse step by step.
-        # Use a tiny helper: parse length-prefixed fields looking for field_number == 4.
         encrypted_blob_bytes = _extract_protobuf_bytes_field(new_payload, field_number=4)
         assert encrypted_blob_bytes is not None
         encrypted_b64 = base64.b64encode(encrypted_blob_bytes).decode("ascii")
         plaintext = decrypt(encrypted_b64, keys.encryption_key)
 
         parsed = json.loads(plaintext)
-        assert parsed["t"] == "Sarah loves Django"
-        assert parsed["c"] == "pref"
-        assert parsed["st"] == "p"
-        assert parsed["sup"] == "old-fact-id"
-
-        # Also round-trip through parse_claim_or_legacy to confirm it's still valid
-        reparsed_json = totalreclaw_core.parse_claim_or_legacy(plaintext)
-        reparsed = json.loads(reparsed_json)
-        assert reparsed["st"] == "p"
+        # v1.1 long-form shape — matches what plugin 3.2.0 emits.
+        assert parsed["text"] == "Sarah loves Django"
+        assert parsed["type"] == "preference"  # from v0 'pref' category upgrade
+        assert parsed["schema_version"].startswith("1.")
+        assert parsed["pin_status"] == "pinned"
+        assert parsed["superseded_by"] == "old-fact-id"
+        # v0 short keys must NOT appear in a v1 blob.
+        assert "t" not in parsed
+        assert "c" not in parsed
+        assert "st" not in parsed
+        assert "sup" not in parsed
 
 
 # ---------------------------------------------------------------------------
@@ -342,9 +347,14 @@ class TestUnpinFact:
 
     @pytest.mark.asyncio
     @patch("totalreclaw.operations.build_and_send_userop", new_callable=AsyncMock)
-    async def test_unpin_new_blob_has_no_status_field(self, mock_send, keys):
-        """When status returns to 'a' (Active), the canonical Claim omits the
-        default-value 'st' short key entirely."""
+    async def test_unpin_new_blob_has_explicit_unpinned_status(self, mock_send, keys):
+        """When unpin writes a new v1.1 blob, ``pin_status`` is set
+        explicitly to ``"unpinned"`` — matches ``skill/plugin/pin.ts``
+        line 550 (``pinStatus = targetStatus === 'pinned' ? 'pinned' : 'unpinned'``).
+
+        Prior to Wave 2a the path emitted a v0 short-key blob that
+        OMITTED ``st`` to mean "active" — that behavior is gone.
+        """
         mock_send.return_value = "0xabc"
         relay = _build_relay_mock(
             keys, fact_id="pinned-fact", text="Likes TDD", status="p"
@@ -373,10 +383,12 @@ class TestUnpinFact:
         encrypted_b64 = base64.b64encode(encrypted_blob_bytes).decode("ascii")
         plaintext = decrypt(encrypted_b64, keys.encryption_key)
         parsed = json.loads(plaintext)
-        # Active status is default — should be omitted per Rust canonicalization
-        assert "st" not in parsed
-        # But supersedes should still be set
-        assert parsed["sup"] == "pinned-fact"
+        # v1.1 shape: explicit unpinned status on the new blob, plus the
+        # superseded_by chain link back to the old pinned fact.
+        assert parsed["schema_version"].startswith("1.")
+        assert parsed["pin_status"] == "unpinned"
+        assert parsed["superseded_by"] == "pinned-fact"
+        assert parsed["text"] == "Likes TDD"
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_wave2a_hermes_fixes.py
+++ b/python/tests/test_wave2a_hermes_fixes.py
@@ -1,0 +1,593 @@
+"""Tests for Wave 2a Hermes fixes (Python 2.2.2 / Plugin 3.2.1).
+
+Covers the three bugs surfaced in the 2026-04-20 QA run of
+``totalreclaw==2.2.1`` on the VPS — see
+``docs/notes/QA-hermes-RC-2.2.1-20260420.md`` (internal repo) for the
+source-of-truth finding details.
+
+Wave 2a bug numbering mirrors the QA report:
+- Bug #4: ``auto_extract`` still requires ``OPENAI_MODEL`` even when
+          ``~/.hermes/config.yaml`` has a valid model + provider.
+- Bug #7: ``~/.totalreclaw/credentials.json`` key divergence —
+          Python wrote ``recovery_phrase``, plugin 3.2.0 wrote
+          ``mnemonic``. Cross-client portability broken.
+- Bug #8: Python ``pin_fact()`` only emits a v=3 tombstone on-chain;
+          the companion v=4 ``pin_status: pinned`` claim that plugin
+          3.2.0 + MCP 3.2.0 (PR #51) produce was missing.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import yaml
+
+from totalreclaw.agent.llm_client import (
+    LLMConfig,
+    _extract_provider_and_model,
+    detect_llm_config,
+    read_hermes_llm_config,
+)
+
+
+# ----------------------------------------------------------------------------
+# Bug #4 — Hermes config.yaml + .env picks up provider/model
+# ----------------------------------------------------------------------------
+
+
+class TestBug4HermesConfigYaml:
+    """``read_hermes_llm_config`` must accept the actual YAML shape that
+    Hermes writes (top-level ``provider`` + ``model`` keys), NOT only the
+    nested ``model: {provider, model}`` shape that the 2.2.1 helper required.
+    """
+
+    def test_extract_accepts_top_level_provider_model(self):
+        cfg = {"provider": "zai", "model": "glm-5-turbo"}
+        provider, model = _extract_provider_and_model(cfg)
+        assert provider == "zai"
+        assert model == "glm-5-turbo"
+
+    def test_extract_accepts_nested_model_block(self):
+        """Defensive — future-proofs against Hermes reorganizing."""
+        cfg = {"model": {"provider": "openai", "model": "gpt-4o-mini"}}
+        provider, model = _extract_provider_and_model(cfg)
+        assert provider == "openai"
+        assert model == "gpt-4o-mini"
+
+    def test_extract_missing_keys_returns_empty(self):
+        assert _extract_provider_and_model({}) == ("", "")
+        assert _extract_provider_and_model({"provider": "zai"}) == ("", "")
+        assert _extract_provider_and_model({"model": "glm-5-turbo"}) == ("", "")
+
+    def test_read_hermes_llm_config_resolves_with_top_level_yaml(self, tmp_path, monkeypatch):
+        """End-to-end: top-level YAML + adjacent .env → full LLMConfig.
+
+        This reproduces the QA scenario EXACTLY — ``config.yaml`` with
+        ``provider: zai`` + ``model: glm-5-turbo`` top-level keys and
+        ``.env`` carrying only ``ZAI_API_KEY``. No ``OPENAI_MODEL`` in
+        process env. Prior to 2.2.2 this returned ``None``.
+        """
+        hermes_dir = tmp_path / ".hermes"
+        hermes_dir.mkdir()
+        (hermes_dir / "config.yaml").write_text(
+            yaml.safe_dump({"provider": "zai", "model": "glm-5-turbo"})
+        )
+        (hermes_dir / ".env").write_text("ZAI_API_KEY=zai-key-123\n")
+
+        # Force the helper to look at our tmp_path (via HERMES_CONFIG override).
+        monkeypatch.setenv("HERMES_CONFIG", str(hermes_dir / "config.yaml"))
+        # Clear all provider env vars so no env-only path resolves first.
+        for k in ("ZAI_API_KEY", "OPENAI_API_KEY", "OPENAI_MODEL", "GLM_API_KEY"):
+            monkeypatch.delenv(k, raising=False)
+
+        config = read_hermes_llm_config()
+        assert config is not None, "expected LLMConfig from top-level YAML shape"
+        assert config.model == "glm-5-turbo"
+        assert config.api_key == "zai-key-123"
+        assert config.api_format == "openai"
+        assert "z.ai" in config.base_url
+
+    def test_read_hermes_llm_config_returns_none_when_no_key(self, tmp_path, monkeypatch):
+        """Config present but .env missing the provider key → None."""
+        hermes_dir = tmp_path / ".hermes"
+        hermes_dir.mkdir()
+        (hermes_dir / "config.yaml").write_text(
+            yaml.safe_dump({"provider": "zai", "model": "glm-5-turbo"})
+        )
+        # No .env file at all.
+
+        monkeypatch.setenv("HERMES_CONFIG", str(hermes_dir / "config.yaml"))
+        for k in ("ZAI_API_KEY", "OPENAI_API_KEY", "OPENAI_MODEL", "GLM_API_KEY"):
+            monkeypatch.delenv(k, raising=False)
+
+        assert read_hermes_llm_config() is None
+
+    def test_detect_llm_config_falls_through_to_hermes_when_env_bare(
+        self, tmp_path, monkeypatch
+    ):
+        """The headline fix: ``detect_llm_config()`` resolves via Hermes
+        YAML when NO env vars are set. This is the path ``extract_facts_llm``
+        takes when no ``llm_config`` is passed explicitly.
+        """
+        hermes_dir = tmp_path / ".hermes"
+        hermes_dir.mkdir()
+        (hermes_dir / "config.yaml").write_text(
+            yaml.safe_dump({"provider": "zai", "model": "glm-5-turbo"})
+        )
+        (hermes_dir / ".env").write_text("ZAI_API_KEY=zai-abc\n")
+
+        monkeypatch.setenv("HERMES_CONFIG", str(hermes_dir / "config.yaml"))
+        # Clear all provider env vars so the env-only path returns None.
+        for k in (
+            "ZAI_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
+            "OPENAI_MODEL", "ANTHROPIC_MODEL", "LLM_MODEL",
+            "GLM_API_KEY", "GROQ_API_KEY", "DEEPSEEK_API_KEY",
+            "OPENROUTER_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY",
+            "XAI_API_KEY", "TOGETHER_API_KEY", "MISTRAL_API_KEY",
+        ):
+            monkeypatch.delenv(k, raising=False)
+
+        config = detect_llm_config()
+        assert config is not None, (
+            "detect_llm_config should fall through to Hermes config.yaml "
+            "when no env vars resolve"
+        )
+        assert config.model == "glm-5-turbo"
+        assert config.api_key == "zai-abc"
+
+    def test_detect_llm_config_prefers_env_over_hermes(self, tmp_path, monkeypatch):
+        """Env vars take priority — if the user set both, we trust the env."""
+        hermes_dir = tmp_path / ".hermes"
+        hermes_dir.mkdir()
+        (hermes_dir / "config.yaml").write_text(
+            yaml.safe_dump({"provider": "zai", "model": "glm-5-turbo"})
+        )
+        (hermes_dir / ".env").write_text("ZAI_API_KEY=zai-from-hermes\n")
+
+        monkeypatch.setenv("HERMES_CONFIG", str(hermes_dir / "config.yaml"))
+        # Clear most, keep OPENAI_API_KEY + OPENAI_MODEL for env priority path.
+        for k in (
+            "ZAI_API_KEY", "ANTHROPIC_API_KEY", "GLM_API_KEY",
+            "ANTHROPIC_MODEL", "LLM_MODEL",
+        ):
+            monkeypatch.delenv(k, raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-env-wins")
+        monkeypatch.setenv("OPENAI_MODEL", "gpt-4o-mini")
+
+        config = detect_llm_config()
+        assert config is not None
+        # Env priority: should resolve via OPENAI_API_KEY + OPENAI_MODEL,
+        # not the z.ai path from config.yaml.
+        assert config.model == "gpt-4o-mini"
+        assert config.api_key == "sk-env-wins"
+
+
+# ----------------------------------------------------------------------------
+# Bug #7 — credentials.json key parity
+# ----------------------------------------------------------------------------
+
+
+class TestBug7CredentialsKeyParity:
+    """Python must accept BOTH ``mnemonic`` (canonical) and
+    ``recovery_phrase`` (legacy) on read, and emit canonical ``mnemonic``
+    on write. Plugin 3.2.0 already does this — symmetric parity is the
+    Wave 2a fix on the Python side.
+    """
+
+    def test_state_reads_legacy_recovery_phrase_key(self, tmp_path, monkeypatch):
+        """Pre-2.2.2 fixture: file keyed as ``recovery_phrase`` still loads."""
+        from totalreclaw.agent.state import AgentState
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        creds_dir = tmp_path / ".totalreclaw"
+        creds_dir.mkdir()
+        (creds_dir / "credentials.json").write_text(
+            json.dumps({"recovery_phrase": "abandon " * 11 + "about"})
+        )
+
+        # Clear any auto-configure env that would short-circuit.
+        monkeypatch.delenv("TOTALRECLAW_RECOVERY_PHRASE", raising=False)
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            state = AgentState()
+
+        assert state.is_configured(), "state should configure from legacy recovery_phrase key"
+
+    def test_state_reads_canonical_mnemonic_key(self, tmp_path, monkeypatch):
+        """Plugin-3.2.0-written file (mnemonic key) also loads."""
+        from totalreclaw.agent.state import AgentState
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        creds_dir = tmp_path / ".totalreclaw"
+        creds_dir.mkdir()
+        (creds_dir / "credentials.json").write_text(
+            json.dumps({"mnemonic": "abandon " * 11 + "about"})
+        )
+        monkeypatch.delenv("TOTALRECLAW_RECOVERY_PHRASE", raising=False)
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            state = AgentState()
+
+        assert state.is_configured(), "state should configure from canonical mnemonic key"
+
+    def test_state_prefers_mnemonic_when_both_keys_present(self, tmp_path, monkeypatch):
+        """Canonical wins — both keys present → ``mnemonic`` is used."""
+        from totalreclaw.agent.state import AgentState
+
+        creds_dir = tmp_path / ".totalreclaw"
+        creds_dir.mkdir()
+        (creds_dir / "credentials.json").write_text(
+            json.dumps({
+                "mnemonic": "abandon " * 11 + "about",
+                "recovery_phrase": "different " * 11 + "phrase",
+            })
+        )
+        monkeypatch.delenv("TOTALRECLAW_RECOVERY_PHRASE", raising=False)
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            state = AgentState()
+
+        assert state.is_configured()
+        # Can't directly inspect the stored mnemonic without exposing it;
+        # the observable effect is that the canonical key wins. We verify
+        # that by calling configure() via the loader and checking the
+        # EOA address matches the canonical phrase.
+        from totalreclaw.client import _get_eoa_address
+        expected_eoa = _get_eoa_address("abandon " * 11 + "about")
+        assert state._client._eoa_address.lower() == expected_eoa.lower()
+
+    def test_state_writes_canonical_mnemonic_key(self, tmp_path, monkeypatch):
+        """After configure(), credentials.json should use the canonical
+        ``mnemonic`` key going forward.
+        """
+        from totalreclaw.agent.state import AgentState
+
+        monkeypatch.delenv("TOTALRECLAW_RECOVERY_PHRASE", raising=False)
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            state = AgentState()
+            assert not state.is_configured()
+            state.configure("abandon " * 11 + "about")
+
+        creds = json.loads((tmp_path / ".totalreclaw" / "credentials.json").read_text())
+        assert creds.get("mnemonic") == "abandon " * 11 + "about", (
+            f"write path must emit canonical mnemonic key (2.2.2); got: {creds}"
+        )
+
+    def test_state_write_preserves_existing_recovery_phrase_file(self, tmp_path):
+        """If a legacy ``recovery_phrase`` file already exists, don't
+        clobber it on configure() — leave it until the user re-onboards.
+
+        Rationale: the file is 0600 and the user may have external
+        tooling that reads it. Migration is opt-in (next fresh onboarding
+        writes the canonical key).
+        """
+        from totalreclaw.agent.state import AgentState
+
+        creds_dir = tmp_path / ".totalreclaw"
+        creds_dir.mkdir()
+        legacy_payload = {"recovery_phrase": "abandon " * 11 + "about"}
+        (creds_dir / "credentials.json").write_text(json.dumps(legacy_payload))
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            state = AgentState()
+            assert state.is_configured(), "legacy-key file should still load"
+
+            # Calling configure() with the SAME mnemonic shouldn't flip the
+            # key (no "migration" on touch). Only a fresh configure() with
+            # a different mnemonic writes the canonical key.
+            state.configure("abandon " * 11 + "about")
+
+        # Legacy key preserved, no accidental downgrade.
+        creds = json.loads((creds_dir / "credentials.json").read_text())
+        assert "recovery_phrase" in creds, "must not drop the legacy key silently"
+
+
+# ----------------------------------------------------------------------------
+# Bug #8 — Python pin path must emit v=4 pinned claim
+# ----------------------------------------------------------------------------
+
+
+TEST_MNEMONIC_PIN = (
+    "abandon abandon abandon abandon abandon abandon abandon abandon "
+    "abandon abandon abandon about"
+)
+
+
+class TestBug8PinEmitsV4Pinned:
+    """Python's ``pin_fact`` must emit a v=4 protobuf wrapper with an
+    inner v1.1 ``MemoryClaimV1`` JSON blob carrying
+    ``pin_status: "pinned"`` — matching the plugin's 3.2.0 pin path
+    (``skill/plugin/pin.ts::executePinOperation``) and MCP 3.2.0 (PR #51).
+
+    The QA report observed that 2.2.1 Python only wrote a v=3 tombstone;
+    the companion v=4 pinned-claim payload was missing. These tests
+    capture the two protobuf payloads the tombstone+new-fact write
+    produces and assert on their shape.
+    """
+
+    @pytest.fixture
+    def keys(self):
+        from totalreclaw.crypto import derive_keys_from_mnemonic
+        return derive_keys_from_mnemonic(TEST_MNEMONIC_PIN)
+
+    @pytest.fixture
+    def eoa(self):
+        from eth_account import Account
+        Account.enable_unaudited_hdwallet_features()
+        acct = Account.from_mnemonic(TEST_MNEMONIC_PIN, account_path="m/44'/60'/0'/0/0")
+        return acct.address, bytes(acct.key)
+
+    @staticmethod
+    def _make_v1_blob_fixture(text: str) -> str:
+        """Produce a v1.1 MemoryClaimV1 JSON blob for the existing fact."""
+        from totalreclaw.claims_helper import build_canonical_claim_v1
+
+        class _Fake:
+            pass
+
+        f = _Fake()
+        f.text = text
+        f.type = "preference"
+        f.importance = 7
+        f.source = "user"
+        f.scope = "work"
+        f.confidence = 0.9
+        f.entities = None
+        f.reasoning = None
+        f.volatility = "stable"
+        return build_canonical_claim_v1(f, importance=7, claim_id="orig-fact-uuid")
+
+    @staticmethod
+    def _encrypted_hex(plaintext: str, key: bytes) -> str:
+        from totalreclaw.crypto import encrypt
+        b64 = encrypt(plaintext, key)
+        return "0x" + base64.b64decode(b64).hex()
+
+    def _build_relay_mock(self, keys, fact_id: str, claim_json: str):
+        from totalreclaw.relay import RelayClient
+        relay = AsyncMock(spec=RelayClient)
+        relay._relay_url = "https://api.totalreclaw.xyz"
+        relay._auth_key_hex = "deadbeef"
+        relay._client_id = "test"
+
+        async def query(query_str, variables, chain=None):
+            if "fact(id" in query_str or "id: $id" in query_str:
+                return {
+                    "data": {
+                        "fact": {
+                            "id": fact_id,
+                            "owner": "0x0000000000000000000000000000000000001234".lower(),
+                            "encryptedBlob": self._encrypted_hex(claim_json, keys.encryption_key),
+                            "encryptedEmbedding": None,
+                            "decayScore": "0.7",
+                            "timestamp": "1760000000",
+                            "createdAt": "1760000000",
+                            "isActive": True,
+                            "contentFp": "abc",
+                        }
+                    }
+                }
+            return {"data": {}}
+
+        relay.query_subgraph = AsyncMock(side_effect=query)
+        return relay
+
+    @staticmethod
+    def _extract_protobuf_version(payload: bytes) -> int:
+        """Extract the outer protobuf ``version`` field (field #11, wire type 0).
+
+        Mirrors the helper in ``test_pin_unpin.py`` but scanning for the
+        specific field we care about. Returns 0 if the field is absent.
+        """
+        from totalreclaw import protobuf
+        # Rather than re-implement a parser, re-use the Python decoder.
+        decoded = protobuf.decode_fact_protobuf(payload)
+        return int(decoded.version or 0)
+
+    @staticmethod
+    def _extract_encrypted_blob(payload: bytes) -> bytes:
+        from totalreclaw import protobuf
+        decoded = protobuf.decode_fact_protobuf(payload)
+        return decoded.encrypted_blob
+
+    @pytest.mark.asyncio
+    @patch("totalreclaw.operations.build_and_send_userop", new_callable=AsyncMock)
+    async def test_pin_emits_v4_for_new_fact(self, mock_send, keys, eoa):
+        """The new-fact write (after the tombstone) MUST carry
+        ``protobuf version = 4`` and an inner v1 MemoryClaimV1 JSON blob.
+        """
+        from totalreclaw.operations import pin_fact
+
+        eoa_addr, eoa_pk = eoa
+        existing_blob = self._make_v1_blob_fixture("Pedro prefers dark mode")
+        relay = self._build_relay_mock(keys, "orig-fact-uuid", existing_blob)
+
+        captured: list[bytes] = []
+
+        async def capture(**kwargs):
+            captured.append(kwargs["protobuf_payload"])
+            return "0xok"
+
+        mock_send.side_effect = capture
+
+        result = await pin_fact(
+            fact_id="orig-fact-uuid",
+            keys=keys,
+            owner="0x0000000000000000000000000000000000001234",
+            relay=relay,
+            eoa_private_key=eoa_pk,
+            eoa_address=eoa_addr,
+            sender="0x0000000000000000000000000000000000001234",
+        )
+
+        assert result["success"] is True
+        assert result["new_status"] == "pinned"
+        assert len(captured) == 2, "expected tombstone + new-fact writes"
+
+        # Second payload = new fact. MUST be v=4 (per QA bug #8).
+        new_payload = captured[1]
+        version = self._extract_protobuf_version(new_payload)
+        assert version == 4, (
+            f"new-fact payload must be protobuf v=4 (v1 taxonomy); "
+            f"got v={version}. Bug #8: pin path was emitting v=3 in 2.2.1."
+        )
+
+    @pytest.mark.asyncio
+    @patch("totalreclaw.operations.build_and_send_userop", new_callable=AsyncMock)
+    async def test_pin_new_blob_carries_pin_status_pinned(self, mock_send, keys, eoa):
+        """The inner blob of the new-fact v=4 payload must be a v1
+        MemoryClaimV1 JSON with ``pin_status: "pinned"``.
+        """
+        from totalreclaw.crypto import decrypt
+        from totalreclaw.operations import pin_fact
+
+        eoa_addr, eoa_pk = eoa
+        existing_blob = self._make_v1_blob_fixture("Sarah loves Django")
+        relay = self._build_relay_mock(keys, "orig-fact-2", existing_blob)
+
+        captured: list[bytes] = []
+
+        async def capture(**kwargs):
+            captured.append(kwargs["protobuf_payload"])
+            return "0xok"
+
+        mock_send.side_effect = capture
+
+        await pin_fact(
+            fact_id="orig-fact-2",
+            keys=keys,
+            owner="0x0000000000000000000000000000000000001234",
+            relay=relay,
+            eoa_private_key=eoa_pk,
+            eoa_address=eoa_addr,
+            sender="0x0000000000000000000000000000000000001234",
+        )
+
+        new_payload = captured[1]
+        encrypted_blob = self._extract_encrypted_blob(new_payload)
+        encrypted_b64 = base64.b64encode(encrypted_blob).decode("ascii")
+        plaintext = decrypt(encrypted_b64, keys.encryption_key)
+
+        parsed = json.loads(plaintext)
+        assert parsed.get("schema_version", "").startswith("1."), (
+            f"expected v1 MemoryClaimV1 JSON; got: {parsed}"
+        )
+        assert parsed.get("pin_status") == "pinned", (
+            f"Bug #8: pin path must emit pin_status=pinned in v1 blob; got: {parsed}"
+        )
+        assert parsed.get("superseded_by") == "orig-fact-2", (
+            "new v1 blob should link to the old fact via superseded_by"
+        )
+        # The v1 inner shape uses long-form keys — verify we're not
+        # accidentally still emitting the short-key v0 format.
+        assert "t" not in parsed or "text" in parsed, (
+            "v1 blob should use long-form 'text', not short-key 't'"
+        )
+        assert parsed.get("text") == "Sarah loves Django"
+
+    @pytest.mark.asyncio
+    @patch("totalreclaw.operations.build_and_send_userop", new_callable=AsyncMock)
+    async def test_pin_tombstone_remains_v3(self, mock_send, keys, eoa):
+        """The first payload (tombstone) should remain at v=3 — matches
+        plugin's behavior exactly (``pin.ts`` line 640: ``version = legacy v3``).
+        """
+        from totalreclaw.operations import pin_fact
+
+        eoa_addr, eoa_pk = eoa
+        existing_blob = self._make_v1_blob_fixture("some preference")
+        relay = self._build_relay_mock(keys, "tombstone-fact", existing_blob)
+
+        captured: list[bytes] = []
+
+        async def capture(**kwargs):
+            captured.append(kwargs["protobuf_payload"])
+            return "0xok"
+
+        mock_send.side_effect = capture
+
+        await pin_fact(
+            fact_id="tombstone-fact",
+            keys=keys,
+            owner="0x0000000000000000000000000000000000001234",
+            relay=relay,
+            eoa_private_key=eoa_pk,
+            eoa_address=eoa_addr,
+            sender="0x0000000000000000000000000000000000001234",
+        )
+
+        tombstone_payload = captured[0]
+        version = self._extract_protobuf_version(tombstone_payload)
+        # v=3 or v=0 (v=0 gets treated as default v=3 on decode).
+        assert version in (0, 3), (
+            f"tombstone should be protobuf v=3 (legacy); got v={version}"
+        )
+
+
+# ----------------------------------------------------------------------------
+# Bug #7 — cross-client parity sanity check
+# ----------------------------------------------------------------------------
+
+
+class TestBug7CrossClientParity:
+    """Round-trip sanity: a plugin-format credentials.json (canonical
+    ``mnemonic`` key) read via the Python loader derives the same wallet
+    as the same mnemonic fed through the Python client directly.
+
+    This is the "cross-client" acceptance gate from the task scope: pick
+    a sample mnemonic, write via one client's format, read via the
+    other, and assert identical wallet derivation.
+    """
+
+    def test_plugin_written_mnemonic_derives_same_smart_account(self, tmp_path):
+        """Simulate the plugin's write: ``{"mnemonic": "..."}`` file at
+        the canonical path. Python loader derives the same EOA.
+        """
+        from totalreclaw.agent.state import AgentState
+        from totalreclaw.client import _get_eoa_address
+
+        test_mnemonic = (
+            "letter sugar brave morning absurd pattern advice flight "
+            "few pledge chef leisure"
+        )
+
+        creds_dir = tmp_path / ".totalreclaw"
+        creds_dir.mkdir()
+        (creds_dir / "credentials.json").write_text(
+            json.dumps({"mnemonic": test_mnemonic})
+        )
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            state = AgentState()
+
+        assert state.is_configured()
+        expected_eoa = _get_eoa_address(test_mnemonic).lower()
+        assert state._client._eoa_address.lower() == expected_eoa
+
+    def test_python_written_mnemonic_readable_by_plugin_shape(self, tmp_path):
+        """After 2.2.2's Python writes a fresh credentials.json, the
+        resulting file has the ``mnemonic`` key — which is exactly what
+        the plugin reads. This is the integrity guarantee: a user who
+        sets up via Python can switch to the plugin without re-onboarding.
+        """
+        from totalreclaw.agent.state import AgentState
+
+        test_mnemonic = (
+            "letter sugar brave morning absurd pattern advice flight "
+            "few pledge chef leisure"
+        )
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            state = AgentState()
+            state.configure(test_mnemonic)
+
+        creds = json.loads((tmp_path / ".totalreclaw" / "credentials.json").read_text())
+        assert creds.get("mnemonic") == test_mnemonic, (
+            "Python write path MUST emit canonical 'mnemonic' key "
+            "for plugin compat (Bug #7)"
+        )

--- a/python/tests/test_wave2a_hermes_fixes.py
+++ b/python/tests/test_wave2a_hermes_fixes.py
@@ -648,3 +648,97 @@ class TestBug7CrossClientParity:
             "Python write path MUST emit canonical 'mnemonic' key "
             "for plugin compat (Bug #7)"
         )
+
+
+# ----------------------------------------------------------------------------
+# Bug #8 — cross-impl byte parity for v1.1 pin blobs
+# ----------------------------------------------------------------------------
+
+
+class TestBug8CrossImplBlobParity:
+    """The task constraint from ``plans/2026-04-20-wave2a-hermes-fixes.md``:
+    "Python + Plugin + MCP must all emit byte-identical pin v1.1 blobs for
+    identical inputs". This locks the field ordering of
+    ``build_canonical_claim_v1`` against a fixed-input regression so any
+    future change that shifts key order surfaces immediately.
+
+    The golden string below is the output of the plugin's
+    ``buildCanonicalClaimV1`` (plugin 3.2.1 + @totalreclaw/core 2.1.1)
+    for the same input. Re-capture via::
+
+        cd skill/plugin && npx tsx /tmp/compare-pin-blob.mjs
+
+    See ``python/tests/test_wave2a_hermes_fixes.py`` for the compare script.
+    """
+
+    EXPECTED_PLUGIN_BLOB = (
+        '{"id":"test-pin-uuid-00000000-0000-0000-0000-000000000001",'
+        '"text":"Pedro prefers dark mode","type":"preference",'
+        '"source":"user","created_at":"2026-04-20T00:00:00.000Z",'
+        '"scope":"personal","importance":8,"confidence":0.9,'
+        '"superseded_by":"original-fact-uuid","pin_status":"pinned",'
+        '"schema_version":"1.0","volatility":"stable"}'
+    )
+
+    def test_python_pin_blob_matches_plugin_byte_for_byte(self):
+        from totalreclaw.claims_helper import build_canonical_claim_v1
+
+        class _F:
+            pass
+
+        f = _F()
+        f.text = "Pedro prefers dark mode"
+        f.type = "preference"
+        f.source = "user"
+        f.scope = "personal"
+        f.volatility = "stable"
+        f.confidence = 0.9
+        f.entities = None
+        f.reasoning = None
+
+        python_blob = build_canonical_claim_v1(
+            f,
+            importance=8,
+            created_at="2026-04-20T00:00:00.000Z",
+            superseded_by="original-fact-uuid",
+            claim_id="test-pin-uuid-00000000-0000-0000-0000-000000000001",
+            pin_status="pinned",
+        )
+
+        assert python_blob == self.EXPECTED_PLUGIN_BLOB, (
+            "Python + Plugin v1.1 pin blobs must be BYTE-IDENTICAL for the "
+            "same input — cross-impl parity is the pin-integrity guarantee.\n"
+            f"Python: {python_blob!r}\n"
+            f"Plugin: {self.EXPECTED_PLUGIN_BLOB!r}"
+        )
+
+    def test_python_pin_blob_is_valid_v1_claim(self):
+        """Sanity: the byte-identical output still parses as a v1 claim."""
+        from totalreclaw.claims_helper import build_canonical_claim_v1
+
+        class _F:
+            pass
+
+        f = _F()
+        f.text = "Pedro prefers dark mode"
+        f.type = "preference"
+        f.source = "user"
+        f.scope = "personal"
+        f.volatility = "stable"
+        f.confidence = 0.9
+        f.entities = None
+        f.reasoning = None
+
+        blob = build_canonical_claim_v1(
+            f,
+            importance=8,
+            created_at="2026-04-20T00:00:00.000Z",
+            superseded_by="original-fact-uuid",
+            claim_id="test-pin-uuid-00000000-0000-0000-0000-000000000001",
+            pin_status="pinned",
+        )
+        parsed = json.loads(blob)
+        assert parsed["schema_version"] == "1.0"
+        assert parsed["type"] == "preference"
+        assert parsed["pin_status"] == "pinned"
+        assert parsed["superseded_by"] == "original-fact-uuid"

--- a/python/tests/test_wave2a_hermes_fixes.py
+++ b/python/tests/test_wave2a_hermes_fixes.py
@@ -379,22 +379,79 @@ class TestBug8PinEmitsV4Pinned:
         return relay
 
     @staticmethod
-    def _extract_protobuf_version(payload: bytes) -> int:
-        """Extract the outer protobuf ``version`` field (field #11, wire type 0).
+    def _scan_protobuf_field(
+        payload: bytes, target_field: int, target_wire: int,
+    ):
+        """Walk a protobuf payload once and return the value of ``target_field``.
 
-        Mirrors the helper in ``test_pin_unpin.py`` but scanning for the
-        specific field we care about. Returns 0 if the field is absent.
+        ``target_wire`` determines the shape of the returned value:
+          * 0 (varint)            → int
+          * 2 (length-delimited)  → bytes
+
+        Returns ``None`` when the field is absent. Used by the Wave 2a pin
+        tests to inspect both the outer version varint (field 8, wire 0)
+        and the encrypted-blob bytes field (field 4, wire 2) without
+        standing up a full protobuf decoder.
         """
-        from totalreclaw import protobuf
-        # Rather than re-implement a parser, re-use the Python decoder.
-        decoded = protobuf.decode_fact_protobuf(payload)
-        return int(decoded.version or 0)
+        i = 0
+        n = len(payload)
+        while i < n:
+            tag = 0
+            shift = 0
+            while True:
+                b = payload[i]
+                i += 1
+                tag |= (b & 0x7F) << shift
+                if not (b & 0x80):
+                    break
+                shift += 7
+            fn = tag >> 3
+            wt = tag & 0x07
 
-    @staticmethod
-    def _extract_encrypted_blob(payload: bytes) -> bytes:
-        from totalreclaw import protobuf
-        decoded = protobuf.decode_fact_protobuf(payload)
-        return decoded.encrypted_blob
+            if wt == 0:  # varint
+                value = 0
+                shift = 0
+                while True:
+                    b = payload[i]
+                    i += 1
+                    value |= (b & 0x7F) << shift
+                    if not (b & 0x80):
+                        break
+                    shift += 7
+                if fn == target_field and wt == target_wire:
+                    return value
+            elif wt == 1:  # fixed64
+                i += 8
+            elif wt == 2:  # length-delimited
+                length = 0
+                shift = 0
+                while True:
+                    b = payload[i]
+                    i += 1
+                    length |= (b & 0x7F) << shift
+                    if not (b & 0x80):
+                        break
+                    shift += 7
+                value_bytes = payload[i : i + length]
+                i += length
+                if fn == target_field and wt == target_wire:
+                    return value_bytes
+            elif wt == 5:  # fixed32
+                i += 4
+            else:
+                raise ValueError(f"unsupported wire type {wt}")
+        return None
+
+    def _extract_protobuf_version(self, payload: bytes) -> int:
+        """Field 8 = ``version`` varint on the outer ``FactPayload`` protobuf."""
+        value = self._scan_protobuf_field(payload, target_field=8, target_wire=0)
+        return int(value) if value is not None else 0
+
+    def _extract_encrypted_blob(self, payload: bytes) -> bytes:
+        """Field 4 = ``encrypted_blob`` bytes on the outer ``FactPayload`` protobuf."""
+        value = self._scan_protobuf_field(payload, target_field=4, target_wire=2)
+        assert value is not None, "payload missing encrypted_blob field"
+        return value
 
     @pytest.mark.asyncio
     @patch("totalreclaw.operations.build_and_send_userop", new_callable=AsyncMock)

--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,50 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1] — 2026-04-20
+
+Cross-client parity patch: bumps the `@totalreclaw/core` peer from
+`^2.0.0` to `^2.1.1` so the plugin's pin/unpin write path produces
+byte-identical blobs to Python 2.2.2 and MCP 3.2.0. Ships alongside
+`totalreclaw==2.2.2` as Wave 2a of the Hermes 2.2.1 QA fix-up (see
+`docs/notes/QA-hermes-RC-2.2.1-20260420.md` in the internal repo).
+
+### Changed
+
+- `package.json`: bumped `@totalreclaw/core` dep from `^2.0.0` to
+  `^2.1.1`. Core 2.0.0 (the previous floor) dropped the v1.1 additive
+  `pin_status` field on the serde round-trip through
+  `validateMemoryClaimV1`, causing the plugin's pin/unpin blob to emit
+  with the field silently stripped. Core 2.1.1 (on npm since PR #51)
+  preserves `pin_status` as expected — 6 pin-unpin parity tests that
+  asserted `pin_status === 'pinned'` on the emitted blob failed on the
+  2.0.0 baseline and pass on 2.1.1. No plugin code changes required.
+
+### Fixed (via core bump + the symmetric Python 2.2.2 fix)
+
+- **Cross-client credentials.json parity** — declarative alignment
+  only; no plugin code change. Plugin 3.2.0 already accepts both
+  canonical `mnemonic` and legacy `recovery_phrase` keys on read and
+  emits canonical `mnemonic` on write (see
+  `skill/plugin/fs-helpers.ts::extractBootstrapMnemonic`). Python 2.2.2
+  gains symmetric behavior so a user who onboards via one client can
+  point the other at the same `~/.totalreclaw/credentials.json` and
+  derive the same Smart Account. Previously Hermes + OpenClaw wrote
+  incompatible key names on the same canonical path (QA Bug #7).
+
+### Spec
+
+- `docs/specs/totalreclaw/flows/01-identity-setup.md` gains a
+  "credentials.json schema" subsection documenting the canonical
+  `{"mnemonic": string}` shape + `recovery_phrase` legacy alias.
+
+### Tests
+
+- `skill/plugin/pin-unpin.test.ts`: 157/157 pass with `@totalreclaw/core@2.1.1`
+  (vs. 151/157 with 2.0.0 — 6 `pin_status` parity assertions flipped
+  from fail to pass).
+- `skill/plugin/credentials-bootstrap.test.ts`: 48/48 pass (unchanged from 3.2.0).
+
 ## [3.2.0] — 2026-04-19
 
 Secure leak-free onboarding for local users. **Breaking UX change:**

--- a/skill/plugin/package-lock.json
+++ b/skill/plugin/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/totalreclaw",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.0.1",
         "@totalreclaw/client": "^1.2.0",
-        "@totalreclaw/core": "^2.0.0",
+        "@totalreclaw/core": "^2.1.1",
         "onnxruntime-node": "^1.24.0"
       }
     },
@@ -754,9 +754,9 @@
       "license": "MIT"
     },
     "node_modules/@totalreclaw/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@totalreclaw/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-L+UOK5Ml76rb53pqfYhV3zsRoFCTnrx4rskvm5WDtVNFPhzDGVGrC2HYM3SwXwMnE9AXyrOUBq5nE1pIrh1WJQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@totalreclaw/core/-/core-2.1.1.tgz",
+      "integrity": "sha512-8qV8o+s3oCOSBTobYv/lNsvM63LKAv1PtFDkVEQ1jmYdeKuyZ6iw5UoZ5zsjpvjawrt0bNo+QfoiT5pzBgDGkQ==",
       "license": "MIT"
     },
     "node_modules/@types/node": {

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "@totalreclaw/client": "^1.2.0",
-    "@totalreclaw/core": "^2.0.0",
+    "@totalreclaw/core": "^2.1.1",
     "@huggingface/transformers": "^4.0.1",
     "onnxruntime-node": "^1.24.0"
   },


### PR DESCRIPTION
## Summary

Wave 2a ships three bug fixes surfaced by the full Hermes QA of `totalreclaw==2.2.1` on the VPS ([internal#14](https://github.com/p-diogo/totalreclaw-internal/pull/14), `docs/notes/QA-hermes-RC-2.2.1-20260420.md`). Each was severe enough to be a ship-stopper for a public release — and two are cross-client portability issues that silently broke the "same phrase works across clients" story.

- **Bug #4 (HIGH)** — Python `auto_extract` still required `OPENAI_MODEL` even when `~/.hermes/config.yaml` had a valid provider + model. The 2.0.2 "fix" only wired the Hermes reader into the hooks layer; the generic `detect_llm_config` still read env vars exclusively, and the YAML reader expected a NESTED `model: {provider, model}` shape while Hermes actually writes TOP-LEVEL `provider:` + `model:` keys.
- **Bug #7 (SHIP-STOPPER)** — `~/.totalreclaw/credentials.json` key divergence: Python wrote `{"recovery_phrase": ...}`, plugin 3.2.0 wrote `{"mnemonic": ...}`. Same canonical path, different keys → cross-client portability silently broken.
- **Bug #8 (MEDIUM)** — Python `pin_fact()` wrote a v=3 tombstone but no companion v=4 pinned claim. Pinned facts were invisible on the subgraph, breaking cross-client pin awareness + the Tier-1 reranker's pin-aware ranking.

## Changes

### Python 2.2.2 (`pyproject.toml` bump + `CHANGELOG.md` entry)

- `agent/llm_client.py` — new `read_hermes_llm_config()` accepts BOTH top-level + nested YAML shapes; scans `$HERMES_CONFIG` → XDG → `~/.config/hermes/` → legacy. `detect_llm_config()` falls through to the Hermes reader when env vars don't resolve.
- `agent/state.py` — `_extract_mnemonic_from_creds` accepts both `mnemonic` + `recovery_phrase` keys; prefers canonical on both-present. `configure()` emits canonical `mnemonic` on fresh writes; preserves legacy shape for same-mnemonic touches (no silent migration).
- `claims_helper.py::build_canonical_claim_v1` — gains a `pin_status` parameter. Reattached post-validation in the same field-order position as core 2.1.1's canonical output — gives byte-identical parity with the plugin.
- `operations.py::_change_claim_status` — ALWAYS emits a fresh v1.1 blob on the pin/unpin write path (long-form `text`/`type`/`pin_status`/`superseded_by`). New `_project_source_to_v1` helper mirrors the plugin's `projectToV1` so v0 sources upgrade on the fly. `FactPayload.version = PROTOBUF_VERSION_V4` so the outer protobuf tags the write as v1 taxonomy. Tombstone stays at v=3.

### Plugin 3.2.1 (`package.json` bump + `CHANGELOG.md` entry)

- `package.json` — `@totalreclaw/core` peer bumped `^2.0.0` → `^2.1.1`. Core 2.0.0 drops the v1.1 additive `pin_status` on serde round-trip; 2.1.1 (on npm since PR #51) preserves it. Without this bump, 6 of the plugin's own `pin-unpin.test.ts` assertions fail.
- Plugin code itself is unchanged — the 3.2.0 `fs-helpers.ts::extractBootstrapMnemonic` already handled both keys correctly. Bug #7 is a symmetric fix on the Python side.

### Spec addendum

- `docs/specs/totalreclaw/flows/01-identity-setup.md` — new "credentials.json schema (v2026-04-20 — canonical)" subsection documenting the canonical `{"mnemonic": string}` shape, the `recovery_phrase` legacy alias, the MUST-accept-both read rule, `mnemonic`-wins priority, the no-silent-migration policy, and reference implementation sites.

## Test plan

- [x] `python -m pytest python/tests/` — 678 passing, 10 skipped, 1 xfailed (no regressions; includes 19 new Wave 2a tests: 7 Bug #4, 7 Bug #7, 3 Bug #8, 2 byte-identical cross-impl parity).
- [x] `cd skill/plugin && npx tsx pin-unpin.test.ts` — 157/157 pass (vs. 151/157 pre-bump).
- [x] `cd skill/plugin && npx tsx credentials-bootstrap.test.ts` — 48/48 pass.
- [x] `cd skill/plugin && npx tsx v1-taxonomy.test.ts` — 128/128 pass.
- [x] Cross-impl byte parity: Python `build_canonical_claim_v1(..., pin_status="pinned")` emits byte-identical JSON to plugin's `buildCanonicalClaimV1({..., pinStatus: "pinned"})` for the same input. Locked in via `test_wave2a_hermes_fixes.py::TestBug8CrossImplBlobParity::EXPECTED_PLUGIN_BLOB` golden string.
- [ ] Full real-user QA against staging with candidate artifacts (per `CLAUDE.md` release gate — user-gated; see `qa-totalreclaw` skill for the playbook).
- [ ] Promote to PyPI + npm after QA GO.

## Known limitations / follow-ups

- The installed `totalreclaw-core==2.1.0` PyPI wheel doesn't round-trip `pin_status` through `validate_memory_claim_v1` (the Rust struct has it; the serde emit drops it in the wheel build). 2.2.2 reattaches `pin_status` after validate — same pattern already used for `schema_version` + `volatility` — so the fix ships independently of core. Once `totalreclaw-core==2.1.1` lands on PyPI, the reattach becomes a no-op but remains safe.
- MCP was NOT touched in this wave — per PR #51 it already emits canonical `mnemonic` + v=4 pinned claims with `pin_status`. Verified by inspection; no changes needed.

Refs: `docs/notes/QA-hermes-RC-2.2.1-20260420.md` (Findings #4, #7, #8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)