### PR TITLE
feat(nanoclaw): 3.1.1-rc.1 first-run onboarding + recovery-phrase terminology

### DIFF
--- a/skill-nanoclaw/CHANGELOG.md
+++ b/skill-nanoclaw/CHANGELOG.md
@@ -1,5 +1,87 @@
 # Changelog — @totalreclaw/skill-nanoclaw
 
+## 3.1.1-rc.1 — 2026-04-20
+
+### First-run onboarding UX parity
+
+Parity with OpenClaw plugin 3.3.0 (first-run welcome via `prependContext`)
+and Hermes 2.3.1 (first-run welcome via stdout). NanoClaw now surfaces a
+canonical welcome message + branch question when the credentials file is
+missing / empty / invalid on session startup. Gates on the
+`@anthropic-ai/claude-agent-sdk` `SessionStart` hook (`source='startup'`)
+and injects via `additionalContext` — the direct NanoClaw analog of the
+plugin's `prependContext`.
+
+### Added
+
+- `src/onboarding/first-run.ts` — library-shaped onboarding module:
+  - `detectFirstRun(credentialsPath)` — returns true when the credentials
+    file is missing, empty, unparseable, lacks a mnemonic field, or has the
+    wrong word count. Deep BIP-39 checksum validation is left to
+    `@totalreclaw/core` at key-derivation time.
+  - `buildWelcomeMessage()` — renders the canonical welcome + branch
+    question + NanoClaw-specific instructions + storage guidance.
+  - `maybeBuildFirstRunContext({ credentialsPath, source })` — full
+    check-and-inject. Gated by a process-scoped sentinel so we emit once
+    per Node process; skips `compact` source entirely (mid-session
+    compactions must NOT re-inject onboarding).
+  - Canonical copy constants exported as module top-level:
+    `WELCOME_MESSAGE`, `BRANCH_QUESTION`, `NANOCLAW_INSTRUCTIONS`,
+    `STORAGE_GUIDANCE`.
+  - `resolveCredentialsPath()` — precedence:
+    `$TOTALRECLAW_CREDENTIALS_PATH` → `$WORKSPACE_DIR/.totalreclaw/credentials.json`
+    → `$HOME/.totalreclaw/credentials.json`.
+- `src/onboarding/index.ts` — barrel re-export.
+- `src/index.ts` — re-exports onboarding module.
+- `tests/first-run.test.js` — 26 tests covering detect / build / hook /
+  path resolution / terminology parity / runner wiring.
+
+### Changed
+
+- `mcp/nanoclaw-agent-runner.ts` — inline first-run detection + SessionStart
+  hook registration. Logic mirrors `src/onboarding/first-run.ts`. The runner
+  is an overlay copied by the NanoClaw skill loader into
+  `container/agent-runner/src/index.ts`, so it cannot `require` the skill
+  package's `dist/` at runtime — duplication is intentional. Any bugfix
+  must be mirrored to the library module (enforced by `tests/first-run.test.js`
+  string-parity checks).
+- `SKILL.md` — terminology sweep: `BIP-39 mnemonic` → `BIP-39 recovery phrase`
+  in user-facing setup copy.
+
+### Hook API findings (research-phase output)
+
+- NanoClaw uses `@anthropic-ai/claude-agent-sdk` directly via `query()`.
+- Supported hooks include `SessionStart`, `UserPromptSubmit`, `PreCompact`,
+  `PostCompact`, `PreToolUse`, `PostToolUse`, `Stop`, `Setup`, etc.
+- `SessionStart` fires at the start of a session with
+  `source: 'startup' | 'resume' | 'clear' | 'compact'`.
+  `SessionStartHookSpecificOutput` carries `additionalContext?: string` —
+  direct analog of OpenClaw plugin's `prependContext`.
+- This IS a "genuine" context injection from a skill — no fallback workaround
+  was needed. SDK support exists and is stable.
+
+### Constraints respected
+
+- No changes to `skill/plugin/`, `python/`, `mcp/`, or `rust/`.
+- No regression to 3.1.0 v1 taxonomy behavior — extraction + recall paths
+  untouched.
+- `@totalreclaw/core` floor stays at `^2.2.0` (no new prompt hoisting).
+- MCP peer-dep stays at `^3.0.0`.
+
+### Known caveats
+
+- **No interactive wizard.** Unlike OpenClaw (`openclaw totalreclaw onboard`)
+  and Hermes (`hermes setup`), NanoClaw runs in a container with no TTY
+  affordance for a wizard. The welcome message directs users to either
+  generate the phrase via an external BIP-39 tool, hand-populate
+  `credentials.json`, or use the OpenClaw / Hermes CLI on a local machine
+  and copy the credentials file into the NanoClaw workspace.
+- **Session-scoped sentinel is in-memory.** The welcome emits once per Node
+  process. If the container restarts after credentials are populated,
+  detection correctly returns false on the next boot and no welcome is
+  emitted. If the container restarts with credentials still missing, the
+  welcome emits again — which is the right behavior.
+
 ## 3.1.0 — 2026-04-19
 
 ### Canonical extraction prompt hoisted to core + ADD-only alignment

--- a/skill-nanoclaw/SKILL.md
+++ b/skill-nanoclaw/SKILL.md
@@ -6,10 +6,10 @@ End-to-end encrypted memory for NanoClaw agents, powered by the `@totalreclaw/mc
 
 ### Step 1: Recovery phrase
 
-The **recovery phrase** is a 12-word BIP-39 mnemonic that derives all encryption keys client-side. TotalReclaw never sends it to the server.
+The **recovery phrase** is a 12-word BIP-39 phrase that derives all encryption keys client-side. TotalReclaw never sends it to the server.
 
-- **New user:** Generate a 12-word BIP-39 mnemonic. Save it securely -- it is the only way to recover your memories.
-- **Returning user:** Use your existing phrase to restore memories on a new device.
+- **New user:** Generate a 12-word BIP-39 recovery phrase. Save it securely -- it is the only way to recover your memories.
+- **Returning user:** Use your existing recovery phrase to restore memories on a new device.
 
 ### Step 2: Configure environment
 

--- a/skill-nanoclaw/mcp/nanoclaw-agent-runner.ts
+++ b/skill-nanoclaw/mcp/nanoclaw-agent-runner.ts
@@ -22,7 +22,7 @@
 
 import fs from 'fs';
 import path from 'path';
-import { query, HookCallback, PreCompactHookInput, PreToolUseHookInput } from '@anthropic-ai/claude-agent-sdk';
+import { query, HookCallback, PreCompactHookInput, PreToolUseHookInput, SessionStartHookInput } from '@anthropic-ai/claude-agent-sdk';
 import { fileURLToPath } from 'url';
 
 interface ContainerInput {
@@ -211,6 +211,98 @@ function createSanitizeBashHook(): HookCallback {
           ...(preInput.tool_input as Record<string, unknown>),
           command: unsetPrefix + command,
         },
+      },
+    };
+  };
+}
+
+// ---------------------------------------------------------------------------
+// First-run onboarding (NanoClaw 3.1.1) — parity with OpenClaw plugin 3.3.0
+// (prependContext) and Hermes 2.3.1 (stdout). The SessionStart hook is the
+// earliest lifecycle hook exposed by @anthropic-ai/claude-agent-sdk and its
+// hookSpecificOutput carries an `additionalContext` string that the SDK
+// injects before the first user prompt — the direct analog of the plugin's
+// `prependContext`.
+//
+// The logic here is intentionally duplicated from `src/onboarding/first-run.ts`
+// (which is the tested, library-shaped version exported from
+// `@totalreclaw/skill-nanoclaw`). The runner is copied into the NanoClaw
+// container's `container/agent-runner/src/index.ts` by the skill loader —
+// at which point it has no access to the skill package's compiled `dist/`.
+// Keeping the runner self-contained avoids that coupling. Any bugfix here
+// should be mirrored into `src/onboarding/first-run.ts` and vice versa.
+// ---------------------------------------------------------------------------
+
+const FIRST_RUN_WELCOME = `Welcome to TotalReclaw — encrypted, agent-portable memory.
+
+Your memories are stored end-to-end encrypted and on-chain. You can restore them on any agent — OpenClaw, Hermes, or NanoClaw — with a single recovery phrase.
+
+Let's set up your account. Do you already have a recovery phrase, or should we generate a new one?
+
+To set up: generate a recovery phrase with your preferred BIP39 tool, or provide one you already have. Save it to ~/.totalreclaw/credentials.json in this shape:
+  { "mnemonic": "word1 word2 ... word12", "scope_address": "0x..." }
+
+Or use the OpenClaw or Hermes CLI to generate one — the phrase will work across all three.
+
+Your recovery phrase is 12 words. Store it somewhere safe — a password manager works well. Use it only for TotalReclaw. Don't reuse it anywhere else. Don't put funds on it.`;
+
+let firstRunWelcomeEmitted = false;
+
+/**
+ * Returns true if the credentials file is missing / empty / invalid and we
+ * should trigger the first-run welcome. Any read/parse error counts as
+ * first-run (safe default — alternative is a cryptic MCP-server fail later).
+ */
+function isFirstRun(credentialsPath: string): boolean {
+  try {
+    if (!fs.existsSync(credentialsPath)) return true;
+    const raw = fs.readFileSync(credentialsPath, 'utf-8').trim();
+    if (raw.length === 0) return true;
+    let parsed: { mnemonic?: string };
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return true;
+    }
+    if (!parsed || typeof parsed !== 'object') return true;
+    const mnemonic = typeof parsed.mnemonic === 'string' ? parsed.mnemonic.trim() : '';
+    if (mnemonic.length === 0) return true;
+    const wordCount = mnemonic.split(/\s+/).filter(Boolean).length;
+    if (wordCount !== 12 && wordCount !== 24) return true;
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * SessionStart hook: inject the first-run welcome as `additionalContext`
+ * when the credentials file is missing. Gated by a process-scoped sentinel
+ * so we only emit once per Node process.
+ *
+ * Source filter: skip `compact` entirely (mid-session compaction must NOT
+ * re-inject onboarding, even if credentials somehow went missing mid-session
+ * — that indicates a different bug). `startup`, `resume`, and `clear` all
+ * count as first-contact candidates — on any of those, if credentials are
+ * still unavailable, the user needs to see the welcome.
+ */
+function createFirstRunHook(credentialsPath: string): HookCallback {
+  return async (input, _toolUseId, _context) => {
+    if (firstRunWelcomeEmitted) return {};
+    const hookInput = input as SessionStartHookInput;
+    const source = hookInput.source;
+    // Mid-session compaction must never re-emit onboarding.
+    if (source === 'compact') return {};
+    // Only `startup` is gated against in terminology-parity tests, but we
+    // accept startup/resume/clear here at runtime.
+    if (source !== 'startup' && source !== 'resume' && source !== 'clear') return {};
+    if (!isFirstRun(credentialsPath)) return {};
+    firstRunWelcomeEmitted = true;
+    log('First-run welcome: credentials missing, injecting welcome context');
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'SessionStart',
+        additionalContext: FIRST_RUN_WELCOME,
       },
     };
   };
@@ -472,6 +564,7 @@ async function runQuery(
         },
       },
       hooks: {
+        SessionStart: [{ hooks: [createFirstRunHook(path.join(WORKSPACE_ROOT, '.totalreclaw', 'credentials.json'))] }],
         PreCompact: [{ hooks: [createPreCompactHook(containerInput.assistantName)] }],
         PreToolUse: [{ matcher: 'Bash', hooks: [createSanitizeBashHook()] }],
       },

--- a/skill-nanoclaw/package.json
+++ b/skill-nanoclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/skill-nanoclaw",
-  "version": "3.1.0",
+  "version": "3.1.1-rc.1",
   "description": "NanoClaw skill for TotalReclaw integration — Memory Taxonomy v1 default",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/skill-nanoclaw/src/index.ts
+++ b/skill-nanoclaw/src/index.ts
@@ -1,3 +1,4 @@
 export * from './hooks/index.js';
 export * from './extraction/index.js';
 export * from './billing.js';
+export * from './onboarding/index.js';

--- a/skill-nanoclaw/src/onboarding/first-run.ts
+++ b/skill-nanoclaw/src/onboarding/first-run.ts
@@ -1,0 +1,201 @@
+/**
+ * First-run onboarding — NanoClaw skill 3.1.1.
+ *
+ * Parity with OpenClaw plugin 3.3.0 (first-run welcome via prependContext) and
+ * Hermes 2.3.1 (first-run welcome via stdout). The NanoClaw equivalent uses
+ * the Claude Agent SDK's SessionStart hook (source='startup') to inject a
+ * one-time welcome + branch question into the agent's additional context
+ * when the credentials file is missing / empty / invalid.
+ *
+ * NOTE: NanoClaw has no interactive CLI onboarding wizard (unlike OpenClaw's
+ * `openclaw totalreclaw onboard` and Hermes's `hermes setup`). The NanoClaw
+ * agent runs in a container; the user must either (a) pre-populate
+ * `$WORKSPACE_DIR/.totalreclaw/credentials.json` with a recovery phrase they
+ * already generated via another client, or (b) use the OpenClaw or Hermes
+ * CLI on a local machine to mint a phrase, then hand-copy the credentials
+ * file into the NanoClaw workspace. This limitation is surfaced verbatim to
+ * the user in the welcome message.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * The canonical welcome message, shared across OpenClaw plugin 3.3.0 +
+ * Hermes 2.3.1 + NanoClaw 3.1.1.
+ */
+export const WELCOME_MESSAGE = `Welcome to TotalReclaw — encrypted, agent-portable memory.
+
+Your memories are stored end-to-end encrypted and on-chain. You can restore them on any agent — OpenClaw, Hermes, or NanoClaw — with a single recovery phrase.`;
+
+/**
+ * The branch question: existing user vs. new user. NanoClaw is a single
+ * runtime (no local/remote distinction like OpenClaw), so no mode-switching
+ * — just ask about the recovery phrase.
+ */
+export const BRANCH_QUESTION = `Let's set up your account. Do you already have a recovery phrase, or should we generate a new one?`;
+
+/**
+ * NanoClaw-specific setup instructions. Unlike OpenClaw / Hermes, NanoClaw
+ * does NOT have an interactive wizard. The user has three paths:
+ *   1. Generate a BIP-39 phrase with an external tool, hand-populate the
+ *      credentials file.
+ *   2. Use the OpenClaw CLI (`openclaw totalreclaw onboard`) or the Hermes
+ *      CLI (`hermes setup`) on a local machine to mint a phrase, then share
+ *      the credentials file with the NanoClaw workspace.
+ *   3. Re-use a phrase they already have from another TotalReclaw client —
+ *      cross-client portability is a v1 contract guarantee.
+ */
+export const NANOCLAW_INSTRUCTIONS = `To set up: generate a recovery phrase with your preferred BIP39 tool, or provide one you already have. Save it to ~/.totalreclaw/credentials.json in this shape:
+  { "mnemonic": "word1 word2 ... word12", "scope_address": "0x..." }
+
+Or use the OpenClaw or Hermes CLI to generate one — the phrase will work across all three.`;
+
+/**
+ * Security + storage guidance. The recovery phrase is the user's only
+ * identity and cannot be recovered if lost.
+ */
+export const STORAGE_GUIDANCE = `Your recovery phrase is 12 words. Store it somewhere safe — a password manager works well. Use it only for TotalReclaw. Don't reuse it anywhere else. Don't put funds on it.`;
+
+/**
+ * Shape of the credentials file written by the OpenClaw / Hermes CLIs. The
+ * NanoClaw MCP server reads the same shape.
+ */
+interface CredentialsShape {
+  mnemonic?: string;
+  scope_address?: string;
+}
+
+/**
+ * Detect first-run state: returns true if the credentials file is missing,
+ * empty, or does not contain a usable mnemonic. Any read / parse error is
+ * treated as first-run (safe default — the alternative is silently failing
+ * with a cryptic error downstream when the MCP server tries to derive keys).
+ */
+export async function detectFirstRun(credentialsPath: string): Promise<boolean> {
+  try {
+    if (!fs.existsSync(credentialsPath)) {
+      return true;
+    }
+    const raw = await fs.promises.readFile(credentialsPath, 'utf-8');
+    const trimmed = raw.trim();
+    if (trimmed.length === 0) {
+      return true;
+    }
+
+    let parsed: CredentialsShape;
+    try {
+      parsed = JSON.parse(trimmed) as CredentialsShape;
+    } catch {
+      // Unparseable JSON — treat as first-run so we re-emit onboarding.
+      return true;
+    }
+
+    if (!parsed || typeof parsed !== 'object') {
+      return true;
+    }
+
+    const mnemonic = typeof parsed.mnemonic === 'string' ? parsed.mnemonic.trim() : '';
+    if (mnemonic.length === 0) {
+      return true;
+    }
+
+    // A valid recovery phrase is 12 BIP-39 words. We don't verify the
+    // checksum here (that's @totalreclaw/core's job at key-derivation
+    // time) — we only check structural validity so we don't emit the
+    // welcome for a clearly-populated file with a bogus phrase; leave
+    // deeper validation to the MCP server + billing.ts.
+    const wordCount = mnemonic.split(/\s+/).filter(Boolean).length;
+    if (wordCount !== 12 && wordCount !== 24) {
+      return true;
+    }
+
+    return false;
+  } catch {
+    // Any unexpected error (permission, IO) → treat as first-run so the
+    // user is walked through the setup rather than hitting a cryptic fail.
+    return true;
+  }
+}
+
+/**
+ * Build the full welcome message injected via `SessionStart` →
+ * `additionalContext`. Includes the branded intro, the branch question, the
+ * NanoClaw-specific setup instructions (no interactive wizard), and the
+ * storage guidance — all four pieces shipped as one block so the agent has
+ * the full picture to answer the user's next message.
+ */
+export function buildWelcomeMessage(): string {
+  return [
+    WELCOME_MESSAGE,
+    '',
+    BRANCH_QUESTION,
+    '',
+    NANOCLAW_INSTRUCTIONS,
+    '',
+    STORAGE_GUIDANCE,
+  ].join('\n');
+}
+
+/**
+ * Resolve the credentials file path the NanoClaw agent-runner uses by
+ * default. Mirrors the precedence documented in SKILL.md / nanoclaw-agent-runner.ts:
+ *
+ *   1. $TOTALRECLAW_CREDENTIALS_PATH (explicit override)
+ *   2. $WORKSPACE_DIR/.totalreclaw/credentials.json (container-scoped)
+ *   3. ~/.totalreclaw/credentials.json (user-scoped fallback)
+ */
+export function resolveCredentialsPath(): string {
+  if (process.env.TOTALRECLAW_CREDENTIALS_PATH) {
+    return process.env.TOTALRECLAW_CREDENTIALS_PATH;
+  }
+  const workspace = process.env.WORKSPACE_DIR;
+  if (workspace) {
+    return path.join(workspace, '.totalreclaw', 'credentials.json');
+  }
+  const home = process.env.HOME ?? '/home/node';
+  return path.join(home, '.totalreclaw', 'credentials.json');
+}
+
+// ---------------------------------------------------------------------------
+// Session-scoped sentinel — emit the welcome at most once per Node process.
+// SessionStart fires for `startup`, `resume`, `clear`, and `compact`; we only
+// want to welcome on real first-contact (startup + missing credentials), not
+// on every compact.
+// ---------------------------------------------------------------------------
+
+let _welcomeEmittedForProcess = false;
+
+/** Test-only reset for the session sentinel. */
+export function _resetWelcomeSentinel(): void {
+  _welcomeEmittedForProcess = false;
+}
+
+/**
+ * Full first-run check-and-inject: returns the welcome `additionalContext`
+ * string if this is a real first-run and we haven't already emitted once,
+ * else returns undefined. Honours SessionStart `source` to avoid emitting
+ * on resume / clear / compact events.
+ */
+export async function maybeBuildFirstRunContext(options: {
+  credentialsPath?: string;
+  source?: 'startup' | 'resume' | 'clear' | 'compact';
+}): Promise<string | undefined> {
+  if (_welcomeEmittedForProcess) {
+    return undefined;
+  }
+  // Only emit on startup-like events. `compact` is a mid-session compaction
+  // and should never re-inject onboarding (even if credentials went missing
+  // mid-session, which would indicate a different bug).
+  const source = options.source ?? 'startup';
+  if (source === 'compact') {
+    return undefined;
+  }
+  const credentialsPath = options.credentialsPath ?? resolveCredentialsPath();
+  const isFirstRun = await detectFirstRun(credentialsPath);
+  if (!isFirstRun) {
+    return undefined;
+  }
+  _welcomeEmittedForProcess = true;
+  return buildWelcomeMessage();
+}

--- a/skill-nanoclaw/src/onboarding/index.ts
+++ b/skill-nanoclaw/src/onboarding/index.ts
@@ -1,0 +1,11 @@
+export {
+  WELCOME_MESSAGE,
+  BRANCH_QUESTION,
+  NANOCLAW_INSTRUCTIONS,
+  STORAGE_GUIDANCE,
+  detectFirstRun,
+  buildWelcomeMessage,
+  resolveCredentialsPath,
+  maybeBuildFirstRunContext,
+  _resetWelcomeSentinel,
+} from './first-run.js';

--- a/skill-nanoclaw/tests/first-run.test.js
+++ b/skill-nanoclaw/tests/first-run.test.js
@@ -1,0 +1,374 @@
+/**
+ * @jest-environment node
+ *
+ * NanoClaw 3.1.1 first-run onboarding tests.
+ *
+ * Covers:
+ *   - detectFirstRun: missing / empty / invalid / partial / valid credentials
+ *   - buildWelcomeMessage: contains brand + recovery-phrase terminology
+ *   - Terminology parity: no legacy `seed phrase` / `recovery code` /
+ *     `recovery key` leak in user-facing strings
+ *   - Session-scoped sentinel: welcome emits at most once per process
+ *   - SessionStart source filter: `compact` does not trigger welcome
+ *
+ * Module under test is TypeScript (`src/onboarding/first-run.ts`) — we load
+ * the compiled output from `dist/`. Running `npm run build` before `npm test`
+ * is part of the normal publish pipeline.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+describe('src/onboarding/first-run — module exports', () => {
+  let onboarding;
+
+  beforeAll(() => {
+    // Compiled output — `npm run build` must have run at least once.
+    onboarding = require(path.join(__dirname, '..', 'dist', 'onboarding', 'first-run.js'));
+  });
+
+  it('exports the canonical welcome copy constants', () => {
+    expect(typeof onboarding.WELCOME_MESSAGE).toBe('string');
+    expect(onboarding.WELCOME_MESSAGE).toContain('Welcome to TotalReclaw');
+    expect(onboarding.WELCOME_MESSAGE).toContain('encrypted');
+    expect(onboarding.WELCOME_MESSAGE).toContain('recovery phrase');
+
+    expect(typeof onboarding.BRANCH_QUESTION).toBe('string');
+    expect(onboarding.BRANCH_QUESTION).toContain('recovery phrase');
+
+    expect(typeof onboarding.NANOCLAW_INSTRUCTIONS).toBe('string');
+    expect(onboarding.NANOCLAW_INSTRUCTIONS).toContain('BIP39');
+    expect(onboarding.NANOCLAW_INSTRUCTIONS).toContain('credentials.json');
+
+    expect(typeof onboarding.STORAGE_GUIDANCE).toBe('string');
+    expect(onboarding.STORAGE_GUIDANCE).toContain('12 words');
+  });
+
+  it('cross-client welcome message matches the shared contract', () => {
+    // Contract — these exact phrases are shipped by plugin 3.3.0 + Hermes 2.3.1.
+    expect(onboarding.WELCOME_MESSAGE).toContain(
+      'Welcome to TotalReclaw — encrypted, agent-portable memory.'
+    );
+    expect(onboarding.BRANCH_QUESTION).toContain(
+      'Do you already have a recovery phrase, or should we generate a new one?'
+    );
+  });
+});
+
+describe('detectFirstRun', () => {
+  let onboarding;
+  let tmpDir;
+
+  beforeAll(() => {
+    onboarding = require(path.join(__dirname, '..', 'dist', 'onboarding', 'first-run.js'));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-onboarding-'));
+  });
+
+  afterAll(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch { /* best-effort */ }
+  });
+
+  it('returns true when the credentials file is missing', async () => {
+    const missingPath = path.join(tmpDir, 'nonexistent.json');
+    await expect(onboarding.detectFirstRun(missingPath)).resolves.toBe(true);
+  });
+
+  it('returns true when the credentials file is empty', async () => {
+    const emptyPath = path.join(tmpDir, 'empty.json');
+    fs.writeFileSync(emptyPath, '', 'utf-8');
+    await expect(onboarding.detectFirstRun(emptyPath)).resolves.toBe(true);
+  });
+
+  it('returns true when the credentials file contains only whitespace', async () => {
+    const wsPath = path.join(tmpDir, 'whitespace.json');
+    fs.writeFileSync(wsPath, '   \n\n\t   ', 'utf-8');
+    await expect(onboarding.detectFirstRun(wsPath)).resolves.toBe(true);
+  });
+
+  it('returns true when the credentials file is invalid JSON', async () => {
+    const badPath = path.join(tmpDir, 'bad.json');
+    fs.writeFileSync(badPath, 'not json {{{', 'utf-8');
+    await expect(onboarding.detectFirstRun(badPath)).resolves.toBe(true);
+  });
+
+  it('returns true when credentials JSON lacks the mnemonic field', async () => {
+    const noMnemPath = path.join(tmpDir, 'no-mnem.json');
+    fs.writeFileSync(noMnemPath, JSON.stringify({ scope_address: '0xabc' }), 'utf-8');
+    await expect(onboarding.detectFirstRun(noMnemPath)).resolves.toBe(true);
+  });
+
+  it('returns true when mnemonic is empty string', async () => {
+    const emptyMnemPath = path.join(tmpDir, 'empty-mnem.json');
+    fs.writeFileSync(emptyMnemPath, JSON.stringify({ mnemonic: '' }), 'utf-8');
+    await expect(onboarding.detectFirstRun(emptyMnemPath)).resolves.toBe(true);
+  });
+
+  it('returns true when mnemonic has wrong word count', async () => {
+    const shortPath = path.join(tmpDir, 'short-mnem.json');
+    fs.writeFileSync(shortPath, JSON.stringify({ mnemonic: 'one two three' }), 'utf-8');
+    await expect(onboarding.detectFirstRun(shortPath)).resolves.toBe(true);
+  });
+
+  it('returns false for a structurally valid 12-word credentials file', async () => {
+    const validPath = path.join(tmpDir, 'valid.json');
+    // 12 placeholder words — no BIP-39 checksum check at this layer
+    // (deep validation is @totalreclaw/core's job at key derivation).
+    const mnemonic = 'abandon ability able about above absent absorb abstract absurd abuse access accident';
+    fs.writeFileSync(
+      validPath,
+      JSON.stringify({ mnemonic, scope_address: '0x1234567890abcdef1234567890abcdef12345678' }),
+      'utf-8',
+    );
+    await expect(onboarding.detectFirstRun(validPath)).resolves.toBe(false);
+  });
+
+  it('returns false for a 24-word credentials file', async () => {
+    const validPath = path.join(tmpDir, 'valid-24.json');
+    const mnemonic = Array(24).fill('abandon').join(' ');
+    fs.writeFileSync(validPath, JSON.stringify({ mnemonic }), 'utf-8');
+    await expect(onboarding.detectFirstRun(validPath)).resolves.toBe(false);
+  });
+
+  it('returns true when the mnemonic is non-string garbage', async () => {
+    const garbagePath = path.join(tmpDir, 'garbage.json');
+    fs.writeFileSync(garbagePath, JSON.stringify({ mnemonic: 12345 }), 'utf-8');
+    await expect(onboarding.detectFirstRun(garbagePath)).resolves.toBe(true);
+  });
+});
+
+describe('buildWelcomeMessage', () => {
+  let onboarding;
+
+  beforeAll(() => {
+    onboarding = require(path.join(__dirname, '..', 'dist', 'onboarding', 'first-run.js'));
+  });
+
+  it('includes all four sections (welcome, branch, instructions, guidance)', () => {
+    const msg = onboarding.buildWelcomeMessage();
+    expect(msg).toContain('Welcome to TotalReclaw');
+    expect(msg).toContain('Do you already have a recovery phrase');
+    expect(msg).toContain('BIP39');
+    expect(msg).toContain('Store it somewhere safe');
+  });
+
+  it('uses "recovery phrase" terminology exclusively', () => {
+    const msg = onboarding.buildWelcomeMessage();
+    // Must be present
+    expect(msg).toMatch(/recovery phrase/i);
+    // Must NOT use legacy terms in the rendered welcome
+    expect(msg).not.toMatch(/\bseed phrase\b/i);
+    expect(msg).not.toMatch(/\brecovery code\b/i);
+    expect(msg).not.toMatch(/\brecovery key\b/i);
+  });
+
+  it('mentions cross-client portability (OpenClaw + Hermes + NanoClaw)', () => {
+    const msg = onboarding.buildWelcomeMessage();
+    expect(msg).toContain('OpenClaw');
+    expect(msg).toContain('Hermes');
+    expect(msg).toContain('NanoClaw');
+  });
+
+  it('documents the NanoClaw-specific "no wizard" path', () => {
+    const msg = onboarding.buildWelcomeMessage();
+    expect(msg).toContain('credentials.json');
+    expect(msg).toContain('OpenClaw or Hermes CLI');
+  });
+});
+
+describe('maybeBuildFirstRunContext', () => {
+  let onboarding;
+  let tmpDir;
+
+  beforeAll(() => {
+    onboarding = require(path.join(__dirname, '..', 'dist', 'onboarding', 'first-run.js'));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-onboarding-hook-'));
+  });
+
+  afterAll(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch { /* best-effort */ }
+  });
+
+  beforeEach(() => {
+    onboarding._resetWelcomeSentinel();
+  });
+
+  it('returns welcome when credentials missing on startup', async () => {
+    const missing = path.join(tmpDir, 'missing.json');
+    const result = await onboarding.maybeBuildFirstRunContext({
+      credentialsPath: missing,
+      source: 'startup',
+    });
+    expect(typeof result).toBe('string');
+    expect(result).toContain('Welcome to TotalReclaw');
+  });
+
+  it('returns undefined when credentials are valid', async () => {
+    const validPath = path.join(tmpDir, 'valid-hook.json');
+    const mnemonic = 'abandon ability able about above absent absorb abstract absurd abuse access accident';
+    fs.writeFileSync(validPath, JSON.stringify({ mnemonic }), 'utf-8');
+    const result = await onboarding.maybeBuildFirstRunContext({
+      credentialsPath: validPath,
+      source: 'startup',
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('emits welcome at most once per process (session sentinel)', async () => {
+    const missing = path.join(tmpDir, 'missing-sentinel.json');
+    const first = await onboarding.maybeBuildFirstRunContext({
+      credentialsPath: missing,
+      source: 'startup',
+    });
+    expect(typeof first).toBe('string');
+
+    const second = await onboarding.maybeBuildFirstRunContext({
+      credentialsPath: missing,
+      source: 'startup',
+    });
+    expect(second).toBeUndefined();
+  });
+
+  it('skips compaction events (never re-inject on mid-session compact)', async () => {
+    const missing = path.join(tmpDir, 'missing-compact.json');
+    const result = await onboarding.maybeBuildFirstRunContext({
+      credentialsPath: missing,
+      source: 'compact',
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('emits on resume if credentials still missing (first-contact on new resume)', async () => {
+    // Resume is treated as a startup-like event for first-run purposes —
+    // if credentials never arrived, the user needs to see the welcome.
+    const missing = path.join(tmpDir, 'missing-resume.json');
+    const result = await onboarding.maybeBuildFirstRunContext({
+      credentialsPath: missing,
+      source: 'resume',
+    });
+    expect(typeof result).toBe('string');
+  });
+});
+
+describe('resolveCredentialsPath', () => {
+  let onboarding;
+  const originalEnv = { ...process.env };
+
+  beforeAll(() => {
+    onboarding = require(path.join(__dirname, '..', 'dist', 'onboarding', 'first-run.js'));
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('honours TOTALRECLAW_CREDENTIALS_PATH override', () => {
+    process.env.TOTALRECLAW_CREDENTIALS_PATH = '/custom/path/creds.json';
+    expect(onboarding.resolveCredentialsPath()).toBe('/custom/path/creds.json');
+  });
+
+  it('falls back to WORKSPACE_DIR/.totalreclaw/credentials.json', () => {
+    delete process.env.TOTALRECLAW_CREDENTIALS_PATH;
+    process.env.WORKSPACE_DIR = '/workspace';
+    expect(onboarding.resolveCredentialsPath()).toBe('/workspace/.totalreclaw/credentials.json');
+  });
+
+  it('falls back to HOME/.totalreclaw/credentials.json when no workspace', () => {
+    delete process.env.TOTALRECLAW_CREDENTIALS_PATH;
+    delete process.env.WORKSPACE_DIR;
+    process.env.HOME = '/home/someone';
+    expect(onboarding.resolveCredentialsPath()).toBe('/home/someone/.totalreclaw/credentials.json');
+  });
+});
+
+describe('Terminology parity — no legacy phrase leaks in user-facing strings', () => {
+  it('src/onboarding/first-run.ts has no legacy terms in string literals', () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, '..', 'src', 'onboarding', 'first-run.ts'),
+      'utf-8',
+    );
+    // Extract only the quoted strings (rough but effective for this scale).
+    // We DO allow "mnemonic" inside JSON examples and field-name mentions —
+    // the credentials file still uses `mnemonic` as its field name, and
+    // the welcome message literally references that field by name.
+    const stringLiterals = src.match(/['"`]([^'"`]*)['"`]/g) || [];
+    const joined = stringLiterals.join(' ');
+
+    // Forbidden legacy terms — checked as whole words, case-insensitive.
+    expect(joined).not.toMatch(/\bseed phrase\b/i);
+    expect(joined).not.toMatch(/\brecovery code\b/i);
+    expect(joined).not.toMatch(/\brecovery key\b/i);
+  });
+
+  it('mcp/nanoclaw-agent-runner.ts first-run welcome uses recovery phrase terminology', () => {
+    const runner = fs.readFileSync(
+      path.join(__dirname, '..', 'mcp', 'nanoclaw-agent-runner.ts'),
+      'utf-8',
+    );
+    // The inlined welcome block
+    const welcomeBlock = runner.substring(
+      runner.indexOf('FIRST_RUN_WELCOME'),
+      runner.indexOf('let firstRunWelcomeEmitted'),
+    );
+    expect(welcomeBlock).toContain('recovery phrase');
+    expect(welcomeBlock).not.toMatch(/\bseed phrase\b/i);
+    expect(welcomeBlock).not.toMatch(/\brecovery code\b/i);
+    expect(welcomeBlock).not.toMatch(/\brecovery key\b/i);
+  });
+
+  it('SKILL.md uses recovery-phrase terminology', () => {
+    const skillMd = fs.readFileSync(path.join(__dirname, '..', 'SKILL.md'), 'utf-8');
+    expect(skillMd).not.toMatch(/\bseed phrase\b/i);
+    expect(skillMd).not.toMatch(/\brecovery code\b/i);
+    expect(skillMd).not.toMatch(/\brecovery key\b/i);
+  });
+
+  it('CHANGELOG.md uses recovery-phrase terminology in shipped copy', () => {
+    const changelog = fs.readFileSync(path.join(__dirname, '..', 'CHANGELOG.md'), 'utf-8');
+    expect(changelog).not.toMatch(/\bseed phrase\b/i);
+    expect(changelog).not.toMatch(/\brecovery code\b/i);
+    expect(changelog).not.toMatch(/\brecovery key\b/i);
+  });
+
+  it('README.md uses recovery-phrase terminology', () => {
+    const readme = fs.readFileSync(path.join(__dirname, '..', 'README.md'), 'utf-8');
+    expect(readme).not.toMatch(/\bseed phrase\b/i);
+    expect(readme).not.toMatch(/\brecovery code\b/i);
+    expect(readme).not.toMatch(/\brecovery key\b/i);
+  });
+});
+
+describe('Runner integration — SessionStart hook is wired', () => {
+  let runner;
+
+  beforeAll(() => {
+    runner = fs.readFileSync(
+      path.join(__dirname, '..', 'mcp', 'nanoclaw-agent-runner.ts'),
+      'utf-8',
+    );
+  });
+
+  it('imports SessionStartHookInput from the SDK', () => {
+    expect(runner).toMatch(/SessionStartHookInput/);
+  });
+
+  it('registers a SessionStart hook in the query() hooks config', () => {
+    expect(runner).toMatch(/SessionStart:\s*\[\s*\{/);
+  });
+
+  it('invokes createFirstRunHook with the credentials path', () => {
+    expect(runner).toMatch(/createFirstRunHook\(/);
+  });
+
+  it('emits hookEventName: SessionStart in the hook output', () => {
+    expect(runner).toMatch(/hookEventName:\s*['"]SessionStart['"]/);
+  });
+
+  it('gates welcome emission on source === "startup"', () => {
+    expect(runner).toMatch(/source\s*!==\s*['"]startup['"]/);
+  });
+});


### PR DESCRIPTION
## Summary

NanoClaw skill **3.1.1-rc.1** — first-run onboarding UX parity with OpenClaw plugin 3.3.0 and Hermes 2.3.1. When the credentials file is missing / empty / invalid on session startup, NanoClaw now surfaces a canonical welcome message + branch question via the `@anthropic-ai/claude-agent-sdk` `SessionStart` hook.

Related parallel PRs (cross-client 3.3.0 / 2.3.1 / 3.1.1 rollout):
- plugin 3.3.0-rc.2 (OpenClaw first-run via `prependContext`) — in flight
- Hermes 2.3.1 (Python CLI first-run via stdout) — in flight
- this PR: NanoClaw 3.1.1-rc.1 (first-run via SDK `SessionStart.additionalContext`)

All three share the same canonical copy constants (verbatim): `WELCOME_MESSAGE`, `BRANCH_QUESTION`.

## Research findings — NanoClaw hook API

NanoClaw skills use `@anthropic-ai/claude-agent-sdk` directly via `query()` in `skill-nanoclaw/mcp/nanoclaw-agent-runner.ts`. The SDK exposes a rich hook taxonomy:

```
PreToolUse | PostToolUse | UserPromptSubmit | SessionStart | SessionEnd |
Stop | PreCompact | PostCompact | Setup | TaskCompleted | ...
```

The earliest lifecycle hook is **`SessionStart`**, fired with `source: 'startup' | 'resume' | 'clear' | 'compact'`. Its `SessionStartHookSpecificOutput` carries `additionalContext?: string` — the **direct analog** of OpenClaw plugin's `prependContext`.

No fallback / workaround was needed — SDK natively supports context injection from hooks. The `UserPromptSubmit` hook also supports `additionalContext` (per-turn), but `SessionStart` is the correct surface for first-run onboarding since it fires once at session init and carries the `source` discriminator we need to skip mid-session compactions.

## Changes

- **`src/onboarding/first-run.ts`** — library-shaped onboarding module:
  - `detectFirstRun(credentialsPath)` — missing / empty / unparseable / no-mnemonic / wrong-wordcount → `true`. Deep BIP-39 checksum validation is left to `@totalreclaw/core` at key-derivation time.
  - `buildWelcomeMessage()` — renders canonical welcome + branch question + NanoClaw-specific setup instructions + storage guidance.
  - `maybeBuildFirstRunContext({ credentialsPath, source })` — full check-and-inject with process-scoped sentinel and `compact`-source filter.
  - Canonical copy constants: `WELCOME_MESSAGE`, `BRANCH_QUESTION`, `NANOCLAW_INSTRUCTIONS`, `STORAGE_GUIDANCE`.
  - `resolveCredentialsPath()` — precedence: `$TOTALRECLAW_CREDENTIALS_PATH` → `$WORKSPACE_DIR/.totalreclaw/credentials.json` → `$HOME/.totalreclaw/credentials.json`.
- **`src/onboarding/index.ts`** — barrel.
- **`src/index.ts`** — re-exports onboarding.
- **`mcp/nanoclaw-agent-runner.ts`** — inline first-run detection + `SessionStart` hook registration. The runner is a self-contained overlay copied by the NanoClaw skill loader into `container/agent-runner/src/index.ts`; it cannot `require` the skill package's `dist/` at runtime, so the logic is intentionally duplicated. String-parity tests enforce that the two stay aligned.
- **`SKILL.md`** — terminology sweep: `BIP-39 mnemonic` → `BIP-39 recovery phrase` in user-facing setup copy.
- **`package.json`** — `3.1.0` → `3.1.1-rc.1`.
- **`CHANGELOG.md`** — full entry with findings, changes, constraints, and caveats.
- **`tests/first-run.test.js`** — 34 new tests.

## Test coverage

New tests in `tests/first-run.test.js` (**34 tests**, all green):

- **Module exports** (2) — canonical copy constants present + cross-client contract strings.
- **detectFirstRun** (10) — missing / empty / whitespace / invalid-JSON / no-mnemonic / empty-mnemonic / wrong-wordcount / valid-12-word / valid-24-word / non-string-garbage.
- **buildWelcomeMessage** (4) — all four sections present + recovery-phrase terminology exclusive + cross-client portability mentions + no-wizard path documented.
- **maybeBuildFirstRunContext** (5) — startup+missing → welcome; startup+valid → undefined; session sentinel emits at most once; `compact` source skipped; `resume` + missing → welcome.
- **resolveCredentialsPath** (3) — env override / workspace fallback / home fallback.
- **Terminology parity** (5) — no `seed phrase` / `recovery code` / `recovery key` leaks in `src/onboarding/first-run.ts` string literals, `mcp/nanoclaw-agent-runner.ts` welcome block, `SKILL.md`, `CHANGELOG.md`, `README.md`.
- **Runner integration** (5) — SDK import wired / SessionStart hook registered / createFirstRunHook invoked / hookEventName emitted / source-filter guard.

**Regression check**: 
- Pre-existing failing suites (`hooks.test.js`, `v1-taxonomy.test.js`) both fail at module-load due to the local `@totalreclaw/core` WASM pkg being at v1.3.0 (missing `getExtractionSystemPrompt` / `getCompactionSystemPrompt` from the 2.2.0 prompt-hoist that merged in #60). CI rebuilds the WASM so these tests pass there; locally, this is environmental. **Zero new failures** — same 2 suites failing on `main` and this branch, new `first-run.test.js` suite adds clean.
- `mcp-tool-discovery.test.js` continues to pass (no regression to MCP server spawn / tool allowlist).

## Known caveats

- **No interactive wizard.** Per user directive, NanoClaw lacks the interactive CLI onboarding present in OpenClaw (`openclaw totalreclaw onboard`) and Hermes (`hermes setup`) because the agent runs in a container without TTY affordance. The welcome message directs users to one of:
  1. Generate a recovery phrase with an external BIP-39 tool, hand-populate `~/.totalreclaw/credentials.json` (documented JSON shape).
  2. Use the OpenClaw or Hermes CLI on a local machine to mint a phrase, then share the credentials file with the NanoClaw workspace.
  3. Re-use a phrase from another TotalReclaw client — cross-client portability is a v1 contract guarantee.
- **Session-scoped sentinel is in-memory.** The welcome emits once per Node process. If the container restarts with credentials populated, detection correctly returns false on next boot. If credentials remain missing across a restart, the welcome re-emits on the new process — which is the right behavior (new process, new first-contact).

## Constraints respected

- No changes to `skill/plugin/`, `python/`, `mcp/`, or `rust/` — separate worktrees per task directive.
- No regression to 3.1.0 v1 taxonomy behavior — extraction + recall + MCP-discovery paths untouched.
- `@totalreclaw/core` floor stays at `^2.2.0`.
- MCP peer-dep stays at `^3.0.0`.
- No destructive git operations.

## Test plan

- [ ] CI green across lint / build / jest.
- [ ] RC publish via `publish-*.yml` with `release-type: rc` + `rc-number: 1`.
- [ ] Per project CLAUDE.md: full real-user QA on staging against the RC tarball before promoting to stable — NanoClaw integration scenario + first-run flow walkthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)