### PR TITLE
ci(clawhub): add slug input for canary publishes

### DIFF
--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -47,6 +47,11 @@ on:
         required: false
         type: number
         default: 1
+      slug:
+        description: 'ClawHub slug (default: totalreclaw). Override for canary / preview / side-channel publishes.'
+        required: false
+        type: string
+        default: totalreclaw
 
 jobs:
   publish:
@@ -97,9 +102,13 @@ jobs:
 
           echo "Publishing to ClawHub: version=$VERSION tags=$TAGS"
 
+          SLUG="${{ github.event.inputs.slug }}"
+          SLUG="${SLUG:-totalreclaw}"
+          echo "Publishing to slug: $SLUG"
+
           clawhub login --token "$CLAWHUB_TOKEN" --no-browser
           clawhub publish ./skill/plugin \
-            --slug totalreclaw \
+            --slug "$SLUG" \
             --version "$VERSION" \
             --tags "$TAGS" \
             --changelog "$CHANGELOG"


### PR DESCRIPTION
Adds `slug` input to `publish-clawhub.yml` — defaults to `totalreclaw` (current behavior preserved). Lets us dispatch with canary / preview slugs without colliding the main listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)