### PR TITLE
fix: 3.3.1-rc.2 plugin + 2.3.1rc2 hermes — rc.1 blockers + user-agent UX feedback

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,87 @@ Hermes Agent plugin are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1rc2] — 2026-04-22
+
+Follow-up RC for UX gaps flagged by Pedro's agent (Hermes) during
+parallel Telegram testing alongside the plugin 3.3.1-rc.1 QA. Ships as
+part of the unified rc.2 wave (plugin 3.3.1-rc.2 + Hermes 2.3.1rc2).
+All 2.3.1rc1 work is preserved.
+
+### Added
+
+- **`totalreclaw` standalone CLI** (new console script). Users who
+  install `pip install totalreclaw` outside of Hermes now have a
+  first-class entry point. Two subcommands:
+    - `totalreclaw setup` — delegates to the shared `hermes setup`
+      wizard so both binaries behave identically. Default silent-save
+      mode (see below) + optional `--emit-phrase` opt-in.
+    - `totalreclaw doctor` — health check across 7 dimensions
+      (credentials exist + parse, mnemonic valid, Smart Account
+      resolved/cached, embedding model cached, LLM provider keys
+      present, Hermes plugin registered, relay reachable). Coloured
+      output when stdout is a TTY; exit 0 = healthy, 1 = warnings,
+      2 = setup not started.
+
+- **Post-install onboarding pointer** — when users run `totalreclaw`
+  with no subcommand on a setup-less machine, they see a helpful
+  "run `totalreclaw setup`" message instead of a bare argparse help.
+
+- **Eager Smart Account resolution in `hermes setup` / `totalreclaw
+  setup`** — after writing credentials.json, the wizard derives the
+  CREATE2 Smart Account address via a one-shot RPC call and merges it
+  back into credentials.json as `scope_address`. Means subsequent
+  status / doctor / agent-tool calls see the real address instead of
+  "pending". Best-effort: a missing network is non-fatal and prints a
+  warning pointing at the "will be derived on first remember/recall"
+  fallback.
+
+- **Embedding-model download progress banner** (`embedding.py`) —
+  before the first call to Harrier, we print a single-line stderr
+  banner: `[TotalReclaw] Downloading embedding model from HuggingFace
+  (~216 MB, one-time)…`. We also enable huggingface_hub's built-in
+  progress bar so users see bytes moving. Suppressable via
+  `TOTALRECLAW_QUIET_EMBEDDING_BANNER=1` for CI.
+
+- **Hermes plugin SKILL.md** (`python/src/totalreclaw/hermes/SKILL.md`)
+  — agent-directive document shipped with the plugin. Tells the agent
+  exactly when to call each tool + enforces RULE 0 (recovery-phrase
+  handling). Replaces the ambiguity in rc.1 where the agent (a) didn't
+  know it had setup authority via `totalreclaw_onboarding_start`, and
+  (b) occasionally echoed phrases back despite the security rules.
+
+- **`totalreclaw_onboarding_start` entry in plugin.yaml** — was
+  implemented in `tools.py` for rc.1 but not listed in the plugin
+  manifest. Agents now discover it via the standard plugin surface.
+
+### Changed
+
+- **Silent-save by default in `setup` generate flow.** Pedro's agent
+  flagged in the Hermes Telegram QA that rc.1 printed the generated
+  BIP-39 phrase to stderr in a 4x3 grid — "for a secrets management
+  plugin, this feels ironic". Terminal recordings, screen-shares, and
+  shoulder-surfers defeat the E2EE promise. rc.2 default: the phrase
+  is written to credentials.json (mode 0600), NEVER displayed. The
+  post-setup banner points the user at
+  `cat ~/.totalreclaw/credentials.json | jq -r .mnemonic` for
+  retrieval when they need it. Behaviour change is gated by a new
+  `--emit-phrase` flag for power users who genuinely want the rc.1
+  4x3-grid + last-3-words-confirmation flow.
+
+- **`LOCAL_MODE_INSTRUCTIONS` / `REMOTE_MODE_INSTRUCTIONS`** now
+  mention both `totalreclaw setup` (standalone) and `hermes setup`
+  (Hermes-specific) so users know which binary to run based on how
+  they installed.
+
+### Preserved from rc.1
+
+All of the 2.3.1rc1 onboarding work carries forward:
+- `detect_first_run`, `maybe_emit_welcome`, canonical copy constants.
+- `hermes setup` wizard (restore + generate branches, non-TTY
+  tolerance, overwrite confirmation).
+- `totalreclaw.onboarding` first-run sentinel.
+- All existing tools, hooks, and the Retrieval v2 Tier 1 reranker.
+
 ## [2.3.1] - 2026-04-20
 
 First-run onboarding UX parity with plugin 3.3.0. Users switching between

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "totalreclaw"
-version = "2.3.1"
+version = "2.3.1rc2"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"
@@ -41,9 +41,14 @@ totalreclaw = "totalreclaw.hermes"
 # plugin 3.3.0 onboarding flow so users switching between OpenClaw and
 # Hermes see the same branch question + recovery-phrase terminology.
 hermes = "totalreclaw.hermes.cli:main"
+# 2.3.1rc2 — standalone `totalreclaw` CLI (setup + doctor). Users who
+# install `pip install totalreclaw` without Hermes get a first-class
+# entry point for initialising the vault and running health checks. The
+# `hermes` binary remains for Hermes-specific flows.
+totalreclaw = "totalreclaw.cli:main"
 
 [tool.setuptools.package-data]
-"totalreclaw.hermes" = ["plugin.yaml"]
+"totalreclaw.hermes" = ["plugin.yaml", "SKILL.md"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/python/src/totalreclaw/__init__.py
+++ b/python/src/totalreclaw/__init__.py
@@ -9,7 +9,7 @@ except Exception:
     # installed-package metadata is absent. Must match pyproject.toml —
     # test_version.py enforces a semver-shape string; the live value in
     # a pip-installed wheel comes from importlib.metadata above.
-    __version__ = "2.3.1"
+    __version__ = "2.3.1rc2"
 
 from .client import TotalReclaw
 

--- a/python/src/totalreclaw/cli.py
+++ b/python/src/totalreclaw/cli.py
@@ -1,0 +1,403 @@
+"""`totalreclaw` CLI — first-class entry point for setup + diagnostics.
+
+Shipped in 2.3.1rc2 after Pedro's agent Hermes flagged a catch-22 in the
+rc.1 UX: users who installed `pip install totalreclaw` standalone (no
+Hermes, no OpenClaw) had nowhere to initialise the encrypted vault. The
+`hermes setup` binary exists, but `pip install totalreclaw` with a bare
+agent framework left users staring at a recovery-phrase-is-required
+error with no CLI surface to reach.
+
+Two subcommands:
+
+* ``totalreclaw setup`` — interactive wizard that generates or restores a
+  recovery phrase. Reuses the ``hermes setup`` logic via the shared
+  :mod:`totalreclaw.hermes.cli` module so the two binaries behave
+  identically. After writing credentials, eagerly derives the Smart
+  Account address via RPC and persists it to ``credentials.json`` so
+  subsequent status / doctor calls show the real address rather than
+  ``pending``.
+
+* ``totalreclaw doctor`` — health check. Verifies:
+    - credentials.json exists, parses, mnemonic is a valid BIP-39 phrase.
+    - Smart Account address is cached OR can be derived.
+    - Embedding model is cached (Harrier-OSS-v1-270M ONNX).
+    - An LLM provider key is present in env OR a Hermes config file.
+    - Hermes plugin is registered (if Hermes is installed).
+    - Relay URL is reachable (best-effort probe, 5s timeout).
+
+Exit codes:
+    0 — all healthy.
+    1 — at least one issue (shown with a yellow ``warn`` or red ``fail``
+        marker and a remediation hint).
+    2 — setup not started (no credentials file) — a fast-path exit so
+        doctor is the one place users see "run `totalreclaw setup`" loudly.
+
+Coloured output is suppressed when stdout is not a TTY (plain text for
+piped use).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+from totalreclaw.onboarding import CANONICAL_CREDENTIALS_PATH, detect_first_run
+
+
+# ---------------------------------------------------------------------------
+# Coloured-output helpers (no dependency — ANSI escape codes only, fallback
+# to plain text when stdout isn't a TTY)
+# ---------------------------------------------------------------------------
+
+
+def _is_color_stream(stream) -> bool:
+    try:
+        return bool(stream.isatty())
+    except Exception:
+        return False
+
+
+def _c(code: str, text: str, stream=None) -> str:
+    stream = stream if stream is not None else sys.stdout
+    if _is_color_stream(stream):
+        return f"\x1b[{code}m{text}\x1b[0m"
+    return text
+
+
+def _ok(text: str) -> str:
+    return _c("32", f"[OK]    {text}")  # green
+
+
+def _warn(text: str) -> str:
+    return _c("33", f"[WARN]  {text}")  # yellow
+
+
+def _fail(text: str) -> str:
+    return _c("31", f"[FAIL]  {text}")  # red
+
+
+def _info(text: str) -> str:
+    return _c("36", f"[INFO]  {text}")  # cyan
+
+
+# ---------------------------------------------------------------------------
+# `setup` — delegates to totalreclaw.hermes.cli so the two binaries share
+# the exact same wizard. After a successful setup, eagerly derives the
+# Smart Account address.
+# ---------------------------------------------------------------------------
+
+
+def run_setup(
+    credentials_path: Optional[Path] = None,
+    emit_phrase: bool = False,
+) -> int:
+    """Run the interactive setup wizard.
+
+    Delegates to the shared hermes wizard (which in 2.3.1rc2 handles
+    eager Smart Account resolution itself — see
+    ``_try_eager_resolve_scope_address`` in ``hermes/cli.py``). This
+    keeps behaviour identical across ``hermes setup`` and
+    ``totalreclaw setup``.
+    """
+    # Delay import so `totalreclaw doctor` on a setup-less box doesn't pay
+    # for eth_account's import cost.
+    from totalreclaw.hermes.cli import run_setup as _hermes_run_setup
+
+    path = credentials_path if credentials_path is not None else CANONICAL_CREDENTIALS_PATH
+    return _hermes_run_setup(credentials_path=path, emit_phrase=emit_phrase)
+
+
+# ---------------------------------------------------------------------------
+# `doctor` — health check. Exits 0 if all green, 1 on warnings, 2 if
+# setup hasn't been started.
+# ---------------------------------------------------------------------------
+
+
+def run_doctor(credentials_path: Optional[Path] = None, relay_url: Optional[str] = None) -> int:
+    """Walk through a fixed checklist and print pass/fail for each step."""
+    path = credentials_path if credentials_path is not None else CANONICAL_CREDENTIALS_PATH
+    issues = 0
+    setup_started = True
+
+    print("TotalReclaw doctor — health check\n")
+
+    # --------------------------------------------------------------------
+    # Check 1 — credentials.json exists + parses
+    # --------------------------------------------------------------------
+    if not path.exists():
+        print(_fail(f"credentials.json not found at {path}"))
+        print(f"        Run `totalreclaw setup` to create it.")
+        setup_started = False
+    else:
+        try:
+            raw = path.read_text(encoding="utf-8")
+            data = json.loads(raw) if raw.strip() else {}
+            if not isinstance(data, dict):
+                print(_fail(f"credentials.json is not a JSON object"))
+                issues += 1
+            else:
+                print(_ok(f"credentials.json exists at {path}"))
+        except (OSError, json.JSONDecodeError) as err:
+            print(_fail(f"credentials.json is corrupt: {err}"))
+            issues += 1
+            setup_started = False
+
+    if not setup_started:
+        # No point running the rest of the checks; user needs to set up first.
+        return 2
+
+    # Re-read data for the remaining checks (we know file exists now).
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw) if raw.strip() else {}
+    except Exception:
+        data = {}
+
+    mnemonic = data.get("mnemonic") or data.get("recovery_phrase")
+
+    # --------------------------------------------------------------------
+    # Check 2 — mnemonic is a valid BIP-39 phrase
+    # --------------------------------------------------------------------
+    if not isinstance(mnemonic, str) or not mnemonic.strip():
+        print(_fail("credentials.json has no mnemonic field"))
+        issues += 1
+    else:
+        try:
+            from eth_account import Account
+            Account.enable_unaudited_hdwallet_features()
+            Account.from_mnemonic(mnemonic.strip(), account_path="m/44'/60'/0'/0/0")
+            print(_ok("Recovery phrase is a valid BIP-39 12-word mnemonic"))
+        except Exception as err:
+            print(_fail(f"Recovery phrase validation failed: {err}"))
+            issues += 1
+
+    # --------------------------------------------------------------------
+    # Check 3 — Smart Account address
+    # --------------------------------------------------------------------
+    cached_sa = data.get("scope_address") or data.get("wallet_address")
+    if cached_sa and isinstance(cached_sa, str):
+        print(_ok(f"Smart Account address cached: {cached_sa}"))
+    elif isinstance(mnemonic, str) and mnemonic.strip():
+        # Derive on-the-fly
+        try:
+            import asyncio
+            from totalreclaw.client import _derive_smart_account_address
+
+            sa = asyncio.run(_derive_smart_account_address(mnemonic.strip()))
+            if sa:
+                print(_ok(f"Smart Account address resolved on-the-fly: {sa}"))
+                print("        (not cached in credentials.json — run `totalreclaw setup` to cache)")
+            else:
+                print(_warn("Smart Account address could not be derived (RPC returned empty)"))
+                issues += 1
+        except Exception as err:
+            print(_warn(f"Smart Account address derivation failed: {err}"))
+            issues += 1
+
+    # --------------------------------------------------------------------
+    # Check 4 — embedding model cached
+    # --------------------------------------------------------------------
+    try:
+        # The embedding module lazy-initialises a singleton; we just probe
+        # the HF cache path to see if the model has already been downloaded.
+        hf_cache_root = Path(
+            os.environ.get("HF_HOME", str(Path.home() / ".cache" / "huggingface"))
+        )
+        hub_cache = hf_cache_root / "hub"
+        # Harrier model id follows HF's `models--owner--repo` pattern.
+        candidates = (
+            list(hub_cache.glob("models--*harrier*"))
+            if hub_cache.exists()
+            else []
+        )
+        if candidates:
+            print(_ok(f"Embedding model cached under {candidates[0].name}"))
+        else:
+            print(_warn("Embedding model NOT cached — first recall will download ~216 MB from HuggingFace"))
+            # Not counted as an issue — it's a first-run one-time cost.
+    except Exception as err:
+        print(_warn(f"Could not verify embedding-model cache: {err}"))
+
+    # --------------------------------------------------------------------
+    # Check 5 — LLM provider key present
+    # --------------------------------------------------------------------
+    env_keys = [
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "ZAI_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "MISTRAL_API_KEY",
+        "GROQ_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "OPENROUTER_API_KEY",
+        "XAI_API_KEY",
+    ]
+    present = [k for k in env_keys if os.environ.get(k)]
+    if present:
+        print(_ok(f"LLM provider key(s) present in env: {', '.join(present)}"))
+    else:
+        print(_warn("No LLM provider key found in env (auto-extraction may be disabled)"))
+        print(
+            "        Set one of: " + ", ".join(env_keys[:4]) + ", ..."
+        )
+
+    # --------------------------------------------------------------------
+    # Check 6 — Hermes plugin registered (if Hermes is installed)
+    # --------------------------------------------------------------------
+    try:
+        import importlib
+
+        importlib.import_module("hermes_agent")
+        hermes_installed = True
+    except ImportError:
+        hermes_installed = False
+
+    if hermes_installed:
+        # Check Hermes plugin entry point
+        try:
+            from importlib.metadata import entry_points
+
+            eps = entry_points()
+            if hasattr(eps, "select"):
+                hermes_eps = list(eps.select(group="hermes_agent.plugins"))
+            else:
+                hermes_eps = eps.get("hermes_agent.plugins", [])  # type: ignore
+            tr_registered = any(ep.name == "totalreclaw" for ep in hermes_eps)
+            if tr_registered:
+                print(_ok("Hermes plugin entry-point `totalreclaw` is registered"))
+            else:
+                print(_warn("Hermes is installed but `totalreclaw` plugin entry is missing"))
+                issues += 1
+        except Exception as err:
+            print(_warn(f"Could not check Hermes plugin registration: {err}"))
+    else:
+        print(_info("Hermes not installed (skipping plugin-registration check)"))
+
+    # --------------------------------------------------------------------
+    # Check 7 — Relay reachable
+    # --------------------------------------------------------------------
+    resolved_relay = (
+        relay_url
+        or os.environ.get("TOTALRECLAW_SERVER_URL")
+        or "https://api.totalreclaw.xyz"
+    )
+    try:
+        import httpx
+
+        with httpx.Client(timeout=5.0) as client:
+            resp = client.get(f"{resolved_relay.rstrip('/')}/health")
+            if 200 <= resp.status_code < 500:
+                print(_ok(f"Relay reachable at {resolved_relay} (HTTP {resp.status_code})"))
+            else:
+                print(_warn(f"Relay at {resolved_relay} returned HTTP {resp.status_code}"))
+                issues += 1
+    except Exception as err:
+        print(_warn(f"Could not reach relay at {resolved_relay}: {err}"))
+
+    # --------------------------------------------------------------------
+    # Summary
+    # --------------------------------------------------------------------
+    print()
+    if issues == 0:
+        print(_ok(f"All checks passed. TotalReclaw is healthy."))
+        return 0
+    else:
+        print(_warn(f"{issues} issue(s) found. See messages above for remediation."))
+        return 1
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="totalreclaw",
+        description=(
+            "TotalReclaw — End-to-end encrypted memory for AI agents (Python client). "
+            "Run `totalreclaw setup` to initialise your encrypted vault or "
+            "`totalreclaw doctor` to diagnose an existing install."
+        ),
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    sp_setup = sub.add_parser(
+        "setup",
+        help=(
+            "Interactive wizard to generate a NEW recovery phrase or restore an existing "
+            "one. Writes credentials to ~/.totalreclaw/credentials.json and eagerly resolves "
+            "the Smart Account address."
+        ),
+    )
+    sp_setup.add_argument(
+        "--credentials-path",
+        type=Path,
+        default=None,
+        help="Override the credentials file location (default: ~/.totalreclaw/credentials.json).",
+    )
+    sp_setup.add_argument(
+        "--emit-phrase",
+        action="store_true",
+        default=False,
+        help=(
+            "POWER-USER OPT-IN. Display the generated recovery phrase in the terminal "
+            "(stderr). Default: silent-save."
+        ),
+    )
+
+    sp_doctor = sub.add_parser(
+        "doctor",
+        help=(
+            "Health check — verifies credentials, mnemonic validity, Smart Account address, "
+            "embedding-model cache, LLM provider keys, Hermes plugin registration, and relay "
+            "reachability. Exits 0 if all pass, 1 on warnings, 2 if setup isn't started."
+        ),
+    )
+    sp_doctor.add_argument(
+        "--credentials-path",
+        type=Path,
+        default=None,
+        help="Override the credentials file location.",
+    )
+    sp_doctor.add_argument(
+        "--relay-url",
+        type=str,
+        default=None,
+        help="Override the relay URL for the reachability check.",
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.command == "setup":
+        return run_setup(
+            credentials_path=args.credentials_path,
+            emit_phrase=getattr(args, "emit_phrase", False),
+        )
+    if args.command == "doctor":
+        return run_doctor(
+            credentials_path=args.credentials_path,
+            relay_url=args.relay_url,
+        )
+
+    # No subcommand — check whether setup has been done, then nudge accordingly.
+    if not CANONICAL_CREDENTIALS_PATH.exists():
+        print(
+            "TotalReclaw is not set up yet. Run `totalreclaw setup` to create a recovery "
+            "phrase and initialise your encrypted vault.\n"
+        )
+    else:
+        print(
+            f"TotalReclaw is configured at {CANONICAL_CREDENTIALS_PATH}. "
+            "Run `totalreclaw doctor` to verify everything is healthy.\n"
+        )
+    parser.print_help()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/python/src/totalreclaw/embedding.py
+++ b/python/src/totalreclaw/embedding.py
@@ -12,6 +12,10 @@ No instruction prefix needed.
 """
 from __future__ import annotations
 
+import os
+import sys
+from pathlib import Path
+
 import numpy as np
 
 _session = None
@@ -19,6 +23,76 @@ _tokenizer = None
 
 MODEL_ID = "onnx-community/harrier-oss-v1-270m-ONNX"
 EMBEDDING_DIMS = 640
+
+# 2.3.1rc2 — approximate download size for the Harrier model + tokenizer.
+# Actual measured bytes land between 200-230 MB depending on HF revision;
+# we advertise 216 MB as the typical figure. The number isn't used for
+# any correctness logic, only for the pre-download banner.
+APPROX_MODEL_SIZE_MB = 216
+
+
+def _hf_cache_has_model() -> bool:
+    """Best-effort probe: does the HF hub cache already contain Harrier?
+
+    Returns True when the expected ``models--onnx-community--harrier-oss-v1-270m-ONNX``
+    directory exists under ``$HF_HOME/hub`` (or the default cache root).
+    False means the next hf_hub_download will fetch ~216 MB from HF.
+    """
+    try:
+        hf_home = Path(os.environ.get("HF_HOME", str(Path.home() / ".cache" / "huggingface")))
+        hub = hf_home / "hub"
+        if not hub.exists():
+            return False
+        candidate = hub / "models--onnx-community--harrier-oss-v1-270m-ONNX"
+        return candidate.exists()
+    except Exception:
+        return False
+
+
+def _emit_download_banner() -> None:
+    """Print a single-line banner BEFORE the (potentially slow) download.
+
+    Sent to stderr so piped stdout stays clean. Respects
+    ``TOTALRECLAW_QUIET_EMBEDDING_BANNER=1`` for silent mode (useful in
+    CI / tests that don't want the line noise).
+    """
+    if os.environ.get("TOTALRECLAW_QUIET_EMBEDDING_BANNER") == "1":
+        return
+    try:
+        sys.stderr.write(
+            f"\n[TotalReclaw] Downloading embedding model from HuggingFace "
+            f"(~{APPROX_MODEL_SIZE_MB} MB, one-time)…\n"
+        )
+        sys.stderr.flush()
+    except Exception:
+        pass
+
+
+def _emit_download_done() -> None:
+    if os.environ.get("TOTALRECLAW_QUIET_EMBEDDING_BANNER") == "1":
+        return
+    try:
+        sys.stderr.write("[TotalReclaw] Embedding model ready.\n\n")
+        sys.stderr.flush()
+    except Exception:
+        pass
+
+
+def _enable_hf_progress_bar() -> None:
+    """Turn on huggingface_hub's built-in tqdm progress bar.
+
+    HF defaults to NO progress output when stderr isn't a TTY. We force
+    it on so users see SOMETHING while 216 MB downloads. The bar itself
+    goes to stderr (tqdm default).
+    """
+    try:
+        from huggingface_hub.utils import enable_progress_bars
+
+        enable_progress_bars()
+    except Exception:
+        # Older huggingface_hub versions (<0.19) lack this helper. Tqdm
+        # is still used internally — we just can't force it.
+        pass
 
 
 def _ensure_loaded():
@@ -29,6 +103,13 @@ def _ensure_loaded():
     import onnxruntime as ort
     from transformers import AutoTokenizer
     from huggingface_hub import hf_hub_download
+
+    # 2.3.1rc2 — pre-download banner + progress bar. If the cache is
+    # already warm, this is a no-op (banner skipped, downloads short-circuit).
+    needs_download = not _hf_cache_has_model()
+    if needs_download:
+        _emit_download_banner()
+        _enable_hf_progress_bar()
 
     model_path = hf_hub_download(
         repo_id=MODEL_ID,
@@ -44,6 +125,9 @@ def _ensure_loaded():
     sess_options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
     _session = ort.InferenceSession(model_path, sess_options)
     _tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+
+    if needs_download:
+        _emit_download_done()
 
     return _session, _tokenizer
 

--- a/python/src/totalreclaw/hermes/SKILL.md
+++ b/python/src/totalreclaw/hermes/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: totalreclaw
+description: "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext. Python / Hermes edition."
+version: 2.3.1rc2
+author: TotalReclaw Team
+license: MIT
+homepage: https://totalreclaw.xyz
+---
+
+# TotalReclaw — Hermes Plugin Skill
+
+**This document is directive for agents, not user-facing copy.** Follow the rules in order; every rule is a hard `MUST` unless stated otherwise.
+
+## RULE 0 — Recovery-phrase handling (security boundary)
+
+The recovery phrase is the ONLY key to the user's encrypted memories. Every agent decision in this skill flows downstream from this rule.
+
+- **NEVER generate a 12-word phrase yourself.** You cannot produce a valid BIP-39 checksum; any phrase you invent is a garbage string that can't recover real memories. Call `totalreclaw_setup` (or the CLI wizard) — those paths use `eth_account.Account.create_with_mnemonic()` which produces real phrases.
+- **NEVER display a phrase in chat.** LLM providers log transcripts; any phrase in a reply leaks to every hop.
+- **NEVER echo back a phrase the user pastes.** If the user pastes one anyway, tell them: "That was pasted into chat — please delete the message immediately and use `totalreclaw setup --mode restore` in your terminal so the phrase stays on your machine."
+- **NEVER ask the user to paste their phrase.** Instead, direct them to run the CLI wizard.
+
+---
+
+## RULE 1 — On plugin load, check setup state
+
+Exactly one of these is true when your session starts:
+
+| State | Detection | Your action |
+|---|---|---|
+| Setup complete | `totalreclaw.agent.state.is_configured() == True` | Do nothing; memory tools are live. |
+| Setup pending | `is_configured() == False` (credentials.json missing/empty) | Proceed to RULE 1a. |
+
+### RULE 1a — Guide onboarding without leaking the phrase
+
+Call `totalreclaw_onboarding_start` (a pointer-only tool — returns a message, no secrets). The tool's return text contains two paths; relay them verbatim:
+
+1. **Terminal wizard (preferred when user has shell access):** `totalreclaw setup` — the wizard generates a phrase silently, saves it to `~/.totalreclaw/credentials.json` (mode 0600), and tells the user to retrieve it with `cat ~/.totalreclaw/credentials.json | jq -r .mnemonic`. The phrase never appears in your output or the user's chat.
+
+2. **Agent-driven tool (where available, e.g., OpenClaw):** call `totalreclaw_setup` — the tool does the same write + pointer, returns `scope_address` but never the phrase.
+
+If the user is on a remote machine without terminal access, use the pair flow (see RULE 5).
+
+---
+
+## RULE 2 — Auto-storage (`totalreclaw_remember`)
+
+When the user says something worth remembering, call `totalreclaw_remember` WITHOUT asking for permission. Candidates include:
+
+- Explicit memory requests: "remember X", "note that Y", "don't forget Z"
+- Stable preferences: "I prefer PostgreSQL", "I always deploy to Vercel"
+- Long-lived context: "I'm working on a React app called Foobar", "my manager is Alice"
+- Corrections to earlier facts: "actually, my location is Porto, not Lisbon"
+
+Do NOT store:
+- Ephemeral state visible only this turn
+- Things the user flagged as temporary ("just for this session")
+- Generic knowledge not about the user
+
+Schema:
+```python
+await client.remember(
+    text="Pedro lives in Porto, Portugal",
+    type="claim",         # or "preference" | "directive" | "commitment" | "episode" | "summary"
+    source="user",        # or "user-inferred" | "assistant" | "external" | "derived"
+    scope="personal",     # or "work" | "health" | "family" | "creative" | "finance" | "misc"
+    importance=7,         # 1-10 (int) or 0-1 (float, auto-normalized)
+)
+```
+
+---
+
+## RULE 3 — Recall (`totalreclaw_recall`)
+
+Call `totalreclaw_recall` when the user:
+
+- Asks "do you remember..." / "what did I tell you about..."
+- References past preferences, decisions, or history
+- Asks a question where prior context would help (e.g., "what's my default deploy target?")
+
+Use the user's natural phrasing as the `query`. Default `k=8` works well; bump to 20 for exhaustive searches (e.g., "list everything you know about me").
+
+**Start-of-session check (optional but recommended):** after RULE 1 passes, call `recall(query="")` with an empty-ish prompt or a broad term like `"user profile"` to surface the top memories before the user types their first real message. This lets you open with "hey Pedro, welcome back from Porto" rather than a cold hello.
+
+---
+
+## RULE 4 — Mutation tools
+
+### `totalreclaw_forget`
+
+When user says: "forget X", "delete the memory about Y", "remove Z from your memory".
+
+**Workflow:** if the user names the memory in natural language, FIRST call `totalreclaw_recall` with their phrase as the query, then pass the top result's `fact_id` to `totalreclaw_forget`. Never invent a fact_id; if you don't have one from recall, say so and ask the user to clarify which specific memory to delete.
+
+### `totalreclaw_pin` / `totalreclaw_unpin`
+
+When user says: "remember this permanently", "never forget that", "always keep", "this is important" → `pin`.
+When user says: "you can forget that", "it's no longer relevant" → `unpin`.
+
+Same recall-first workflow as forget: if no `fact_id`, recall first.
+
+### `totalreclaw_retype` (OpenClaw plugin 3.3.1-rc.2+)
+
+When user corrects a memory's category: "that's a preference, not a fact", "file this as a commitment instead of a claim". Valid types: `claim`, `preference`, `directive`, `commitment`, `episode`, `summary`. Recall first to find `fact_id`.
+
+### `totalreclaw_set_scope` (OpenClaw plugin 3.3.1-rc.2+)
+
+When user re-categorizes a memory's domain: "put that under work", "this is a health thing", "move this to personal". Valid scopes: `work`, `personal`, `health`, `family`, `creative`, `finance`, `misc`, `unspecified`. Recall first to find `fact_id`.
+
+---
+
+## RULE 5 — Remote setup (QR pair flow)
+
+If the user says they don't have terminal access (running Hermes on a remote VPS, inside Docker without exec, etc.), call the plugin-level `totalreclaw_pair` tool. The tool returns a URL + 6-digit PIN + ASCII QR code.
+
+Relay ALL THREE to the user verbatim:
+- Paste the URL in their phone browser (or scan the QR).
+- Type the PIN into the browser page when prompted.
+- The browser generates / accepts the recovery phrase and uploads it end-to-end encrypted.
+- Tell the user: "come back to chat when the browser says 'Pairing complete'."
+
+The phrase NEVER crosses chat. Even if the user insists, refuse to accept a pasted phrase and remind them of RULE 0.
+
+Hermes Python 2.3.1rc2 does not ship its own pair implementation — use the OpenClaw plugin tool when available, or fall back to directing the user to set up locally on another machine and `totalreclaw export` → paste into Hermes's `totalreclaw_restore` flow.
+
+---
+
+## RULE 6 — Status + billing
+
+When user asks "how many memories do I have?", "am I over my quota?", or anything about their TotalReclaw subscription: call `totalreclaw_status`. Returns `{ tier, quota, usage, resetsAt, upgradeUrl? }`.
+
+When user asks to upgrade: call `totalreclaw_upgrade`. Returns a Stripe checkout URL — paste it verbatim; never summarize it.
+
+---
+
+## RULE 7 — Import from other agents
+
+When user says "I used to use Mem0 / MCP Memory Server / ChatGPT Memory / Claude Projects / Gemini Memory / MemoClaw — can you bring those in?": call `totalreclaw_import_from`. Ask for the source name + API key (or file content) first. Use `dry_run=True` to preview before committing.
+
+Supported sources: `mem0`, `mcp-memory-server`, `chatgpt`, `claude`, `gemini`, `memoclaw`, `generic-json`, `generic-csv`.
+
+---
+
+## RULE 8 — Consolidate
+
+When user notices duplicates or says "clean up my memory": call `totalreclaw_consolidate` with `dry_run=True` first to show proposed merges. If user approves, call again with `dry_run=False` to commit.
+
+---
+
+## RULE 9 — Error handling
+
+- Tool returns `onboarding required`: re-run RULE 1 / RULE 1a.
+- Tool returns `quota exceeded`: call `totalreclaw_status` to confirm, then offer `totalreclaw_upgrade`.
+- Tool returns a generic error: surface the message, don't retry blindly — the backoff is inside the tool, not you.
+
+---
+
+## Memory Taxonomy v1 reference
+
+The on-chain v1 contract (as of plugin 3.0.0 / Hermes 2.3.0 / core 2.2.0):
+
+| Field | Required | Values |
+|---|---|---|
+| `text` | yes | 5-512 UTF-8 chars |
+| `type` | yes | `claim` / `preference` / `directive` / `commitment` / `episode` / `summary` |
+| `source` | yes | `user` / `user-inferred` / `assistant` / `external` / `derived` |
+| `scope` | no | `work` / `personal` / `health` / `family` / `creative` / `finance` / `misc` / `unspecified` |
+| `volatility` | no | `stable` / `updatable` / `ephemeral` |
+| `importance` | no | 1-10 (int) or 0-1 (float) |
+
+Retrieval v2 Tier 1 ranks user-sourced facts above assistant-sourced facts on tied BM25 + cosine scores. Use `source="user"` for verbatim user statements and `source="user-inferred"` when you're stating something the user implied but didn't say outright.

--- a/python/src/totalreclaw/hermes/cli.py
+++ b/python/src/totalreclaw/hermes/cli.py
@@ -199,6 +199,51 @@ def _write_credentials(credentials_path: Path, mnemonic: str) -> None:
         logger.debug("Could not chmod 0600 on %s", credentials_path, exc_info=True)
 
 
+def _try_eager_resolve_scope_address(credentials_path: Path, mnemonic: str, io: _IO) -> None:
+    """2.3.1rc2 — resolve the Smart Account address immediately after setup
+    and persist it back to credentials.json so status / doctor see the
+    real address instead of ``pending``. Best-effort; a missing network
+    is non-fatal.
+    """
+    try:
+        import asyncio
+
+        from totalreclaw.client import _derive_smart_account_address
+
+        try:
+            sa = asyncio.run(_derive_smart_account_address(mnemonic))
+        except RuntimeError:
+            # Already inside an event loop (rare but possible if the wizard is
+            # driven programmatically). Fall back to loop.run_until_complete.
+            loop = asyncio.new_event_loop()
+            try:
+                sa = loop.run_until_complete(_derive_smart_account_address(mnemonic))
+            finally:
+                loop.close()
+        if not sa:
+            return
+        # Merge into existing JSON, preserving any other fields.
+        try:
+            raw = credentials_path.read_text(encoding="utf-8")
+            data = json.loads(raw) if raw.strip() else {}
+        except Exception:
+            data = {"mnemonic": mnemonic}
+        if not isinstance(data, dict):
+            data = {"mnemonic": mnemonic}
+        data["scope_address"] = sa
+        credentials_path.write_text(json.dumps(data, indent=2))
+        try:
+            credentials_path.chmod(0o600)
+        except OSError:
+            pass
+        io.write(f"Smart Account address resolved: {sa}\n")
+    except Exception as err:
+        io.write_err(
+            f"Note: Smart Account address could not be resolved right now ({err}). "
+            "It will be derived on the first remember/recall call.\n"
+        )
+
+
 def _last_n_words(mnemonic: str, n: int = 3) -> list[str]:
     return mnemonic.split()[-n:]
 
@@ -286,11 +331,31 @@ def _run_restore(io: _IO, credentials_path: Path) -> int:
         f"\nAccount restored. Credentials saved to {credentials_path} "
         "(mode 0600).\nMemory tools are now active in Hermes.\n"
     )
+    # 2.3.1rc2: eager Smart Account resolution — caches the address so
+    # subsequent status/doctor calls show the real value, not ``pending``.
+    _try_eager_resolve_scope_address(credentials_path, phrase, io)
     return 0
 
 
-def _run_generate(io: _IO, credentials_path: Path) -> int:
-    """Interactive generate flow. Returns exit code."""
+def _run_generate(io: _IO, credentials_path: Path, emit_phrase: bool = False) -> int:
+    """Interactive generate flow. Returns exit code.
+
+    Parameters
+    ----------
+    emit_phrase : bool
+        When True (``--emit-phrase`` power-user flag), display the phrase
+        in a 4x3 grid on stderr before asking for confirmation. This
+        matches the rc.1 behaviour.
+
+        When False (default for 2.3.1rc2), do NOT display the phrase at
+        all. The user is instead pointed at the credentials.json file
+        and told how to retrieve it with ``cat ... | jq -r .mnemonic``.
+
+    2.3.1rc2 rationale: Pedro's agent flagged that printing the phrase
+    to stdout is ironic for a "secrets management" product — any
+    terminal-recording tool, screen-share, or shoulder-surfer defeats
+    the end-to-end encryption promise. Default is silent-save + pointer.
+    """
     try:
         mnemonic = _generate_mnemonic()
     except Exception as e:
@@ -303,41 +368,45 @@ def _run_generate(io: _IO, credentials_path: Path) -> int:
         )
         return 2
 
-    # STORAGE_GUIDANCE copy — print BEFORE showing the phrase so the
-    # user reads the handling rules before they're tempted to screenshot.
+    # STORAGE_GUIDANCE copy — print regardless of emit-phrase, so the
+    # user understands the handling rules.
     io.write("\n" + STORAGE_GUIDANCE + "\n")
 
-    # Phrase banner to stderr — keeps it out of `hermes setup > out.txt`.
-    io.write_err("\nYour recovery phrase (WRITE THIS DOWN):\n\n")
-    # Render as a 4x3 grid, numbered.
-    for row in range(3):
-        cells = []
-        for col in range(4):
-            idx = row * 4 + col
-            cells.append(f"{idx + 1:>2}. {words[idx]:<12}")
-        io.write_err("  " + "".join(cells) + "\n")
-    io.write_err("\n")
-
-    # Last-3-words confirmation challenge — matches the plugin's
-    # "retype probe words" pattern, simplified to the tail 3 since
-    # users typically write the phrase top-to-bottom.
-    io.write(
-        "Before we save, type the LAST 3 words of your phrase "
-        "(space-separated) to confirm you wrote it down:\n> "
-    )
-    try:
-        typed = io.stdin.readline().rstrip("\r\n").strip().lower()
-    except Exception:
-        typed = ""
-
-    expected = " ".join(_last_n_words(mnemonic, 3))
-    if typed != expected:
+    if emit_phrase:
+        # Power-user opt-in path. Display the phrase in a 4x3 grid on
+        # stderr + demand last-3-words confirmation (prevents accidental
+        # runs where the user didn't actually transcribe the phrase).
         io.write_err(
-            "\nWord mismatch. No credentials have been written. "
-            "Write the phrase down carefully and re-run `hermes setup`.\n"
+            "\n⚠ --emit-phrase enabled — the recovery phrase will be VISIBLE in this terminal.\n"
+            "   Ensure no one can see your screen and no recording software is active.\n"
         )
-        return 1
+        io.write_err("\nYour recovery phrase (WRITE THIS DOWN NOW):\n\n")
+        for row in range(3):
+            cells = []
+            for col in range(4):
+                idx = row * 4 + col
+                cells.append(f"{idx + 1:>2}. {words[idx]:<12}")
+            io.write_err("  " + "".join(cells) + "\n")
+        io.write_err("\n")
 
+        io.write(
+            "Before we save, type the LAST 3 words of your phrase "
+            "(space-separated) to confirm you wrote it down:\n> "
+        )
+        try:
+            typed = io.stdin.readline().rstrip("\r\n").strip().lower()
+        except Exception:
+            typed = ""
+
+        expected = " ".join(_last_n_words(mnemonic, 3))
+        if typed != expected:
+            io.write_err(
+                "\nWord mismatch. No credentials have been written. "
+                "Write the phrase down carefully and re-run `hermes setup --emit-phrase`.\n"
+            )
+            return 1
+
+    # Silent-save path (default): persist without ever showing the phrase.
     try:
         _write_credentials(credentials_path, mnemonic)
     except OSError as e:
@@ -346,9 +415,17 @@ def _run_generate(io: _IO, credentials_path: Path) -> int:
 
     io.write("\n" + GENERATED_CONFIRMATION + "\n")
     io.write(
-        f"\nCredentials saved to {credentials_path} (mode 0600). "
-        "Memory tools are now active in Hermes.\n"
+        f"\n✓ Recovery phrase generated. Saved to {credentials_path} (mode 0600).\n"
     )
+    if not emit_phrase:
+        io.write(
+            f"  Retrieve it with:\n"
+            f"      cat {credentials_path} | jq -r .mnemonic\n"
+            f"  ⚠ STORE IT SAFELY — it's the only way to recover your vault.\n"
+        )
+    io.write("  Memory tools are now active in Hermes.\n")
+    # 2.3.1rc2: eager Smart Account resolution — same rationale as _run_restore.
+    _try_eager_resolve_scope_address(credentials_path, mnemonic, io)
     return 0
 
 
@@ -360,6 +437,7 @@ def _run_generate(io: _IO, credentials_path: Path) -> int:
 def run_setup(
     credentials_path: Optional[Path] = None,
     io: Optional[_IO] = None,
+    emit_phrase: bool = False,
 ) -> int:
     """Run the interactive setup wizard. Returns exit code.
 
@@ -369,6 +447,11 @@ def run_setup(
         Override for tests. Defaults to ``CANONICAL_CREDENTIALS_PATH``.
     io : _IO, optional
         Pre-built IO adapter. Defaults to stdin/stdout/stderr.
+    emit_phrase : bool
+        When True, passes ``emit_phrase=True`` to ``_run_generate`` so
+        the phrase is displayed on stderr (rc.1 behaviour). Default
+        False in 2.3.1rc2 — the phrase is never shown and the user is
+        pointed at credentials.json instead.
     """
     path = credentials_path if credentials_path is not None else CANONICAL_CREDENTIALS_PATH
     wizard_io = io if io is not None else _IO()
@@ -389,7 +472,7 @@ def run_setup(
     if branch == "restore":
         return _run_restore(wizard_io, path)
     if branch == "generate":
-        return _run_generate(wizard_io, path)
+        return _run_generate(wizard_io, path, emit_phrase=emit_phrase)
 
     wizard_io.write_err(
         "\nUnrecognised choice. Expected 'restore' or 'generate'. Aborting.\n"
@@ -424,11 +507,26 @@ def main(argv: Optional[list[str]] = None) -> int:
         default=None,
         help="Override the credentials file location (default: ~/.totalreclaw/credentials.json).",
     )
+    sp_setup.add_argument(
+        "--emit-phrase",
+        action="store_true",
+        default=False,
+        help=(
+            "POWER-USER OPT-IN. Display the generated recovery phrase in the terminal "
+            "on stderr (useful for automation / immediate-transcription workflows). "
+            "Default: silent-save — the phrase is written to credentials.json and "
+            "NOT shown to avoid accidental capture in terminal recordings, screenshots, "
+            "or shared screens."
+        ),
+    )
 
     args = parser.parse_args(argv)
 
     if args.command == "setup":
-        return run_setup(credentials_path=args.credentials_path)
+        return run_setup(
+            credentials_path=args.credentials_path,
+            emit_phrase=getattr(args, "emit_phrase", False),
+        )
 
     parser.print_help()
     return 0

--- a/python/src/totalreclaw/hermes/plugin.yaml
+++ b/python/src/totalreclaw/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: totalreclaw
-version: 2.3.1
+version: 2.3.1rc2
 description: End-to-end encrypted memory vault for AI agents (Memory Taxonomy v1)
 author: TotalReclaw Team
 provides_tools:
@@ -15,6 +15,7 @@ provides_tools:
   - totalreclaw_import_batch
   - totalreclaw_upgrade
   - totalreclaw_debrief
+  - totalreclaw_onboarding_start
 provides_hooks:
   - on_session_start
   - pre_llm_call

--- a/python/src/totalreclaw/onboarding.py
+++ b/python/src/totalreclaw/onboarding.py
@@ -79,10 +79,10 @@ BRANCH_QUESTION = """
 Let's set up your account. Do you already have a recovery phrase, or should we generate a new one?
 """.strip()
 
-LOCAL_MODE_INSTRUCTIONS = "Run: hermes setup"
+LOCAL_MODE_INSTRUCTIONS = "Run: totalreclaw setup  (or: hermes setup)"
 
 REMOTE_MODE_INSTRUCTIONS = """
-Run: hermes setup
+Run: totalreclaw setup  (or: hermes setup if you're on a Hermes-specific install)
 
 You'll be prompted to either restore from an existing recovery phrase or generate a new one. Your phrase never leaves this machine.
 """.strip()

--- a/python/tests/test_hermes_setup_cli.py
+++ b/python/tests/test_hermes_setup_cli.py
@@ -132,15 +132,13 @@ class TestRestoreFlow:
 
 
 class TestGenerateFlow:
-    def test_happy_path(self, tmp_path: Path) -> None:
-        """Generate + confirm last-3-words → file written + banners printed."""
+    def test_happy_path_silent(self, tmp_path: Path) -> None:
+        """2.3.1rc2 default: generate → file written, phrase NOT shown, no confirmation prompt."""
         creds = tmp_path / "credentials.json"
 
-        # Mock the mnemonic generator so the test is deterministic.
         fake_mnem = VALID_MNEMONIC
-        last3 = " ".join(fake_mnem.split()[-3:])
-
-        stdin_text = f"generate\n{last3}\n"
+        # No retype needed in silent mode — just pick the generate branch.
+        stdin_text = "generate\n"
         io, stdout, stderr = _make_io(stdin_text)
 
         with patch.object(hermes_cli, "_generate_mnemonic", return_value=fake_mnem):
@@ -154,21 +152,56 @@ class TestGenerateFlow:
         out = stdout.getvalue()
         err = stderr.getvalue()
 
-        # STORAGE_GUIDANCE must appear in stdout BEFORE the phrase is shown.
         from totalreclaw.onboarding import STORAGE_GUIDANCE, GENERATED_CONFIRMATION
 
         assert STORAGE_GUIDANCE in out
         assert GENERATED_CONFIRMATION in out
-        # Confirmation banner includes "write it down" copy.
-        assert "write it down" in out.lower()
 
-        # Phrase goes to STDERR not STDOUT — key security invariant.
-        assert fake_mnem.split()[0] in err  # first word printed to stderr
-        # Phrase is NOT in stdout.
+        # 2.3.1rc2: phrase is NOT echoed to stdout OR stderr in default mode.
         assert fake_mnem not in out
+        assert fake_mnem not in err
+        # Individual words also absent (defensive — catches partial prints).
+        assert fake_mnem.split()[0] not in err
+        # Pointer to credentials.json retrieval is present.
+        assert "cat" in out and "jq" in out and "mnemonic" in out
+        # Warning that the phrase must be stored safely.
+        assert "store" in out.lower() and "safely" in out.lower()
 
-    def test_wrong_confirmation_rejects(self, tmp_path: Path) -> None:
-        """Mistyped last-3-words → non-zero exit + no file written."""
+    def test_emit_phrase_opt_in(self, tmp_path: Path) -> None:
+        """`--emit-phrase` (2.3.1rc2 opt-in) → phrase shown on stderr + last-3-words confirmation."""
+        creds = tmp_path / "credentials.json"
+
+        fake_mnem = VALID_MNEMONIC
+        last3 = " ".join(fake_mnem.split()[-3:])
+
+        stdin_text = f"generate\n{last3}\n"
+        io, stdout, stderr = _make_io(stdin_text)
+
+        with patch.object(hermes_cli, "_generate_mnemonic", return_value=fake_mnem):
+            rc = hermes_cli.run_setup(credentials_path=creds, io=io, emit_phrase=True)
+
+        assert rc == 0, stderr.getvalue()
+        assert creds.exists()
+        saved = json.loads(creds.read_text())
+        assert saved["mnemonic"] == fake_mnem
+
+        out = stdout.getvalue()
+        err = stderr.getvalue()
+
+        from totalreclaw.onboarding import STORAGE_GUIDANCE, GENERATED_CONFIRMATION
+
+        assert STORAGE_GUIDANCE in out
+        assert GENERATED_CONFIRMATION in out
+
+        # Phrase words appear in STDERR (opt-in behaviour).
+        assert fake_mnem.split()[0] in err
+        # Phrase is NOT in stdout regardless of opt-in.
+        assert fake_mnem not in out
+        # Opt-in warning about terminal visibility is present.
+        assert "visible" in err.lower() or "visible" in out.lower()
+
+    def test_emit_phrase_wrong_confirmation_rejects(self, tmp_path: Path) -> None:
+        """With --emit-phrase, mistyped last-3-words → non-zero exit + no file written."""
         creds = tmp_path / "credentials.json"
         fake_mnem = VALID_MNEMONIC
 
@@ -176,23 +209,21 @@ class TestGenerateFlow:
         io, stdout, stderr = _make_io(stdin_text)
 
         with patch.object(hermes_cli, "_generate_mnemonic", return_value=fake_mnem):
-            rc = hermes_cli.run_setup(credentials_path=creds, io=io)
+            rc = hermes_cli.run_setup(credentials_path=creds, io=io, emit_phrase=True)
 
         assert rc != 0
         assert not creds.exists()
         assert "mismatch" in stderr.getvalue().lower()
-        # GENERATED_CONFIRMATION must NOT be printed on failure.
         from totalreclaw.onboarding import GENERATED_CONFIRMATION
 
         assert GENERATED_CONFIRMATION not in stdout.getvalue()
 
-    def test_non_tty_generate_still_works(self, tmp_path: Path) -> None:
-        """Generate flow tolerates non-TTY stdin (scripted installers)."""
+    def test_non_tty_generate_silent_still_works(self, tmp_path: Path) -> None:
+        """Generate flow (default silent mode) tolerates non-TTY stdin."""
         creds = tmp_path / "credentials.json"
         fake_mnem = VALID_MNEMONIC
-        last3 = " ".join(fake_mnem.split()[-3:])
 
-        stdin_text = f"generate\n{last3}\n"
+        stdin_text = "generate\n"
         io, _stdout, _stderr = _make_io(stdin_text, is_tty=False)
 
         with patch.object(hermes_cli, "_generate_mnemonic", return_value=fake_mnem):
@@ -263,4 +294,12 @@ class TestMainEntry:
         with patch.object(hermes_cli, "run_setup", return_value=0) as m:
             rc = hermes_cli.main(["setup", "--credentials-path", str(creds)])
         assert rc == 0
-        m.assert_called_once_with(credentials_path=creds)
+        m.assert_called_once_with(credentials_path=creds, emit_phrase=False)
+
+    def test_main_setup_emit_phrase_forwarded(self, tmp_path: Path) -> None:
+        """`hermes setup --emit-phrase` forwards the flag to run_setup."""
+        creds = tmp_path / "c.json"
+        with patch.object(hermes_cli, "run_setup", return_value=0) as m:
+            rc = hermes_cli.main(["setup", "--credentials-path", str(creds), "--emit-phrase"])
+        assert rc == 0
+        m.assert_called_once_with(credentials_path=creds, emit_phrase=True)

--- a/python/tests/test_onboarding.py
+++ b/python/tests/test_onboarding.py
@@ -222,12 +222,18 @@ class TestCopyConstants:
         assert "generate" in q.lower()
 
     def test_local_instructions(self) -> None:
-        assert onboarding.LOCAL_MODE_INSTRUCTIONS == "Run: hermes setup"
+        # 2.3.1rc2: LOCAL_MODE_INSTRUCTIONS now mentions both `totalreclaw setup`
+        # (standalone CLI added in rc.2) and `hermes setup` (Hermes-specific).
+        assert "totalreclaw setup" in onboarding.LOCAL_MODE_INSTRUCTIONS
+        assert "hermes setup" in onboarding.LOCAL_MODE_INSTRUCTIONS
+        assert onboarding.LOCAL_MODE_INSTRUCTIONS.startswith("Run: ")
 
     def test_remote_instructions_contents(self) -> None:
         r = onboarding.REMOTE_MODE_INSTRUCTIONS
         assert r == r.strip()
-        assert "Run: hermes setup" in r
+        # 2.3.1rc2: now mentions both totalreclaw setup and hermes setup.
+        assert "totalreclaw setup" in r
+        assert "hermes setup" in r
         # The load-bearing security claim.
         assert "never leaves this machine" in r
 

--- a/python/tests/test_totalreclaw_cli.py
+++ b/python/tests/test_totalreclaw_cli.py
@@ -1,0 +1,117 @@
+"""Tests for the standalone `totalreclaw` CLI (added 2.3.1rc2).
+
+Covers:
+- `totalreclaw` (no subcommand) prints help + returns 0.
+- `totalreclaw setup` delegates to hermes_cli.run_setup with emit_phrase plumbed through.
+- `totalreclaw doctor` returns 2 when no credentials file (fast-path "setup first").
+- `totalreclaw doctor` returns 0 or 1 when credentials exist (depending on checks).
+- `totalreclaw doctor` detects a corrupt credentials.json and returns 2.
+- `totalreclaw doctor` validates BIP-39 mnemonic and flags invalid ones.
+
+Network-touching checks (SA derivation, relay health probe) are best-effort
+and won't fail the test run when offline — the doctor degrades gracefully.
+"""
+from __future__ import annotations
+
+import json
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from totalreclaw import cli as tr_cli
+
+
+# A canonical 12-word test vector with a valid BIP-39 checksum.
+VALID_MNEMONIC = (
+    "abandon abandon abandon abandon abandon abandon "
+    "abandon abandon abandon abandon abandon about"
+)
+
+
+class TestMainEntry:
+    def test_no_subcommand_prints_help(self, capsys) -> None:
+        """`totalreclaw` with no subcommand prints a helpful message."""
+        rc = tr_cli.main([])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "totalreclaw" in captured.out.lower()
+
+    def test_setup_forwards_to_hermes_run_setup(self, tmp_path: Path) -> None:
+        """`totalreclaw setup --credentials-path <p>` → hermes_cli.run_setup."""
+        creds = tmp_path / "credentials.json"
+        with patch("totalreclaw.hermes.cli.run_setup", return_value=0) as m:
+            rc = tr_cli.main(["setup", "--credentials-path", str(creds)])
+        assert rc == 0
+        m.assert_called_once()
+        args, kwargs = m.call_args
+        assert kwargs.get("credentials_path") == creds
+        assert kwargs.get("emit_phrase") is False
+
+    def test_setup_emit_phrase_forwarded(self, tmp_path: Path) -> None:
+        """`totalreclaw setup --emit-phrase` forwards the flag."""
+        creds = tmp_path / "credentials.json"
+        with patch("totalreclaw.hermes.cli.run_setup", return_value=0) as m:
+            rc = tr_cli.main(["setup", "--credentials-path", str(creds), "--emit-phrase"])
+        assert rc == 0
+        args, kwargs = m.call_args
+        assert kwargs.get("emit_phrase") is True
+
+
+class TestDoctor:
+    def test_no_credentials_returns_2(self, tmp_path: Path, capsys) -> None:
+        """Missing credentials file → exit 2 + prompt to run setup."""
+        creds = tmp_path / "does-not-exist.json"
+        rc = tr_cli.run_doctor(credentials_path=creds)
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert "totalreclaw setup" in captured.out.lower()
+
+    def test_corrupt_credentials_returns_2(self, tmp_path: Path, capsys) -> None:
+        """credentials.json that doesn't parse → exit 2 (setup-level failure)."""
+        creds = tmp_path / "credentials.json"
+        creds.write_text("this is not json at all")
+        rc = tr_cli.run_doctor(credentials_path=creds)
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert "corrupt" in captured.out.lower() or "fail" in captured.out.lower()
+
+    def test_valid_mnemonic_progresses_past_parse(self, tmp_path: Path, capsys) -> None:
+        """Valid credentials → doctor progresses past the parse check to the rest."""
+        creds = tmp_path / "credentials.json"
+        creds.write_text(json.dumps({"mnemonic": VALID_MNEMONIC}))
+
+        # We don't care about the exit code here (network/LLM checks may
+        # produce warnings). What matters: the mnemonic check passes.
+        rc = tr_cli.run_doctor(credentials_path=creds)
+        assert rc in (0, 1)  # NOT 2 — setup is complete.
+        captured = capsys.readouterr()
+        assert "valid BIP-39" in captured.out
+
+    def test_invalid_mnemonic_flagged(self, tmp_path: Path, capsys) -> None:
+        """Garbage mnemonic → doctor flags it but still progresses."""
+        creds = tmp_path / "credentials.json"
+        creds.write_text(json.dumps({"mnemonic": "not really a real phrase here at all just words"}))
+
+        rc = tr_cli.run_doctor(credentials_path=creds)
+        assert rc in (0, 1)
+        captured = capsys.readouterr()
+        assert "validation failed" in captured.out.lower() or "fail" in captured.out.lower()
+
+    def test_cached_scope_address_surfaced(self, tmp_path: Path, capsys) -> None:
+        """A pre-cached scope_address is shown in doctor output."""
+        creds = tmp_path / "credentials.json"
+        creds.write_text(
+            json.dumps(
+                {
+                    "mnemonic": VALID_MNEMONIC,
+                    "scope_address": "0x1234567890abcdef1234567890abcdef12345678",
+                }
+            )
+        )
+        rc = tr_cli.run_doctor(credentials_path=creds)
+        assert rc in (0, 1)
+        captured = capsys.readouterr()
+        assert "0x1234567890abcdef1234567890abcdef12345678" in captured.out.lower() or \
+               "0x1234567890abcdef1234567890abcdef12345678" in captured.out

--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,125 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1-rc.2] — 2026-04-22
+
+Follow-up RC for the 3.3.1-rc.1 QA NO-GO
+(`docs/notes/QA-plugin-3.3.1-rc.1-20260422-0121.md` in
+`totalreclaw-internal`). Fixes 3 ship-stoppers + 1 serious non-blocker
+identified by the first real-user-flow QA under the 2026-04-22 chat-only
+discipline, plus several UX gaps flagged by Pedro's agent (Hermes) during
+parallel Telegram testing. All 3.3.1-rc.1 provider-agnostic LLM work is
+preserved.
+
+### Changed
+
+- **`gateway-url.ts` — drop `child_process` subprocess probe.** The rc.1
+  implementation shelled out to `tailscale status --json` via
+  `child_process.execFileSync` to discover the local MagicDNS hostname.
+  This tripped the OpenClaw dangerous-code scanner's shell-execution
+  rule and **blocked every `openclaw plugins install @totalreclaw/totalreclaw`**.
+  rc.2 swaps to a passive probe: `os.networkInterfaces()` detects a
+  `tailscale*` NIC carrying a CGNAT IPv4 (100.64/10), and we surface
+  the raw IP as the auto-detected host. Operators who want a proper
+  `https://<magicdns>.ts.net` URL now set
+  `plugins.entries.totalreclaw.config.publicUrl` explicitly (documented
+  in SKILL.md). The six-layer URL cascade is otherwise unchanged.
+
+- **`check-scanner.mjs` — add shell-execution rule (catches `child_process`).**
+  Scanner-sim now mirrors the real OpenClaw `shell-execution` rule that
+  trips on any `child_process` substring (no context gate). Prevents a
+  repeat of the rc.1 regression. See `skill/scripts/check-scanner.mjs`
+  SHELL_EXEC_PATTERN.
+
+- **`totalreclaw_forget` — route through `submitFactBatchOnChain` and write
+  tombstones at legacy v3.** The rc.1 implementation used the single-fact
+  `submitFactOnChain` path and wrote the tombstone at protobuf v4, which
+  the subgraph did NOT reflect as `isActive=false`. rc.2 mirrors the
+  pin/unpin tombstone shape exactly (legacy v3, `source="tombstone"`,
+  single-payload batch via `submitFactBatchOnChain`). Also adds
+  UUID-shape validation on `factId` to reject LLM hallucinations
+  ("forget that I live in Porto" passed as the factId) with a clear
+  message pointing the agent at `totalreclaw_recall` first.
+
+- **`totalreclaw_forget` tool description** — rewritten from terse
+  ("Delete a specific memory by its ID.") to agent-instructive with a
+  recall-first workflow hint. Fixes the rc.1 QA failure where the LLM
+  hallucinated "Done" without actually calling the tool.
+
+- **`chatCompletion` — exponential-backoff retry for 429 / timeouts.**
+  rc.1 QA: 5 of 6 extraction windows returned 0 raw facts because zai
+  429s and timeouts had no retry path. rc.2 adds a retry wrapper:
+  3 attempts with 1s → 2s → 4s backoff; 30s per-attempt timeout;
+  fail-fast on 4xx-other-than-429. Every extractor callsite
+  (`extractFacts`, `extractFactsForCompaction`, `comparativeRescoreV1`,
+  `extractDebriefFacts`) opts in to the retry + logger. See
+  `isRetryable()` for the classification list.
+
+- **`llm-profile-reader.ts` — fallback to legacy `models.json` format.**
+  rc.1 QA VPS had `~/.openclaw/agents/<agent>/agent/models.json` (the
+  pre-auth-profiles shape, `{ providers: { zai: { apiKey: "..." } } }`)
+  not `auth-profiles.json`. The auto-resolve silently no-op'd.
+  rc.2 adds a 5th cascade tier: `readAllProfileKeys` reads
+  auth-profiles.json FIRST (takes precedence on overlap), then merges
+  in models.json entries for any provider not already covered.
+
+### Added
+
+- **`totalreclaw_onboard`** (agent tool) — lets the agent drive the
+  non-interactive onboard flow from chat without shelling out. Generate
+  mode only (restore still requires `openclaw totalreclaw onboard --mode
+  restore` in the local terminal for security). Returns scope address +
+  credentials path; NEVER returns the mnemonic. Directly wraps
+  `runNonInteractiveOnboard` in-process.
+
+- **`totalreclaw_pair`** (agent tool) — lets the agent start a pairing
+  session from chat and relay the URL + PIN + QR ASCII to the user.
+  Built on the same `createPairSession` + `buildPairingUrl` surface the
+  CLI uses, no subprocess. The recovery phrase still never crosses the
+  LLM — it's generated/entered in the BROWSER and uploaded E2EE.
+
+- **`totalreclaw_retype`** (agent tool) — reclassify an existing memory
+  from one taxonomy type to another (claim/preference/directive/
+  commitment/episode/summary). Writes a new v1.1 claim with the updated
+  type, tombstones the old fact on-chain. rc.1 QA confirmed this tool
+  was documented in SKILL.md but NOT registered — agents couldn't call
+  it.
+
+- **`totalreclaw_set_scope`** (agent tool) — move an existing memory to
+  a different scope (work/personal/health/family/creative/finance/misc/
+  unspecified). Same write pattern as retype. Also previously
+  documented-not-registered; rc.1 QA showed agents falling back to a
+  hallucinated delete+re-store workaround.
+
+- **`skill/plugin/retype-setscope.ts`** — new pure-logic module
+  supporting the two agent tools above. Tightly mirrors pin.ts but
+  without the idempotent-status short-circuit (user may be confirming
+  a prior auto-extraction label) and without feedback wiring.
+
+- **`skill/plugin/gateway-url.test.ts`** — unit coverage for the new
+  passive Tailscale + LAN detection. 17 cases, all green.
+
+- **`skill/plugin/retype-setscope.test.ts`** — 31 cases covering arg
+  validation, successful rewrites, fact-not-found, submit failure,
+  malformed-blob, invalid-type/scope.
+
+- **`skill/plugin/llm-client-retry.test.ts`** — 29 cases for the retry
+  wrapper: isRetryable classification, backoff behaviour, fail-fast on
+  non-retryable errors, logger interaction.
+
+- **`skill/plugin/llm-profile-reader.test.ts`** — 13 additional cases
+  for models.json parsing + combined reader.
+
+### Preserved from rc.1
+
+All the rc.1 LLM-autoresolve work carries forward unchanged:
+- 4-tier cascade (plugin config → openclawProviders → auth-profiles →
+  env). With rc.2's `models.json` fallback it's effectively 5 tiers.
+- `openclaw totalreclaw onboard --non-interactive --json --mode` CLI.
+- `openclaw totalreclaw pair generate --json` CLI.
+- `extraction.llm` plugin-config override block.
+- Synchronous HTTP-route registration, manifest `kind` drop, etc.
+
 ## [3.3.1-rc.1] — 2026-04-22
 
 First release candidate for 3.3.1. Comprehensive patch release addressing

--- a/skill/plugin/extractor.ts
+++ b/skill/plugin/extractor.ts
@@ -754,7 +754,12 @@ export async function extractFactsForCompaction(
     response = await chatCompletion(config, [
       { role: 'system', content: COMPACTION_SYSTEM_PROMPT },
       { role: 'user', content: userPrompt },
-    ]);
+    ], {
+      // 3.3.1-rc.2: retry transient 429 / timeout (same policy as extractFacts).
+      retry: { attempts: 3, baseDelayMs: 1000 },
+      timeoutMs: 30_000,
+      logger,
+    });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     logger?.warn?.(`extractFactsForCompaction: chatCompletion threw: ${msg}`);
@@ -907,7 +912,11 @@ export async function extractDebrief(
     const response = await chatCompletion(config, [
       { role: 'system', content: systemPrompt },
       { role: 'user', content: `Review this conversation and provide a debrief:\n\n${conversationText}` },
-    ]);
+    ], {
+      // 3.3.1-rc.2: retry transient 429 / timeout.
+      retry: { attempts: 3, baseDelayMs: 1000 },
+      timeoutMs: 30_000,
+    });
 
     if (!response) return [];
     return parseDebriefResponse(response);
@@ -1313,7 +1322,14 @@ export async function comparativeRescoreV1(
     response = await chatCompletion(config, [
       { role: 'system', content: COMPARATIVE_PROMPT_V1 },
       { role: 'user', content: userPrompt },
-    ]);
+    ], {
+      // 3.3.1-rc.2: retry transient 429 / timeout (rescore is an inner
+      // call after extractFacts — if extraction backs off successfully
+      // the rescore usually also passes on first try, but keep symmetry).
+      retry: { attempts: 3, baseDelayMs: 1000 },
+      timeoutMs: 30_000,
+      logger,
+    });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     logger?.warn?.(`comparativeRescoreV1: chatCompletion threw: ${msg}`);
@@ -1422,7 +1438,15 @@ export async function extractFacts(
     response = await chatCompletion(config, [
       { role: 'system', content: systemPrompt },
       { role: 'user', content: userPrompt },
-    ]);
+    ], {
+      // 3.3.1-rc.2: the headline fix for the rc.1 QA NO-GO — 5/6 extraction
+      // windows failed on zai 429 + timeouts with no retry. 3 attempts with
+      // 1s → 2s → 4s backoff recovers virtually all transient rate-limit
+      // hiccups. Graceful timeout: per-attempt 30s, total worst-case 30+1+30+2+30+4≈97s.
+      retry: { attempts: 3, baseDelayMs: 1000 },
+      timeoutMs: 30_000,
+      logger,
+    });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     logger?.warn?.(`extractFacts: chatCompletion threw: ${msg}`);

--- a/skill/plugin/gateway-url.test.ts
+++ b/skill/plugin/gateway-url.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Tests for gateway-url.ts — 3.3.1-rc.2 passive host autodetect.
+ *
+ * Covers:
+ *   - detectTailscaleHost picks CGNAT IPv4 on tailscale* NIC
+ *   - detectTailscaleHost ignores non-tailscale NICs
+ *   - detectTailscaleHost ignores non-CGNAT IPv4 on tailscale* NIC
+ *   - detectLanHost picks first physical IPv4, skips virtual NICs
+ *   - detectGatewayHost prefers Tailscale over LAN when both present
+ *   - detectGatewayHost falls through to null when nothing is available
+ *   - No subprocess execution / no network I/O used (enforced by
+ *     check-scanner.mjs child-process rule on this file + code-read)
+ *
+ * Run with: npx tsx gateway-url.test.ts
+ */
+
+import type os from 'node:os';
+import { detectTailscaleHost, detectLanHost, detectGatewayHost } from './gateway-url.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond: boolean, name: string): void {
+  const n = passed + failed + 1;
+  if (cond) {
+    console.log(`ok ${n} - ${name}`);
+    passed++;
+  } else {
+    console.log(`not ok ${n} - ${name}`);
+    failed++;
+  }
+}
+
+function fakeNetifs(
+  nifs: NodeJS.Dict<os.NetworkInterfaceInfo[]>,
+): () => NodeJS.Dict<os.NetworkInterfaceInfo[]> {
+  return () => nifs;
+}
+
+// Helper: build a NetworkInterfaceInfo record without pulling the real types.
+function iface(addr: string, family: 'IPv4' | 'IPv6', internal = false): os.NetworkInterfaceInfo {
+  return {
+    address: addr,
+    netmask: '255.255.255.0',
+    family,
+    mac: '00:00:00:00:00:00',
+    internal,
+    cidr: `${addr}/24`,
+  } as os.NetworkInterfaceInfo;
+}
+
+// ---------------------------------------------------------------------------
+// detectTailscaleHost
+// ---------------------------------------------------------------------------
+
+{
+  const result = detectTailscaleHost({
+    networkInterfaces: fakeNetifs({
+      lo0: [iface('127.0.0.1', 'IPv4', true)],
+      tailscale0: [iface('100.64.5.12', 'IPv4')],
+    }),
+  });
+  assert(result !== null && result.kind === 'tailscale', 'tailscale: CGNAT IP on tailscale0 detected');
+  assert(result?.host === '100.64.5.12', 'tailscale: host = CGNAT IPv4');
+  assert(result?.tls === false, 'tailscale: tls=false (no MagicDNS, use gateway tls config)');
+  assert(typeof result?.note === 'string' && result!.note!.includes('CGNAT'), 'tailscale: note mentions CGNAT');
+}
+
+{
+  // tailscale NIC present but IP is NOT in CGNAT range
+  const result = detectTailscaleHost({
+    networkInterfaces: fakeNetifs({
+      tailscale0: [iface('192.168.1.1', 'IPv4')],
+    }),
+  });
+  assert(result === null, 'tailscale: non-CGNAT IP on tailscale0 ignored');
+}
+
+{
+  // No tailscale NIC
+  const result = detectTailscaleHost({
+    networkInterfaces: fakeNetifs({
+      eth0: [iface('192.168.1.10', 'IPv4')],
+      en0: [iface('100.64.5.12', 'IPv4')], // CGNAT but wrong NIC
+    }),
+  });
+  assert(result === null, 'tailscale: CGNAT on non-tailscale NIC ignored');
+}
+
+{
+  // Upper boundary of CGNAT
+  const result = detectTailscaleHost({
+    networkInterfaces: fakeNetifs({
+      tailscale1: [iface('100.127.255.254', 'IPv4')],
+    }),
+  });
+  assert(result !== null && result.host === '100.127.255.254', 'tailscale: CGNAT upper boundary (100.127.x.x) accepted');
+}
+
+{
+  // Just outside CGNAT
+  const result = detectTailscaleHost({
+    networkInterfaces: fakeNetifs({
+      tailscale0: [iface('100.128.0.1', 'IPv4')],
+    }),
+  });
+  assert(result === null, 'tailscale: IP just above CGNAT range rejected');
+}
+
+{
+  // Internal tailscale IP (should be skipped)
+  const result = detectTailscaleHost({
+    networkInterfaces: fakeNetifs({
+      tailscale0: [iface('100.64.5.12', 'IPv4', /* internal */ true)],
+    }),
+  });
+  assert(result === null, 'tailscale: internal=true IP ignored');
+}
+
+// ---------------------------------------------------------------------------
+// detectLanHost
+// ---------------------------------------------------------------------------
+
+{
+  const result = detectLanHost({
+    networkInterfaces: fakeNetifs({
+      lo0: [iface('127.0.0.1', 'IPv4', true)],
+      eth0: [iface('192.168.1.10', 'IPv4')],
+      docker0: [iface('172.17.0.1', 'IPv4')],
+    }),
+  });
+  assert(result?.kind === 'lan', 'lan: detected kind=lan');
+  assert(result?.host === '192.168.1.10', 'lan: picks eth0 over docker0 (virtual) and lo0 (loopback)');
+}
+
+{
+  // Headless VPS with only lo + tailscale
+  const result = detectLanHost({
+    networkInterfaces: fakeNetifs({
+      lo0: [iface('127.0.0.1', 'IPv4', true)],
+      tailscale0: [iface('100.64.5.12', 'IPv4')],
+    }),
+  });
+  assert(result === null, 'lan: no physical NIC → null');
+}
+
+{
+  // Skip all known virtual prefixes
+  const result = detectLanHost({
+    networkInterfaces: fakeNetifs({
+      'br-abc123': [iface('172.20.0.1', 'IPv4')],
+      'veth0': [iface('10.0.0.1', 'IPv4')],
+      'utun0': [iface('10.1.0.1', 'IPv4')],
+      'tun0': [iface('10.2.0.1', 'IPv4')],
+      'wg0': [iface('10.3.0.1', 'IPv4')],
+    }),
+  });
+  assert(result === null, 'lan: all virtual-prefix NICs skipped');
+}
+
+// ---------------------------------------------------------------------------
+// detectGatewayHost — composed
+// ---------------------------------------------------------------------------
+
+{
+  // Tailscale wins over LAN
+  const result = detectGatewayHost({
+    networkInterfaces: fakeNetifs({
+      eth0: [iface('192.168.1.10', 'IPv4')],
+      tailscale0: [iface('100.64.5.12', 'IPv4')],
+    }),
+  });
+  assert(result?.kind === 'tailscale', 'composed: tailscale preferred over LAN');
+}
+
+{
+  // Only LAN available
+  const result = detectGatewayHost({
+    networkInterfaces: fakeNetifs({
+      eth0: [iface('192.168.1.10', 'IPv4')],
+    }),
+  });
+  assert(result?.kind === 'lan', 'composed: LAN fallback when tailscale absent');
+}
+
+{
+  // Nothing available
+  const result = detectGatewayHost({
+    networkInterfaces: fakeNetifs({
+      lo0: [iface('127.0.0.1', 'IPv4', true)],
+    }),
+  });
+  assert(result === null, 'composed: null when only loopback');
+}
+
+// ---------------------------------------------------------------------------
+// Scanner-surface sanity check (meta-test): this file should NOT import
+// child-process, fetch, or any outbound-request primitives. The scanner-sim
+// check-scanner.mjs enforces this at pre-publish. We verify here that the
+// module behaves sync (no Promise returns) so buildPairingUrl remains sync.
+// ---------------------------------------------------------------------------
+
+{
+  const r = detectGatewayHost({
+    networkInterfaces: fakeNetifs({}),
+  });
+  assert(r === null, 'meta: detectGatewayHost returns sync null on empty NIC table');
+  // If detectGatewayHost returned a Promise, the assertion above would be
+  // `Promise<null>` which is truthy — so `r === null` catches it.
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log(`# fail: ${failed}`);
+console.log(`# ${passed}/${passed + failed} passed`);
+if (failed > 0) {
+  console.log('SOME TESTS FAILED');
+  process.exit(1);
+}
+console.log('ALL TESTS PASSED');

--- a/skill/plugin/gateway-url.ts
+++ b/skill/plugin/gateway-url.ts
@@ -1,33 +1,38 @@
 /**
  * gateway-url — autodetect the gateway's externally-reachable URL for QR
- * pairing. Three layers that we can detect locally (no outbound-request
- * triggers in this file):
+ * pairing. This module runs sync + network-I/O-free so the OpenClaw
+ * dangerous-code scanner never flags it (the 3.3.1-rc.1 implementation
+ * used `child-process.execFileSync('tailscale', ...)` which blocked every
+ * `openclaw plugins install` — see QA report
+ * `docs/notes/QA-plugin-3.3.1-rc.1-20260422-0121.md`).
  *
- *   1. Tailscale — `tailscale status --json` via `child_process.execFileSync`.
- *      If the local node has a MagicDNS name and Tailscale is up, return
- *      `https://<magicdns-name>` and assume `tailscale serve` proxies to
- *      the gateway port on 443. Caller gets an opinionated default; user
- *      can override via `publicUrl`.
+ * Two layers:
  *
- *   2. LAN — pick the first non-loopback IPv4 address on a physical
- *      interface (skipping `lo`, `tailscale0`, `docker*`, `utun*`,
- *      `bridge*`, `veth*`). Emit with a caveat that the URL only works
- *      on the same network.
+ *   1. Tailscale — PASSIVE detection via `os.networkInterfaces()`. If a
+ *      `tailscale*` NIC has a CGNAT IPv4 (100.64/10), we return that IP
+ *      as an auto-detected host — the operator can verify + override via
+ *      `plugins.entries.totalreclaw.config.publicUrl` when they want a
+ *      proper MagicDNS hostname. We DO NOT call `tailscale` the CLI —
+ *      that requires `child-process` which the scanner blocks.
  *
- *   3. Nothing — return null. Caller falls through to localhost with a
- *      warning.
+ *   2. LAN — first non-loopback, non-virtual IPv4 interface. Emit with a
+ *      caveat that the URL only works on the same network.
+ *
+ *   3. Null — no signal; caller falls through to localhost with a warning.
+ *
+ * The caller is expected to surface `detected.note` to the operator and
+ * tell them to set `publicUrl` when auto-detect isn't good enough
+ * (remote-accessible https, MagicDNS, etc.).
  *
  * Scope and scanner surface
  * -------------------------
- * - This file does NOT do network I/O. `tailscale status --json` runs as
- *   a subprocess (`execFileSync`) which is NOT a scanner trigger.
- * - This file does NOT contain the substrings that the scanner's
- *   outbound-request rule matches.
- * - Callers that need to compose a final URL pull in this module via a
- *   named import and receive a plain record back.
+ * - No `child-process` import — the original scanner-blocking flaw.
+ * - No `fetch` / `post` / `http.request` substrings — the potential-
+ *   exfiltration rule is also clear.
+ * - Only `node:os` (synchronous, local) is used; no disk reads, no
+ *   subprocess execution, no network calls.
  */
 
-import { execFileSync } from 'node:child_process';
 import os from 'node:os';
 
 // ---------------------------------------------------------------------------
@@ -46,64 +51,53 @@ export interface DetectedGatewayHost {
 }
 
 // ---------------------------------------------------------------------------
-// Tailscale
+// Tailscale — passive detection (no subprocess, no network I/O)
 // ---------------------------------------------------------------------------
 
+/** CGNAT range 100.64.0.0/10 — Tailscale assigns IPs here by default. */
+function isTailscaleCGNAT(addr: string): boolean {
+  if (!/^\d{1,3}(?:\.\d{1,3}){3}$/.test(addr)) return false;
+  const parts = addr.split('.').map((p) => Number.parseInt(p, 10));
+  if (parts[0] !== 100) return false;
+  return parts[1] >= 64 && parts[1] <= 127;
+}
+
 /**
- * Attempt to discover a local Tailscale MagicDNS name. Returns null if
- * tailscale isn't installed, isn't running, or has no MagicDNS name.
+ * Passive Tailscale detection — checks `os.networkInterfaces()` for a
+ * `tailscale*` NIC carrying a CGNAT IPv4. Returns null if not found.
  *
- * Implementation:
- *   1. `tailscale status --json` — returns a JSON blob with `Self.DNSName`.
- *      DNSName is the fully-qualified MagicDNS (`myhost.tailxxx.ts.net.`).
- *   2. Strip the trailing dot.
- *   3. Assume Tailscale Serve is configured on 443. Callers that know
- *      better can override via pluginConfig.publicUrl.
+ * Unlike rc.1, this does NOT shell out to `tailscale status` — that
+ * tripped the OpenClaw scanner's dangerous-code detector and blocked
+ * install. The trade-off: we surface the raw CGNAT IP instead of the
+ * MagicDNS hostname. Operators who want a MagicDNS host must set
+ * `plugins.entries.totalreclaw.config.publicUrl` explicitly (documented
+ * in SKILL.md).
  */
 export function detectTailscaleHost(options?: {
-  /** Override the `tailscale` binary lookup (tests). */
-  execTailscale?: (args: string[]) => string;
+  /** Override os.networkInterfaces for tests. */
+  networkInterfaces?: () => NodeJS.Dict<os.NetworkInterfaceInfo[]>;
 }): DetectedGatewayHost | null {
-  const exec =
-    options?.execTailscale ??
-    ((args: string[]) => {
-      // 2s timeout is plenty — tailscale status is instantaneous when
-      // the daemon is up. `stdio: 'pipe'` suppresses tailscale's chatter.
-      return execFileSync('tailscale', args, {
-        timeout: 2000,
-        stdio: ['ignore', 'pipe', 'ignore'],
-        encoding: 'utf-8',
-      });
-    });
-
-  let raw: string;
-  try {
-    raw = exec(['status', '--json']);
-  } catch {
-    return null;
+  const nif = (options?.networkInterfaces ?? os.networkInterfaces)();
+  for (const [name, addrs] of Object.entries(nif)) {
+    if (!name.toLowerCase().startsWith('tailscale')) continue;
+    if (!addrs) continue;
+    for (const a of addrs) {
+      if (a.family !== 'IPv4' || a.internal) continue;
+      if (isTailscaleCGNAT(a.address)) {
+        return {
+          kind: 'tailscale',
+          host: a.address,
+          tls: false,
+          note:
+            `Tailscale CGNAT IP detected on interface ${name}. For a proper ` +
+            `https://<magicdns>.ts.net URL, set plugins.entries.totalreclaw.config.publicUrl ` +
+            `(Tailscale CLI auto-resolution was removed in 3.3.1-rc.2 to pass the ` +
+            `OpenClaw security scanner).`,
+        };
+      }
+    }
   }
-  if (!raw) return null;
-
-  let blob: unknown;
-  try {
-    blob = JSON.parse(raw) as unknown;
-  } catch {
-    return null;
-  }
-  if (typeof blob !== 'object' || blob === null) return null;
-  const self = (blob as { Self?: unknown }).Self;
-  if (typeof self !== 'object' || self === null) return null;
-  const dnsName = (self as { DNSName?: unknown }).DNSName;
-  if (typeof dnsName !== 'string') return null;
-  const trimmed = dnsName.replace(/\.$/, '').trim();
-  if (!trimmed) return null;
-
-  return {
-    kind: 'tailscale',
-    host: trimmed,
-    tls: true,
-    note: `Tailscale MagicDNS host detected — assumes \`tailscale serve\` is configured on port 443.`,
-  };
+  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -163,14 +157,16 @@ export function detectLanHost(options?: {
 // ---------------------------------------------------------------------------
 
 /**
- * Try Tailscale first, then LAN. Returns null when neither is available
- * (caller falls through to localhost).
+ * Try Tailscale first (passive NIC probe), then LAN. Returns null when
+ * neither is available (caller falls through to localhost).
+ *
+ * Sync: no I/O, no subprocess, no network. Safe in sync callers like
+ * `buildPairingUrl` in index.ts.
  */
 export function detectGatewayHost(options?: {
-  execTailscale?: (args: string[]) => string;
   networkInterfaces?: () => NodeJS.Dict<os.NetworkInterfaceInfo[]>;
 }): DetectedGatewayHost | null {
-  const ts = detectTailscaleHost({ execTailscale: options?.execTailscale });
+  const ts = detectTailscaleHost({ networkInterfaces: options?.networkInterfaces });
   if (ts) return ts;
   const lan = detectLanHost({ networkInterfaces: options?.networkInterfaces });
   if (lan) return lan;

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -76,7 +76,7 @@ import {
 import { initLLMClient, resolveLLMConfig, chatCompletion, generateEmbedding, getEmbeddingDims } from './llm-client.js';
 import {
   defaultAuthProfilesRoot,
-  readAllAuthProfileKeys,
+  readAllProfileKeys,
   dedupeByProvider,
 } from './llm-profile-reader.js';
 import { LSHHasher } from './lsh.js';
@@ -122,6 +122,17 @@ import {
   validatePinArgs,
   type PinOpDeps,
 } from './pin.js';
+import {
+  executeRetype,
+  executeSetScope,
+  validateRetypeArgs,
+  validateSetScopeArgs,
+  type RetypeSetScopeDeps,
+} from './retype-setscope.js';
+import {
+  runNonInteractiveOnboard,
+  type NonInteractiveOnboardResult,
+} from './onboarding-cli.js';
 import { PluginHotCache, type HotFact } from './hot-cache-wrapper.js';
 import { CONFIG, setRecoveryPhraseOverride } from './config.js';
 import {
@@ -325,7 +336,7 @@ function buildPairingUrl(
   else if (cfg?.gateway?.bind === 'custom' && cfg.gateway.customBindHost) {
     base = `${scheme}://${cfg.gateway.customBindHost}:${port}`;
   }
-  // Layers 4 + 5 — auto-detect via gateway-url helper (Tailscale, then LAN)
+  // Layers 4 + 5 — auto-detect via gateway-url helper (Tailscale CGNAT, then LAN)
   else {
     let detected: ReturnType<typeof detectGatewayHost> = null;
     try {
@@ -336,11 +347,15 @@ function buildPairingUrl(
       );
     }
     if (detected?.kind === 'tailscale') {
-      // Tailscale Serve is conventionally on 443 — the MagicDNS name is
-      // TLS-terminated by Tailscale itself.
-      base = `https://${detected.host}`;
-      api.logger.info(
-        `TotalReclaw: pairing URL using Tailscale host ${detected.host} (MagicDNS). ` +
+      // 3.3.1-rc.2: we surface the raw Tailscale CGNAT IP because passive
+      // NIC detection (no subprocess) cannot resolve the MagicDNS name.
+      // Caller can override via `publicUrl` for a proper https://<magicdns>.
+      // The IP + port URL still works inside the tailnet (peers can reach
+      // each other by CGNAT IP directly). TLS defaults to the gateway's
+      // own config because we no longer assume `tailscale serve`.
+      base = `${scheme}://${detected.host}:${port}`;
+      api.logger.warn(
+        `TotalReclaw: pairing URL using Tailscale CGNAT IP ${detected.host}:${port} — ` +
           detected.note,
       );
     } else if (detected?.kind === 'lan') {
@@ -2797,16 +2812,19 @@ const plugin = {
     try {
       const root = defaultAuthProfilesRoot(CONFIG.home);
       if (root) {
-        const all = readAllAuthProfileKeys({ root });
+        // 3.3.1-rc.2 — readAllProfileKeys merges auth-profiles.json AND
+        // the legacy models.json format (pre-auth-profiles OpenClaw
+        // installs). Auth-profiles wins when both have the same provider.
+        const all = readAllProfileKeys({ root });
         // Dedupe so each provider appears once (last-wins — later agent
         // files shadow earlier ones).
         const byProvider = dedupeByProvider(all);
         harvestedKeys = Object.values(byProvider);
       }
     } catch (err) {
-      // Never crash plugin init on a bad auth-profiles.json.
+      // Never crash plugin init on a bad auth-profiles.json / models.json.
       const msg = err instanceof Error ? err.message : String(err);
-      api.logger.warn(`TotalReclaw: could not read OpenClaw auth-profiles.json (${msg}) — falling through to env vars`);
+      api.logger.warn(`TotalReclaw: could not read OpenClaw profile JSONs (${msg}) — falling through to env vars`);
     }
 
     initLLMClient({
@@ -3536,13 +3554,21 @@ const plugin = {
       {
         name: 'totalreclaw_forget',
         label: 'Forget',
-        description: 'Delete a specific memory by its ID.',
+        description:
+          'Delete a specific memory. Use when the user asks to forget, delete, or remove ' +
+          'something specific (e.g. "forget that I live in Porto", "delete the memory about my old job"). ' +
+          'Writes an on-chain tombstone — the delete is permanent and propagates across all devices. ' +
+          'If the user names the memory in natural language instead of an ID, FIRST call ' +
+          '`totalreclaw_recall` with their phrase as the query, then pass the top result\'s `id` as ' +
+          '`factId`. Non-reversible.',
         parameters: {
           type: 'object',
           properties: {
             factId: {
               type: 'string',
-              description: 'The UUID of the memory to delete',
+              description:
+                'The UUID of the memory to delete. Get this from a prior `totalreclaw_recall` result — ' +
+                'the `memories[i].id` field. Never invent a factId; if you don\'t have one, call recall first.',
             },
           },
           required: ['factId'],
@@ -3552,12 +3578,58 @@ const plugin = {
           try {
             await requireFullSetup(api.logger);
 
+            // Validate factId shape BEFORE any on-chain work. Prevents
+            // silent no-op when the LLM fabricates a non-UUID factId —
+            // the classic failure mode from 3.3.1-rc.1 QA where the
+            // agent replied "Done" without calling the tool at all, OR
+            // called the tool with a plain natural-language string.
+            const factId = typeof params.factId === 'string' ? params.factId.trim() : '';
+            if (!factId) {
+              return {
+                content: [{
+                  type: 'text',
+                  text:
+                    'Cannot forget without a memory ID. Call `totalreclaw_recall` first with ' +
+                    'the user\'s phrasing as the query — the top result\'s `id` field is the ' +
+                    'factId to pass here.',
+                }],
+                details: { deleted: false, error: 'missing-fact-id' },
+              };
+            }
+            // UUID-v4-ish shape check (loose — accepts any hex-dashed id).
+            // Prevents cases like `factId: "that I live in Porto"` from
+            // reaching the UserOp path and silently failing on-chain.
+            const looksLikeFactId = /^[0-9a-f-]{8,}$/i.test(factId);
+            if (!looksLikeFactId) {
+              api.logger.warn(
+                `totalreclaw_forget: rejected likely-invalid factId "${factId.slice(0, 40)}" ` +
+                  `— expected a UUID from a prior recall result, not natural language.`,
+              );
+              return {
+                content: [{
+                  type: 'text',
+                  text:
+                    `"${factId.slice(0, 60)}" doesn\'t look like a memory ID. Call ` +
+                    '`totalreclaw_recall` first with the user\'s phrasing as the query, then ' +
+                    'pass the top result\'s `id` field (a hex UUID) as `factId`.',
+                }],
+                details: { deleted: false, error: 'invalid-fact-id' },
+              };
+            }
+
             if (isSubgraphMode()) {
               // On-chain tombstone: write a minimal protobuf with decayScore=0
-              // The subgraph will overwrite the fact and set isActive=false
+              // The subgraph picks this up and sets isActive=false.
+              //
+              // 3.3.1-rc.2 fix: route through submitFactBatchOnChain with a
+              // single-payload batch so we share the tombstone codepath the
+              // pin/unpin flow uses (that flow is known-good and the QA
+              // confirms pin works). Also write at legacy v3 (NOT v4) so the
+              // subgraph handler matches the source="tombstone" + version=3
+              // shape the contradiction/pin tombstones use.
               const config = { ...getSubgraphConfig(), authKeyHex: authKeyHex!, walletAddress: subgraphOwner ?? undefined };
               const tombstone: FactPayload = {
-                id: params.factId,
+                id: factId,
                 timestamp: new Date().toISOString(),
                 owner: subgraphOwner || userId!,
                 encryptedBlob: '00', // minimal 1-byte placeholder
@@ -3565,24 +3637,31 @@ const plugin = {
                 decayScore: 0,
                 source: 'tombstone',
                 contentFp: '',
-                agentId: 'openclaw-plugin',
-                version: PROTOBUF_VERSION_V4,
+                agentId: 'openclaw-plugin-forget',
+                // Deliberately NO version: field → uses the default (legacy v3).
+                // The pin/unpin tombstones use v3 (see pin.ts:611-621) — we
+                // MUST match that shape or the subgraph may not flip isActive.
               };
               const protobuf = encodeFactProtobuf(tombstone);
-              const result = await submitFactOnChain(protobuf, config);
+              const result = await submitFactBatchOnChain([protobuf], config);
               if (!result.success) {
                 throw new Error(`On-chain tombstone failed (tx=${result.txHash?.slice(0, 10) || 'none'}…)`);
               }
-              api.logger.info(`Tombstone written for ${params.factId}: tx=${result.txHash}`);
+              api.logger.info(`Tombstone written for ${factId}: tx=${result.txHash}`);
               return {
-                content: [{ type: 'text', text: `Memory ${params.factId} deleted (on-chain tombstone, tx: ${result.txHash})` }],
-                details: { deleted: true, txHash: result.txHash },
+                content: [{
+                  type: 'text',
+                  text:
+                    `Memory ${factId} deleted on-chain (tx: ${result.txHash}). ` +
+                    'The subgraph will reflect isActive=false within ~30 seconds.',
+                }],
+                details: { deleted: true, txHash: result.txHash, factId },
               };
             } else {
-              await apiClient!.deleteFact(params.factId, authKeyHex!);
+              await apiClient!.deleteFact(factId, authKeyHex!);
               return {
-                content: [{ type: 'text', text: `Memory ${params.factId} deleted` }],
-                details: { deleted: true },
+                content: [{ type: 'text', text: `Memory ${factId} deleted` }],
+                details: { deleted: true, factId },
               };
             }
           } catch (err: unknown) {
@@ -4203,6 +4282,215 @@ const plugin = {
     );
 
     // ---------------------------------------------------------------
+    // Shared deps for retype + set_scope (same shape as pin deps).
+    // Built lazily so the closure captures the current encryption key /
+    // subgraph owner at call time rather than at register() time.
+    // ---------------------------------------------------------------
+    const buildRetypeSetScopeDeps = (): RetypeSetScopeDeps => {
+      const owner = subgraphOwner || userId || '';
+      const config = {
+        ...getSubgraphConfig(),
+        authKeyHex: authKeyHex!,
+        walletAddress: subgraphOwner ?? undefined,
+      };
+      return {
+        owner,
+        sourceAgent: 'openclaw-plugin',
+        fetchFactById: (factId: string) => fetchFactById(owner, factId, authKeyHex!),
+        decryptBlob: (hex: string) => decryptFromHex(hex, encryptionKey!),
+        encryptBlob: (plaintext: string) => encryptToHex(plaintext, encryptionKey!),
+        submitBatch: async (payloads: Buffer[]) => {
+          const result = await submitFactBatchOnChain(payloads, config);
+          return { txHash: result.txHash, success: result.success };
+        },
+        generateIndices: async (text: string, entityNames: string[]) => {
+          if (!text) return { blindIndices: [] };
+          const wordIndices = generateBlindIndices(text);
+          let lshIndices: string[] = [];
+          let encryptedEmbedding: string | undefined;
+          try {
+            const embedding = await generateEmbedding(text);
+            const hasher = getLSHHasher(api.logger);
+            if (hasher) lshIndices = hasher.hash(embedding);
+            encryptedEmbedding = encryptToHex(JSON.stringify(embedding), encryptionKey!);
+          } catch {
+            // Best-effort: word + entity trapdoors alone still surface the claim.
+          }
+          const entityTrapdoors = entityNames.map((n) => computeEntityTrapdoor(n));
+          return {
+            blindIndices: [...wordIndices, ...lshIndices, ...entityTrapdoors],
+            encryptedEmbedding,
+          };
+        },
+      };
+    };
+
+    // ---------------------------------------------------------------
+    // Tool: totalreclaw_retype (3.3.1-rc.2 — agent-facing taxonomy edit)
+    // ---------------------------------------------------------------
+
+    api.registerTool(
+      {
+        name: 'totalreclaw_retype',
+        label: 'Retype',
+        description:
+          'Reclassify an existing memory from one taxonomy type to another (claim / preference / ' +
+          'directive / commitment / episode / summary). Use when the user corrects a memory\'s ' +
+          'category — e.g. "that\'s actually a preference, not a fact" or "file this as a ' +
+          'commitment, not a claim". Writes a new v1.1 blob with the updated type and tombstones ' +
+          'the old fact on-chain.\n\n' +
+          'If the user names the memory in natural language, FIRST call `totalreclaw_recall` to ' +
+          'find the fact_id, then pass it here with the new type.',
+        parameters: {
+          type: 'object',
+          properties: {
+            fact_id: {
+              type: 'string',
+              description:
+                'The UUID of the memory to reclassify. Get this from a prior ' +
+                '`totalreclaw_recall` result.',
+            },
+            new_type: {
+              type: 'string',
+              enum: ['claim', 'preference', 'directive', 'commitment', 'episode', 'summary'],
+              description:
+                'The new taxonomy type. claim=factual statement, preference=opinion/like/dislike, ' +
+                'directive=instruction, commitment=promise/plan, episode=event, summary=aggregate.',
+            },
+          },
+          required: ['fact_id', 'new_type'],
+          additionalProperties: false,
+        },
+        async execute(_toolCallId: string, params: Record<string, unknown>) {
+          try {
+            await requireFullSetup(api.logger);
+            if (!isSubgraphMode()) {
+              return {
+                content: [{
+                  type: 'text',
+                  text: 'Retype is only supported with the managed service. Self-hosted mode does not yet implement the status-flip supersession flow.',
+                }],
+              };
+            }
+            const validation = validateRetypeArgs(params);
+            if (!validation.ok) {
+              return { content: [{ type: 'text', text: validation.error }] };
+            }
+            const deps = buildRetypeSetScopeDeps();
+            const result = await executeRetype(validation.factId, validation.newType, deps);
+            if (result.success) {
+              api.logger.info(
+                `totalreclaw_retype: ${result.fact_id} (${result.previous_type} → ${result.new_type}) → ${result.new_fact_id} (tx ${result.tx_hash?.slice(0, 10)})`,
+              );
+              return {
+                content: [{
+                  type: 'text',
+                  text:
+                    `Retyped memory ${result.fact_id} from ${result.previous_type} to ${result.new_type}. ` +
+                    `New fact id: ${result.new_fact_id} (tx: ${result.tx_hash}).`,
+                }],
+                details: result,
+              };
+            }
+            api.logger.error(`totalreclaw_retype failed: ${result.error}`);
+            return {
+              content: [{ type: 'text', text: `Failed to retype memory: ${humanizeError(result.error ?? 'unknown error')}` }],
+              details: result,
+            };
+          } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : String(err);
+            api.logger.error(`totalreclaw_retype failed: ${message}`);
+            return {
+              content: [{ type: 'text', text: `Failed to retype memory: ${humanizeError(message)}` }],
+            };
+          }
+        },
+      },
+      { name: 'totalreclaw_retype' },
+    );
+
+    // ---------------------------------------------------------------
+    // Tool: totalreclaw_set_scope (3.3.1-rc.2 — agent-facing scope edit)
+    // ---------------------------------------------------------------
+
+    api.registerTool(
+      {
+        name: 'totalreclaw_set_scope',
+        label: 'Set Scope',
+        description:
+          'Move an existing memory to a different scope (work / personal / health / family / ' +
+          'creative / finance / misc / unspecified). Use when the user re-categorizes a memory\'s ' +
+          'domain — e.g. "put that under work", "this is a health thing", "move this to personal". ' +
+          'Writes a new v1.1 blob with the updated scope and tombstones the old fact on-chain.\n\n' +
+          'If the user names the memory in natural language, FIRST call `totalreclaw_recall` to ' +
+          'find the fact_id, then pass it here with the new scope.',
+        parameters: {
+          type: 'object',
+          properties: {
+            fact_id: {
+              type: 'string',
+              description:
+                'The UUID of the memory to rescope. Get this from a prior `totalreclaw_recall` result.',
+            },
+            new_scope: {
+              type: 'string',
+              enum: ['work', 'personal', 'health', 'family', 'creative', 'finance', 'misc', 'unspecified'],
+              description:
+                'The new scope. Used for filtered recall — e.g. "recall work-related memories only".',
+            },
+          },
+          required: ['fact_id', 'new_scope'],
+          additionalProperties: false,
+        },
+        async execute(_toolCallId: string, params: Record<string, unknown>) {
+          try {
+            await requireFullSetup(api.logger);
+            if (!isSubgraphMode()) {
+              return {
+                content: [{
+                  type: 'text',
+                  text: 'Set-scope is only supported with the managed service. Self-hosted mode does not yet implement the status-flip supersession flow.',
+                }],
+              };
+            }
+            const validation = validateSetScopeArgs(params);
+            if (!validation.ok) {
+              return { content: [{ type: 'text', text: validation.error }] };
+            }
+            const deps = buildRetypeSetScopeDeps();
+            const result = await executeSetScope(validation.factId, validation.newScope, deps);
+            if (result.success) {
+              api.logger.info(
+                `totalreclaw_set_scope: ${result.fact_id} (${result.previous_scope ?? 'unspecified'} → ${result.new_scope}) → ${result.new_fact_id} (tx ${result.tx_hash?.slice(0, 10)})`,
+              );
+              return {
+                content: [{
+                  type: 'text',
+                  text:
+                    `Moved memory ${result.fact_id} from scope "${result.previous_scope ?? 'unspecified'}" to "${result.new_scope}". ` +
+                    `New fact id: ${result.new_fact_id} (tx: ${result.tx_hash}).`,
+                }],
+                details: result,
+              };
+            }
+            api.logger.error(`totalreclaw_set_scope failed: ${result.error}`);
+            return {
+              content: [{ type: 'text', text: `Failed to set scope: ${humanizeError(result.error ?? 'unknown error')}` }],
+              details: result,
+            };
+          } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : String(err);
+            api.logger.error(`totalreclaw_set_scope failed: ${message}`);
+            return {
+              content: [{ type: 'text', text: `Failed to set scope: ${humanizeError(message)}` }],
+            };
+          }
+        },
+      },
+      { name: 'totalreclaw_set_scope' },
+    );
+
+    // ---------------------------------------------------------------
     // Tool: totalreclaw_import_from
     // ---------------------------------------------------------------
 
@@ -4731,6 +5019,265 @@ const plugin = {
         },
       },
       { name: 'totalreclaw_onboarding_start' },
+    );
+
+    // ---------------------------------------------------------------
+    // Tool: totalreclaw_onboard (3.3.1-rc.2 — agent-callable onboard)
+    //
+    // Lets the agent drive the non-interactive onboard flow without
+    // shelling out to `openclaw totalreclaw onboard` (subprocess work
+    // is not available inside the plugin runtime and the OpenClaw
+    // security scanner blocks the standard subprocess module).
+    //
+    // Security envelope (same as the CLI path):
+    //   - NEVER accepts a recovery phrase through chat (mode=restore
+    //     is rejected here — that still requires the local CLI wizard).
+    //   - The generated phrase is written to ~/.totalreclaw/credentials.json
+    //     (mode 0600) by `runNonInteractiveOnboard`. We explicitly pass
+    //     `emitPhrase: false` so the phrase NEVER appears in the tool
+    //     return value.
+    //   - Returns only: scope_address + credentials_path + ok/error.
+    // ---------------------------------------------------------------
+    api.registerTool(
+      {
+        name: 'totalreclaw_onboard',
+        label: 'Onboard (generate new recovery phrase)',
+        description:
+          'Generate a NEW TotalReclaw recovery phrase on this machine without the user ' +
+          'leaving chat. The phrase is written ONLY to ~/.totalreclaw/credentials.json (mode ' +
+          '0600) and NEVER returned through this tool — the response contains just the derived ' +
+          'Smart Account (scope) address and the credentials path so the user can retrieve ' +
+          'their phrase locally (e.g. `cat ~/.totalreclaw/credentials.json | jq -r .mnemonic`).\n\n' +
+          'Use when a fresh user asks you to set up TotalReclaw or enable memory. Refuses if ' +
+          'onboarding is already active (the user can delete the credentials file to re-onboard, ' +
+          'but we will NOT silently overwrite). For RESTORE (import an existing phrase), tell ' +
+          'the user to run `openclaw totalreclaw onboard --mode restore` in their local ' +
+          'terminal — this tool refuses to accept phrases through chat.',
+        parameters: {
+          type: 'object',
+          properties: {
+            mode: {
+              type: 'string',
+              enum: ['generate'],
+              description:
+                'Only "generate" is supported via this tool (creates a fresh 12-word BIP-39 ' +
+                'phrase). "restore" requires the local CLI wizard because pasting a phrase ' +
+                'through chat ships it to the LLM provider, defeating end-to-end encryption.',
+              default: 'generate',
+            },
+          },
+          additionalProperties: false,
+        },
+        async execute(_toolCallId: string, params: Record<string, unknown>) {
+          const mode = params?.mode;
+          if (mode !== undefined && mode !== 'generate') {
+            return {
+              content: [{
+                type: 'text',
+                text:
+                  'Only mode="generate" is supported through chat. For RESTORE (import an ' +
+                  'existing recovery phrase), ask the user to run `openclaw totalreclaw onboard ' +
+                  '--mode restore` in their local terminal — the phrase is read from stdin and ' +
+                  'never touches the LLM provider or the transcript.',
+              }],
+            };
+          }
+          try {
+            const result: NonInteractiveOnboardResult = await runNonInteractiveOnboard({
+              credentialsPath: CREDENTIALS_PATH,
+              statePath: CONFIG.onboardingStatePath,
+              mode: 'generate',
+              emitPhrase: false, // NEVER include the phrase in agent-visible output.
+              deriveScopeAddress: async (mnemonic: string) => {
+                try {
+                  return await deriveSmartAccountAddress(mnemonic, CONFIG.chainId);
+                } catch (err) {
+                  api.logger.warn(
+                    `totalreclaw_onboard: scope-address derivation failed: ${
+                      err instanceof Error ? err.message : String(err)
+                    }`,
+                  );
+                  return undefined;
+                }
+              },
+            });
+            if (!result.ok) {
+              // already-active, write-failed, etc. Never leaks the phrase.
+              api.logger.info(`totalreclaw_onboard: ok=false error=${result.error}`);
+              return {
+                content: [{
+                  type: 'text',
+                  text:
+                    result.error === 'already-active'
+                      ? 'TotalReclaw is already set up on this machine. Memory tools are unblocked. To re-onboard, delete ~/.totalreclaw/credentials.json first.'
+                      : `Onboard failed: ${result.error_detail ?? result.error}`,
+                }],
+                details: {
+                  ok: false,
+                  error: result.error,
+                  action: result.action,
+                },
+              };
+            }
+            api.logger.info(
+              `totalreclaw_onboard: generated phrase, scope=${result.scope_address?.slice(0, 10) ?? 'unknown'}…, credentials=${result.credentials_path}`,
+            );
+            // Crucially: the mnemonic field is NEVER emitted in details
+            // (emitPhrase=false enforces that on the result object).
+            return {
+              content: [{
+                type: 'text',
+                text:
+                  `TotalReclaw setup complete. A new 12-word recovery phrase was generated and ` +
+                  `saved to ${result.credentials_path} (mode 0600). ` +
+                  (result.scope_address
+                    ? `Your on-chain scope (Smart Account) address is ${result.scope_address}. `
+                    : '') +
+                  `To view your recovery phrase, run on the user's local terminal:\n\n` +
+                  `    cat ${result.credentials_path} | jq -r .mnemonic\n\n` +
+                  `IMPORTANT: the recovery phrase is the ONLY way to recover memories on another ` +
+                  `device. Tell the user to store it safely — a password manager or a paper backup. ` +
+                  `TotalReclaw cannot recover it if lost.`,
+              }],
+              details: {
+                ok: true,
+                action: 'generate',
+                scope_address: result.scope_address,
+                credentials_path: result.credentials_path,
+                // Deliberately NO mnemonic field.
+              },
+            };
+          } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : String(err);
+            api.logger.error(`totalreclaw_onboard failed: ${message}`);
+            return {
+              content: [{ type: 'text', text: `Onboard failed: ${humanizeError(message)}` }],
+              details: { ok: false, error: 'unexpected', error_detail: message },
+            };
+          }
+        },
+      },
+      { name: 'totalreclaw_onboard' },
+    );
+
+    // ---------------------------------------------------------------
+    // Tool: totalreclaw_pair (3.3.1-rc.2 — agent-callable pair-generate)
+    //
+    // Creates a pairing session (browser-mediated recovery-phrase sync),
+    // returns the URL + PIN + QR ASCII to the agent. The agent relays
+    // these to the user (paste-URL or scan-QR flow). The phrase itself
+    // NEVER crosses the gateway — the pair-http endpoint does the E2EE
+    // handshake with the browser pair-page.
+    // ---------------------------------------------------------------
+    api.registerTool(
+      {
+        name: 'totalreclaw_pair',
+        label: 'QR pair — start remote pairing session',
+        description:
+          'Start a remote pairing session so the user can create or import a TotalReclaw ' +
+          'recovery phrase from their phone or another browser. Returns a pairing URL, a ' +
+          '6-digit PIN, and an ASCII QR code that the agent relays to the user. The recovery ' +
+          'phrase itself is generated/entered in the BROWSER and uploaded end-to-end encrypted ' +
+          'to this gateway — it NEVER touches the LLM provider or the chat transcript.\n\n' +
+          'Use when a user wants to set up TotalReclaw on a machine they don\'t have terminal ' +
+          'access to (a VPS, a friend\'s computer), or when they prefer a phone-mediated flow. ' +
+          'For local-machine setup with a terminal, prefer `totalreclaw_onboard` (generate) or ' +
+          '`totalreclaw_onboarding_start` (pointer to local CLI for restore).',
+        parameters: {
+          type: 'object',
+          properties: {
+            mode: {
+              type: 'string',
+              enum: ['generate', 'import'],
+              description:
+                '"generate" = the browser will create a NEW recovery phrase. "import" = the ' +
+                'browser will accept an EXISTING phrase that the user pastes in their browser ' +
+                '(never through chat).',
+              default: 'generate',
+            },
+          },
+          additionalProperties: false,
+        },
+        async execute(_toolCallId: string, params: Record<string, unknown>) {
+          const rawMode = params?.mode;
+          const mode: 'generate' | 'import' =
+            rawMode === 'import' ? 'import' : 'generate';
+          try {
+            const { createPairSession } = await import('./pair-session-store.js');
+            const { generateGatewayKeypair } = await import('./pair-crypto.js');
+            const { defaultRenderQr } = await import('./pair-cli.js');
+            const kp = generateGatewayKeypair();
+            const session = await createPairSession(CONFIG.pairSessionsPath, {
+              mode,
+              operatorContext: { channel: 'agent' },
+              rngPrivateKey: () => Buffer.from(kp.skB64, 'base64url'),
+              rngPublicKey: () => Buffer.from(kp.pkB64, 'base64url'),
+            });
+            const url = buildPairingUrl(api, session);
+            const qrAscii = await new Promise<string>((resolve) => {
+              let settled = false;
+              const t = setTimeout(() => {
+                if (!settled) {
+                  settled = true;
+                  resolve('');
+                }
+              }, 5_000);
+              try {
+                defaultRenderQr(url, (ascii: string) => {
+                  if (settled) return;
+                  settled = true;
+                  clearTimeout(t);
+                  resolve(ascii);
+                });
+              } catch {
+                if (settled) return;
+                settled = true;
+                clearTimeout(t);
+                resolve('');
+              }
+            });
+            api.logger.info(
+              `totalreclaw_pair: session ${session.sid.slice(0, 8)}… mode=${mode} url=${url}`,
+            );
+            return {
+              content: [{
+                type: 'text',
+                text:
+                  `Pairing session started.\n\n` +
+                  `URL: ${url}\n\n` +
+                  `PIN (type this into the browser): ${session.secondaryCode}\n\n` +
+                  (qrAscii ? `QR code:\n\n${qrAscii}\n\n` : '') +
+                  `Instructions for the user:\n` +
+                  `1. Open the URL above on their phone or another browser (scan the QR or copy-paste).\n` +
+                  `2. ` +
+                  (mode === 'generate'
+                    ? `The browser will generate a NEW 12-word recovery phrase and ask the user to write it down + retype 3 words before finalizing.`
+                    : `The browser will accept an EXISTING phrase that the user pastes in the browser (never through chat).`) +
+                  `\n3. Enter the 6-digit PIN shown above into the browser.\n` +
+                  `4. The encrypted phrase uploads to this gateway — it NEVER touches the LLM.\n` +
+                  `5. Come back to chat once the browser says "Pairing complete".\n\n` +
+                  `This session expires in ~5 minutes. Run this tool again if you need a fresh URL.`,
+              }],
+              details: {
+                sid: session.sid,
+                url,
+                pin: session.secondaryCode,
+                mode,
+                expires_at_ms: session.expiresAtMs,
+                qr_ascii: qrAscii,
+              },
+            };
+          } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : String(err);
+            api.logger.error(`totalreclaw_pair failed: ${message}`);
+            return {
+              content: [{ type: 'text', text: `Failed to start pairing session: ${humanizeError(message)}` }],
+              details: { error: message },
+            };
+          }
+        },
+      },
+      { name: 'totalreclaw_pair' },
     );
 
     // ---------------------------------------------------------------

--- a/skill/plugin/llm-client-retry.test.ts
+++ b/skill/plugin/llm-client-retry.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for the 3.3.1-rc.2 retry wrapper added to llm-client.chatCompletion.
+ *
+ * Covers:
+ *   - isRetryable classifies 429, 502/503/504, timeouts as retryable
+ *   - isRetryable classifies 401/403/404/parse-errors as non-retryable
+ *   - chatCompletion retries transient failures with exponential backoff
+ *   - chatCompletion fails fast on non-retryable errors
+ *   - chatCompletion respects `attempts: 0` (still runs once) and
+ *     `attempts: 3` caps retry count
+ *   - Logger is called with the right levels (INFO on first failure,
+ *     DEBUG on subsequent, WARN on final give-up)
+ *
+ * Run with: npx tsx llm-client-retry.test.ts
+ */
+
+import { isRetryable, chatCompletion, type LLMClientConfig } from './llm-client.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond: boolean, name: string): void {
+  const n = passed + failed + 1;
+  if (cond) {
+    console.log(`ok ${n} - ${name}`);
+    passed++;
+  } else {
+    console.log(`not ok ${n} - ${name}`);
+    failed++;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// isRetryable
+// ---------------------------------------------------------------------------
+
+assert(isRetryable('LLM API 429: rate limit reached'), 'isRetryable: 429 → true');
+assert(isRetryable('Rate limit reached for requests'), 'isRetryable: "rate limit" → true');
+assert(isRetryable('LLM API 502: bad gateway'), 'isRetryable: 502 → true');
+assert(isRetryable('LLM API 503: unavailable'), 'isRetryable: 503 → true');
+assert(isRetryable('LLM API 504: timeout'), 'isRetryable: 504 → true');
+assert(isRetryable('The operation was aborted due to timeout'), 'isRetryable: timeout msg → true');
+assert(isRetryable('AbortError: aborted'), 'isRetryable: AbortError → true');
+
+assert(!isRetryable('LLM API 401: unauthorized'), 'isRetryable: 401 → false');
+assert(!isRetryable('LLM API 403: forbidden'), 'isRetryable: 403 → false');
+assert(!isRetryable('LLM API 404: not found'), 'isRetryable: 404 → false');
+assert(!isRetryable('LLM API 400: bad request'), 'isRetryable: 400 → false');
+assert(!isRetryable('JSON parse error'), 'isRetryable: JSON parse → false');
+
+// ---------------------------------------------------------------------------
+// chatCompletion retry harness — we monkey-patch fetch for determinism.
+// ---------------------------------------------------------------------------
+
+// Save the real fetch.
+const realFetch = globalThis.fetch;
+
+function stubFetch(sequence: Array<() => Promise<Response>>): () => number {
+  let callIdx = 0;
+  globalThis.fetch = (async (..._args: unknown[]): Promise<Response> => {
+    const next = sequence[Math.min(callIdx, sequence.length - 1)];
+    callIdx++;
+    return next();
+  }) as unknown as typeof fetch;
+  return () => callIdx;
+}
+
+function restoreFetch(): void {
+  globalThis.fetch = realFetch;
+}
+
+function mockResponse(status: number, body: string): Response {
+  return new Response(body, {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function okResponse(content: string): Response {
+  return mockResponse(
+    200,
+    JSON.stringify({
+      choices: [{ message: { content } }],
+    }),
+  );
+}
+
+const testConfig: LLMClientConfig = {
+  apiKey: 'test',
+  baseUrl: 'http://example.test/v1',
+  model: 'test-model',
+  apiFormat: 'openai',
+};
+
+// ---------------------------------------------------------------------------
+// Happy path — first attempt succeeds, no retries.
+// ---------------------------------------------------------------------------
+
+{
+  const getCount = stubFetch([
+    async () => okResponse('hello from LLM'),
+  ]);
+  try {
+    const logs: Array<[string, string]> = [];
+    const logger = {
+      info: (msg: string) => logs.push(['info', msg]),
+      warn: (msg: string) => logs.push(['warn', msg]),
+      debug: (msg: string) => logs.push(['debug', msg]),
+    };
+    const result = await chatCompletion(testConfig, [
+      { role: 'user', content: 'hi' },
+    ], { logger });
+    assert(result === 'hello from LLM', 'retry: first-attempt-success returns content');
+    assert(getCount() === 1, 'retry: first-attempt-success → 1 fetch');
+    assert(logs.length === 0, 'retry: first-attempt-success → no log lines');
+  } finally {
+    restoreFetch();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 429 → retry → success
+// ---------------------------------------------------------------------------
+
+{
+  const getCount = stubFetch([
+    async () => mockResponse(429, '{"error":{"message":"Rate limit reached"}}'),
+    async () => okResponse('recovered'),
+  ]);
+  try {
+    const logs: Array<[string, string]> = [];
+    const logger = {
+      info: (msg: string) => logs.push(['info', msg]),
+      warn: (msg: string) => logs.push(['warn', msg]),
+      debug: (msg: string) => logs.push(['debug', msg]),
+    };
+    const result = await chatCompletion(testConfig, [
+      { role: 'user', content: 'hi' },
+    ], { logger, retry: { attempts: 3, baseDelayMs: 10 } });
+    assert(result === 'recovered', 'retry: 429 → 200 returns content from 2nd attempt');
+    assert(getCount() === 2, 'retry: 429 → 200 made 2 fetch calls');
+    assert(logs.some(([lvl]) => lvl === 'info'), 'retry: 429 → 200 emits INFO log on first failure');
+  } finally {
+    restoreFetch();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// All attempts fail with 429 → give up with warn
+// ---------------------------------------------------------------------------
+
+{
+  const getCount = stubFetch([
+    async () => mockResponse(429, '{"error":{"message":"Rate limit"}}'),
+    async () => mockResponse(429, '{"error":{"message":"Rate limit"}}'),
+    async () => mockResponse(429, '{"error":{"message":"Rate limit"}}'),
+  ]);
+  try {
+    const logs: Array<[string, string]> = [];
+    const logger = {
+      info: (msg: string) => logs.push(['info', msg]),
+      warn: (msg: string) => logs.push(['warn', msg]),
+      debug: (msg: string) => logs.push(['debug', msg]),
+    };
+    let thrown: unknown;
+    try {
+      await chatCompletion(testConfig, [
+        { role: 'user', content: 'hi' },
+      ], { logger, retry: { attempts: 3, baseDelayMs: 10 } });
+    } catch (err) {
+      thrown = err;
+    }
+    assert(thrown instanceof Error, 'retry: all-fail throws');
+    assert(getCount() === 3, 'retry: all-fail with attempts=3 → 3 fetches');
+    assert(logs.some(([lvl]) => lvl === 'warn'), 'retry: all-fail emits WARN on give-up');
+    assert(logs.some(([lvl]) => lvl === 'info'), 'retry: all-fail emits INFO on first failure');
+    assert(logs.some(([lvl]) => lvl === 'debug'), 'retry: all-fail emits DEBUG on 2nd retry attempt');
+  } finally {
+    restoreFetch();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 401 (unauth) → fail-fast, no retry
+// ---------------------------------------------------------------------------
+
+{
+  const getCount = stubFetch([
+    async () => mockResponse(401, '{"error":{"message":"unauthorized"}}'),
+  ]);
+  try {
+    let thrown: unknown;
+    try {
+      await chatCompletion(testConfig, [
+        { role: 'user', content: 'hi' },
+      ], { retry: { attempts: 3, baseDelayMs: 10 } });
+    } catch (err) {
+      thrown = err;
+    }
+    assert(thrown instanceof Error, 'retry: 401 throws');
+    assert(getCount() === 1, 'retry: 401 is fail-fast (1 fetch)');
+  } finally {
+    restoreFetch();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Timeout / AbortError → retry
+// ---------------------------------------------------------------------------
+
+{
+  const getCount = stubFetch([
+    async () => {
+      throw new Error('The operation was aborted due to timeout');
+    },
+    async () => okResponse('recovered from timeout'),
+  ]);
+  try {
+    const logs: Array<[string, string]> = [];
+    const logger = {
+      info: (msg: string) => logs.push(['info', msg]),
+      warn: (msg: string) => logs.push(['warn', msg]),
+      debug: (msg: string) => logs.push(['debug', msg]),
+    };
+    const result = await chatCompletion(testConfig, [
+      { role: 'user', content: 'hi' },
+    ], { logger, retry: { attempts: 3, baseDelayMs: 10 } });
+    assert(result === 'recovered from timeout', 'retry: timeout → retry → success');
+    assert(getCount() === 2, 'retry: timeout → 2 fetches');
+  } finally {
+    restoreFetch();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Disable retry: attempts set to 1 → no retry even on 429
+// ---------------------------------------------------------------------------
+
+{
+  const getCount = stubFetch([
+    async () => mockResponse(429, '{"error":{"message":"Rate limit"}}'),
+  ]);
+  try {
+    let thrown: unknown;
+    try {
+      await chatCompletion(testConfig, [
+        { role: 'user', content: 'hi' },
+      ], { retry: { attempts: 1, baseDelayMs: 10 } });
+    } catch (err) {
+      thrown = err;
+    }
+    assert(thrown instanceof Error, 'retry: attempts=1 → throws on 429');
+    assert(getCount() === 1, 'retry: attempts=1 → single fetch, no retry');
+  } finally {
+    restoreFetch();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log(`# fail: ${failed}`);
+console.log(`# ${passed}/${passed + failed} passed`);
+if (failed > 0) {
+  console.log('SOME TESTS FAILED');
+  process.exit(1);
+}
+console.log('ALL TESTS PASSED');

--- a/skill/plugin/llm-client.ts
+++ b/skill/plugin/llm-client.ts
@@ -485,26 +485,128 @@ export function resolveLLMConfig(): LLMClientConfig | null {
 }
 
 /**
+ * Options for chatCompletion. `retry` controls the 429 + timeout backoff
+ * loop added in 3.3.1-rc.2 — 5 of 6 extraction windows failed in the
+ * 3.3.1-rc.1 QA because zai 429s had no retry path.
+ */
+export interface ChatCompletionOptions {
+  maxTokens?: number;
+  temperature?: number;
+  /**
+   * Retry behaviour. Defaults to { attempts: 3, baseDelayMs: 1000 } —
+   * 1s → 2s → 4s exponential backoff on 429 or transient timeout. First
+   * failure logs at INFO (single-line, no stack), subsequent attempts at
+   * DEBUG. Set `attempts: 0` to disable retry entirely. Pass a `logger`
+   * for visibility; without one, retries are silent.
+   */
+  retry?: {
+    attempts?: number;
+    baseDelayMs?: number;
+  };
+  logger?: {
+    info?: (msg: string) => void;
+    warn?: (msg: string) => void;
+    debug?: (msg: string) => void;
+  };
+  /** Timeout per attempt in ms (default 30_000). */
+  timeoutMs?: number;
+}
+
+/**
  * Call the LLM chat completion endpoint.
  *
  * Supports both OpenAI-compatible format and Anthropic Messages API,
  * determined by `config.apiFormat`.
+ *
+ * 3.3.1-rc.2 — adds an exponential-backoff retry wrapper for HTTP 429 +
+ * timeout transients. Every retry attempt respects the per-attempt
+ * `timeoutMs` (default 30s). Max 3 total attempts by default (1s, 2s, 4s
+ * backoff). Non-retryable errors (4xx other than 429, network refused,
+ * JSON parse) fail fast on the first attempt.
  *
  * @returns The assistant's response content, or null on failure.
  */
 export async function chatCompletion(
   config: LLMClientConfig,
   messages: ChatMessage[],
-  options?: { maxTokens?: number; temperature?: number },
+  options?: ChatCompletionOptions,
 ): Promise<string | null> {
   const maxTokens = options?.maxTokens ?? 2048;
   const temperature = options?.temperature ?? 0; // Deterministic output for dedup (same input → same text → same content fingerprint)
+  const attempts = Math.max(1, options?.retry?.attempts ?? 3);
+  const baseDelayMs = Math.max(100, options?.retry?.baseDelayMs ?? 1000);
+  const timeoutMs = options?.timeoutMs ?? 30_000;
+  const logger = options?.logger;
 
-  if (config.apiFormat === 'anthropic') {
-    return chatCompletionAnthropic(config, messages, maxTokens, temperature);
+  const callOnce = (): Promise<string | null> =>
+    config.apiFormat === 'anthropic'
+      ? chatCompletionAnthropic(config, messages, maxTokens, temperature, timeoutMs)
+      : chatCompletionOpenAI(config, messages, maxTokens, temperature, timeoutMs);
+
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await callOnce();
+    } catch (err) {
+      lastErr = err;
+      const msg = err instanceof Error ? err.message : String(err);
+      const retryable = isRetryable(msg);
+      const isFinalAttempt = attempt >= attempts;
+      if (!retryable || isFinalAttempt) {
+        // Fail-fast OR last attempt — rethrow.
+        if (attempt > 1) {
+          logger?.warn?.(`chatCompletion: giving up after ${attempt} attempts: ${msg.slice(0, 200)}`);
+        }
+        throw err;
+      }
+      // Retry. INFO on first failure (visible), DEBUG on subsequent.
+      const delayMs = baseDelayMs * Math.pow(2, attempt - 1);
+      if (attempt === 1) {
+        logger?.info?.(
+          `chatCompletion: retrying after transient failure (attempt ${attempt}/${attempts}, wait ${delayMs}ms): ${msg.slice(0, 160)}`,
+        );
+      } else {
+        logger?.debug?.(
+          `chatCompletion: retry attempt ${attempt}/${attempts} (wait ${delayMs}ms): ${msg.slice(0, 160)}`,
+        );
+      }
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
   }
+  // Defensive — should never reach here since the loop always throws on the
+  // final attempt when it fails. Keeps TS happy.
+  throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
+}
 
-  return chatCompletionOpenAI(config, messages, maxTokens, temperature);
+/**
+ * Which LLM-call errors are worth retrying. Exported for testability.
+ *
+ * Retryable:
+ *   - HTTP 429 (rate limit)
+ *   - HTTP 503 / 502 / 504 (gateway transients)
+ *   - AbortError / "aborted due to timeout" / "TimeoutError"
+ *
+ * NOT retryable:
+ *   - HTTP 400 / 401 / 403 / 404 (auth / request errors — no point retrying)
+ *   - JSON parse errors
+ *   - DNS / connection refused (usually misconfig, not transient)
+ */
+export function isRetryable(errorMessage: string): boolean {
+  const m = errorMessage.toLowerCase();
+  // Rate limit
+  if (/\b429\b/.test(errorMessage) || m.includes('rate limit')) return true;
+  // Transient gateway errors
+  if (/\b50(2|3|4)\b/.test(errorMessage)) return true;
+  // Timeouts
+  if (
+    m.includes('timeout') ||
+    m.includes('aborterror') ||
+    m.includes('was aborted') ||
+    m.includes('operation was aborted')
+  ) {
+    return true;
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -516,6 +618,7 @@ async function chatCompletionOpenAI(
   messages: ChatMessage[],
   maxTokens: number,
   temperature: number,
+  timeoutMs: number,
 ): Promise<string | null> {
   const url = `${config.baseUrl}/chat/completions`;
 
@@ -534,7 +637,7 @@ async function chatCompletionOpenAI(
         Authorization: `Bearer ${config.apiKey}`,
       },
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(30_000), // 30 second timeout
+      signal: AbortSignal.timeout(timeoutMs),
     });
 
     if (!res.ok) {
@@ -559,6 +662,7 @@ async function chatCompletionAnthropic(
   messages: ChatMessage[],
   maxTokens: number,
   temperature: number,
+  timeoutMs: number,
 ): Promise<string | null> {
   const url = `${config.baseUrl}/messages`;
 
@@ -594,7 +698,7 @@ async function chatCompletionAnthropic(
         'anthropic-version': '2023-06-01',
       },
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(30_000),
+      signal: AbortSignal.timeout(timeoutMs),
     });
 
     if (!res.ok) {

--- a/skill/plugin/llm-profile-reader.test.ts
+++ b/skill/plugin/llm-profile-reader.test.ts
@@ -22,6 +22,10 @@ import {
   readAllAuthProfileKeys,
   dedupeByProvider,
   defaultAuthProfilesRoot,
+  parseModelsJsonFile,
+  findModelsJsonFiles,
+  readAllModelsJsonKeys,
+  readAllProfileKeys,
 } from './llm-profile-reader.js';
 
 let passed = 0;
@@ -187,6 +191,127 @@ function mkTmp(): string {
   const byProvider = dedupeByProvider(all);
   assert(byProvider['openai']?.apiKey === 'sk-beta', 'dedupeByProvider: later file wins for openai');
   assert(byProvider['anthropic']?.apiKey === 'sk-ant', 'dedupeByProvider: anthropic only in beta');
+}
+
+// ---------------------------------------------------------------------------
+// 3.3.1-rc.2 — legacy models.json reader
+// ---------------------------------------------------------------------------
+
+{
+  const tmp = mkTmp();
+  const file = path.join(tmp, 'models.json');
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      providers: {
+        zai: { apiKey: 'zai-legacy' },
+        openai: { apiKey: 'sk-legacy' },
+        anthropic: { apiKey: 'sk-ant-legacy' },
+      },
+    }),
+  );
+  const entries = parseModelsJsonFile(file);
+  const byProvider = dedupeByProvider(entries);
+  assert(byProvider['zai']?.apiKey === 'zai-legacy', 'models.json: zai captured');
+  assert(byProvider['openai']?.apiKey === 'sk-legacy', 'models.json: openai captured');
+  assert(byProvider['anthropic']?.apiKey === 'sk-ant-legacy', 'models.json: anthropic captured');
+  assert(byProvider['zai']?.profileId?.includes('models-json-legacy') ?? false, 'models.json: profileId marks legacy source');
+}
+
+{
+  // Accepts apiKey / api_key / key
+  const tmp = mkTmp();
+  const file = path.join(tmp, 'models.json');
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      providers: {
+        zai: { api_key: 'snake-case' },
+        openai: { key: 'plain-key' },
+      },
+    }),
+  );
+  const entries = parseModelsJsonFile(file);
+  const byProvider = dedupeByProvider(entries);
+  assert(byProvider['zai']?.apiKey === 'snake-case', 'models.json: api_key snake_case variant accepted');
+  assert(byProvider['openai']?.apiKey === 'plain-key', 'models.json: plain "key" variant accepted');
+}
+
+{
+  // Missing / malformed — graceful null
+  const tmp = mkTmp();
+  const file = path.join(tmp, 'models.json');
+  fs.writeFileSync(file, 'not json');
+  assert(parseModelsJsonFile(file).length === 0, 'models.json: invalid JSON → []');
+
+  fs.writeFileSync(file, JSON.stringify({ something_else: {} }));
+  assert(parseModelsJsonFile(file).length === 0, 'models.json: missing "providers" field → []');
+}
+
+{
+  // findModelsJsonFiles
+  const tmp = mkTmp();
+  const root = path.join(tmp, '.openclaw', 'agents');
+  fs.mkdirSync(path.join(root, 'agent-x', 'agent'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'agent-x', 'agent', 'models.json'), '{}');
+  const files = findModelsJsonFiles(root);
+  assert(files.length === 1, 'findModelsJsonFiles: finds agent-x/agent/models.json');
+}
+
+{
+  // Combined reader: auth-profiles wins over models.json on overlap
+  const tmp = mkTmp();
+  const root = path.join(tmp, '.openclaw', 'agents');
+  fs.mkdirSync(path.join(root, 'agent-a', 'agent'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, 'agent-a', 'agent', 'auth-profiles.json'),
+    JSON.stringify({
+      profiles: { 'openai:default': { key: 'sk-from-auth' } },
+    }),
+  );
+  fs.writeFileSync(
+    path.join(root, 'agent-a', 'agent', 'models.json'),
+    JSON.stringify({
+      providers: {
+        openai: { apiKey: 'sk-from-models-legacy' },
+        anthropic: { apiKey: 'sk-ant-from-models' },
+      },
+    }),
+  );
+  const merged = readAllProfileKeys({ root });
+  const byProvider = dedupeByProvider(merged);
+  assert(
+    byProvider['openai']?.apiKey === 'sk-from-auth',
+    'readAllProfileKeys: auth-profiles wins over models.json on overlap',
+  );
+  assert(
+    byProvider['anthropic']?.apiKey === 'sk-ant-from-models',
+    'readAllProfileKeys: models.json-only provider is picked up',
+  );
+}
+
+{
+  // Combined reader: models.json alone works when auth-profiles absent
+  const tmp = mkTmp();
+  const root = path.join(tmp, '.openclaw', 'agents');
+  fs.mkdirSync(path.join(root, 'agent-b', 'agent'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, 'agent-b', 'agent', 'models.json'),
+    JSON.stringify({
+      providers: { zai: { apiKey: 'zai-only' } },
+    }),
+  );
+  const merged = readAllProfileKeys({ root });
+  const byProvider = dedupeByProvider(merged);
+  assert(
+    byProvider['zai']?.apiKey === 'zai-only',
+    'readAllProfileKeys: models.json-only root yields its keys',
+  );
+}
+
+{
+  const allKeys = readAllModelsJsonKeys({ root: '/path/that/does/not/exist' });
+  assert(allKeys.length === 0, 'readAllModelsJsonKeys: missing root → []');
 }
 
 // ---------------------------------------------------------------------------

--- a/skill/plugin/llm-profile-reader.ts
+++ b/skill/plugin/llm-profile-reader.ts
@@ -41,6 +41,24 @@
  * Non-default profile ids are ignored — a deliberate choice so users who
  * have multiple profiles (`openai:work`, `openai:personal`) see the one
  * they've explicitly flagged as `default`.
+ *
+ * File format (models.json, legacy OpenClaw shape) — 3.3.1-rc.2
+ * ------------------------------------------------------------
+ *   {
+ *     "providers": {
+ *       "zai":        { "apiKey": "..." },
+ *       "openai":     { "apiKey": "sk-..." },
+ *       "anthropic":  { "apiKey": "sk-ant-..." },
+ *       ...
+ *     }
+ *   }
+ *
+ * 3.3.1-rc.1 QA found that some real OpenClaw installs (the VPS used for
+ * QA in particular) still have the pre-auth-profiles format — a single
+ * `models.json` at the same path with a `providers` map. Reading only
+ * auth-profiles.json silently no-op'd on those hosts. 3.3.1-rc.2 adds a
+ * 5th tier to the cascade: if auth-profiles.json is absent, fall back to
+ * the adjacent `models.json`.
  */
 
 import fs from 'node:fs';
@@ -215,6 +233,115 @@ export function dedupeByProvider(entries: AuthProfileKey[]): Record<string, Auth
     map[e.provider] = e;
   }
   return map;
+}
+
+// ---------------------------------------------------------------------------
+// 3.3.1-rc.2 — legacy models.json reader
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk `$HOME/.openclaw/agents/*` and return every
+ * `agent/models.json` path that exists on disk. Mirrors findAuthProfilesFiles
+ * but targets the pre-auth-profiles filename.
+ */
+export function findModelsJsonFiles(root: string): string[] {
+  if (!root) return [];
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const e of entries) {
+    if (!e.isDirectory()) continue;
+    if (e.name.startsWith('.')) continue;
+    const candidate = path.join(root, e.name, 'agent', 'models.json');
+    try {
+      if (fs.statSync(candidate).isFile()) out.push(candidate);
+    } catch {
+      // missing — skip.
+    }
+  }
+  out.sort();
+  return out;
+}
+
+/**
+ * Parse a legacy `models.json` file into AuthProfileKey entries. Unknown
+ * provider namespaces (anything not in PROFILE_NS_TO_PROVIDER) are
+ * skipped silently. Accepts `apiKey`, `api_key`, or `key` as the key
+ * field — different OpenClaw versions used different names.
+ */
+export function parseModelsJsonFile(filePath: string): AuthProfileKey[] {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    return [];
+  }
+  let json: unknown;
+  try {
+    json = JSON.parse(raw) as unknown;
+  } catch {
+    return [];
+  }
+  if (typeof json !== 'object' || json === null) return [];
+  const providersField = (json as { providers?: unknown }).providers;
+  if (typeof providersField !== 'object' || providersField === null) return [];
+  const providers = providersField as Record<string, unknown>;
+
+  const out: AuthProfileKey[] = [];
+  for (const [providerName, entryRaw] of Object.entries(providers)) {
+    const nsKey = providerName.toLowerCase();
+    const provider = PROFILE_NS_TO_PROVIDER[nsKey];
+    if (!provider) continue;
+    if (typeof entryRaw !== 'object' || entryRaw === null) continue;
+    const rec = entryRaw as Record<string, unknown>;
+    const rawKey = rec.apiKey ?? rec.api_key ?? rec.key;
+    if (typeof rawKey !== 'string') continue;
+    const trimmed = rawKey.trim();
+    if (!trimmed) continue;
+    out.push({
+      provider,
+      apiKey: trimmed,
+      sourcePath: filePath,
+      profileId: `${providerName}:models-json-legacy`,
+    });
+  }
+  return out;
+}
+
+/**
+ * Read every models.json file under the agents root. Counterpart to
+ * `readAllAuthProfileKeys`.
+ */
+export function readAllModelsJsonKeys(options: { root: string }): AuthProfileKey[] {
+  const files = findModelsJsonFiles(options.root);
+  const out: AuthProfileKey[] = [];
+  for (const file of files) {
+    const keys = parseModelsJsonFile(file);
+    out.push(...keys);
+  }
+  return out;
+}
+
+/**
+ * 3.3.1-rc.2 — combined reader. Reads auth-profiles.json first (if
+ * present), then merges in models.json entries for any provider NOT
+ * already covered by auth-profiles. The newer format wins on overlap.
+ */
+export function readAllProfileKeys(options: { root: string }): AuthProfileKey[] {
+  const primary = readAllAuthProfileKeys(options);
+  const primaryProviders = new Set(primary.map((e) => e.provider));
+  const legacy = readAllModelsJsonKeys(options);
+  const merged = [...primary];
+  for (const entry of legacy) {
+    if (!primaryProviders.has(entry.provider)) {
+      merged.push(entry);
+    }
+  }
+  return merged;
 }
 
 // ---------------------------------------------------------------------------

--- a/skill/plugin/package-lock.json
+++ b/skill/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.1-rc.1",
+  "version": "3.3.1-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/totalreclaw",
-      "version": "3.3.1-rc.1",
+      "version": "3.3.1-rc.2",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.0.1",

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.1-rc.1",
+  "version": "3.3.1-rc.2",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [
@@ -50,7 +50,7 @@
     "skill.json"
   ],
   "scripts": {
-    "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts",
+    "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx llm-client-retry.test.ts && npx tsx gateway-url.test.ts && npx tsx retype-setscope.test.ts && npx tsx tool-gating.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts",
     "check-scanner": "node ../scripts/check-scanner.mjs",
     "prepublishOnly": "node ../scripts/check-scanner.mjs"
   },

--- a/skill/plugin/retype-setscope.test.ts
+++ b/skill/plugin/retype-setscope.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for retype-setscope.ts — 3.3.1-rc.2 retype + set_scope operations.
+ *
+ * Covers:
+ *   - validateRetypeArgs accepts / rejects well- and ill-formed inputs
+ *   - validateSetScopeArgs accepts / rejects well- and ill-formed inputs
+ *   - executeRetype: fetches existing, decrypts, mutates type, writes
+ *     tombstone + new, returns previous/new type in result
+ *   - executeSetScope: same, for scope
+ *   - missing fact returns clear error
+ *   - malformed blob returns clear error
+ *   - submitBatch failure propagates as success=false
+ *
+ * Run with: npx tsx retype-setscope.test.ts
+ */
+
+import { Buffer } from 'node:buffer';
+
+import {
+  executeRetype,
+  executeSetScope,
+  validateRetypeArgs,
+  validateSetScopeArgs,
+  type RetypeSetScopeDeps,
+} from './retype-setscope.js';
+
+import { buildV1ClaimBlob } from './claims-helper.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond: boolean, name: string): void {
+  const n = passed + failed + 1;
+  if (cond) {
+    console.log(`ok ${n} - ${name}`);
+    passed++;
+  } else {
+    console.log(`not ok ${n} - ${name}`);
+    failed++;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// validateRetypeArgs
+// ---------------------------------------------------------------------------
+
+{
+  const r = validateRetypeArgs({ fact_id: 'abc-123', new_type: 'preference' });
+  assert(r.ok === true, 'validateRetypeArgs: accepts fact_id + new_type');
+  if (r.ok) assert(r.newType === 'preference', 'validateRetypeArgs: newType=preference');
+}
+
+{
+  const r = validateRetypeArgs({ factId: 'abc-123', newType: 'claim' });
+  assert(r.ok === true, 'validateRetypeArgs: accepts camelCase variants');
+}
+
+{
+  const r = validateRetypeArgs({ fact_id: 'abc-123', new_type: 'banana' });
+  assert(r.ok === false, 'validateRetypeArgs: rejects invalid type');
+}
+
+{
+  const r = validateRetypeArgs({ new_type: 'claim' });
+  assert(r.ok === false, 'validateRetypeArgs: rejects missing fact_id');
+}
+
+{
+  const r = validateRetypeArgs({ fact_id: '', new_type: 'claim' });
+  assert(r.ok === false, 'validateRetypeArgs: rejects empty fact_id');
+}
+
+{
+  const r = validateRetypeArgs(null);
+  assert(r.ok === false, 'validateRetypeArgs: rejects null');
+}
+
+// ---------------------------------------------------------------------------
+// validateSetScopeArgs
+// ---------------------------------------------------------------------------
+
+{
+  const r = validateSetScopeArgs({ fact_id: 'abc-123', new_scope: 'work' });
+  assert(r.ok === true, 'validateSetScopeArgs: accepts fact_id + new_scope');
+  if (r.ok) assert(r.newScope === 'work', 'validateSetScopeArgs: newScope=work');
+}
+
+{
+  const r = validateSetScopeArgs({ fact_id: 'abc-123', new_scope: 'health' });
+  assert(r.ok === true, 'validateSetScopeArgs: accepts health');
+}
+
+{
+  const r = validateSetScopeArgs({ fact_id: 'abc-123', new_scope: 'banana' });
+  assert(r.ok === false, 'validateSetScopeArgs: rejects invalid scope');
+}
+
+{
+  const r = validateSetScopeArgs({ fact_id: '', new_scope: 'work' });
+  assert(r.ok === false, 'validateSetScopeArgs: rejects empty fact_id');
+}
+
+// ---------------------------------------------------------------------------
+// executeRetype / executeSetScope — integration-style with mock deps
+// ---------------------------------------------------------------------------
+
+function buildMockDeps(opts: {
+  existingV1Blob: string;
+  submitShouldFail?: boolean;
+  fetchReturnsNull?: boolean;
+}): RetypeSetScopeDeps & {
+  _captured: { payloads: Buffer[] | null; fetchCalls: string[] };
+} {
+  const captured = { payloads: null as Buffer[] | null, fetchCalls: [] as string[] };
+  return {
+    owner: '0xowner',
+    sourceAgent: 'test',
+    fetchFactById: async (factId: string) => {
+      captured.fetchCalls.push(factId);
+      if (opts.fetchReturnsNull) return null;
+      return {
+        id: factId,
+        encryptedBlob: '0x' + Buffer.from(opts.existingV1Blob, 'utf-8').toString('hex'),
+        encryptedEmbedding: null,
+        decayScore: '1000000',
+        timestamp: new Date().toISOString(),
+        isActive: true,
+      };
+    },
+    decryptBlob: (hex: string) => {
+      // "decrypt" = raw hex → utf-8 (mock)
+      return Buffer.from(hex, 'hex').toString('utf-8');
+    },
+    encryptBlob: (plaintext: string) => {
+      // "encrypt" = utf-8 → hex (mock)
+      return Buffer.from(plaintext, 'utf-8').toString('hex');
+    },
+    submitBatch: async (payloads: Buffer[]) => {
+      captured.payloads = payloads;
+      if (opts.submitShouldFail) return { txHash: '0xfail', success: false };
+      return { txHash: '0xfeedfeed', success: true };
+    },
+    generateIndices: async (_text: string, _entities: string[]) => ({
+      blindIndices: ['test-trapdoor-1', 'test-trapdoor-2'],
+      encryptedEmbedding: 'testembedding',
+    }),
+    _captured: captured,
+  };
+}
+
+// Happy path — retype a claim to a preference
+{
+  const v1Blob = buildV1ClaimBlob({
+    id: 'abc-123',
+    text: 'I prefer PostgreSQL over MySQL',
+    type: 'claim',
+    source: 'user',
+    createdAt: new Date().toISOString(),
+    importance: 7,
+    confidence: 0.9,
+  });
+  const deps = buildMockDeps({ existingV1Blob: v1Blob });
+  const r = await executeRetype('abc-123', 'preference', deps);
+  assert(r.success, 'executeRetype: success');
+  assert(r.fact_id === 'abc-123', 'executeRetype: fact_id preserved');
+  assert(r.new_fact_id !== undefined && r.new_fact_id !== 'abc-123', 'executeRetype: new_fact_id allocated');
+  assert(r.previous_type === 'claim', 'executeRetype: previous_type captured');
+  assert(r.new_type === 'preference', 'executeRetype: new_type set');
+  assert(r.tx_hash === '0xfeedfeed', 'executeRetype: tx_hash propagated');
+  assert(deps._captured.payloads?.length === 2, 'executeRetype: submitted 2 payloads (tombstone + new)');
+}
+
+// Happy path — set scope to work
+{
+  const v1Blob = buildV1ClaimBlob({
+    id: 'abc-456',
+    text: 'My manager is Alice',
+    type: 'claim',
+    source: 'user',
+    createdAt: new Date().toISOString(),
+    importance: 5,
+    confidence: 0.9,
+  });
+  const deps = buildMockDeps({ existingV1Blob: v1Blob });
+  const r = await executeSetScope('abc-456', 'work', deps);
+  assert(r.success, 'executeSetScope: success');
+  assert(r.new_scope === 'work', 'executeSetScope: new_scope set');
+  // readV1Blob normalizes missing scope to 'unspecified' → that's what projectFromDecrypted reports.
+  assert(r.previous_scope === 'unspecified', 'executeSetScope: previous_scope=unspecified (default when not set)');
+  assert(deps._captured.payloads?.length === 2, 'executeSetScope: submitted 2 payloads');
+}
+
+// Fact not found
+{
+  const v1Blob = buildV1ClaimBlob({
+    id: 'abc-789',
+    text: 'doesnt matter',
+    type: 'claim',
+    source: 'user',
+    createdAt: new Date().toISOString(),
+  });
+  const deps = buildMockDeps({ existingV1Blob: v1Blob, fetchReturnsNull: true });
+  const r = await executeRetype('abc-789', 'preference', deps);
+  assert(!r.success, 'executeRetype: not-found → success=false');
+  assert(r.error?.includes('not found') ?? false, 'executeRetype: error mentions not-found');
+}
+
+// Submit batch fails
+{
+  const v1Blob = buildV1ClaimBlob({
+    id: 'abc-err',
+    text: 'stay here',
+    type: 'claim',
+    source: 'user',
+    createdAt: new Date().toISOString(),
+  });
+  const deps = buildMockDeps({ existingV1Blob: v1Blob, submitShouldFail: true });
+  const r = await executeSetScope('abc-err', 'work', deps);
+  assert(!r.success, 'executeSetScope: submit-fails → success=false');
+  assert(r.tx_hash === '0xfail', 'executeSetScope: failed tx hash surfaced');
+}
+
+// Invalid new_type
+{
+  const v1Blob = buildV1ClaimBlob({
+    id: 'abc-1',
+    text: 'x',
+    type: 'claim',
+    source: 'user',
+    createdAt: new Date().toISOString(),
+  });
+  const deps = buildMockDeps({ existingV1Blob: v1Blob });
+  const r = await executeRetype('abc-1', 'bogus' as unknown as 'claim', deps);
+  assert(!r.success, 'executeRetype: invalid type → error');
+}
+
+// Invalid new_scope
+{
+  const v1Blob = buildV1ClaimBlob({
+    id: 'abc-2',
+    text: 'x',
+    type: 'claim',
+    source: 'user',
+    createdAt: new Date().toISOString(),
+  });
+  const deps = buildMockDeps({ existingV1Blob: v1Blob });
+  const r = await executeSetScope('abc-2', 'bogus' as unknown as 'work', deps);
+  assert(!r.success, 'executeSetScope: invalid scope → error');
+}
+
+// Malformed blob (not parseable)
+{
+  const deps = buildMockDeps({ existingV1Blob: 'not json at all' });
+  const r = await executeRetype('abc-mal', 'preference', deps);
+  assert(!r.success, 'executeRetype: malformed blob → success=false');
+  assert(r.error?.toLowerCase().includes('blob') ?? false, 'executeRetype: error mentions blob');
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log(`# fail: ${failed}`);
+console.log(`# ${passed}/${passed + failed} passed`);
+if (failed > 0) {
+  console.log('SOME TESTS FAILED');
+  process.exit(1);
+}
+console.log('ALL TESTS PASSED');

--- a/skill/plugin/retype-setscope.ts
+++ b/skill/plugin/retype-setscope.ts
@@ -1,0 +1,474 @@
+/**
+ * retype / set_scope pure operations for OpenClaw plugin — v1.1 taxonomy.
+ *
+ * Agents need to be able to reclassify an existing memory's `type`
+ * (claim ↔ preference, etc.) or its `scope` (work ↔ personal ↔ health, ...)
+ * without destroying the underlying text. The subgraph is append-only,
+ * so like pin/unpin both operations tombstone the existing fact and
+ * write a fresh v1.1 blob with the changed field. The new fact's
+ * `superseded_by` points to the old fact id so cross-device readers see
+ * the correct resolution.
+ *
+ * Why this module is separate from pin.ts
+ * ---------------------------------------
+ * `executePinOperation` is tightly coupled to `pin_status` handling
+ * (idempotent short-circuit on matching status, decision-log recovery
+ * for auto-supersede victims, feedback wiring into the tuning loop).
+ * retype and set_scope are simpler — they don't short-circuit when the
+ * new value equals the old (the user might be confirming a prior
+ * auto-extraction's label) and they don't write feedback rows. Sharing
+ * the transport / crypto deps with pin is still useful; callers pass
+ * the same `RetypeSetScopeDeps` object.
+ *
+ * Scope and scanner surface
+ * -------------------------
+ * - No env-var reads — config is centralized in config.ts.
+ * - No outbound HTTP — all network work happens inside the injected
+ *   `submitBatch` dep (callers wire it to subgraph-store).
+ * - No disk reads — callers supply an in-memory pre-loaded fact.
+ */
+
+import crypto from 'node:crypto';
+import { createRequire } from 'node:module';
+import {
+  buildV1ClaimBlob,
+  mapTypeToCategory,
+  readV1Blob,
+} from './claims-helper.js';
+import {
+  isValidMemoryType,
+  VALID_MEMORY_SCOPES,
+  V0_TO_V1_TYPE,
+} from './extractor.js';
+import type {
+  MemoryType,
+  MemorySource,
+  MemoryScope,
+  MemoryVolatility,
+} from './extractor.js';
+import { PROTOBUF_VERSION_V4 } from './subgraph-store.js';
+import type { SubgraphSearchFact } from './subgraph-search.js';
+
+// Lazy-load WASM core — mirrors pin.ts pattern.
+const requireWasm = createRequire(import.meta.url);
+let _wasm: typeof import('@totalreclaw/core') | null = null;
+function getWasm(): typeof import('@totalreclaw/core') {
+  if (!_wasm) _wasm = requireWasm('@totalreclaw/core');
+  return _wasm!;
+}
+
+/** Minimal FactPayload shape — intentionally duplicated from pin.ts so this module stays standalone. */
+export interface FactPayload {
+  id: string;
+  timestamp: string;
+  owner: string;
+  encryptedBlob: string;
+  blindIndices: string[];
+  decayScore: number;
+  source: string;
+  contentFp: string;
+  agentId: string;
+  encryptedEmbedding?: string;
+}
+
+function encodeFactProtobufLocal(fact: FactPayload, version: number): Buffer {
+  const json = JSON.stringify({
+    id: fact.id,
+    timestamp: fact.timestamp,
+    owner: fact.owner,
+    encrypted_blob_hex: fact.encryptedBlob,
+    blind_indices: fact.blindIndices,
+    decay_score: fact.decayScore,
+    source: fact.source,
+    content_fp: fact.contentFp,
+    agent_id: fact.agentId,
+    encrypted_embedding: fact.encryptedEmbedding || null,
+    version,
+  });
+  return Buffer.from(getWasm().encodeFactProtobuf(json));
+}
+
+// ---------------------------------------------------------------------------
+// Deps
+// ---------------------------------------------------------------------------
+
+/** Injected dependencies — shared shape with pin.ts (owner, crypto, batch submitter, indices). */
+export interface RetypeSetScopeDeps {
+  owner: string;
+  sourceAgent: string;
+  fetchFactById: (factId: string) => Promise<SubgraphSearchFact | null>;
+  decryptBlob: (hexEncryptedBlob: string) => string;
+  encryptBlob: (plaintext: string) => string; // returns hex
+  submitBatch: (protobufPayloads: Buffer[]) => Promise<{ txHash: string; success: boolean }>;
+  generateIndices: (text: string, entityNames: string[]) => Promise<{
+    blindIndices: string[];
+    encryptedEmbedding?: string;
+  }>;
+}
+
+export interface RetypeSetScopeResult {
+  success: boolean;
+  fact_id: string;
+  new_fact_id?: string;
+  previous_type?: MemoryType;
+  new_type?: MemoryType;
+  previous_scope?: MemoryScope;
+  new_scope?: MemoryScope;
+  tx_hash?: string;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Normalized projector — takes decrypted plaintext, returns v1 shape for
+// mutation. Shared between retype + set_scope.
+// ---------------------------------------------------------------------------
+
+interface NormalizedFact {
+  text: string;
+  type: MemoryType;
+  source: MemorySource;
+  scope?: MemoryScope;
+  volatility?: MemoryVolatility;
+  reasoning?: string;
+  entities?: Array<{ name: string; type: string; role?: string }>;
+  importance: number;
+  confidence: number;
+  createdAt: string;
+  expiresAt?: string;
+}
+
+function projectFromDecrypted(decrypted: string): NormalizedFact | null {
+  let obj: Record<string, unknown>;
+  try {
+    obj = JSON.parse(decrypted) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  // v1 blob (schema_version "1.x")
+  if (
+    typeof obj.text === 'string' &&
+    typeof obj.type === 'string' &&
+    typeof obj.schema_version === 'string' &&
+    obj.schema_version.startsWith('1.')
+  ) {
+    const v1 = readV1Blob(decrypted);
+    if (v1) {
+      return {
+        text: v1.text,
+        type: v1.type,
+        source: v1.source,
+        scope: v1.scope,
+        volatility: v1.volatility,
+        reasoning: v1.reasoning,
+        entities: v1.entities,
+        importance: v1.importance,
+        confidence: v1.confidence,
+        createdAt: v1.createdAt,
+        expiresAt: v1.expiresAt,
+      };
+    }
+  }
+
+  // v0 short-key blob — upgrade to v1 shape.
+  if (typeof obj.t === 'string' && typeof obj.c === 'string') {
+    const v0Type = typeof obj.c === 'string' ? obj.c : 'fact';
+    const v1Type: MemoryType = (V0_TO_V1_TYPE as Record<string, MemoryType>)[v0Type] ?? 'claim';
+    const imp = typeof obj.i === 'number' ? obj.i : 5;
+    const conf = typeof obj.cf === 'number' ? obj.cf : 0.85;
+    const sa = typeof obj.sa === 'string' ? obj.sa : 'user';
+    const validSource: MemorySource = (
+      ['user', 'user-inferred', 'assistant', 'external', 'derived'] as const
+    ).includes(sa as MemorySource)
+      ? (sa as MemorySource)
+      : 'user';
+    const ea = typeof obj.ea === 'string' ? obj.ea : new Date().toISOString();
+    const entities = Array.isArray(obj.e)
+      ? (obj.e as unknown[])
+          .map((e) => {
+            if (!e || typeof e !== 'object') return null;
+            const entity = e as Record<string, unknown>;
+            const name = typeof entity.n === 'string' ? entity.n : '';
+            const entType = typeof entity.tp === 'string' ? entity.tp : 'concept';
+            if (!name) return null;
+            const role = typeof entity.r === 'string' ? entity.r : undefined;
+            return { name, type: entType, role };
+          })
+          .filter((e): e is { name: string; type: string; role?: string } => e !== null)
+      : undefined;
+    return {
+      text: typeof obj.t === 'string' ? obj.t : '',
+      type: v1Type,
+      source: validSource,
+      scope: undefined,
+      volatility: undefined,
+      reasoning: undefined,
+      entities,
+      importance: Math.max(1, Math.min(10, Math.round(imp))),
+      confidence: Math.max(0, Math.min(1, conf)),
+      createdAt: ea,
+    };
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Core: retrieve existing fact, decrypt, rewrite with mutated field
+// ---------------------------------------------------------------------------
+
+async function rewriteWithMutation(
+  factId: string,
+  deps: RetypeSetScopeDeps,
+  mutate: (existing: NormalizedFact) => NormalizedFact,
+): Promise<RetypeSetScopeResult> {
+  const existing = await deps.fetchFactById(factId);
+  if (!existing) {
+    return { success: false, fact_id: factId, error: `Fact not found: ${factId}` };
+  }
+  const blobHex = existing.encryptedBlob.startsWith('0x')
+    ? existing.encryptedBlob.slice(2)
+    : existing.encryptedBlob;
+  let plaintext: string;
+  try {
+    plaintext = deps.decryptBlob(blobHex);
+  } catch (err) {
+    return {
+      success: false,
+      fact_id: factId,
+      error: `Failed to decrypt fact: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const current = projectFromDecrypted(plaintext);
+  if (!current) {
+    return {
+      success: false,
+      fact_id: factId,
+      error: `Unrecognized blob shape for fact ${factId} — cannot retype/rescope`,
+    };
+  }
+
+  const next = mutate(current);
+  const newFactId = crypto.randomUUID();
+
+  let canonicalJson: string;
+  try {
+    canonicalJson = buildV1ClaimBlob({
+      id: newFactId,
+      text: next.text,
+      type: next.type,
+      source: next.source,
+      scope: next.scope,
+      volatility: next.volatility,
+      reasoning: next.reasoning,
+      entities: next.entities,
+      importance: next.importance,
+      confidence: next.confidence,
+      createdAt: new Date().toISOString(),
+      supersededBy: factId,
+    });
+  } catch (err) {
+    return {
+      success: false,
+      fact_id: factId,
+      error: `Failed to build v1 claim blob: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  let newBlobHex: string;
+  try {
+    newBlobHex = deps.encryptBlob(canonicalJson);
+  } catch (err) {
+    return {
+      success: false,
+      fact_id: factId,
+      error: `Failed to encrypt updated claim: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const entityNames: string[] = next.entities
+    ? next.entities
+        .map((e) => e.name)
+        .filter((n): n is string => typeof n === 'string' && n.length > 0)
+    : [];
+  let regenerated: { blindIndices: string[]; encryptedEmbedding?: string };
+  try {
+    regenerated = await deps.generateIndices(next.text, entityNames);
+  } catch {
+    regenerated = { blindIndices: [] };
+  }
+
+  const tombstonePayload: FactPayload = {
+    id: factId,
+    timestamp: new Date().toISOString(),
+    owner: deps.owner,
+    encryptedBlob: '00',
+    blindIndices: [],
+    decayScore: 0,
+    source: 'tombstone',
+    contentFp: '',
+    agentId: deps.sourceAgent,
+  };
+  const newPayload: FactPayload = {
+    id: newFactId,
+    timestamp: new Date().toISOString(),
+    owner: deps.owner,
+    encryptedBlob: newBlobHex,
+    blindIndices: regenerated.blindIndices,
+    decayScore: 1.0,
+    source: 'openclaw-plugin-retype',
+    contentFp: '',
+    agentId: deps.sourceAgent,
+    encryptedEmbedding: regenerated.encryptedEmbedding,
+  };
+  const payloads = [
+    encodeFactProtobufLocal(tombstonePayload, /* legacy v3 */ 3),
+    encodeFactProtobufLocal(newPayload, PROTOBUF_VERSION_V4),
+  ];
+
+  try {
+    const { txHash, success } = await deps.submitBatch(payloads);
+    if (!success) {
+      return {
+        success: false,
+        fact_id: factId,
+        error: 'On-chain batch submission failed',
+        tx_hash: txHash,
+      };
+    }
+    return {
+      success: true,
+      fact_id: factId,
+      new_fact_id: newFactId,
+      previous_type: current.type,
+      new_type: next.type,
+      previous_scope: current.scope,
+      new_scope: next.scope,
+      tx_hash: txHash,
+    };
+  } catch (err) {
+    return {
+      success: false,
+      fact_id: factId,
+      error: `Failed to submit retype/rescope batch: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public entry points
+// ---------------------------------------------------------------------------
+
+/**
+ * Re-type an existing memory. Writes a new v1.1 claim with `type` changed;
+ * tombstones the old fact. `superseded_by` on the new fact points to the
+ * old id so cross-device readers see the correct resolution.
+ */
+export async function executeRetype(
+  factId: string,
+  newType: MemoryType,
+  deps: RetypeSetScopeDeps,
+): Promise<RetypeSetScopeResult> {
+  if (!isValidMemoryType(newType)) {
+    return {
+      success: false,
+      fact_id: factId,
+      error: `Invalid new type "${newType}". Must be one of: claim, preference, directive, commitment, episode, summary.`,
+    };
+  }
+  return rewriteWithMutation(factId, deps, (current) => ({
+    ...current,
+    type: newType,
+  }));
+}
+
+/**
+ * Re-scope an existing memory. Writes a new v1.1 claim with `scope` changed;
+ * tombstones the old fact.
+ */
+export async function executeSetScope(
+  factId: string,
+  newScope: MemoryScope,
+  deps: RetypeSetScopeDeps,
+): Promise<RetypeSetScopeResult> {
+  if (!(VALID_MEMORY_SCOPES as readonly string[]).includes(newScope)) {
+    return {
+      success: false,
+      fact_id: factId,
+      error: `Invalid new scope "${newScope}". Must be one of: ${VALID_MEMORY_SCOPES.join(', ')}.`,
+    };
+  }
+  return rewriteWithMutation(factId, deps, (current) => ({
+    ...current,
+    scope: newScope,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+export interface RetypeArgsValid {
+  ok: true;
+  factId: string;
+  newType: MemoryType;
+}
+export interface RetypeArgsInvalid {
+  ok: false;
+  error: string;
+}
+
+export function validateRetypeArgs(args: unknown): RetypeArgsValid | RetypeArgsInvalid {
+  if (typeof args !== 'object' || args === null) {
+    return { ok: false, error: 'totalreclaw_retype requires an object argument.' };
+  }
+  const rec = args as Record<string, unknown>;
+  const factId = rec.fact_id ?? rec.factId;
+  if (typeof factId !== 'string' || factId.trim().length === 0) {
+    return { ok: false, error: 'fact_id is required and must be a non-empty string.' };
+  }
+  const newType = rec.new_type ?? rec.newType ?? rec.type;
+  if (typeof newType !== 'string' || !isValidMemoryType(newType)) {
+    return {
+      ok: false,
+      error: `new_type must be one of: ${[...['claim', 'preference', 'directive', 'commitment', 'episode', 'summary']].join(', ')}`,
+    };
+  }
+  return { ok: true, factId: factId.trim(), newType: newType as MemoryType };
+}
+
+export interface SetScopeArgsValid {
+  ok: true;
+  factId: string;
+  newScope: MemoryScope;
+}
+export interface SetScopeArgsInvalid {
+  ok: false;
+  error: string;
+}
+
+export function validateSetScopeArgs(args: unknown): SetScopeArgsValid | SetScopeArgsInvalid {
+  if (typeof args !== 'object' || args === null) {
+    return { ok: false, error: 'totalreclaw_set_scope requires an object argument.' };
+  }
+  const rec = args as Record<string, unknown>;
+  const factId = rec.fact_id ?? rec.factId;
+  if (typeof factId !== 'string' || factId.trim().length === 0) {
+    return { ok: false, error: 'fact_id is required and must be a non-empty string.' };
+  }
+  const newScope = rec.new_scope ?? rec.newScope ?? rec.scope;
+  if (typeof newScope !== 'string' || !(VALID_MEMORY_SCOPES as readonly string[]).includes(newScope)) {
+    return {
+      ok: false,
+      error: `new_scope must be one of: ${VALID_MEMORY_SCOPES.join(', ')}`,
+    };
+  }
+  return { ok: true, factId: factId.trim(), newScope: newScope as MemoryScope };
+}
+
+// ---------------------------------------------------------------------------
+// Export mapTypeToCategory re-export so callers (index.ts) don't need
+// a separate import path.
+// ---------------------------------------------------------------------------
+export { mapTypeToCategory };

--- a/skill/plugin/tool-gating.test.ts
+++ b/skill/plugin/tool-gating.test.ts
@@ -50,6 +50,9 @@ const EXPECTED_GATED = [
   'totalreclaw_consolidate',
   'totalreclaw_pin',
   'totalreclaw_unpin',
+  // 3.3.1-rc.2: retype + set_scope are gated (require onboarding state=active).
+  'totalreclaw_retype',
+  'totalreclaw_set_scope',
   'totalreclaw_import_from',
   'totalreclaw_import_batch',
 ];

--- a/skill/plugin/tool-gating.ts
+++ b/skill/plugin/tool-gating.ts
@@ -29,6 +29,8 @@ export const GATED_TOOL_NAMES: readonly string[] = Object.freeze([
   'totalreclaw_consolidate',
   'totalreclaw_pin',
   'totalreclaw_unpin',
+  'totalreclaw_retype',
+  'totalreclaw_set_scope',
   'totalreclaw_import_from',
   'totalreclaw_import_batch',
 ]);

--- a/skill/scripts/check-scanner.mjs
+++ b/skill/scripts/check-scanner.mjs
@@ -92,6 +92,25 @@ const EXFIL_CONTEXT_PATTERN = /\bfetch\b|\bpost\b|http\.request/i;
 // though the file never actually CALLS eval, the regex fired.
 const DYNAMIC_CODE_PATTERN = /\beval\s*\(|new\s+Function\s*\(/;
 
+// Mirrors OpenClaw SOURCE_RULES[shell-execution]:
+//   pattern:         /child_process/
+//   requiresContext: <none> — the import alone trips the scanner.
+// Shipped 2026-04-22 after 3.3.1-rc.1 NO-GO: `gateway-url.ts` imported
+// `child_process.execFileSync` for Tailscale auto-detect, which the
+// OpenClaw scanner flagged as "Shell command execution detected" and
+// BLOCKED install with:
+//   WARNING: Plugin "totalreclaw" contains dangerous code patterns:
+//   Shell command execution detected (child_process)
+// Even the import line alone fires the rule — the scanner doesn't
+// require an actual `spawn`/`exec*` call site. Fix by either:
+//   1. Removing the child_process usage entirely (preferred — most
+//      subprocess needs have a pure-node alternative), OR
+//   2. Moving the subprocess call into a separate post-install helper
+//      that OpenClaw sandboxes (NOT covered by this scanner), OR
+//   3. Applying for a scanner exemption (see docs/notes/
+//      INVESTIGATION-OPENCLAW-SCANNER-EXEMPTION-*).
+const SHELL_EXEC_PATTERN = /child_process/;
+
 const ALLOW_COMMENT = /^\s*(?:\/\/|\*|\/\*).*scanner-sim:\s*allow/i;
 
 function isSuppressed(source) {
@@ -152,6 +171,7 @@ for (let i = 2; i < process.argv.length; i++) {
 const envFindings = [];
 const exfilFindings = [];
 const dynCodeFindings = [];
+const shellExecFindings = [];
 
 if (!fs.existsSync(ROOT)) {
   console.error(`scanner-sim: root directory not found at ${ROOT}`);
@@ -195,9 +215,19 @@ for (const absPath of files) {
       hits: hits.slice(0, 10),
     });
   }
+
+  // Rule 4 — shell-execution (no context-trigger gate)
+  if (SHELL_EXEC_PATTERN.test(src)) {
+    const hits = allLinesMatching(lines, SHELL_EXEC_PATTERN);
+    shellExecFindings.push({
+      file: relPath,
+      hits: hits.slice(0, 10),
+    });
+  }
 }
 
-const totalFindings = envFindings.length + exfilFindings.length + dynCodeFindings.length;
+const totalFindings =
+  envFindings.length + exfilFindings.length + dynCodeFindings.length + shellExecFindings.length;
 if (jsonMode) {
   process.stdout.write(
     JSON.stringify(
@@ -206,6 +236,7 @@ if (jsonMode) {
         envHarvesting: envFindings,
         potentialExfiltration: exfilFindings,
         dynamicCodeExecution: dynCodeFindings,
+        shellExecution: shellExecFindings,
       },
       null,
       2,
@@ -216,7 +247,7 @@ if (jsonMode) {
 
 if (totalFindings === 0) {
   console.log(
-    `scanner-sim: OK — ${files.length} files scanned, 0 flags (env-harvesting + potential-exfiltration + dynamic-code-execution) under ${
+    `scanner-sim: OK — ${files.length} files scanned, 0 flags (env-harvesting + potential-exfiltration + dynamic-code-execution + shell-execution) under ${
       path.relative(process.cwd(), ROOT) || ROOT
     }`,
   );
@@ -224,7 +255,7 @@ if (totalFindings === 0) {
 }
 
 console.error(
-  `scanner-sim: FAIL — ${envFindings.length} env-harvesting + ${exfilFindings.length} potential-exfiltration + ${dynCodeFindings.length} dynamic-code-execution flag(s)`,
+  `scanner-sim: FAIL — ${envFindings.length} env-harvesting + ${exfilFindings.length} potential-exfiltration + ${dynCodeFindings.length} dynamic-code-execution + ${shellExecFindings.length} shell-execution flag(s)`,
 );
 console.error('');
 
@@ -278,6 +309,30 @@ if (dynCodeFindings.length > 0) {
   console.error('  2. Removing the call entirely if it is actual runtime code.');
   console.error('');
   for (const f of dynCodeFindings) {
+    console.error(`  ${f.file}`);
+    for (const t of f.hits) {
+      console.error(`    :${t.line}  hit -> ${t.text.slice(0, 120)}`);
+    }
+  }
+  console.error('');
+}
+
+if (shellExecFindings.length > 0) {
+  console.error('[shell-execution]');
+  console.error('Each of these files contains at least one match for `child_process` —');
+  console.error('even importing the module (`import ... from "child_process"` or');
+  console.error('`require("child_process")`) is enough to trip the rule. OpenClaw refuses');
+  console.error('to install plugins that can execute shell commands.');
+  console.error('');
+  console.error('This rule shipped after 3.3.1-rc.1 NO-GO: `gateway-url.ts` used');
+  console.error('`child_process.execFileSync(\"tailscale\", ...)` for MagicDNS auto-detect');
+  console.error('and blocked every `openclaw plugins install`. Fix by either:');
+  console.error('  1. Removing the child_process usage entirely (prefer pure-node');
+  console.error('     alternatives — os.networkInterfaces(), node:dns, node:fs), OR');
+  console.error('  2. Moving subprocess logic into a separate post-install helper');
+  console.error('     script that OpenClaw sandboxes (NOT inside the main plugin tree).');
+  console.error('');
+  for (const f of shellExecFindings) {
     console.error(`  ${f.file}`);
     for (const t of f.hits) {
       console.error(`    :${t.line}  hit -> ${t.text.slice(0, 120)}`);


### PR DESCRIPTION
## Summary

Unified rc.2 wave for the TotalReclaw plugin (npm) and Hermes Python client (PyPI). Addresses the plugin 3.3.1-rc.1 NO-GO report (3 ship-stoppers + 1 non-blocker) and 7 UX gaps flagged by Pedro's agent (Hermes) during parallel Telegram testing.

- **Plugin 3.3.1-rc.2** (`skill/plugin/`): removes install-time scanner regression, fixes on-chain forget, wires 4 missing agent tools (onboard / pair / retype / set_scope), adds 429 backoff + retry, falls back to legacy `models.json`.
- **Hermes Python 2.3.1rc2** (`python/`): new `totalreclaw` standalone CLI (setup + doctor), eager Smart Account resolution, embedding-download progress, silent-save default for generated phrases, agent-directive `SKILL.md`.

## Scope A — Plugin 3.3.1-rc.2 per-item verification

### A1. Remove `child_process` from gateway-url.ts — scanner-install gate

- `skill/plugin/gateway-url.ts` rewritten to use `os.networkInterfaces()` only. Tailscale detection is now a passive probe for a `tailscale*` NIC carrying a CGNAT IPv4 (100.64/10); MagicDNS hostname resolution is the operator's job via `plugins.entries.totalreclaw.config.publicUrl`.
- `skill/scripts/check-scanner.mjs` gained a `shell-execution` rule that mirrors the OpenClaw scanner's `child_process` detector.
- Verification: `node skill/scripts/check-scanner.mjs` → 0 flags across 84 files.
- Tests: `skill/plugin/gateway-url.test.ts` — 17 cases covering CGNAT detection, NIC skipping, composed resolver, meta-sync-ness.

### A2. Wire agent tools for the new CLI surface

Registered in `skill/plugin/index.ts`:

- `totalreclaw_onboard` — wraps `runNonInteractiveOnboard` in-process (no subprocess). Generate mode only through chat; restore still requires local terminal. Returns scope_address + credentials_path; NEVER returns the mnemonic.
- `totalreclaw_pair` — wraps `createPairSession` + `buildPairingUrl` + `defaultRenderQr` in-process. Returns URL + 6-digit PIN + ASCII QR for the agent to relay.
- `totalreclaw_retype` — documented in SKILL.md for rc.1 but NOT registered. Now registered + gated.
- `totalreclaw_set_scope` — same.

### A3. Fix `totalreclaw_forget` on-chain tombstone

Root cause: rc.1 used `submitFactOnChain` (single-fact path) and wrote the tombstone at protobuf v4. The subgraph only flips `isActive=false` when the tombstone matches the shape pin/unpin uses — `submitFactBatchOnChain` with a single-payload batch at legacy v3.

- Routed through `submitFactBatchOnChain` to match the pin/unpin tombstone shape exactly.
- Removed `version: PROTOBUF_VERSION_V4` from the tombstone FactPayload (defaults to v3 now).
- Added UUID-shape validation on `factId` so LLM hallucinations ("forget that I live in Porto" passed as the factId) get a clear error + recall-first hint instead of silently failing on-chain.

### A4. 429 backoff + retry in extraction

`skill/plugin/llm-client.ts` gained a retry wrapper around `chatCompletion`:

- 3 attempts with 1s → 2s → 4s exponential backoff
- 30s per-attempt timeout (was 30s global, now scoped per attempt)
- Classification via `isRetryable(errorMessage)`: 429 / 502 / 503 / 504 / timeout → retry; 4xx-other / JSON parse → fail-fast
- DEBUG log on subsequent retries, INFO on first failure, WARN on final give-up
- Every extractor callsite opts in: `extractFacts`, `extractFactsForCompaction`, `comparativeRescoreV1`, `extractDebriefFacts`

Tests: `skill/plugin/llm-client-retry.test.ts` — 29 cases.

### A5. Fallback to legacy `models.json` in llm-profile-reader.ts

- New `parseModelsJsonFile`, `findModelsJsonFiles`, `readAllModelsJsonKeys`, and combined `readAllProfileKeys` (auth-profiles wins on overlap).
- `index.ts` switched to `readAllProfileKeys`.
- Tests: `skill/plugin/llm-profile-reader.test.ts` — added 13 cases covering the new reader.

### A6. Tool descriptions rewritten to be agent-instructive

- `totalreclaw_forget`: describes the recall-first workflow, warns agents not to invent factIds.
- `totalreclaw_retype` / `totalreclaw_set_scope`: agent-directive descriptions with the full enum lists.
- SKILL.md updated to match.

### A7. CHANGELOG + version bump

- `skill/plugin/package.json`: `3.3.1-rc.1` → `3.3.1-rc.2`
- `skill/plugin/package-lock.json`: same
- `skill/plugin/CHANGELOG.md`: new `[3.3.1-rc.2]` entry
- `skill/plugin/SKILL.md`: version bump + new tool sections

## Scope B — Hermes 2.3.1rc2 per-item verification

### B1. `totalreclaw setup` + `totalreclaw doctor` CLI

- `python/src/totalreclaw/cli.py`: new module.
- `python/pyproject.toml`: `[project.scripts] totalreclaw = "totalreclaw.cli:main"`.
- `setup` delegates to the shared `hermes_cli.run_setup` so the two binaries behave identically.
- `doctor` checks: credentials exist + parse → mnemonic valid BIP-39 → Smart Account cached/derivable → embedding model cached → LLM provider keys present → Hermes plugin registered → relay reachable. Exit 0 / 1 / 2. Coloured output when stdout is a TTY.

### B2. Post-install banner

- `main()` default branch prints "TotalReclaw is not set up yet. Run `totalreclaw setup`" when credentials.json is absent.
- `LOCAL_MODE_INSTRUCTIONS` / `REMOTE_MODE_INSTRUCTIONS` now mention both `totalreclaw setup` and `hermes setup`.

### B3. Eager Smart Account resolution

- `_try_eager_resolve_scope_address` in `hermes/cli.py` runs after a successful wizard write; derives the SA via `_derive_smart_account_address` and merges `scope_address` back into credentials.json.
- Best-effort: a missing network is non-fatal; user sees a "will be derived on first call" warning.

### B4. Embedding download progress

- `embedding.py` adds `_emit_download_banner` / `_emit_download_done` + `_enable_hf_progress_bar`.
- Banner only prints when the HF cache is cold (single line to stderr).
- Respects `TOTALRECLAW_QUIET_EMBEDDING_BANNER=1` for CI.

### B5. Silent-save for generated recovery phrase

- `_run_generate(io, credentials_path, emit_phrase=False)` — default is silent-save: write credentials.json + print the retrieval command (`cat ... | jq -r .mnemonic`), NEVER display the phrase in terminal.
- `--emit-phrase` opt-in preserves rc.1 behaviour (4x3 grid on stderr + last-3-words confirmation).
- Both `hermes setup` and `totalreclaw setup` thread the flag.

### B6. Toolset registration — explicit entry-point docs

- `doctor` checks `importlib.metadata.entry_points(group="hermes_agent.plugins")` for `totalreclaw`; flags when missing.
- `plugin.yaml` adds `totalreclaw_onboarding_start` to `provides_tools`.

### B7. Hermes plugin SKILL.md rewrite (agent-directive)

- New file at `python/src/totalreclaw/hermes/SKILL.md` — 9 rules covering recovery-phrase handling, onboarding state, auto-storage, recall, mutation tools, remote setup, status, imports, consolidation, and error handling.
- `pyproject.toml` includes it in `package-data`.

### B8. CHANGELOG + version bump

- `python/pyproject.toml`: `2.3.1` → `2.3.1rc2` (PEP-440)
- `python/src/totalreclaw/__init__.py`: fallback version bumped
- `python/src/totalreclaw/hermes/plugin.yaml`: `2.3.1` → `2.3.1rc2`
- `python/CHANGELOG.md`: new `[2.3.1rc2]` entry

## Test plan

- [ ] CI plugin tests (all 10 suites) green
- [ ] CI Python tests (742 passing) green
- [ ] `node skill/scripts/check-scanner.mjs` → 0 flags
- [ ] Auto-QA dispatched by the rc2 publish workflow returns GO on both clients
  - [ ] OpenClaw plugin: full guide install + 5+ turn conversation + forget verified on-chain + retype/set_scope called via natural language
  - [ ] Hermes: `totalreclaw setup` + `totalreclaw doctor` + 5+ turn conversation + fresh-session recall + on-chain verification
- [ ] Only after auto-QA GO: dispatch `promote-rc.yml` (plugin) + `publish-python.yml` with `release-type: stable` (since PyPI has no retag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)