### PR TITLE
fix(plugin): 3.3.0-rc.6 drop kind:"memory" from manifest (OpenClaw startup registry bug)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
         with:
           node-version: '20'
 
-      # Plugin has no test script yet — just verify deps install cleanly.
       # We delete the lockfile because it was last regenerated against a local
       # `file:` dep for `@totalreclaw/core`; the current `package.json` uses
       # `^2.0.0` from npm and a fresh install resolves against the registry.
@@ -50,6 +49,13 @@ jobs:
       # ClawHub again. See docs/notes/INVESTIGATION-OPENCLAW-SCANNER-*.
       - name: Scanner-sim (env-harvesting false-positive check)
         run: node skill/scripts/check-scanner.mjs
+
+      # Manifest shape regression guard (3.3.0-rc.6): asserts that
+      # openclaw.plugin.json does NOT have "kind":"memory" (startup registry fix)
+      # AND that index.ts still declares kind:'memory' as const (memory-slot
+      # matching preserved). Uses npx tsx — available without a devDependency.
+      - name: Plugin manifest shape tests
+        run: cd skill/plugin && npm test
 
   mcp-tests:
     name: MCP Server Tests

--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,68 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0-rc.6] — 2026-04-20
+
+Sixth release candidate for 3.3.0. Single manifest-only fix for the
+root cause of every rc.2–rc.5 HTTP-route failure: the gateway's startup
+registry pin silently excluded our plugin because the manifest declared
+`kind: "memory"`. All prior fixes (scanner, auth literal, sync
+registration) are preserved. No code changes in `index.ts` or any other
+source file. No protocol / on-chain changes vs 3.3.0.
+
+See research report: `docs/notes/RESEARCH-openclaw-http-route-plumbing-20260420-1608.md`
+in `totalreclaw-internal`, and `totalreclaw-internal#21` comment 4282038854.
+
+### Fixed
+
+- **`skill/plugin/openclaw.plugin.json` — drop `"kind": "memory"`**.
+  `resolveGatewayStartupPluginIds` (channel-plugin-ids-*.js) excludes
+  plugins with `kind: "memory"` from the gateway's startup set unless
+  they also declare a configured channel. Because TotalReclaw has no
+  channel, `loadGatewayPlugins` (gateway-cli-*.js:19807–19813) took an
+  empty-list early return, passed an empty HTTP route registry to
+  `createGatewayRuntimeState`, and `pinActivePluginHttpRouteRegistry`
+  locked that empty registry. The plugin still loaded later via the
+  memory-backend path and pushed its 4 routes into a NEW registry, but
+  `setActivePluginRegistry`'s `syncTrackedSurface` early-returns when
+  `surface.pinned === true` (runtime-*.js:60–67). Net: every `/pair/*`
+  HTTP route returned 404/SPA-fallthrough at runtime despite
+  `httpRouteCount: 4` in `openclaw plugins inspect`.
+
+  Removing `"kind": "memory"` from the manifest restores startup
+  inclusion via the sidecar path (`hasRuntimeContractSurface` becomes
+  false), so the gateway pins a registry that already contains the 4
+  routes.
+
+  **The JS plugin definition (`index.ts` line ~2626) still returns
+  `kind: 'memory' as const`.** The OpenClaw loader re-merges the JS
+  definition into `record.kind` at line 2090, so memory-slot matching
+  via `config.slots.memory === "totalreclaw"` still works and all
+  memory-gated behavior is unchanged.
+
+  This is a workaround for an upstream OpenClaw bug — see "Upstream
+  OpenClaw bug" section in the linked PR for the bug report draft and
+  proposed proper fixes.
+
+### Added
+
+- **`skill/plugin/manifest-shape.test.ts`** — dual-assertion regression
+  guard documenting the intentional manifest/JS asymmetry:
+  1. `openclaw.plugin.json` does NOT contain `"kind": "memory"` (guard
+     against accidentally re-adding).
+  2. The exported plugin definition in `index.ts` DOES have
+     `kind: 'memory' as const` (guard against accidental removal from
+     JS, which would break memory-slot matching).
+
+### Unchanged
+
+No changes to: `index.ts`, `pair-http.ts`, or any other source file.
+Scanner-sim: 0 flags. Tarball contents: same files; diff is
+`openclaw.plugin.json` (1 line removed) + `package.json` version bump +
+`CHANGELOG.md`.
+
+---
+
 ## [3.3.0-rc.5] — 2026-04-20
 
 Fifth release candidate for 3.3.0. Single ship-stopper fix for rc.4's

--- a/skill/plugin/manifest-shape.test.ts
+++ b/skill/plugin/manifest-shape.test.ts
@@ -1,0 +1,184 @@
+/**
+ * manifest-shape.test.ts — Regression guard for the intentional manifest/JS
+ * asymmetry introduced in 3.3.0-rc.6.
+ *
+ * Background (OpenClaw startup registry bug):
+ *   `resolveGatewayStartupPluginIds` excludes plugins with `kind: "memory"`
+ *   from the gateway's startup set unless they also declare a configured
+ *   channel. TotalReclaw has no channel, so the gateway startup path took an
+ *   empty-list early return in `loadGatewayPlugins`, pinned an empty HTTP
+ *   route registry, and never exposed the 4 pair routes — even though the
+ *   plugin loaded later and registered them.
+ *
+ *   Fix: drop `"kind": "memory"` from `openclaw.plugin.json` (manifest) only.
+ *   The JS plugin definition in `index.ts` still returns `kind: 'memory' as const`
+ *   because the OpenClaw loader re-merges the JS definition into `record.kind`
+ *   at line 2090, preserving memory-slot matching via
+ *   `config.slots.memory === "totalreclaw"`.
+ *
+ * This test asserts BOTH sides of the asymmetry:
+ *   1. The manifest does NOT declare `kind: "memory"` (startup registry fix).
+ *   2. The JS plugin source DOES declare `kind: 'memory' as const` (memory-slot
+ *      behaviour preserved).
+ *
+ * Implementation note on assertion 2:
+ *   `index.ts` has a heavy init chain (onnxruntime-node, HuggingFace
+ *   transformers, viem, protobufjs, etc.) that requires native addons and
+ *   cannot be dynamically imported in a bare test runner without a full mock
+ *   harness. We therefore inspect the `index.ts` source as text — a node-based
+ *   regex check is precise, deterministic, and unambiguous for the single
+ *   declaration site. The test comment near that declaration (`// Plugin
+ *   definition`) makes the location stable. If the declaration is ever moved or
+ *   refactored, this test fails loudly, which is the desired behaviour.
+ *
+ * References:
+ *   - Research: docs/notes/RESEARCH-openclaw-http-route-plumbing-20260420-1608.md
+ *     (totalreclaw-internal)
+ *   - PR comment: totalreclaw-internal#21 comment 4282038854
+ *   - Upstream bug: see "Upstream OpenClaw bug" section in the rc.6 PR body.
+ *
+ * Run with: npx tsx manifest-shape.test.ts
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, name: string): void {
+  const n = passed + failed + 1;
+  if (condition) {
+    console.log(`ok ${n} - ${name}`);
+    passed++;
+  } else {
+    console.log(`not ok ${n} - ${name}`);
+    failed++;
+  }
+}
+
+function assertEq<T>(actual: T, expected: T, name: string): void {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (!ok) {
+    console.log(`  actual:   ${JSON.stringify(actual)}`);
+    console.log(`  expected: ${JSON.stringify(expected)}`);
+  }
+  assert(ok, name);
+}
+
+// ---------------------------------------------------------------------------
+// 1. Manifest assertions
+// ---------------------------------------------------------------------------
+
+const manifestPath = path.join(__dirname, 'openclaw.plugin.json');
+let manifest: Record<string, unknown>;
+
+{
+  let parseOk = true;
+  try {
+    const raw = fs.readFileSync(manifestPath, 'utf8');
+    manifest = JSON.parse(raw) as Record<string, unknown>;
+  } catch (err) {
+    parseOk = false;
+    manifest = {};
+    console.log(`  error: ${String(err)}`);
+  }
+
+  assert(parseOk, 'openclaw.plugin.json is valid JSON');
+}
+
+{
+  // 1a. The manifest must NOT have "kind": "memory".
+  // Presence of this field causes resolveGatewayStartupPluginIds to exclude
+  // the plugin from the startup set, pinning an empty HTTP route registry.
+  assert(
+    !('kind' in manifest),
+    'openclaw.plugin.json does NOT contain "kind" field (startup registry fix)',
+  );
+}
+
+{
+  // 1b. Absence of "kind" in manifest is intentional — document the expected
+  // shape to catch accidental re-addition.
+  const kindValue = manifest['kind'];
+  assert(
+    kindValue === undefined,
+    'openclaw.plugin.json "kind" is undefined (not "memory" or any other value)',
+  );
+}
+
+{
+  // 1c. The string "memory" must not appear as a JSON value for any field
+  // named "kind" — raw-string check as an extra guard.
+  const raw = fs.readFileSync(manifestPath, 'utf8');
+  const hasKindMemory = /"kind"\s*:\s*"memory"/.test(raw);
+  assert(
+    !hasKindMemory,
+    'openclaw.plugin.json source does NOT match /"kind"\\s*:\\s*"memory"/ (raw regex guard)',
+  );
+}
+
+{
+  // 1d. Manifest still has "id", "name", "description" — basic shape sanity.
+  assertEq(manifest['id'], 'totalreclaw', 'manifest id === "totalreclaw"');
+  assertEq(manifest['name'], 'TotalReclaw', 'manifest name === "TotalReclaw"');
+  assert(
+    typeof manifest['description'] === 'string' && (manifest['description'] as string).length > 0,
+    'manifest description is a non-empty string',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 2. JS plugin definition assertions (source inspection)
+// ---------------------------------------------------------------------------
+
+const indexPath = path.join(__dirname, 'index.ts');
+const indexSrc = fs.readFileSync(indexPath, 'utf8');
+
+{
+  // 2a. index.ts must declare `kind: 'memory' as const` in the plugin object.
+  // The OpenClaw loader re-merges this into record.kind (line 2090), so
+  // memory-slot matching (config.slots.memory === "totalreclaw") still works.
+  const hasKindMemory = /kind:\s*'memory'\s*as\s*const/.test(indexSrc);
+  assert(
+    hasKindMemory,
+    "index.ts plugin definition contains `kind: 'memory' as const` (memory-slot matching preserved)",
+  );
+}
+
+{
+  // 2b. Regression guard: the JS plugin object is `export default plugin` —
+  // confirm the export is present so we know the declaration we found above
+  // is the same object that OpenClaw's loader receives.
+  const hasExportDefault = /^export default plugin;/m.test(indexSrc);
+  assert(
+    hasExportDefault,
+    'index.ts has `export default plugin;` (loader receives the checked object)',
+  );
+}
+
+{
+  // 2c. The JS declaration must NOT use `'gateway'` or any other kind value.
+  // This guards against someone changing the kind in JS while fixing a future
+  // unrelated issue, which would break memory-slot matching silently.
+  const hasWrongKind = /kind:\s*'gateway'\s*as\s*const/.test(indexSrc);
+  assert(
+    !hasWrongKind,
+    "index.ts plugin definition does NOT use `kind: 'gateway' as const`",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log(`# fail: ${failed}`);
+console.log(`# ${passed}/${passed + failed} passed`);
+if (failed > 0) {
+  console.log('SOME TESTS FAILED');
+  process.exit(1);
+}
+console.log('ALL TESTS PASSED');

--- a/skill/plugin/openclaw.plugin.json
+++ b/skill/plugin/openclaw.plugin.json
@@ -1,7 +1,6 @@
 {
   "id": "totalreclaw",
   "name": "TotalReclaw",
-  "kind": "memory",
   "description": "End-to-end encrypted memory vault for AI agents",
   "configSchema": {
     "type": "object",

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.0-rc.5",
+  "version": "3.3.0-rc.6",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [
@@ -50,6 +50,7 @@
     "skill.json"
   ],
   "scripts": {
+    "test": "npx tsx manifest-shape.test.ts",
     "check-scanner": "node ../scripts/check-scanner.mjs",
     "prepublishOnly": "node ../scripts/check-scanner.mjs"
   },


### PR DESCRIPTION
## Summary

- **Root cause found**: `resolveGatewayStartupPluginIds` excludes plugins with `kind: "memory"` from the gateway's startup set unless they declare a configured channel. TotalReclaw has no channel → `loadGatewayPlugins` took an empty-list early return → empty HTTP route registry was pinned by `pinActivePluginHttpRouteRegistry` → all 4 pair routes returned 404 despite `httpRouteCount: 4` in `openclaw plugins inspect`. Every rc.2–rc.5 fix (auth field, auth literal, sync registration) addressed symptoms on top of this latent root cause.
- **Fix**: drop `"kind": "memory"` from `skill/plugin/openclaw.plugin.json`. One line removed, no other changes.
- **JS keeps `kind: 'memory' as const`**: the OpenClaw loader re-merges the JS plugin definition into `record.kind` at line 2090, so memory-slot matching via `config.slots.memory === "totalreclaw"` is unchanged and all memory-gated behavior is preserved.

Research report: `docs/notes/RESEARCH-openclaw-http-route-plumbing-20260420-1608.md` (totalreclaw-internal), thread at [totalreclaw-internal#21](https://github.com/p-diogo/totalreclaw-internal/issues/21) comment 4282038854.

## Changes

| File | Change |
|---|---|
| `skill/plugin/openclaw.plugin.json` | Remove `"kind": "memory"` line (1 line, the fix) |
| `skill/plugin/package.json` | Version bump 3.3.0-rc.5 → 3.3.0-rc.6; add `test` script |
| `skill/plugin/CHANGELOG.md` | Add `[3.3.0-rc.6]` entry |
| `skill/plugin/manifest-shape.test.ts` | New: dual-assertion regression guard |
| `.github/workflows/ci.yml` | Add plugin manifest shape test step |

## Manifest diff

```diff
-  "kind": "memory",
```

That is the entire source change. No other manifest edits, no code changes in `index.ts`, `pair-http.ts`, or any other source.

## Verification

```
$ node skill/scripts/check-scanner.mjs
scanner-sim: OK — 73 files scanned, 0 flags (env-harvesting + potential-exfiltration + dynamic-code-execution)

$ npm test  (in skill/plugin/)
ok 1 - openclaw.plugin.json is valid JSON
ok 2 - openclaw.plugin.json does NOT contain "kind" field (startup registry fix)
ok 3 - openclaw.plugin.json "kind" is undefined (not "memory" or any other value)
ok 4 - openclaw.plugin.json source does NOT match /"kind"\s*:\s*"memory"/ (raw regex guard)
ok 5 - manifest id === "totalreclaw"
ok 6 - manifest name === "TotalReclaw"
ok 7 - manifest description is a non-empty string
ok 8 - index.ts plugin definition contains `kind: 'memory' as const` (memory-slot matching preserved)
ok 9 - index.ts has `export default plugin;` (loader receives the checked object)
ok 10 - index.ts plugin definition does NOT use `kind: 'gateway' as const`
# fail: 0
# 10/10 passed
ALL TESTS PASSED

$ npm pack --dry-run  (in skill/plugin/)
npm notice total files: 44   ← same as rc.5; manifest-shape.test.ts excluded by "!**/*.test.ts"
npm notice version: 3.3.0-rc.6
```

## Upstream OpenClaw bug

### OpenClaw bug — memory-kind plugins without channels are dropped from startup HTTP route registry

Affected version: openclaw@2026.4.2

Summary:
`resolveGatewayStartupPluginIds` (channel-plugin-ids-*.js) excludes plugins with `kind: "memory"` from the gateway's startup plugin set unless they ALSO declare a configured channel. For memory plugins that register HTTP routes (via `api.registerHttpRoute`) but don't expose a channel, the gateway startup path takes an empty-list early return in `loadGatewayPlugins` (gateway-cli-*.js:19807-19813), passes an empty registry to `createGatewayRuntimeState`, and pins that empty registry via `pinActivePluginHttpRouteRegistry`. The plugin still gets loaded later via `startGatewayMemoryBackend → ensureMemoryRuntime → resolveRuntimePluginRegistry → loadOpenClawPlugins` (no kind filter), at which point it pushes its HTTP routes into a NEW registry. But `setActivePluginRegistry`'s `syncTrackedSurface` early-returns when `surface.pinned === true` (runtime-*.js:60-67), and `resolveActivePluginHttpRouteRegistry`'s fallback is the pinned empty registry. Net: HTTP route dispatch returns 404 / SPA fallthrough for all routes defined by these plugins.

Reproduces on VPS with TotalReclaw plugin 3.3.0-rc.5 (memory plugin, no channel, 4 registerHttpRoute calls). `openclaw plugins inspect totalreclaw --json | jq .httpRouteCount` reports `4` (plugin's own registry). `findMatchingPluginHttpRoutes` called from the HTTP dispatcher sees `[]` (the pinned startup registry). Verified via ad-hoc node probe.

Workaround for plugin authors: do NOT set `"kind": "memory"` in openclaw.plugin.json manifest. You can keep `kind: 'memory' as const` in the JS plugin definition — the loader re-merges from there (line 2090). This restores startup inclusion via the sidecar path (hasRuntimeContractSurface becomes false), and memory-slot matching still works via `config.slots.memory === "<plugin-id>"`.

Proper fix ideas:
  1. `resolveGatewayStartupPluginIds` should also include memory plugins that define `httpRoutes` or an equivalent HTTP surface, regardless of channel.
  2. `pinActivePluginHttpRouteRegistry` semantics should be "best registry so far" (re-pin on later registrations) rather than "first registry wins".
  3. Document the exclusion: if intentional, warn loudly when a memory plugin calls `registerHttpRoute` after pin.

Impact: any memory plugin shipping HTTP routes (browser onboarding, QR pairing, custom admin UI, webhooks) is broken until this is fixed or until the author drops `kind: "memory"` from the manifest.