### PR TITLE
fix(plugin): 3.3.0-rc.5 register pair HTTP routes synchronously (remove async IIFE)

### DIFF
--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,104 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0-rc.5] — 2026-04-20
+
+Fifth release candidate for 3.3.0. Single ship-stopper fix for rc.4's
+QR-pairing flow, root-caused by the auto-QA run against rc.4 artifacts
+(report: `docs/notes/QA-plugin-3.3.0-rc.4-20260420-1517.md` in
+`totalreclaw-internal`, thread at `totalreclaw-internal#21` comment
+4281568050). rc.2 (scanner), rc.3 (auth literal path), and rc.4 (auth
+`'plugin'` literal + `ensureSessionsFileDir` mkdir before lock) fixes are
+all preserved. No protocol / on-chain changes vs 3.3.0.
+
+### Fixed
+
+- **`skill/plugin/index.ts` — register pair HTTP routes synchronously
+  (remove async IIFE)**. rc.2–rc.4 wrapped the 4 `api.registerHttpRoute`
+  calls in a fire-and-forget `(async () => { ... })()` block whose three
+  `await import(...)` calls (`./pair-http.js`, `@scure/bip39`, and
+  `@scure/bip39/wordlists/english.js`) settled one microtask AFTER the
+  SDK loader had already called `register()` and frozen the plugin's
+  HTTP-route registry. The 4 post-activation pushes landed on the
+  dispatcher's "inactive" copy and never reached the live router;
+  `openclaw plugins inspect totalreclaw --json | jq .httpRouteCount`
+  returned `0` on rc.4 despite both the `auth: 'plugin'` literal (rc.4)
+  and the `ensureSessionsFileDir` mkdir (rc.4) being correct. rc.5:
+
+  1. `buildPairRoutes`, `validateMnemonic`, and `wordlist` are now
+     **static top-of-file imports** (alongside the existing
+     `onboarding-cli.ts` / `generate-mnemonic.ts` static imports of the
+     same modules — no new deps, no circular-dep risk).
+  2. `writeOnboardingState` is added to the existing static
+     `./fs-helpers.js` import (it was the only dynamic import inside
+     the `completePairing` callback).
+  3. The async IIFE is deleted. `buildPairRoutes(...)` and the 4
+     `api.registerHttpRoute({...})` calls are now in the synchronous
+     body of `register(api)`, inside the existing
+     `if (typeof api.registerHttpRoute === 'function')` guard. The
+     `else` branch and warning are unchanged. The post-registration
+     info log now reads `'registered 4 QR-pairing HTTP routes
+     synchronously'` for clearer debug output.
+  4. `completePairing` remains `async` (it does disk I/O) — that is
+     fine because `registerHttpRoute` accepts async handlers. Only the
+     REGISTRATION had to be synchronous; the handler itself can
+     defer-to-microtask freely at runtime.
+
+  Scanner: static imports don't trigger any rule that dynamic imports
+  don't already trigger (verified via `node skill/scripts/check-scanner.mjs`,
+  0 flags, 72 files scanned).
+
+  **Before (rc.4):**
+  ```ts
+  if (typeof api.registerHttpRoute === 'function') {
+    (async () => {
+      try {
+        const { buildPairRoutes } = await import('./pair-http.js');
+        const { validateMnemonic } = await import('@scure/bip39');
+        const { wordlist } = await import('@scure/bip39/wordlists/english.js');
+        const bundle = buildPairRoutes({ /* ... */ });
+        api.registerHttpRoute!({ path: bundle.finishPath, /*...*/, auth: 'plugin' });
+        api.registerHttpRoute!({ path: bundle.startPath,  /*...*/, auth: 'plugin' });
+        api.registerHttpRoute!({ path: bundle.respondPath,/*...*/, auth: 'plugin' });
+        api.registerHttpRoute!({ path: bundle.statusPath, /*...*/, auth: 'plugin' });
+        // ^^ these 4 pushes happen AFTER register() has returned + the
+        //    SDK loader has already activated the (empty) route registry.
+      } catch (err) { /* ... */ }
+    })();
+  }
+  ```
+
+  **After (rc.5):**
+  ```ts
+  // top of file
+  import { buildPairRoutes } from './pair-http.js';
+  import { validateMnemonic } from '@scure/bip39';
+  import { wordlist } from '@scure/bip39/wordlists/english.js';
+  // ... fs-helpers import now also includes writeOnboardingState
+
+  // inside register(api)
+  if (typeof api.registerHttpRoute === 'function') {
+    const bundle = buildPairRoutes({ /* ... */ });
+    api.registerHttpRoute!({ path: bundle.finishPath,  /*...*/, auth: 'plugin' });
+    api.registerHttpRoute!({ path: bundle.startPath,   /*...*/, auth: 'plugin' });
+    api.registerHttpRoute!({ path: bundle.respondPath, /*...*/, auth: 'plugin' });
+    api.registerHttpRoute!({ path: bundle.statusPath,  /*...*/, auth: 'plugin' });
+    // ^^ these 4 pushes happen synchronously BEFORE register() returns,
+    //    i.e. BEFORE the SDK loader activates the registry.
+    api.logger.info('TotalReclaw: registered 4 QR-pairing HTTP routes synchronously');
+  }
+  ```
+
+- **`skill/plugin/pair-http-route-registration.test.ts` — rc.5 regression
+  guard**. The existing SIMULATION suite (27 assertions covering the 4
+  routes' `auth` literal, path shape, handler type) is preserved. Added
+  a new SYNCHRONY suite (14 assertions) that invokes `plugin.register(mockApi)`
+  with a minimal mocked OpenClaw API and asserts `mockApi.registerHttpRoute`
+  has been called 4 times IMMEDIATELY after `register()` returns — no
+  `await`, no tick wait. This assertion would fail under the rc.4 async-IIFE
+  implementation and guards against any future refactor that re-introduces
+  an async boundary at the registration site. Total: 41/41 passing.
+
 ## [3.3.0-rc.4] — 2026-04-20
 
 Fourth release candidate for 3.3.0. Two independent ship-stopper fixes for

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -133,10 +133,14 @@ import {
   isRunningInDocker,
   deleteFileIfExists,
   resolveOnboardingState,
+  writeOnboardingState,
   type OnboardingState,
 } from './fs-helpers.js';
 import { decideToolGate, isGatedToolName } from './tool-gating.js';
 import { detectFirstRun, buildWelcomePrepend, type GatewayMode } from './first-run.js';
+import { buildPairRoutes } from './pair-http.js';
+import { validateMnemonic } from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english.js';
 import crypto from 'node:crypto';
 
 // ---------------------------------------------------------------------------
@@ -2711,62 +2715,64 @@ const plugin = {
     // encrypted mnemonic payload, and expose a status polled by the
     // CLI. See pair-http.ts and the 2026-04-20 design doc.
     if (typeof api.registerHttpRoute === 'function') {
-      (async () => {
-        try {
-          const { buildPairRoutes } = await import('./pair-http.js');
-          const { validateMnemonic } = await import('@scure/bip39');
-          const { wordlist } = await import('@scure/bip39/wordlists/english.js');
-          const bundle = buildPairRoutes({
-            sessionsPath: CONFIG.pairSessionsPath,
-            apiBase: '/plugin/totalreclaw/pair',
-            logger: api.logger,
-            validateMnemonic: (p) => validateMnemonic(p, wordlist),
-            completePairing: async ({ mnemonic }) => {
-              // Write credentials.json + flip state to 'active' via
-              // fs-helpers. This centralizes disk I/O off the
-              // pair-http surface (scanner isolation).
-              const creds = loadCredentialsJson(CREDENTIALS_PATH) ?? {};
-              const next = { ...creds, mnemonic };
-              if (!writeCredentialsJson(CREDENTIALS_PATH, next)) {
-                return { state: 'error', error: 'credentials_write_failed' };
-              }
-              // Hot-reload: update the runtime override so existing
-              // in-memory state picks up the new phrase without a
-              // process restart.
-              setRecoveryPhraseOverride(mnemonic);
-              // Flip onboarding state. writeOnboardingState is in
-              // fs-helpers; dynamic import to keep it out of any
-              // potential scanner collision surface in this file.
-              const { writeOnboardingState } = await import('./fs-helpers.js');
-              writeOnboardingState(CONFIG.onboardingStatePath, {
-                onboardingState: 'active',
-                createdBy: 'generate',
-                credentialsCreatedAt: new Date().toISOString(),
-                version: '3.3.0',
-              });
-              return { state: 'active' };
-            },
+      // rc.5 — the 4 `registerHttpRoute` calls MUST happen synchronously inside
+      // `register(api)` because the SDK loader freezes the plugin's HTTP-route
+      // registry as soon as `register()` returns. In rc.2–rc.4 this block was
+      // wrapped in a fire-and-forget async IIFE whose `await import(...)`
+      // settled one microtask AFTER the loader had already activated the
+      // (empty) route list — the post-activation pushes landed on the
+      // dispatcher's "inactive" copy and `openclaw plugins inspect
+      // totalreclaw --json | jq .httpRouteCount` returned 0. See
+      // `docs/notes/QA-plugin-3.3.0-rc.4-20260420-1517.md` (internal#21).
+      // Moving `buildPairRoutes`, `@scure/bip39`, and `fs-helpers`
+      // `writeOnboardingState` to static top-of-file imports keeps the
+      // registration site synchronous and makes the call order deterministic.
+      // `completePairing` remains async (it does disk I/O) — that is fine,
+      // since `registerHttpRoute` accepts async handlers; only the
+      // REGISTRATION must be synchronous.
+      const bundle = buildPairRoutes({
+        sessionsPath: CONFIG.pairSessionsPath,
+        apiBase: '/plugin/totalreclaw/pair',
+        logger: api.logger,
+        validateMnemonic: (p) => validateMnemonic(p, wordlist),
+        completePairing: async ({ mnemonic }) => {
+          // Write credentials.json + flip state to 'active' via
+          // fs-helpers. This centralizes disk I/O off the
+          // pair-http surface (scanner isolation).
+          const creds = loadCredentialsJson(CREDENTIALS_PATH) ?? {};
+          const next = { ...creds, mnemonic };
+          if (!writeCredentialsJson(CREDENTIALS_PATH, next)) {
+            return { state: 'error', error: 'credentials_write_failed' };
+          }
+          // Hot-reload: update the runtime override so existing
+          // in-memory state picks up the new phrase without a
+          // process restart.
+          setRecoveryPhraseOverride(mnemonic);
+          // Flip onboarding state.
+          writeOnboardingState(CONFIG.onboardingStatePath, {
+            onboardingState: 'active',
+            createdBy: 'generate',
+            credentialsCreatedAt: new Date().toISOString(),
+            version: '3.3.0',
           });
-          // auth: 'plugin' — the 4 pair routes are reached from the operator's
-          // phone/laptop browser, which has no gateway bearer token. The plugin
-          // authenticates each request itself via (a) the in-memory pair session
-          // (sid + secondaryCode + single-use consumption), (b) ECDH + AEAD for
-          // the encrypted mnemonic payload. See gateway-cli dist
-          // `matchedPluginRoutesRequireGatewayAuth` / `enforcePluginRouteGatewayAuth`
-          // — routes with `auth: 'gateway'` require a bearer token and 401 any
-          // browser caller, which is the wrong semantic for QR-pair. rc.3
-          // shipped `auth: 'gateway'` and the QA agent confirmed the routes
-          // were unreachable from a browser (QA-plugin-3.3.0-rc.3 report).
-          api.registerHttpRoute!({ path: bundle.finishPath, handler: bundle.handlers.finish, auth: 'plugin' });
-          api.registerHttpRoute!({ path: bundle.startPath, handler: bundle.handlers.start, auth: 'plugin' });
-          api.registerHttpRoute!({ path: bundle.respondPath, handler: bundle.handlers.respond, auth: 'plugin' });
-          api.registerHttpRoute!({ path: bundle.statusPath, handler: bundle.handlers.status, auth: 'plugin' });
-          api.logger.info('TotalReclaw: registered 4 QR-pairing HTTP routes');
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          api.logger.error(`TotalReclaw: failed to register pairing HTTP routes: ${msg}`);
-        }
-      })();
+          return { state: 'active' };
+        },
+      });
+      // auth: 'plugin' — the 4 pair routes are reached from the operator's
+      // phone/laptop browser, which has no gateway bearer token. The plugin
+      // authenticates each request itself via (a) the in-memory pair session
+      // (sid + secondaryCode + single-use consumption), (b) ECDH + AEAD for
+      // the encrypted mnemonic payload. See gateway-cli dist
+      // `matchedPluginRoutesRequireGatewayAuth` / `enforcePluginRouteGatewayAuth`
+      // — routes with `auth: 'gateway'` require a bearer token and 401 any
+      // browser caller, which is the wrong semantic for QR-pair. rc.3
+      // shipped `auth: 'gateway'` and the QA agent confirmed the routes
+      // were unreachable from a browser (QA-plugin-3.3.0-rc.3 report).
+      api.registerHttpRoute!({ path: bundle.finishPath, handler: bundle.handlers.finish, auth: 'plugin' });
+      api.registerHttpRoute!({ path: bundle.startPath, handler: bundle.handlers.start, auth: 'plugin' });
+      api.registerHttpRoute!({ path: bundle.respondPath, handler: bundle.handlers.respond, auth: 'plugin' });
+      api.registerHttpRoute!({ path: bundle.statusPath, handler: bundle.handlers.status, auth: 'plugin' });
+      api.logger.info('TotalReclaw: registered 4 QR-pairing HTTP routes synchronously');
     } else {
       api.logger.warn(
         'api.registerHttpRoute is unavailable on this OpenClaw version — /totalreclaw pair will not work. ' +

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.0-rc.4",
+  "version": "3.3.0-rc.5",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [

--- a/skill/plugin/pair-http-route-registration.test.ts
+++ b/skill/plugin/pair-http-route-registration.test.ts
@@ -1,43 +1,59 @@
 /**
- * Tests that the 4 QR-pairing HTTP routes are registered with the correct
- * `auth: 'plugin'` literal required by OpenClaw 2026.4.2+.
+ * Tests that the 4 QR-pairing HTTP routes are registered:
+ *   1. With the correct `auth: 'plugin'` literal (rc.4 fix, preserved in rc.5).
+ *   2. **Synchronously** during `plugin.register(api)` — never inside an async
+ *      IIFE or other microtask-deferred construct (rc.5 fix).
  *
- * Background:
+ * Background / history:
  *   - rc.2 shipped without the `auth` field — OpenClaw's loader silently
  *     dropped all 4 registrations (`httpRouteCount: 0`).
  *   - rc.3 added `auth: 'gateway'`. The SDK accepted the literal but its
  *     runtime semantics ("requires gateway bearer token") blocks every
  *     browser caller (phones never have the token), so `/pair/*` was 401
  *     at the plugin-auth stage before ever reaching the handler.
- *   - rc.4 switches to `auth: 'plugin'`, the SDK's second valid literal.
- *     Verified in the shipped gateway dist at
- *     `loader-BkOjign1.js:662` (`if (params.auth !== "gateway" && params.auth !== "plugin")`)
- *     and `gateway-cli-CWpalJNJ.js:23186`
- *     (`matchedPluginRoutesRequireGatewayAuth` only trips on `=== "gateway"`).
- *     Under `auth: 'plugin'`, the route handler runs without a prior bearer
- *     check; our handlers authenticate via sid + 6-digit secondaryCode +
- *     single-use session consumption + ECDH AEAD payload.
+ *   - rc.4 switched to `auth: 'plugin'`, the SDK's second valid literal
+ *     (verified in shipped gateway dist at `loader-BkOjign1.js:662`). The
+ *     `auth` literal was correct. But the 4 `registerHttpRoute` calls were
+ *     wrapped in a fire-and-forget async IIFE (`(async () => { ... })()`)
+ *     whose `await import('./pair-http.js')` settled one microtask AFTER
+ *     the SDK loader had already activated the plugin's (empty) HTTP-route
+ *     registry. The post-activation pushes landed on the dispatcher's
+ *     "inactive" copy; `openclaw plugins inspect totalreclaw --json
+ *     | jq .httpRouteCount` returned 0. QA report:
+ *     `docs/notes/QA-plugin-3.3.0-rc.4-20260420-1517.md` (internal#21).
+ *   - rc.5 (this test) converts the dynamic imports to static top-of-file
+ *     imports and moves `buildPairRoutes` + `registerHttpRoute` into the
+ *     synchronous body of `register(api)`. The `completePairing` callback
+ *     remains async (it does disk I/O) — that's fine, `registerHttpRoute`
+ *     accepts async handlers; only the REGISTRATION must be synchronous.
  *
- * The plugin's own `logger.info('registered 4 QR-pairing HTTP routes')` still
- * fires whether or not the routes actually land in the gateway's registry,
- * so this unit test is NOT sufficient end-to-end proof — it's a guard that
- * ensures the production call sites pass the exact literal the SDK accepts
- * AND the literal whose runtime semantics match the browser-first flow.
+ * The plugin's own `logger.info('registered ...')` still fires whether or
+ * not the routes actually land in the gateway's registry, so this unit
+ * test is NOT sufficient end-to-end proof — it's a guard that ensures:
+ *   a) Every production call site passes `auth: 'plugin'`.
+ *   b) The calls happen synchronously inside `register()` — no await, no
+ *      queueMicrotask, no IIFE shenanigans.
  *
- * References: totalreclaw-internal#21,
- * docs/notes/QA-plugin-3.3.0-rc.3-20260420-1440.md
+ * References: totalreclaw-internal#21, QA reports for rc.3 + rc.4.
  *
  * Run with: npx tsx pair-http-route-registration.test.ts
  *
  * Test matrix:
- *   1. registerHttpRoute is called exactly 4 times when api provides it.
- *   2. Each call receives an `auth` field.
- *   3. Each `auth` value equals `'plugin'` (NOT `'gateway'`).
- *   4. Each call includes a `path` containing the '/pair/' prefix.
- *   5. Each call includes a `handler` function.
- *   6. When api does NOT provide registerHttpRoute, no call is made + no throw.
- *   7. The 4 paths cover finish, start, respond, status (by substring).
- *   8. `'gateway'` is NOT accidentally used (regression guard against rc.3).
+ *   SIMULATION (mirror of the index.ts call pattern)
+ *     1. registerHttpRoute is called exactly 4 times when api provides it.
+ *     2. Each call receives an `auth` field.
+ *     3. Each `auth` value equals `'plugin'` (NOT `'gateway'`).
+ *     4. Each call includes a `path` containing the '/pair/' prefix.
+ *     5. Each call includes a `handler` function.
+ *     6. When api does NOT provide registerHttpRoute, no call is made + no throw.
+ *     7. The 4 paths cover finish, start, respond, status (by substring).
+ *     8. `'gateway'` is NOT accidentally used (regression guard against rc.3).
+ *
+ *   SYNCHRONY (rc.5 regression guard — calls happen inside register())
+ *     9. plugin.register(mockApi) synchronously calls registerHttpRoute 4 times
+ *        BEFORE control returns to the caller (no await, no tick wait needed).
+ *    10. All 4 auth literals are `'plugin'` when invoked through register().
+ *    11. All 4 paths contain '/pair/' when invoked through register().
  */
 
 import fs from 'node:fs';
@@ -45,6 +61,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { buildPairRoutes, type PairRouteBundle } from './pair-http.js';
+import plugin from './index.js';
 
 let passed = 0;
 let failed = 0;
@@ -70,7 +87,7 @@ function assertEq<T>(actual: T, expected: T, name: string): void {
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Helpers — SIMULATION path (mirrors the synchronous call sites in index.ts)
 // ---------------------------------------------------------------------------
 
 interface RouteCall {
@@ -104,7 +121,7 @@ function buildAndRegister(): { calls: RouteCall[] } {
     completePairing: async () => ({ state: 'active' }),
   });
 
-  // Simulate the 4 registration calls from index.ts (the fixed version).
+  // Simulate the 4 registration calls from index.ts (the rc.5 synchronous version).
   const calls: RouteCall[] = [];
   const registerHttpRoute = (params: RouteCall): void => {
     calls.push(params);
@@ -119,34 +136,80 @@ function buildAndRegister(): { calls: RouteCall[] } {
 }
 
 // ---------------------------------------------------------------------------
-// 1–5. Happy path — registerHttpRoute provided
+// Helpers — SYNCHRONY path (actually invokes plugin.register())
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal OpenClaw plugin-API mock sufficient to drive
+ * `plugin.register(mockApi)` to completion. Captures every
+ * `registerHttpRoute` call into `calls` so the test can assert on them
+ * immediately after `register()` returns (no await / tick wait).
+ */
+function buildMockApi(): {
+  api: unknown;
+  calls: RouteCall[];
+  registerHttpRouteCallCount: () => number;
+} {
+  const calls: RouteCall[] = [];
+  const noop = (): void => {};
+  const logger = {
+    info: noop,
+    warn: noop,
+    error: noop,
+    debug: noop,
+  };
+  const api = {
+    logger,
+    config: {
+      agents: { defaults: { model: { primary: undefined as string | undefined } } },
+      models: { providers: {} },
+    },
+    pluginConfig: {},
+    registerTool: noop,
+    registerService: noop,
+    on: noop,
+    registerCli: noop,
+    registerCommand: noop,
+    registerHttpRoute: (params: RouteCall): void => {
+      calls.push(params);
+    },
+  };
+  return {
+    api,
+    calls,
+    registerHttpRouteCallCount: () => calls.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1–5. SIMULATION happy path — registerHttpRoute provided
 // ---------------------------------------------------------------------------
 
 {
   const { calls } = buildAndRegister();
 
   // 1. Exactly 4 calls
-  assertEq(calls.length, 4, 'registerHttpRoute is called exactly 4 times');
+  assertEq(calls.length, 4, 'SIM: registerHttpRoute is called exactly 4 times');
 
   // 2–3. auth field present and equals 'plugin' on every call
   for (let i = 0; i < calls.length; i++) {
-    assert('auth' in calls[i], `call[${i}] has auth field`);
-    assertEq(calls[i].auth, 'plugin', `call[${i}].auth === 'plugin'`);
+    assert('auth' in calls[i], `SIM: call[${i}] has auth field`);
+    assertEq(calls[i].auth, 'plugin', `SIM: call[${i}].auth === 'plugin'`);
     // 8. Regression guard: ensure the rc.3 value is gone.
-    assert(calls[i].auth !== 'gateway', `call[${i}].auth is NOT 'gateway' (rc.3 regression guard)`);
+    assert(calls[i].auth !== 'gateway', `SIM: call[${i}].auth is NOT 'gateway' (rc.3 regression guard)`);
   }
 
   // 4. Every path contains the '/pair/' segment
   for (let i = 0; i < calls.length; i++) {
     assert(
       typeof calls[i].path === 'string' && calls[i].path.includes('/pair/'),
-      `call[${i}].path contains '/pair/'`,
+      `SIM: call[${i}].path contains '/pair/'`,
     );
   }
 
   // 5. Every handler is a function
   for (let i = 0; i < calls.length; i++) {
-    assert(typeof calls[i].handler === 'function', `call[${i}].handler is a function`);
+    assert(typeof calls[i].handler === 'function', `SIM: call[${i}].handler is a function`);
   }
 }
 
@@ -180,12 +243,12 @@ function buildAndRegister(): { calls: RouteCall[] } {
     threw = true;
   }
 
-  assert(!threw, 'no registerHttpRoute present → no throw');
-  assertEq(callCount, 0, 'no registerHttpRoute present → zero calls');
+  assert(!threw, 'SIM: no registerHttpRoute present → no throw');
+  assertEq(callCount, 0, 'SIM: no registerHttpRoute present → zero calls');
 }
 
 // ---------------------------------------------------------------------------
-// 7. Path segments cover all four endpoints (finish / start / respond / status)
+// 7. SIMULATION — path segments cover all four endpoints
 // ---------------------------------------------------------------------------
 
 {
@@ -195,7 +258,59 @@ function buildAndRegister(): { calls: RouteCall[] } {
   for (const segment of ['finish', 'start', 'respond', 'status']) {
     assert(
       paths.some((p) => p.includes(segment)),
-      `a registered path includes '${segment}'`,
+      `SIM: a registered path includes '${segment}'`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 9–11. SYNCHRONY — plugin.register(mockApi) really IS synchronous (rc.5)
+// ---------------------------------------------------------------------------
+//
+// This is the rc.5 regression guard. In rc.2–rc.4 the 4 registerHttpRoute
+// calls were inside `(async () => { ... })()` — the callCount at THIS
+// point would be 0 immediately after register() returned. Any future
+// refactor that re-introduces an async wrapper here will flip these
+// assertions red.
+
+{
+  const mock = buildMockApi();
+
+  // Snapshot the call count BEFORE register() — must be 0.
+  assertEq(mock.registerHttpRouteCallCount(), 0, 'SYNC: pre-register → 0 registerHttpRoute calls');
+
+  // Invoke register synchronously. No await.
+  plugin.register(mock.api as Parameters<typeof plugin.register>[0]);
+
+  // IMMEDIATELY after register() returns — no tick wait, no microtask flush.
+  // If the 4 calls are NOT visible now, we've regressed to rc.4 behaviour
+  // (async IIFE deferring the pushes past the SDK's registry-activation
+  // boundary).
+  assertEq(
+    mock.registerHttpRouteCallCount(),
+    4,
+    'SYNC: register(api) synchronously calls registerHttpRoute 4 times',
+  );
+
+  // All 4 auth literals must be 'plugin'.
+  for (let i = 0; i < mock.calls.length; i++) {
+    assertEq(mock.calls[i].auth, 'plugin', `SYNC: register-call[${i}].auth === 'plugin'`);
+  }
+
+  // All 4 paths must contain '/pair/'.
+  for (let i = 0; i < mock.calls.length; i++) {
+    assert(
+      typeof mock.calls[i].path === 'string' && mock.calls[i].path.includes('/pair/'),
+      `SYNC: register-call[${i}].path contains '/pair/'`,
+    );
+  }
+
+  // Path coverage: finish / start / respond / status all present.
+  const paths = mock.calls.map((c) => c.path);
+  for (const segment of ['finish', 'start', 'respond', 'status']) {
+    assert(
+      paths.some((p) => p.includes(segment)),
+      `SYNC: a registered path includes '${segment}'`,
     );
   }
 }


### PR DESCRIPTION
## Summary

Critical ship-stopper fix for rc.4's QR-pairing flow. rc.4 auto-QA
confirmed `openclaw plugins inspect totalreclaw --json | jq .httpRouteCount`
returns `0` despite both the `auth: 'plugin'` literal (rc.4) and the
`ensureSessionsFileDir` mkdir (rc.4) being correct.

QA report:
[`docs/notes/QA-plugin-3.3.0-rc.4-20260420-1517.md`](https://github.com/p-diogo/totalreclaw-internal/issues/21#issuecomment-4281568050)
(totalreclaw-internal#21, comment 4281568050).

## Root cause

The 4 `api.registerHttpRoute` calls at `skill/plugin/index.ts` lines
2713–2767 were wrapped in a **fire-and-forget async IIFE** whose three
`await import(...)` calls (`./pair-http.js`, `@scure/bip39`,
`@scure/bip39/wordlists/english.js`) settled one microtask AFTER the
SDK loader had already called `register(api)` and activated the
plugin's (empty) HTTP-route registry. The 4 post-activation pushes
landed on the dispatcher's "inactive" copy and never reached the live
router.

## Fix

1. Convert the 3 dynamic imports to **static top-of-file imports**:
   - `buildPairRoutes` from `./pair-http.js`
   - `validateMnemonic` from `@scure/bip39`
   - `wordlist` from `@scure/bip39/wordlists/english.js`
2. Add `writeOnboardingState` to the existing static `./fs-helpers.js`
   import (was the only dynamic import inside the `completePairing`
   callback).
3. Delete the async IIFE. `buildPairRoutes(...)` + the 4
   `api.registerHttpRoute({...})` calls are now in the synchronous body
   of `register(api)`, inside the existing
   `if (typeof api.registerHttpRoute === 'function')` guard. The `else`
   branch with its warning is unchanged.
4. `completePairing` remains `async` (it does disk I/O) — that is fine,
   `registerHttpRoute` accepts async handlers; only the REGISTRATION
   had to be synchronous.

### Why static imports are safe

- `@scure/bip39` is already a transitive dep (via `@totalreclaw/core`)
  and is already statically imported in `onboarding-cli.ts` +
  `generate-mnemonic.ts`. No new dep, no new dep surface.
- `./pair-http.ts`, `./fs-helpers.ts` are internal modules. No circular
  import risk (`pair-http.ts` doesn't import `index.ts`).
- No conditional load — these are always needed when the plugin is
  loaded.
- Scanner: static imports don't trigger any rule that dynamic imports
  don't already trigger. Verified: `node skill/scripts/check-scanner.mjs`
  → 0 flags, 72 files scanned.

### rc.2 / rc.3 / rc.4 fixes preserved

- rc.2 scanner fixes (no `fs.*` / `process.env` / `eval(` patterns).
- rc.3's switch from implicit-auth to explicit `auth: 'plugin'` literal.
- rc.4's `ensureSessionsFileDir` mkdir before `openSync(wx)` lock.

## Before / after of the IIFE block

**Before (rc.4):**
```ts
if (typeof api.registerHttpRoute === 'function') {
  (async () => {
    try {
      const { buildPairRoutes } = await import('./pair-http.js');
      const { validateMnemonic } = await import('@scure/bip39');
      const { wordlist } = await import('@scure/bip39/wordlists/english.js');
      const bundle = buildPairRoutes({ /* ... */ });
      api.registerHttpRoute!({ path: bundle.finishPath,  /*...*/, auth: 'plugin' });
      api.registerHttpRoute!({ path: bundle.startPath,   /*...*/, auth: 'plugin' });
      api.registerHttpRoute!({ path: bundle.respondPath, /*...*/, auth: 'plugin' });
      api.registerHttpRoute!({ path: bundle.statusPath,  /*...*/, auth: 'plugin' });
      // ^^ these 4 pushes happen AFTER register() has returned + the
      //    SDK loader has already activated the (empty) route registry.
    } catch (err) { /* ... */ }
  })();
}
```

**After (rc.5):**
```ts
// top of file
import { buildPairRoutes } from './pair-http.js';
import { validateMnemonic } from '@scure/bip39';
import { wordlist } from '@scure/bip39/wordlists/english.js';
// ... fs-helpers import now also includes writeOnboardingState

// inside register(api)
if (typeof api.registerHttpRoute === 'function') {
  const bundle = buildPairRoutes({ /* ... */ });
  api.registerHttpRoute!({ path: bundle.finishPath,  /*...*/, auth: 'plugin' });
  api.registerHttpRoute!({ path: bundle.startPath,   /*...*/, auth: 'plugin' });
  api.registerHttpRoute!({ path: bundle.respondPath, /*...*/, auth: 'plugin' });
  api.registerHttpRoute!({ path: bundle.statusPath,  /*...*/, auth: 'plugin' });
  // ^^ these 4 pushes happen synchronously BEFORE register() returns,
  //    i.e. BEFORE the SDK loader activates the registry.
  api.logger.info('TotalReclaw: registered 4 QR-pairing HTTP routes synchronously');
}
```

## Test plan

- [x] `skill/plugin/pair-http-route-registration.test.ts` — 41/41 passing.
  - SIMULATION suite (27 assertions): auth literal / path / handler
    shape on each of the 4 routes, `'gateway'` regression guard, absent
    `registerHttpRoute` → no-throw no-calls.
  - **SYNCHRONY suite (14 assertions, new in rc.5)**: invoke
    `plugin.register(mockApi)` with a minimal mocked OpenClaw API and
    assert `mockApi.registerHttpRoute` has been called 4 times
    IMMEDIATELY after `register()` returns — no `await`, no tick wait.
    This would fail under the rc.4 async-IIFE implementation and guards
    against any future refactor that re-introduces an async boundary at
    the registration site.
- [x] `node skill/scripts/check-scanner.mjs` → 0 flags, 72 files.
- [x] `npm pack --dry-run` → 44 files, identical file set to rc.4,
  version bumped to 3.3.0-rc.5.
- [x] Other pair tests (`pair-cli`, `pair-crypto`, `pair-e2e-leak-audit`,
  `pair-http`, `pair-page`, `pair-session-store`) all green.
- [x] Full plugin test suite: all green except `contradiction-sync.test.ts`
  test #21 and `lsh.test.ts` (both pre-existing failures, reproduced
  under rc.4 source — unrelated to this change).
- [ ] CI green
- [ ] Dispatch `publish-npm.yml` with `release-type: rc`, `rc-number: 5`
- [ ] Auto-QA against rc.5 artifacts

## Version / CHANGELOG

- `skill/plugin/package.json`: `3.3.0-rc.4` → `3.3.0-rc.5`
- `skill/plugin/CHANGELOG.md`: `[3.3.0-rc.5] — 2026-04-20` section added
  describing the IIFE removal + why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)