### PR TITLE
fix(wave2c): plugin 3.2.3 printStatus legacy-key + python 2.2.4 __version__ export

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,25 @@ Hermes Agent plugin are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.4] - 2026-04-19
+
+Wave 2c cleanup: expose `totalreclaw.__version__` at the package top-level
+so `import totalreclaw; print(totalreclaw.__version__)` works. Sourced from
+`importlib.metadata` when the package is installed, falls back to the
+hardcoded `"2.2.4"` string in editable / source-tree installs where
+metadata may not be available.
+
+### Added
+
+- `python/src/totalreclaw/__init__.py` — `__version__` exported via
+  `importlib.metadata.version("totalreclaw")` with a `"2.2.4"` fallback;
+  added to `__all__`.
+
+### Tests
+
+- `python/tests/test_version.py`: 4 assertions — non-empty string, semver
+  shape, presence in `__all__`, importable via `from totalreclaw import
+  __version__`.
 ## [2.2.3] - 2026-04-20
 
 Pin/unpin made atomic — patch. Fixes the Hermes 2.2.2 staging QA

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "totalreclaw"
-version = "2.2.3"
+version = "2.2.4"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"

--- a/python/src/totalreclaw/__init__.py
+++ b/python/src/totalreclaw/__init__.py
@@ -1,5 +1,12 @@
 """TotalReclaw — End-to-end encrypted memory for AI agents."""
 
+try:
+    from importlib.metadata import version as _pkg_version
+
+    __version__ = _pkg_version("totalreclaw")
+except Exception:
+    __version__ = "2.2.4"
+
 from .client import TotalReclaw
 
-__all__ = ["TotalReclaw"]
+__all__ = ["TotalReclaw", "__version__"]

--- a/python/tests/test_version.py
+++ b/python/tests/test_version.py
@@ -1,0 +1,36 @@
+"""Tests for top-level totalreclaw.__version__ export (added in 2.2.4)."""
+
+import re
+
+
+def test_version_string_exists():
+    """totalreclaw.__version__ must be importable and non-empty."""
+    import totalreclaw
+
+    assert hasattr(totalreclaw, "__version__"), "__version__ missing from totalreclaw package"
+    v = totalreclaw.__version__
+    assert isinstance(v, str) and v.strip(), "__version__ must be a non-empty string"
+
+
+def test_version_semver_shape():
+    """__version__ must look like a semver string (MAJOR.MINOR.PATCH[...])."""
+    import totalreclaw
+
+    # Accept PEP 440 / semver — just requires at least X.Y.Z prefix.
+    assert re.match(r"^\d+\.\d+\.\d+", totalreclaw.__version__), (
+        f"__version__ does not look like a version string: {totalreclaw.__version__!r}"
+    )
+
+
+def test_version_in_all():
+    """__version__ must appear in totalreclaw.__all__."""
+    import totalreclaw
+
+    assert "__version__" in totalreclaw.__all__, "__version__ not listed in totalreclaw.__all__"
+
+
+def test_version_accessible_via_import_alias():
+    """Callers can do `from totalreclaw import __version__` without ImportError."""
+    from totalreclaw import __version__  # noqa: F401
+
+    assert isinstance(__version__, str)

--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.3] — 2026-04-19
+
+Wave 2c cleanup: `printStatus` now recognises legacy `recovery_phrase`
+credentials so `openclaw totalreclaw status` correctly reports "complete"
+for users whose credentials were written by an older client (or Hermes
+pre-2.2.4). No behaviour change for canonical `mnemonic` credentials.
+
+### Fixed
+
+- `onboarding-cli.ts::printStatus` — checked only the canonical `mnemonic`
+  key; users with legacy `recovery_phrase`-keyed credentials saw
+  "onboarding: not complete" even though all memory tools worked. Now checks
+  both keys (same back-compat pattern as `fs-helpers.ts::extractBootstrapMnemonic`).
+
+### Tests
+
+- `onboarding-cli.test.ts`: new test 11 — `printStatus` reports "complete"
+  for credentials containing only the legacy `recovery_phrase` key.
 ## [3.2.2] — 2026-04-20
 
 Cross-client pin/unpin batch parity — patch. Ships alongside

--- a/skill/plugin/onboarding-cli.test.ts
+++ b/skill/plugin/onboarding-cli.test.ts
@@ -403,7 +403,42 @@ const INVALID_PHRASE = 'not a valid phrase for anything not a valid phrase for a
 }
 
 // ---------------------------------------------------------------------------
-// 11. Copy strings — the scripted ones that tests depend on exist
+// 11. printStatus with legacy recovery_phrase key → reports "complete"
+// ---------------------------------------------------------------------------
+{
+  const tmp = mkTmp();
+  const credPath = path.join(tmp, 'credentials.json');
+  const statePath = path.join(tmp, 'state.json');
+  // Write credentials with the LEGACY key only (no `mnemonic` field).
+  fs.writeFileSync(credPath, JSON.stringify({ recovery_phrase: VALID_PHRASE }), { mode: 0o600 });
+  fs.writeFileSync(
+    statePath,
+    JSON.stringify({ onboardingState: 'active', createdBy: 'import', credentialsCreatedAt: '2026-04-19T00:00:00.000Z', version: '3.2.0' }),
+    { mode: 0o600 },
+  );
+
+  let buf = '';
+  const out = {
+    write(chunk: string | Uint8Array) {
+      buf += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8');
+      return true;
+    },
+  } as unknown as NodeJS.WritableStream;
+
+  printStatus(credPath, statePath, out);
+
+  assert(buf.includes('onboarding: complete'), 'status-legacy-key: prints "complete" for recovery_phrase creds');
+  assert(!buf.includes('not complete'), 'status-legacy-key: does NOT print "not complete"');
+  // Mnemonic words must never leak.
+  for (const w of VALID_PHRASE.split(' ')) {
+    assert(!buf.includes(w), `status-legacy-key: does NOT leak phrase word "${w}"`);
+  }
+
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+
+// ---------------------------------------------------------------------------
+// 13. Copy strings — the scripted ones that tests depend on exist
 // ---------------------------------------------------------------------------
 {
   assert(COPY.welcome.includes('TotalReclaw'), 'copy: welcome references product');

--- a/skill/plugin/onboarding-cli.ts
+++ b/skill/plugin/onboarding-cli.ts
@@ -472,7 +472,11 @@ export function printStatus(
   const stateFileExists = fs.existsSync(statePath);
   if (credExists) {
     const creds = loadCredentialsJson(credentialsPath);
-    const hasMnemonic = typeof creds?.mnemonic === 'string' && creds.mnemonic.trim().length > 0;
+    // Accept both canonical `mnemonic` and legacy `recovery_phrase` — same
+    // back-compat pattern used by fs-helpers.ts::extractBootstrapMnemonic.
+    const hasMnemonic =
+      (typeof creds?.mnemonic === 'string' && creds.mnemonic.trim().length > 0) ||
+      (typeof creds?.recovery_phrase === 'string' && creds.recovery_phrase.trim().length > 0);
     if (hasMnemonic) {
       out.write(COPY.statusActive);
       if (stateFileExists) {

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary

- **plugin 3.2.3** — `printStatus` in `onboarding-cli.ts` now checks both `mnemonic` and `recovery_phrase` keys (same back-compat pattern as `extractBootstrapMnemonic`). Users whose credentials were written by older clients (Python pre-2.2.4, hand-edited files) no longer see a false "not complete" status.
- **python 2.2.4** — `totalreclaw.__version__` is now exported at package top-level via `importlib.metadata.version("totalreclaw")` with a hardcoded fallback. Added to `__all__`.
- Version bumps and CHANGELOGs updated. Skips 3.2.2 / 2.2.3 (reserved by pin-atomic-batch branch).

## Test plan

- [ ] Plugin: `npx tsx onboarding-cli.test.ts` → 97/97 pass (includes new test 11 for legacy-key credentials)
- [ ] Python: `pytest python/tests/test_version.py -v` → 4/4 pass
- [ ] `openclaw totalreclaw status` on a machine with `recovery_phrase`-keyed credentials reports "complete"
- [ ] `import totalreclaw; print(totalreclaw.__version__)` prints `2.2.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)