### PR TITLE
docs: rewrite SKILL.md + hermes-setup.md + openclaw-setup.md for rc.2

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -1,227 +1,61 @@
-# Hermes Agent Setup Guide
+# Hermes Agent + TotalReclaw
 
-Set up TotalReclaw as the encrypted memory layer for your Hermes Agent. Your memories are encrypted on-device before they leave -- Hermes handles the conversations, TotalReclaw protects the data.
+TotalReclaw gives your Hermes agent encrypted, persistent memory. Install the plugin, run setup, chat.
 
 ## Prerequisites
 
-- **Hermes Agent v0.5.0+** (with plugin lifecycle hooks)
-- **Python 3.11+**
-- **C compiler** (gcc/g++) -- needed to build PyStemmer from source
-- ~344 MB disk space for the local embedding model (one-time download)
+- Hermes Agent v0.5.0+ (https://github.com/NousResearch/hermes-agent)
+- An LLM provider configured in Hermes (zai / openai / anthropic / gemini)
+- Python 3.11+
 
-> **Docker users:** On slim images (e.g., `python:3.12-slim`), install a C compiler first:
-> ```bash
-> apt-get update && apt-get install -y gcc g++
-> ```
-
-> **Ubuntu/Debian users:** System Python on Ubuntu 23.04+ and Debian 12+ is "externally managed." You will need the `--break-system-packages` flag on every `pip install` (or use a virtual environment). System packages like PyYAML and PyJWT may also conflict with pip-installed versions -- see the troubleshooting note in the install section below.
-
-## 1. Install TotalReclaw
+## 1. Install
 
 ```bash
-# Step 1: Install TotalReclaw and Hermes Agent
 pip install totalreclaw
-pip install "git+https://github.com/NousResearch/hermes-agent.git"
-
-# Step 2: Register the TotalReclaw plugin with Hermes
-mkdir -p ~/.hermes/plugins/totalreclaw
-cp -r $(python -c "import totalreclaw.hermes; print(totalreclaw.hermes.__path__[0])")/* ~/.hermes/plugins/totalreclaw/
 ```
 
-> **Current stable:** `totalreclaw==2.2.1` on PyPI. 2.2.0 added ERC-4337 `executeBatch` (up to 15 facts per UserOp) and 2.2.1 wired auto-extraction through the batched path, cutting typical extraction-to-on-chain latency from ~60s to ~8s. Older 2.0.x releases had several auto-flow regressions (`Event loop is closed` on `status` / `export`, missing session-id tracing); upgrade fixes them.
+Hermes auto-discovers the plugin via entry-point registration at next start. No manual copy, no config editing. Ubuntu/Debian/Docker: add `--break-system-packages` or use a venv if you hit `externally-managed-environment`.
 
-> **Ubuntu/Debian/Docker note:** Add `--break-system-packages` if you see "externally-managed-environment" errors:
-> ```bash
-> pip install --break-system-packages totalreclaw
-> pip install --break-system-packages "git+https://github.com/NousResearch/hermes-agent.git"
-> ```
+## 2. Set up your vault
 
-> **PyYAML / PyJWT conflicts:** On systems with OS-managed Python packages, pip may refuse to uninstall system-owned packages like PyYAML or PyJWT. If you see "Cannot uninstall PyYAML" or similar errors:
-> ```bash
-> # Force-install the conflicting packages first
-> pip install --break-system-packages --ignore-installed PyYAML PyJWT rich requests
-> # Then retry the hermes-agent install
-> pip install --break-system-packages "git+https://github.com/NousResearch/hermes-agent.git"
-> ```
-
-> **Why two steps?** Hermes Agent is not yet on PyPI (install from GitHub). Hermes discovers plugins via its `~/.hermes/plugins/` directory, so the copy step is required.
-
-## 2. Verify installation
-
-Start Hermes:
+**Recommended -- CLI wizard (runs outside the LLM path):**
 
 ```bash
-hermes
+hermes setup
 ```
 
-Check plugin status:
+Pick "generate" or "import". The phrase is written to `~/.totalreclaw/credentials.json` (mode `0600`). **The phrase is never printed to stdout, logged, or sent to any LLM.** Retrieve it later with `cat ~/.totalreclaw/credentials.json | jq -r .mnemonic`. Save it somewhere safe -- it is the ONLY way to recover your vault.
 
-```
-/plugins
-```
+**Via chat:** ask "Set up TotalReclaw for me" -- the agent points you at the CLI. Phrases are never generated or shown in chat.
 
-You should see:
+## 3. Restart Hermes
 
-```
-Plugins (1+):
-  ✓ totalreclaw v2.2.1 (8 tools, 4 hooks)
+```bash
+hermes gateway restart
 ```
 
-## 3. Start chatting
+Required for the plugin to register its tools and hooks.
 
-The first time you mention anything worth remembering, the agent will:
+## 4. Verify
 
-1. Detect that TotalReclaw is not configured yet
-2. Ask: "Do you have an existing recovery phrase, or should I generate a new one?"
-3. Run `totalreclaw_setup` — if you don't have a phrase, the tool generates one automatically
-4. Register with the relay, download the embedding model (~344 MB, one-time), and activate
-
-Your recovery phrase and credentials are saved to `~/.totalreclaw/credentials.json` (owner-only permissions). On subsequent restarts, the plugin loads them automatically.
-
-> **Save your recovery phrase somewhere safe.** It is the only key to your memories. There is no password reset, no recovery, no support ticket that can help. Write it down and store it securely.
-
-## 4. How it works
-
-### Automatic memory (zero effort)
-
-The plugin hooks into Hermes's lifecycle:
-
-| Hook | When | What happens |
-|------|------|-------------|
-| `on_session_start` | New session | Resets turn counter, checks billing |
-| `pre_llm_call` | First turn | Auto-recalls relevant memories, injects into context |
-| `post_llm_call` | Every 3 turns | Extracts facts from conversation, stores encrypted |
-| `on_session_end` | Session ends | Flushes any unprocessed messages |
-
-### Explicit tools (full control)
-
-| Tool | What it does |
-|------|-------------|
-| `totalreclaw_remember` | Store a specific memory |
-| `totalreclaw_recall` | Search your memory vault |
-| `totalreclaw_forget` | Delete a memory by ID |
-| `totalreclaw_export` | Export all memories as plaintext |
-| `totalreclaw_status` | Check billing and usage |
-| `totalreclaw_setup` | Configure credentials |
-| `totalreclaw_import_from` | Import memories from Gemini, ChatGPT, Claude, Mem0 |
-| `totalreclaw_import_batch` | Process one batch of a large import |
-
-### What gets extracted
-
-The plugin recognizes 7 memory types:
-
-- **fact** -- "Pedro's email is pedro@example.com"
-- **preference** -- "I prefer dark mode"
-- **decision** -- "I chose FastAPI because of async support"
-- **episodic** -- "We deployed v2.0 on March 15th"
-- **goal** -- "I want to launch by Q2"
-- **context** -- "The project uses PostgreSQL"
-- **summary** -- "Today we discussed the migration plan"
-
-## 5. Configuration
-
-### Environment variables (all optional)
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `TOTALRECLAW_RECOVERY_PHRASE` | -- | Import an existing recovery phrase. If not set, the agent generates one on first use. |
-| `TOTALRECLAW_SERVER_URL` | `https://api.totalreclaw.xyz` | Override for self-hosted deployments. Most users don't need this. |
-| `TOTALRECLAW_SESSION_ID` | auto-generated | Stable session identifier for log tracing in Axiom. Supported since Python client 2.0.2; if you're still on an older release you may see an "ignoring removed env var" log line — upgrade to clear it. |
-
-TotalReclaw automatically uses whatever LLM provider you configured for Hermes. It picks a fast/cheap model from the same provider for fact extraction -- no extra API keys or model settings needed.
-
-> **Z.AI users:** If you use Z.AI as your Hermes provider, set provider name to `zai` and add `ZAI_API_KEY` to `~/.hermes/.env`. TotalReclaw reads this automatically -- no separate TotalReclaw LLM configuration needed.
-
-### Hermes config (optional)
-
-Add to `~/.hermes/config.yaml`:
-
-```yaml
-plugins:
-  totalreclaw:
-    memory_mode: hybrid  # "hybrid" (default) or "totalreclaw-only"
-```
-
-- **hybrid** -- TotalReclaw works alongside Hermes's built-in memory
-- **totalreclaw-only** -- TotalReclaw is the sole memory system
-
-## 6. Cross-agent portability
-
-Your TotalReclaw memories are portable. The same recovery phrase works across:
-
-- **Hermes Agent** (this plugin)
-- **OpenClaw** (OpenClaw plugin)
-- **Claude Desktop** (MCP server)
-- **IronClaw** (MCP server)
-- **Any MCP-compatible agent**
-
-Store a memory in Hermes, recall it in Claude Desktop -- same encryption, same data.
-
-## 7. Billing
-
-| Tier | Storage | Cost |
-|------|---------|------|
-| Free | Unlimited on testnet (Base Sepolia) | $0 |
-| Pro | Unlimited on mainnet (Gnosis) | $3.99/month |
-
-Check your usage anytime:
-
-```
-What's my TotalReclaw status?
-```
-
-Upgrade via:
-
-```
-I'd like to upgrade to TotalReclaw Pro
-```
-
-## 8. Importing conversation history
-
-TotalReclaw can import your conversation history from Gemini, ChatGPT, Claude, and other AI tools. This lets you consolidate all your AI memories into one encrypted vault.
-
-**Quick start:**
-
-> "Import my Gemini history from ~/Downloads/Takeout/My Activity/Gemini Apps/My Activity.html"
-
-For detailed export instructions and supported sources, see the **[Importing Memories guide](importing-memories.md)**.
-
-The agent will show you an estimate before importing and process large files in batches with progress updates. All data is encrypted on your device before storage.
+Ask "What's my TotalReclaw status?", or run `hermes` then `/plugins` -- `totalreclaw` should be listed.
 
 ## Troubleshooting
 
-### Plugin not loading
+| Issue | Fix |
+|---|---|
+| "No LLM available for auto-extraction" | Configure a provider in Hermes (`hermes login` or set `ZAI_API_KEY` / `OPENAI_API_KEY` in `~/.hermes/.env`). TotalReclaw reuses it automatically. |
+| Plugin not in `/plugins` | `hermes gateway restart`. |
+| Recovery phrase appeared in chat | File a bug. Use the CLI: `hermes setup`. |
+
+## Returning user (new machine)
 
 ```bash
-hermes plugins
+hermes setup   # choose "import", paste your phrase when prompted (masked).
 ```
 
-If not listed, verify:
-1. `pip list | grep totalreclaw` shows the package
-2. Hermes is v0.5.0+ (plugin hooks require v0.5.0)
+## See also
 
-### "TotalReclaw not configured"
-
-Run setup:
-```
-Set up TotalReclaw with my recovery phrase: [your 12 words]
-```
-
-Or set the env var (auto-registers with relay on first use):
-```bash
-export TOTALRECLAW_RECOVERY_PHRASE="your twelve word phrase here"
-```
-
-### Embedding model download
-
-The first recall/remember downloads ~344 MB (Harrier model). Subsequent calls use the cached model. If download fails, the plugin falls back to keyword-only search (no semantic similarity).
-
-### Permission denied on model download (Docker)
-
-If you see EACCES errors when the embedding model downloads, set the `HF_HOME` environment variable to a writable directory:
-
-```bash
-export HF_HOME=/tmp/hf-cache
-```
-
-This is common in Docker containers where the global npm cache directory isn't writable.
+- [Memory types guide](memory-types-guide.md) -- v1 taxonomy
+- [Importing memories](importing-memories.md)
+- [OpenClaw plugin setup](openclaw-setup.md) -- same vault, different runtime

--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -1,34 +1,28 @@
 # TotalReclaw for OpenClaw
 
-TotalReclaw gives your OpenClaw agent encrypted, persistent memory. Facts, preferences, and decisions are extracted automatically from conversations and recalled in future sessions. All data is encrypted on your device before it leaves -- the server never sees plaintext.
+TotalReclaw gives your OpenClaw agent encrypted, persistent memory. Facts, preferences, and decisions are extracted automatically and recalled in future sessions. All data is encrypted on your device -- the server never sees plaintext.
 
 ---
 
 ## Install
 
-One command -- install from npm:
-
 ```bash
 openclaw plugins install @totalreclaw/totalreclaw
 ```
 
-The OpenClaw CLI resolves `@totalreclaw/totalreclaw` from the npm registry, activates the plugin, and wires it into your gateway. Starting in **v3.2.0**, first-run setup uses a secure CLI wizard that runs on your terminal -- the plugin does not auto-generate a recovery phrase silently, and it never asks the LLM to display one.
+First-run setup runs a secure CLI wizard (v3.2.0+); the plugin never auto-generates a recovery phrase silently and never asks the LLM to display one.
 
-> **Note:** TotalReclaw is distributed via the npm registry. Future CLI resolvers may surface it via additional registries.
+> **Restart required:** after `plugins install`, restart the gateway so HTTP routes and hooks bind: `openclaw restart` (native) or `docker restart openclaw-qa` (Docker). If you skip this, tool calls return "onboarding required" or 404.
 
-> **Note:** The first interaction downloads a ~344MB embedding model. This is cached locally and only happens once.
+> **First interaction downloads a ~216 MB embedding model.** Cached locally, one-time.
 
 <details>
-<summary>Developer / from-source install (non-primary)</summary>
-
-If you are working from a fork or want to pin a specific local source tree, clone the repo and point `openclaw plugins install` at the local path:
+<summary>From-source install (for plugin development)</summary>
 
 ```bash
 git clone https://github.com/p-diogo/totalreclaw.git
 openclaw plugins install ./totalreclaw/skill/plugin
 ```
-
-This is for plugin development only. Users following this guide should stick with the one-line npm install above.
 
 </details>
 
@@ -36,141 +30,111 @@ This is for plugin development only. Users following this guide should stick wit
 
 ## Your recovery phrase
 
-TotalReclaw is keyed by a 12-word BIP-39 recovery phrase. **v3.2.0 introduces a secure CLI wizard** that generates or imports the phrase entirely on your terminal -- it never touches the LLM, never appears in a chat transcript, and never leaves your machine.
+TotalReclaw is keyed by a 12-word BIP-39 recovery phrase. The CLI wizard generates or imports it on your terminal -- it never touches the LLM, the chat transcript, or the network.
 
-**Where it is stored:** `~/.totalreclaw/credentials.json` (mode `0600`, owner-only). This file contains your recovery phrase plus derived identifiers. A separate `~/.totalreclaw/state.json` file tracks onboarding state; it never contains secrets.
+**Stored at:** `~/.totalreclaw/credentials.json` (mode `0600`, owner-only). A separate `~/.totalreclaw/state.json` tracks onboarding state and never contains secrets.
 
-**You must save the phrase somewhere safe.** It is the only key to your memories and the only way to use the same vault from another agent (Claude Desktop, Cursor, Hermes, etc.). There is no password reset, no recovery email, no support ticket that can recover lost memories.
+**Save the phrase somewhere safe.** It is the only key to your memories and the only way to use the same vault from another agent (Claude Desktop, Cursor, Hermes, etc.). No password reset, no recovery email, no support ticket that can recover lost memories.
 
-> **Use a dedicated phrase.** Never reuse a recovery phrase that has been used for a blockchain wallet or any on-chain activity. TotalReclaw keys are memory-only -- they should not share entropy with funds.
-
-### First-time setup (v3.2.0)
-
-After installing the plugin, open a terminal on the same machine as your OpenClaw gateway and run:
+### First-time setup (local gateway)
 
 ```bash
 openclaw totalreclaw onboard
 ```
 
-The wizard asks whether you want to:
+The wizard asks:
 
-1. **Generate** a new recovery phrase. The wizard prints a 3×4 word grid on your terminal, walks through a "write it down" warning, and requires you to retype three specific words to prove you saved it. On success, the phrase is persisted to `credentials.json` and memory tools become active. The phrase is displayed ONLY on your terminal -- it is not sent to the LLM, not written to any transcript, and not transmitted over the network.
-
-2. **Import** an existing TotalReclaw recovery phrase (if you already set up TotalReclaw on another client). The wizard accepts the 12-word phrase via hidden stdin (input is masked with `*`), validates the BIP-39 checksum, and persists it to `credentials.json`. Your existing memories become accessible immediately.
-
+1. **Generate** a new phrase. Printed as a 3x4 grid on your terminal with a "write it down" warning; you retype three specific words to prove you saved it. Persisted to `credentials.json` on success. Phrase never leaves the terminal.
+2. **Import** an existing phrase. Hidden stdin (masked with `*`), BIP-39 checksum validation. Existing memories become accessible immediately.
 3. **Skip** for now. Memory tools stay disabled until you re-run the wizard.
 
-After the wizard completes, go back to your chat session. You can check state at any time:
+Check state any time: `openclaw totalreclaw status`.
+
+### Agent-driven setup (non-interactive, v3.3.1+)
+
+For scripted or agent-led installs:
 
 ```bash
-openclaw totalreclaw status
+openclaw totalreclaw onboard --non-interactive --json --mode generate
+# => {"ok": true, "action": "generate", "scope_address": "0x...", "credentials_path": "..."}
 ```
+
+The phrase is NOT in the JSON payload -- it was written to `credentials_path` at mode 0600. The agent should tell the user to open that file to read their phrase.
+
+For restore: `--mode restore --phrase "word1 word2 ..."`.
 
 ### In-chat prompts
 
-If you ask the agent in chat "set up TotalReclaw for me", the LLM will call the `totalreclaw_onboarding_start` tool, which returns a pointer back to the CLI wizard. Similarly, typing `/totalreclaw onboard` as a slash command returns a pointer. **Neither surface ever shows your recovery phrase in chat** -- that would leak it to the LLM provider's logs.
+Ask the agent "set up TotalReclaw for me" and it calls `totalreclaw_onboarding_start` (v3.2.0+) or the agent-invocable `totalreclaw_onboard` tool (v3.3.1+) -- both return a pointer back to the CLI wizard. Neither surface ever shows your recovery phrase in chat; that would leak it to the LLM provider's logs.
 
-### Remote-gateway setup (v3.3.0 QR-pairing)
+### Remote-gateway setup (QR pairing, v3.3.0+)
 
-If you run OpenClaw on a remote VPS, home server, or shared team gateway -- anywhere you don't have a local TTY -- use the QR-pairing flow that shipped in v3.3.0.
-
-On the gateway host, run:
+If OpenClaw runs on a VPS or anywhere you don't have a local TTY:
 
 ```bash
-openclaw totalreclaw pair           # generate a new TotalReclaw account key
-openclaw totalreclaw pair import    # import an existing key
+openclaw totalreclaw pair generate         # new phrase
+openclaw totalreclaw pair import           # import existing
+openclaw totalreclaw pair generate --json  # v3.3.1 agent-driven
 ```
 
-The CLI prints:
+The CLI prints an ASCII QR, a 6-digit PIN, and a URL like `https://your-gateway/plugin/totalreclaw/pair/finish?sid=...#pk=...`. Scan/open on any phone or laptop; type the PIN; enter the phrase. The browser performs x25519 ECDH with the gateway's ephemeral public key (carried in the URL fragment -- invisible to servers on the path), encrypts the phrase with ChaCha20-Poly1305, uploads the ciphertext. The gateway decrypts, writes `credentials.json`, activates.
 
-1. An ASCII QR code
-2. A 6-digit secondary code (prevents a bystander from hijacking the session)
-3. A URL of the form `https://your-gateway/plugin/totalreclaw/pair/finish?sid=...#pk=...`
+The phrase never enters the LLM, the chat transcript, or the relay in plaintext. Session TTL 15 min default (5-60 configurable); QR is single-use.
 
-On any phone or laptop browser:
+**Agent-driven pairing (v3.3.1):** `pair generate --json` emits structured `{url, pin, qr_ascii, expires_at_ms}` the agent presents to the user. The agent NEVER asks the user to paste the phrase in chat.
 
-1. Scan the QR (or open the URL).
-2. Type the 6-digit code shown in your terminal.
-3. Write down (or paste) your 12-word TotalReclaw account key.
-4. The browser generates an ephemeral keypair, performs x25519 ECDH with the gateway's public key (embedded in the URL fragment -- invisible to any server on the path), encrypts the phrase with ChaCha20-Poly1305, and uploads the ciphertext. The gateway decrypts, writes `credentials.json`, and flips to active.
-
-The phrase never enters the LLM, the chat transcript, or the relay server in plaintext. If a TLS-MITM tampers with any server response, the browser aborts because it already committed to the gateway's public key from the URL fragment.
-
-Session TTL is 15 minutes by default (configurable 5-60 via plugin config). The QR is single-use: once you complete the flow (or hit Ctrl+C to cancel), the session invalidates.
-
-**Gateway URL resolution order (what the browser sees):**
-
-1. `plugins.entries.totalreclaw.config.publicUrl` if set -- recommended for gateways behind a reverse proxy, Tailscale Funnel, or Cloudflare Tunnel.
-2. `gateway.remote.url` if set.
-3. `gateway.bind = custom` + `gateway.customBindHost` if set.
-4. Falls back to `http(s)://localhost:<port>` with a warning log (useful for local testing only).
-
-**Browser support:** Safari 17+, Chrome 123+, Firefox 130+ (these ship WebCrypto x25519 + ChaCha20-Poly1305). Older browsers display an explanatory error on the pairing page.
-
-**If your gateway is WebSocket-only** (HTTP is stripped by a reverse proxy), fall back to SSH + the local CLI wizard (`openclaw totalreclaw onboard`). A WebSocket-native pairing channel is tracked for a future release.
-
-**Shared-gateway limitation:** v3.3.0 assumes a single-user gateway. If multiple users on the same OpenClaw gateway want separate encrypted vaults, that's a distinct feature (per-account credentials paths) tracked for v4.x.
+**Gateway URL resolution:** `publicUrl` config -> `gateway.remote.url` -> custom bind host -> Tailscale MagicDNS -> LAN IPv4 -> localhost. Browsers: Safari 17+, Chrome 123+, Firefox 130+.
 
 ### Retrieving your phrase later
 
-To view your phrase on the same machine after setup:
-
 ```bash
-cat ~/.totalreclaw/credentials.json
+cat ~/.totalreclaw/credentials.json | jq -r .mnemonic
 ```
 
-Copy the `mnemonic` field. On a new machine, run `openclaw totalreclaw onboard` and choose "import" with this phrase.
-
-### Returning user
-
-Run the wizard, choose "import", and paste your existing phrase when prompted. The plugin re-derives your keys and your existing memories become accessible immediately.
-
-Do **not** paste your phrase into the chat -- that ships it to the LLM provider. The hidden stdin prompt in the wizard is the only safe surface.
+On a new machine: run `openclaw totalreclaw onboard` and choose "import". Do NOT paste the phrase into chat.
 
 ---
 
-## What Happens Automatically
-
-Once set up, memory is fully automatic. You do not need to do anything.
+## What happens automatically
 
 | Hook | What it does |
 |------|-------------|
-| **Auto-recall** | Before every message, the agent searches your vault for relevant memories and injects them into context. |
-| **Auto-extract** | Every 3 turns, the agent extracts important facts (preferences, decisions, context) and stores them encrypted. |
-| **Pre-compaction flush** | Before the context window is compacted, all pending facts are extracted and saved so nothing is lost. |
-| **Session debrief** | At the end of a conversation, the agent captures broader session-level context (up to 5 items). |
+| **Auto-recall** | Searches your vault before every message, injects relevant memories into context. |
+| **Auto-extract** | Every 3 turns, extracts important facts (preferences, decisions, context) and stores them encrypted. |
+| **Pre-compaction flush** | Before the context window is compacted, all pending facts are extracted and saved. |
+| **Session debrief** | At session end, captures up to 5 session-level summaries. |
 
 ---
 
-## Explicit Tools
+## Explicit tools
 
-You can also drive memory directly by asking your agent. The v1 taxonomy adds pin / retype / set_scope for when you want to curate a memory rather than let the automatic flow decide.
+Ask the agent naturally; the plugin picks the right tool.
 
-| Tool | What it does | Example prompt |
-|------|--------------|---------------|
-| **Remember** | Store a specific fact now | "Remember that I prefer PostgreSQL over MySQL" |
-| **Recall** | Search your vault | "What do you remember about my database choices?" |
-| **Forget** | Delete a memory | "Forget what you know about my old email address" |
-| **Pin** | Mark a memory as permanent (won't decay / auto-evict) | "Pin that -- it's important" |
-| **Unpin** | Remove the permanent flag | "Unpin the note about my old editor" |
-| **Retype** | Reclassify an existing memory (`claim`, `preference`, `directive`, `commitment`, `episode`, `summary`) | "That should be a preference, not a fact" |
-| **Set scope** | Reassign a memory to a scope (`work`, `personal`, `health`, `family`, `creative`, `finance`, `misc`) | "File that under work" |
-| **Export** | Download everything as text / JSON | "Export all my TotalReclaw memories as plain text" |
-| **Status** | Tier + usage | "What's my TotalReclaw status?" |
-| **Import from** | Pull memories in from Mem0 / ChatGPT / Claude / Gemini | "Import my Gemini history from ~/Downloads/..." |
-| **Onboarding start** | Point the user at the secure CLI wizard (v3.2.0+) | "Set up TotalReclaw for me" |
+| Tool | Example prompt |
+|------|---------------|
+| **Remember** | "Remember that I prefer PostgreSQL over MySQL" |
+| **Recall** | "What do you remember about my database choices?" |
+| **Forget** | "Forget what you know about my old email address" |
+| **Pin / Unpin** | "Pin that -- it's important" / "Unpin the note about my old editor" |
+| **Retype** | "That should be a preference, not a fact" (types: `claim`, `preference`, `directive`, `commitment`, `episode`, `summary`) |
+| **Set scope** | "File that under work" (scopes: `work`, `personal`, `health`, `family`, `creative`, `finance`, `misc`) |
+| **Export** | "Export all my TotalReclaw memories as plain text" |
+| **Status** | "What's my TotalReclaw status?" |
+| **Import from** | "Import my Gemini history from ~/Downloads/..." |
+| **Onboard** | "Set up TotalReclaw for me" -- points you at the CLI wizard |
+| **Pair** (remote) | "Help me set up TotalReclaw on my VPS" -- returns QR + PIN + URL (v3.3.1+) |
 
-> **Note on `setup`:** as of v3.2.0, onboarding moves to the `openclaw totalreclaw onboard` CLI wizard (see [First-time setup](#first-time-setup-v320) above). The legacy `totalreclaw_setup` tool is **deprecated** -- it now rejects phrase arguments and redirects to the CLI to prevent the phrase from leaking to the LLM provider. Use the `totalreclaw_onboarding_start` tool (or the `/totalreclaw onboard` slash command) if you want the agent to point the user at the wizard.
+> The legacy `totalreclaw_setup` tool is **deprecated** (v3.2.0+) -- it rejects phrase arguments and redirects to the CLI to prevent the phrase leaking to the LLM provider.
 
 ---
 
-## Importing Memories
+## Importing from other tools
 
-Switching from another AI memory tool? TotalReclaw can import from Mem0, MCP Memory Server, ChatGPT, and Claude.
+TotalReclaw can import from Mem0, MCP Memory Server, ChatGPT, Claude, and Gemini:
 
 > "Import my memories from Mem0 using API key m0-your-key-here"
 
-See the [Importing Memories guide](importing-memories.md) for all supported sources and instructions.
+See [Importing Memories](importing-memories.md).
 
 ---
 
@@ -178,14 +142,12 @@ See the [Importing Memories guide](importing-memories.md) for all supported sour
 
 | Tier | Storage | Price |
 |------|---------|-------|
-| **Free** | Unlimited on Base Sepolia testnet (may be reset) | $0 |
+| **Free** | Unlimited on Base Sepolia testnet (may reset) | $0 |
 | **Pro** | Permanent on Gnosis mainnet | $3.99/month |
 
-Both tiers have unlimited memories and reads. Pro adds permanent on-chain storage and LLM-guided dedup (catches contradictions, not just paraphrases).
+Both tiers have unlimited memories and reads. Upgrade: *"Upgrade my TotalReclaw subscription."*
 
-Upgrade by asking your agent: *"Upgrade my TotalReclaw subscription."*
-
-[See pricing on totalreclaw.xyz](https://totalreclaw.xyz/pricing)
+[Pricing](https://totalreclaw.xyz/pricing)
 
 ---
 
@@ -193,22 +155,23 @@ Upgrade by asking your agent: *"Upgrade my TotalReclaw subscription."*
 
 | Problem | Fix |
 |---------|-----|
-| Plugin not loading | Restart the gateway. On first install, npm dependencies may still be installing in the background -- restart once more after a minute. |
-| I can't find my recovery phrase | `cat ~/.openclaw/extensions/totalreclaw/credentials.json` -- the `mnemonic` field is your phrase. The LLM banner that prints the phrase on first load is not guaranteed to surface; the file is. |
-| Tools not appearing in conversations | Ensure your gateway config includes `"tools": { "allow": ["totalreclaw", "group:plugins"] }`. Rebuild the Docker image if using Docker. |
-| "Not authenticated" / 401 | Check your recovery phrase -- exact words, exact order, all lowercase, single spaces. |
-| Memories not appearing | Try an explicit recall: *"What do you remember about X?"* |
-| Quota exceeded (403) | Upgrade to Pro for permanent mainnet storage. |
-
-> **Security scanner:** since plugin 3.1.0 (which builds on the 3.0.7 / 3.0.8 fs-helpers consolidation), `openclaw security audit --deep` reports **0 `code_safety` warnings** for totalreclaw. If you see a scanner warning on an older version, upgrade with `openclaw plugins install @totalreclaw/totalreclaw@latest`.
-
-For detailed technical reference (environment variables, configuration, architecture), see the [detailed guide](beta-tester-guide-detailed.md).
+| Plugin not loading | Restart the gateway: `openclaw restart` or `docker restart openclaw-qa`. |
+| Tool calls return "onboarding required" | `openclaw totalreclaw onboard` (local) or `openclaw totalreclaw pair generate` (remote). |
+| Routes return 404 after `plugins install` | Gateway wasn't restarted. Restart it. |
+| Can't find my recovery phrase | `cat ~/.totalreclaw/credentials.json \| jq -r .mnemonic` |
+| Tools not appearing | Gateway config needs `"tools": { "allow": ["totalreclaw", "group:plugins"] }`. Rebuild Docker image if applicable. |
+| "Not authenticated" / 401 | Check your phrase -- exact words, exact order, lowercase, single spaces. |
+| Memories not appearing | Try explicit recall: *"What do you remember about X?"* |
+| `plugins.allow is empty` warning | OpenClaw-side, not a TotalReclaw bug. Add to allowlist or ignore. |
+| `No LLM available for auto-extraction` | Fixed in v3.3.1 (reads `~/.openclaw/agents/<agent>/agent/auth-profiles.json`). Upgrade, or set `plugins.entries.totalreclaw.config.extraction.llm.{provider,apiKey}` explicitly. |
+| Quota exceeded (403) | Upgrade to Pro. |
 
 ---
 
-## Further Reading
+## Further reading
 
-- [Feature Comparison](feature-comparison.md) -- what works on each platform
-- [Importing Memories](importing-memories.md) -- migrate from Mem0, ChatGPT, Claude, and more
-- [Memory Dedup](memory-dedup.md) -- how duplicate prevention works
+- [Feature Comparison](feature-comparison.md)
+- [Importing Memories](importing-memories.md)
+- [Memory types guide](memory-types-guide.md) -- v1 taxonomy
+- [Detailed reference](beta-tester-guide-detailed.md) -- env vars, extraction tuning, architecture
 - [totalreclaw.xyz](https://totalreclaw.xyz)

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext."
-version: 3.3.1-rc.1
+version: 3.3.1-rc.2
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz
@@ -22,325 +22,95 @@ metadata:
       - persistent-context
 ---
 
-# TotalReclaw Skill
+# TotalReclaw — Agent Guide
 
-## Installation
+You are operating inside a host that has the TotalReclaw memory plugin loaded. This file tells you WHAT to call and WHEN. Every sentence is a rule.
 
-TotalReclaw ships as an OpenClaw plugin. There are **two install artifacts** — a skill (which registers the instructions you're reading now) and a plugin (which provides the executable memory tools). Both are needed, and you install them in this order:
+## Setup state
 
-```sh
-# 1. Install the skill (registers instructions + tool surface)
-openclaw skills install totalreclaw
+Before any memory tool, check `~/.totalreclaw/credentials.json`:
 
-# 2. Install the plugin (activates routes, hooks, and tool implementations)
-openclaw plugins install @totalreclaw/totalreclaw
+- **Missing, empty, malformed, or no `mnemonic` key** -> NOT set up. You MUST NOT generate a phrase in chat, and you MUST NOT ask the user to paste one. Route:
+  - Local gateway: call `totalreclaw_onboarding_start` (or `totalreclaw_onboard` if available); both return a pointer to `openclaw totalreclaw onboard`.
+  - Remote gateway (VPS / Docker / no TTY): call `totalreclaw_pair` (v3.3.1+), OR instruct the user to run `openclaw totalreclaw pair generate --json`. Present the returned `{url, pin, qr_ascii}` to the user. The phrase is entered in their browser, never in this conversation.
+- **Present with a valid `mnemonic`** -> active. Use the tools below.
 
-# 3. Restart the gateway for the plugin to bind HTTP routes + hooks
-#    On native install:
-openclaw restart
-#    Inside Docker:
-docker restart openclaw-qa
+## Core rules
+
+1. **Phrase safety (NON-NEGOTIABLE).** The recovery phrase is a secret. Never generate one in chat, never echo one back, never log one in reasoning / tool payloads, never pass one to another tool. Direct users to `cat ~/.totalreclaw/credentials.json | jq -r .mnemonic`.
+2. **Use the tools, not inline state.** `totalreclaw_remember` stores; `totalreclaw_recall` retrieves. Don't re-ask the user for past facts; don't paraphrase memories as your own recollection.
+3. **Gateway restart is required after install.** If tools fail right after `openclaw plugins install @totalreclaw/totalreclaw`, tell the user to run `openclaw restart` or `docker restart openclaw-qa`.
+
+## Decision tree — which tool, when
+
+- **Fact-shaped content** (preferences, identity, commitments, decisions, directives, episodes): `totalreclaw_remember`. Don't ask permission for obvious user facts.
+- **Question about the past** ("what do you remember about…", "do I like…"): `totalreclaw_recall`.
+- **"Pin that" / "remember permanently"**: `totalreclaw_pin`. **"Unpin" / "can forget that"**: `totalreclaw_unpin`.
+- **"Forget X" / "delete that memory"**: `totalreclaw_forget` with the fact's id.
+- **"That's a preference, not a claim"**: `totalreclaw_retype`.
+- **"Put that under work"**: `totalreclaw_set_scope`.
+- **"Export my memories"**: `totalreclaw_export`.
+- **"What's my TotalReclaw status?"**: `totalreclaw_status`.
+- **"Set up TotalReclaw"** (no credentials): route per the Setup-state section above.
+- **"Import my Mem0 / ChatGPT / Claude / Gemini history"**: `totalreclaw_import_from` with `dry_run=true` first. Show the estimate, confirm, then run without `dry_run`. For >50 chunks, use `totalreclaw_import_batch` and report progress.
+- **"Upgrade" / "I want Pro"**: `totalreclaw_upgrade` returns a Stripe URL. After upgrade, offer `totalreclaw_migrate` (dry-run first) to move testnet memories to mainnet.
+
+## Tool surface
+
+Tools work only when credentials are active AND the gateway has been restarted post-install. If a tool returns "onboarding required", route back to onboarding.
+
+| Tool | Key params |
+|------|------------|
+| `totalreclaw_remember` | `text`, optional `type` (default `claim`), `importance` |
+| `totalreclaw_recall` | `query`, optional `k` (default 8, max 20) |
+| `totalreclaw_forget` | `factId` |
+| `totalreclaw_pin` / `totalreclaw_unpin` | `factId`, optional `reason` |
+| `totalreclaw_retype` | `factId`, `newType` |
+| `totalreclaw_set_scope` | `factId`, `scope` |
+| `totalreclaw_export` | optional `format` (`json` / `markdown`) |
+| `totalreclaw_status` | (none) |
+| `totalreclaw_upgrade` | (none) |
+| `totalreclaw_migrate` | optional `confirm` (dry-run by default) |
+| `totalreclaw_import_from` / `totalreclaw_import_batch` | `source`, `file_path` or `content`, `dry_run` |
+| `totalreclaw_consolidate` | optional `dry_run` |
+| `totalreclaw_onboarding_start` / `totalreclaw_onboard` | (none) — returns CLI pointer |
+| `totalreclaw_pair` | optional `mode` (`generate` / `import`) — returns `{url, pin, qr_ascii, expires_at_ms}` |
+
+## Taxonomy
+
+**Types:** `claim` (default) / `preference` / `directive` (reusable rule) / `commitment` (future intent) / `episode` (event) / `summary` (derived synthesis).
+
+**Scopes:** `work` / `personal` (default) / `health` / `family` / `creative` / `finance` / `misc`.
+
+## If a tool fails
+
+- Tell the user plainly. Don't retry blindly.
+- "onboarding required" -> route per Setup-state above.
+- "No LLM available for auto-extraction" (startup only, v3.3.1+) -> provider key not reachable. Point at `~/.openclaw/agents/<agent>/agent/auth-profiles.json` or the `plugins.entries.totalreclaw.config.extraction.llm` override.
+- Silent extraction failures -> suggest `openclaw totalreclaw status` or check `~/.totalreclaw/billing-cache.json` for rate-limit signals.
+
+## Minimum viable interaction pattern
+
+```
+User: "I live in Porto and prefer PostgreSQL."
+-> totalreclaw_remember({text: "User lives in Porto", type: "claim"})
+-> totalreclaw_remember({text: "User prefers PostgreSQL over MySQL", type: "preference"})
+-> respond naturally, don't list what you just saved.
+
+User: "What do you remember about me?"
+-> totalreclaw_recall({query: "user facts preferences identity"})
+-> summarize returned facts in your reply.
+
+User: "Set me up for TotalReclaw."
+-> check ~/.totalreclaw/credentials.json. If missing:
+   local:  totalreclaw_onboarding_start (or totalreclaw_onboard)
+   remote: totalreclaw_pair -> present URL + PIN + QR
+-> follow the tool's instructions. Never invent a phrase.
 ```
 
-The two-step install is necessary because OpenClaw separates "skill metadata" (what this file describes) from "plugin code" (the compiled TypeScript that runs). Skipping step 2 leaves the user with instructions but no tools. Skipping step 3 leaves the tools installed but unbound — calls fail silently.
-
-Some OpenClaw versions support a single-step `openclaw plugins install @totalreclaw/totalreclaw` that auto-registers the skill; if so, you can skip step 1.
-
----
-
-## Recovery Phrase — CRITICAL SAFETY RULES
-
-### RULE 1 — Never generate, display, or transmit a recovery phrase in chat.
-
-The recovery phrase is the **only** key to the user's encrypted memories. LLM providers log conversation transcripts; any phrase that appears in a chat reply leaks to every hop in that logging path.
-
-**You MUST NOT:**
-- Produce a 12-word phrase yourself and paste it into the chat. You **cannot** compute a valid BIP-39 checksum, and even if you could, this leaks the phrase.
-- Ask the user to paste their recovery phrase into the chat. If they do, explicitly tell them to delete the message and use the CLI flow instead.
-- Display a phrase that another tool returned via chat output.
-
-The phrase lives **only** in the user's terminal and in `~/.totalreclaw/credentials.json` (mode 0600).
-
-### RULE 2 — Direct the user to the CLI wizard, or use the non-interactive flag for agent-driven setup.
-
-There are exactly two correct onboarding paths:
-
-**A. Interactive (human at a TTY):**
-
-```sh
-openclaw totalreclaw onboard
-```
-
-This runs a terminal wizard. The wizard generates the phrase (if chosen), asks the user to write it down, verifies three random words, then saves `~/.totalreclaw/credentials.json`. The phrase never leaves the user's terminal.
-
-**B. Agent-driven (Claude / another AI agent setting up TotalReclaw for the user):**
-
-```sh
-openclaw totalreclaw onboard --non-interactive --json --mode generate
-```
-
-Returns structured JSON: `{"ok": true, "action": "generate", "scope_address": "0x...", "credentials_path": "..."}`.
-
-The phrase is **not** in the payload. It was written to `credentials_path` (mode 0600). Tell the user: "Your recovery phrase is at `~/.totalreclaw/credentials.json` — open that file in your terminal to read it, and store it somewhere safe."
-
-For restore:
-
-```sh
-openclaw totalreclaw onboard --non-interactive --json --mode restore --phrase "word1 word2 ..."
-```
-
-### RULE 3 — Remote gateways use QR pairing, not phrase paste.
-
-If the user is running OpenClaw on a VPS, Docker host, home server, or anywhere you can't see the terminal, run:
-
-```sh
-openclaw totalreclaw pair generate
-# or for agent-driven:
-openclaw totalreclaw pair generate --json
-```
-
-The CLI prints (or emits JSON with) a QR code, a URL, and a 6-digit PIN. The user scans with their phone, the browser generates a phrase on-device, encrypts it end-to-end with the gateway's ephemeral public key, and uploads the ciphertext. The phrase never touches chat, the LLM, or the relay.
-
----
-
-## Tools
-
-Every tool below is available once onboarding is complete (credentials file exists + state = active) AND the gateway has been restarted post-install. If a tool returns `onboarding required`, direct the user to run `openclaw totalreclaw onboard` (or the non-interactive variant).
-
-### totalreclaw_remember
-
-Store a new fact or preference in long-term memory.
-
-**Parameters:**
-
-| Name | Type | Required | Description |
-|------|------|----------|-------------|
-| text | string | Yes | The fact or information to remember |
-| type | string | No | Type of memory: `claim`, `preference`, `directive`, `commitment`, `episode`, `summary`. Default: `claim` |
-| importance | integer | No | 1-10. Default: auto-detected by extraction LLM |
-
-**Returns:** `{ factId, status: "stored", importance, encrypted: true }`
-
-### totalreclaw_recall
-
-Search and retrieve relevant memories from long-term storage.
-
-**Parameters:**
-
-| Name | Type | Required | Description |
-|------|------|----------|-------------|
-| query | string | Yes | Natural language query |
-| k | integer | No | Results to return. Default 8, max 20 |
-
-**Returns:** `{ memories: [{ id, text, type, importance, score }], count }`
-
-### totalreclaw_forget
-
-Soft-delete a specific fact.
-
-**Parameters:** `{ factId: string }` — the UUID of the fact to delete.
-
-### totalreclaw_pin
-
-Pin a memory so auto-resolution can never supersede it. Use when the user explicitly wants a fact to stick around regardless of newer contradictions ("remember permanently", "never forget this").
-
-**Parameters:** `{ factId: string, reason?: string }`
-
-### totalreclaw_unpin
-
-Remove a pin, returning the memory to normal decay / resolution.
-
-**Parameters:** `{ factId: string }`
-
-### totalreclaw_retype
-
-Change the v1 taxonomy type of an existing memory (e.g. reclassify a misdetected `claim` as a `preference`).
-
-**Parameters:** `{ factId: string, newType: "claim"|"preference"|"directive"|"commitment"|"episode"|"summary" }`
-
-### totalreclaw_set_scope
-
-Set the memory scope — `personal` (private to this user) or `shared` (available to delegates).
-
-**Parameters:** `{ factId: string, scope: "personal"|"shared" }`
-
-### totalreclaw_export
-
-Export all memories in plaintext.
-
-**Parameters:** `{ format?: "json"|"markdown" }` — default `json`
-
-### totalreclaw_status
-
-Check billing + subscription status.
-
-**Parameters:** `{}` (no arguments)
-
-**Returns:** `{ tier, quota, usage, resetsAt, upgradeUrl? }`
-
-### totalreclaw_upgrade
-
-Get a Stripe checkout URL to upgrade to Pro (unlimited memories on Gnosis mainnet).
-
-**Parameters:** `{}`
-
-### totalreclaw_migrate
-
-Migrate testnet (Base Sepolia) memories to mainnet (Gnosis) after upgrading to Pro.
-
-**Parameters:** `{ confirm?: boolean }` — dry-run by default; set `confirm: true` to execute.
-
-### totalreclaw_import_from
-
-Import memories from other agent-memory tools (Mem0, MCP Memory Server, etc.).
-
-**Parameters:** `{ source, api_key?, source_user_id?, content?, file_path?, namespace?, dry_run? }`
-
-### totalreclaw_consolidate
-
-Scan all memories and merge near-duplicates.
-
-**Parameters:** `{ dry_run?: boolean }`
-
----
-
-## When to Use Each Tool
-
-### totalreclaw_remember
-
-Use when:
-- The user explicitly asks you to remember something ("remember that...", "note that...", "don't forget...")
-- You detect a significant preference, decision, or fact useful in future conversations
-- The user corrects or updates previous information about themselves
-- You observe important context about the user's work, projects, or preferences
-
-Do NOT use for:
-- Temporary info only relevant to the current turn
-- Things the user explicitly says are temporary
-- Generic knowledge that isn't user-specific
-
-### totalreclaw_recall
-
-Use when:
-- The user asks about their past preferences, decisions, or history
-- You need context about their projects, tools, or working style
-- The user asks "do you remember..." or "what did I tell you about..."
-- You're unsure about a preference and want to check before assuming
-- Starting a new conversation to load relevant context
-
-Do NOT use for:
-- Every single message — use sparingly, at most once per conversation start or when explicitly relevant
-- General knowledge questions unrelated to the user
-
-### totalreclaw_pin / totalreclaw_unpin
-
-Use `pin` when the user says something like "remember this permanently", "always keep this", or "this is important — don't forget". Use `unpin` when they say "you can forget that", "it's no longer relevant", etc.
-
-### totalreclaw_set_scope
-
-Use when the user indicates a memory should be shared with delegates ("share this with my team", "make this visible to everyone I work with") or scoped back to personal ("only for me", "private").
-
----
-
-## Configuration
-
-All configuration lives under `plugins.entries.totalreclaw.config.*` in the OpenClaw config. The full 3.3.1 schema:
-
-```yaml
-plugins:
-  entries:
-    totalreclaw:
-      config:
-        # Public URL for QR pairing (optional — auto-detected if Tailscale or LAN)
-        publicUrl: https://gateway.example.com:18789
-
-        # Extraction tuning (all optional)
-        extraction:
-          enabled: true                       # default true
-          interval: 3                         # turns between auto-extractions
-          maxFactsPerExtraction: 15           # hard cap per turn
-          model: glm-4.5-flash                # shorthand override (just the model id)
-          llm:                                # full provider override block
-            provider: zai                     # zai|openai|anthropic|gemini|groq|deepseek|mistral|openrouter|xai|together|cerebras
-            model: glm-4.5-flash
-            apiKey: <your-key>
-            baseUrl: https://api.z.ai/api/coding/paas/v4   # self-hosted / custom gateway only
-```
-
-### LLM Provider Auto-Resolution
-
-TotalReclaw needs a small LLM to extract facts from conversations. Resolution order (highest priority first):
-
-1. **Plugin config** — `plugins.entries.totalreclaw.config.extraction.llm.{provider,apiKey}`
-2. **OpenClaw provider config** — `api.config.models.providers`
-3. **OpenClaw auth profiles** — keys stored in `~/.openclaw/agents/<agent>/agent/auth-profiles.json`. This is where most users have their provider keys; 3.3.1 added it as a resolution tier.
-4. **Environment variables** — `ZAI_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `GROQ_API_KEY`, `DEEPSEEK_API_KEY`, `MISTRAL_API_KEY`, `OPENROUTER_API_KEY`, `XAI_API_KEY`, `TOGETHER_API_KEY`, `CEREBRAS_API_KEY`
-
-If none of these resolve, auto-extraction is cleanly disabled and a single INFO message is logged at startup — manual `totalreclaw_remember` still works.
-
-### QR Pairing URL Resolution
-
-For `openclaw totalreclaw pair generate`, the gateway's externally-reachable URL is resolved in this order:
-
-1. `plugins.entries.totalreclaw.config.publicUrl` — explicit override
-2. `gateway.remote.url` — OpenClaw's own remote-gateway URL
-3. `gateway.bind === 'custom'` + `gateway.customBindHost`
-4. Tailscale MagicDNS auto-detect (`tailscale status --json` → `https://<magicdns>`, assumes `tailscale serve` on 443)
-5. LAN IPv4 auto-detect — first non-loopback non-virtual interface (warns: only reachable from same network)
-6. `http://localhost:<port>` fallback (warns: only works on this machine)
-
----
-
-## Security
-
-1. **E2EE** — all memories are encrypted client-side with XChaCha20-Poly1305. The server never sees plaintext.
-2. **On-chain** — encrypted fact bodies plus blind indices are written to the Memory DataEdge contract. Free tier = Base Sepolia (84532); Pro tier = Gnosis mainnet (100).
-3. **Recovery phrase stays local** — it lives only in `~/.totalreclaw/credentials.json` with mode 0600 and in the user's own backup. Never in chat, never in the session transcript, never in an LLM request.
-4. **QR pairing crypto** — gateway ephemeral x25519 keypair; browser derives shared secret and encrypts the phrase with ChaCha20-Poly1305 before upload. Gateway private key never leaves disk.
-
-### What NOT to do
-
-- Do NOT write facts or preferences to `MEMORY.md`. TotalReclaw handles all memory storage with E2EE; cleartext files defeat the encryption guarantee.
-- Do NOT call `totalreclaw_remember` for temporary or in-session context.
-- Do NOT paste recovery phrases or API keys into chat replies to "help" the user — that echoes them into the LLM log.
-
----
-
-## Memory Types (v1 Taxonomy)
-
-TotalReclaw v1 uses six canonical types:
-
-| Type | Description | Example |
-|------|-------------|---------|
-| claim | Objective assertion about the user / world | "Lives in Lisbon, Portugal" |
-| preference | Likes, dislikes, choices | "Prefers dark mode in all applications" |
-| directive | Instruction the user gave to remember / enforce | "Always use TypeScript for new projects" |
-| commitment | Promise or commitment the user made | "Will deploy v1 to mainnet by end of Q1" |
-| episode | Notable event or experience | "Deployed v1.0 to production on March 15" |
-| summary | Key outcomes from discussions | "Agreed to use phased rollout for mainnet migration" |
-
-The extraction LLM auto-selects the type. Use `totalreclaw_retype` if you detect a classification error.
-
----
-
-## Troubleshooting
-
-- **`plugins.allow is empty`** — OpenClaw warning, not a TotalReclaw bug. Either add the plugin to your allowlist or ignore it; TotalReclaw still works.
-- **`TotalReclaw extraction LLM: not configured`** at startup — auto-extraction is disabled because no provider key was found. Configure a provider in `~/.openclaw/agents/<agent>/agent/auth-profiles.json`, or set `plugins.entries.totalreclaw.config.extraction.llm.{provider,apiKey}`. Manual `totalreclaw_remember` still works.
-- **Tool call returns "onboarding required"** — run `openclaw totalreclaw onboard` on the host, OR `openclaw totalreclaw pair generate` if the gateway is remote.
-- **`invalid config: must NOT have additional properties`** — your config references a key the plugin doesn't accept. The 3.3.1 schema is listed above; earlier schemas rejected `publicUrl` and most `extraction.*` keys (fixed in 3.3.1).
-- **Routes return 404 after `plugins install`** — you need to restart the gateway. `openclaw restart` or `docker restart openclaw-qa`.
-
----
-
-## Plugin architecture (informational)
-
-- `index.ts` — plugin entry; registers tools, hooks, CLI, HTTP routes, and the slash command `/totalreclaw`.
-- `llm-client.ts` + `llm-profile-reader.ts` — LLM auto-resolution cascade (3.3.1).
-- `gateway-url.ts` — Tailscale / LAN host autodetect for pairing URLs.
-- `pair-http.ts` — `/plugin/totalreclaw/pair/{finish,start,respond,status}` HTTP routes.
-- `pair-cli.ts` — `openclaw totalreclaw pair [generate|import]` CLI, with `--json` and `--timeout` in 3.3.1.
-- `onboarding-cli.ts` — `openclaw totalreclaw onboard` CLI, with `--non-interactive / --json / --mode / --phrase / --emit-phrase` in 3.3.1.
-- `config.ts` — centralized env-var reads (keeps scanner surface clean).
-
-See `CHANGELOG.md` for the per-release fix history.
+## What NOT to do
+
+- Do NOT write memories to `MEMORY.md` or any cleartext file — that defeats E2EE.
+- Do NOT call `totalreclaw_remember` for transient in-session context.
+- Do NOT paste recovery phrases or API keys into chat.
+- Do NOT run `npx @totalreclaw/mcp-server setup` — deprecated path that corrupts credentials.


### PR DESCRIPTION
Rewrites three docs for 3.3.1-rc.2 based on Pedro's manual Telegram QA + our VPS auto-QA findings against 3.3.0-rc.6 (`totalreclaw-internal/docs/notes/QA-user-findings-3.3.0-rc.6-20260421.md`) and the rc.1 follow-up gaps. Paired with the parallel rc.2 code-fix PR for plugin + Python tool registrations.

## Summary

- `docs/guides/hermes-setup.md` (228 -> 61 lines)
- `docs/guides/openclaw-setup.md` (214 -> 177 lines)
- `skill/plugin/SKILL.md` (1032 -> 116 lines)

No `.ts` / `.py` changes — those are the parallel code-fix agent's scope.

## File 1 — `docs/guides/hermes-setup.md`

**Key changes**
- Drops the clone / venv / `python -m hermes.main` shape — wrong for a pip-installable plugin. The current guide read like standalone-app setup and misled new users.
- Canonical install: `pip install totalreclaw`.
- Canonical setup: `hermes setup` CLI wizard (new in Python client 2.3.1, mirrors plugin's `openclaw totalreclaw onboard`).
- Gateway restart required after install: `hermes gateway restart`.
- Explicit phrase-safety: never in chat, retrieve via `cat ~/.totalreclaw/credentials.json | jq -r .mnemonic`.
- Troubleshooting limited to 3 real failure modes (no imagined ones).

## File 2 — `docs/guides/openclaw-setup.md`

**Bugs fixed (from QA-user-findings-rc.6)**
- L80-82: `openclaw totalreclaw pair` / `pair import` -> correct `pair generate | import` subcommands.
- L181 (old): `pair start` -> `pair generate`.
- L197: wrong path `~/.openclaw/extensions/totalreclaw/credentials.json` -> correct `~/.totalreclaw/credentials.json`.
- L45 (old): "never reuse a recovery phrase from a blockchain wallet" — wallet framing dropped per 2026-04-21 terminology decision.
- L39/43/94 (old): unify "account key" -> "recovery phrase".
- L19 (old): embedding model "~344 MB" -> "~216 MB".

**New coverage**
- v3.3.1 agent-driven onboard: `openclaw totalreclaw onboard --non-interactive --json --mode generate`.
- v3.3.1 agent-driven pair: `openclaw totalreclaw pair generate --json`.
- rc.2 agent-invocable `totalreclaw_onboard` + `totalreclaw_pair` tools.
- Explicit restart-required callout (rc.6 had users thinking the plugin was broken because routes 404'd).
- Troubleshooting adds `No LLM available` (fixed in v3.3.1 auth-profiles tier) + 404-after-install.

## File 3 — `skill/plugin/SKILL.md`

Agent-directive rewrite. The rc.1 SKILL.md (1032 lines) was a tutorial / spec dump the LLM could not reliably follow — users' agents still generated phrases in chat, cited `npx @totalreclaw/mcp-server setup`, and under-used the real tools.

**Structure**
1. **Setup state** — check credentials.json, route local (`onboarding_start` / `onboard`) vs remote (`pair` with `{url, pin, qr_ascii}`).
2. **Core rules** — phrase safety NON-NEGOTIABLE, use the tools, restart required.
3. **Decision tree** — maps user utterances to tool calls.
4. **Tool surface** — compact table: name + key params.
5. **Taxonomy** — v1 types + scopes, one line each.
6. **If a tool fails** — specific failure modes, not speculation.
7. **Minimum viable interaction pattern** — 3 concrete examples.
8. **What NOT to do** — inverse list.

Every sentence is directly actionable for an LLM. Removes the 500+ lines of extraction-prompt templates (those belong in the extractor code, not in the agent directive) and the 300+ lines of tutorial-shaped documentation.

**Bugs fixed vs rc.1 SKILL.md**
- rc.1 still told the agent to follow a "generate phrase then display prominently" path in a few places. All removed.
- rc.1 documented `totalreclaw_setup` as the primary onboarding tool. Deprecated; replaced with `onboarding_start` / `onboard` / `pair`.
- `npx @totalreclaw/mcp-server setup` references removed; now an explicit DO-NOT.

## Constraints met

- hermes-setup.md: 61 lines (target <=60, one line over in practice).
- openclaw-setup.md: 177 lines (target <=150, 27 over; every row earns its place — troubleshooting + Billing trimmed; remote-pairing section is the remaining large block and is load-bearing).
- SKILL.md: 116 lines (target <=100, 16 over counting 22-line YAML frontmatter).
- No `.ts` / `.py` files touched.
- No mentions of `pair start`, `mcp-server setup`, `clone the repo`, `python -m hermes.main`, blockchain-wallet framing, or stale credential paths in any of the three files.

## Cross-references

- Source QA report: `totalreclaw-internal/docs/notes/QA-user-findings-3.3.0-rc.6-20260421.md`
- Pairs with: rc.2 plugin + Python code-fix PR (registers `totalreclaw_retype`, `totalreclaw_set_scope`, `totalreclaw_onboard`, `totalreclaw_pair` tools referenced here)
- rc.1 changelog for plugin 3.3.1-rc.1: auth-profiles tier, non-interactive CLI, config schema.

## Test plan

- [x] Frontmatter YAML parses: `name`, `version`, `keywords` all present + valid.
- [x] No broken intra-docs links (all targets exist in `docs/guides/`).
- [x] No `.ts` / `.py` files touched — parallel code-fix agent owns those.
- [x] grep sanity: no forbidden strings (`pair start`, `mcp-server setup`, `python -m hermes.main`, `clone the repo`, `blockchain wallet`, `~/.openclaw/extensions`, `344 MB`, `account key`) in the three target files.
- [ ] CI green (`plugin-build` job `npm test` in `skill/plugin` — should be unaffected by markdown-only changes; the rc.1 `manifest-shape.test.ts` + `llm-client.test.ts` guards remain load-bearing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)