### PR TITLE
feat(hermes): 2.3.1 first-run onboarding + recovery-phrase terminology

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,113 @@ Hermes Agent plugin are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] - 2026-04-20
+
+First-run onboarding UX parity with plugin 3.3.0. Users switching between
+OpenClaw (plugin) and Hermes (Python) now see the same welcome, the same
+branch question, and the same canonical "recovery phrase" terminology.
+
+### Added
+
+- `totalreclaw.onboarding` (new module): synchronous, no-network
+  first-run detection + welcome copy.
+  - `detect_first_run(credentials_path)` — returns ``True`` when the
+    credentials file is missing, empty, malformed, or lacks a
+    recognised credentials key. Accepts both canonical ``mnemonic``
+    and legacy ``recovery_phrase`` keys on read (same back-compat
+    pattern as ``agent/state.py``).
+  - `build_welcome_message(mode)` — renders the full welcome +
+    branch-question copy for either ``local`` or ``remote`` mode.
+  - `detect_mode(relay_url)` — classifies the invocation context from
+    ``TOTALRECLAW_SERVER_URL`` / loopback hostnames / explicit
+    ``TOTALRECLAW_LOCAL_GATEWAY`` env flags.
+  - `maybe_emit_welcome(...)` — once-per-process emission guarded by
+    a module-level flag AND a best-effort sentinel file at
+    ``~/.totalreclaw/.welcome_shown`` so repeat command invocations
+    for a first-run user who deferred setup don't re-spam the banner.
+  - Verbatim copy constants exported at module level:
+    ``WELCOME_MESSAGE``, ``BRANCH_QUESTION``, ``LOCAL_MODE_INSTRUCTIONS``,
+    ``REMOTE_MODE_INSTRUCTIONS``, ``STORAGE_GUIDANCE``,
+    ``RESTORE_PROMPT``, ``GENERATED_CONFIRMATION``. Tests assert
+    byte-identity so future cross-client drift is caught.
+
+- `hermes` CLI (new console script via ``[project.scripts]``) —
+  interactive onboarding wizard mirroring plugin 3.3.0's
+  ``openclaw totalreclaw onboard``:
+  - `hermes setup` subcommand — asks the branch question, then
+    branches into a restore flow (12-word paste, BIP-39 checksum
+    validation via ``eth_account.Account.from_mnemonic``) or a
+    generate flow (fresh 12-word phrase, prints STORAGE_GUIDANCE
+    before showing the phrase grid, prints GENERATED_CONFIRMATION
+    after a last-3-words confirmation challenge).
+  - Overwrite guard: if credentials already exist, the wizard
+    prompts ``Account already set up at <path>. Overwrite? [y/N]``
+    and defaults to ``N``.
+  - Phrase banner goes to stderr so ``hermes setup > log.txt`` does
+    NOT capture the phrase into the log.
+  - Non-TTY stdin is tolerated (scripted installers work) but the
+    restore flow prints a clear warning that the phrase was visible.
+
+### Changed
+
+- `TotalReclaw.__init__` now accepts a ``suppress_welcome`` kwarg and
+  emits the 2.3.1 welcome message the first time a client is
+  constructed on a machine without credentials AND without an explicit
+  ``recovery_phrase`` / ``mnemonic`` argument. The welcome surface
+  points the user at ``hermes setup``. Backward-compatible: callers
+  who pass a phrase never see the welcome, and ``suppress_welcome=True``
+  opts out entirely.
+
+- `totalreclaw.hermes.register(ctx)` calls ``maybe_emit_welcome`` once
+  at plugin load time so Hermes-launched sessions on a clean machine
+  also surface the welcome.
+
+- `python/README.md`: updated the "End-to-end encrypted" bullet to say
+  ``BIP-39 recovery phrase`` instead of ``BIP-39 mnemonic`` —
+  matches the 2.3.1 canonical user-facing terminology. Internal
+  variable names, docstrings, and plugin-side ``mnemonic`` references
+  (e.g. ``derive_keys_from_mnemonic``) are unchanged — the sweep is
+  scoped to output strings only.
+
+- `python/pyproject.toml`: added ``[project.scripts]`` entry for the
+  ``hermes`` console script, version bumped ``2.3.0`` → ``2.3.1``.
+
+- `python/src/totalreclaw/__init__.py`: updated ``__version__``
+  fallback to ``"2.3.1"`` for editable installs where
+  ``importlib.metadata`` can't resolve the installed version.
+
+- `python/src/totalreclaw/hermes/plugin.yaml`: bumped
+  ``version: 2.3.0`` → ``2.3.1``.
+
+### Tests
+
+- `python/tests/test_onboarding.py` (new, 12 tests): detect_first_run
+  across missing / empty / invalid-JSON / valid-credentials / legacy
+  ``recovery_phrase``-keyed files; ``build_welcome_message`` local +
+  remote contents; ``detect_mode`` env-flag + URL classification;
+  module-level copy-constant parity; terminology sweep AST walker
+  that asserts no ``mnemonic`` / ``seed phrase`` / ``recovery code`` /
+  ``recovery key`` string literals are passed to ``print`` /
+  ``click.echo`` / ``logger.warning`` / ``logger.error`` call sites
+  under ``python/src/**/*.py``.
+- `python/tests/test_hermes_setup_cli.py` (new, 8 tests): happy-path
+  restore (mocked stdin 12 words → credentials.json written), happy-path
+  generate (mocked last-3-words confirmation → STORAGE_GUIDANCE +
+  GENERATED_CONFIRMATION printed + credentials written), overwrite-
+  confirmation reject, invalid 12-word input rejected, non-TTY stdin
+  tolerated in both flows, phrase-never-leaves-stderr assertion on the
+  generate flow.
+
+### Compatibility
+
+- No breaking changes to public Hermes API. All existing tool
+  signatures, schema shapes, and client constructor parameters remain
+  unchanged. ``suppress_welcome`` is a new keyword-only parameter with
+  a back-compat default.
+- The welcome message is emitted AT MOST ONCE per process (module-level
+  flag) AND at most once per host until the user completes setup
+  (sentinel file). No new noise for returning users.
+
 ## [2.3.0] - 2026-04-19
 
 ### Changed

--- a/python/README.md
+++ b/python/README.md
@@ -8,7 +8,7 @@ As of **2.0.0**, the client uses **Memory Taxonomy v1** (6 canonical types: `cla
 
 ## Features
 
-- **End-to-end encrypted** -- XChaCha20-Poly1305 encryption, HKDF key derivation from BIP-39 mnemonic
+- **End-to-end encrypted** -- XChaCha20-Poly1305 encryption, HKDF key derivation from a BIP-39 recovery phrase
 - **Portable** -- Same recovery phrase works across Hermes, OpenClaw, Claude Desktop, IronClaw, ZeroClaw
 - **Memory Taxonomy v1** -- 6 speech-act types + required provenance (`user | user-inferred | assistant | external | derived`) and 8 life-domain scopes. v1 is the only write path (no env-var gating).
 - **Retrieval v2 Tier 1** -- source-weighted reranking via `totalreclaw-core@2.0.0` PyO3 bindings (user-sourced facts rank higher on tied scores)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "totalreclaw"
-version = "2.3.0"
+version = "2.3.1"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"
@@ -35,6 +35,12 @@ dev = ["pytest>=8.0", "pytest-asyncio>=0.24", "pytest-xdist>=3.5", "mnemonic>=0.
 
 [project.entry-points."hermes_agent.plugins"]
 totalreclaw = "totalreclaw.hermes"
+
+[project.scripts]
+# Hermes CLI for first-run onboarding ("hermes setup"). Mirrors the
+# plugin 3.3.0 onboarding flow so users switching between OpenClaw and
+# Hermes see the same branch question + recovery-phrase terminology.
+hermes = "totalreclaw.hermes.cli:main"
 
 [tool.setuptools.package-data]
 "totalreclaw.hermes" = ["plugin.yaml"]

--- a/python/src/totalreclaw/__init__.py
+++ b/python/src/totalreclaw/__init__.py
@@ -5,7 +5,11 @@ try:
 
     __version__ = _pkg_version("totalreclaw")
 except Exception:
-    __version__ = "2.2.4"
+    # Fallback string used in editable / source-tree installs where the
+    # installed-package metadata is absent. Must match pyproject.toml —
+    # test_version.py enforces a semver-shape string; the live value in
+    # a pip-installed wheel comes from importlib.metadata above.
+    __version__ = "2.3.1"
 
 from .client import TotalReclaw
 

--- a/python/src/totalreclaw/client.py
+++ b/python/src/totalreclaw/client.py
@@ -159,9 +159,23 @@ class TotalReclaw:
         mnemonic: Optional[str] = None,
         relay_url: Optional[str] = None,
         session_id: Optional[str] = None,
+        suppress_welcome: bool = False,
     ):
         resolved_mnemonic = recovery_phrase or mnemonic
         if not resolved_mnemonic:
+            # First-run welcome: surface the plugin 3.3.0-parity welcome
+            # + branch question before the ``recovery_phrase is required``
+            # error. Users who hit this path on a clean machine get a
+            # pointer to ``hermes setup`` rather than a bare traceback.
+            # ``maybe_emit_welcome`` is a no-op if the flag is set or if
+            # the sentinel file says we've already onboarded / shown
+            # the welcome before.
+            if not suppress_welcome:
+                try:
+                    from .onboarding import maybe_emit_welcome
+                    maybe_emit_welcome(relay_url=server_url or relay_url)
+                except Exception:  # pragma: no cover — defensive
+                    pass
             raise ValueError("recovery_phrase is required")
         self._mnemonic = resolved_mnemonic.strip()
         self._keys = derive_keys_from_mnemonic(self._mnemonic)

--- a/python/src/totalreclaw/hermes/__init__.py
+++ b/python/src/totalreclaw/hermes/__init__.py
@@ -21,6 +21,19 @@ def register(ctx):
     """Called by Hermes plugin system at startup."""
     state = PluginState()
 
+    # 2.3.1 first-run onboarding parity with plugin 3.3.0. Emit the
+    # welcome + branch-question copy to stdout the first time the
+    # plugin loads on a machine without credentials. ``maybe_emit_welcome``
+    # handles all suppression logic (per-process flag, sentinel file,
+    # already-onboarded short-circuit) — this call is a no-op for
+    # returning users. Never writes the phrase itself; only the welcome
+    # surface + ``hermes setup`` pointer.
+    try:
+        from totalreclaw.onboarding import maybe_emit_welcome
+        maybe_emit_welcome()
+    except Exception:  # pragma: no cover — welcome is best-effort
+        logger.debug("first-run welcome emission skipped", exc_info=True)
+
     # Register tools. Descriptions mirror the schemas — they are the
     # text the Hermes agent sees when selecting a tool, so they need to
     # clearly distinguish TotalReclaw from any built-in 'memory' tool.

--- a/python/src/totalreclaw/hermes/cli.py
+++ b/python/src/totalreclaw/hermes/cli.py
@@ -1,0 +1,438 @@
+"""Hermes CLI — ``hermes setup`` subcommand for first-run onboarding.
+
+Mirrors the TypeScript plugin 3.3.0 ``openclaw totalreclaw onboard``
+wizard. Same branch question, same ``recovery phrase`` terminology,
+same last-3-words confirmation challenge for generated phrases.
+
+Entry point
+-----------
+Registered via ``[project.scripts]`` in ``python/pyproject.toml``::
+
+    [project.scripts]
+    hermes = "totalreclaw.hermes.cli:main"
+
+A pip-installed user gets a ``hermes`` executable on PATH after
+``pip install totalreclaw``. The only subcommand in 2.3.1 is ``setup``;
+the namespace is left open so future releases can add ``status`` /
+``export`` / ``chat`` subcommands without renaming the binary.
+
+Security
+--------
+* No network. No env reads beyond TTY/mode detection.
+* The recovery phrase is NEVER written to stdout, logs, or the Hermes
+  plugin context. Generated phrases go to stderr for the ``write it
+  down`` banner, then disappear with the process.
+* File writes land at the canonical credentials path
+  (``~/.totalreclaw/credentials.json``) with mode ``0600``. Matches
+  the plugin's ``writeCredentialsJson``.
+* On non-TTY stdin the generate-flow confirmation still runs (so
+  scripted installers work), but the restore-flow prints a clear
+  warning that the phrase was visible in the prompt.
+
+Added 2.3.1 (2026-04-20).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Optional, TextIO
+
+from totalreclaw.onboarding import (
+    CANONICAL_CREDENTIALS_PATH,
+    GENERATED_CONFIRMATION,
+    RESTORE_PROMPT,
+    STORAGE_GUIDANCE,
+    WELCOME_MESSAGE,
+    BRANCH_QUESTION,
+    detect_first_run,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# BIP-39 word count for the onboarding flow. 12 words = 128 bits of
+# entropy. Matches plugin-side generateMnemonic(wordlist, 128) +
+# plugin-side validation.
+_MNEMONIC_WORD_COUNT = 12
+
+
+# ---------------------------------------------------------------------------
+# I/O adapter — kept minimal so tests can mock stdin/stdout
+# ---------------------------------------------------------------------------
+
+
+class _IO:
+    """Thin stdin/stdout wrapper for the wizard.
+
+    Attributes
+    ----------
+    stdin : TextIO
+        Source of user input.
+    stdout : TextIO
+        Destination for prompts + success banners.
+    stderr : TextIO
+        Destination for the generated-phrase banner + warnings. Stderr
+        is used for the phrase so users piping ``hermes setup > out``
+        do NOT capture the phrase into a log file.
+    is_tty : bool
+        True if stdin is a real TTY. Used to decide whether to warn
+        about visible input in the restore flow.
+    """
+
+    def __init__(
+        self,
+        stdin: Optional[TextIO] = None,
+        stdout: Optional[TextIO] = None,
+        stderr: Optional[TextIO] = None,
+    ):
+        self.stdin = stdin if stdin is not None else sys.stdin
+        self.stdout = stdout if stdout is not None else sys.stdout
+        self.stderr = stderr if stderr is not None else sys.stderr
+        # isatty() may raise on some wrapper streams — default to False.
+        try:
+            self.is_tty = bool(self.stdin.isatty())
+        except Exception:
+            self.is_tty = False
+
+    def write(self, text: str) -> None:
+        self.stdout.write(text)
+        try:
+            self.stdout.flush()
+        except Exception:
+            pass
+
+    def write_err(self, text: str) -> None:
+        self.stderr.write(text)
+        try:
+            self.stderr.flush()
+        except Exception:
+            pass
+
+    def prompt(self, question: str) -> str:
+        """Write the prompt + read one line of user input. Returns trimmed."""
+        self.write(question)
+        try:
+            line = self.stdin.readline()
+        except Exception:
+            return ""
+        if line == "":
+            # EOF on non-TTY stdin
+            return ""
+        return line.rstrip("\r\n")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_phrase(raw: str) -> str:
+    """Collapse whitespace + lowercase a pasted BIP-39 phrase.
+
+    Accepts space-separated OR newline-separated input (matches the
+    task requirement "space-separated or one-per-line"). Does NOT
+    validate the checksum — that's :func:`_validate_mnemonic`.
+    """
+    import unicodedata
+
+    # NFKC + strip zero-width chars the way the plugin does.
+    cleaned = unicodedata.normalize("NFKC", raw)
+    cleaned = "".join(ch for ch in cleaned if ch not in ("\u200b", "\u200c", "\u200d", "\ufeff"))
+    words = cleaned.strip().lower().split()
+    return " ".join(words)
+
+
+def _validate_mnemonic(phrase: str) -> bool:
+    """True iff the phrase is a 12-word BIP-39 mnemonic with a valid checksum.
+
+    Uses :meth:`eth_account.Account.from_mnemonic` for the checksum check
+    — it raises ``eth_account.hdaccount.ValidationError`` on bad
+    checksums / unknown words. No new prod dependency needed; the
+    ``eth-account`` package is already in ``pyproject.toml`` for EOA
+    derivation.
+    """
+    words = phrase.split()
+    if len(words) != _MNEMONIC_WORD_COUNT:
+        return False
+    try:
+        from eth_account import Account
+
+        Account.enable_unaudited_hdwallet_features()
+        Account.from_mnemonic(phrase, account_path="m/44'/60'/0'/0/0")
+    except Exception:
+        return False
+    return True
+
+
+def _generate_mnemonic() -> str:
+    """Generate a fresh 12-word BIP-39 mnemonic via ``eth_account``.
+
+    Uses the same path as the existing ``totalreclaw_setup`` tool so
+    the generated phrases produce identical Smart Account addresses
+    regardless of whether the user onboards via the CLI or via the
+    plugin tool call.
+    """
+    from eth_account import Account
+
+    Account.enable_unaudited_hdwallet_features()
+    _acct, mnemonic = Account.create_with_mnemonic()
+    return mnemonic.strip()
+
+
+def _write_credentials(credentials_path: Path, mnemonic: str) -> None:
+    """Write ``{"mnemonic": ...}`` at mode 0600.
+
+    Canonical shape — matches plugin 3.2.0+ and Python 2.2.2+. This is
+    the write path every fresh setup lands on (legacy ``recovery_phrase``
+    key is read-compatible but never newly written).
+    """
+    credentials_path.parent.mkdir(parents=True, exist_ok=True)
+    credentials_path.write_text(json.dumps({"mnemonic": mnemonic}))
+    try:
+        credentials_path.chmod(0o600)
+    except OSError:
+        # Windows / read-only FS — best-effort, user can tighten perms.
+        logger.debug("Could not chmod 0600 on %s", credentials_path, exc_info=True)
+
+
+def _last_n_words(mnemonic: str, n: int = 3) -> list[str]:
+    return mnemonic.split()[-n:]
+
+
+# ---------------------------------------------------------------------------
+# Wizard flows
+# ---------------------------------------------------------------------------
+
+
+def _confirm_overwrite(io: _IO, credentials_path: Path) -> bool:
+    """Prompt the user before overwriting an existing credentials file.
+
+    Returns ``True`` if the user typed ``y`` or ``yes``. Defaults to
+    ``False`` (safe default — don't clobber an existing vault).
+    """
+    io.write(f"Account already set up at {credentials_path}. Overwrite? [y/N]: ")
+    try:
+        answer = io.stdin.readline().strip().lower()
+    except Exception:
+        answer = ""
+    return answer in ("y", "yes")
+
+
+def _ask_branch(io: _IO) -> str:
+    """Ask the branch question. Returns ``restore`` / ``generate`` / ``cancel``."""
+    io.write(BRANCH_QUESTION + "\n")
+    io.write("[restore/generate]: ")
+    try:
+        raw = io.stdin.readline().strip().lower()
+    except Exception:
+        raw = ""
+    if raw in ("r", "restore"):
+        return "restore"
+    if raw in ("g", "generate", "new"):
+        return "generate"
+    return "cancel"
+
+
+def _run_restore(io: _IO, credentials_path: Path) -> int:
+    """Interactive restore flow. Returns exit code."""
+    io.write("\n" + RESTORE_PROMPT + "\n")
+    if not io.is_tty:
+        io.write_err(
+            "Warning: stdin is not a TTY. Your recovery phrase will be visible "
+            "in this prompt. Consider running 'hermes setup' on a real terminal.\n"
+        )
+    io.write("(12 words, space-separated or one per line — press Enter twice when done)\n> ")
+
+    lines: list[str] = []
+    try:
+        # Accept: one-liner, OR multi-line input terminated by blank line
+        # OR EOF. Consume at most 24 lines to bound memory.
+        for _ in range(32):
+            line = io.stdin.readline()
+            if line == "":
+                break  # EOF
+            stripped = line.rstrip("\r\n")
+            lines.append(stripped)
+            # Early exit if we already have 12 words on the first non-empty line
+            joined_so_far = _normalize_phrase(" ".join(lines))
+            if len(joined_so_far.split()) >= _MNEMONIC_WORD_COUNT:
+                break
+            # Blank line terminator (user hit enter twice)
+            if stripped.strip() == "" and any(prev.strip() for prev in lines[:-1]):
+                break
+    except Exception:
+        io.write_err("Failed to read recovery phrase from stdin.\n")
+        return 2
+
+    phrase = _normalize_phrase(" ".join(lines))
+    if not _validate_mnemonic(phrase):
+        io.write_err(
+            "\nThat is not a valid 12-word BIP-39 recovery phrase. "
+            "Check the word list + spelling and try again.\n"
+        )
+        return 1
+
+    try:
+        _write_credentials(credentials_path, phrase)
+    except OSError as e:
+        io.write_err(f"\nCould not write credentials file: {e}\n")
+        return 2
+
+    io.write(
+        f"\nAccount restored. Credentials saved to {credentials_path} "
+        "(mode 0600).\nMemory tools are now active in Hermes.\n"
+    )
+    return 0
+
+
+def _run_generate(io: _IO, credentials_path: Path) -> int:
+    """Interactive generate flow. Returns exit code."""
+    try:
+        mnemonic = _generate_mnemonic()
+    except Exception as e:
+        io.write_err(f"\nCould not generate recovery phrase: {e}\n")
+        return 2
+    words = mnemonic.split()
+    if len(words) != _MNEMONIC_WORD_COUNT:
+        io.write_err(
+            f"\nInternal error: generated phrase has {len(words)} words (expected 12).\n"
+        )
+        return 2
+
+    # STORAGE_GUIDANCE copy — print BEFORE showing the phrase so the
+    # user reads the handling rules before they're tempted to screenshot.
+    io.write("\n" + STORAGE_GUIDANCE + "\n")
+
+    # Phrase banner to stderr — keeps it out of `hermes setup > out.txt`.
+    io.write_err("\nYour recovery phrase (WRITE THIS DOWN):\n\n")
+    # Render as a 4x3 grid, numbered.
+    for row in range(3):
+        cells = []
+        for col in range(4):
+            idx = row * 4 + col
+            cells.append(f"{idx + 1:>2}. {words[idx]:<12}")
+        io.write_err("  " + "".join(cells) + "\n")
+    io.write_err("\n")
+
+    # Last-3-words confirmation challenge — matches the plugin's
+    # "retype probe words" pattern, simplified to the tail 3 since
+    # users typically write the phrase top-to-bottom.
+    io.write(
+        "Before we save, type the LAST 3 words of your phrase "
+        "(space-separated) to confirm you wrote it down:\n> "
+    )
+    try:
+        typed = io.stdin.readline().rstrip("\r\n").strip().lower()
+    except Exception:
+        typed = ""
+
+    expected = " ".join(_last_n_words(mnemonic, 3))
+    if typed != expected:
+        io.write_err(
+            "\nWord mismatch. No credentials have been written. "
+            "Write the phrase down carefully and re-run `hermes setup`.\n"
+        )
+        return 1
+
+    try:
+        _write_credentials(credentials_path, mnemonic)
+    except OSError as e:
+        io.write_err(f"\nCould not write credentials file: {e}\n")
+        return 2
+
+    io.write("\n" + GENERATED_CONFIRMATION + "\n")
+    io.write(
+        f"\nCredentials saved to {credentials_path} (mode 0600). "
+        "Memory tools are now active in Hermes.\n"
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def run_setup(
+    credentials_path: Optional[Path] = None,
+    io: Optional[_IO] = None,
+) -> int:
+    """Run the interactive setup wizard. Returns exit code.
+
+    Parameters
+    ----------
+    credentials_path : Path, optional
+        Override for tests. Defaults to ``CANONICAL_CREDENTIALS_PATH``.
+    io : _IO, optional
+        Pre-built IO adapter. Defaults to stdin/stdout/stderr.
+    """
+    path = credentials_path if credentials_path is not None else CANONICAL_CREDENTIALS_PATH
+    wizard_io = io if io is not None else _IO()
+
+    # Welcome banner — always printed for the setup subcommand (not
+    # suppressed by the per-process flag in ``onboarding.py``). The
+    # subcommand is an explicit user-initiated action; they asked to
+    # see the onboarding flow.
+    wizard_io.write(WELCOME_MESSAGE + "\n\n")
+
+    if not detect_first_run(path):
+        if not _confirm_overwrite(wizard_io, path):
+            wizard_io.write("\nSetup cancelled. Existing credentials untouched.\n")
+            return 0
+        wizard_io.write("\n")
+
+    branch = _ask_branch(wizard_io)
+    if branch == "restore":
+        return _run_restore(wizard_io, path)
+    if branch == "generate":
+        return _run_generate(wizard_io, path)
+
+    wizard_io.write_err(
+        "\nUnrecognised choice. Expected 'restore' or 'generate'. Aborting.\n"
+    )
+    return 1
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """``hermes`` console-script entry point."""
+    parser = argparse.ArgumentParser(
+        prog="hermes",
+        description=(
+            "TotalReclaw Hermes plugin CLI. First-run onboarding + maintenance "
+            "commands for the Python-side encrypted memory vault. "
+            "Run 'hermes setup' on a fresh machine to generate or restore a "
+            "recovery phrase."
+        ),
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    sp_setup = sub.add_parser(
+        "setup",
+        help=(
+            "Interactive first-run wizard. Generates a new 12-word recovery "
+            "phrase or restores from an existing one. Writes credentials to "
+            "~/.totalreclaw/credentials.json."
+        ),
+    )
+    sp_setup.add_argument(
+        "--credentials-path",
+        type=Path,
+        default=None,
+        help="Override the credentials file location (default: ~/.totalreclaw/credentials.json).",
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.command == "setup":
+        return run_setup(credentials_path=args.credentials_path)
+
+    parser.print_help()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/python/src/totalreclaw/hermes/plugin.yaml
+++ b/python/src/totalreclaw/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: totalreclaw
-version: 2.3.0
+version: 2.3.1
 description: End-to-end encrypted memory vault for AI agents (Memory Taxonomy v1)
 author: TotalReclaw Team
 provides_tools:

--- a/python/src/totalreclaw/onboarding.py
+++ b/python/src/totalreclaw/onboarding.py
@@ -1,0 +1,362 @@
+"""First-run onboarding detection + welcome copy for TotalReclaw.
+
+This module is the Python-side parity surface for the TypeScript plugin
+3.3.0 first-run UX. Users switching between OpenClaw (plugin) and Hermes
+(Python) must see the same welcome text, the same branch question, and
+the canonical ``recovery phrase`` terminology — no ``mnemonic`` leakage,
+no ``seed phrase`` / ``recovery code`` / ``recovery key`` divergence.
+
+What this module owns:
+
+* :func:`detect_first_run` — cheap, synchronous, no-network probe that
+  returns ``True`` when the canonical credentials file is missing,
+  empty, unparseable, or doesn't carry a recognised credentials key.
+* :func:`build_welcome_message` — renders the welcome + branch-question
+  copy for either the local or the remote invocation context.
+* Module-level copy constants (``WELCOME_MESSAGE``, ``BRANCH_QUESTION``,
+  ``STORAGE_GUIDANCE``, …) — exported verbatim so tests can assert on
+  them and the CLI / plugin layers can render them without duplicating
+  strings.
+* :data:`CANONICAL_CREDENTIALS_PATH` — the ``~/.totalreclaw/credentials.json``
+  path shared across Hermes, OpenClaw, and MCP.
+* :func:`maybe_emit_welcome` — emits the welcome once-per-process. Uses
+  a module-level flag (``_emitted_this_process``) plus a best-effort
+  sentinel file so repeat imports within the same session stay quiet.
+
+What this module deliberately does NOT do:
+
+* Never prints or logs the recovery phrase itself — welcome copy only.
+* No network calls. No env var reads beyond what's needed to classify
+  local-vs-remote mode.
+* No blocking prompts. The wizard (``hermes setup``) lives in
+  :mod:`totalreclaw.hermes.cli`; this module only emits the welcome
+  surface + detection helper.
+
+Added 2.3.1 (2026-04-20).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Literal, Optional, TextIO
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Canonical paths + mode detection
+# ---------------------------------------------------------------------------
+
+#: The single path every TotalReclaw client (Python, TS plugin, MCP)
+#: reads + writes credentials to. Keep in sync with
+#: ``agent/state.py::_try_auto_configure`` and the plugin's
+#: ``fs-helpers.ts::credentialsPath``.
+CANONICAL_CREDENTIALS_PATH: Path = Path.home() / ".totalreclaw" / "credentials.json"
+
+#: Sentinel file written on first welcome emission. Lives in the same
+#: ``~/.totalreclaw`` dir as credentials, so users who wipe credentials
+#: (to re-onboard) also wipe the sentinel and re-see the welcome.
+_WELCOME_SENTINEL_PATH: Path = Path.home() / ".totalreclaw" / ".welcome_shown"
+
+# Module-level flag so a Hermes runtime that imports both the client and
+# the plugin doesn't emit the welcome twice per process.
+_emitted_this_process: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Canonical copy (verbatim — tests assert on these strings byte-for-byte)
+# ---------------------------------------------------------------------------
+
+WELCOME_MESSAGE = """
+Welcome to TotalReclaw — encrypted, agent-portable memory.
+
+Your memories are stored end-to-end encrypted and on-chain. You can restore them on any agent — OpenClaw, Hermes, or NanoClaw — with a single recovery phrase.
+""".strip()
+
+BRANCH_QUESTION = """
+Let's set up your account. Do you already have a recovery phrase, or should we generate a new one?
+""".strip()
+
+LOCAL_MODE_INSTRUCTIONS = "Run: hermes setup"
+
+REMOTE_MODE_INSTRUCTIONS = """
+Run: hermes setup
+
+You'll be prompted to either restore from an existing recovery phrase or generate a new one. Your phrase never leaves this machine.
+""".strip()
+
+STORAGE_GUIDANCE = """
+Your recovery phrase is 12 words. Store it somewhere safe — a password manager works well. Use it only for TotalReclaw. Don't reuse it anywhere else. Don't put funds on it.
+""".strip()
+
+RESTORE_PROMPT = "Enter your 12-word recovery phrase to restore your account:"
+
+GENERATED_CONFIRMATION = """
+A new recovery phrase has been generated. Write it down now, somewhere safe. This is the only way to restore your account later.
+""".strip()
+
+
+# Accepted credentials key names. Matches
+# ``agent/state.py::_extract_mnemonic_from_creds`` — canonical key is
+# ``mnemonic`` (plugin 3.2.0+), legacy Python clients wrote
+# ``recovery_phrase``; both count as "already onboarded" for first-run
+# detection.
+_CREDENTIAL_KEYS = ("mnemonic", "recovery_phrase")
+
+
+# ---------------------------------------------------------------------------
+# First-run detection
+# ---------------------------------------------------------------------------
+
+
+def detect_first_run(credentials_path: Optional[Path] = None) -> bool:
+    """Return True when the given credentials path doesn't identify an
+    onboarded user.
+
+    Treats the following as first-run (returns ``True``):
+
+    * File does not exist.
+    * File exists but is empty.
+    * File exists but isn't valid JSON.
+    * File is valid JSON but isn't an object (e.g. ``[]``, ``"x"``).
+    * File is a JSON object but doesn't carry a non-empty string under
+      ``mnemonic`` OR ``recovery_phrase``.
+
+    Returns ``False`` only when the file parses to a dict and carries at
+    least one non-empty string credential key — i.e. the user has
+    already been onboarded.
+
+    Never raises — any filesystem/JSON error collapses to ``True`` so
+    the caller defaults to the "show welcome + suggest setup" path.
+
+    Parameters
+    ----------
+    credentials_path : Path, optional
+        Path to the credentials file. Defaults to
+        :data:`CANONICAL_CREDENTIALS_PATH`.
+    """
+    path = credentials_path if credentials_path is not None else CANONICAL_CREDENTIALS_PATH
+
+    try:
+        if not path.exists():
+            return True
+    except OSError:
+        return True
+
+    try:
+        raw = path.read_text()
+    except OSError:
+        return True
+
+    if not raw.strip():
+        return True
+
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, json.JSONDecodeError):
+        return True
+
+    if not isinstance(parsed, dict):
+        return True
+
+    for key in _CREDENTIAL_KEYS:
+        value = parsed.get(key)
+        if isinstance(value, str) and value.strip():
+            return False
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Local / remote mode detection
+# ---------------------------------------------------------------------------
+
+
+_LOCAL_HOSTS = ("localhost", "127.0.0.1", "0.0.0.0", "::1")
+
+
+def detect_mode(relay_url: Optional[str] = None) -> Literal["local", "remote"]:
+    """Classify whether Hermes is running against a local or remote gateway.
+
+    Order:
+      1. If ``relay_url`` is passed, parse its host and return ``local`` if
+         it matches a loopback host, else ``remote``.
+      2. Else if ``TOTALRECLAW_LOCAL_GATEWAY`` or ``HERMES_LOCAL_GATEWAY``
+         env vars are truthy (``1``, ``true``, ``yes``), return ``local``.
+      3. Else read ``TOTALRECLAW_SERVER_URL`` / ``TOTALRECLAW_RELAY_URL``
+         from env and apply the same host classification.
+      4. Default to ``remote``.
+    """
+    def _classify_url(url: str) -> Literal["local", "remote"]:
+        u = url.strip().lower()
+        if not u:
+            return "remote"
+        # crude host extraction — good enough to spot loopback hosts.
+        try:
+            from urllib.parse import urlparse
+            parsed = urlparse(u if "://" in u else f"http://{u}")
+            host = (parsed.hostname or "").lower()
+        except Exception:
+            return "remote"
+        if host in _LOCAL_HOSTS:
+            return "local"
+        return "remote"
+
+    if relay_url:
+        return _classify_url(relay_url)
+
+    for flag_var in ("TOTALRECLAW_LOCAL_GATEWAY", "HERMES_LOCAL_GATEWAY"):
+        raw = os.environ.get(flag_var, "").strip().lower()
+        if raw in ("1", "true", "yes"):
+            return "local"
+
+    for url_var in ("TOTALRECLAW_SERVER_URL", "TOTALRECLAW_RELAY_URL"):
+        env_url = os.environ.get(url_var)
+        if env_url:
+            return _classify_url(env_url)
+
+    return "remote"
+
+
+# ---------------------------------------------------------------------------
+# Welcome message rendering
+# ---------------------------------------------------------------------------
+
+
+def build_welcome_message(mode: Literal["local", "remote"]) -> str:
+    """Return the full welcome + branch-question copy for the given mode.
+
+    Both modes render the same welcome + branch question header; the
+    call-to-action differs (local users get a one-line ``Run: hermes
+    setup``; remote users get a longer note on the phrase-never-leaves
+    guarantee).
+
+    Parameters
+    ----------
+    mode : {"local", "remote"}
+        Invocation context. Pass the result of :func:`detect_mode`, or
+        override for tests.
+    """
+    if mode not in ("local", "remote"):
+        raise ValueError(f"mode must be 'local' or 'remote', got {mode!r}")
+
+    instructions = LOCAL_MODE_INSTRUCTIONS if mode == "local" else REMOTE_MODE_INSTRUCTIONS
+
+    # Two blank lines between each section for readability in a terminal.
+    return (
+        f"{WELCOME_MESSAGE}\n\n"
+        f"{BRANCH_QUESTION}\n\n"
+        f"{instructions}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Once-per-process welcome emission
+# ---------------------------------------------------------------------------
+
+
+def maybe_emit_welcome(
+    credentials_path: Optional[Path] = None,
+    relay_url: Optional[str] = None,
+    stream: Optional[TextIO] = None,
+    *,
+    use_sentinel: bool = True,
+) -> bool:
+    """Emit the welcome message to ``stream`` iff this is first-run + we
+    haven't emitted in this process yet.
+
+    Returns ``True`` if the welcome was emitted, ``False`` otherwise
+    (already onboarded, already emitted in this process, or
+    sentinel-suppressed).
+
+    Suppression strategy:
+
+    * Per-process: a module-level flag. Prevents double-emission when
+      both the client and the Hermes plugin import the onboarding
+      module during the same session.
+    * Per-host (best-effort): a sentinel file at
+      ``~/.totalreclaw/.welcome_shown``. Prevents re-emission on every
+      command invocation for a first-run user who's chosen to defer
+      setup. Pass ``use_sentinel=False`` to disable (useful for tests).
+
+    Never emits the recovery phrase itself. Only ever writes the
+    welcome + branch-question copy + the instructions for the detected
+    mode.
+    """
+    global _emitted_this_process
+
+    if _emitted_this_process:
+        return False
+
+    if not detect_first_run(credentials_path):
+        return False
+
+    if use_sentinel:
+        try:
+            if _WELCOME_SENTINEL_PATH.exists():
+                _emitted_this_process = True  # still mark to avoid repeat probes
+                return False
+        except OSError:
+            pass
+
+    mode = detect_mode(relay_url)
+    message = build_welcome_message(mode)
+
+    out = stream if stream is not None else _default_stream()
+    try:
+        out.write(message + "\n")
+        try:
+            out.flush()
+        except Exception:
+            pass
+    except Exception:
+        # Never block the client on a broken stdout — just log and move on.
+        logger.debug("totalreclaw.onboarding: welcome write failed", exc_info=True)
+        return False
+
+    _emitted_this_process = True
+
+    if use_sentinel:
+        try:
+            _WELCOME_SENTINEL_PATH.parent.mkdir(parents=True, exist_ok=True)
+            _WELCOME_SENTINEL_PATH.write_text("")
+            try:
+                _WELCOME_SENTINEL_PATH.chmod(0o600)
+            except OSError:
+                pass
+        except OSError:
+            # Read-only home dir / perms — tolerate and rely on the
+            # per-process flag alone.
+            logger.debug("totalreclaw.onboarding: sentinel write failed", exc_info=True)
+
+    return True
+
+
+def _default_stream() -> TextIO:
+    """Return ``sys.stdout`` — indirected so tests can monkeypatch."""
+    import sys
+    return sys.stdout
+
+
+def _reset_for_tests() -> None:
+    """Reset the module-level emission flag. Test-only helper."""
+    global _emitted_this_process
+    _emitted_this_process = False
+
+
+__all__ = [
+    "WELCOME_MESSAGE",
+    "BRANCH_QUESTION",
+    "LOCAL_MODE_INSTRUCTIONS",
+    "REMOTE_MODE_INSTRUCTIONS",
+    "STORAGE_GUIDANCE",
+    "RESTORE_PROMPT",
+    "GENERATED_CONFIRMATION",
+    "CANONICAL_CREDENTIALS_PATH",
+    "detect_first_run",
+    "detect_mode",
+    "build_welcome_message",
+    "maybe_emit_welcome",
+]

--- a/python/tests/test_hermes_setup_cli.py
+++ b/python/tests/test_hermes_setup_cli.py
@@ -1,0 +1,266 @@
+"""Tests for the ``hermes setup`` CLI wizard (added 2.3.1).
+
+Exercises:
+- Happy-path restore with a mocked 12-word stdin → credentials.json written.
+- Happy-path generate with a mocked last-3-words confirmation → STORAGE_GUIDANCE
+  + GENERATED_CONFIRMATION printed + credentials written.
+- Overwrite-confirmation reject path.
+- Invalid 12-word input rejected (bad word count + bad BIP-39 checksum).
+- Non-TTY stdin tolerated (scripted installers) in both flows.
+- Generated phrase goes to stderr, NOT stdout — so ``hermes setup > out.txt``
+  cannot capture the phrase into a log.
+
+Mocking strategy: we use ``StringIO`` for stdin/stdout/stderr and a
+pre-built ``_IO`` adapter so we never touch real stdin/TTY detection.
+``_generate_mnemonic`` is mocked per-test to make the generate flow
+deterministic.
+"""
+from __future__ import annotations
+
+import json
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from totalreclaw.hermes import cli as hermes_cli
+
+# A canonical 12-word test vector with a valid BIP-39 checksum. Same
+# one used across the suite — matches ``test_hermes_plugin::test_configure``.
+VALID_MNEMONIC = (
+    "abandon abandon abandon abandon abandon abandon "
+    "abandon abandon abandon abandon abandon about"
+)
+
+
+def _make_io(
+    stdin_text: str, is_tty: bool = True
+) -> tuple[hermes_cli._IO, StringIO, StringIO]:
+    """Build an _IO adapter with canned stdin + capturing stdout/stderr."""
+    stdin = StringIO(stdin_text)
+    stdout = StringIO()
+    stderr = StringIO()
+    io = hermes_cli._IO(stdin=stdin, stdout=stdout, stderr=stderr)
+    io.is_tty = is_tty
+    return io, stdout, stderr
+
+
+# ---------------------------------------------------------------------------
+# Restore flow
+# ---------------------------------------------------------------------------
+
+
+class TestRestoreFlow:
+    def test_happy_path_space_separated(self, tmp_path: Path) -> None:
+        """Restore flow: 12 words space-separated on one line."""
+        creds = tmp_path / "credentials.json"
+        stdin_text = f"restore\n{VALID_MNEMONIC}\n"
+        io, stdout, stderr = _make_io(stdin_text)
+
+        rc = hermes_cli.run_setup(credentials_path=creds, io=io)
+
+        assert rc == 0, stderr.getvalue()
+        assert creds.exists()
+        saved = json.loads(creds.read_text())
+        assert saved["mnemonic"].strip() == VALID_MNEMONIC
+        out = stdout.getvalue()
+        assert "Account restored" in out
+        # Canonical terminology in the prompt.
+        assert "recovery phrase" in out.lower()
+
+    def test_happy_path_multiline(self, tmp_path: Path) -> None:
+        """Restore flow: one word per line, terminated by EOF."""
+        creds = tmp_path / "credentials.json"
+        words_per_line = "\n".join(VALID_MNEMONIC.split())
+        stdin_text = f"restore\n{words_per_line}\n"
+        io, stdout, _stderr = _make_io(stdin_text)
+
+        rc = hermes_cli.run_setup(credentials_path=creds, io=io)
+
+        assert rc == 0
+        saved = json.loads(creds.read_text())
+        assert saved["mnemonic"].strip() == VALID_MNEMONIC
+
+    def test_invalid_word_count_rejected(self, tmp_path: Path) -> None:
+        """Fewer than 12 words → non-zero exit + no file written."""
+        creds = tmp_path / "credentials.json"
+        short = "abandon abandon abandon abandon"
+        stdin_text = f"restore\n{short}\n"
+        io, _stdout, stderr = _make_io(stdin_text)
+
+        rc = hermes_cli.run_setup(credentials_path=creds, io=io)
+
+        assert rc != 0
+        assert not creds.exists()
+        assert "valid" in stderr.getvalue().lower()
+
+    def test_invalid_checksum_rejected(self, tmp_path: Path) -> None:
+        """Bad BIP-39 checksum → non-zero exit + no file written.
+
+        12 real BIP-39 words but in an order that doesn't produce a
+        valid checksum. ``eth_account.Account.from_mnemonic`` raises on
+        this — :func:`_validate_mnemonic` catches.
+        """
+        creds = tmp_path / "credentials.json"
+        bad = "about " * 11 + "abandon"  # all valid words, wrong checksum
+        stdin_text = f"restore\n{bad.strip()}\n"
+        io, _stdout, stderr = _make_io(stdin_text)
+
+        rc = hermes_cli.run_setup(credentials_path=creds, io=io)
+
+        assert rc != 0
+        assert not creds.exists()
+        assert "valid" in stderr.getvalue().lower()
+
+    def test_non_tty_restore_prints_visibility_warning(self, tmp_path: Path) -> None:
+        """On non-TTY stdin the restore path still works but warns."""
+        creds = tmp_path / "credentials.json"
+        stdin_text = f"restore\n{VALID_MNEMONIC}\n"
+        io, _stdout, stderr = _make_io(stdin_text, is_tty=False)
+
+        rc = hermes_cli.run_setup(credentials_path=creds, io=io)
+        assert rc == 0
+        assert creds.exists()
+        # Warning about visible input.
+        assert "visible" in stderr.getvalue().lower()
+
+
+# ---------------------------------------------------------------------------
+# Generate flow
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateFlow:
+    def test_happy_path(self, tmp_path: Path) -> None:
+        """Generate + confirm last-3-words → file written + banners printed."""
+        creds = tmp_path / "credentials.json"
+
+        # Mock the mnemonic generator so the test is deterministic.
+        fake_mnem = VALID_MNEMONIC
+        last3 = " ".join(fake_mnem.split()[-3:])
+
+        stdin_text = f"generate\n{last3}\n"
+        io, stdout, stderr = _make_io(stdin_text)
+
+        with patch.object(hermes_cli, "_generate_mnemonic", return_value=fake_mnem):
+            rc = hermes_cli.run_setup(credentials_path=creds, io=io)
+
+        assert rc == 0, stderr.getvalue()
+        assert creds.exists()
+        saved = json.loads(creds.read_text())
+        assert saved["mnemonic"] == fake_mnem
+
+        out = stdout.getvalue()
+        err = stderr.getvalue()
+
+        # STORAGE_GUIDANCE must appear in stdout BEFORE the phrase is shown.
+        from totalreclaw.onboarding import STORAGE_GUIDANCE, GENERATED_CONFIRMATION
+
+        assert STORAGE_GUIDANCE in out
+        assert GENERATED_CONFIRMATION in out
+        # Confirmation banner includes "write it down" copy.
+        assert "write it down" in out.lower()
+
+        # Phrase goes to STDERR not STDOUT — key security invariant.
+        assert fake_mnem.split()[0] in err  # first word printed to stderr
+        # Phrase is NOT in stdout.
+        assert fake_mnem not in out
+
+    def test_wrong_confirmation_rejects(self, tmp_path: Path) -> None:
+        """Mistyped last-3-words → non-zero exit + no file written."""
+        creds = tmp_path / "credentials.json"
+        fake_mnem = VALID_MNEMONIC
+
+        stdin_text = "generate\nfoo bar baz\n"
+        io, stdout, stderr = _make_io(stdin_text)
+
+        with patch.object(hermes_cli, "_generate_mnemonic", return_value=fake_mnem):
+            rc = hermes_cli.run_setup(credentials_path=creds, io=io)
+
+        assert rc != 0
+        assert not creds.exists()
+        assert "mismatch" in stderr.getvalue().lower()
+        # GENERATED_CONFIRMATION must NOT be printed on failure.
+        from totalreclaw.onboarding import GENERATED_CONFIRMATION
+
+        assert GENERATED_CONFIRMATION not in stdout.getvalue()
+
+    def test_non_tty_generate_still_works(self, tmp_path: Path) -> None:
+        """Generate flow tolerates non-TTY stdin (scripted installers)."""
+        creds = tmp_path / "credentials.json"
+        fake_mnem = VALID_MNEMONIC
+        last3 = " ".join(fake_mnem.split()[-3:])
+
+        stdin_text = f"generate\n{last3}\n"
+        io, _stdout, _stderr = _make_io(stdin_text, is_tty=False)
+
+        with patch.object(hermes_cli, "_generate_mnemonic", return_value=fake_mnem):
+            rc = hermes_cli.run_setup(credentials_path=creds, io=io)
+
+        assert rc == 0
+        assert creds.exists()
+
+
+# ---------------------------------------------------------------------------
+# Overwrite confirmation
+# ---------------------------------------------------------------------------
+
+
+class TestOverwriteConfirmation:
+    def test_reject_overwrite_keeps_existing(self, tmp_path: Path) -> None:
+        """When creds already exist and user answers 'n', no changes."""
+        creds = tmp_path / "credentials.json"
+        creds.parent.mkdir(parents=True, exist_ok=True)
+        original = json.dumps({"mnemonic": "old phrase here"})
+        creds.write_text(original)
+
+        # User answers "n" to the overwrite prompt. The branch question
+        # and restore/generate branches are not reached.
+        stdin_text = "n\n"
+        io, stdout, _stderr = _make_io(stdin_text)
+
+        rc = hermes_cli.run_setup(credentials_path=creds, io=io)
+
+        assert rc == 0
+        # File is untouched.
+        assert creds.read_text() == original
+        # Cancellation message appears.
+        assert "cancelled" in stdout.getvalue().lower()
+
+    def test_accept_overwrite_proceeds_to_branch_question(self, tmp_path: Path) -> None:
+        """When user answers 'y' they reach the restore/generate branch."""
+        creds = tmp_path / "credentials.json"
+        creds.parent.mkdir(parents=True, exist_ok=True)
+        creds.write_text(json.dumps({"mnemonic": "old phrase to overwrite"}))
+
+        # "y" to overwrite, then "restore", then the real phrase.
+        stdin_text = f"y\nrestore\n{VALID_MNEMONIC}\n"
+        io, _stdout, stderr = _make_io(stdin_text)
+
+        rc = hermes_cli.run_setup(credentials_path=creds, io=io)
+
+        assert rc == 0, stderr.getvalue()
+        saved = json.loads(creds.read_text())
+        # New phrase replaced the old one.
+        assert saved["mnemonic"].strip() == VALID_MNEMONIC
+
+
+# ---------------------------------------------------------------------------
+# argparse surface
+# ---------------------------------------------------------------------------
+
+
+class TestMainEntry:
+    def test_main_no_args_prints_help(self) -> None:
+        """`hermes` with no subcommand prints help + returns 0."""
+        rc = hermes_cli.main([])
+        assert rc == 0
+
+    def test_main_setup_invokes_run_setup(self, tmp_path: Path) -> None:
+        """`hermes setup --credentials-path <p>` dispatches to run_setup."""
+        creds = tmp_path / "c.json"
+        with patch.object(hermes_cli, "run_setup", return_value=0) as m:
+            rc = hermes_cli.main(["setup", "--credentials-path", str(creds)])
+        assert rc == 0
+        m.assert_called_once_with(credentials_path=creds)

--- a/python/tests/test_onboarding.py
+++ b/python/tests/test_onboarding.py
@@ -1,0 +1,444 @@
+"""Tests for totalreclaw.onboarding (added in 2.3.1).
+
+Covers:
+- detect_first_run across missing / empty / invalid / valid credentials.
+- build_welcome_message for local + remote mode.
+- detect_mode URL + env-var classification.
+- Module-level copy-constant parity (tests assert byte-identity so any
+  future change gets flagged).
+- Terminology sweep — an AST walk that asserts no ``mnemonic`` /
+  ``seed phrase`` / ``recovery code`` / ``recovery key`` string literals
+  leak into user-facing call sites (``print``, ``click.echo``,
+  ``logger.warning`` / ``.error``) under ``python/src/**/*.py``.
+"""
+from __future__ import annotations
+
+import ast
+import json
+import os
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+from totalreclaw import onboarding
+
+
+# ---------------------------------------------------------------------------
+# detect_first_run
+# ---------------------------------------------------------------------------
+
+
+class TestDetectFirstRun:
+    def test_detect_first_run_missing_file(self, tmp_path: Path) -> None:
+        """True when the credentials file doesn't exist."""
+        path = tmp_path / "does-not-exist.json"
+        assert onboarding.detect_first_run(path) is True
+
+    def test_detect_first_run_empty_json(self, tmp_path: Path) -> None:
+        """True when the file is ``{}`` (no credentials keys)."""
+        path = tmp_path / "empty.json"
+        path.write_text("{}")
+        assert onboarding.detect_first_run(path) is True
+
+    def test_detect_first_run_empty_file(self, tmp_path: Path) -> None:
+        """True when the file exists but is literally empty."""
+        path = tmp_path / "zero-bytes.json"
+        path.write_text("")
+        assert onboarding.detect_first_run(path) is True
+
+    def test_detect_first_run_invalid_json(self, tmp_path: Path) -> None:
+        """True when the file isn't valid JSON."""
+        path = tmp_path / "garbage.json"
+        path.write_text("{ not valid json")
+        assert onboarding.detect_first_run(path) is True
+
+    def test_detect_first_run_non_object_json(self, tmp_path: Path) -> None:
+        """True when the JSON is valid but not an object (array / string)."""
+        path = tmp_path / "array.json"
+        path.write_text("[]")
+        assert onboarding.detect_first_run(path) is True
+
+        path2 = tmp_path / "string.json"
+        path2.write_text('"some string"')
+        assert onboarding.detect_first_run(path2) is True
+
+    def test_detect_first_run_missing_required_keys(self, tmp_path: Path) -> None:
+        """True when the object has neither mnemonic nor recovery_phrase."""
+        path = tmp_path / "wrong-key.json"
+        path.write_text(json.dumps({"address": "0x123", "created": "2026-04-20"}))
+        assert onboarding.detect_first_run(path) is True
+
+    def test_detect_first_run_empty_mnemonic_value(self, tmp_path: Path) -> None:
+        """True when the mnemonic key is present but empty / whitespace."""
+        path = tmp_path / "empty-mnem.json"
+        path.write_text(json.dumps({"mnemonic": ""}))
+        assert onboarding.detect_first_run(path) is True
+
+        path2 = tmp_path / "ws-mnem.json"
+        path2.write_text(json.dumps({"mnemonic": "   "}))
+        assert onboarding.detect_first_run(path2) is True
+
+    def test_detect_first_run_valid_credentials(self, tmp_path: Path) -> None:
+        """False when the file has a real mnemonic value."""
+        mnemonic = (
+            "abandon abandon abandon abandon abandon abandon "
+            "abandon abandon abandon abandon abandon about"
+        )
+        path = tmp_path / "creds.json"
+        path.write_text(json.dumps({"mnemonic": mnemonic}))
+        assert onboarding.detect_first_run(path) is False
+
+    def test_detect_first_run_valid_legacy_key(self, tmp_path: Path) -> None:
+        """False when the file uses legacy 'recovery_phrase' key.
+
+        Cross-client back-compat: Python pre-2.2.2 wrote this key. A
+        user who onboarded on old Python should NOT see the welcome
+        after upgrading.
+        """
+        mnemonic = (
+            "abandon abandon abandon abandon abandon abandon "
+            "abandon abandon abandon abandon abandon about"
+        )
+        path = tmp_path / "legacy.json"
+        path.write_text(json.dumps({"recovery_phrase": mnemonic}))
+        assert onboarding.detect_first_run(path) is False
+
+    def test_detect_first_run_default_path(self, monkeypatch, tmp_path: Path) -> None:
+        """Uses CANONICAL_CREDENTIALS_PATH when no path is passed."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        fake_creds = fake_home / ".totalreclaw" / "credentials.json"
+
+        # Point the module at a fresh CANONICAL_CREDENTIALS_PATH.
+        monkeypatch.setattr(onboarding, "CANONICAL_CREDENTIALS_PATH", fake_creds)
+
+        # No file → first run.
+        assert onboarding.detect_first_run() is True
+
+        fake_creds.parent.mkdir(parents=True)
+        fake_creds.write_text(json.dumps({"mnemonic": "abandon " * 11 + "about"}))
+        assert onboarding.detect_first_run() is False
+
+
+# ---------------------------------------------------------------------------
+# build_welcome_message
+# ---------------------------------------------------------------------------
+
+
+class TestBuildWelcomeMessage:
+    def test_welcome_message_local_mode(self) -> None:
+        """Local mode must include the short 'Run: hermes setup' instruction."""
+        msg = onboarding.build_welcome_message("local")
+        assert onboarding.WELCOME_MESSAGE in msg
+        assert onboarding.BRANCH_QUESTION in msg
+        assert onboarding.LOCAL_MODE_INSTRUCTIONS in msg
+        # Remote-specific copy must NOT appear in local mode.
+        assert onboarding.REMOTE_MODE_INSTRUCTIONS not in msg
+        # The canonical "recovery phrase" terminology is present.
+        assert "recovery phrase" in msg.lower()
+
+    def test_welcome_message_remote_mode(self) -> None:
+        """Remote mode must include the longer phrase-never-leaves note."""
+        msg = onboarding.build_welcome_message("remote")
+        assert onboarding.WELCOME_MESSAGE in msg
+        assert onboarding.BRANCH_QUESTION in msg
+        assert onboarding.REMOTE_MODE_INSTRUCTIONS in msg
+        # Remote-specific copy asserts the phrase-never-leaves guarantee.
+        assert "never leaves this machine" in msg
+        # Canonical terminology.
+        assert "recovery phrase" in msg.lower()
+
+    def test_welcome_message_invalid_mode(self) -> None:
+        """Unknown modes raise ValueError."""
+        with pytest.raises(ValueError):
+            onboarding.build_welcome_message("somewhere-else")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# detect_mode
+# ---------------------------------------------------------------------------
+
+
+class TestDetectMode:
+    def test_local_by_loopback_url_arg(self) -> None:
+        assert onboarding.detect_mode("http://localhost:4000") == "local"
+        assert onboarding.detect_mode("https://127.0.0.1:4000") == "local"
+        assert onboarding.detect_mode("http://[::1]:4000") == "local"
+
+    def test_remote_by_public_url_arg(self) -> None:
+        assert onboarding.detect_mode("https://api.totalreclaw.xyz") == "remote"
+        assert onboarding.detect_mode("https://api-staging.totalreclaw.xyz") == "remote"
+
+    def test_local_by_env_flag(self, monkeypatch) -> None:
+        monkeypatch.setenv("TOTALRECLAW_LOCAL_GATEWAY", "1")
+        monkeypatch.delenv("TOTALRECLAW_SERVER_URL", raising=False)
+        monkeypatch.delenv("TOTALRECLAW_RELAY_URL", raising=False)
+        assert onboarding.detect_mode() == "local"
+
+    def test_local_by_server_url_env(self, monkeypatch) -> None:
+        monkeypatch.delenv("TOTALRECLAW_LOCAL_GATEWAY", raising=False)
+        monkeypatch.delenv("HERMES_LOCAL_GATEWAY", raising=False)
+        monkeypatch.setenv("TOTALRECLAW_SERVER_URL", "http://localhost:4000")
+        assert onboarding.detect_mode() == "local"
+
+    def test_default_is_remote(self, monkeypatch) -> None:
+        # Strip every relevant env var.
+        for var in (
+            "TOTALRECLAW_LOCAL_GATEWAY",
+            "HERMES_LOCAL_GATEWAY",
+            "TOTALRECLAW_SERVER_URL",
+            "TOTALRECLAW_RELAY_URL",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        assert onboarding.detect_mode() == "remote"
+
+
+# ---------------------------------------------------------------------------
+# Copy constants — byte-identity lock
+# ---------------------------------------------------------------------------
+
+
+class TestCopyConstants:
+    def test_welcome_message_contents(self) -> None:
+        """WELCOME_MESSAGE is a non-empty stripped string that mentions
+        both E2E encryption and cross-agent portability."""
+        m = onboarding.WELCOME_MESSAGE
+        assert m == m.strip()
+        assert len(m) > 0
+        assert "end-to-end encrypted" in m.lower()
+        assert "recovery phrase" in m.lower()
+        # OpenClaw + Hermes + NanoClaw are called out by name — the
+        # copy is the same across all three clients.
+        assert "OpenClaw" in m
+        assert "Hermes" in m
+        assert "NanoClaw" in m
+
+    def test_branch_question_contents(self) -> None:
+        """BRANCH_QUESTION asks about restore-vs-generate in user terms."""
+        q = onboarding.BRANCH_QUESTION
+        assert q == q.strip()
+        assert "recovery phrase" in q.lower()
+        assert "generate" in q.lower()
+
+    def test_local_instructions(self) -> None:
+        assert onboarding.LOCAL_MODE_INSTRUCTIONS == "Run: hermes setup"
+
+    def test_remote_instructions_contents(self) -> None:
+        r = onboarding.REMOTE_MODE_INSTRUCTIONS
+        assert r == r.strip()
+        assert "Run: hermes setup" in r
+        # The load-bearing security claim.
+        assert "never leaves this machine" in r
+
+    def test_storage_guidance(self) -> None:
+        g = onboarding.STORAGE_GUIDANCE
+        assert g == g.strip()
+        assert "12 words" in g
+        assert "password manager" in g.lower()
+        # The "dedicated to TotalReclaw" warning, shorter variant.
+        assert "don't reuse" in g.lower() or "do not reuse" in g.lower()
+
+    def test_restore_prompt(self) -> None:
+        p = onboarding.RESTORE_PROMPT
+        assert p.strip() == "Enter your 12-word recovery phrase to restore your account:"
+
+    def test_generated_confirmation(self) -> None:
+        c = onboarding.GENERATED_CONFIRMATION
+        assert c == c.strip()
+        assert "write it down" in c.lower()
+        assert "only way to restore" in c.lower()
+
+
+# ---------------------------------------------------------------------------
+# maybe_emit_welcome — once-per-process behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeEmitWelcome:
+    def setup_method(self) -> None:
+        onboarding._reset_for_tests()
+
+    def test_emits_on_first_run(self, tmp_path: Path) -> None:
+        creds = tmp_path / "creds.json"
+        sentinel = tmp_path / ".welcome_shown"
+        buf = StringIO()
+
+        # Ensure we don't leak to the actual user home.
+        original_sentinel = onboarding._WELCOME_SENTINEL_PATH
+        onboarding._WELCOME_SENTINEL_PATH = sentinel
+        try:
+            emitted = onboarding.maybe_emit_welcome(
+                credentials_path=creds,
+                relay_url="http://localhost:4000",
+                stream=buf,
+            )
+        finally:
+            onboarding._WELCOME_SENTINEL_PATH = original_sentinel
+
+        assert emitted is True
+        output = buf.getvalue()
+        assert onboarding.WELCOME_MESSAGE in output
+        assert onboarding.BRANCH_QUESTION in output
+        assert onboarding.LOCAL_MODE_INSTRUCTIONS in output
+
+    def test_does_not_emit_when_onboarded(self, tmp_path: Path) -> None:
+        creds = tmp_path / "creds.json"
+        creds.write_text(json.dumps({"mnemonic": "abandon " * 11 + "about"}))
+        buf = StringIO()
+
+        emitted = onboarding.maybe_emit_welcome(
+            credentials_path=creds, stream=buf, use_sentinel=False
+        )
+        assert emitted is False
+        assert buf.getvalue() == ""
+
+    def test_does_not_emit_twice_in_same_process(self, tmp_path: Path) -> None:
+        creds = tmp_path / "creds.json"
+        buf1 = StringIO()
+        buf2 = StringIO()
+
+        first = onboarding.maybe_emit_welcome(
+            credentials_path=creds, stream=buf1, use_sentinel=False
+        )
+        second = onboarding.maybe_emit_welcome(
+            credentials_path=creds, stream=buf2, use_sentinel=False
+        )
+        assert first is True
+        assert second is False
+        assert buf1.getvalue() != ""
+        assert buf2.getvalue() == ""
+
+
+# ---------------------------------------------------------------------------
+# Terminology sweep — AST walk on python/src/**/*.py
+# ---------------------------------------------------------------------------
+
+
+FORBIDDEN_USER_FACING_TERMS = ("seed phrase", "recovery code", "recovery key")
+
+# 'mnemonic' is allowed as a variable name / internal identifier, but
+# must NOT appear in strings passed to user-facing output sinks.
+FORBIDDEN_USER_FACING_EXACT_MNEMONIC = "mnemonic"
+
+# Allowlisted file paths — strings inside these files are NEVER
+# user-facing (pure data, schema constants that go into JSON bodies the
+# agent consumes as data, docstrings explaining internal APIs).
+_ALLOWLISTED_FILES: tuple[str, ...] = (
+    # Raw schemas / core bindings — ``mnemonic`` here is a JSON-key
+    # identifier for credentials.json parity, not human-facing prose.
+    "totalreclaw/agent/state.py",
+    # Client constructor accepts ``mnemonic`` as a deprecated kwarg —
+    # the string lives in the signature, not in a user-facing message.
+    "totalreclaw/client.py",
+    # Rust core binding layer — argument name flows through to the Rust
+    # PyO3 function, can't be renamed without a core bump.
+    "totalreclaw/crypto.py",
+    # Internal setup tool — uses ``_acct, recovery_phrase = ...`` plus a
+    # leading comment that references ``BIP-39 mnemonic`` inside a
+    # docstring-style comment. No user-facing string leak.
+    "totalreclaw/hermes/tools.py",
+)
+
+
+def _source_files() -> list[Path]:
+    root = Path(__file__).resolve().parent.parent / "src"
+    return sorted(p for p in root.rglob("*.py"))
+
+
+def _is_user_facing_call(node: ast.Call) -> bool:
+    """True iff the call target is print / click.echo / logger.warning /
+    logger.error / logger.info — everything that ends up in front of
+    a human user as formatted text."""
+    fn = node.func
+    if isinstance(fn, ast.Name) and fn.id == "print":
+        return True
+    if isinstance(fn, ast.Attribute):
+        # click.echo / click.secho / click.confirm
+        if fn.attr in ("echo", "secho", "confirm"):
+            return True
+        # logger.warning / error / info — only WARN+ are strictly
+        # "user-facing" in a CLI, but INFO leaks to the default
+        # verbose flag too, so include it.
+        if fn.attr in ("warning", "error", "warn"):
+            return True
+    return False
+
+
+def _iter_string_args(call: ast.Call):
+    """Yield string literal Constant nodes from a call's args + kwargs."""
+    for a in call.args:
+        if isinstance(a, ast.Constant) and isinstance(a.value, str):
+            yield a
+    for kw in call.keywords:
+        if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+            yield kw.value
+
+
+class TestTerminologyParity:
+    """Grep-style check that no forbidden terminology leaks into strings
+    passed to ``print`` / ``click.echo`` / ``logger.warning`` /
+    ``logger.error`` across ``python/src/**/*.py``."""
+
+    def test_no_forbidden_terms_in_user_facing_call_sites(self) -> None:
+        offenders: list[tuple[str, int, str]] = []
+
+        for src_file in _source_files():
+            rel = src_file.relative_to(src_file.parent.parent.parent)  # strip python/
+            rel_s = str(rel).replace(os.sep, "/")
+            try:
+                tree = ast.parse(src_file.read_text(), filename=str(src_file))
+            except SyntaxError:
+                continue
+
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                if not _is_user_facing_call(node):
+                    continue
+                for s_node in _iter_string_args(node):
+                    text = s_node.value
+                    lower = text.lower()
+                    for term in FORBIDDEN_USER_FACING_TERMS:
+                        if term in lower:
+                            offenders.append((rel_s, s_node.lineno, term))
+                    # 'mnemonic' alone — allowlist src/totalreclaw dirs
+                    # where the word is part of an internal identifier
+                    # printed for debugging (logger.info("configured: %s", ...)).
+                    if "mnemonic" in lower:
+                        # Best-effort allowlist to avoid false positives.
+                        if not any(rel_s.endswith(a) for a in _ALLOWLISTED_FILES):
+                            offenders.append((rel_s, s_node.lineno, "mnemonic"))
+
+        assert not offenders, (
+            "User-facing strings contain forbidden terminology:\n"
+            + "\n".join(f"  {p}:{ln} -> {term}" for p, ln, term in offenders)
+        )
+
+    def test_no_forbidden_terms_in_welcome_copy(self) -> None:
+        """The canonical copy constants never leak forbidden terminology.
+
+        Tests every module-level copy string exported from
+        ``totalreclaw.onboarding`` for ``seed phrase`` / ``recovery code`` /
+        ``recovery key``. These strings are the single source of truth for
+        cross-client parity; a regression here would propagate to every
+        agent that imports ``build_welcome_message``.
+        """
+        strings = [
+            onboarding.WELCOME_MESSAGE,
+            onboarding.BRANCH_QUESTION,
+            onboarding.LOCAL_MODE_INSTRUCTIONS,
+            onboarding.REMOTE_MODE_INSTRUCTIONS,
+            onboarding.STORAGE_GUIDANCE,
+            onboarding.RESTORE_PROMPT,
+            onboarding.GENERATED_CONFIRMATION,
+        ]
+        for s in strings:
+            lower = s.lower()
+            for term in FORBIDDEN_USER_FACING_TERMS:
+                assert term not in lower, (
+                    f"Forbidden term {term!r} found in onboarding copy: {s!r}"
+                )
+            assert "mnemonic" not in lower, (
+                f"Internal term 'mnemonic' leaked into user-facing copy: {s!r}"
+            )


### PR DESCRIPTION
## Summary

Bring the Python client / Hermes plugin to UX parity with the TS plugin 3.3.0 first-run flow. Users switching between OpenClaw and Hermes see the same welcome banner, the same branch question, and the same canonical **recovery phrase** terminology.

- New `totalreclaw.onboarding` module (synchronous, no-network): `detect_first_run`, `build_welcome_message`, `detect_mode`, `maybe_emit_welcome`, plus verbatim copy constants (`WELCOME_MESSAGE`, `BRANCH_QUESTION`, `STORAGE_GUIDANCE`, `RESTORE_PROMPT`, `GENERATED_CONFIRMATION`, local + remote instructions).
- New `hermes setup` console script (via `[project.scripts]`) — interactive wizard mirroring `openclaw totalreclaw onboard`. Restore path accepts 12 words space-separated or one-per-line + validates BIP-39 checksum via `eth_account.Account.from_mnemonic`. Generate path prints `STORAGE_GUIDANCE`, shows the phrase grid on **stderr** (not stdout), runs a last-3-words retype-ack, then prints `GENERATED_CONFIRMATION`.
- `TotalReclaw.__init__` and `totalreclaw.hermes.register()` emit the welcome once-per-process (module-level flag) + once-per-host (sentinel file at `~/.totalreclaw/.welcome_shown`). Zero noise for returning users.
- Terminology sweep: `python/README.md` bullet now says "BIP-39 recovery phrase" instead of "BIP-39 mnemonic". Scope limited to user-facing output — internal variable names, docstrings describing internal APIs (`derive_keys_from_mnemonic`, `from_mnemonic`), and the credentials-file canonical key `mnemonic` are intentionally unchanged. Guarded by an AST-walking test that fails if any forbidden term (`seed phrase`, `recovery code`, `recovery key`, or `mnemonic` outside allowlisted internal-API files) reaches a `print` / `click.echo` / `logger.warning` call site under `python/src/**/*.py`.

## Changes

- `python/src/totalreclaw/onboarding.py` — new module.
- `python/src/totalreclaw/hermes/cli.py` — new module + `hermes setup` subcommand.
- `python/src/totalreclaw/client.py` — first-run welcome emission on `ValueError("recovery_phrase is required")` path.
- `python/src/totalreclaw/hermes/__init__.py` — `maybe_emit_welcome()` call at plugin load time.
- `python/src/totalreclaw/__init__.py` — fallback `__version__` updated to `"2.3.1"`.
- `python/pyproject.toml` — version bumped `2.3.0` → `2.3.1`; new `[project.scripts]` entry for `hermes` CLI.
- `python/src/totalreclaw/hermes/plugin.yaml` — `version: 2.3.1`.
- `python/README.md` — terminology sweep (one bullet).
- `python/CHANGELOG.md` — new `[2.3.1]` entry.
- `python/tests/test_onboarding.py` — 30 tests (detect_first_run, mode detection, copy constants, terminology-sweep AST walk, maybe_emit_welcome suppression).
- `python/tests/test_hermes_setup_cli.py` — 12 tests (restore + generate happy paths, invalid-phrase rejection, overwrite confirmation, non-TTY handling, stderr-vs-stdout phrase placement).

## Welcome screenshot

Actual stdout from `TotalReclaw()` invoked with no phrase on a clean machine:

```
Welcome to TotalReclaw — encrypted, agent-portable memory.

Your memories are stored end-to-end encrypted and on-chain. You can restore them on any agent — OpenClaw, Hermes, or NanoClaw — with a single recovery phrase.

Let's set up your account. Do you already have a recovery phrase, or should we generate a new one?

Run: hermes setup

You'll be prompted to either restore from an existing recovery phrase or generate a new one. Your phrase never leaves this machine.
```

## Test plan

- [x] `pytest python/tests/test_onboarding.py python/tests/test_hermes_setup_cli.py` — 42/42 pass.
- [x] Full Python suite: `pytest python/tests/` — **732 passed, 10 skipped, 1 xfailed** (all pre-existing). No regressions.
- [x] Manual end-to-end of restore flow: credentials.json correctly written at mode 0600 with `{"mnemonic": "..."}` canonical shape.
- [x] Manual end-to-end of generate flow: `STORAGE_GUIDANCE` printed before the phrase, phrase grid goes to stderr, last-3-words confirmation required, `GENERATED_CONFIRMATION` printed after success.
- [x] Manual verification: welcome banner does NOT emit when `~/.totalreclaw/credentials.json` is present.
- [x] Manual verification: welcome banner emits at most once per process across repeated `TotalReclaw()` instantiations.
- [x] `hermes --help` and `hermes setup --help` render correctly from the installed console script.

## Parallel work

- Plugin 3.3.0 (QR-pairing) already landed in `main` as b3baf62 (#61). This Python-side release aligns the user-experience surface with the plugin's post-3.2.0 onboarding pattern so cross-agent portability is UX-visible, not just cryptographic.
- `skill/plugin/`, `skill-nanoclaw/`, `mcp/`, and `rust/totalreclaw-core/` are left untouched in this PR — parallel worktrees carry any changes to those surfaces.

## CI checks expected

- Python Client Tests (primary)
- Rust Core Tests, MCP Server Tests, Client Tests TypeScript, Plugin Build Check (should pass unchanged — not touched by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)