### PR TITLE
fix(plugin): 3.3.0-rc.4 correct pair-route auth literal + mkdir before lock

### DIFF
--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,115 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0-rc.4] — 2026-04-20
+
+Fourth release candidate for 3.3.0. Two independent ship-stopper fixes for
+rc.3's QR-pairing flow, both surfaced by the auto-QA run against rc.3
+artifacts (report: `docs/notes/QA-plugin-3.3.0-rc.3-20260420-1440.md` in
+`totalreclaw-internal`, thread at `totalreclaw-internal#21`). No protocol /
+on-chain changes vs 3.3.0. Bundled into a single RC because shipping them
+separately would require two more QA loops for what are, individually,
+one-line fixes.
+
+### Fixed
+
+- **`skill/plugin/index.ts` — pair HTTP routes must use `auth: 'plugin'`, not
+  `'gateway'`** (lines 2750–2753, now 2760–2763 after added comment). rc.3
+  added `auth: 'gateway'` to the 4 `api.registerHttpRoute` calls, which the
+  SDK loader accepted as a legal value but whose runtime semantics are
+  "requires gateway bearer token" (see
+  `matchedPluginRoutesRequireGatewayAuth` at
+  `gateway-cli-CWpalJNJ.js:23186`). For the 4 pair routes — reached from a
+  phone/laptop browser with no bearer token — that means `/pair/*` is 401'd
+  at the plugin-auth stage before the handler ever runs. The second valid
+  literal, `auth: 'plugin'` (verified as the only other accepted value at
+  `loader-BkOjign1.js:662`), lets the plugin's handler run directly and
+  authenticate itself via the in-session sid + 6-digit secondaryCode +
+  single-use consumption + ECDH AEAD payload, which is the correct model
+  for QR-pair. QA observed `httpRouteCount: 0` in rc.3 via `plugins inspect`
+  and confirmed all 4 `/plugin/totalreclaw/pair/*` paths returned 404 / SPA
+  fallthrough. rc.4 switches all 4 to `auth: 'plugin'`.
+
+  **Before (rc.3):**
+  ```ts
+  api.registerHttpRoute!({ path: bundle.finishPath,  handler: bundle.handlers.finish,  auth: 'gateway' });
+  api.registerHttpRoute!({ path: bundle.startPath,   handler: bundle.handlers.start,   auth: 'gateway' });
+  api.registerHttpRoute!({ path: bundle.respondPath, handler: bundle.handlers.respond, auth: 'gateway' });
+  api.registerHttpRoute!({ path: bundle.statusPath,  handler: bundle.handlers.status,  auth: 'gateway' });
+  ```
+
+  **After (rc.4):**
+  ```ts
+  api.registerHttpRoute!({ path: bundle.finishPath,  handler: bundle.handlers.finish,  auth: 'plugin' });
+  api.registerHttpRoute!({ path: bundle.startPath,   handler: bundle.handlers.start,   auth: 'plugin' });
+  api.registerHttpRoute!({ path: bundle.respondPath, handler: bundle.handlers.respond, auth: 'plugin' });
+  api.registerHttpRoute!({ path: bundle.statusPath,  handler: bundle.handlers.status,  auth: 'plugin' });
+  ```
+
+- **`skill/plugin/pair-session-store.ts::acquireSessionsFileLock` — mkdir
+  parent before `openSync(wx)`**. On a fresh install with no
+  `~/.totalreclaw/` directory, the lock's `openSync(path, 'wx')` returned
+  `ENOENT (No such file or directory)` and the retry loop misinterpreted
+  that as "lock already held", spinning at 50 ms intervals for the full
+  10 s `LOCK_WAIT_MS` before throwing `could not acquire lock`. The CLI
+  surfaced this as a hung `openclaw totalreclaw pair generate` with no QR,
+  URL, or secondary code ever rendered. `writePairSessionsFileSync`
+  already had a mkdir, but it was never reached because the lock never
+  acquired. rc.4 extracts a shared `ensureSessionsFileDir(sessionsPath)`
+  helper (mkdir `-p` with mode 0700) and calls it at the TOP of both
+  `acquireSessionsFileLock` AND `writePairSessionsFileSync` so the two
+  code paths can't drift. QA strace evidence in
+  `totalreclaw-internal#21`.
+
+  **Before (rc.3):**
+  ```ts
+  async function acquireSessionsFileLock(sessionsPath) {
+    const lockPath = `${sessionsPath}.lock`;
+    // ...
+    while (true) {
+      try {
+        const fd = fs.openSync(lockPath, 'wx');  // ENOENT here on fresh install
+        // ...
+  ```
+
+  **After (rc.4):**
+  ```ts
+  function ensureSessionsFileDir(sessionsPath) {
+    const dir = path.dirname(sessionsPath);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+
+  async function acquireSessionsFileLock(sessionsPath) {
+    ensureSessionsFileDir(sessionsPath);   // NEW — guarantees parent dir
+    const lockPath = `${sessionsPath}.lock`;
+    // ...
+  ```
+
+### Added
+
+- `skill/plugin/pair-session-store.test.ts` — two new blocks (§17, §18)
+  covering the fresh-install regression: `createPairSession` against a
+  path whose parent directory does NOT exist completes in < 2 s (was
+  10 s hang), materializes the missing dir with the correct mode, writes
+  the sessions file at 0600, and leaves no lock sentinel. Plus read-path
+  defensive tests: `getPairSession` / `listActivePairSessions` against
+  a missing dir return null / `[]` without throwing (previously would
+  have hit the same ENOENT hang).
+- `skill/plugin/pair-http-route-registration.test.ts` — assertions
+  updated from `'gateway'` to `'plugin'`, plus a per-call regression
+  guard asserting `auth !== 'gateway'` so rc.3's value cannot sneak back
+  in. Test count: 23 → 27 assertions.
+
+### Unchanged
+
+No changes to: scanner-sim rules (still 0 flags), tarball contents (same
+44 files; diff is content of 3 `.ts` files + `package.json` bump +
+`CHANGELOG.md`), UX copy, terminology (`recovery phrase` throughout),
+protobuf schema, Memory Taxonomy v1, on-chain contract surface, MCP
+wiring, client integration, Hermes / NanoClaw / core (plugin-only RC).
+
+---
+
 ## [3.3.0-rc.3] — 2026-04-20
 
 Third release candidate for 3.3.0. Sole change vs rc.2: adds the mandatory

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -2747,10 +2747,20 @@ const plugin = {
               return { state: 'active' };
             },
           });
-          api.registerHttpRoute!({ path: bundle.finishPath, handler: bundle.handlers.finish, auth: 'gateway' });
-          api.registerHttpRoute!({ path: bundle.startPath, handler: bundle.handlers.start, auth: 'gateway' });
-          api.registerHttpRoute!({ path: bundle.respondPath, handler: bundle.handlers.respond, auth: 'gateway' });
-          api.registerHttpRoute!({ path: bundle.statusPath, handler: bundle.handlers.status, auth: 'gateway' });
+          // auth: 'plugin' — the 4 pair routes are reached from the operator's
+          // phone/laptop browser, which has no gateway bearer token. The plugin
+          // authenticates each request itself via (a) the in-memory pair session
+          // (sid + secondaryCode + single-use consumption), (b) ECDH + AEAD for
+          // the encrypted mnemonic payload. See gateway-cli dist
+          // `matchedPluginRoutesRequireGatewayAuth` / `enforcePluginRouteGatewayAuth`
+          // — routes with `auth: 'gateway'` require a bearer token and 401 any
+          // browser caller, which is the wrong semantic for QR-pair. rc.3
+          // shipped `auth: 'gateway'` and the QA agent confirmed the routes
+          // were unreachable from a browser (QA-plugin-3.3.0-rc.3 report).
+          api.registerHttpRoute!({ path: bundle.finishPath, handler: bundle.handlers.finish, auth: 'plugin' });
+          api.registerHttpRoute!({ path: bundle.startPath, handler: bundle.handlers.start, auth: 'plugin' });
+          api.registerHttpRoute!({ path: bundle.respondPath, handler: bundle.handlers.respond, auth: 'plugin' });
+          api.registerHttpRoute!({ path: bundle.statusPath, handler: bundle.handlers.status, auth: 'plugin' });
           api.logger.info('TotalReclaw: registered 4 QR-pairing HTTP routes');
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.0-rc.3",
+  "version": "3.3.0-rc.4",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [

--- a/skill/plugin/pair-http-route-registration.test.ts
+++ b/skill/plugin/pair-http-route-registration.test.ts
@@ -1,26 +1,43 @@
 /**
- * Tests that the 4 QR-pairing HTTP routes are registered with the mandatory
- * `auth: 'gateway'` field required by OpenClaw 2026.4.2+.
+ * Tests that the 4 QR-pairing HTTP routes are registered with the correct
+ * `auth: 'plugin'` literal required by OpenClaw 2026.4.2+.
  *
- * Background: rc.2 shipped without the `auth` field — OpenClaw's loader
- * silently dropped all 4 registrations. The plugin's own
- * `logger.info('registered 4 QR-pairing HTTP routes')` still fired, making
- * the failure invisible. `GET /plugin/totalreclaw/pair/finish` fell through
- * to the SPA and `POST /pair/respond` returned 404. This test guards against
- * that class of regression.
+ * Background:
+ *   - rc.2 shipped without the `auth` field — OpenClaw's loader silently
+ *     dropped all 4 registrations (`httpRouteCount: 0`).
+ *   - rc.3 added `auth: 'gateway'`. The SDK accepted the literal but its
+ *     runtime semantics ("requires gateway bearer token") blocks every
+ *     browser caller (phones never have the token), so `/pair/*` was 401
+ *     at the plugin-auth stage before ever reaching the handler.
+ *   - rc.4 switches to `auth: 'plugin'`, the SDK's second valid literal.
+ *     Verified in the shipped gateway dist at
+ *     `loader-BkOjign1.js:662` (`if (params.auth !== "gateway" && params.auth !== "plugin")`)
+ *     and `gateway-cli-CWpalJNJ.js:23186`
+ *     (`matchedPluginRoutesRequireGatewayAuth` only trips on `=== "gateway"`).
+ *     Under `auth: 'plugin'`, the route handler runs without a prior bearer
+ *     check; our handlers authenticate via sid + 6-digit secondaryCode +
+ *     single-use session consumption + ECDH AEAD payload.
  *
- * References: totalreclaw-internal#21
+ * The plugin's own `logger.info('registered 4 QR-pairing HTTP routes')` still
+ * fires whether or not the routes actually land in the gateway's registry,
+ * so this unit test is NOT sufficient end-to-end proof — it's a guard that
+ * ensures the production call sites pass the exact literal the SDK accepts
+ * AND the literal whose runtime semantics match the browser-first flow.
+ *
+ * References: totalreclaw-internal#21,
+ * docs/notes/QA-plugin-3.3.0-rc.3-20260420-1440.md
  *
  * Run with: npx tsx pair-http-route-registration.test.ts
  *
  * Test matrix:
  *   1. registerHttpRoute is called exactly 4 times when api provides it.
  *   2. Each call receives an `auth` field.
- *   3. Each `auth` value equals `'gateway'`.
+ *   3. Each `auth` value equals `'plugin'` (NOT `'gateway'`).
  *   4. Each call includes a `path` containing the '/pair/' prefix.
  *   5. Each call includes a `handler` function.
  *   6. When api does NOT provide registerHttpRoute, no call is made + no throw.
  *   7. The 4 paths cover finish, start, respond, status (by substring).
+ *   8. `'gateway'` is NOT accidentally used (regression guard against rc.3).
  */
 
 import fs from 'node:fs';
@@ -93,10 +110,10 @@ function buildAndRegister(): { calls: RouteCall[] } {
     calls.push(params);
   };
 
-  registerHttpRoute({ path: bundle.finishPath, handler: bundle.handlers.finish, auth: 'gateway' });
-  registerHttpRoute({ path: bundle.startPath, handler: bundle.handlers.start, auth: 'gateway' });
-  registerHttpRoute({ path: bundle.respondPath, handler: bundle.handlers.respond, auth: 'gateway' });
-  registerHttpRoute({ path: bundle.statusPath, handler: bundle.handlers.status, auth: 'gateway' });
+  registerHttpRoute({ path: bundle.finishPath, handler: bundle.handlers.finish, auth: 'plugin' });
+  registerHttpRoute({ path: bundle.startPath, handler: bundle.handlers.start, auth: 'plugin' });
+  registerHttpRoute({ path: bundle.respondPath, handler: bundle.handlers.respond, auth: 'plugin' });
+  registerHttpRoute({ path: bundle.statusPath, handler: bundle.handlers.status, auth: 'plugin' });
 
   return { calls };
 }
@@ -111,10 +128,12 @@ function buildAndRegister(): { calls: RouteCall[] } {
   // 1. Exactly 4 calls
   assertEq(calls.length, 4, 'registerHttpRoute is called exactly 4 times');
 
-  // 2–3. auth field present and equals 'gateway' on every call
+  // 2–3. auth field present and equals 'plugin' on every call
   for (let i = 0; i < calls.length; i++) {
     assert('auth' in calls[i], `call[${i}] has auth field`);
-    assertEq(calls[i].auth, 'gateway', `call[${i}].auth === 'gateway'`);
+    assertEq(calls[i].auth, 'plugin', `call[${i}].auth === 'plugin'`);
+    // 8. Regression guard: ensure the rc.3 value is gone.
+    assert(calls[i].auth !== 'gateway', `call[${i}].auth is NOT 'gateway' (rc.3 regression guard)`);
   }
 
   // 4. Every path contains the '/pair/' segment

--- a/skill/plugin/pair-session-store.test.ts
+++ b/skill/plugin/pair-session-store.test.ts
@@ -511,6 +511,73 @@ async function main(): Promise<void> {
   }
 
   // ---------------------------------------------------------------------
+  // 17. Fresh-install regression — parent dir does NOT exist
+  //
+  // Regression for rc.3 (totalreclaw-internal#21, QA strace evidence):
+  // acquireSessionsFileLock ran openSync(lockPath, 'wx') BEFORE ensuring
+  // the parent dir existed. On a fresh user account with no
+  // `~/.totalreclaw/`, every attempt returned ENOENT; the retry loop
+  // spun for LOCK_WAIT_MS (10s) and threw "could not acquire lock".
+  // The CLI surfaced that as a hung `openclaw totalreclaw pair generate`
+  // with no QR / URL / code ever rendered.
+  //
+  // Expectation: createPairSession against a deep missing path succeeds
+  // QUICKLY (well under the 10s deadline), creates all missing
+  // intermediates, persists the session, and leaves no lock file.
+  // ---------------------------------------------------------------------
+  {
+    const root = mkTmp();
+    // Three levels deep to prove `{ recursive: true }` is honored.
+    const missingDeep = path.join(root, 'a', 'b', 'c');
+    const p = path.join(missingDeep, 'pair-sessions.json');
+
+    assert(!fs.existsSync(missingDeep), 'fresh-install: parent dir absent pre-create');
+
+    const started = Date.now();
+    const s = await createPairSession(p, {
+      mode: 'generate',
+      operatorContext: { channel: 'cli' },
+    });
+    const elapsed = Date.now() - started;
+
+    assert(elapsed < 2_000, `fresh-install: create completes promptly (got ${elapsed}ms, bug was 10_000ms+)`);
+    assert(fs.existsSync(missingDeep), 'fresh-install: deep parent dir created');
+    assert(fs.existsSync(p), 'fresh-install: sessions file created');
+    assert(!fs.existsSync(`${p}.lock`), 'fresh-install: lock released');
+    assert(typeof s.sid === 'string' && s.sid.length === 32, 'fresh-install: session has valid sid');
+
+    // Bonus: the on-disk file has 0o600 even though we created a missing
+    // parent dir — the mkdir mode doesn't leak into the file mode.
+    const mode = fs.statSync(p).mode & 0o777;
+    assert(mode === 0o600, `fresh-install: file mode still 0o600 (got ${mode.toString(8)})`);
+
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+
+  // ---------------------------------------------------------------------
+  // 18. Fresh-install regression — read paths also tolerate missing dir
+  //
+  // Defensive: `getPairSession` is called by the HTTP handler before the
+  // CLI has had a chance to create anything. If the operator pokes the
+  // browser page before `pair start` writes any state, we should return
+  // null cleanly rather than throwing. `listActivePairSessions` is used
+  // by the CLI's "is a pairing already in flight?" guard on a fresh box.
+  // ---------------------------------------------------------------------
+  {
+    const root = mkTmp();
+    const missingDeep = path.join(root, 'never', 'made');
+    const p = path.join(missingDeep, 'pair-sessions.json');
+
+    const found = await getPairSession(p, 'deadbeef'.repeat(4));
+    assert(found === null, 'fresh-install: getPairSession returns null, no throw');
+
+    const active = await listActivePairSessions(p);
+    assert(Array.isArray(active) && active.length === 0, 'fresh-install: listActive returns [], no throw');
+
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+
+  // ---------------------------------------------------------------------
   // Summary
   // ---------------------------------------------------------------------
   console.log(`# ${passed} passed, ${failed} failed`);

--- a/skill/plugin/pair-session-store.ts
+++ b/skill/plugin/pair-session-store.ts
@@ -239,6 +239,25 @@ export const LOCK_WAIT_MS = 10_000;
 export const LOCK_RETRY_MS = 50;
 
 /**
+ * Ensure the parent directory of `sessionsPath` exists, creating it
+ * (and any missing intermediates) with 0700 mode. This is called from
+ * BOTH the lock-acquisition and the write paths — if we only create
+ * the dir on write, a fresh install hits ENOENT on the lock's
+ * `openSync(path, 'wx')` and spins the retry loop until deadline (rc.3
+ * regression: QA-plugin-3.3.0-rc.3 report).
+ *
+ * Best-effort: a mkdir failure is re-thrown to the caller, which will
+ * surface it via the lock-acquisition error path (for lock) or the
+ * try/catch in `writePairSessionsFileSync` (for write). 0700 mode
+ * matches the privacy posture of the sessions file (0600) — if the
+ * user can read the directory they can already read the file.
+ */
+function ensureSessionsFileDir(sessionsPath: string): void {
+  const dir = path.dirname(sessionsPath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+}
+
+/**
  * Acquire an exclusive lock on the given sessions-file path by
  * atomically creating `<path>.lock` with `wx` mode. Retries up to
  * `LOCK_WAIT_MS`; breaks a lock older than `LOCK_STALE_MS`; returns
@@ -251,6 +270,16 @@ export const LOCK_RETRY_MS = 50;
  * and self-contained is safer than fighting the scanner.
  */
 async function acquireSessionsFileLock(sessionsPath: string): Promise<() => void> {
+  // Guarantee the parent directory exists BEFORE the first openSync(wx).
+  // Without this, a fresh install where `~/.totalreclaw/` doesn't yet
+  // exist gets ENOENT on every attempt, tight-loops until deadline, and
+  // throws "could not acquire lock" — which the CLI surfaces as a hung
+  // pair command with no QR / code / URL ever rendered (rc.3 blocker;
+  // QA-plugin-3.3.0-rc.3 strace evidence in totalreclaw-internal#21).
+  // `writePairSessionsFileSync` already creates the dir, but that path
+  // is never reached because the lock never acquires.
+  ensureSessionsFileDir(sessionsPath);
+
   const lockPath = `${sessionsPath}.lock`;
   const deadline = Date.now() + LOCK_WAIT_MS;
 
@@ -349,8 +378,9 @@ export function writePairSessionsFileSync(
   file: PairSessionFile,
 ): boolean {
   try {
-    const dir = path.dirname(sessionsPath);
-    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    // Same ensureSessionsFileDir used by acquireSessionsFileLock so the
+    // two paths can't drift.
+    ensureSessionsFileDir(sessionsPath);
     const tmp = `${sessionsPath}.tmp-${process.pid}-${Date.now()}`;
     fs.writeFileSync(tmp, JSON.stringify(file), { mode: 0o600 });
     fs.renameSync(tmp, sessionsPath);


### PR DESCRIPTION
## Summary

rc.3 auto-QA found two independent ship-stoppers for the QR-pairing flow. Either alone blocks every fresh-user restore path. Bundled into one RC because they're one-line fixes and shipping them separately would require two more QA loops for the same surface.

- **Fix 1** — The 4 `api.registerHttpRoute` calls shipped with `auth: 'gateway'` in rc.3. The SDK loader accepts it, but the runtime semantics (`matchedPluginRoutesRequireGatewayAuth`) are "requires gateway bearer token" — 401 for every browser-reachable call. rc.4 switches to `auth: 'plugin'`, the SDK's other accepted literal, so the plugin's handlers run and authenticate themselves via sid + 6-digit secondary code + single-use consumption + ECDH AEAD.
- **Fix 2** — `acquireSessionsFileLock` called `openSync(lockPath, 'wx')` without ensuring the parent dir existed. On a fresh install (no `~/.totalreclaw/`), ENOENT was misread as "lock held" and the retry loop spun for 10 s before throwing. rc.4 extracts a shared `ensureSessionsFileDir` helper called at the top of both the lock and write paths so they cannot drift.

## SDK inspection — why `auth: 'plugin'`

Two pieces of evidence from the shipped gateway dist on the VPS (`totalreclaw-cc-tests`, OpenClaw `2026.4.2`):

1. **SDK loader — validator.** `/usr/lib/node_modules/openclaw/dist/loader-BkOjign1.js:662`:
   ```js
   if (params.auth !== "gateway" && params.auth !== "plugin") {
     pushDiagnostic({ level: "error", ..., message: `http route registration missing or invalid auth: ${normalizedPath}` });
     return;
   }
   ```
   Exactly two legal literals. No `'none'`, `'public'`, `'browser'`, etc.
2. **Runtime enforcement.** `/usr/lib/node_modules/openclaw/dist/gateway-cli-CWpalJNJ.js`:
   - `matchedPluginRoutesRequireGatewayAuth` (line 23186) returns `true` when ANY matched route has `auth === "gateway"`. That trips `enforcePluginRouteGatewayAuth` → `authorizeGatewayBearerRequestOrReply` (line 23056): bearer-token check, 401 on miss.
   - `createGatewayPluginRequestHandler` (line 23211): when `requiresGatewayAuth && dispatchContext?.gatewayAuthSatisfied === false`, logs `plugin http route blocked without gateway auth` and returns `false` (SPA fallthrough).
   - `createPluginRouteRuntimeClient(requiresGatewayAuth)` (line 23196): `auth: 'plugin'` → `scopes = []` (no WRITE_SCOPE) — the handler runs inside a scope-limited runtime, as expected for plugin-managed auth.

The 4 pair routes are hit from a phone/laptop browser that has no gateway bearer token. `auth: 'plugin'` is the only runtime-correct choice; the plugin already authenticates via the ECDH + secondary-code + single-use-consumption chain.

QA evidence in `totalreclaw-internal#21` (comment thread on the PR-linking issue) and the report at `docs/notes/QA-plugin-3.3.0-rc.3-20260420-1440.md`: `openclaw plugins inspect totalreclaw --json` on rc.3 reported `httpRouteCount: 0`; curl against `/plugin/totalreclaw/pair/finish` with a real sid returned the OpenClaw Control SPA (fallthrough), not the plugin's pairing page.

## Fix 2 — ENOENT loop

QA agent's strace on a fresh VPS install (edited for brevity — hundreds of identical lines):
```
742495 openat(AT_FDCWD, "/root/.totalreclaw/pair-sessions.json.lock",
        O_WRONLY|O_CREAT|O_EXCL|O_TRUNC|O_CLOEXEC, 0666)
       = -1 ENOENT (No such file or directory)
   [repeats ~200 times until the shell kill-switch fires]
```

`acquireSessionsFileLock`'s catch block treats any openSync failure as "lock exists" and retries — ENOENT had no special case, so it tight-looped until `LOCK_WAIT_MS=10_000ms` then threw `could not acquire lock`. `writePairSessionsFileSync` already had a mkdir, but that path is never reached because the lock never acquires.

Rather than catch ENOENT specifically in the loop (still racy if the dir gets deleted under us), we mkdir BEFORE the first attempt, via a shared `ensureSessionsFileDir` helper:

```ts
function ensureSessionsFileDir(sessionsPath: string): void {
  const dir = path.dirname(sessionsPath);
  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
}
```

Called at the top of `acquireSessionsFileLock` AND `writePairSessionsFileSync` so they cannot drift. 0700 mode matches the privacy posture of the sessions file (0600) — already-user-readable dir.

## Before / after

### Fix 1 — `skill/plugin/index.ts` lines 2750–2763

**Before (rc.3):**
```ts
api.registerHttpRoute!({ path: bundle.finishPath,  handler: bundle.handlers.finish,  auth: 'gateway' });
api.registerHttpRoute!({ path: bundle.startPath,   handler: bundle.handlers.start,   auth: 'gateway' });
api.registerHttpRoute!({ path: bundle.respondPath, handler: bundle.handlers.respond, auth: 'gateway' });
api.registerHttpRoute!({ path: bundle.statusPath,  handler: bundle.handlers.status,  auth: 'gateway' });
```

**After (rc.4):**
```ts
// auth: 'plugin' — the 4 pair routes are reached from the operator's
// phone/laptop browser, which has no gateway bearer token. The plugin
// authenticates each request itself via (a) the in-memory pair session
// (sid + secondaryCode + single-use consumption), (b) ECDH + AEAD for
// the encrypted mnemonic payload. [...]
api.registerHttpRoute!({ path: bundle.finishPath,  handler: bundle.handlers.finish,  auth: 'plugin' });
api.registerHttpRoute!({ path: bundle.startPath,   handler: bundle.handlers.start,   auth: 'plugin' });
api.registerHttpRoute!({ path: bundle.respondPath, handler: bundle.handlers.respond, auth: 'plugin' });
api.registerHttpRoute!({ path: bundle.statusPath,  handler: bundle.handlers.status,  auth: 'plugin' });
```

### Fix 2 — `skill/plugin/pair-session-store.ts::acquireSessionsFileLock`

**Before (rc.3):**
```ts
async function acquireSessionsFileLock(sessionsPath: string): Promise<() => void> {
  const lockPath = `${sessionsPath}.lock`;
  const deadline = Date.now() + LOCK_WAIT_MS;
  while (true) {
    try {
      const fd = fs.openSync(lockPath, 'wx');   // ENOENT here on fresh install
      // ...
```

**After (rc.4):**
```ts
function ensureSessionsFileDir(sessionsPath: string): void {
  const dir = path.dirname(sessionsPath);
  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
}

async function acquireSessionsFileLock(sessionsPath: string): Promise<() => void> {
  // Guarantee the parent directory exists BEFORE the first openSync(wx).
  ensureSessionsFileDir(sessionsPath);

  const lockPath = `${sessionsPath}.lock`;
  const deadline = Date.now() + LOCK_WAIT_MS;
  while (true) {
    try {
      const fd = fs.openSync(lockPath, 'wx');
      // ...
```

`writePairSessionsFileSync` also calls `ensureSessionsFileDir` (replacing its previous inline mkdir) so the two paths share one source of truth.

## Test plan

- [x] `npx tsx pair-session-store.test.ts` — 85 passed, 0 failed (was 76). New §17 fresh-install regression test: `createPairSession` against a 3-deep missing parent completes in 1ms (was 10s hang), materializes all intermediates, writes file at 0600, leaves no lock. §18 read-path defense: `getPairSession` / `listActivePairSessions` against missing dir return null / `[]` without throwing.
- [x] `npx tsx pair-http-route-registration.test.ts` — 27 passed, 0 failed (was 23). Per-call regression guard asserts `auth !== 'gateway'` so rc.3's literal can't sneak back.
- [x] `node skill/scripts/check-scanner.mjs` — 72 files scanned, 0 flags (env-harvesting + potential-exfiltration + dynamic-code-execution).
- [x] `npm pack --dry-run` — 44 files (unchanged vs rc.3). Only diff: 2 production `.ts` files + 2 tests + CHANGELOG + version bump.
- [x] All other pair-* tests green (pair-http 55, pair-cli 20, pair-crypto 39, pair-e2e-leak-audit 26, pair-page 57).
- [x] Adjacent tests green: fs-helpers 38, first-run 29, onboarding-state 39, onboarding-cli 97, credentials-bootstrap 48, config 27.
- [x] `contradiction-sync.test.ts` and `lsh.test.ts` — pre-existing failures on `origin/main` unrelated to this RC (embedding-threshold assertion + ESM/CJS `require` mismatch with Node v25). Verified by running against rc.3 tree.

## Release plan

- Dispatch `publish-plugin.yml` with `release-type: rc`, `rc-number: 4` after merge.
- Auto-QA against `@totalreclaw/totalreclaw@3.3.0-rc.4` per the RC auto-QA policy.
- If GO on all scenarios, promote via `promote-rc.yml`. If NO-GO, yank and iterate.

Internal references: `totalreclaw-internal#21`, `docs/notes/QA-plugin-3.3.0-rc.3-20260420-1440.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)