### PR TITLE
chore(core): bump pyproject 2.1.0 -> 2.1.1 (fix PyPI publish)

### DIFF
--- a/rust/totalreclaw-core/pyproject.toml
+++ b/rust/totalreclaw-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "totalreclaw-core"
-version = "2.1.0"
+version = "2.1.1"
 description = "TotalReclaw crypto core — E2EE, LSH, blind indices, protobuf encoding (Rust)"
 requires-python = ">=3.10"
 license = { text = "MIT" }


### PR DESCRIPTION
## Why
PR #41 + PR #51 bumped `rust/totalreclaw-core/Cargo.toml` to 2.1.0 then 2.1.1 but left `rust/totalreclaw-core/pyproject.toml` at 2.1.0. Maturin builds PyO3 wheels from pyproject.toml. Publish-pypi workflow retry just failed with `400 File already exists` because it tried to re-upload 2.1.0.

## Fix
One-line: bump pyproject.toml to 2.1.1 so maturin builds 2.1.1 wheels + PyPI accepts.

## After merge
Re-fire `publish-pypi.yml release-type=stable` → should publish `totalreclaw-core@2.1.1` to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)