### PR TITLE
docs: RC/pre-release install guidance in both setup guides

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -16,6 +16,14 @@ pip install totalreclaw
 
 Hermes auto-discovers the plugin via entry-point registration at next start. No manual copy, no config editing. Ubuntu/Debian/Docker: add `--break-system-packages` or use a venv if you hit `externally-managed-environment`.
 
+**Installing a release candidate (RC / pre-release)?** Pre-releases on PyPI are hidden from `pip install` by default. Use `--pre` and pin the version explicitly:
+
+```bash
+pip install --pre totalreclaw==2.3.1rc2        # replace with the RC version you want
+```
+
+Find the latest RC via `pip index versions totalreclaw --pre` or on [PyPI](https://pypi.org/project/totalreclaw/#history). Never install an RC on production — only for QA against staging.
+
 ## 2. Set up your vault
 
 **Recommended -- CLI wizard (runs outside the LLM path):**

--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -16,6 +16,15 @@ First-run setup runs a secure CLI wizard (v3.2.0+); the plugin never auto-genera
 
 > **First interaction downloads a ~216 MB embedding model.** Cached locally, one-time.
 
+**Installing a release candidate (RC / pre-release)?** npm pre-releases are published under the `rc` dist-tag (or you can pin by exact version). Never install an RC on production — only for QA against staging.
+
+```bash
+openclaw plugins install @totalreclaw/totalreclaw@rc               # always the latest RC
+openclaw plugins install @totalreclaw/totalreclaw@3.3.1-rc.2       # pin exact version
+```
+
+Find the current RC via `npm view @totalreclaw/totalreclaw dist-tags` or the [npm page](https://www.npmjs.com/package/@totalreclaw/totalreclaw?activeTab=versions).
+
 <details>
 <summary>From-source install (for plugin development)</summary>
 


### PR DESCRIPTION
Small doc patch. Both setup guides now explain how to install release candidates when explicitly asked by users. Tested by QA finding 2026-04-22: agents couldn't install RCs on Telegram chat because the guide defaulted to stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)