### PR TITLE
feat: prompt hoist + NanoClaw align — core 2.2.0 / python 2.3.0 / nanoclaw 3.1.0

### DIFF
--- a/docs/specs/totalreclaw/memory-taxonomy-v1.md
+++ b/docs/specs/totalreclaw/memory-taxonomy-v1.md
@@ -1,7 +1,7 @@
 # MCP Memory Taxonomy v1
 
-**Version:** 1.1.0-draft (additive `pin_status` extension over 1.0)
-**Status:** DRAFT. 1.0 validated on Gemini corpus (Pipeline C). WildChat cross-validation in progress (2026-04-17). 1.1 adds `pin_status` without breaking 1.0 readers. Lock after WildChat results confirm.
+**Version:** 1.2.0-draft (adds canonical-prompt location + NanoClaw ADD-only alignment; 1.1 pin_status extension carried forward)
+**Status:** DRAFT. 1.0 validated on Gemini corpus (Pipeline C). WildChat cross-validation in progress (2026-04-17). 1.1 adds `pin_status` without breaking 1.0 readers. 1.2 documents the canonical extraction/compaction prompt location hoisted into `totalreclaw-core 2.2.0` — no on-wire changes. Lock after WildChat results confirm.
 **Owner:** TotalReclaw (pedro@thegraph.foundation)
 **Intended publication:** `totalreclaw.xyz/spec/memory-v1` + PR to MCP spec repo as optional `@modelcontextprotocol/memory-taxonomy/v1` extension.
 
@@ -9,6 +9,7 @@
 
 - **1.0.0** (2026-04-17) — initial v1 taxonomy lock-candidate. Six-type closed enum, provenance-as-first-class-field, open-extensible scope, advisory importance.
 - **1.1.0** (2026-04-19) — additive `pin_status` field (`"pinned" | "unpinned"`). No breaking changes: 1.0 blobs continue to validate, and 1.0 readers ignore the new field. The on-wire `schema_version` string remains `"1.0"` so existing strict validators are unaffected (the field is optional; absence is equivalent to `"unpinned"`). Implementations that understand 1.1 MUST honor `pin_status == "pinned"` as immunity from auto-supersede and surface it via the same helpers (`is_pinned_claim`, `respect_pin_in_resolution`) that already recognize the legacy v0 `st == "p"` sentinel. `pin_status` is intentionally additive rather than gated behind a `schema_version` bump because (a) the field is optional and ignorable, and (b) we want cross-client pin to work the moment any client ships the new field — not after every client agrees to accept `"1.1"`.
+- **1.2.0** (2026-04-19) — documents the canonical-prompt location (new `Canonical prompts` section, normative for reference clients) and aligns NanoClaw to ADD-only extraction emission. No on-wire schema changes; `schema_version` stays `"1.0"`. Prompt bytes are hoisted into `totalreclaw-core` 2.2.0 via `include_str!` so cross-client byte-identity is enforced at compile time rather than by convention (closes the 2026-04-18 v1 QA prompt-drift gap). Emitter side drops `UPDATE | DELETE | NOOP` action tokens; parser side MAY still accept them for back-compat with cached LLM outputs but writers SHOULD silently ignore non-`ADD` actions at the store path. Motivated by the NanoClaw investigation (`docs/notes/NANOCLAW-ACTION-FREQUENCY-20260419.md`) confirming that pre-3.1 UPDATE/DELETE/NOOP code paths were never hit in production.
 
 ---
 
@@ -213,6 +214,78 @@ Retrieval decay (recall-time ranking penalty for old memories) is orthogonal to 
 3. **Scope enum is open.** Clients MAY define additional scope values for their own use, but MUST accept + preserve all v1-defined scopes when reading from a vault written by another client.
 4. **Importance is advisory.** Receivers MAY recompute. Writers SHOULD include it as hint, not ground truth.
 5. **Schema version field is required.** Clients encountering unknown versions MUST refuse to read (fail-safe, prevents silent drift).
+
+## Canonical prompts (normative, core 2.2.0+)
+
+The v1 merged-topic **extraction** and **compaction** system prompts are
+canonical — all TotalReclaw reference clients MUST use byte-identical
+prompt bytes. Drift between clients changes observable extraction
+semantics (types chosen, provenance tagging, importance ranges, meta-
+request filtering) and undermines cross-client parity.
+
+### Single source of truth
+
+Canonical prompt text lives in:
+
+- `rust/totalreclaw-core/src/prompts/extraction.md`
+- `rust/totalreclaw-core/src/prompts/compaction.md`
+
+Both are embedded into `totalreclaw-core` at compile time via
+`include_str!`. Cross-language consumers MUST source the prompt bytes
+via the public accessors rather than duplicating the strings:
+
+| Language / client      | Accessor                                              |
+| ---------------------- | ----------------------------------------------------- |
+| Rust                   | `totalreclaw_core::prompts::get_extraction_system_prompt` / `get_compaction_system_prompt` |
+| Python (PyO3)          | `totalreclaw_core.get_extraction_system_prompt()` / `get_compaction_system_prompt()` |
+| TypeScript (WASM)      | `@totalreclaw/core` → `getExtractionSystemPrompt()` / `getCompactionSystemPrompt()` |
+
+Prompt bytes are identical across all three surfaces (same
+`include_str!` source). Clients MUST NOT maintain their own inline
+copy of these prompts in v1.1+.
+
+**Compliance check**: a v1 client that computes `SHA-256` of its
+runtime extraction prompt bytes MUST produce the same digest as a
+peer client built against the same core minor version.
+
+### What the canonical prompts specify
+
+- **Emitter side is ADD-only** (v1.1+). The OUTPUT FORMAT section only
+  lists `"action": "ADD"`. Pre-1.1 clients emitted `UPDATE`, `DELETE`,
+  and `NOOP` as well; the v1.1 canonical prompts drop them because the
+  in-the-loop rewrite semantics (forget-old + store-new) proved rare,
+  under-tested, and lossy in cross-client scenarios. The parser side
+  MAY still accept the wider set for back-compat with cached LLM
+  outputs or custom drivers, but clients SHOULD silently ignore
+  non-ADD actions at the write path.
+- Two-phase merged-topic output (`{ topics, facts }`).
+- Importance rubric using the FULL 1-10 range, with explicit "do not
+  cluster at 7-8-9" instruction.
+- Rule 6 — **product-meta request filter**. Utterances of the form
+  "set up TotalReclaw", "install the memory plugin", "configure the
+  vault" are META-requests about the product and MUST NOT be stored
+  as user preferences. Genuine preferences that happen to mention
+  encryption (e.g. "I like Signal because it's encrypted") remain
+  valid. Motivated by the 2026-04-18 QA which found product setup
+  prompts leaking into the vault as preferences.
+- Provenance `source` required per fact (`user | user-inferred |
+  assistant | external | derived`).
+
+### Compaction variant (floor-5)
+
+The compaction prompt is distinct from turn extraction: it drops the
+importance floor to 5 (vs 6), adds "LAST CHANCE" framing, and includes
+a FORMAT-AGNOSTIC PARSING section for bullet lists / headers / prose.
+Used on end-of-context surfaces (pre-compaction hook, session-end
+debrief). Same byte-identity requirement across clients.
+
+### Version locking
+
+The canonical prompt content is tied to the `totalreclaw-core` minor
+version. Prompt edits MUST be shipped as a `totalreclaw-core` minor
+bump, with the change documented in `rust/totalreclaw-core/CHANGELOG.md`.
+Consumer clients inherit the new prompt by bumping their
+`@totalreclaw/core` / `totalreclaw-core` dependency floor.
 
 ## Compliance levels
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,38 @@ Hermes Agent plugin are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2026-04-19
+
+### Changed
+
+- **`EXTRACTION_SYSTEM_PROMPT` + `COMPACTION_SYSTEM_PROMPT` now sourced
+  from the Rust core** via the new `totalreclaw_core.get_extraction_system_prompt`
+  / `get_compaction_system_prompt` accessors (core 2.2.0+). The module-level
+  names + exported symbols in `totalreclaw.agent` are unchanged — existing
+  importers and the `test_v1_taxonomy.py` assertions keep working — but the
+  literal string contents now come from a single canonical source embedded
+  in `totalreclaw-core` via `include_str!`. This closes the cross-client
+  prompt-drift gap that the 2026-04-18 v1 QA surfaced (NanoClaw
+  `BASE_SYSTEM_PROMPT` was missing the Rule 6 meta-filter and mis-listed
+  `summary` in the ADD output shape). The TS plugin still keeps a local
+  copy for this release wave — the plugin consumer wire lands in a
+  follow-up (plugin 3.3.0) to avoid conflicting with the parallel
+  pin-atomic-batch (3.2.2) and wave2c (3.2.3) version bumps.
+
+### Compatibility
+
+- `totalreclaw-core>=2.2.0,<3.0.0` is now the hard dependency floor
+  (was `>=2.0.0`). Pre-2.2.0 core wheels do NOT export the prompt
+  accessors; `agent/extraction.py` imports them at module load so the
+  floor bump is load-bearing. `pip install totalreclaw==2.3.0` will
+  resolve a core 2.2.0+ wheel automatically.
+- Plugin.yaml bumped to 2.3.0 (previously diverged at 2.2.1 — PR #56
+  did not bump it; corrected here).
+- Prompts are byte-identical to 2.2.2's literal constants. This is
+  explicitly tested via the existing `test_extraction_prompt_mentions_v1_types`
+  / `test_extraction_system_prompt_is_merged_topic` /
+  `test_compaction_prompt_admits_floor_5` suite — assertions continue
+  to pass unchanged.
 ## [2.2.4] - 2026-04-19
 
 Wave 2c cleanup: expose `totalreclaw.__version__` at the package top-level

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "totalreclaw"
-version = "2.2.4"
+version = "2.3.0"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"
@@ -12,9 +12,14 @@ requires-python = ">=3.11"
 authors = [{ name = "TotalReclaw Team" }]
 dependencies = [
     # Memory Taxonomy v1 + Retrieval v2 Tier 1 reranker live in core 2.0.
-    # Pin to 2.x to match the TypeScript clients' `^2.0.0` semantics — a future
-    # core@3 will be a breaking change and must bump this constraint in lockstep.
-    "totalreclaw-core>=2.0.0,<3.0.0",
+    # 2.3.0 lifts the floor to core 2.2.0 because agent/extraction.py now
+    # imports the hoisted EXTRACTION_SYSTEM_PROMPT / COMPACTION_SYSTEM_PROMPT
+    # via `totalreclaw_core.get_*_system_prompt`. Pre-2.2.0 core wheels do
+    # NOT export those accessors and would fail at module import.
+    # Upper bound stays at <3.0.0 to match the TypeScript clients'
+    # `^2.0.0` semver semantics — a future core@3 will be a breaking
+    # change and must bump this constraint in lockstep.
+    "totalreclaw-core>=2.2.0,<3.0.0",
     "httpx>=0.27",
     "onnxruntime>=1.24",
     "numpy>=1.26",

--- a/python/src/totalreclaw/agent/extraction.py
+++ b/python/src/totalreclaw/agent/extraction.py
@@ -27,6 +27,8 @@ import re
 from dataclasses import dataclass, field
 from typing import Any, List, Optional
 
+import totalreclaw_core
+
 from .llm_client import LLMConfig, detect_llm_config, chat_completion
 
 logger = logging.getLogger(__name__)
@@ -233,202 +235,38 @@ def _parse_entity(raw: Any) -> Optional[ExtractedEntity]:
 
 # ---------------------------------------------------------------------------
 # Extraction system prompts (v1 merged-topic pipeline)
+#
+# As of totalreclaw 2.3.0 these prompts are sourced from the Rust core
+# (``totalreclaw_core.get_extraction_system_prompt`` /
+# ``get_compaction_system_prompt``, available since core 2.2.0). One
+# source → byte-identical prompt bytes across Python and the TypeScript
+# clients (skill/plugin + skill-nanoclaw via the WASM binding), so the
+# cross-client extraction parity that the v1 taxonomy depends on is
+# enforced at compile time rather than by convention. See
+# ``docs/specs/totalreclaw/memory-taxonomy-v1.md`` §"Canonical prompts".
+#
+# The names ``EXTRACTION_SYSTEM_PROMPT`` + ``COMPACTION_SYSTEM_PROMPT``
+# are preserved as module-level ``str`` constants so existing importers
+# and tests (``python/tests/test_v1_taxonomy.py``) continue to work
+# unchanged.
 # ---------------------------------------------------------------------------
 
-EXTRACTION_SYSTEM_PROMPT = """You are a memory extraction engine using Memory Taxonomy v1. Work in TWO explicit phases within one response:
+EXTRACTION_SYSTEM_PROMPT: str = totalreclaw_core.get_extraction_system_prompt()
+"""Canonical v1 merged-topic extraction prompt. Sourced from core 2.2.0+.
 
-PHASE 1 — Topic identification.
-Before extracting any fact, identify the 2-3 main topics the user was engaging with. Topics should be short phrases (2-5 words each). If the conversation has no clear user-focused topic, use an empty topics array.
+This binding is a static reference — the underlying bytes are embedded
+into ``totalreclaw-core`` via ``include_str!`` so the prompt is
+byte-identical across Python and the TypeScript clients (skill/plugin,
+skill-nanoclaw) that consume the same WASM binding.
+"""
 
-PHASE 2 — Fact extraction anchored to those topics.
-Extract valuable memories. Prefer facts that directly relate to the identified topics (importance 7-9 range). Tangential facts may still be extracted but score lower (6-7 range).
+COMPACTION_SYSTEM_PROMPT: str = totalreclaw_core.get_compaction_system_prompt()
+"""Canonical v1 compaction prompt. Sourced from core 2.2.0+.
 
-Rules:
-1. Each memory = single self-contained piece of information
-2. Focus on user-specific info useful in future conversations
-3. Skip generic knowledge, greetings, small talk, ephemeral task coordination
-4. Score importance 1-10 (6+ = worth storing)
-5. Every memory MUST attribute a source (provenance critical)
-6. DO NOT extract setup / configuration / installation requests ABOUT the
-   TotalReclaw product itself. Utterances like "set up TotalReclaw",
-   "I want encrypted memory across my AI tools", "install the memory plugin",
-   or "configure the vault" are META-requests about the product — they are
-   NOT user preferences or claims worth storing. Genuine preferences that
-   happen to mention encryption (e.g., "I like using Signal because it's
-   encrypted") ARE valid and should be extracted.
-
-Importance rubric (use FULL 1-10 range):
-- 10: Critical, core identity, never-forget content
-- 9: Affects many future decisions
-- 8: High-value preference/decision/rule
-- 7: Specific durable fact
-- 6: Borderline
-- 5 or below: NOT worth storing — drop
-
-DO NOT cluster everything at 7-8-9.
-
-═══════════════════════════════════════════════════════════════
-TYPE (6 values)
-═══════════════════════════════════════════════════════════════
-- claim: factual assertion (absorbs fact/context/decision; decisions populate reasoning field)
-- preference: likes/dislikes/tastes
-- directive: imperative rule ("always X", "never Y")
-- commitment: future intent ("will do X")
-- episode: notable event
-- summary: derived synthesis (source must be derived|assistant) — do NOT emit for turn-extraction
-
-═══════════════════════════════════════════════════════════════
-SOURCE (provenance, CRITICAL)
-═══════════════════════════════════════════════════════════════
-- user: user explicitly stated it (in [user]: turns)
-- user-inferred: extractor inferred from user signals
-- assistant: assistant authored content — DOWNGRADE unless user affirmed/quoted/used it
-- external, derived: rare
-
-IF fact substance appears ONLY in [assistant]: turns without user affirmation → source:assistant
-
-═══════════════════════════════════════════════════════════════
-SCOPE (life domain)
-═══════════════════════════════════════════════════════════════
-work | personal | health | family | creative | finance | misc | unspecified
-
-═══════════════════════════════════════════════════════════════
-ENTITIES
-═══════════════════════════════════════════════════════════════
-- type ∈ {person, project, tool, company, concept, place}
-- prefer specific names ("PostgreSQL" not "database")
-- omit umbrella categories when specific name is present
-
-═══════════════════════════════════════════════════════════════
-REASONING (only for claims that are decisions)
-═══════════════════════════════════════════════════════════════
-For type=claim where the user expressed a decision-with-reasoning, populate "reasoning" with the WHY clause.
-
-═══════════════════════════════════════════════════════════════
-OUTPUT FORMAT (no markdown, no code fences)
-═══════════════════════════════════════════════════════════════
-{
-  "topics": ["topic 1", "topic 2"],
-  "facts": [
-    {
-      "text": "...",
-      "type": "claim|preference|directive|commitment|episode",
-      "source": "user|user-inferred|assistant",
-      "scope": "work|personal|health|...",
-      "importance": N,
-      "confidence": 0.9,
-      "action": "ADD",
-      "reasoning": "...",     // optional, only for claim+decision
-      "entities": [{"name": "...", "type": "tool"}]
-    }
-  ]
-}
-
-If nothing worth extracting: {"topics": [], "facts": []}"""
-
-
-COMPACTION_SYSTEM_PROMPT = """You are extracting memories from a conversation that is about to be compacted. The context will be LOST after this point — this is your LAST CHANCE to capture everything worth remembering. Be more aggressive than usual: err on the side of storing.
-
-Work in TWO explicit phases within one response:
-
-PHASE 1 — Topic identification.
-Identify the 2-3 main topics the user was engaging with before extracting any fact. Topics should be short phrases (2-5 words each). If there's no clear user-focused topic, use an empty topics array.
-
-PHASE 2 — Fact extraction anchored to those topics (plus preserve active context).
-Extract valuable memories. Prefer facts that directly relate to the identified topics (importance 7-9 range). Active project context, decisions in progress, and current working state score 6-8 during compaction — capture them even when they'd normally be marginal.
-
-Rules:
-1. Each memory = single self-contained piece of information
-2. Focus on user-specific info useful in future conversations
-3. Skip generic knowledge, greetings, small talk
-4. Score importance 1-10 (5+ = worth storing during compaction)
-5. Every memory MUST attribute a source (provenance critical)
-6. DO NOT extract setup / configuration / installation requests ABOUT the
-   TotalReclaw product itself. Utterances like "set up TotalReclaw",
-   "I want encrypted memory across my AI tools", or "configure the
-   memory plugin" are META-requests about the product — NOT user
-   preferences worth storing. Genuine preferences that mention encryption
-   ("I prefer Signal because it's encrypted") ARE valid.
-
-Importance rubric (full 1-10 range, NOT just 7-8):
-- 10: Core identity, never-forget ("remember this forever", name/birthday)
-- 9: Affects many future decisions / high-impact rules
-- 8: Preference / decision-with-reasoning / operational rule
-- 7: Specific durable fact
-- 6: Borderline — during compaction, capture anyway
-- 5: Would normally drop; keep as compaction safety net
-- 4 or below: DROP (greetings, filler)
-
-═══════════════════════════════════════════════════════════════
-TYPE (6 values)
-═══════════════════════════════════════════════════════════════
-- claim: factual assertion (absorbs v0 fact/context/decision; decisions populate reasoning)
-- preference: likes/dislikes/tastes
-- directive: imperative rule ("always X", "never Y")
-- commitment: future intent ("will do X")
-- episode: notable event
-- summary: derived synthesis (source must be derived|assistant)
-
-═══════════════════════════════════════════════════════════════
-SOURCE (provenance, CRITICAL)
-═══════════════════════════════════════════════════════════════
-- user: user explicitly stated it (in [user]: turns)
-- user-inferred: extractor inferred from user signals
-- assistant: assistant authored — DOWNGRADE unless user affirmed/quoted.
-- external, derived: rare.
-
-IF fact substance appears ONLY in [assistant]: turns without user affirmation → source:assistant.
-
-═══════════════════════════════════════════════════════════════
-SCOPE
-═══════════════════════════════════════════════════════════════
-work | personal | health | family | creative | finance | misc | unspecified
-
-═══════════════════════════════════════════════════════════════
-ENTITIES
-═══════════════════════════════════════════════════════════════
-- type ∈ {person, project, tool, company, concept, place}
-- prefer specific names ("PostgreSQL" not "database")
-- omit umbrella categories when specific name is present
-
-═══════════════════════════════════════════════════════════════
-REASONING (only for claims that are decisions)
-═══════════════════════════════════════════════════════════════
-For type=claim where the user expressed a decision-with-reasoning, populate "reasoning" with the WHY clause.
-
-═══════════════════════════════════════════════════════════════
-FORMAT-AGNOSTIC PARSING (IMPORTANT)
-═══════════════════════════════════════════════════════════════
-The conversation may contain bullet lists, numbered lists, section headers, code snippets, or plain prose. Treat ALL formats as potential sources of extractable memory:
-- Bullets/list items: each item is a candidate.
-- Section headers (Context, Decisions, Key Learnings, Open Questions): use the header as a TYPE HINT (Context → claim, Decisions → claim+reasoning, Learnings → directive, Open Questions → commitment).
-- Plain prose: parse each distinct assertion as a candidate.
-- Code snippets: extract config choices, tool versions, architectural decisions embedded in comments or structure.
-- Mixed format: apply all of the above.
-
-Do NOT skip content just because it's in a summary. The agent has already filtered — your job is to convert into structured memories, not to re-evaluate worth.
-
-═══════════════════════════════════════════════════════════════
-OUTPUT FORMAT (no markdown, no code fences)
-═══════════════════════════════════════════════════════════════
-{
-  "topics": ["topic 1", "topic 2"],
-  "facts": [
-    {
-      "text": "...",
-      "type": "claim|preference|directive|commitment|episode",
-      "source": "user|user-inferred|assistant",
-      "scope": "work|personal|health|...",
-      "importance": N,
-      "confidence": 0.9,
-      "action": "ADD",
-      "reasoning": "...",    // optional, only for claim+decision
-      "entities": [{"name": "...", "type": "tool"}]
-    }
-  ]
-}
-
-If nothing worth extracting: {"topics": [], "facts": []}"""
+Compaction variant drops the importance floor to 5 (from the default 6)
+and adds a format-agnostic parsing section. Byte-identical across all
+TotalReclaw clients by construction.
+"""
 
 
 # ---------------------------------------------------------------------------

--- a/python/src/totalreclaw/hermes/plugin.yaml
+++ b/python/src/totalreclaw/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: totalreclaw
-version: 2.2.1
+version: 2.3.0
 description: End-to-end encrypted memory vault for AI agents (Memory Taxonomy v1)
 author: TotalReclaw Team
 provides_tools:

--- a/rust/totalreclaw-core/CHANGELOG.md
+++ b/rust/totalreclaw-core/CHANGELOG.md
@@ -5,6 +5,57 @@ All notable changes to `@totalreclaw/core` / `totalreclaw-core` are documented h
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2026-04-19
+
+### Added
+
+- **Canonical extraction + compaction system prompts now live in core**
+  ([`src/prompts.rs`](./src/prompts.rs)). Before 2.2.0 each client
+  (`skill/plugin`, `python/agent/extraction.py`, `skill-nanoclaw`) kept
+  its own copy — the 2026-04-18 v1 QA uncovered real prompt drift
+  between them (NanoClaw `BASE_SYSTEM_PROMPT` was missing the Rule 6
+  meta-request filter and mis-listed `summary` in the ADD output shape).
+  Hoisting into core makes byte-identity the compile-time default.
+- The canonical prompt text is embedded from `src/prompts/extraction.md`
+  and `src/prompts/compaction.md` via `include_str!`. The markdown
+  files are the source of truth — diffs there show up directly as
+  prompt changes. Shape comes from the plugin / Python pipeline
+  (includes Rule 6 meta-filter).
+- **Public Rust API**:
+  - [`prompts::EXTRACTION_SYSTEM_PROMPT`](./src/prompts.rs) /
+    [`prompts::COMPACTION_SYSTEM_PROMPT`](./src/prompts.rs) — static
+    `&str` constants.
+  - [`prompts::get_extraction_system_prompt`](./src/prompts.rs) /
+    [`prompts::get_compaction_system_prompt`](./src/prompts.rs) —
+    thin accessors (preferred for cross-client consumers).
+- **WASM bindings** (`crate::wasm`):
+  - `getExtractionSystemPrompt() -> string`
+  - `getCompactionSystemPrompt() -> string`
+- **PyO3 bindings** (`totalreclaw_core`):
+  - `get_extraction_system_prompt() -> str`
+  - `get_compaction_system_prompt() -> str`
+- Unit tests on `prompts::tests` verify the embedded bytes are
+  non-empty, stable across calls (same `as_ptr()`), contain the 6 v1
+  types, carry the two-phase merged-topic shape, and include Rule 6
+  in both variants. Compaction prompt additionally asserts the
+  importance-floor-5 language.
+- `Cargo.toml` now declares an explicit `package.include` list that
+  spells out `src/prompts/*.md` so future refactors can't accidentally
+  drop the canonical prompt files from the published tarball.
+
+### Notes / Compatibility
+
+- Minor-version bump (additive public surface only). No breaking changes.
+- Python `totalreclaw` (2.3.0) and NanoClaw (3.1.0) consume the hoisted
+  prompts via their respective bindings in this release wave. The
+  OpenClaw plugin keeps its local copy for this wave — the consumer
+  wire lands in plugin 3.3.0 (tracked separately to avoid colliding
+  with plugin 3.2.2 / 3.2.3 from the parallel pin-atomic-batch +
+  wave2c PRs).
+- Byte-identity between Python + WASM callers is load-bearing for
+  cross-client extraction parity. See
+  `docs/specs/totalreclaw/memory-taxonomy-v1.md` §"Canonical prompts".
+
 ## [2.1.1] - 2026-04-19
 
 ### Added

--- a/rust/totalreclaw-core/Cargo.lock
+++ b/rust/totalreclaw-core/Cargo.lock
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "totalreclaw-core"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/rust/totalreclaw-core/Cargo.toml
+++ b/rust/totalreclaw-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "totalreclaw-core"
-version = "2.1.1"
+version = "2.2.0"
 edition = "2021"
 description = "TotalReclaw core — E2EE crypto, reranker, wallet, UserOp, store/search pipelines. Single source of truth for all clients."
 license = "MIT"
@@ -9,6 +9,20 @@ homepage = "https://totalreclaw.xyz"
 readme = "README.md"
 keywords = ["e2ee", "memory", "crypto", "erc4337", "ai"]
 categories = ["cryptography", "api-bindings"]
+# Ensure the canonical extraction + compaction prompts ship with the
+# published crate. `src/prompts.rs` embeds these `.md` files via
+# `include_str!` at compile time — the Cargo default package rules
+# include files under `src/**`, but we spell it out so future
+# refactors (e.g. moving prompts outside `src/`) can't accidentally
+# drop them from the tarball. The plugin consumer wire (plugin 3.3.0)
+# depends on this.
+include = [
+    "src/**/*.rs",
+    "src/prompts/*.md",
+    "Cargo.toml",
+    "pyproject.toml",
+    "README.md",
+]
 
 [features]
 default = ["managed"]

--- a/rust/totalreclaw-core/pyproject.toml
+++ b/rust/totalreclaw-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "totalreclaw-core"
-version = "2.1.1"
+version = "2.2.0"
 description = "TotalReclaw crypto core — E2EE, LSH, blind indices, protobuf encoding (Rust)"
 requires-python = ">=3.10"
 license = { text = "MIT" }

--- a/rust/totalreclaw-core/src/lib.rs
+++ b/rust/totalreclaw-core/src/lib.rs
@@ -22,6 +22,7 @@
 //! - [`consolidation`] — Store-time near-duplicate detection + supersede logic
 //! - [`smart_import`] — Smart import profiling (prompt construction + response parsing)
 //! - [`memory_types`] — Memory Taxonomy v1 string-level constants + runtime guard
+//! - [`prompts`] — Canonical extraction + compaction system prompts (2.2.0)
 
 pub mod blind;
 pub mod claims;
@@ -36,6 +37,7 @@ pub mod fingerprint;
 pub mod hotcache;
 pub mod lsh;
 pub mod memory_types;
+pub mod prompts;
 pub mod protobuf;
 pub mod reranker;
 pub mod smart_import;

--- a/rust/totalreclaw-core/src/prompts.rs
+++ b/rust/totalreclaw-core/src/prompts.rs
@@ -1,0 +1,147 @@
+//! Canonical LLM prompts — single source of truth for all TotalReclaw clients.
+//!
+//! As of core 2.2.0 the canonical extraction + compaction system prompts live
+//! here and are embedded at compile time via [`include_str!`]. TypeScript
+//! (via WASM) and Python (via PyO3) consumers call the thin accessors in
+//! [`crate::wasm`] / [`crate::python`] and get byte-identical bytes on every
+//! platform.
+//!
+//! Why hoist:
+//!   * Before 2.2.0, each client (`skill/plugin`, `python/agent/extraction.py`,
+//!     `skill-nanoclaw`) kept its own copy. Prompt drift between clients
+//!     produced real bugs — the 2026-04-18 v1 QA uncovered the NanoClaw
+//!     BASE_SYSTEM_PROMPT diverging from the plugin/Python shape (no Rule 6
+//!     meta-filter, `summary` mis-listed in the ADD output shape).
+//!   * One source → identical behaviour across clients, and the spec
+//!     (`docs/specs/totalreclaw/memory-taxonomy-v1.md`) can point at a single
+//!     file.
+//!
+//! Canonical shape comes from the plugin / Python pipeline (Rule 6 meta-request
+//! filter included — see `docs/notes/extraction-prompt-map.md`).
+
+/// Canonical v1 merged-topic extraction system prompt.
+///
+/// Two-phase output (topics + facts). Emits v1 taxonomy types only.
+/// Includes Rule 6 (product-meta request filter) that was introduced in
+/// Python 2.0.2 / plugin 3.0.0 after the v1 QA surfaced spurious extraction
+/// of product setup utterances as user preferences.
+pub const EXTRACTION_SYSTEM_PROMPT: &str = include_str!("prompts/extraction.md");
+
+/// Canonical v1 compaction system prompt.
+///
+/// Same two-phase shape as [`EXTRACTION_SYSTEM_PROMPT`] but tuned for
+/// end-of-context compaction: importance floor 5 (not 6), explicit
+/// format-agnostic-parsing section for bullet lists / headers / prose.
+pub const COMPACTION_SYSTEM_PROMPT: &str = include_str!("prompts/compaction.md");
+
+/// Return the canonical v1 extraction system prompt.
+///
+/// This is the function cross-client consumers should call so the embedded
+/// contents are never accidentally duplicated into TS/Python source trees.
+pub fn get_extraction_system_prompt() -> &'static str {
+    EXTRACTION_SYSTEM_PROMPT
+}
+
+/// Return the canonical v1 compaction system prompt.
+///
+/// Mirrors [`get_extraction_system_prompt`] but for the end-of-context
+/// compaction surface.
+pub fn get_compaction_system_prompt() -> &'static str {
+    COMPACTION_SYSTEM_PROMPT
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extraction_prompt_is_nonempty() {
+        assert!(!EXTRACTION_SYSTEM_PROMPT.is_empty());
+        assert!(EXTRACTION_SYSTEM_PROMPT.len() > 1000, "extraction prompt suspiciously short");
+    }
+
+    #[test]
+    fn compaction_prompt_is_nonempty() {
+        assert!(!COMPACTION_SYSTEM_PROMPT.is_empty());
+        assert!(COMPACTION_SYSTEM_PROMPT.len() > 1000, "compaction prompt suspiciously short");
+    }
+
+    #[test]
+    fn extraction_prompt_stable_across_calls() {
+        // Embedded via include_str! — each call returns a &'static str
+        // pointing at the same compile-time buffer.
+        let a = get_extraction_system_prompt();
+        let b = get_extraction_system_prompt();
+        assert_eq!(a, b);
+        assert_eq!(a.as_ptr(), b.as_ptr(), "prompt should be a single static buffer");
+    }
+
+    #[test]
+    fn compaction_prompt_stable_across_calls() {
+        let a = get_compaction_system_prompt();
+        let b = get_compaction_system_prompt();
+        assert_eq!(a, b);
+        assert_eq!(a.as_ptr(), b.as_ptr());
+    }
+
+    #[test]
+    fn extraction_prompt_mentions_v1_types() {
+        // The canonical prompt must list all 6 v1 types.
+        for t in &["claim", "preference", "directive", "commitment", "episode", "summary"] {
+            assert!(
+                EXTRACTION_SYSTEM_PROMPT.contains(t),
+                "extraction prompt missing v1 type {:?}",
+                t
+            );
+        }
+    }
+
+    #[test]
+    fn extraction_prompt_has_merged_topic_shape() {
+        // Two explicit phases + the merged output shape.
+        assert!(EXTRACTION_SYSTEM_PROMPT.contains("PHASE 1"));
+        assert!(EXTRACTION_SYSTEM_PROMPT.contains("PHASE 2"));
+        assert!(EXTRACTION_SYSTEM_PROMPT.contains("\"topics\""));
+        assert!(EXTRACTION_SYSTEM_PROMPT.contains("\"facts\""));
+    }
+
+    #[test]
+    fn extraction_prompt_includes_rule_6_meta_filter() {
+        // Canonical source includes the meta-request filter (Rule 6 in Python).
+        assert!(
+            EXTRACTION_SYSTEM_PROMPT.contains("META-request")
+                || EXTRACTION_SYSTEM_PROMPT.contains("META-requests"),
+            "extraction prompt missing Rule 6 meta-filter language"
+        );
+        assert!(EXTRACTION_SYSTEM_PROMPT.contains("TotalReclaw"));
+    }
+
+    #[test]
+    fn compaction_prompt_admits_importance_5() {
+        // Compaction floor is 5 (one below the default 6).
+        assert!(
+            COMPACTION_SYSTEM_PROMPT.contains("5+")
+                || COMPACTION_SYSTEM_PROMPT.contains("5 "),
+            "compaction prompt must mention importance floor 5"
+        );
+    }
+
+    #[test]
+    fn compaction_prompt_includes_rule_6_meta_filter() {
+        assert!(
+            COMPACTION_SYSTEM_PROMPT.contains("META-request")
+                || COMPACTION_SYSTEM_PROMPT.contains("META-requests"),
+            "compaction prompt missing Rule 6 meta-filter language"
+        );
+        assert!(COMPACTION_SYSTEM_PROMPT.contains("TotalReclaw"));
+    }
+
+    #[test]
+    fn prompts_are_distinct() {
+        // They share structure but the compaction prompt has the
+        // "LAST CHANCE" framing + format-agnostic section.
+        assert_ne!(EXTRACTION_SYSTEM_PROMPT, COMPACTION_SYSTEM_PROMPT);
+        assert!(COMPACTION_SYSTEM_PROMPT.contains("LAST CHANCE"));
+        assert!(COMPACTION_SYSTEM_PROMPT.contains("FORMAT-AGNOSTIC"));
+    }
+}

--- a/rust/totalreclaw-core/src/prompts/compaction.md
+++ b/rust/totalreclaw-core/src/prompts/compaction.md
@@ -1,0 +1,102 @@
+You are extracting memories from a conversation that is about to be compacted. The context will be LOST after this point — this is your LAST CHANCE to capture everything worth remembering. Be more aggressive than usual: err on the side of storing.
+
+Work in TWO explicit phases within one response:
+
+PHASE 1 — Topic identification.
+Identify the 2-3 main topics the user was engaging with before extracting any fact. Topics should be short phrases (2-5 words each). If there's no clear user-focused topic, use an empty topics array.
+
+PHASE 2 — Fact extraction anchored to those topics (plus preserve active context).
+Extract valuable memories. Prefer facts that directly relate to the identified topics (importance 7-9 range). Active project context, decisions in progress, and current working state score 6-8 during compaction — capture them even when they'd normally be marginal.
+
+Rules:
+1. Each memory = single self-contained piece of information
+2. Focus on user-specific info useful in future conversations
+3. Skip generic knowledge, greetings, small talk
+4. Score importance 1-10 (5+ = worth storing during compaction)
+5. Every memory MUST attribute a source (provenance critical)
+6. DO NOT extract setup / configuration / installation requests ABOUT the
+   TotalReclaw product itself. Utterances like "set up TotalReclaw",
+   "I want encrypted memory across my AI tools", or "configure the
+   memory plugin" are META-requests about the product — NOT user
+   preferences worth storing. Genuine preferences that mention encryption
+   ("I prefer Signal because it's encrypted") ARE valid.
+
+Importance rubric (full 1-10 range, NOT just 7-8):
+- 10: Core identity, never-forget ("remember this forever", name/birthday)
+- 9: Affects many future decisions / high-impact rules
+- 8: Preference / decision-with-reasoning / operational rule
+- 7: Specific durable fact
+- 6: Borderline — during compaction, capture anyway
+- 5: Would normally drop; keep as compaction safety net
+- 4 or below: DROP (greetings, filler)
+
+═══════════════════════════════════════════════════════════════
+TYPE (6 values)
+═══════════════════════════════════════════════════════════════
+- claim: factual assertion (absorbs v0 fact/context/decision; decisions populate reasoning)
+- preference: likes/dislikes/tastes
+- directive: imperative rule ("always X", "never Y")
+- commitment: future intent ("will do X")
+- episode: notable event
+- summary: derived synthesis (source must be derived|assistant)
+
+═══════════════════════════════════════════════════════════════
+SOURCE (provenance, CRITICAL)
+═══════════════════════════════════════════════════════════════
+- user: user explicitly stated it (in [user]: turns)
+- user-inferred: extractor inferred from user signals
+- assistant: assistant authored — DOWNGRADE unless user affirmed/quoted.
+- external, derived: rare.
+
+IF fact substance appears ONLY in [assistant]: turns without user affirmation → source:assistant.
+
+═══════════════════════════════════════════════════════════════
+SCOPE
+═══════════════════════════════════════════════════════════════
+work | personal | health | family | creative | finance | misc | unspecified
+
+═══════════════════════════════════════════════════════════════
+ENTITIES
+═══════════════════════════════════════════════════════════════
+- type ∈ {person, project, tool, company, concept, place}
+- prefer specific names ("PostgreSQL" not "database")
+- omit umbrella categories when specific name is present
+
+═══════════════════════════════════════════════════════════════
+REASONING (only for claims that are decisions)
+═══════════════════════════════════════════════════════════════
+For type=claim where the user expressed a decision-with-reasoning, populate "reasoning" with the WHY clause.
+
+═══════════════════════════════════════════════════════════════
+FORMAT-AGNOSTIC PARSING (IMPORTANT)
+═══════════════════════════════════════════════════════════════
+The conversation may contain bullet lists, numbered lists, section headers, code snippets, or plain prose. Treat ALL formats as potential sources of extractable memory:
+- Bullets/list items: each item is a candidate.
+- Section headers (Context, Decisions, Key Learnings, Open Questions): use the header as a TYPE HINT (Context → claim, Decisions → claim+reasoning, Learnings → directive, Open Questions → commitment).
+- Plain prose: parse each distinct assertion as a candidate.
+- Code snippets: extract config choices, tool versions, architectural decisions embedded in comments or structure.
+- Mixed format: apply all of the above.
+
+Do NOT skip content just because it's in a summary. The agent has already filtered — your job is to convert into structured memories, not to re-evaluate worth.
+
+═══════════════════════════════════════════════════════════════
+OUTPUT FORMAT (no markdown, no code fences)
+═══════════════════════════════════════════════════════════════
+{
+  "topics": ["topic 1", "topic 2"],
+  "facts": [
+    {
+      "text": "...",
+      "type": "claim|preference|directive|commitment|episode",
+      "source": "user|user-inferred|assistant",
+      "scope": "work|personal|health|...",
+      "importance": N,
+      "confidence": 0.9,
+      "action": "ADD",
+      "reasoning": "...",    // optional, only for claim+decision
+      "entities": [{"name": "...", "type": "tool"}]
+    }
+  ]
+}
+
+If nothing worth extracting: {"topics": [], "facts": []}

--- a/rust/totalreclaw-core/src/prompts/extraction.md
+++ b/rust/totalreclaw-core/src/prompts/extraction.md
@@ -1,0 +1,90 @@
+You are a memory extraction engine using Memory Taxonomy v1. Work in TWO explicit phases within one response:
+
+PHASE 1 — Topic identification.
+Before extracting any fact, identify the 2-3 main topics the user was engaging with. Topics should be short phrases (2-5 words each). If the conversation has no clear user-focused topic, use an empty topics array.
+
+PHASE 2 — Fact extraction anchored to those topics.
+Extract valuable memories. Prefer facts that directly relate to the identified topics (importance 7-9 range). Tangential facts may still be extracted but score lower (6-7 range).
+
+Rules:
+1. Each memory = single self-contained piece of information
+2. Focus on user-specific info useful in future conversations
+3. Skip generic knowledge, greetings, small talk, ephemeral task coordination
+4. Score importance 1-10 (6+ = worth storing)
+5. Every memory MUST attribute a source (provenance critical)
+6. DO NOT extract setup / configuration / installation requests ABOUT the
+   TotalReclaw product itself. Utterances like "set up TotalReclaw",
+   "I want encrypted memory across my AI tools", "install the memory plugin",
+   or "configure the vault" are META-requests about the product — they are
+   NOT user preferences or claims worth storing. Genuine preferences that
+   happen to mention encryption (e.g., "I like using Signal because it's
+   encrypted") ARE valid and should be extracted.
+
+Importance rubric (use FULL 1-10 range):
+- 10: Critical, core identity, never-forget content
+- 9: Affects many future decisions
+- 8: High-value preference/decision/rule
+- 7: Specific durable fact
+- 6: Borderline
+- 5 or below: NOT worth storing — drop
+
+DO NOT cluster everything at 7-8-9.
+
+═══════════════════════════════════════════════════════════════
+TYPE (6 values)
+═══════════════════════════════════════════════════════════════
+- claim: factual assertion (absorbs fact/context/decision; decisions populate reasoning field)
+- preference: likes/dislikes/tastes
+- directive: imperative rule ("always X", "never Y")
+- commitment: future intent ("will do X")
+- episode: notable event
+- summary: derived synthesis (source must be derived|assistant) — do NOT emit for turn-extraction
+
+═══════════════════════════════════════════════════════════════
+SOURCE (provenance, CRITICAL)
+═══════════════════════════════════════════════════════════════
+- user: user explicitly stated it (in [user]: turns)
+- user-inferred: extractor inferred from user signals
+- assistant: assistant authored content — DOWNGRADE unless user affirmed/quoted/used it
+- external, derived: rare
+
+IF fact substance appears ONLY in [assistant]: turns without user affirmation → source:assistant
+
+═══════════════════════════════════════════════════════════════
+SCOPE (life domain)
+═══════════════════════════════════════════════════════════════
+work | personal | health | family | creative | finance | misc | unspecified
+
+═══════════════════════════════════════════════════════════════
+ENTITIES
+═══════════════════════════════════════════════════════════════
+- type ∈ {person, project, tool, company, concept, place}
+- prefer specific names ("PostgreSQL" not "database")
+- omit umbrella categories when specific name is present
+
+═══════════════════════════════════════════════════════════════
+REASONING (only for claims that are decisions)
+═══════════════════════════════════════════════════════════════
+For type=claim where the user expressed a decision-with-reasoning, populate "reasoning" with the WHY clause.
+
+═══════════════════════════════════════════════════════════════
+OUTPUT FORMAT (no markdown, no code fences)
+═══════════════════════════════════════════════════════════════
+{
+  "topics": ["topic 1", "topic 2"],
+  "facts": [
+    {
+      "text": "...",
+      "type": "claim|preference|directive|commitment|episode",
+      "source": "user|user-inferred|assistant",
+      "scope": "work|personal|health|...",
+      "importance": N,
+      "confidence": 0.9,
+      "action": "ADD",
+      "reasoning": "...",     // optional, only for claim+decision
+      "entities": [{"name": "...", "type": "tool"}]
+    }
+  ]
+}
+
+If nothing worth extracting: {"topics": [], "facts": []}

--- a/rust/totalreclaw-core/src/python.rs
+++ b/rust/totalreclaw-core/src/python.rs
@@ -337,6 +337,28 @@ fn get_debrief_system_prompt() -> &'static str {
 }
 
 // ---------------------------------------------------------------------------
+// Canonical extraction + compaction system prompts (core 2.2.0 hoist)
+// ---------------------------------------------------------------------------
+
+/// Get the canonical v1 merged-topic extraction system prompt.
+///
+/// Single source of truth across Python (via this binding), TypeScript
+/// (via the WASM binding `getExtractionSystemPrompt`), and Rust callers.
+/// The prompt includes the Rule 6 meta-request filter.
+#[pyfunction]
+fn get_extraction_system_prompt() -> &'static str {
+    crate::prompts::get_extraction_system_prompt()
+}
+
+/// Get the canonical v1 compaction system prompt.
+///
+/// Used on the pre-compaction surface (importance floor 5, not 6).
+#[pyfunction]
+fn get_compaction_system_prompt() -> &'static str {
+    crate::prompts::get_compaction_system_prompt()
+}
+
+// ---------------------------------------------------------------------------
 // Reranker
 // ---------------------------------------------------------------------------
 
@@ -1514,6 +1536,10 @@ fn totalreclaw_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Debrief
     m.add_function(wrap_pyfunction!(parse_debrief_response, m)?)?;
     m.add_function(wrap_pyfunction!(get_debrief_system_prompt, m)?)?;
+
+    // Canonical extraction + compaction system prompts (core 2.2.0 hoist).
+    m.add_function(wrap_pyfunction!(get_extraction_system_prompt, m)?)?;
+    m.add_function(wrap_pyfunction!(get_compaction_system_prompt, m)?)?;
 
     // Reranker
     m.add_function(wrap_pyfunction!(py_rerank, m)?)?;

--- a/rust/totalreclaw-core/src/wasm.rs
+++ b/rust/totalreclaw-core/src/wasm.rs
@@ -297,6 +297,26 @@ pub fn wasm_get_debrief_system_prompt() -> String {
     debrief::DEBRIEF_SYSTEM_PROMPT.to_string()
 }
 
+/// Get the canonical v1 merged-topic extraction system prompt.
+///
+/// Single source of truth across all TotalReclaw clients — TS/WASM
+/// callers get the same bytes the Python `totalreclaw_core` module
+/// returns from `get_extraction_system_prompt()`. Includes the Rule 6
+/// meta-request filter (see the docstring on `prompts.rs`).
+#[wasm_bindgen(js_name = "getExtractionSystemPrompt")]
+pub fn wasm_get_extraction_system_prompt() -> String {
+    crate::prompts::get_extraction_system_prompt().to_string()
+}
+
+/// Get the canonical v1 compaction system prompt.
+///
+/// Used on end-of-context surfaces where the importance floor is 5 rather
+/// than the default 6.
+#[wasm_bindgen(js_name = "getCompactionSystemPrompt")]
+pub fn wasm_get_compaction_system_prompt() -> String {
+    crate::prompts::get_compaction_system_prompt().to_string()
+}
+
 /// Build the debrief prompt with already-stored facts filled in.
 ///
 /// `stored_facts_json`: JSON array of strings (fact texts already stored).

--- a/skill-nanoclaw/CHANGELOG.md
+++ b/skill-nanoclaw/CHANGELOG.md
@@ -1,5 +1,70 @@
 # Changelog — @totalreclaw/skill-nanoclaw
 
+## 3.1.0 — 2026-04-19
+
+### Canonical extraction prompt hoisted to core + ADD-only alignment
+
+NanoClaw now sources its extraction + compaction system prompts from the
+Rust core (`@totalreclaw/core` 2.2.0+) via `getExtractionSystemPrompt()` /
+`getCompactionSystemPrompt()`. Previously `BASE_SYSTEM_PROMPT` in
+`src/extraction/prompts.ts` was a local copy that had drifted from the
+plugin / Python canonical version (the 2026-04-18 v1 QA surfaced this —
+NanoClaw was missing the Rule 6 product-meta filter AND mis-listed
+`summary` in the emitter ADD output shape).
+
+**The hoisted prompt is ADD-only on the emitter side.** The output
+schema only lists `"action": "ADD"`. The accompanying investigation
+(`docs/notes/NANOCLAW-ACTION-FREQUENCY-20260419.md`) confirmed that
+pre-3.1 NanoClaw UPDATE / DELETE / NOOP code paths were never hit in
+production — `agent-end.ts` only ever stored ADDs (see
+`agent-end.ts` line ~108), and `pre-compact.ts` had branches that
+could fire but were rare / untested in practice.
+
+### Changed
+
+- `src/extraction/prompts.ts`:
+  - `BASE_SYSTEM_PROMPT` is now `wasm.getExtractionSystemPrompt()` —
+    evaluated at module load, byte-identical to the Python client's
+    `EXTRACTION_SYSTEM_PROMPT` and the canonical source in
+    `rust/totalreclaw-core/src/prompts/extraction.md`.
+  - New public const `COMPACTION_SYSTEM_PROMPT` sourced from
+    `wasm.getCompactionSystemPrompt()`. `PRE_COMPACTION_PROMPT.system`
+    now points at it (previously shared `BASE_SYSTEM_PROMPT`, which
+    used the turn-extraction floor-6 variant — this aligns with the
+    Python client that has had floor-5 compaction from day one).
+  - `ExtractionAction` type still includes all four tokens
+    (`'ADD' | 'UPDATE' | 'DELETE' | 'NOOP'`) on the parser side so
+    cached LLM outputs or custom drivers don't hard-fail validation.
+    Hooks silently ignore anything that isn't ADD.
+- `src/hooks/pre-compact.ts`:
+  - Switch statement replaced with `if (fact.action !== 'ADD') continue`.
+  - Debrief "already stored" context now filters by `action === 'ADD'`
+    only (previously included UPDATE as "stored").
+- `src/hooks/agent-end.ts`: unchanged in behavior — already ADD-only
+  (line ~108 `fact.action === 'ADD'` guard).
+- Prompt objects (`PRE_COMPACTION_PROMPT`, `POST_TURN_PROMPT`,
+  `EXPLICIT_COMMAND_PROMPT`): `.user` template no longer instructs the
+  LLM to "classify as UPDATE/DELETE/NOOP" in the existing-memories
+  section — reworded to "skip any fact that is already captured or
+  overlaps with an existing memory". Matches the ADD-only emitter.
+
+### Compatibility
+
+- `@totalreclaw/core` dependency floor bumps `^2.0.0 → ^2.2.0`. Pre-2.2.0
+  WASM builds do NOT export `getExtractionSystemPrompt` /
+  `getCompactionSystemPrompt`, so the import would fail at module load.
+- Tests updated: the three preCompact tests that previously asserted
+  UPDATE forget+remember / DELETE forget behavior now assert those
+  actions are silently ignored. agent-end UPDATE/DELETE/NOOP
+  silently-ignored tests pass unchanged.
+
+### Motivation
+
+- 2026-04-18 v1 QA → prompt-drift incident.
+- Removes the last "action-dispatch" complexity from NanoClaw, reducing
+  the surface area for prompt-regression bugs. Plugin + Python + NanoClaw
+  now share one prompt + one behavior contract.
+
 ## 3.0.0 — 2026-04-18
 
 Memory Taxonomy v1 is now the default (and only) extraction path. The legacy

--- a/skill-nanoclaw/package-lock.json
+++ b/skill-nanoclaw/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@totalreclaw/skill-nanoclaw",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/skill-nanoclaw",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@totalreclaw/client": "^1.2.0",
-        "@totalreclaw/core": "file:../rust/totalreclaw-core/pkg"
+        "@totalreclaw/core": "^2.2.0"
       },
       "devDependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.81",
@@ -65,7 +65,7 @@
     },
     "../rust/totalreclaw-core/pkg": {
       "name": "@totalreclaw/core",
-      "version": "2.0.0",
+      "version": "2.2.0",
       "license": "MIT"
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {

--- a/skill-nanoclaw/package.json
+++ b/skill-nanoclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/skill-nanoclaw",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "NanoClaw skill for TotalReclaw integration — Memory Taxonomy v1 default",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "@totalreclaw/client": "^1.2.0",
-    "@totalreclaw/core": "^2.0.0"
+    "@totalreclaw/core": "^2.2.0"
   },
   "peerDependencies": {
     "@totalreclaw/mcp-server": "^3.0.0"

--- a/skill-nanoclaw/src/extraction/prompts.ts
+++ b/skill-nanoclaw/src/extraction/prompts.ts
@@ -1,16 +1,38 @@
 /**
  * TotalReclaw NanoClaw Skill — LLM Prompts for Fact Extraction (v1 taxonomy).
  *
- * As of NanoClaw 3.0.0, Memory Taxonomy v1 is the only extraction path.
- * The 6 canonical types (claim, preference, directive, commitment, episode,
- * summary) replace the legacy v0 8-type list. Legacy v0 tokens are still
- * accepted on the read/parse side via ``V0_TO_V1_TYPE`` so pre-v1 vault
- * entries still round-trip.
+ * As of NanoClaw 3.1.0:
  *
- * Aligned with the canonical extraction prompt from
- * ``skill/plugin/extractor.ts`` (plugin v3.0.0).
+ *   1. The canonical extraction system prompt is sourced from the Rust core
+ *      (`@totalreclaw/core` 2.2.0+) via `getExtractionSystemPrompt()` —
+ *      byte-identical to what the Python client consumes from PyO3. One
+ *      source of truth eliminates the prompt drift the 2026-04-18 v1 QA
+ *      uncovered.
+ *   2. Extraction is **ADD-only** on the emitter side. The hoisted prompt
+ *      output schema only lists `"action": "ADD"` and the hooks silently
+ *      ignore any UPDATE/DELETE/NOOP tokens that leak through. This
+ *      aligns with the investigation finding that NanoClaw pre-3.1 never
+ *      actually acted on UPDATE/DELETE/NOOP in production paths —
+ *      `agent-end.ts` only ever stored ADDs (see `agent-end.ts` line ~108),
+ *      and `pre-compact.ts` had branches that could fire but were rare /
+ *      untested in practice. See
+ *      `docs/notes/NANOCLAW-ACTION-FREQUENCY-20260419.md`.
+ *
+ * Memory Taxonomy v1 (the 6 canonical types) remains the only extraction
+ * taxonomy. Legacy v0 tokens are still accepted on the read/parse side via
+ * ``V0_TO_V1_TYPE`` so pre-v1 vault entries still round-trip.
  */
 
+import * as wasm from '@totalreclaw/core';
+
+/**
+ * Extraction action tokens. The LLM output schema only emits `"ADD"` now
+ * (see the hoisted `getExtractionSystemPrompt` contents), but `validateExtractionResponse`
+ * still accepts all four on the parser side — legacy cached LLM outputs or
+ * custom model drivers might still produce the wider set, and we prefer to
+ * parse them and let the hooks decide to silently ignore than to hard-fail
+ * validation.
+ */
 export type ExtractionAction = 'ADD' | 'UPDATE' | 'DELETE' | 'NOOP';
 
 // ---------------------------------------------------------------------------
@@ -142,93 +164,38 @@ export interface ExtractedFact {
 }
 
 // ---------------------------------------------------------------------------
-// v1 merged-topic extraction prompt
+// v1 merged-topic extraction prompt (hoisted canonical source)
+//
+// The extraction + compaction system prompts live in the Rust core
+// (`rust/totalreclaw-core/src/prompts/{extraction,compaction}.md`,
+// accessed via `@totalreclaw/core` 2.2.0+). NanoClaw consumes the hoisted
+// version so all TotalReclaw clients (plugin, Python, NanoClaw) use
+// byte-identical prompt bytes — no more drift.
+//
+// The canonical prompt is ADD-only on the emitter side (only `"action": "ADD"`
+// appears in the output schema). Hooks (`agent-end.ts`, `pre-compact.ts`)
+// silently ignore any UPDATE/DELETE/NOOP tokens that might still leak
+// through from cached outputs or custom drivers.
 // ---------------------------------------------------------------------------
 
-const BASE_SYSTEM_PROMPT = `You are a memory extraction engine using Memory Taxonomy v1. Work in TWO explicit phases within one response:
+/**
+ * Canonical v1 extraction system prompt — sourced from @totalreclaw/core 2.2.0+.
+ *
+ * Evaluated at module-load time so downstream consumers (the three prompt
+ * objects below) get a plain string. Identical bytes across all clients.
+ */
+export const BASE_SYSTEM_PROMPT: string = wasm.getExtractionSystemPrompt();
 
-PHASE 1 — Topic identification.
-Before extracting any fact, identify the 2-3 main topics the user was engaging with. Topics should be short phrases (2-5 words each). If the conversation has no clear user-focused topic, use an empty topics array.
-
-PHASE 2 — Fact extraction anchored to those topics.
-Extract valuable memories. Prefer facts that directly relate to the identified topics (importance 7-9 range). Tangential facts may still be extracted but score lower (6-7 range).
-
-Rules:
-1. Each memory = single self-contained piece of information
-2. Focus on user-specific info useful in future conversations
-3. Skip generic knowledge, greetings, small talk, ephemeral task coordination
-4. Score importance 1-10 (6+ = worth storing)
-5. Every memory MUST attribute a source (provenance critical)
-
-Importance rubric (use FULL 1-10 range):
-- 10: Critical, core identity, never-forget content
-- 9: Affects many future decisions
-- 8: High-value preference/decision/rule
-- 7: Specific durable fact
-- 6: Borderline
-- 5 or below: NOT worth storing — drop
-
-DO NOT cluster everything at 7-8-9.
-
-═══════════════════════════════════════════════════════════════
-TYPE (6 values)
-═══════════════════════════════════════════════════════════════
-- claim: factual assertion (absorbs fact/context/decision; decisions populate reasoning field)
-- preference: likes/dislikes/tastes
-- directive: imperative rule ("always X", "never Y")
-- commitment: future intent ("will do X")
-- episode: notable event
-- summary: derived synthesis (source must be derived|assistant) — do NOT emit for turn-extraction
-
-═══════════════════════════════════════════════════════════════
-SOURCE (provenance, CRITICAL)
-═══════════════════════════════════════════════════════════════
-- user: user explicitly stated it (in [user]: turns)
-- user-inferred: extractor inferred from user signals
-- assistant: assistant authored content — DOWNGRADE unless user affirmed/quoted/used it
-- external, derived: rare
-
-IF fact substance appears ONLY in [assistant]: turns without user affirmation → source:assistant
-
-═══════════════════════════════════════════════════════════════
-SCOPE (life domain)
-═══════════════════════════════════════════════════════════════
-work | personal | health | family | creative | finance | misc | unspecified
-
-═══════════════════════════════════════════════════════════════
-REASONING (only for claims that are decisions)
-═══════════════════════════════════════════════════════════════
-For type=claim where the user expressed a decision-with-reasoning, populate "reasoning" with the WHY clause.
-
-Actions (compare against existing memories if provided):
-- ADD: New memory, no conflict with existing
-- UPDATE: Refines or corrects an existing memory (provide existingFactId)
-- DELETE: Contradicts an existing memory — the old one is now wrong (provide existingFactId)
-- NOOP: Already captured or not worth storing
-
-═══════════════════════════════════════════════════════════════
-OUTPUT FORMAT (no markdown, no code fences)
-═══════════════════════════════════════════════════════════════
-{
-  "topics": ["topic 1", "topic 2"],
-  "facts": [
-    {
-      "text": "...",
-      "type": "claim|preference|directive|commitment|episode|summary",
-      "source": "user|user-inferred|assistant",
-      "scope": "work|personal|health|...",
-      "importance": N,
-      "action": "ADD|UPDATE|DELETE|NOOP",
-      "reasoning": "...",      // optional, only for claim+decision
-      "existingFactId": "..."  // only for UPDATE/DELETE
-    }
-  ]
-}
-
-If nothing worth extracting: {"topics": [], "facts": []}`;
+/**
+ * Canonical v1 compaction system prompt — sourced from @totalreclaw/core 2.2.0+.
+ *
+ * Variant used on the pre-compaction surface (importance floor 5 instead
+ * of 6, format-agnostic parsing section).
+ */
+export const COMPACTION_SYSTEM_PROMPT: string = wasm.getCompactionSystemPrompt();
 
 export const PRE_COMPACTION_PROMPT = {
-  system: BASE_SYSTEM_PROMPT,
+  system: COMPACTION_SYSTEM_PROMPT,
 
   user: `Extract ALL valuable long-term memories from this conversation before it is lost:
 
@@ -240,7 +207,7 @@ export const PRE_COMPACTION_PROMPT = {
     existingMemories: string;
   }): { system: string; user: string } {
     const memoriesSection = context.existingMemories && context.existingMemories !== '(No existing memories)'
-      ? `\n\nExisting memories (use these for dedup — classify as UPDATE/DELETE/NOOP if they conflict or overlap):\n${context.existingMemories}`
+      ? `\n\nExisting memories (skip any fact that is already captured or overlaps with an existing memory):\n${context.existingMemories}`
       : '';
     return {
       system: this.system,
@@ -264,7 +231,7 @@ export const POST_TURN_PROMPT = {
     existingMemories: string;
   }): { system: string; user: string } {
     const memoriesSection = context.existingMemories && context.existingMemories !== '(No existing memories)'
-      ? `\n\nExisting memories (use these for dedup — classify as UPDATE/DELETE/NOOP if they conflict or overlap):\n${context.existingMemories}`
+      ? `\n\nExisting memories (skip any fact that is already captured or overlaps with an existing memory):\n${context.existingMemories}`
       : '';
     return {
       system: this.system,

--- a/skill-nanoclaw/src/hooks/pre-compact.ts
+++ b/skill-nanoclaw/src/hooks/pre-compact.ts
@@ -81,6 +81,17 @@ export async function preCompact(
     for (const fact of validation.facts!) {
       if (quotaExceeded) break;
 
+      // NanoClaw 3.1.0: extraction is ADD-only. The hoisted core prompt
+      // no longer emits UPDATE/DELETE/NOOP, and the pre-3.1 branches for
+      // those were never hit in production (see
+      // docs/notes/NANOCLAW-ACTION-FREQUENCY-20260419.md). Any stray
+      // UPDATE/DELETE/NOOP that slips through (cached outputs, custom
+      // drivers) is silently ignored here — the parser still accepts
+      // them so we don't hard-fail, but we don't act on them.
+      if (fact.action !== 'ADD') {
+        continue;
+      }
+
       // Defensive default for source (v1 write path requires it).
       if (!fact.source) fact.source = 'user-inferred';
       const metadata: FactMetadata = {
@@ -89,38 +100,13 @@ export async function preCompact(
         tags: buildV1Tags(fact, input.groupFolder),
       };
 
-      switch (fact.action) {
-        case 'ADD':
-          try {
-            await client.remember(fact.text, metadata);
-            factsStored++;
-          } catch (err: unknown) {
-            if (handleQuotaError(err)) {
-              quotaExceeded = true;
-            }
-          }
-          break;
-
-        case 'UPDATE':
-        case 'DELETE':
-          if (fact.existingFactId) {
-            try {
-              await client.forget(fact.existingFactId);
-              if (fact.action === 'UPDATE') {
-                await client.remember(fact.text, metadata);
-                factsStored++;
-              }
-            } catch (err: unknown) {
-              if (handleQuotaError(err)) {
-                quotaExceeded = true;
-              }
-              // Skip if delete/update fails for other reasons
-            }
-          }
-          break;
-
-        case 'NOOP':
-          break;
+      try {
+        await client.remember(fact.text, metadata);
+        factsStored++;
+      } catch (err: unknown) {
+        if (handleQuotaError(err)) {
+          quotaExceeded = true;
+        }
       }
     }
 
@@ -128,8 +114,10 @@ export async function preCompact(
     let debriefStored = 0;
     if (llmClient && validation.facts && validation.facts.length > 0) {
       try {
+        // NanoClaw 3.1.0: ADD-only alignment — debrief context reflects
+        // only the facts that were actually stored by this hook.
         const storedTexts = validation.facts
-          .filter(f => f.action === 'ADD' || f.action === 'UPDATE')
+          .filter(f => f.action === 'ADD')
           .map(f => f.text);
         const alreadyStored = storedTexts.length > 0
           ? storedTexts.map(t => `- ${t}`).join('\n')

--- a/skill-nanoclaw/tests/hooks.test.js
+++ b/skill-nanoclaw/tests/hooks.test.js
@@ -197,7 +197,12 @@ describe('preCompact', () => {
     expect(result.factsStored).toBe(1);
   });
 
-  it('should handle UPDATE action', async () => {
+  // NanoClaw 3.1.0: ADD-only alignment. The hoisted core prompt
+  // (rust/totalreclaw-core/src/prompts/*.md) no longer emits
+  // UPDATE/DELETE/NOOP — any stray tokens that slip through are
+  // silently ignored. preCompact no longer forget-then-remember's on
+  // UPDATE, and no longer forget's on DELETE.
+  it('should silently ignore UPDATE action (ADD-only alignment)', async () => {
     const mockClient = createMockClient();
     const mockLLMClient = {
       generate: jest.fn().mockResolvedValue(JSON.stringify({
@@ -220,8 +225,9 @@ describe('preCompact', () => {
       groupFolder: 'main',
     });
 
-    expect(mockClient.forget).toHaveBeenCalledWith('old-fact-id');
-    expect(result.factsStored).toBe(1);
+    expect(mockClient.forget).not.toHaveBeenCalled();
+    expect(mockClient.remember).not.toHaveBeenCalled();
+    expect(result.factsStored).toBe(0);
   });
 });
 
@@ -505,7 +511,7 @@ describe('agentEnd extended', () => {
 });
 
 describe('preCompact extended', () => {
-  it('should handle DELETE action', async () => {
+  it('should silently ignore DELETE action (ADD-only alignment)', async () => {
     const mockClient = createMockClient();
     const mockLLMClient = {
       generate: jest.fn().mockResolvedValue(JSON.stringify({
@@ -528,7 +534,10 @@ describe('preCompact extended', () => {
       groupFolder: 'main',
     });
 
-    expect(mockClient.forget).toHaveBeenCalledWith('old-fact-123');
+    // NanoClaw 3.1.0: DELETE is silently ignored — the hoisted core
+    // prompt no longer emits DELETE, and any stray DELETE tokens do NOT
+    // trigger a forget.
+    expect(mockClient.forget).not.toHaveBeenCalled();
     expect(result.factsStored).toBe(0);
   });
 
@@ -1007,22 +1016,26 @@ describe('agentEnd dedup interaction', () => {
 });
 
 /**
- * preCompact vs agentEnd: complementary dedup design.
+ * preCompact vs agentEnd: complementary hooks, both ADD-only (NanoClaw 3.1.0).
  *
  * Key design:
- * - agent-end is LIGHTWEIGHT: runs every N turns, ADD-only, importance >= 7,
- *   delegates near-dup protection to MCP store-time dedup
- * - pre-compaction is COMPREHENSIVE: runs once before context loss, handles
- *   full ADD/UPDATE/DELETE/NOOP with explicit forget+remember for mutations
+ * - agent-end is LIGHTWEIGHT: runs every N turns, ADD-only, importance >= 6.
+ * - pre-compaction is COMPREHENSIVE: runs once before context loss, also
+ *   ADD-only (3.1.0 alignment) but with no importance floor.
  *
- * This means:
- * - Only pre-compaction can UPDATE a fact (forget old ID + store new text)
- * - Only pre-compaction can DELETE a fact (forget old ID, don't store)
- * - Both can ADD, but agent-end filters by importance while pre-compaction doesn't
- * - Both rely on MCP store-time dedup for near-duplicate detection on ADDs
+ * As of NanoClaw 3.1.0 (see
+ * `rust/totalreclaw-core/src/prompts/extraction.md` +
+ * `docs/notes/NANOCLAW-ACTION-FREQUENCY-20260419.md`):
+ * - Both hooks silently ignore UPDATE / DELETE / NOOP actions that might
+ *   leak through from cached LLM outputs — the hoisted core prompt no
+ *   longer emits them, and the investigation found that pre-3.1
+ *   UPDATE/DELETE code paths were never hit in production.
+ * - Both can ADD. agent-end filters by importance (>=6), pre-compaction
+ *   does not.
+ * - Both rely on MCP store-time dedup for near-duplicate detection on ADDs.
  */
-describe('preCompact vs agentEnd: complementary dedup', () => {
-  it('preCompact handles UPDATE (forget old + remember new) — agentEnd does not', async () => {
+describe('preCompact vs agentEnd: complementary hooks (ADD-only)', () => {
+  it('both hooks silently ignore UPDATE (ADD-only alignment)', async () => {
     const updateFacts = JSON.stringify({
       facts: [{
         factText: 'User now prefers Rust over TypeScript',
@@ -1036,7 +1049,7 @@ describe('preCompact vs agentEnd: complementary dedup', () => {
       }],
     });
 
-    // Test agentEnd — should NOT process UPDATE
+    // Test agentEnd — should silently ignore UPDATE.
     const agentEndClient = createMockClient();
     const agentEndLLM = { generate: jest.fn().mockResolvedValue(updateFacts) };
     const { agentEnd } = require('../dist/hooks/agent-end.js');
@@ -1050,7 +1063,7 @@ describe('preCompact vs agentEnd: complementary dedup', () => {
     expect(agentEndClient.forget).not.toHaveBeenCalled();
     expect(agentEndClient.remember).not.toHaveBeenCalled();
 
-    // Test preCompact — SHOULD process UPDATE (forget old + remember new)
+    // Test preCompact — 3.1.0: also silently ignores UPDATE.
     const preCompactClient = createMockClient();
     const preCompactLLM = { generate: jest.fn().mockResolvedValue(updateFacts) };
     const { preCompact } = require('../dist/hooks/pre-compact.js');
@@ -1059,15 +1072,12 @@ describe('preCompact vs agentEnd: complementary dedup', () => {
       groupFolder: 'main',
     });
 
-    expect(preCompactResult.factsStored).toBe(1);
-    expect(preCompactClient.forget).toHaveBeenCalledWith('old-ts-fact');
-    expect(preCompactClient.remember).toHaveBeenCalledWith(
-      'User now prefers Rust over TypeScript',
-      expect.objectContaining({ source: 'pre_compaction' })
-    );
+    expect(preCompactResult.factsStored).toBe(0);
+    expect(preCompactClient.forget).not.toHaveBeenCalled();
+    expect(preCompactClient.remember).not.toHaveBeenCalled();
   });
 
-  it('preCompact handles DELETE (forget old, no store) — agentEnd does not', async () => {
+  it('both hooks silently ignore DELETE (ADD-only alignment)', async () => {
     const deleteFacts = JSON.stringify({
       facts: [{
         factText: 'User no longer uses Python',
@@ -1081,7 +1091,7 @@ describe('preCompact vs agentEnd: complementary dedup', () => {
       }],
     });
 
-    // Test agentEnd — should NOT process DELETE
+    // Test agentEnd — should silently ignore DELETE.
     const agentEndClient = createMockClient();
     const agentEndLLM = { generate: jest.fn().mockResolvedValue(deleteFacts) };
     const { agentEnd } = require('../dist/hooks/agent-end.js');
@@ -1094,7 +1104,7 @@ describe('preCompact vs agentEnd: complementary dedup', () => {
     expect(agentEndResult.factsStored).toBe(0);
     expect(agentEndClient.forget).not.toHaveBeenCalled();
 
-    // Test preCompact — SHOULD process DELETE (forget old, no store)
+    // Test preCompact — 3.1.0: also silently ignores DELETE.
     const preCompactClient = createMockClient();
     const preCompactLLM = { generate: jest.fn().mockResolvedValue(deleteFacts) };
     const { preCompact } = require('../dist/hooks/pre-compact.js');
@@ -1104,7 +1114,7 @@ describe('preCompact vs agentEnd: complementary dedup', () => {
     });
 
     expect(preCompactResult.factsStored).toBe(0);
-    expect(preCompactClient.forget).toHaveBeenCalledWith('python-fact-id');
+    expect(preCompactClient.forget).not.toHaveBeenCalled();
     expect(preCompactClient.remember).not.toHaveBeenCalled();
   });
 
@@ -1149,7 +1159,11 @@ describe('preCompact vs agentEnd: complementary dedup', () => {
     expect(preCompactClient.remember).toHaveBeenCalled();
   });
 
-  it('preCompact handles full CRUD in a single extraction', async () => {
+  it('preCompact stores only ADDs in a mixed-action batch (ADD-only alignment)', async () => {
+    // NanoClaw 3.1.0: the hoisted core prompt only emits ADD. A real
+    // LLM following the current prompt wouldn't produce this mixed batch,
+    // but cached outputs or custom drivers might — this test verifies
+    // the hook quietly drops the non-ADD actions without erroring.
     const fullCrudFacts = JSON.stringify({
       facts: [
         {
@@ -1201,29 +1215,22 @@ describe('preCompact vs agentEnd: complementary dedup', () => {
       groupFolder: 'main',
     });
 
-    // All 4 extracted
+    // All 4 extracted by the validator.
     expect(result.factsExtracted).toBe(4);
-    // ADD + UPDATE stored (2), DELETE and NOOP not stored
-    expect(result.factsStored).toBe(2);
+    // Only the ADD stores — UPDATE/DELETE/NOOP are silently skipped.
+    expect(result.factsStored).toBe(1);
 
-    // ADD: remember called for new fact
+    // ADD: remember called for the new fact.
     expect(mockClient.remember).toHaveBeenCalledWith(
       'User started learning Go',
       expect.objectContaining({ source: 'pre_compaction' })
     );
 
-    // UPDATE: forget old + remember new
-    expect(mockClient.forget).toHaveBeenCalledWith('light-mode-fact');
-    expect(mockClient.remember).toHaveBeenCalledWith(
-      'User now prefers dark mode',
-      expect.objectContaining({ source: 'pre_compaction' })
-    );
+    // UPDATE/DELETE: no forget-then-remember, no forget-only.
+    expect(mockClient.forget).not.toHaveBeenCalled();
 
-    // DELETE: forget old only
-    expect(mockClient.forget).toHaveBeenCalledWith('vim-fact');
-
-    // Total: 2 remember calls (ADD + UPDATE), 2 forget calls (UPDATE + DELETE)
-    expect(mockClient.remember).toHaveBeenCalledTimes(2);
-    expect(mockClient.forget).toHaveBeenCalledTimes(2);
+    // Total: 1 remember call (the ADD), 0 forget calls.
+    expect(mockClient.remember).toHaveBeenCalledTimes(1);
+    expect(mockClient.forget).toHaveBeenCalledTimes(0);
   });
 });

--- a/skill-nanoclaw/tests/v1-taxonomy.test.js
+++ b/skill-nanoclaw/tests/v1-taxonomy.test.js
@@ -717,15 +717,25 @@ describe('Extraction prompts — v1 content', () => {
     expect(system).toContain('unspecified');
   });
 
-  it('pre-compaction prompt uses the same v1 system content', () => {
-    expect(prompts.PRE_COMPACTION_PROMPT.system).toBe(prompts.POST_TURN_PROMPT.system);
-  });
-
-  it('explicit-command prompt uses the same v1 system content', () => {
+  it('post-turn and explicit-command prompts share the v1 extraction system content', () => {
+    // POST_TURN + EXPLICIT_COMMAND both use the canonical extraction prompt
+    // (floor-6 / turn-extraction variant).
     expect(prompts.EXPLICIT_COMMAND_PROMPT.system).toBe(prompts.POST_TURN_PROMPT.system);
+    expect(prompts.POST_TURN_PROMPT.system).toBe(prompts.BASE_SYSTEM_PROMPT);
   });
 
-  it('format() produces a prompt containing the conversation and existing memories', () => {
+  it('pre-compaction prompt uses the dedicated v1 compaction system content', () => {
+    // NanoClaw 3.1.0: PRE_COMPACTION switches to the compaction prompt
+    // (floor-5 + format-agnostic section), aligning with the Python client
+    // which has had that variant since 2.0.0. Previously NanoClaw shared
+    // the single BASE_SYSTEM_PROMPT across all surfaces.
+    expect(prompts.PRE_COMPACTION_PROMPT.system).toBe(prompts.COMPACTION_SYSTEM_PROMPT);
+    expect(prompts.PRE_COMPACTION_PROMPT.system).not.toBe(prompts.POST_TURN_PROMPT.system);
+    // Compaction variant admits importance 5; extraction variant floors at 6.
+    expect(prompts.COMPACTION_SYSTEM_PROMPT).toContain('LAST CHANCE');
+  });
+
+  it('format() produces a prompt containing the conversation and existing-memories header', () => {
     const { POST_TURN_PROMPT } = prompts;
     const result = POST_TURN_PROMPT.format({
       conversationHistory: 'turn 1\nturn 2',
@@ -733,7 +743,11 @@ describe('Extraction prompts — v1 content', () => {
     });
     expect(result.user).toContain('turn 1');
     expect(result.user).toContain('[ID: abc] prior fact');
-    expect(result.user).toContain('dedup');
+    // NanoClaw 3.1.0: the existing-memories header no longer names
+    // UPDATE/DELETE/NOOP actions (extraction is ADD-only). Now it just
+    // instructs the LLM to skip already-captured facts.
+    expect(result.user).toContain('Existing memories');
+    expect(result.user).toContain('already captured');
   });
 
   it('debrief prompt lists v1 + v0 debrief types', () => {


### PR DESCRIPTION
## Summary

- Rebased replacement for PR #45 (the stalled prompt-hoist + NanoClaw ADD-only branch). Starts fresh from `main` post-Wave 1 + Wave 2a.
- **core 2.1.1 → 2.2.0** — hoists the canonical v1 extraction + compaction system prompts into a new `totalreclaw-core::prompts` module. Prompt text lives in `src/prompts/{extraction,compaction}.md`, embedded at compile time via `include_str!`, exposed through WASM (`getExtractionSystemPrompt` / `getCompactionSystemPrompt`) + PyO3 (`get_extraction_system_prompt` / `get_compaction_system_prompt`).
- **python 2.2.2 → 2.3.0** — `agent/extraction.py` replaces the two inline triple-quoted `EXTRACTION_SYSTEM_PROMPT` / `COMPACTION_SYSTEM_PROMPT` constants with calls to the new PyO3 accessors. Module-level names preserved, `test_v1_taxonomy.py` assertions still pass. Dependency floor lifts to `totalreclaw-core>=2.2.0,<3.0.0`.
- **nanoclaw 3.0.0 → 3.1.0** — strips UPDATE/DELETE/NOOP emitter-side language from the prompt, consumes the hoisted prompt via the WASM binding, simplifies `pre-compact.ts` to ADD-only (no more forget-then-remember branch). `@totalreclaw/core` floor bumps to `^2.2.0`.
- **spec v1.2** — adds normative "Canonical prompts" section documenting the one-source-of-truth rule + the ADD-only alignment. No on-wire schema changes.

## Motivation

2026-04-18 v1 QA uncovered real prompt drift between clients — NanoClaw `BASE_SYSTEM_PROMPT` was missing the Rule 6 product-meta filter AND mis-listed `summary` in the ADD output shape. Hoisting into core makes byte-identity a compile-time invariant. The NanoClaw action-frequency investigation (`docs/notes/NANOCLAW-ACTION-FREQUENCY-20260419.md`) confirmed the UPDATE/DELETE/NOOP code paths were never hit in production, so aligning to ADD-only reduces surface area without behavior loss.

## Plugin consumer deferred

OpenClaw plugin keeps its local `EXTRACTION_SYSTEM_PROMPT` for this wave — follow-up task to wire (plugin 3.3.0). Deferred to avoid colliding with plugin 3.2.2 (pin-atomic-batch) + 3.2.3 (wave2c) version bumps landing in parallel.

## Commits

- `feat(core): v2.2.0 — hoist extraction + compaction system prompts`
- `refactor(python): v2.3.0 — consume hoisted prompts from core via PyO3`
- `refactor(nanoclaw): v3.1.0 — ADD-only + consume hoisted prompts`
- `docs(spec): v1.2 — canonical-prompt location + NanoClaw ADD-only alignment`

## Test plan

- [x] `cargo test --lib` — 492 passed
- [x] `cargo test --features python --lib` — 545 passed (includes 10 new `prompts::tests`)
- [x] `cargo build --features wasm --target wasm32-unknown-unknown` — succeeds
- [x] `wasm-pack build --target nodejs --features wasm` — succeeds; `getExtractionSystemPrompt` / `getCompactionSystemPrompt` present in `.d.ts`
- [x] Python: `PYTHONPATH=python/src python3 -m pytest python/tests/` — 680 passed, 10 skipped, 1 xfailed. No regressions.
- [x] `agent/extraction.EXTRACTION_SYSTEM_PROMPT` is byte-identical to `totalreclaw_core.get_extraction_system_prompt()`.
- [x] NanoClaw: `npm run build` + `npx jest` — 73 passed, 11 upstream failures unchanged from baseline (confirmed by stash-compare). 3 preCompact tests updated to reflect ADD-only behavior. 2 prompt-shape tests updated for PRE_COMPACTION now using COMPACTION_SYSTEM_PROMPT.
- [x] Byte-identity: `/tmp/py_extraction.md` diff against `rust/totalreclaw-core/src/prompts/extraction.md` → 0 bytes diff. Same for compaction.

## Notes on test delta

NanoClaw has 11 pre-existing upstream failures (agent-end billing cache / interval-mock issues). They're unchanged — same 11 tests fail pre- and post-my-changes. The 3 preCompact CRUD tests that previously asserted UPDATE forget+remember / DELETE forget now assert silent-ignore, matching the ADD-only behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)