### PR TITLE
plugin 3.3.1-rc.4 + hermes 2.3.1rc4: phrase safety + console-script fix

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -1,12 +1,13 @@
 # Hermes Agent + TotalReclaw
 
-TotalReclaw gives your Hermes agent encrypted, persistent memory. Install the plugin, run setup, chat.
+TotalReclaw gives your Hermes agent encrypted, persistent memory. Install the plugin, pair your vault from your browser, chat.
 
 ## Prerequisites
 
 - Hermes Agent v0.5.0+ (https://github.com/NousResearch/hermes-agent)
 - An LLM provider configured in Hermes (zai / openai / anthropic / gemini)
 - Python 3.11+
+- An up-to-date browser with WebCrypto x25519 + ChaCha20-Poly1305 (Safari 17.2+ or Chromium 118+) for QR pairing
 
 ## 1. Install
 
@@ -19,32 +20,46 @@ Hermes auto-discovers the plugin via entry-point registration at next start. No 
 **Installing a release candidate (RC / pre-release)?** Pre-releases on PyPI are hidden from `pip install` by default. Use `--pre` and pin the version explicitly:
 
 ```bash
-pip install --pre totalreclaw==2.3.1rc2        # replace with the RC version you want
+pip install --pre totalreclaw==2.3.1rc4        # replace with the RC version you want
 ```
 
 Find the latest RC via `pip index versions totalreclaw --pre` or on [PyPI](https://pypi.org/project/totalreclaw/#history). Never install an RC on production — only for QA against staging.
 
-## 2. Set up your vault
+> **2.3.1rc4 changed the console-script list.** rc.3 and earlier shipped a `hermes` entry point that collided with the upstream `hermes-agent` CLI. rc.4 removes it — now `pip install totalreclaw` only creates the `totalreclaw` binary. If you upgraded from rc.3 and your `hermes` binary was overwritten, reinstall hermes-agent to restore it (`pip install --force-reinstall hermes-agent`).
 
-**Recommended -- CLI wizard (runs outside the LLM path):**
+## 2. Set up your vault (default: QR pair flow)
 
-```bash
-hermes setup
-```
+In any Hermes chat session, ask the agent to set up TotalReclaw. The agent will call the `totalreclaw_pair` tool and relay a URL + 6-digit PIN:
 
-Pick "generate" or "import". The phrase is written to `~/.totalreclaw/credentials.json` (mode `0600`). **The phrase is never printed to stdout, logged, or sent to any LLM.** Retrieve it later with `cat ~/.totalreclaw/credentials.json | jq -r .mnemonic`. Save it somewhere safe -- it is the ONLY way to recover your vault.
+> "Open http://127.0.0.1:58391/pair/\<token\> in your browser, enter your phrase (or let the browser generate a new one), and confirm PIN 492731."
 
-**Via chat:** ask "Set up TotalReclaw for me" -- the agent points you at the CLI. Phrases are never generated or shown in chat.
+**What happens under the hood:**
 
-## 3. Restart Hermes
+1. Your browser fetches the pair page over loopback HTTP.
+2. The browser generates an ephemeral x25519 keypair, does ECDH against the gateway's ephemeral pubkey (passed in the URL `#fragment`, so it never hits server logs), derives a ChaCha20-Poly1305 key via HKDF-SHA256.
+3. You type (or let the browser generate) your recovery phrase.
+4. The browser encrypts the phrase locally and POSTs ciphertext + nonce + its pubkey to the gateway.
+5. The gateway decrypts server-side and writes `~/.totalreclaw/credentials.json` (mode `0600`).
+
+**The recovery phrase never crosses the LLM context.** Not the chat transcript, not the agent's shell stdout, not the tool-call payload. Browser-side crypto keeps it isolated from the LLM round-trip by construction.
+
+After the browser says "Pairing complete", restart Hermes so the plugin picks up the new credentials:
 
 ```bash
 hermes gateway restart
 ```
 
-Required for the plugin to register its tools and hooks.
+### If you prefer local-terminal setup (user-terminal ONLY — do NOT run this through an agent)
 
-## 4. Verify
+```bash
+totalreclaw setup
+```
+
+This runs the phrase wizard entirely in **your** terminal. Pick "generate" or "import". The phrase is written to `~/.totalreclaw/credentials.json` (mode `0600`) silently. Retrieve it later with `cat ~/.totalreclaw/credentials.json | jq -r .mnemonic`. Save it somewhere safe — it is the ONLY way to recover your vault.
+
+> **Do NOT ask an agent to run `totalreclaw setup` for you.** The agent's shell-tool stdout is captured into LLM context. Even though `totalreclaw setup` never prints the phrase by default, running phrase-related CLIs through the agent's shell is a phrase-safety hazard: any future flag change or regression could leak. The agent should ONLY use `totalreclaw_pair`.
+
+## 3. Verify
 
 Ask "What's my TotalReclaw status?", or run `hermes` then `/plugins` -- `totalreclaw` should be listed.
 
@@ -54,13 +69,13 @@ Ask "What's my TotalReclaw status?", or run `hermes` then `/plugins` -- `totalre
 |---|---|
 | "No LLM available for auto-extraction" | Configure a provider in Hermes (`hermes login` or set `ZAI_API_KEY` / `OPENAI_API_KEY` in `~/.hermes/.env`). TotalReclaw reuses it automatically. |
 | Plugin not in `/plugins` | `hermes gateway restart`. |
-| Recovery phrase appeared in chat | File a bug. Use the CLI: `hermes setup`. |
+| Pair page says "browser lacks x25519" | Upgrade to Safari 17.2+ or a recent Chromium. Older browsers can't run the AEAD crypto. |
+| Pair URL unreachable from phone | The pair HTTP server binds to `127.0.0.1` by default. For remote-phone setup, SSH-port-forward the port (`ssh -L 58391:127.0.0.1:58391 ...`) or run the browser on the gateway host directly. |
+| Recovery phrase appeared in chat | File a bug. Rotate: generate a new wallet via `totalreclaw_pair` with `mode=generate`. The leaked phrase is unrecoverable once shipped through LLM context. |
 
 ## Returning user (new machine)
 
-```bash
-hermes setup   # choose "import", paste your phrase when prompted (masked).
-```
+Use `totalreclaw_pair` with `mode=import`: the browser page accepts your existing 12/24-word phrase and encrypts it against the gateway's ephemeral key before uploading.
 
 ## See also
 

--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -39,13 +39,33 @@ openclaw plugins install ./totalreclaw/skill/plugin
 
 ## Your recovery phrase
 
-TotalReclaw is keyed by a 12-word BIP-39 recovery phrase. The CLI wizard generates or imports it on your terminal -- it never touches the LLM, the chat transcript, or the network.
+TotalReclaw is keyed by a 12-word BIP-39 recovery phrase. QR pairing generates or imports it in your **browser**, which then ships the phrase to the gateway end-to-end-encrypted. The phrase never touches the LLM, the chat transcript, or the agent's shell-tool stdout.
 
 **Stored at:** `~/.totalreclaw/credentials.json` (mode `0600`, owner-only). A separate `~/.totalreclaw/state.json` tracks onboarding state and never contains secrets.
 
 **Save the phrase somewhere safe.** It is the only key to your memories and the only way to use the same vault from another agent (Claude Desktop, Cursor, Hermes, etc.). No password reset, no recovery email, no support ticket that can recover lost memories.
 
-### First-time setup (local gateway)
+### Setup (default: QR pairing — agent-facilitated)
+
+Ask the OpenClaw agent in chat: "Set up TotalReclaw for me." The agent will call the `totalreclaw_pair` tool and relay a URL + 6-digit PIN:
+
+> "Open https://your-gateway/plugin/totalreclaw/pair/finish?sid=...#pk=... in your browser, enter your phrase (or let the browser generate one), and confirm PIN 492731."
+
+**What happens under the hood:**
+
+1. Your browser fetches the pair page.
+2. The browser performs x25519 ECDH against the gateway's ephemeral public key (passed in the URL `#fragment` — never hits server logs), derives a ChaCha20-Poly1305 key via HKDF-SHA256.
+3. You type (or let the browser generate) your recovery phrase.
+4. The browser encrypts locally and uploads ciphertext + nonce + its own pubkey + PIN.
+5. The gateway decrypts server-side and writes `~/.totalreclaw/credentials.json` (mode 0600).
+
+**The recovery phrase never enters the LLM context.** Not the chat, not the agent's reasoning, not the agent's shell stdout, not the tool-call payload. Browser-side crypto keeps it isolated by construction.
+
+Session TTL is 15 minutes by default (5-60 min configurable). The QR URL is single-use. Supported browsers: Safari 17.2+, Chromium 118+.
+
+### Setup (user-terminal ONLY — do NOT run this through an agent)
+
+If you prefer to set up entirely in your own terminal:
 
 ```bash
 openclaw totalreclaw onboard
@@ -54,45 +74,24 @@ openclaw totalreclaw onboard
 The wizard asks:
 
 1. **Generate** a new phrase. Printed as a 3x4 grid on your terminal with a "write it down" warning; you retype three specific words to prove you saved it. Persisted to `credentials.json` on success. Phrase never leaves the terminal.
-2. **Import** an existing phrase. Hidden stdin (masked with `*`), BIP-39 checksum validation. Existing memories become accessible immediately.
-3. **Skip** for now. Memory tools stay disabled until you re-run the wizard.
+2. **Import** an existing phrase. Hidden stdin (masked with `*`), BIP-39 checksum validation.
+3. **Skip** for now. Memory tools stay disabled until you re-run.
 
 Check state any time: `openclaw totalreclaw status`.
 
-### Agent-driven setup (non-interactive, v3.3.1+)
-
-For scripted or agent-led installs:
-
-```bash
-openclaw totalreclaw onboard --non-interactive --json --mode generate
-# => {"ok": true, "action": "generate", "scope_address": "0x...", "credentials_path": "..."}
-```
-
-The phrase is NOT in the JSON payload -- it was written to `credentials_path` at mode 0600. The agent should tell the user to open that file to read their phrase.
-
-For restore: `--mode restore --phrase "word1 word2 ..."`.
+> **Do NOT ask an agent to run `openclaw totalreclaw onboard` through its shell tool.** Agent shell stdout is captured into LLM context. Even though the wizard doesn't print the phrase by default, running phrase-related CLIs via an agent shell is a phrase-safety hazard — the agent MUST use `totalreclaw_pair` instead. The CLI is for you, not the agent.
 
 ### In-chat prompts
 
-Ask the agent "set up TotalReclaw for me" and it calls `totalreclaw_onboarding_start` (v3.2.0+) or the agent-invocable `totalreclaw_onboard` tool (v3.3.1+) -- both return a pointer back to the CLI wizard. Neither surface ever shows your recovery phrase in chat; that would leak it to the LLM provider's logs.
+Ask the agent "set up TotalReclaw for me" and it should call `totalreclaw_pair` directly. For users who explicitly prefer local-terminal setup, the agent falls back to `totalreclaw_onboarding_start` — a pointer-only tool that tells YOU to run the CLI wizard yourself. The agent never runs the wizard for you.
 
-### Remote-gateway setup (QR pairing, v3.3.0+)
+### rc.4 phrase-safety changes (3.3.1-rc.4+)
 
-If OpenClaw runs on a VPS or anywhere you don't have a local TTY:
+Per `project_phrase_safety_rule.md`:
 
-```bash
-openclaw totalreclaw pair generate         # new phrase
-openclaw totalreclaw pair import           # import existing
-openclaw totalreclaw pair generate --json  # v3.3.1 agent-driven
-```
-
-The CLI prints an ASCII QR, a 6-digit PIN, and a URL like `https://your-gateway/plugin/totalreclaw/pair/finish?sid=...#pk=...`. Scan/open on any phone or laptop; type the PIN; enter the phrase. The browser performs x25519 ECDH with the gateway's ephemeral public key (carried in the URL fragment -- invisible to servers on the path), encrypts the phrase with ChaCha20-Poly1305, uploads the ciphertext. The gateway decrypts, writes `credentials.json`, activates.
-
-The phrase never enters the LLM, the chat transcript, or the relay in plaintext. Session TTL 15 min default (5-60 configurable); QR is single-use.
-
-**Agent-driven pairing (v3.3.1):** `pair generate --json` emits structured `{url, pin, qr_ascii, expires_at_ms}` the agent presents to the user. The agent NEVER asks the user to paste the phrase in chat.
-
-**Gateway URL resolution:** `publicUrl` config -> `gateway.remote.url` -> custom bind host -> Tailscale MagicDNS -> LAN IPv4 -> localhost. Browsers: Safari 17+, Chrome 123+, Firefox 130+.
+- `totalreclaw_onboard` agent tool — **REMOVED**. Even with `emitPhrase: false`, nothing architecturally prevented leakage. Use `totalreclaw_pair`.
+- `totalreclaw setup` / `openclaw totalreclaw onboard` CLI commands — **KEPT but user-terminal only**. They MUST NOT be invoked via any agent shell tool.
+- `totalreclaw_pair` agent tool — **CANONICAL**. Browser-side x25519 + ChaCha20-Poly1305 + HKDF-SHA256 keeps the phrase out of the LLM round-trip by construction. Now ported to Hermes Python as well (v2.3.1rc4+).
 
 ### Retrieving your phrase later
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,41 @@ Hermes Agent plugin are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1rc4] — 2026-04-22
+
+Phrase-safety hardening + console-script collision fix. Paired with plugin `3.3.1-rc.4`. This release introduces architectural enforcement of the "recovery phrase MUST NEVER cross the LLM context" rule by porting the OpenClaw plugin's QR-pair flow to Hermes Python and removing every phrase-generating agent tool.
+
+### Fixed (ship-stopper)
+
+- **`pyproject.toml` — removed the `hermes = "totalreclaw.hermes.cli:main"` console script.** rc.3 shipped with this entry, which OVERWROTE the upstream `hermes-agent` CLI on `pip install totalreclaw`. Users hit `hermes gateway → argument command: invalid choice: 'gateway' (choose from setup)`, the Docker container restart-looped, the TR plugin never loaded, and zero memories were extracted. rc.4 drops the colliding binary — only `totalreclaw = "totalreclaw.cli:main"` remains. Users on rc.3 whose `hermes` binary was overwritten can restore it via `pip install --force-reinstall hermes-agent`.
+
+### Added
+
+- **`totalreclaw.pair`** — new module. x25519 ECDH + HKDF-SHA256 + ChaCha20-Poly1305 AEAD. Ports `skill/plugin/pair-crypto.ts` to Python via the `cryptography` library. Includes:
+  - `totalreclaw/pair/crypto.py` — `generate_gateway_keypair`, `compute_shared_secret`, `derive_aead_key_from_ecdh`, `aead_decrypt`, `encrypt_pairing_payload`, `decrypt_pairing_payload`, `compare_secondary_codes_ct`. Constants (HKDF info, AEAD key/nonce/tag lengths) match the TS module so a ciphertext produced by either side decrypts on the other.
+  - `totalreclaw/pair/session_store.py` — atomic TTL-evicted session store at `~/.totalreclaw/pair-sessions.json` (mode 0600). `.lock` sentinel via `O_CREAT | O_EXCL`. Stale-lock break at 30 s. Schema parity with the TS store: same field names on-disk (camelCase), same status values (`awaiting_scan` / `device_connected` / `consumed` / `completed` / `expired` / `rejected`), same TTL bounds (5-60 min, default 15), same 5-strike secondary-code lockout.
+  - `totalreclaw/pair/http_server.py` — stdlib `http.server` pinned to `127.0.0.1`. `GET /pair/<token>` serves the self-contained pair page; `POST /pair/<token>` accepts `{v, sid, pk_d, nonce, ct, pin}`, verifies PIN constant-time, decrypts, calls the caller-supplied completion handler, returns 204. CSP locked down, no-store cache, no LAN exposure.
+  - `totalreclaw/pair/pair_page.py` — browser HTML with inline crypto (x25519 + ChaCha via WebCrypto). No CDN, no external scripts. Refuses to run on browsers that lack WebCrypto x25519 (Safari <17.2, Chromium <118).
+- **`totalreclaw.hermes.pair_tool`** — `totalreclaw_pair` agent-tool handler. Returns `{url, pin, expires_at, mode, instructions}`. No phrase-adjacent data in the payload. Spawns (or reuses) a module-singleton background HTTP server on the first call.
+- **`cryptography>=42.0`** runtime dep. OpenSSL-backed; provides `ChaCha20Poly1305` + `X25519PrivateKey`.
+
+### Removed (phrase-safety enforcement — BREAKING for agent tool callers)
+
+- **`totalreclaw_setup` agent tool — REMOVED.** rc.3 accepted a `recovery_phrase` tool argument (phrase-in via LLM tool-call payload) AND on phrase-less invocations GENERATED a fresh BIP-39 mnemonic and RETURNED it in the JSON response (phrase-out). Either path is a vault-compromise-class violation of `project_phrase_safety_rule.md`. The underlying `tools.setup` function stays in the module for CLI delegation (`totalreclaw setup` -> `hermes.cli.run_setup`) and test compat, but is NO LONGER registered as an agent tool. Agents route through `totalreclaw_pair` instead.
+- Error messages in `tools.py` that previously pointed agents at `totalreclaw_setup` now point at `totalreclaw_pair`.
+
+### Changed
+
+- **`hermes/SKILL.md` — RULE 0 rewritten.** Now states the absolute rule ("phrase MUST NEVER cross the LLM context") and enumerates forbidden patterns (running `totalreclaw setup` / `hermes setup` via shell tool, passing phrase as tool-call arg, generating phrase in-chat, echoing pasted phrase, asking user to paste). RULE 1a rewritten around `totalreclaw_pair` as the canonical agent setup surface. RULE 5 (remote setup) collapsed into RULE 1a — QR pair is now the default for ALL users, not just remote/headless.
+- **`hermes/plugin.yaml` — tool list updated.** `totalreclaw_setup` and `totalreclaw_onboarding_start` removed; `totalreclaw_pair` added.
+- **`docs/guides/hermes-setup.md` — QR pair flow is now the default.** CLI wizard (`totalreclaw setup`) relegated to an "if you prefer local-terminal setup" subsection with a prominent "do NOT run this through an agent shell" warning.
+
+### Tests
+
+- **`tests/test_pair_crypto.py`** — 22 tests. Round-trip encrypt/decrypt, tamper rejection, sid binding, wrong-key rejection, constant-time PIN compare, RFC 5869 HKDF vector parity.
+- **`tests/test_pair_http.py`** — 11 tests. Spins up the embedded server; asserts happy path (204 + completion), PIN mismatch (403), expired session (410), unknown token (404), tampered ciphertext (400). Also validates the `GET` pair page (CSP, cache-control, content).
+- **`tests/test_agent_tools_phrase_safety.py`** — 5 tests. Enforces the phrase-safety contract: forbidden tool names NEVER registered, `totalreclaw_pair` IS registered, pair schema has no phrase-adjacent params, pair tool return value contains no phrase-adjacent keys.
+
 ## [2.3.1rc3] — 2026-04-22
 
 Hermes-side companion to the plugin `3.3.1-rc.3` wave. Paired fixes for the two zai endpoint paths, a bigger retry budget, AA25 nonce serialisation, a new RC-gated bug-report tool, and two SKILL.md addendums. All prior rc.1 + rc.2 fixes preserved.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "totalreclaw"
-version = "2.3.1rc3"
+version = "2.3.1rc4"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"
@@ -27,6 +27,15 @@ dependencies = [
     "transformers>=4.40",
     "huggingface-hub>=0.23",
     "eth-account>=0.13",
+    # 2.3.1rc4 — QR-pair flow ports the TS plugin's x25519 + ChaCha20-Poly1305
+    # AEAD handshake to Python so Hermes gains a phrase-safe setup path. The
+    # `cryptography` library provides both primitives via a single well-
+    # audited C backend (OpenSSL). Lower bound 42 matches the first release
+    # with the Python-wrapped `ChaCha20Poly1305` that we rely on; upper
+    # bound stays open — this is a security-critical dep that MUST track
+    # upstream patches. Hybrid ML-KEM is deferred to rc.5 per the phrase-
+    # safety rule's "document + ship pure x25519 for rc.4" carve-out.
+    "cryptography>=42.0",
 ]
 
 [project.optional-dependencies]
@@ -37,14 +46,13 @@ dev = ["pytest>=8.0", "pytest-asyncio>=0.24", "pytest-xdist>=3.5", "mnemonic>=0.
 totalreclaw = "totalreclaw.hermes"
 
 [project.scripts]
-# Hermes CLI for first-run onboarding ("hermes setup"). Mirrors the
-# plugin 3.3.0 onboarding flow so users switching between OpenClaw and
-# Hermes see the same branch question + recovery-phrase terminology.
-hermes = "totalreclaw.hermes.cli:main"
-# 2.3.1rc2 — standalone `totalreclaw` CLI (setup + doctor). Users who
-# install `pip install totalreclaw` without Hermes get a first-class
-# entry point for initialising the vault and running health checks. The
-# `hermes` binary remains for Hermes-specific flows.
+# 2.3.1rc4 — canonical user-facing CLI. Only one console script is
+# declared by this package: the colliding `hermes` binary (that would
+# overwrite hermes-agent's own CLI on `pip install totalreclaw`) was
+# REMOVED in rc.4 after rc.3 QA surfaced the "hermes gateway →
+# invalid choice: 'gateway'" restart-loop bug. Users who want the
+# Hermes-specific first-run wizard run `totalreclaw hermes-setup`
+# (see `totalreclaw.cli:main` for the subcommand router).
 totalreclaw = "totalreclaw.cli:main"
 
 [tool.setuptools.package-data]

--- a/python/src/totalreclaw/__init__.py
+++ b/python/src/totalreclaw/__init__.py
@@ -9,7 +9,7 @@ except Exception:
     # installed-package metadata is absent. Must match pyproject.toml —
     # test_version.py enforces a semver-shape string; the live value in
     # a pip-installed wheel comes from importlib.metadata above.
-    __version__ = "2.3.1rc3"
+    __version__ = "2.3.1rc4"
 
 from .client import TotalReclaw
 

--- a/python/src/totalreclaw/hermes/SKILL.md
+++ b/python/src/totalreclaw/hermes/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext. Python / Hermes edition."
-version: 2.3.1rc3
+version: 2.3.1rc4
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz
@@ -11,14 +11,19 @@ homepage: https://totalreclaw.xyz
 
 **This document is directive for agents, not user-facing copy.** Follow the rules in order; every rule is a hard `MUST` unless stated otherwise.
 
-## RULE 0 — Recovery-phrase handling (security boundary)
+## RULE 0 — Recovery-phrase handling (security boundary, ABSOLUTE)
 
-The recovery phrase is the ONLY key to the user's encrypted memories. Every agent decision in this skill flows downstream from this rule.
+The recovery phrase is the ONLY key to the user's encrypted memories. A single leaked phrase equals a fully compromised vault: the LLM provider (and anyone with access to its logs) can decrypt every memory the user has ever stored. Phrases do NOT rotate — once leaked, always leaked.
 
-- **NEVER generate a 12-word phrase yourself.** You cannot produce a valid BIP-39 checksum; any phrase you invent is a garbage string that can't recover real memories. Call `totalreclaw_setup` (or the CLI wizard) — those paths use `eth_account.Account.create_with_mnemonic()` which produces real phrases.
+**Absolute rule:** the recovery phrase MUST NEVER cross the LLM context in ANY form — not in your replies, not in tool-call arguments, not in tool-call return values, not in your reasoning, not in shell-tool stdout.
+
+- **NEVER invoke `totalreclaw setup`, `hermes setup`, or any phrase-generating / phrase-restoring CLI via your shell tool.** Those commands print (or could print, with flags like `--emit-phrase`, or with a silent-save regression) the phrase. Your shell-tool stdout is captured into LLM context. Those CLIs exist for users to run in their OWN terminal, OUTSIDE any agent shell.
+- **NEVER pass a recovery phrase as a tool-call argument.** The entire tool-call payload is in LLM context. The `totalreclaw_setup` tool that accepted a `recovery_phrase` parameter in rc.3 has been REMOVED in rc.4 for this reason.
+- **NEVER generate a 12-word phrase yourself.** You cannot produce a valid BIP-39 checksum; any phrase you invent is garbage that can't recover real memories.
 - **NEVER display a phrase in chat.** LLM providers log transcripts; any phrase in a reply leaks to every hop.
-- **NEVER echo back a phrase the user pastes.** If the user pastes one anyway, tell them: "That was pasted into chat — please delete the message immediately and use `totalreclaw setup --mode restore` in your terminal so the phrase stays on your machine."
-- **NEVER ask the user to paste their phrase.** Instead, direct them to run the CLI wizard.
+- **NEVER ask the user to paste their phrase.** If they do anyway, tell them immediately: "That was pasted into chat — please delete the message and generate a new wallet via `totalreclaw_pair` with `mode=generate`. The phrase you pasted is now compromised and cannot be un-leaked."
+
+The ONLY agent-facilitated setup path is `totalreclaw_pair` (see RULE 1a). Browser-side crypto keeps the phrase out of the LLM round-trip by construction.
 
 ---
 
@@ -31,15 +36,19 @@ Exactly one of these is true when your session starts:
 | Setup complete | `totalreclaw.agent.state.is_configured() == True` | Do nothing; memory tools are live. |
 | Setup pending | `is_configured() == False` (credentials.json missing/empty) | Proceed to RULE 1a. |
 
-### RULE 1a — Guide onboarding without leaking the phrase
+### RULE 1a — Setting up a user's TotalReclaw recovery phrase
 
-Call `totalreclaw_onboarding_start` (a pointer-only tool — returns a message, no secrets). The tool's return text contains two paths; relay them verbatim:
+**Agent path (default, only secure path): call the `totalreclaw_pair` tool.** It returns a URL + 6-digit PIN + `expires_at`. Tell the user:
 
-1. **Terminal wizard (preferred when user has shell access):** `totalreclaw setup` — the wizard generates a phrase silently, saves it to `~/.totalreclaw/credentials.json` (mode 0600), and tells the user to retrieve it with `cat ~/.totalreclaw/credentials.json | jq -r .mnemonic`. The phrase never appears in your output or the user's chat.
+> "Open <URL> in your browser, enter your phrase (or let the browser generate a new one), and confirm PIN <PIN>. Your phrase is encrypted in the browser and uploaded end-to-end-encrypted to this gateway — it never crosses this chat."
 
-2. **Agent-driven tool (where available, e.g., OpenClaw):** call `totalreclaw_setup` — the tool does the same write + pointer, returns `scope_address` but never the phrase.
+The browser does x25519 + ChaCha20-Poly1305 encryption against the gateway's ephemeral key. The gateway decrypts server-side and writes `~/.totalreclaw/credentials.json`. The LLM never sees the phrase at any point in the flow.
 
-If the user is on a remote machine without terminal access, use the pair flow (see RULE 5).
+**After the user confirms "pairing complete" in their browser:** tell them to restart the Hermes gateway so the plugin picks up the new credentials. Plugin routes and hooks only bind on fresh gateway start.
+
+**NEVER** invoke `totalreclaw setup`, `hermes setup`, `openclaw totalreclaw onboard`, or any phrase-generating CLI via your shell tool. Those commands are for users running them in their own terminal — not for you. Agent shell stdout is captured into LLM context; running them leaks the phrase.
+
+**NEVER** ask the user to paste their phrase into chat. If they do, immediately tell them to rotate by generating a new wallet via `totalreclaw_pair` with `mode=generate`; the pasted phrase is compromised and there is no rotation after-the-fact.
 
 ---
 
@@ -123,19 +132,13 @@ When user re-categorizes a memory's domain: "put that under work", "this is a he
 
 ---
 
-## RULE 5 — Remote setup (QR pair flow)
+## RULE 5 — QR pair is the canonical setup flow (RULE 1a applies to ALL users)
 
-If the user says they don't have terminal access (running Hermes on a remote VPS, inside Docker without exec, etc.), call the plugin-level `totalreclaw_pair` tool. The tool returns a URL + 6-digit PIN + ASCII QR code.
+RULE 1a's `totalreclaw_pair` flow is canonical for EVERY user, regardless of whether they have terminal access. Local users, remote users, Docker users, VPS users — all go through `totalreclaw_pair`. The browser-side crypto is what keeps the phrase out of the LLM context, and that protection matters whether the user is on the same machine or on a phone halfway around the world.
 
-Relay ALL THREE to the user verbatim:
-- Paste the URL in their phone browser (or scan the QR).
-- Type the PIN into the browser page when prompted.
-- The browser generates / accepts the recovery phrase and uploads it end-to-end encrypted.
-- Tell the user: "come back to chat when the browser says 'Pairing complete'."
+If a user explicitly says they prefer to set up entirely in their own terminal (no browser, no URL to open), point them at the CLI `totalreclaw setup` — but tell them to run it IN THEIR OWN TERMINAL, not through you. Do NOT call that CLI via your shell tool. Your shell-tool stdout is captured into LLM context.
 
-The phrase NEVER crosses chat. Even if the user insists, refuse to accept a pasted phrase and remind them of RULE 0.
-
-Hermes Python 2.3.1rc2 does not ship its own pair implementation — use the OpenClaw plugin tool when available, or fall back to directing the user to set up locally on another machine and `totalreclaw export` → paste into Hermes's `totalreclaw_restore` flow.
+Hermes Python 2.3.1rc4 ships a native `totalreclaw_pair` implementation (x25519 + ChaCha20-Poly1305). Use it directly — no fallback to external tools needed.
 
 ---
 

--- a/python/src/totalreclaw/hermes/__init__.py
+++ b/python/src/totalreclaw/hermes/__init__.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import logging
 
-from . import schemas, tools, hooks
+from . import schemas, tools, hooks, pair_tool
 from .state import PluginState
 
 logger = logging.getLogger(__name__)
@@ -77,12 +77,30 @@ def register(ctx):
         is_async=True,
         description=schemas.STATUS["description"],
     )
+    # 2.3.1rc4 — `totalreclaw_setup` agent tool REMOVED for phrase-safety.
+    #
+    # rc.3 registered a `totalreclaw_setup` tool whose handler (a) accepted
+    # a `recovery_phrase` tool argument, piping the phrase directly through
+    # the LLM tool-call payload, and (b) on phrase-less invocations
+    # GENERATED a fresh BIP-39 mnemonic and RETURNED it in the tool's JSON
+    # response. Either path crosses the LLM context, which is a vault-
+    # compromise-class violation of
+    # `project_phrase_safety_rule.md` (memory file in the internal repo;
+    # the absolute rule: "recovery phrase MUST NEVER cross the LLM context
+    # in ANY form"). rc.4 drops the registration entirely. The underlying
+    # `state.configure(phrase)` code path is still used — by the pair-
+    # flow HTTP handler (browser-side crypto) and by the `totalreclaw
+    # setup` CLI (user's own terminal) — but the agent has no direct
+    # surface that could leak the phrase.
+    #
+    # Agents route to `totalreclaw_pair` instead; see registration below.
     ctx.register_tool(
-        name="totalreclaw_setup",
+        name="totalreclaw_pair",
         toolset="totalreclaw",
-        schema=schemas.SETUP,
-        handler=lambda args, **kw: tools.setup(args, state, **kw),
-        description=schemas.SETUP["description"],
+        schema=pair_tool.PAIR_SCHEMA,
+        handler=lambda args, **kw: pair_tool.pair(args, state, **kw),
+        is_async=True,
+        description=pair_tool.PAIR_SCHEMA["description"],
     )
     ctx.register_tool(
         name="totalreclaw_import_from",

--- a/python/src/totalreclaw/hermes/pair_tool.py
+++ b/python/src/totalreclaw/hermes/pair_tool.py
@@ -1,0 +1,231 @@
+"""Hermes agent tool: ``totalreclaw_pair``.
+
+Shipped in 2.3.1rc4 as part of the phrase-safety hardening. Called by
+the Hermes agent when the user asks to set up TotalReclaw. Spins up (or
+reuses) a local-loopback HTTP pair server, creates a session, and
+returns ``{url, pin, expires_at}`` to the agent — no phrase-adjacent
+data. The agent relays the URL + PIN to the user, who completes the
+flow in their browser. The recovery phrase NEVER crosses the LLM
+context.
+
+See ``~/.claude/projects/-Users-pdiogo-Documents-code-totalreclaw-
+internal/memory/project_phrase_safety_rule.md`` for the governing rule.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+if TYPE_CHECKING:
+    from .state import PluginState
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+PAIR_SCHEMA: Dict[str, Any] = {
+    "name": "totalreclaw_pair",
+    "description": (
+        "Start a remote pairing session so the user can create or import "
+        "a TotalReclaw recovery phrase from their browser. Returns a "
+        "pairing URL and a 6-digit PIN. Relay both to the user verbatim — "
+        "the user opens the URL in their browser and types the PIN. The "
+        "phrase is entered and encrypted IN THE BROWSER and uploaded "
+        "end-to-end-encrypted to this Hermes gateway; it NEVER touches "
+        "the LLM provider or this chat transcript. Use this tool whenever "
+        "the user wants to set up TotalReclaw. NEVER shell out to "
+        "`totalreclaw setup` or `hermes setup` — those commands are for "
+        "users running them in their own terminal OUTSIDE an agent shell."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "mode": {
+                "type": "string",
+                "enum": ["generate", "import"],
+                "description": (
+                    '"generate" = the browser will create a NEW 12-word '
+                    'recovery phrase. "import" = the user pastes an '
+                    "EXISTING phrase in the browser (never in this chat)."
+                ),
+            },
+        },
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Module-singleton pair-HTTP server (lazy)
+# ---------------------------------------------------------------------------
+
+_SERVER_LOCK = threading.Lock()
+_SERVER_INSTANCE: Optional["PairServerSingleton"] = None
+
+
+class PairServerSingleton:
+    """Wrap a single :class:`PairHttpServer` so multiple tool calls
+    reuse one background server (one port, one credentials-write path).
+
+    Not thread-safe for construction; caller uses the module-level lock.
+    """
+
+    def __init__(self, server, sessions_path: Path) -> None:
+        self.server = server
+        self.sessions_path = sessions_path
+        self.started = False
+
+    def ensure_started(self) -> None:
+        if not self.started:
+            self.server.start()
+            self.started = True
+
+
+def _resolve_sessions_dir() -> Path:
+    """Default to ``~/.totalreclaw`` — the same dir credentials.json lives in.
+
+    Kept as a helper so tests can monkeypatch ``pathlib.Path.home``.
+    """
+    return Path.home() / ".totalreclaw"
+
+
+def _complete_pairing_handler(state: "PluginState"):
+    """Closure that writes credentials.json + configures state.
+
+    ``state.configure(phrase)`` is the same code path that
+    ``tools.setup`` used in rc.3. We reuse it because it handles the EOA
+    derivation + credentials write atomically. The critical difference:
+    this path runs INSIDE the HTTP handler after the browser has
+    end-to-end-encrypted the phrase. The agent never saw the phrase, and
+    this handler's return payload to the browser contains NO phrase data.
+    """
+    from .pair_tool_completion import complete_pairing
+
+    def _handler(phrase: str, session) -> Any:
+        return complete_pairing(phrase, session, state)
+
+    return _handler
+
+
+def _get_or_build_server(state: "PluginState"):
+    """Return the module-singleton pair server; build on first call."""
+    global _SERVER_INSTANCE
+    with _SERVER_LOCK:
+        if _SERVER_INSTANCE is not None:
+            return _SERVER_INSTANCE
+
+        # Late import to avoid pulling cryptography into module load if
+        # the tool is never called (e.g. on a stable build that hasn't
+        # shipped this tool yet).
+        from ..pair import build_pair_http_server, default_pair_sessions_path
+        from ..pair.http_server import PairHttpConfig
+
+        base_dir = _resolve_sessions_dir()
+        base_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        sessions_path = default_pair_sessions_path(base_dir)
+
+        # Bind host: 127.0.0.1 by default. Operators running Hermes in
+        # Docker need to publish the port OR SSH-tunnel; those paths are
+        # documented in the setup guides. No LAN bind.
+        bind_host = os.environ.get("TOTALRECLAW_PAIR_BIND_HOST", "127.0.0.1")
+        bind_port_raw = os.environ.get("TOTALRECLAW_PAIR_BIND_PORT", "0")
+        try:
+            bind_port = int(bind_port_raw)
+        except ValueError:
+            bind_port = 0
+
+        cfg = PairHttpConfig(
+            sessions_path=sessions_path,
+            complete_pairing=_complete_pairing_handler(state),
+            bind_host=bind_host,
+            bind_port=bind_port,
+            logger=logger,
+        )
+        server = build_pair_http_server(cfg)
+        _SERVER_INSTANCE = PairServerSingleton(server=server, sessions_path=sessions_path)
+        return _SERVER_INSTANCE
+
+
+# ---------------------------------------------------------------------------
+# Tool handler
+# ---------------------------------------------------------------------------
+
+
+async def pair(args: dict, state: "PluginState", **kwargs) -> str:
+    """Agent-callable handler for ``totalreclaw_pair``.
+
+    Returns a JSON-encoded ``{url, pin, expires_at}`` payload. NO phrase
+    data crosses this return value.
+    """
+    raw_mode = args.get("mode", "generate")
+    mode = "import" if raw_mode == "import" else "generate"
+
+    try:
+        from ..pair import (
+            create_pair_session,
+            generate_gateway_keypair,
+        )
+
+        singleton = _get_or_build_server(state)
+        singleton.ensure_started()
+
+        kp = generate_gateway_keypair()
+        session = create_pair_session(
+            singleton.sessions_path,
+            mode=mode,
+            sk_b64=kp.sk_b64,
+            pk_b64=kp.pk_b64,
+        )
+
+        base_url = singleton.server.url_for(session.sid)
+        # The pubkey goes in the fragment so it never hits server logs.
+        url = f"{base_url}#pk={kp.pk_b64}"
+
+        expires_iso = datetime.fromtimestamp(
+            session.expires_at_ms / 1000.0, tz=timezone.utc
+        ).isoformat()
+
+        logger.info(
+            "totalreclaw_pair: session %s… mode=%s port=%d",
+            session.sid[:8],
+            mode,
+            singleton.server.port,
+        )
+
+        return json.dumps(
+            {
+                "url": url,
+                "pin": session.secondary_code,
+                "expires_at": expires_iso,
+                "mode": mode,
+                "instructions": (
+                    f"Relay these to the user verbatim:\n"
+                    f"1. Open {url} in your browser.\n"
+                    f"2. Enter PIN {session.secondary_code} when asked.\n"
+                    f"3. "
+                    + (
+                        "The browser generates a new 12-word recovery phrase. "
+                        "Write it down BEFORE confirming — the phrase is "
+                        "unrecoverable if lost.\n"
+                        if mode == "generate"
+                        else "Paste your existing 12 or 24-word recovery phrase "
+                        "in the browser (never in this chat).\n"
+                    )
+                    + f"4. The encrypted phrase uploads to this gateway; it never crosses "
+                    f"this chat.\n"
+                    f"5. Come back to chat once the browser says 'Pairing complete'. "
+                    f"Restart the Hermes gateway so the plugin picks up the new "
+                    f"credentials."
+                ),
+            }
+        )
+    except Exception as err:
+        logger.error("totalreclaw_pair failed: %s", err)
+        return json.dumps({"error": f"Failed to start pairing session: {err}"})

--- a/python/src/totalreclaw/hermes/pair_tool_completion.py
+++ b/python/src/totalreclaw/hermes/pair_tool_completion.py
@@ -1,0 +1,65 @@
+"""Pair-flow completion handler — writes credentials.json + configures
+the Hermes plugin state from the decrypted browser-uploaded phrase.
+
+Split out of ``pair_tool.py`` so the HTTP-server-side code stays free of
+any Hermes runtime imports at module-load time. The phrase enters this
+module ONCE, gets persisted via ``PluginState.configure``, and never
+leaves.
+
+Phrase-safety invariants enforced here:
+
+- NEVER returns the phrase in the :class:`CompletePairingResult`. Only
+  ``account_id`` (EOA address, safe) and ``state`` are passed back to the
+  HTTP handler, which forwards them to the browser. The browser shows
+  the "pairing complete" confirmation; the agent's chat transcript never
+  sees the phrase.
+- Best-effort zeroization of local variables holding the phrase after
+  state configure.
+- No logging of phrase content. Only the EOA address (already public)
+  and sid prefix are logged.
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .state import PluginState
+    from ..pair.session_store import PairSession
+
+from ..pair.http_server import CompletePairingResult
+
+logger = logging.getLogger(__name__)
+
+
+def complete_pairing(
+    phrase: str,
+    session: "PairSession",
+    state: "PluginState",
+) -> CompletePairingResult:
+    """Apply a browser-decrypted phrase to the Hermes plugin state.
+
+    Called FROM the HTTP handler thread. ``state.configure`` is synchronous
+    (writes credentials.json, derives the EOA address). The async Smart-
+    Account derivation happens lazily on the first remember/recall call.
+    """
+    try:
+        state.configure(phrase)
+        client = state.get_client()
+        eoa = getattr(client, "_eoa_address", None)
+        logger.info(
+            "pair-tool: credentials configured for EOA %s (session %s…)",
+            eoa or "unknown",
+            session.sid[:8],
+        )
+        return CompletePairingResult(state="active", account_id=eoa)
+    except Exception as err:  # pragma: no cover — defensive
+        logger.error(
+            "pair-tool: complete_pairing failed for session %s…: %r",
+            session.sid[:8],
+            err,
+        )
+        return CompletePairingResult(state="error", error=str(err))
+    finally:
+        # Best-effort phrase zeroization.
+        phrase = ""  # noqa: F841

--- a/python/src/totalreclaw/hermes/plugin.yaml
+++ b/python/src/totalreclaw/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: totalreclaw
-version: 2.3.1rc3
+version: 2.3.1rc4
 description: End-to-end encrypted memory vault for AI agents (Memory Taxonomy v1)
 author: TotalReclaw Team
 provides_tools:
@@ -8,14 +8,13 @@ provides_tools:
   - totalreclaw_forget
   - totalreclaw_export
   - totalreclaw_status
-  - totalreclaw_setup
+  - totalreclaw_pair
   - totalreclaw_pin
   - totalreclaw_unpin
   - totalreclaw_import_from
   - totalreclaw_import_batch
   - totalreclaw_upgrade
   - totalreclaw_debrief
-  - totalreclaw_onboarding_start
 provides_hooks:
   - on_session_start
   - pre_llm_call

--- a/python/src/totalreclaw/hermes/tools.py
+++ b/python/src/totalreclaw/hermes/tools.py
@@ -33,7 +33,7 @@ async def remember(args: dict, state: "PluginState", **kwargs) -> str:
 
     client = state.get_client()
     if not client:
-        return json.dumps({"error": "TotalReclaw not configured. Run totalreclaw_setup first."})
+        return json.dumps({"error": "TotalReclaw not configured. Call totalreclaw_pair to set up — browser-side crypto keeps the phrase out of this chat."})
 
     text = args.get("text", "").strip()
     if not text:
@@ -92,7 +92,7 @@ async def recall(args: dict, state: "PluginState", **kwargs) -> str:
     """Search memories in TotalReclaw."""
     client = state.get_client()
     if not client:
-        return json.dumps({"error": "TotalReclaw not configured. Run totalreclaw_setup first."})
+        return json.dumps({"error": "TotalReclaw not configured. Call totalreclaw_pair to set up — browser-side crypto keeps the phrase out of this chat."})
 
     query = args.get("query", "").strip()
     if not query:
@@ -125,7 +125,7 @@ async def forget(args: dict, state: "PluginState", **kwargs) -> str:
     """Delete a memory from TotalReclaw."""
     client = state.get_client()
     if not client:
-        return json.dumps({"error": "TotalReclaw not configured. Run totalreclaw_setup first."})
+        return json.dumps({"error": "TotalReclaw not configured. Call totalreclaw_pair to set up — browser-side crypto keeps the phrase out of this chat."})
 
     fact_id = args.get("fact_id", "").strip()
     if not fact_id:
@@ -149,7 +149,7 @@ async def pin(args: dict, state: "PluginState", **kwargs) -> str:
     """
     client = state.get_client()
     if not client:
-        return json.dumps({"error": "TotalReclaw not configured. Run totalreclaw_setup first."})
+        return json.dumps({"error": "TotalReclaw not configured. Call totalreclaw_pair to set up — browser-side crypto keeps the phrase out of this chat."})
 
     raw = args.get("fact_id")
     if not isinstance(raw, str):
@@ -187,7 +187,7 @@ async def unpin(args: dict, state: "PluginState", **kwargs) -> str:
     """
     client = state.get_client()
     if not client:
-        return json.dumps({"error": "TotalReclaw not configured. Run totalreclaw_setup first."})
+        return json.dumps({"error": "TotalReclaw not configured. Call totalreclaw_pair to set up — browser-side crypto keeps the phrase out of this chat."})
 
     raw = args.get("fact_id")
     if not isinstance(raw, str):
@@ -220,7 +220,7 @@ async def export_all(args: dict, state: "PluginState", **kwargs) -> str:
     """Export all memories from TotalReclaw."""
     client = state.get_client()
     if not client:
-        return json.dumps({"error": "TotalReclaw not configured. Run totalreclaw_setup first."})
+        return json.dumps({"error": "TotalReclaw not configured. Call totalreclaw_pair to set up — browser-side crypto keeps the phrase out of this chat."})
 
     try:
         facts = await client.export_all()
@@ -234,7 +234,7 @@ async def status(args: dict, state: "PluginState", **kwargs) -> str:
     """Check TotalReclaw billing status."""
     client = state.get_client()
     if not client:
-        return json.dumps({"error": "TotalReclaw not configured. Run totalreclaw_setup first."})
+        return json.dumps({"error": "TotalReclaw not configured. Call totalreclaw_pair to set up — browser-side crypto keeps the phrase out of this chat."})
 
     try:
         billing = await client.status()
@@ -250,7 +250,20 @@ async def status(args: dict, state: "PluginState", **kwargs) -> str:
 
 
 def setup(args: dict, state: "PluginState", **kwargs) -> str:
-    """Configure TotalReclaw credentials. Generates a new recovery phrase if none provided."""
+    """Configure TotalReclaw credentials. Generates a new recovery phrase if none provided.
+
+    .. warning::
+
+       In 2.3.1rc4 this function is NO LONGER registered as an agent tool —
+       ``project_phrase_safety_rule.md`` requires that recovery phrases
+       never cross the LLM context, and both the ``recovery_phrase``
+       parameter path (phrase-in) AND the phrase-less generation path
+       (phrase-out in the return JSON) violated that rule. The function
+       stays in the module for test compatibility and for the CLI
+       delegation chain (``totalreclaw setup`` -> ``hermes.cli.run_setup``).
+       Calling it from an agent-tool handler is forbidden; route the agent
+       to ``totalreclaw_pair`` instead.
+    """
     recovery_phrase = args.get("recovery_phrase", "").strip()
     generated = False
 
@@ -305,7 +318,7 @@ async def upgrade(args: dict, state: "PluginState", **kwargs) -> str:
     client = state.get_client()
     if not client:
         return json.dumps(
-            {"error": "TotalReclaw not configured. Run totalreclaw_setup first."}
+            {"error": "TotalReclaw not configured. Call totalreclaw_pair to set up — browser-side crypto keeps the phrase out of this chat."}
         )
 
     try:
@@ -356,7 +369,7 @@ async def debrief(args: dict, state: "PluginState", **kwargs) -> str:
     client = state.get_client()
     if not client:
         return json.dumps(
-            {"error": "TotalReclaw not configured. Run totalreclaw_setup first."}
+            {"error": "TotalReclaw not configured. Call totalreclaw_pair to set up — browser-side crypto keeps the phrase out of this chat."}
         )
 
     # Short-circuit guard so the tool returns a clear explanation to the
@@ -478,7 +491,7 @@ async def import_from(args: dict, state: "PluginState", **kwargs) -> str:
     """Import memories from other AI tools (Gemini, ChatGPT, Claude, Mem0, etc.)."""
     client = state.get_client()
     if not client:
-        return json.dumps({"error": "TotalReclaw not configured. Run totalreclaw_setup first."})
+        return json.dumps({"error": "TotalReclaw not configured. Call totalreclaw_pair to set up — browser-side crypto keeps the phrase out of this chat."})
 
     source = args.get("source", "")
     file_path = args.get("file_path")
@@ -536,7 +549,7 @@ async def import_batch(args: dict, state: "PluginState", **kwargs) -> str:
     """Process one batch of a large import. Call repeatedly with increasing offset."""
     client = state.get_client()
     if not client:
-        return json.dumps({"error": "TotalReclaw not configured. Run totalreclaw_setup first."})
+        return json.dumps({"error": "TotalReclaw not configured. Call totalreclaw_pair to set up — browser-side crypto keeps the phrase out of this chat."})
 
     source = args.get("source", "")
     file_path = args.get("file_path")

--- a/python/src/totalreclaw/onboarding.py
+++ b/python/src/totalreclaw/onboarding.py
@@ -79,10 +79,10 @@ BRANCH_QUESTION = """
 Let's set up your account. Do you already have a recovery phrase, or should we generate a new one?
 """.strip()
 
-LOCAL_MODE_INSTRUCTIONS = "Run: totalreclaw setup  (or: hermes setup)"
+LOCAL_MODE_INSTRUCTIONS = "Run: totalreclaw setup"
 
 REMOTE_MODE_INSTRUCTIONS = """
-Run: totalreclaw setup  (or: hermes setup if you're on a Hermes-specific install)
+Run: totalreclaw setup
 
 You'll be prompted to either restore from an existing recovery phrase or generate a new one. Your phrase never leaves this machine.
 """.strip()

--- a/python/src/totalreclaw/pair/__init__.py
+++ b/python/src/totalreclaw/pair/__init__.py
@@ -1,0 +1,83 @@
+"""TotalReclaw Hermes QR-pair flow (2.3.1rc4).
+
+Browser-side crypto handoff that keeps the recovery phrase out of the
+LLM context. The gateway publishes an ephemeral x25519 public key via a
+local-loopback HTTP endpoint; the user's browser does x25519 ECDH +
+ChaCha20-Poly1305 AEAD encryption of the phrase against that key and
+POSTs the ciphertext back. The gateway decrypts, writes
+``~/.totalreclaw/credentials.json`` (0600), and the agent never sees the
+plaintext at any point.
+
+Parity with the TypeScript plugin's ``skill/plugin/pair-*.ts`` modules
+(3.3.0). Cipher-suite wire format is identical:
+
+- x25519 ECDH key agreement (32-byte raw keys).
+- HKDF-SHA256 with ``salt = sid`` (UTF-8 bytes) and
+  ``info = "totalreclaw-pair-v1"`` (UTF-8) -> 32-byte AEAD key.
+- ChaCha20-Poly1305 AEAD, 12-byte nonce, 16-byte tag, ``AD = sid`` bytes.
+- Base64url encoding for every wire field.
+
+ML-KEM hybrid parity (per ``project_phrase_safety_rule.md``) is DEFERRED
+to rc.5 — pure x25519 ships in rc.4 so Hermes gains *some* phrase-safe
+setup path without blocking on the hybrid port. The TS plugin is
+currently also pure x25519; adding hybrid in rc.5 will land in both
+stacks together.
+"""
+from __future__ import annotations
+
+from .crypto import (
+    AEAD_KEY_BYTES,
+    AEAD_NONCE_BYTES,
+    AEAD_TAG_BYTES,
+    HKDF_INFO,
+    X25519_KEY_BYTES,
+    GatewayKeypair,
+    compute_shared_secret,
+    decrypt_pairing_payload,
+    derive_aead_key_from_ecdh,
+    derive_session_keys,
+    generate_gateway_keypair,
+)
+from .session_store import (
+    DEFAULT_PAIR_TTL_MS,
+    MAX_SECONDARY_CODE_ATTEMPTS,
+    PairSession,
+    PairSessionStatus,
+    consume_pair_session,
+    create_pair_session,
+    default_pair_sessions_path,
+    get_pair_session,
+    register_failed_secondary_code,
+    reject_pair_session,
+    transition_pair_session,
+)
+from .http_server import PairHttpServer, build_pair_http_server
+from .pair_page import render_pair_page
+
+__all__ = [
+    "AEAD_KEY_BYTES",
+    "AEAD_NONCE_BYTES",
+    "AEAD_TAG_BYTES",
+    "HKDF_INFO",
+    "X25519_KEY_BYTES",
+    "DEFAULT_PAIR_TTL_MS",
+    "MAX_SECONDARY_CODE_ATTEMPTS",
+    "GatewayKeypair",
+    "PairSession",
+    "PairSessionStatus",
+    "PairHttpServer",
+    "build_pair_http_server",
+    "compute_shared_secret",
+    "consume_pair_session",
+    "create_pair_session",
+    "decrypt_pairing_payload",
+    "default_pair_sessions_path",
+    "derive_aead_key_from_ecdh",
+    "derive_session_keys",
+    "generate_gateway_keypair",
+    "get_pair_session",
+    "register_failed_secondary_code",
+    "reject_pair_session",
+    "render_pair_page",
+    "transition_pair_session",
+]

--- a/python/src/totalreclaw/pair/crypto.py
+++ b/python/src/totalreclaw/pair/crypto.py
@@ -1,0 +1,359 @@
+"""pair.crypto — gateway-side x25519 + ChaCha20-Poly1305 primitives.
+
+Python parity of ``skill/plugin/pair-crypto.ts`` (v3.3.0). Every wire
+constant (HKDF info, salt binding, tag length, key length) matches the
+TS module so a ciphertext produced by one side decrypts on the other
+unchanged.
+
+Cipher suite (per design doc section 3a-3b, ratified 2026-04-20):
+
+- ECDH on x25519 for key agreement.
+- HKDF-SHA256 for symmetric-key derivation from the shared secret.
+- ChaCha20-Poly1305 AEAD for the ciphertext payload, with the sid
+  bound as associated data (``AD = sid UTF-8 bytes``).
+
+Every primitive is provided by the ``cryptography`` package (OpenSSL-
+backed). No phrase material, private keys, or secondary codes EVER flow
+through logs or return values.
+
+Byte encoding: every wire field is base64url (``urlsafe_b64``) with
+``"="`` padding stripped, matching Node's ``Buffer.toString('base64url')``
+output. Helpers ``_b64url_encode`` / ``_b64url_decode`` live here so every
+caller uses the same padding policy.
+
+Base64url round-trip parity sanity-check: a 32-byte raw x25519 key
+becomes 43 base64url chars (no padding), matching the TS-side output.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import os
+import secrets
+from dataclasses import dataclass
+from typing import Union
+
+from cryptography.hazmat.primitives.asymmetric.x25519 import (
+    X25519PrivateKey,
+    X25519PublicKey,
+)
+from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    PrivateFormat,
+    PublicFormat,
+    NoEncryption,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants — MUST stay in lockstep with skill/plugin/pair-crypto.ts
+# ---------------------------------------------------------------------------
+
+#: HKDF "info" parameter — fixes the domain separation for this protocol.
+#: MUST match the browser-side constant in the pair-page bundle.
+HKDF_INFO = "totalreclaw-pair-v1"
+
+#: HKDF output length — 32 bytes = 256-bit ChaCha20-Poly1305 key.
+AEAD_KEY_BYTES = 32
+
+#: ChaCha20-Poly1305 nonce length — 12 bytes per RFC 7539.
+AEAD_NONCE_BYTES = 12
+
+#: ChaCha20-Poly1305 auth-tag length — 16 bytes standard.
+AEAD_TAG_BYTES = 16
+
+#: Raw x25519 public/private key length — 32 bytes per RFC 7748.
+X25519_KEY_BYTES = 32
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GatewayKeypair:
+    """Ephemeral gateway keypair, both halves base64url-encoded.
+
+    Mirrors the TS ``GatewayKeypair`` type. ``sk_b64`` stays on disk under
+    the pair-session record's 0600 file; ``pk_b64`` goes into the QR URL
+    fragment.
+    """
+
+    sk_b64: str
+    pk_b64: str
+
+
+@dataclass(frozen=True)
+class SessionKeys:
+    """Fully-derived session keys. Caller uses ``k_enc`` for AEAD ops."""
+
+    k_enc: bytes
+
+
+# ---------------------------------------------------------------------------
+# Base64url helpers (strip ``=`` padding for Node parity)
+# ---------------------------------------------------------------------------
+
+
+def _b64url_encode(raw: bytes) -> str:
+    """Encode bytes as base64url without trailing ``=`` padding."""
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(s: str) -> bytes:
+    """Decode base64url with optional ``=`` padding."""
+    pad = (-len(s)) % 4
+    return base64.urlsafe_b64decode(s + ("=" * pad))
+
+
+# ---------------------------------------------------------------------------
+# Key generation / conversion
+# ---------------------------------------------------------------------------
+
+
+def generate_gateway_keypair() -> GatewayKeypair:
+    """Generate a fresh ephemeral x25519 keypair for a pairing session.
+
+    Returns raw 32-byte values base64url-encoded. Caller persists the
+    private half in pair-session-store (under the session record's 0600
+    file) and embeds the public half in the QR URL fragment.
+    """
+    sk = X25519PrivateKey.generate()
+    sk_raw = sk.private_bytes(
+        encoding=Encoding.Raw,
+        format=PrivateFormat.Raw,
+        encryption_algorithm=NoEncryption(),
+    )
+    pk_raw = sk.public_key().public_bytes(
+        encoding=Encoding.Raw,
+        format=PublicFormat.Raw,
+    )
+    return GatewayKeypair(
+        sk_b64=_b64url_encode(sk_raw),
+        pk_b64=_b64url_encode(pk_raw),
+    )
+
+
+def _public_key_from_b64(pk_b64: str) -> X25519PublicKey:
+    raw = _b64url_decode(pk_b64)
+    if len(raw) != X25519_KEY_BYTES:
+        raise ValueError(
+            f"pair.crypto: public key must be {X25519_KEY_BYTES} bytes (got {len(raw)})"
+        )
+    return X25519PublicKey.from_public_bytes(raw)
+
+
+def _private_key_from_b64(sk_b64: str) -> X25519PrivateKey:
+    raw = _b64url_decode(sk_b64)
+    if len(raw) != X25519_KEY_BYTES:
+        raise ValueError(
+            f"pair.crypto: private key must be {X25519_KEY_BYTES} bytes (got {len(raw)})"
+        )
+    return X25519PrivateKey.from_private_bytes(raw)
+
+
+def derive_public_from_private(sk_b64: str) -> str:
+    """Derive the public key (base64url) from a raw base64url private key."""
+    sk = _private_key_from_b64(sk_b64)
+    pk_raw = sk.public_key().public_bytes(
+        encoding=Encoding.Raw,
+        format=PublicFormat.Raw,
+    )
+    return _b64url_encode(pk_raw)
+
+
+# ---------------------------------------------------------------------------
+# ECDH + HKDF
+# ---------------------------------------------------------------------------
+
+
+def compute_shared_secret(sk_local_b64: str, pk_remote_b64: str) -> bytes:
+    """Perform x25519 ECDH between local private + remote public.
+
+    Produces a 32-byte shared secret. Both sides running this with swapped
+    halves MUST produce the same secret — validated by the round-trip
+    tests against TS-generated vectors.
+    """
+    sk = _private_key_from_b64(sk_local_b64)
+    pk = _public_key_from_b64(pk_remote_b64)
+    shared = sk.exchange(pk)
+    if len(shared) != X25519_KEY_BYTES:
+        raise ValueError(
+            f"pair.crypto: ECDH output wrong length ({len(shared)} != {X25519_KEY_BYTES})"
+        )
+    return shared
+
+
+def _hkdf_sha256(salt: bytes, ikm: bytes, info: bytes, length: int) -> bytes:
+    """Minimal RFC 5869 HKDF-SHA256 — Node parity.
+
+    Python's stdlib exposes ``hashlib.hkdf`` only in 3.12+, but we still
+    support 3.11 per pyproject (``requires-python = ">=3.11"``). Writing
+    this out directly avoids the dep-floor bump and is ~10 lines.
+    """
+    # Extract: PRK = HMAC-SHA256(salt, ikm)
+    prk = hmac.new(salt, ikm, hashlib.sha256).digest()
+    # Expand: T(1..N) = HMAC(PRK, T(i-1) || info || i); OKM = concat || trim
+    okm = b""
+    t = b""
+    i = 1
+    while len(okm) < length:
+        t = hmac.new(prk, t + info + bytes([i]), hashlib.sha256).digest()
+        okm += t
+        i += 1
+    return okm[:length]
+
+
+def derive_session_keys(shared_secret: bytes, sid: str) -> SessionKeys:
+    """Derive the AEAD key from a shared secret via HKDF-SHA256.
+
+    Uses the session id as the salt and the fixed protocol tag as the
+    info. The sid binding means a ciphertext encrypted for session A is
+    decryptable ONLY under session A's derived key.
+    """
+    if len(shared_secret) != X25519_KEY_BYTES:
+        raise ValueError("pair.crypto: shared secret must be 32 bytes")
+    if not isinstance(sid, str) or len(sid) == 0:
+        raise ValueError("pair.crypto: sid is required for HKDF salt binding")
+    salt = sid.encode("utf-8")
+    info = HKDF_INFO.encode("utf-8")
+    okm = _hkdf_sha256(salt=salt, ikm=shared_secret, info=info, length=AEAD_KEY_BYTES)
+    return SessionKeys(k_enc=okm)
+
+
+def derive_aead_key_from_ecdh(sk_local_b64: str, pk_remote_b64: str, sid: str) -> SessionKeys:
+    """One-shot convenience: ECDH + HKDF in a single call."""
+    shared = compute_shared_secret(sk_local_b64=sk_local_b64, pk_remote_b64=pk_remote_b64)
+    try:
+        return derive_session_keys(shared_secret=shared, sid=sid)
+    finally:
+        # Best-effort: wipe the shared secret from the local scope. Python
+        # can't guarantee zeroization (immutable bytes) but rebinding at
+        # least drops the reference.
+        shared = b"\x00" * AEAD_KEY_BYTES  # noqa: F841
+
+
+# ---------------------------------------------------------------------------
+# AEAD
+# ---------------------------------------------------------------------------
+
+
+def aead_decrypt(k_enc: bytes, nonce_b64: str, sid: str, ciphertext_b64: str) -> bytes:
+    """Decrypt a ChaCha20-Poly1305 ciphertext.
+
+    The ``cryptography`` library's ``ChaCha20Poly1305.decrypt`` expects
+    the ciphertext in combined ``plaintext || tag`` form and takes the
+    AD bytes directly — matching the Node API's ``setAAD`` behaviour.
+
+    Raises ``cryptography.exceptions.InvalidTag`` on tag mismatch (either
+    tampering or wrong key), which the HTTP handler catches and maps to
+    a 400 response.
+    """
+    nonce = _b64url_decode(nonce_b64)
+    if len(nonce) != AEAD_NONCE_BYTES:
+        raise ValueError(
+            f"pair.crypto: nonce must be {AEAD_NONCE_BYTES} bytes (got {len(nonce)})"
+        )
+    if len(k_enc) != AEAD_KEY_BYTES:
+        raise ValueError(f"pair.crypto: AEAD key must be {AEAD_KEY_BYTES} bytes")
+    combined = _b64url_decode(ciphertext_b64)
+    if len(combined) < AEAD_TAG_BYTES:
+        raise ValueError("pair.crypto: ciphertext too short to contain tag")
+
+    aead = ChaCha20Poly1305(k_enc)
+    return aead.decrypt(nonce, combined, sid.encode("utf-8"))
+
+
+def decrypt_pairing_payload(
+    sk_gateway_b64: str,
+    pk_device_b64: str,
+    sid: str,
+    nonce_b64: str,
+    ciphertext_b64: str,
+) -> bytes:
+    """One-shot decrypt: ECDH + HKDF + AEAD.
+
+    Called by the HTTP respond handler. Returns the plaintext bytes on
+    success; raises on ANY failure (wrong key length, invalid curve
+    point, tag mismatch).
+    """
+    keys = derive_aead_key_from_ecdh(
+        sk_local_b64=sk_gateway_b64,
+        pk_remote_b64=pk_device_b64,
+        sid=sid,
+    )
+    return aead_decrypt(
+        k_enc=keys.k_enc,
+        nonce_b64=nonce_b64,
+        sid=sid,
+        ciphertext_b64=ciphertext_b64,
+    )
+
+
+def aead_encrypt_with_session_key(
+    k_enc: bytes,
+    sid: str,
+    plaintext: Union[bytes, bytearray, memoryview],
+    nonce_b64: Union[str, None] = None,
+) -> tuple[str, str]:
+    """Encrypt (used by tests + any future gateway-to-device ACK path).
+
+    Emits (nonce_b64, ciphertext_b64). A 12-byte random nonce is drawn
+    when ``nonce_b64`` is not supplied. Returns tuple, NOT a dict, to
+    keep the module stdlib-only in its public surface.
+    """
+    if len(k_enc) != AEAD_KEY_BYTES:
+        raise ValueError(f"pair.crypto: AEAD key must be {AEAD_KEY_BYTES} bytes")
+    if nonce_b64 is None:
+        nonce = os.urandom(AEAD_NONCE_BYTES)
+    else:
+        nonce = _b64url_decode(nonce_b64)
+    if len(nonce) != AEAD_NONCE_BYTES:
+        raise ValueError(f"pair.crypto: nonce must be {AEAD_NONCE_BYTES} bytes")
+
+    pt = bytes(plaintext)
+    aead = ChaCha20Poly1305(k_enc)
+    ct = aead.encrypt(nonce, pt, sid.encode("utf-8"))
+    return (_b64url_encode(nonce), _b64url_encode(ct))
+
+
+def encrypt_pairing_payload(
+    sk_local_b64: str,
+    pk_remote_b64: str,
+    sid: str,
+    plaintext: Union[bytes, bytearray, memoryview],
+    nonce_b64: Union[str, None] = None,
+) -> tuple[str, str]:
+    """One-shot encrypt: ECDH + HKDF + AEAD. Test helper."""
+    keys = derive_aead_key_from_ecdh(
+        sk_local_b64=sk_local_b64,
+        pk_remote_b64=pk_remote_b64,
+        sid=sid,
+    )
+    return aead_encrypt_with_session_key(
+        k_enc=keys.k_enc,
+        sid=sid,
+        plaintext=plaintext,
+        nonce_b64=nonce_b64,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Constant-time secondary-code comparison
+# ---------------------------------------------------------------------------
+
+
+def compare_secondary_codes_ct(a: str, b: str) -> bool:
+    """Constant-time compare two 6-digit numeric strings.
+
+    ``secrets.compare_digest`` is constant-time with respect to the length
+    of the LONGER input; mismatched lengths leak a length bit but never a
+    per-character timing side channel. Pairing flows use fixed 6-digit
+    codes so the length bit is not exploitable.
+    """
+    if not isinstance(a, str) or not isinstance(b, str):
+        return False
+    return secrets.compare_digest(a, b)

--- a/python/src/totalreclaw/pair/http_server.py
+++ b/python/src/totalreclaw/pair/http_server.py
@@ -1,0 +1,475 @@
+"""pair.http_server — embedded HTTP server for the Hermes QR-pair flow.
+
+Python parity of ``skill/plugin/pair-http.ts``. Spawns a stdlib
+``http.server`` on ``127.0.0.1:<ephemeral>`` (fixed port configurable
+for tests) that serves:
+
+- ``GET /pair/<token>`` — the browser pair page (HTML + inline crypto).
+  Browser reads the gateway's ephemeral pubkey from the URL fragment
+  (``#pk=<b64url>``) — the fragment NEVER hits the server, which keeps
+  the pubkey out of server logs.
+
+- ``POST /pair/<token>`` — accepts ``{v, sid, pk_d, pin, nonce, ct}``,
+  verifies the PIN, decrypts the phrase via x25519 ECDH + HKDF-SHA256
+  + ChaCha20-Poly1305, writes ``~/.totalreclaw/credentials.json``, and
+  returns ``204``. Errors: ``403`` for PIN / attempt-exhausted, ``410``
+  for expired, ``400`` for bad body / decrypt fail, ``404`` for unknown
+  token.
+
+The server is bound to ``127.0.0.1`` only — no LAN exposure. For remote
+phones, the CLI instructions tell the user to SSH-port-forward the
+ephemeral port, or (recommended) run the pair flow from the same phone's
+browser on the gateway host directly.
+
+Scanner / surface hygiene:
+
+- No ``urllib.request``, no outbound HTTP, no env-var reads. All config
+  flows in via ``PairHttpConfig``.
+- No phrase material in logs. Session ids are logged with a prefix-only
+  redaction.
+- No ``os.environ`` reads; the caller supplies paths + ports.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import threading
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Tuple
+from urllib.parse import urlparse
+
+from cryptography.exceptions import InvalidTag
+
+from .crypto import decrypt_pairing_payload
+from .pair_page import render_pair_page
+from .session_store import (
+    MAX_SECONDARY_CODE_ATTEMPTS,
+    PairSession,
+    consume_pair_session,
+    default_now_ms,
+    get_pair_session,
+    register_failed_secondary_code,
+    reject_pair_session,
+    transition_pair_session,
+)
+from ..pair.crypto import compare_secondary_codes_ct
+
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CompletePairingResult:
+    """Returned by the caller-injected completion handler."""
+
+    state: str  # "active" or "error"
+    account_id: Optional[str] = None
+    error: Optional[str] = None
+
+
+CompletePairingHandler = Callable[[str, PairSession], CompletePairingResult]
+
+
+@dataclass
+class PairHttpConfig:
+    """Config bundle for :func:`build_pair_http_server`.
+
+    ``sessions_path`` and ``complete_pairing`` are required. The rest have
+    reasonable defaults (ephemeral port bind, 8 KiB body cap, default BIP-
+    39 word-count validator).
+    """
+
+    sessions_path: Path
+    complete_pairing: CompletePairingHandler
+    bind_host: str = "127.0.0.1"
+    bind_port: int = 0  # 0 = ephemeral
+    max_body_bytes: int = 8 * 1024
+    validate_mnemonic: Optional[Callable[[str], bool]] = None
+    now: Optional[Callable[[], int]] = None
+    logger: logging.Logger = field(default=logger)
+
+
+# ---------------------------------------------------------------------------
+# Default BIP-39 word-count validator (same policy as the TS default)
+# ---------------------------------------------------------------------------
+
+
+def _default_mnemonic_validator(phrase: str) -> bool:
+    words = phrase.strip().split(" ")
+    if len(words) not in (12, 24):
+        return False
+    return all(w.isascii() and w.isalpha() and w.islower() for w in words)
+
+
+# ---------------------------------------------------------------------------
+# Server
+# ---------------------------------------------------------------------------
+
+
+class PairHttpServer:
+    """Thin wrapper around an ``HTTPServer`` with start / stop / url helpers."""
+
+    def __init__(self, http_server: HTTPServer, config: PairHttpConfig):
+        self._server = http_server
+        self._config = config
+        self._thread: Optional[threading.Thread] = None
+
+    @property
+    def port(self) -> int:
+        return self._server.server_address[1]
+
+    @property
+    def host(self) -> str:
+        return self._server.server_address[0]
+
+    def url_for(self, token: str) -> str:
+        return f"http://{self.host}:{self.port}/pair/{token}"
+
+    def start(self) -> None:
+        """Run the server in a background daemon thread."""
+        if self._thread is not None:
+            return
+        t = threading.Thread(
+            target=self._server.serve_forever,
+            name="totalreclaw-pair-http",
+            daemon=True,
+        )
+        t.start()
+        self._thread = t
+
+    def stop(self) -> None:
+        try:
+            self._server.shutdown()
+        finally:
+            self._server.server_close()
+            self._thread = None
+
+    def handle_one_request(self) -> None:
+        """Test helper — serve a single request synchronously."""
+        self._server.handle_request()
+
+
+def _parse_pair_token(path: str) -> Optional[str]:
+    """Extract the pair token from ``/pair/<token>``.
+
+    Rejects paths with extra segments or query params containing the token.
+    Query params on ``/pair/<token>?x=y`` are tolerated (urlparse.path
+    strips them), but ``/pair/<token>/more`` is rejected.
+    """
+    parsed = urlparse(path)
+    parts = parsed.path.strip("/").split("/")
+    if len(parts) != 2 or parts[0] != "pair":
+        return None
+    tok = parts[1]
+    if not tok or not tok.replace("-", "").replace("_", "").isalnum():
+        return None
+    return tok
+
+
+def _redact_sid(sid: str) -> str:
+    if len(sid) <= 10:
+        return "[redacted-sid]"
+    return f"{sid[:6]}…{sid[-2:]}"
+
+
+def build_pair_http_server(config: PairHttpConfig) -> PairHttpServer:
+    """Construct a ``PairHttpServer`` wired to ``config``.
+
+    Returns the server without starting it; caller calls ``.start()``.
+    """
+    cfg = config
+    now_fn = cfg.now or default_now_ms
+    validate = cfg.validate_mnemonic or _default_mnemonic_validator
+    log = cfg.logger
+
+    class Handler(BaseHTTPRequestHandler):
+        # Quiet default access-logging; we emit our own redacted lines via logger.
+        def log_message(self, format: str, *args: Any) -> None:  # noqa: A003
+            log.debug("pair-http: %s", format % args)
+
+        # ---- Responses -------------------------------------------------
+
+        def _send_html(self, code: int, body: str) -> None:
+            body_bytes = body.encode("utf-8")
+            self.send_response(code)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body_bytes)))
+            self.send_header("Cache-Control", "no-store, no-cache, must-revalidate")
+            self.send_header("Pragma", "no-cache")
+            # Tight CSP — mirror the TS side. Inline scripts + styles are
+            # required for the self-contained page; no external resources
+            # are loaded.
+            self.send_header(
+                "Content-Security-Policy",
+                "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; "
+                "img-src data:; connect-src 'self'; base-uri 'none'; form-action 'none'; "
+                "frame-ancestors 'none'",
+            )
+            self.send_header("Referrer-Policy", "no-referrer")
+            self.send_header("X-Content-Type-Options", "nosniff")
+            self.send_header("X-Frame-Options", "DENY")
+            self.end_headers()
+            self.wfile.write(body_bytes)
+
+        def _send_plain(self, code: int, body: str) -> None:
+            body_bytes = body.encode("utf-8")
+            self.send_response(code)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Length", str(len(body_bytes)))
+            self.send_header("Cache-Control", "no-store, no-cache, must-revalidate")
+            self.end_headers()
+            self.wfile.write(body_bytes)
+
+        def _send_json(self, code: int, body: Dict[str, Any]) -> None:
+            body_bytes = json.dumps(body).encode("utf-8")
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(body_bytes)))
+            self.send_header("Cache-Control", "no-store, no-cache, must-revalidate")
+            self.end_headers()
+            self.wfile.write(body_bytes)
+
+        def _send_empty(self, code: int) -> None:
+            self.send_response(code)
+            self.send_header("Content-Length", "0")
+            self.send_header("Cache-Control", "no-store, no-cache, must-revalidate")
+            self.end_headers()
+
+        # ---- Routing ---------------------------------------------------
+
+        def do_GET(self) -> None:  # noqa: N802
+            token = _parse_pair_token(self.path)
+            if token is None:
+                self._send_plain(404, "not found")
+                return
+            session = get_pair_session(cfg.sessions_path, token, now_fn)
+            if session is None:
+                self._send_plain(404, "session not found or already expired")
+                return
+            if session.status in ("completed", "consumed", "expired", "rejected"):
+                self._send_plain(410, "session is no longer available")
+                return
+            api_base = f"/pair/{token}"
+            html = render_pair_page(
+                sid=session.sid,
+                mode=session.mode,
+                expires_at_ms=session.expires_at_ms,
+                api_base=api_base,
+                now_ms=now_fn(),
+            )
+            self._send_html(200, html)
+
+        def do_POST(self) -> None:  # noqa: N802
+            token = _parse_pair_token(self.path)
+            if token is None:
+                self._send_json(404, {"error": "not_found"})
+                return
+
+            # Body read with size cap
+            length_hdr = self.headers.get("Content-Length", "0")
+            try:
+                length = int(length_hdr)
+            except (TypeError, ValueError):
+                self._send_json(400, {"error": "bad_content_length"})
+                return
+            if length > cfg.max_body_bytes:
+                self._send_json(413, {"error": "body_too_large"})
+                return
+            ct_type = (self.headers.get("Content-Type") or "").lower()
+            if "application/json" not in ct_type:
+                self._send_json(400, {"error": "content_type_must_be_json"})
+                return
+
+            try:
+                raw = self.rfile.read(length)
+                body = json.loads(raw.decode("utf-8"))
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+                self._send_json(400, {"error": "invalid_json"})
+                return
+
+            parsed = _validate_respond_body(body)
+            if parsed is None:
+                self._send_json(400, {"error": "bad_body"})
+                return
+            sid, pk_d, nonce, ct, pin = parsed
+
+            # Enforce sid-matches-token: the URL-path token IS the session
+            # id. The body MAY omit sid; if present, it must match.
+            if sid != token:
+                self._send_json(400, {"error": "sid_mismatch"})
+                return
+
+            # Look up session for PIN check FIRST — before consuming.
+            session = get_pair_session(cfg.sessions_path, token, now_fn)
+            if session is None:
+                self._send_json(404, {"error": "not_found"})
+                return
+            if now_fn() > session.expires_at_ms:
+                self._send_json(410, {"error": "expired"})
+                return
+            if session.status in ("completed", "consumed", "expired", "rejected"):
+                status_map = {
+                    "rejected": 403,
+                    "expired": 410,
+                    "completed": 409,
+                    "consumed": 409,
+                }
+                self._send_json(status_map[session.status], {"error": session.status})
+                return
+
+            # Constant-time PIN compare + strike counter.
+            if not compare_secondary_codes_ct(pin, session.secondary_code):
+                after = register_failed_secondary_code(cfg.sessions_path, token, now_fn)
+                if after and after.status == "rejected":
+                    log.warning(
+                        "pair-http: session %s locked out after %d wrong PINs",
+                        _redact_sid(token),
+                        MAX_SECONDARY_CODE_ATTEMPTS,
+                    )
+                    self._send_json(403, {"error": "attempts_exhausted"})
+                    return
+                self._send_json(403, {"error": "wrong_pin"})
+                return
+
+            # Consume atomically — flips to 'consumed' before crypto work.
+            consumed = consume_pair_session(cfg.sessions_path, token, now_fn)
+            if not consumed.ok or consumed.session is None:
+                code_map = {
+                    "not_found": 404,
+                    "expired": 410,
+                    "rejected": 403,
+                    "already_consumed": 409,
+                }
+                err = consumed.error or "not_found"
+                self._send_json(code_map.get(err, 409), {"error": err})
+                return
+
+            session = consumed.session
+
+            # Decrypt.
+            try:
+                plaintext = decrypt_pairing_payload(
+                    sk_gateway_b64=session.sk_gateway_b64,
+                    pk_device_b64=pk_d,
+                    sid=token,
+                    nonce_b64=nonce,
+                    ciphertext_b64=ct,
+                )
+            except (InvalidTag, ValueError) as err:
+                reject_pair_session(cfg.sessions_path, token, now_fn)
+                log.warning(
+                    "pair-http: session %s decrypt failed: %s",
+                    _redact_sid(token),
+                    type(err).__name__,
+                )
+                self._send_json(400, {"error": "decrypt_failed"})
+                return
+
+            try:
+                phrase = plaintext.decode("utf-8")
+                # NFKC + lowercase + collapse whitespace (BIP-39 norm).
+                import unicodedata
+
+                phrase = unicodedata.normalize("NFKC", phrase).strip().lower()
+                phrase = " ".join(phrase.split())
+            except UnicodeDecodeError:
+                reject_pair_session(cfg.sessions_path, token, now_fn)
+                self._send_json(400, {"error": "bad_utf8"})
+                return
+            finally:
+                # Best-effort zero (bytes is immutable in Python; rebinding
+                # drops our reference but other copies may linger).
+                plaintext = b"\x00" * len(plaintext)  # noqa: F841
+
+            if not validate(phrase):
+                reject_pair_session(cfg.sessions_path, token, now_fn)
+                log.warning(
+                    "pair-http: session %s invalid phrase payload",
+                    _redact_sid(token),
+                )
+                # The JSON error code stays ``invalid_mnemonic`` for API
+                # parity with the TS side; the log line above uses the
+                # canonical user-facing terminology ("phrase") to stay
+                # aligned with the ``test_onboarding.py`` terminology
+                # parity check.
+                self._send_json(400, {"error": "invalid_mnemonic"})
+                return
+
+            # Hand off to the caller's completion handler — writes
+            # credentials.json + flips onboarding state.
+            try:
+                result = cfg.complete_pairing(phrase, session)
+            except Exception as err:  # pragma: no cover — defensive
+                log.error("pair-http: complete_pairing raised: %r", err)
+                self._send_json(500, {"error": "completion_failed"})
+                return
+            finally:
+                # Drop the phrase reference. Python can't guarantee GC but
+                # rebinding at least releases our handle.
+                phrase = ""  # noqa: F841
+
+            if result.state == "active":
+                transition_pair_session(cfg.sessions_path, token, "completed", now_fn)
+                log.info("pair-http: session %s completed", _redact_sid(token))
+                # 204 means "processed, nothing to say" — the browser
+                # treats any 2xx as success.
+                self._send_empty(204)
+            else:
+                log.warning(
+                    "pair-http: session %s completion error: %s",
+                    _redact_sid(token),
+                    result.error or "unknown",
+                )
+                self._send_json(500, {"error": result.error or "completion_state_unknown"})
+
+        # Silence the stdlib's verbose "code 200, message OK" default log.
+        def log_request(self, code="-", size="-"):  # noqa: D401
+            log.debug("pair-http: %s %s -> %s", self.command, self.path, code)
+
+    http = HTTPServer((cfg.bind_host, cfg.bind_port), Handler)
+    return PairHttpServer(http, cfg)
+
+
+# ---------------------------------------------------------------------------
+# Body validation (stays out of the handler class for testability)
+# ---------------------------------------------------------------------------
+
+
+def _validate_respond_body(
+    body: Any,
+) -> Optional[Tuple[str, str, str, str, str]]:
+    """Return ``(sid, pk_d, nonce, ct, pin)`` if valid, else ``None``."""
+    if not isinstance(body, dict):
+        return None
+    if body.get("v") != 1:
+        return None
+    sid = body.get("sid")
+    pk_d = body.get("pk_d")
+    nonce = body.get("nonce")
+    ct = body.get("ct")
+    pin = body.get("pin")
+    if not all(isinstance(x, str) for x in (sid, pk_d, nonce, ct, pin)):
+        return None
+
+    # Basic shape checks — avoid expensive crypto on obviously-bad input.
+    if not (isinstance(sid, str) and 16 <= len(sid) <= 64):
+        return None
+    if not (isinstance(pk_d, str) and 40 <= len(pk_d) <= 48):  # 32 bytes b64url ~= 43 chars
+        return None
+    if not (isinstance(nonce, str) and 14 <= len(nonce) <= 18):  # 12 bytes b64url = 16 chars
+        return None
+    if not (isinstance(ct, str) and 20 <= len(ct) <= 4096):
+        return None
+    if not (isinstance(pin, str) and len(pin) == 6 and pin.isdigit()):
+        return None
+
+    return (sid, pk_d, nonce, ct, pin)

--- a/python/src/totalreclaw/pair/pair_page.py
+++ b/python/src/totalreclaw/pair/pair_page.py
@@ -1,0 +1,544 @@
+"""pair.pair_page — self-contained HTML + inline JS + CSS for the browser
+side of the QR-pair handshake.
+
+Python parity of ``skill/plugin/pair-page.ts``. The browser loads this
+page at ``GET /pair/<token>``, reads the gateway's ephemeral pubkey from
+the URL fragment (``#pk=<b64url>``), does x25519 ECDH + HKDF +
+ChaCha20-Poly1305 encrypt against the user's typed / generated phrase,
+and POSTs the ciphertext to ``POST /pair/<token>``.
+
+UI mirrors the TS page's UX:
+
+- Brand-consistent copy ("your TotalReclaw account key", "Use it ONLY
+  with TotalReclaw", etc).
+- Consequence blocks ("With it you can" / "Without it").
+- Two modes: ``generate`` (browser generates BIP-39) and ``import`` (user
+  pastes).
+- PIN entry (6-digit) + acknowledge-gate BEFORE reveal.
+
+Security properties:
+
+- Entirely self-contained (no CDN, no external fetch). Inline CSS + JS.
+- No ``console.log`` of phrase / PIN / key material.
+- Memory scrubbed after submit (best-effort — browser GC is not
+  guaranteed).
+- ``cache-control: no-store`` + strict CSP on the response (set by the
+  HTTP server, not this module).
+
+BIP-39 wordlist: kept out of this module to reduce the Python wheel's
+size; on ``generate`` mode the page uses the browser's ``crypto.getRandomValues``
++ a compact 2048-word list compiled from the ``mnemonic`` package at
+build time. See :func:`_bip39_words` for the lazy loader.
+
+ML-KEM hybrid port: NOT in rc.4. Both TS and Python pages use pure
+x25519 + ChaCha20-Poly1305. Hybrid KEM lands in rc.5 in lockstep across
+both stacks.
+"""
+from __future__ import annotations
+
+import html
+import json
+from functools import lru_cache
+from typing import List
+
+
+@lru_cache(maxsize=1)
+def _bip39_words() -> List[str]:
+    """Load the BIP-39 English wordlist from the ``mnemonic`` package if
+    available; otherwise return an empty list and let the browser skip
+    ``generate`` mode (``import`` still works).
+
+    The ``mnemonic`` package is a ``dev`` extra, not a core dep — we
+    don't want to pull it into every ``pip install totalreclaw``. If a
+    user runs the pair flow without it, they can still use ``import``
+    mode to paste an existing phrase; ``generate`` mode falls back to
+    a "please install ``mnemonic`` to generate" error page.
+    """
+    try:
+        from mnemonic import Mnemonic  # type: ignore
+
+        m = Mnemonic("english")
+        words = list(m.wordlist)
+        if len(words) == 2048:
+            return words
+        return []
+    except Exception:
+        return []
+
+
+def _escape_js_string(s: str) -> str:
+    """JSON-encode a string for safe ``<script>`` embedding.
+
+    ``json.dumps`` produces a valid JS string literal. We still escape
+    ``<``, ``>``, ``&``, and U+2028/U+2029 because ``</script>`` in the
+    payload would close the script block.
+    """
+    encoded = json.dumps(s, ensure_ascii=False)
+    return (
+        encoded.replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+        .replace("\u2028", "\\u2028")
+        .replace("\u2029", "\\u2029")
+    )
+
+
+def render_pair_page(
+    *,
+    sid: str,
+    mode: str,
+    expires_at_ms: int,
+    api_base: str,
+    now_ms: int,
+) -> str:
+    """Render the self-contained pair HTML page.
+
+    ``api_base`` is the prefix that the pair respond endpoint lives under
+    (e.g. ``/pair/<token>``). The browser POSTs the encrypted payload to
+    the same URL it was served from, so the page embeds ``api_base``
+    verbatim.
+    """
+    if mode not in ("generate", "import"):
+        raise ValueError(f"pair.pair_page: invalid mode '{mode}'")
+
+    sid_js = _escape_js_string(sid)
+    mode_js = _escape_js_string(mode)
+    api_base_js = _escape_js_string(api_base)
+    bip39 = _bip39_words()
+    bip39_js = json.dumps(bip39)
+    expires_safe = int(expires_at_ms)
+    now_safe = int(now_ms)
+
+    sid_html = html.escape(sid)
+    mode_html = html.escape(mode)
+
+    # The HTML template is big; we compose it in pieces to keep line
+    # length reasonable.
+    script = _PAIR_PAGE_SCRIPT.format(
+        sid_js=sid_js,
+        mode_js=mode_js,
+        api_base_js=api_base_js,
+        expires_at_ms=expires_safe,
+        now_ms=now_safe,
+        bip39_js=bip39_js,
+    )
+
+    return _PAIR_PAGE_HTML.format(
+        sid_html=sid_html,
+        mode_html=mode_html,
+        style=_PAIR_PAGE_STYLE,
+        script=script,
+    )
+
+
+# ---------------------------------------------------------------------------
+# HTML / CSS / JS templates
+# ---------------------------------------------------------------------------
+
+_PAIR_PAGE_STYLE = """
+  :root {
+    --bg: #0b0d12;
+    --fg: #f4f4f7;
+    --muted: #9aa2b4;
+    --accent: #7c66ff;
+    --warn: #ffb84d;
+    --danger: #ff5a6a;
+    --card: #14181f;
+    --border: #242936;
+  }
+  * { box-sizing: border-box; }
+  html, body {
+    margin: 0; padding: 0;
+    background: var(--bg); color: var(--fg);
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    font-size: 16px; line-height: 1.5;
+    min-height: 100vh;
+  }
+  .page {
+    max-width: 640px; margin: 0 auto;
+    padding: 24px 20px 40px;
+  }
+  h1 { font-size: 1.6rem; margin: 0 0 8px; letter-spacing: -0.01em; }
+  h2 { font-size: 1.15rem; margin: 24px 0 8px; }
+  p { margin: 0 0 12px; }
+  .muted { color: var(--muted); }
+  .card {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 20px;
+    margin: 16px 0;
+  }
+  .warn-card { border-color: var(--warn); }
+  .danger-card { border-color: var(--danger); }
+  button {
+    background: var(--accent); color: #fff; border: 0;
+    font-size: 1rem; font-weight: 600;
+    padding: 14px 20px; border-radius: 10px;
+    cursor: pointer; width: 100%;
+  }
+  button:disabled { opacity: 0.4; cursor: not-allowed; }
+  .secondary-button {
+    background: transparent; color: var(--accent);
+    border: 1px solid var(--accent);
+  }
+  label { display: block; font-weight: 600; margin: 12px 0 6px; }
+  input[type="text"], input[type="password"], textarea {
+    width: 100%; padding: 12px 14px;
+    background: var(--bg); color: var(--fg);
+    border: 1px solid var(--border); border-radius: 8px;
+    font-size: 1rem; font-family: inherit;
+  }
+  textarea { min-height: 120px; resize: vertical; font-family: ui-monospace, Menlo, Consolas, monospace; }
+  .pin-input { letter-spacing: 0.3em; text-align: center; font-size: 1.4rem; font-family: ui-monospace, Menlo, monospace; }
+  .phrase-box {
+    background: #000; color: #a6d0ff;
+    border: 1px solid var(--border); border-radius: 10px;
+    padding: 16px; font-family: ui-monospace, Menlo, Consolas, monospace;
+    font-size: 1.05rem; line-height: 1.7;
+    word-spacing: 0.15em;
+    user-select: text;
+  }
+  ol { padding-left: 24px; }
+  ol li { margin: 6px 0; }
+  .consequence { display: flex; gap: 16px; margin: 12px 0; }
+  .consequence > div { flex: 1; padding: 14px; border-radius: 10px; border: 1px solid var(--border); }
+  .hidden { display: none; }
+  #status { margin: 20px 0; padding: 14px; border-radius: 10px; font-weight: 600; text-align: center; }
+  #status.info { background: rgba(124,102,255,0.12); color: var(--accent); }
+  #status.ok { background: rgba(69,209,120,0.12); color: #45d178; }
+  #status.err { background: rgba(255,90,106,0.12); color: var(--danger); }
+  .countdown { font-variant-numeric: tabular-nums; color: var(--muted); font-size: 0.9rem; }
+"""
+
+
+_PAIR_PAGE_SCRIPT = r"""
+  "use strict";
+  (function() {{
+    const SID = {sid_js};
+    const MODE = {mode_js};
+    const API_BASE = {api_base_js};
+    const EXPIRES_AT_MS = {expires_at_ms};
+    const NOW_MS = {now_ms};
+    const BIP39 = {bip39_js};
+
+    const HKDF_INFO = "totalreclaw-pair-v1";
+    const AEAD_KEY_BYTES = 32;
+    const AEAD_NONCE_BYTES = 12;
+
+    // ---- Base64url helpers (matching Node / Python side) ----
+    function b64url(buf) {{
+      const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+      let s = "";
+      for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+      return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    }}
+    function b64urlDecode(s) {{
+      const pad = "=".repeat((4 - (s.length % 4)) % 4);
+      const b64 = (s + pad).replace(/-/g, "+").replace(/_/g, "/");
+      const raw = atob(b64);
+      const out = new Uint8Array(raw.length);
+      for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i);
+      return out;
+    }}
+
+    // ---- URL fragment → gateway pubkey ----
+    function readGatewayPubkeyFromHash() {{
+      const h = window.location.hash || "";
+      const m = /#pk=([A-Za-z0-9_\-]+)/.exec(h);
+      if (!m) return null;
+      try {{ return b64urlDecode(m[1]); }} catch (_e) {{ return null; }}
+    }}
+
+    // ---- Web Crypto: x25519 ECDH + HKDF-SHA256 + ChaCha20-Poly1305 ----
+    // WebCrypto's x25519 + ChaCha20-Poly1305 support lands in Safari 17.2
+    // and Chromium 118. Older browsers fall back to a fail-closed error
+    // page ("update your browser to pair securely"). No polyfill ship.
+    async function deriveKey(gatewayPub, sid) {{
+      // Generate an ephemeral x25519 keypair for the device side.
+      const kp = await crypto.subtle.generateKey({{ name: "X25519" }}, true, ["deriveBits"]);
+      const pkRaw = await crypto.subtle.exportKey("raw", kp.publicKey);
+
+      const pubCrypto = await crypto.subtle.importKey(
+        "raw", gatewayPub, {{ name: "X25519" }}, false, []
+      );
+      const sharedBits = await crypto.subtle.deriveBits(
+        {{ name: "X25519", public: pubCrypto }}, kp.privateKey, 256
+      );
+      const shared = new Uint8Array(sharedBits);
+
+      // HKDF: extract with salt=sid, expand with info="totalreclaw-pair-v1".
+      const baseKey = await crypto.subtle.importKey(
+        "raw", shared, "HKDF", false, ["deriveBits"]
+      );
+      const keyBits = await crypto.subtle.deriveBits(
+        {{
+          name: "HKDF",
+          hash: "SHA-256",
+          salt: new TextEncoder().encode(sid),
+          info: new TextEncoder().encode(HKDF_INFO),
+        }},
+        baseKey,
+        AEAD_KEY_BYTES * 8
+      );
+      return {{ kEnc: new Uint8Array(keyBits), pkRaw: new Uint8Array(pkRaw) }};
+    }}
+
+    async function aeadEncrypt(kEnc, sid, plaintext) {{
+      const key = await crypto.subtle.importKey(
+        "raw", kEnc, {{ name: "ChaCha20-Poly1305" }}, false, ["encrypt"]
+      );
+      const nonce = crypto.getRandomValues(new Uint8Array(AEAD_NONCE_BYTES));
+      const ct = await crypto.subtle.encrypt(
+        {{ name: "ChaCha20-Poly1305", iv: nonce, additionalData: new TextEncoder().encode(sid) }},
+        key,
+        plaintext
+      );
+      return {{ nonce, ct: new Uint8Array(ct) }};
+    }}
+
+    // ---- BIP-39 generate (browser side) ----
+    function bytesToBits(bytes) {{
+      const bits = [];
+      for (let i = 0; i < bytes.length; i++) {{
+        const b = bytes[i];
+        for (let j = 7; j >= 0; j--) bits.push((b >> j) & 1);
+      }}
+      return bits;
+    }}
+    async function sha256(data) {{
+      const d = await crypto.subtle.digest("SHA-256", data);
+      return new Uint8Array(d);
+    }}
+    async function generateMnemonic12() {{
+      if (!BIP39 || BIP39.length !== 2048) {{
+        throw new Error("BIP-39 wordlist unavailable. Use 'import' mode or install the 'mnemonic' Python package on the gateway.");
+      }}
+      const entropy = crypto.getRandomValues(new Uint8Array(16));
+      const digest = await sha256(entropy);
+      const checksumBits = bytesToBits(digest).slice(0, 4);
+      const bits = bytesToBits(entropy).concat(checksumBits);
+      const words = [];
+      for (let i = 0; i < bits.length; i += 11) {{
+        let v = 0;
+        for (let j = 0; j < 11; j++) v = (v << 1) | bits[i + j];
+        words.push(BIP39[v]);
+      }}
+      return words.join(" ");
+    }}
+
+    // ---- DOM helpers ----
+    const $ = (id) => document.getElementById(id);
+    function setStatus(text, kind) {{
+      const el = $("status");
+      el.textContent = text;
+      el.className = kind || "info";
+      el.classList.remove("hidden");
+    }}
+    function hide(id) {{ $(id).classList.add("hidden"); }}
+    function show(id) {{ $(id).classList.remove("hidden"); }}
+
+    // ---- Countdown ----
+    function renderCountdown() {{
+      const remaining = Math.max(0, EXPIRES_AT_MS - Date.now());
+      const m = Math.floor(remaining / 60000);
+      const s = Math.floor((remaining % 60000) / 1000);
+      $("countdown").textContent = remaining > 0
+        ? `Expires in ${{m}}:${{String(s).padStart(2,"0")}}`
+        : "Session expired. Ask the agent for a fresh URL.";
+      if (remaining <= 0) {{
+        document.querySelectorAll("button").forEach(b => b.disabled = true);
+      }}
+    }}
+    setInterval(renderCountdown, 1000); renderCountdown();
+
+    // ---- PIN gate → unlock phrase flow ----
+    $("pin-submit").addEventListener("click", () => {{
+      const pin = ($("pin").value || "").trim();
+      if (!/^\d{{6}}$/.test(pin)) {{
+        setStatus("Enter the 6-digit PIN the agent showed you.", "err");
+        return;
+      }}
+      // Store the PIN locally; we'll send it with the encrypted payload.
+      window.__PAIR_PIN = pin;
+      hide("pin-step");
+      if (MODE === "generate") show("gen-step"); else show("import-step");
+      setStatus("PIN accepted. Continue below.", "ok");
+    }});
+
+    // ---- Generate flow ----
+    let generatedPhrase = null;
+    $("gen-button").addEventListener("click", async () => {{
+      try {{
+        generatedPhrase = await generateMnemonic12();
+        $("phrase-display").textContent = generatedPhrase;
+        show("phrase-display-box");
+        hide("gen-button");
+        show("gen-ack-step");
+      }} catch (err) {{
+        setStatus("Could not generate phrase: " + err.message, "err");
+      }}
+    }});
+    $("gen-confirm").addEventListener("click", async () => {{
+      if (!$("gen-ack").checked) {{
+        setStatus("Check the acknowledgment before continuing.", "err");
+        return;
+      }}
+      if (!generatedPhrase) {{
+        setStatus("No phrase to submit. Retry generate.", "err");
+        return;
+      }}
+      await submitPhrase(generatedPhrase);
+    }});
+
+    // ---- Import flow ----
+    $("import-submit").addEventListener("click", async () => {{
+      const raw = ($("import-phrase").value || "").trim().toLowerCase().replace(/\s+/g, " ");
+      if (!raw) {{
+        setStatus("Paste your 12 or 24-word phrase.", "err");
+        return;
+      }}
+      const n = raw.split(" ").length;
+      if (n !== 12 && n !== 24) {{
+        setStatus("Phrase must be exactly 12 or 24 words.", "err");
+        return;
+      }}
+      await submitPhrase(raw);
+    }});
+
+    // ---- Submit: encrypt + POST ----
+    async function submitPhrase(phrase) {{
+      try {{
+        const gw = readGatewayPubkeyFromHash();
+        if (!gw) {{
+          setStatus("Gateway key missing from URL. Ask for a fresh pair URL.", "err");
+          return;
+        }}
+        setStatus("Encrypting phrase end-to-end…", "info");
+        const {{ kEnc, pkRaw }} = await deriveKey(gw, SID);
+        const plaintext = new TextEncoder().encode(phrase);
+        const {{ nonce, ct }} = await aeadEncrypt(kEnc, SID, plaintext);
+
+        // Zero the plaintext buffer — best-effort (browser GC is not
+        // guaranteed; but we at least drop our reference).
+        plaintext.fill(0);
+
+        const body = JSON.stringify({{
+          v: 1,
+          sid: SID,
+          pk_d: b64url(pkRaw),
+          pin: window.__PAIR_PIN,
+          nonce: b64url(nonce),
+          ct: b64url(ct),
+        }});
+        window.__PAIR_PIN = null; // drop reference
+        const res = await fetch(API_BASE, {{
+          method: "POST",
+          headers: {{ "Content-Type": "application/json" }},
+          body,
+          cache: "no-store",
+        }});
+        if (res.status === 204 || res.status === 200) {{
+          hide("gen-step"); hide("import-step"); hide("gen-ack-step");
+          show("done-step");
+          setStatus("Pairing complete. Tell the agent you're done; it will confirm on its side.", "ok");
+          return;
+        }}
+        if (res.status === 403) {{
+          setStatus("PIN mismatch or too many failed attempts. Ask the agent for a fresh URL.", "err");
+          return;
+        }}
+        if (res.status === 410) {{
+          setStatus("Session expired. Ask the agent for a fresh URL.", "err");
+          return;
+        }}
+        const detail = await res.text();
+        setStatus(`Pairing failed (${{res.status}}): ${{detail || "unknown error"}}`, "err");
+      }} catch (err) {{
+        setStatus("Encryption failed: " + (err && err.message ? err.message : String(err)), "err");
+      }}
+    }}
+
+    // Capability gate: refuse to run on browsers without x25519 + ChaCha.
+    (async () => {{
+      try {{
+        const ok = crypto && crypto.subtle && typeof crypto.subtle.generateKey === "function";
+        if (!ok) throw new Error("no webcrypto");
+        // Probe X25519 support without actually using a key.
+        await crypto.subtle.generateKey({{ name: "X25519" }}, true, ["deriveBits"]);
+      }} catch (err) {{
+        setStatus("This browser lacks x25519 + ChaCha20-Poly1305 support. Please use an up-to-date Safari (17.2+) or Chromium (118+) browser to pair securely.", "err");
+        document.querySelectorAll("button").forEach(b => b.disabled = true);
+      }}
+    }})();
+  }})();
+"""
+
+
+_PAIR_PAGE_HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+<meta name="referrer" content="no-referrer" />
+<meta name="robots" content="noindex, nofollow" />
+<title>TotalReclaw Pair</title>
+<style>{style}</style>
+</head>
+<body>
+<main class="page">
+  <h1>TotalReclaw pairing</h1>
+  <p class="muted">Mode: <strong>{mode_html}</strong>. Session: <code>{sid_html}</code>.</p>
+  <p class="countdown" id="countdown">Loading…</p>
+
+  <div id="status" class="info hidden"></div>
+
+  <section class="card" id="pin-step">
+    <h2>Step 1. Verify PIN</h2>
+    <p>The TotalReclaw agent showed you a 6-digit PIN. Type it here so the gateway knows you're the right browser.</p>
+    <label for="pin">6-digit PIN</label>
+    <input id="pin" class="pin-input" type="text" inputmode="numeric" pattern="\\d{{6}}" maxlength="6" autocomplete="off" />
+    <p></p>
+    <button id="pin-submit">Verify</button>
+  </section>
+
+  <section class="card hidden" id="gen-step">
+    <h2>Step 2. Generate your TotalReclaw account key</h2>
+    <p>This is your <strong>one and only</strong> key to your encrypted memory vault. Treat it like a master password — it cannot be reset if lost.</p>
+    <div class="consequence">
+      <div><strong>With it you can:</strong> recover access from any device, export your memories, switch agents.</div>
+      <div><strong>Without it:</strong> your memories are permanently unrecoverable. There is no "forgot password".</div>
+    </div>
+    <p class="muted">Store it in a password manager, encrypted notes, or on paper in a safe. <strong>Never</strong> share it with anyone. <strong>Use it ONLY with TotalReclaw</strong> — never paste it into other apps, not even ones that ask nicely.</p>
+    <button id="gen-button">Generate now</button>
+    <div id="phrase-display-box" class="hidden">
+      <label>Your account key (write this down)</label>
+      <div class="phrase-box" id="phrase-display"></div>
+    </div>
+  </section>
+
+  <section class="card hidden warn-card" id="gen-ack-step">
+    <h2>Step 3. Acknowledge</h2>
+    <p>Before we seal the key into your TotalReclaw account on this gateway, confirm:</p>
+    <label><input type="checkbox" id="gen-ack" /> I have written down or securely stored the 12 words above. I understand losing them means losing access to my memories forever.</label>
+    <p></p>
+    <button id="gen-confirm">Seal key and finish</button>
+  </section>
+
+  <section class="card hidden" id="import-step">
+    <h2>Step 2. Paste your existing TotalReclaw account key</h2>
+    <p>Paste your 12 or 24-word phrase below. The phrase is encrypted in this browser tab before leaving — it never crosses the LLM context.</p>
+    <label for="import-phrase">Your 12 or 24-word phrase</label>
+    <textarea id="import-phrase" autocomplete="off" spellcheck="false"></textarea>
+    <button id="import-submit">Seal key and finish</button>
+  </section>
+
+  <section class="card hidden" id="done-step">
+    <h2>Pairing complete</h2>
+    <p>Your key is sealed into this TotalReclaw gateway. You can close this tab and go back to the agent. If the agent asks, tell it "pairing complete" — it will verify and restart the memory plugin if needed.</p>
+  </section>
+</main>
+<script>{script}</script>
+</body>
+</html>
+"""

--- a/python/src/totalreclaw/pair/session_store.py
+++ b/python/src/totalreclaw/pair/session_store.py
@@ -1,0 +1,650 @@
+"""pair.session_store — atomic TTL-evicted session store for the Hermes
+QR-pairing flow.
+
+Python parity of ``skill/plugin/pair-session-store.ts`` (v3.3.0). Same
+on-disk schema (so a CLI run against the TS gateway can inspect the
+same file, though in practice each gateway owns its own sessions file),
+same status values, same retention windows.
+
+Storage path: ``~/.totalreclaw/pair-sessions.json`` (default — tests pass
+a hermetic tmpdir). Mode 0600; parent dir mode 0700. Atomic writes via
+temp-file + rename.
+
+Locking: a cooperative ``.lock`` sentinel via ``os.O_CREAT | os.O_EXCL``
+— the Python equivalent of Node's ``openSync(path, 'wx')``. Stale locks
+older than 30 s are force-broken. No multi-process races expected (one
+gateway per host), but the lock still prevents tearing between the
+async agent-tool path and the HTTP handler path.
+
+No recovery-phrase material EVER enters this module. Private keys (sk_b64)
+are stored cleartext under the 0600 file — attacker model per design doc
+§5d (rooted gateway host is out-of-scope).
+"""
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
+
+
+# ---------------------------------------------------------------------------
+# Types (mirrored in skill/plugin/pair-session-store.ts)
+# ---------------------------------------------------------------------------
+
+#: Mode the operator chose when starting the session. Drives the browser
+#: pair-page's UI branch.
+PairSessionMode = Literal["generate", "import"]
+
+#: Lifecycle state. Matches TS ``PairSessionStatus``.
+PairSessionStatus = Literal[
+    "awaiting_scan",
+    "device_connected",
+    "completed",
+    "consumed",
+    "expired",
+    "rejected",
+]
+
+
+@dataclass
+class PairOperatorContext:
+    channel: str = "agent"
+    sender_id: Optional[str] = None
+    account_id: Optional[str] = None
+
+
+@dataclass
+class PairSession:
+    """Persistent record written to ``~/.totalreclaw/pair-sessions.json``.
+
+    Field names stay in snake_case on the Python side but the on-disk JSON
+    uses the TS-side camelCase so a future migration (or a TS plugin
+    sharing the same file) reads the same record. :func:`_session_to_dict`
+    / :func:`_session_from_dict` handle the rename.
+    """
+
+    sid: str
+    sk_gateway_b64: str
+    pk_gateway_b64: str
+    created_at_ms: int
+    expires_at_ms: int
+    secondary_code: str
+    secondary_code_attempts: int
+    operator_context: PairOperatorContext
+    mode: PairSessionMode
+    status: PairSessionStatus
+    last_status_change_at_ms: int
+
+
+@dataclass
+class PairSessionFile:
+    version: int = 1
+    sessions: List[PairSession] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+PAIR_SESSION_FILE_VERSION = 1
+DEFAULT_PAIR_TTL_MS = 15 * 60 * 1000
+MIN_PAIR_TTL_MS = 5 * 60 * 1000
+MAX_PAIR_TTL_MS = 60 * 60 * 1000
+TERMINAL_RETENTION_MS = 60 * 60 * 1000
+MAX_SECONDARY_CODE_ATTEMPTS = 5
+
+LOCK_STALE_MS = 30_000
+LOCK_WAIT_MS = 10_000
+LOCK_RETRY_MS = 50
+
+NowFn = Callable[[], int]
+
+
+def default_now_ms() -> int:
+    """Default milliseconds-since-epoch clock. Mirrors TS ``Date.now``."""
+    return int(time.time() * 1000)
+
+
+def default_pair_sessions_path(base_dir: Path) -> Path:
+    """Return the pair-sessions.json path inside ``base_dir``."""
+    return Path(base_dir) / "pair-sessions.json"
+
+
+# ---------------------------------------------------------------------------
+# Default randomness
+# ---------------------------------------------------------------------------
+
+
+def _default_sid() -> str:
+    """16 random bytes rendered as 32 hex chars — same as TS ``defaultRngSid``."""
+    return secrets.token_hex(16)
+
+
+def _default_secondary_code() -> str:
+    """Uniform 6-digit numeric string, left-padded. Reject-sample to
+    avoid the small bias of naive ``secrets.randbelow(1_000_000)``.
+
+    Actually ``secrets.randbelow`` is already uniform (it uses a reject-
+    sample internally), so we can call it directly. Kept as a helper so
+    tests can swap it for a deterministic stub.
+    """
+    return f"{secrets.randbelow(1_000_000):06d}"
+
+
+# ---------------------------------------------------------------------------
+# JSON (de)serialization
+# ---------------------------------------------------------------------------
+
+_TS_KEY_MAP = {
+    "sid": "sid",
+    "sk_gateway_b64": "skGatewayB64",
+    "pk_gateway_b64": "pkGatewayB64",
+    "created_at_ms": "createdAtMs",
+    "expires_at_ms": "expiresAtMs",
+    "secondary_code": "secondaryCode",
+    "secondary_code_attempts": "secondaryCodeAttempts",
+    "operator_context": "operatorContext",
+    "mode": "mode",
+    "status": "status",
+    "last_status_change_at_ms": "lastStatusChangeAtMs",
+}
+
+_OPCTX_TS_MAP = {
+    "channel": "channel",
+    "sender_id": "senderId",
+    "account_id": "accountId",
+}
+
+_PY_KEY_MAP = {ts: py for py, ts in _TS_KEY_MAP.items()}
+_OPCTX_PY_MAP = {ts: py for py, ts in _OPCTX_TS_MAP.items()}
+
+
+def _operator_context_to_dict(ctx: PairOperatorContext) -> Dict[str, Any]:
+    d: Dict[str, Any] = {"channel": ctx.channel}
+    if ctx.sender_id is not None:
+        d["senderId"] = ctx.sender_id
+    if ctx.account_id is not None:
+        d["accountId"] = ctx.account_id
+    return d
+
+
+def _operator_context_from_dict(raw: Any) -> PairOperatorContext:
+    if not isinstance(raw, dict):
+        return PairOperatorContext()
+    kwargs: Dict[str, Any] = {}
+    for ts_key, py_key in _OPCTX_PY_MAP.items():
+        if ts_key in raw and isinstance(raw[ts_key], (str, type(None))):
+            kwargs[py_key] = raw[ts_key]
+    return PairOperatorContext(**kwargs)
+
+
+def _session_to_dict(s: PairSession) -> Dict[str, Any]:
+    return {
+        "sid": s.sid,
+        "skGatewayB64": s.sk_gateway_b64,
+        "pkGatewayB64": s.pk_gateway_b64,
+        "createdAtMs": s.created_at_ms,
+        "expiresAtMs": s.expires_at_ms,
+        "secondaryCode": s.secondary_code,
+        "secondaryCodeAttempts": s.secondary_code_attempts,
+        "operatorContext": _operator_context_to_dict(s.operator_context),
+        "mode": s.mode,
+        "status": s.status,
+        "lastStatusChangeAtMs": s.last_status_change_at_ms,
+    }
+
+
+def _session_from_dict(raw: Any) -> Optional[PairSession]:
+    if not isinstance(raw, dict):
+        return None
+    required = {
+        "sid",
+        "skGatewayB64",
+        "pkGatewayB64",
+        "createdAtMs",
+        "expiresAtMs",
+        "secondaryCode",
+        "secondaryCodeAttempts",
+        "operatorContext",
+        "mode",
+        "status",
+        "lastStatusChangeAtMs",
+    }
+    if not required.issubset(raw.keys()):
+        return None
+    try:
+        if raw["mode"] not in ("generate", "import"):
+            return None
+        sec_code = raw["secondaryCode"]
+        if not (isinstance(sec_code, str) and len(sec_code) == 6 and sec_code.isdigit()):
+            return None
+        return PairSession(
+            sid=str(raw["sid"]),
+            sk_gateway_b64=str(raw["skGatewayB64"]),
+            pk_gateway_b64=str(raw["pkGatewayB64"]),
+            created_at_ms=int(raw["createdAtMs"]),
+            expires_at_ms=int(raw["expiresAtMs"]),
+            secondary_code=sec_code,
+            secondary_code_attempts=int(raw["secondaryCodeAttempts"]),
+            operator_context=_operator_context_from_dict(raw["operatorContext"]),
+            mode=raw["mode"],
+            status=raw["status"],
+            last_status_change_at_ms=int(raw["lastStatusChangeAtMs"]),
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Path + lock primitives
+# ---------------------------------------------------------------------------
+
+
+def _ensure_sessions_file_dir(sessions_path: Path) -> None:
+    parent = sessions_path.parent
+    parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+
+
+def _acquire_lock(sessions_path: Path, wait_ms: int = LOCK_WAIT_MS) -> Callable[[], None]:
+    """Exclusive-create a ``.lock`` sentinel. Return an unlocker.
+
+    Deadline-bounded retry with stale-lock break, mirroring the TS version.
+    Raises ``TimeoutError`` on deadline.
+    """
+    _ensure_sessions_file_dir(sessions_path)
+    lock_path = Path(str(sessions_path) + ".lock")
+    deadline = time.monotonic() + (wait_ms / 1000.0)
+
+    while True:
+        try:
+            fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            try:
+                os.write(fd, f"{os.getpid()}\n".encode("ascii"))
+            finally:
+                os.close(fd)
+
+            def release() -> None:
+                try:
+                    lock_path.unlink()
+                except FileNotFoundError:
+                    pass
+
+            return release
+        except FileExistsError:
+            try:
+                mtime_ns = lock_path.stat().st_mtime_ns
+                age_ms = (time.time_ns() - mtime_ns) / 1_000_000
+                if age_ms > LOCK_STALE_MS:
+                    try:
+                        lock_path.unlink()
+                    except FileNotFoundError:
+                        pass
+                    continue
+            except FileNotFoundError:
+                continue
+
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"pair-session-store: could not acquire lock at {lock_path} within {wait_ms}ms"
+                )
+            time.sleep(LOCK_RETRY_MS / 1000.0)
+
+
+# ---------------------------------------------------------------------------
+# Load / save (no lock — callers wrap via _acquire_lock)
+# ---------------------------------------------------------------------------
+
+
+def _empty_file() -> PairSessionFile:
+    return PairSessionFile(version=PAIR_SESSION_FILE_VERSION, sessions=[])
+
+
+def _load_pair_sessions_file(sessions_path: Path) -> PairSessionFile:
+    """Load sessions file; return empty on any read/parse error."""
+    try:
+        if not sessions_path.exists():
+            return _empty_file()
+        raw = sessions_path.read_text(encoding="utf-8")
+        parsed = json.loads(raw)
+        if (
+            not isinstance(parsed, dict)
+            or parsed.get("version") != PAIR_SESSION_FILE_VERSION
+            or not isinstance(parsed.get("sessions"), list)
+        ):
+            return _empty_file()
+        clean: List[PairSession] = []
+        for s in parsed["sessions"]:
+            parsed_s = _session_from_dict(s)
+            if parsed_s is not None:
+                clean.append(parsed_s)
+        return PairSessionFile(version=PAIR_SESSION_FILE_VERSION, sessions=clean)
+    except (OSError, json.JSONDecodeError, ValueError):
+        return _empty_file()
+
+
+def _write_pair_sessions_file(sessions_path: Path, file: PairSessionFile) -> bool:
+    """Atomic write: temp file + rename. 0600. Returns False on I/O error."""
+    try:
+        _ensure_sessions_file_dir(sessions_path)
+        tmp = Path(f"{sessions_path}.tmp-{os.getpid()}-{int(time.time() * 1_000_000)}")
+        serialized = {
+            "version": file.version,
+            "sessions": [_session_to_dict(s) for s in file.sessions],
+        }
+        # Write with 0600 from the start (use os.open to control the mode).
+        fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            os.write(fd, json.dumps(serialized).encode("utf-8"))
+        finally:
+            os.close(fd)
+        os.replace(str(tmp), str(sessions_path))
+        return True
+    except OSError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Pruning — lazy, idempotent
+# ---------------------------------------------------------------------------
+
+
+def _prune_stale_sessions(
+    file: PairSessionFile,
+    now_ms: int,
+) -> Tuple[PairSessionFile, List[str]]:
+    keepers: List[PairSession] = []
+    pruned: List[str] = []
+
+    for s in file.sessions:
+        terminal = s.status in ("completed", "consumed", "expired", "rejected")
+        next_s = s
+        if not terminal and now_ms > s.expires_at_ms:
+            next_s = PairSession(
+                **{**asdict(s), "operator_context": s.operator_context},
+            )
+            # dataclasses.asdict flattens nested dataclasses; rebuild op ctx.
+            next_s.operator_context = s.operator_context
+            next_s.status = "expired"
+            next_s.last_status_change_at_ms = s.expires_at_ms
+
+        now_terminal = next_s.status in ("completed", "consumed", "expired", "rejected")
+        if now_terminal and (now_ms - next_s.last_status_change_at_ms) > TERMINAL_RETENTION_MS:
+            pruned.append(next_s.sid)
+            continue
+        keepers.append(next_s)
+
+    return PairSessionFile(version=file.version, sessions=keepers), pruned
+
+
+def _clamp_ttl_ms(ttl_ms: Optional[int]) -> int:
+    raw = ttl_ms if isinstance(ttl_ms, int) and ttl_ms > 0 else DEFAULT_PAIR_TTL_MS
+    return max(MIN_PAIR_TTL_MS, min(MAX_PAIR_TTL_MS, raw))
+
+
+# ---------------------------------------------------------------------------
+# Public API — all operations go through the lock
+# ---------------------------------------------------------------------------
+
+
+def create_pair_session(
+    sessions_path: Path,
+    *,
+    mode: PairSessionMode,
+    operator_context: Optional[PairOperatorContext] = None,
+    ttl_ms: Optional[int] = None,
+    sk_b64: Optional[str] = None,
+    pk_b64: Optional[str] = None,
+    sid: Optional[str] = None,
+    secondary_code: Optional[str] = None,
+    now: Optional[NowFn] = None,
+) -> PairSession:
+    """Create and persist a new session. Returns the in-memory record.
+
+    ``sk_b64``, ``pk_b64``, ``sid``, ``secondary_code`` default to fresh
+    random values. Callers MUST pass the base64url-encoded public/private
+    keys if they want crypto-capable sessions (the defaults are 32 bytes
+    of random data — valid x25519 scalar space but useless for a real
+    handshake). Normal usage: wire via :func:`generate_gateway_keypair`.
+    """
+    now_fn = now or default_now_ms
+    t = now_fn()
+    ttl = _clamp_ttl_ms(ttl_ms)
+    op_ctx = operator_context or PairOperatorContext()
+
+    session = PairSession(
+        sid=sid or _default_sid(),
+        sk_gateway_b64=sk_b64 or _b64url_placeholder(),
+        pk_gateway_b64=pk_b64 or _b64url_placeholder(),
+        created_at_ms=t,
+        expires_at_ms=t + ttl,
+        secondary_code=secondary_code or _default_secondary_code(),
+        secondary_code_attempts=0,
+        operator_context=op_ctx,
+        mode=mode,
+        status="awaiting_scan",
+        last_status_change_at_ms=t,
+    )
+
+    release = _acquire_lock(sessions_path)
+    try:
+        current = _load_pair_sessions_file(sessions_path)
+        pruned, _ = _prune_stale_sessions(current, t)
+        pruned.sessions.append(session)
+        _write_pair_sessions_file(sessions_path, pruned)
+    finally:
+        release()
+
+    return session
+
+
+def _b64url_placeholder() -> str:
+    """Return a 32-byte random value base64url-encoded. Used when the caller
+    didn't supply explicit key material (tests, no-crypto stubs). NOT a
+    valid x25519 scalar for actual ECDH — callers expected to pass real
+    keys from :func:`generate_gateway_keypair`."""
+    return secrets.token_urlsafe(32).rstrip("=")[:43]
+
+
+def get_pair_session(
+    sessions_path: Path,
+    sid: str,
+    now: Optional[NowFn] = None,
+) -> Optional[PairSession]:
+    now_fn = now or default_now_ms
+    release = _acquire_lock(sessions_path)
+    try:
+        file = _load_pair_sessions_file(sessions_path)
+        pruned, pruned_sids = _prune_stale_sessions(file, now_fn())
+        if pruned_sids:
+            _write_pair_sessions_file(sessions_path, pruned)
+        for s in pruned.sessions:
+            if s.sid == sid:
+                return s
+        return None
+    finally:
+        release()
+
+
+def _update_pair_session(
+    sessions_path: Path,
+    sid: str,
+    mutate: Callable[[PairSession], Optional[PairSession]],
+    now: Optional[NowFn] = None,
+) -> Optional[PairSession]:
+    now_fn = now or default_now_ms
+    release = _acquire_lock(sessions_path)
+    try:
+        file = _load_pair_sessions_file(sessions_path)
+        pruned, pruned_sids = _prune_stale_sessions(file, now_fn())
+        idx = next((i for i, s in enumerate(pruned.sessions) if s.sid == sid), -1)
+        if idx < 0:
+            if pruned_sids:
+                _write_pair_sessions_file(sessions_path, pruned)
+            return None
+        current = pruned.sessions[idx]
+        nxt = mutate(current)
+        if nxt is None:
+            pruned.sessions.pop(idx)
+            result: Optional[PairSession] = None
+        else:
+            pruned.sessions[idx] = nxt
+            result = nxt
+        _write_pair_sessions_file(sessions_path, pruned)
+        return result
+    finally:
+        release()
+
+
+def transition_pair_session(
+    sessions_path: Path,
+    sid: str,
+    next_status: PairSessionStatus,
+    now: Optional[NowFn] = None,
+) -> Optional[PairSession]:
+    now_fn = now or default_now_ms
+
+    def mutate(s: PairSession) -> PairSession:
+        if s.status == next_status:
+            return s
+        return PairSession(
+            sid=s.sid,
+            sk_gateway_b64=s.sk_gateway_b64,
+            pk_gateway_b64=s.pk_gateway_b64,
+            created_at_ms=s.created_at_ms,
+            expires_at_ms=s.expires_at_ms,
+            secondary_code=s.secondary_code,
+            secondary_code_attempts=s.secondary_code_attempts,
+            operator_context=s.operator_context,
+            mode=s.mode,
+            status=next_status,
+            last_status_change_at_ms=now_fn(),
+        )
+
+    return _update_pair_session(sessions_path, sid, mutate, now_fn)
+
+
+def register_failed_secondary_code(
+    sessions_path: Path,
+    sid: str,
+    now: Optional[NowFn] = None,
+) -> Optional[PairSession]:
+    now_fn = now or default_now_ms
+
+    def mutate(s: PairSession) -> PairSession:
+        nxt_attempts = s.secondary_code_attempts + 1
+        should_reject = nxt_attempts >= MAX_SECONDARY_CODE_ATTEMPTS
+        return PairSession(
+            sid=s.sid,
+            sk_gateway_b64=s.sk_gateway_b64,
+            pk_gateway_b64=s.pk_gateway_b64,
+            created_at_ms=s.created_at_ms,
+            expires_at_ms=s.expires_at_ms,
+            secondary_code=s.secondary_code,
+            secondary_code_attempts=nxt_attempts,
+            operator_context=s.operator_context,
+            mode=s.mode,
+            status="rejected" if should_reject else s.status,
+            last_status_change_at_ms=now_fn() if should_reject else s.last_status_change_at_ms,
+        )
+
+    return _update_pair_session(sessions_path, sid, mutate, now_fn)
+
+
+@dataclass
+class ConsumeResult:
+    ok: bool
+    error: Optional[str] = None
+    session: Optional[PairSession] = None
+
+
+def consume_pair_session(
+    sessions_path: Path,
+    sid: str,
+    now: Optional[NowFn] = None,
+) -> ConsumeResult:
+    """Flip session to ``consumed`` and return the pre-transition record.
+
+    Called by the HTTP ``/pair/respond`` handler BEFORE crypto work, so
+    concurrent retries see ``already_consumed`` and the creds-write logic
+    doesn't race.
+    """
+    now_fn = now or default_now_ms
+    outcome: ConsumeResult = ConsumeResult(ok=False, error="not_found")
+
+    def mutate(s: PairSession) -> PairSession:
+        nonlocal outcome
+        t = now_fn()
+        if t > s.expires_at_ms:
+            outcome = ConsumeResult(ok=False, error="expired")
+            return PairSession(
+                sid=s.sid,
+                sk_gateway_b64=s.sk_gateway_b64,
+                pk_gateway_b64=s.pk_gateway_b64,
+                created_at_ms=s.created_at_ms,
+                expires_at_ms=s.expires_at_ms,
+                secondary_code=s.secondary_code,
+                secondary_code_attempts=s.secondary_code_attempts,
+                operator_context=s.operator_context,
+                mode=s.mode,
+                status="expired",
+                last_status_change_at_ms=t,
+            )
+        if s.status in ("completed", "consumed"):
+            outcome = ConsumeResult(ok=False, error="already_consumed")
+            return s
+        if s.status in ("rejected", "expired"):
+            outcome = ConsumeResult(ok=False, error=s.status)
+            return s
+        outcome = ConsumeResult(ok=True, session=s)
+        return PairSession(
+            sid=s.sid,
+            sk_gateway_b64=s.sk_gateway_b64,
+            pk_gateway_b64=s.pk_gateway_b64,
+            created_at_ms=s.created_at_ms,
+            expires_at_ms=s.expires_at_ms,
+            secondary_code=s.secondary_code,
+            secondary_code_attempts=s.secondary_code_attempts,
+            operator_context=s.operator_context,
+            mode=s.mode,
+            status="consumed",
+            last_status_change_at_ms=t,
+        )
+
+    _update_pair_session(sessions_path, sid, mutate, now_fn)
+    return outcome
+
+
+def reject_pair_session(
+    sessions_path: Path,
+    sid: str,
+    now: Optional[NowFn] = None,
+) -> Optional[PairSession]:
+    return transition_pair_session(sessions_path, sid, "rejected", now)
+
+
+def list_active_pair_sessions(
+    sessions_path: Path,
+    now: Optional[NowFn] = None,
+) -> List[PairSession]:
+    now_fn = now or default_now_ms
+    release = _acquire_lock(sessions_path)
+    try:
+        file = _load_pair_sessions_file(sessions_path)
+        pruned, pruned_sids = _prune_stale_sessions(file, now_fn())
+        if pruned_sids:
+            _write_pair_sessions_file(sessions_path, pruned)
+        return [s for s in pruned.sessions if s.status in ("awaiting_scan", "device_connected")]
+    finally:
+        release()
+
+
+def redact_pair_session(s: PairSession) -> Dict[str, Any]:
+    """Scrub sensitive fields for safe logging."""
+    d = _session_to_dict(s)
+    d["skGatewayB64"] = "[redacted]"
+    d["secondaryCode"] = "[redacted]"
+    return d

--- a/python/tests/test_agent_tools_phrase_safety.py
+++ b/python/tests/test_agent_tools_phrase_safety.py
@@ -1,0 +1,152 @@
+"""2.3.1rc4 phrase-safety contract tests for the Hermes agent plugin.
+
+Governed by ``~/.claude/projects/-Users-pdiogo-Documents-code-
+totalreclaw-internal/memory/project_phrase_safety_rule.md``:
+
+    "recovery phrase MUST NEVER cross the LLM context in ANY form."
+
+These tests enforce the architectural half of that rule — the tool
+registry. If any of these assertions start failing, a phrase-generating
+agent surface has re-entered the plugin and a vault-compromise-class
+leak is now possible.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+FORBIDDEN_TOOL_NAMES = (
+    "totalreclaw_setup",
+    "totalreclaw_onboard",
+    "totalreclaw_onboarding_start",
+    "totalreclaw_onboard_generate",
+    "totalreclaw_restore",
+    "totalreclaw_restore_phrase",
+    "totalreclaw_generate_phrase",
+    "totalreclaw_mnemonic",
+)
+
+
+def _register_and_list_tools():
+    """Call ``hermes.register(ctx)`` with a mock and return the tool names."""
+    from totalreclaw.hermes import register
+
+    ctx = MagicMock()
+    with patch.dict(os.environ, {}, clear=True):
+        with patch.object(Path, "exists", return_value=False):
+            register(ctx)
+    return [call.kwargs["name"] for call in ctx.register_tool.call_args_list]
+
+
+class TestPhraseSafetyContract:
+    def test_no_forbidden_tool_registered(self):
+        names = _register_and_list_tools()
+        for forbidden in FORBIDDEN_TOOL_NAMES:
+            assert forbidden not in names, (
+                f"Phrase-safety violation: {forbidden!r} is registered as an "
+                f"agent tool. Recovery phrases MUST NEVER cross the LLM "
+                f"context. Use `totalreclaw_pair` (browser-side crypto) "
+                f"instead."
+            )
+
+    def test_pair_tool_is_registered(self):
+        """The ONLY approved agent-facilitated setup surface."""
+        names = _register_and_list_tools()
+        assert "totalreclaw_pair" in names, (
+            "`totalreclaw_pair` MUST be registered — it's the only "
+            "phrase-safe agent-tool setup path."
+        )
+
+    def test_pair_schema_has_no_phrase_params(self):
+        """The pair tool's argument schema MUST NOT accept any field that
+        could carry phrase material into an LLM tool-call payload."""
+        from totalreclaw.hermes import pair_tool
+
+        props = pair_tool.PAIR_SCHEMA["parameters"]["properties"]
+        phrase_adjacent = (
+            "recovery_phrase",
+            "phrase",
+            "mnemonic",
+            "seed",
+            "seed_phrase",
+            "secret",
+            "private_key",
+        )
+        for f in phrase_adjacent:
+            assert f not in props, (
+                f"Phrase-safety violation: `totalreclaw_pair` accepts "
+                f"phrase-adjacent param {f!r}. The tool-call payload is "
+                f"in LLM context — any phrase-typed argument leaks."
+            )
+
+    def test_setup_schema_still_exists_but_not_registered(self):
+        """``schemas.SETUP`` is intentionally retained for in-process
+        callers (CLI delegation, test fixtures). The security invariant
+        is that the schema is NOT wired into any ``register_tool`` call —
+        verified in ``test_no_forbidden_tool_registered`` above."""
+        from totalreclaw.hermes import schemas
+
+        assert schemas.SETUP["name"] == "totalreclaw_setup"
+        # The existence is fine; the registration is what mattered.
+
+
+class TestPairToolReturnsNoPhrase:
+    @pytest.mark.asyncio
+    async def test_tool_response_never_contains_phrase_adjacent_keys(self, tmp_path: Path):
+        """``totalreclaw_pair`` MUST return {url, pin, expires_at, mode, instructions}
+        only. Any phrase-shaped key in the returned JSON would leak into
+        the agent's tool-result payload."""
+        import json as _json
+
+        from totalreclaw.hermes import pair_tool
+        from totalreclaw.hermes.state import PluginState
+
+        # Force the pair-server bind to a hermetic tmp dir.
+        with patch.object(pair_tool, "_resolve_sessions_dir", return_value=tmp_path):
+            # Fresh singleton per test.
+            pair_tool._SERVER_INSTANCE = None  # type: ignore[attr-defined]
+            with patch.dict(os.environ, {"TOTALRECLAW_PAIR_BIND_PORT": "0"}, clear=True):
+                with patch.object(Path, "exists", return_value=False):
+                    state = PluginState()
+                try:
+                    result_json = await pair_tool.pair({"mode": "generate"}, state)
+                finally:
+                    # Shut down the server so the tmp_path fixture can clean up.
+                    if pair_tool._SERVER_INSTANCE is not None:  # type: ignore[attr-defined]
+                        pair_tool._SERVER_INSTANCE.server.stop()  # type: ignore[attr-defined]
+                        pair_tool._SERVER_INSTANCE = None  # type: ignore[attr-defined]
+
+        payload = _json.loads(result_json)
+        forbidden_keys = (
+            "recovery_phrase",
+            "phrase",
+            "mnemonic",
+            "seed",
+            "seed_phrase",
+            "secret",
+        )
+        # Walk the entire payload tree (values too — a phrase could sneak
+        # into an instructions string if a future regression lands).
+        def _walk(obj, path=""):
+            if isinstance(obj, dict):
+                for k, v in obj.items():
+                    for forbidden in forbidden_keys:
+                        assert forbidden not in str(k).lower(), (
+                            f"Phrase-safety violation: key {path}.{k!r} "
+                            f"contains phrase-adjacent token."
+                        )
+                    _walk(v, f"{path}.{k}")
+            elif isinstance(obj, list):
+                for i, v in enumerate(obj):
+                    _walk(v, f"{path}[{i}]")
+
+        _walk(payload)
+
+        # Positive assertions: the expected phrase-safe fields ARE there.
+        assert "url" in payload
+        assert "pin" in payload
+        assert "expires_at" in payload

--- a/python/tests/test_debrief_tool.py
+++ b/python/tests/test_debrief_tool.py
@@ -70,7 +70,9 @@ class TestDebriefTool:
                 state = PluginState()
         result = json.loads(await debrief({}, state))
         assert "error" in result
-        assert "totalreclaw_setup" in result["error"]
+        # 2.3.1rc4 — error messages now point to totalreclaw_pair (the
+        # phrase-safe replacement), not totalreclaw_setup (removed).
+        assert "totalreclaw_pair" in result["error"]
 
     @pytest.mark.asyncio
     async def test_too_short_session_returns_skipped(self) -> None:

--- a/python/tests/test_hermes_plugin.py
+++ b/python/tests/test_hermes_plugin.py
@@ -169,10 +169,27 @@ class TestSchemas:
         assert schemas.STATUS["name"] == "totalreclaw_status"
 
     def test_setup_schema(self):
+        # 2.3.1rc4 — ``totalreclaw_setup`` schema is retained in schemas.py
+        # for backward-compat with older code, but is NO LONGER registered
+        # as an agent tool (see ``TestRegister.test_register`` below). The
+        # schema itself still validates because internal callers may
+        # reference the shape; the security invariant is enforced at
+        # registration time.
         assert schemas.SETUP["name"] == "totalreclaw_setup"
         assert "recovery_phrase" in schemas.SETUP["parameters"]["properties"]
-        # recovery_phrase is optional (generates one if omitted)
         assert "required" not in schemas.SETUP["parameters"]
+
+    def test_pair_schema(self):
+        """2.3.1rc4 — totalreclaw_pair is the canonical agent-tool surface
+        for setup. Returns {url, pin, expires_at} — no phrase material."""
+        from totalreclaw.hermes import pair_tool
+
+        assert pair_tool.PAIR_SCHEMA["name"] == "totalreclaw_pair"
+        props = pair_tool.PAIR_SCHEMA["parameters"]["properties"]
+        assert "mode" in props
+        # No phrase-shaped params — crucial for the phrase-safety contract.
+        for forbidden in ("recovery_phrase", "phrase", "mnemonic"):
+            assert forbidden not in props
 
 
 class TestTools:
@@ -494,8 +511,10 @@ class TestRegister:
                 register(ctx)
         # v2.1.0 — 10 base tools (+ upgrade + debrief).
         # 2.3.1rc3 — +1 RC-gated `totalreclaw_report_qa_bug` when the
-        # installed version is a pre-release. We infer RC-gating dynamically
-        # so the test stays honest across stable/RC publishes.
+        # installed version is a pre-release.
+        # 2.3.1rc4 — `totalreclaw_setup` REMOVED (phrase-safety), replaced
+        # by `totalreclaw_pair`. Count stays the same (10 stable, 11 RC)
+        # because it's a 1-for-1 swap.
         from totalreclaw import __version__
         from totalreclaw.hermes.qa_bug_report import is_rc_build
         expected_tools = 11 if is_rc_build(__version__) else 10
@@ -505,14 +524,15 @@ class TestRegister:
         )
         assert ctx.register_hook.call_count == 4
 
-        # Check tool names
+        # Check tool names — every memory tool plus the new pair tool.
         tool_names = [call.kwargs["name"] for call in ctx.register_tool.call_args_list]
         assert "totalreclaw_remember" in tool_names
         assert "totalreclaw_recall" in tool_names
         assert "totalreclaw_forget" in tool_names
         assert "totalreclaw_export" in tool_names
         assert "totalreclaw_status" in tool_names
-        assert "totalreclaw_setup" in tool_names
+        # 2.3.1rc4 — the canonical setup surface is now pair, not setup.
+        assert "totalreclaw_pair" in tool_names
         assert "totalreclaw_import_from" in tool_names
         assert "totalreclaw_import_batch" in tool_names
         assert "totalreclaw_upgrade" in tool_names
@@ -524,3 +544,36 @@ class TestRegister:
         assert "pre_llm_call" in hook_names
         assert "post_llm_call" in hook_names
         assert "on_session_end" in hook_names
+
+    def test_register_phrase_safety_no_onboard_or_setup_tool(self):
+        """2.3.1rc4 phrase-safety contract: NEITHER `totalreclaw_setup`
+        nor any `totalreclaw_onboard*` variant may be registered as an
+        agent tool. Governed by
+        ``~/.claude/projects/-Users-pdiogo-Documents-code-totalreclaw-
+        internal/memory/project_phrase_safety_rule.md`` — recovery phrases
+        MUST NEVER cross the LLM context in any form. `totalreclaw_pair`
+        is the single approved agent-facilitated setup path (browser-side
+        crypto keeps the phrase out of the LLM round-trip)."""
+        from totalreclaw.hermes import register
+        ctx = MagicMock()
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(Path, "exists", return_value=False):
+                register(ctx)
+        tool_names = [call.kwargs["name"] for call in ctx.register_tool.call_args_list]
+
+        forbidden = [
+            "totalreclaw_setup",
+            "totalreclaw_onboard",
+            "totalreclaw_onboarding_start",
+            "totalreclaw_onboard_generate",
+            "totalreclaw_restore",
+            "totalreclaw_restore_phrase",
+        ]
+        for f in forbidden:
+            assert f not in tool_names, (
+                f"Phrase-safety violation: agent tool {f!r} is registered. "
+                f"Recovery phrases MUST NEVER cross the LLM context. "
+                f"Use totalreclaw_pair instead."
+            )
+        # And the approved replacement MUST be present.
+        assert "totalreclaw_pair" in tool_names

--- a/python/tests/test_onboarding.py
+++ b/python/tests/test_onboarding.py
@@ -222,18 +222,20 @@ class TestCopyConstants:
         assert "generate" in q.lower()
 
     def test_local_instructions(self) -> None:
-        # 2.3.1rc2: LOCAL_MODE_INSTRUCTIONS now mentions both `totalreclaw setup`
-        # (standalone CLI added in rc.2) and `hermes setup` (Hermes-specific).
+        # 2.3.1rc4: the colliding `hermes` console script was removed to
+        # stop overwriting the upstream hermes-agent CLI on
+        # `pip install totalreclaw`. Only the canonical `totalreclaw setup`
+        # remains in the hint.
         assert "totalreclaw setup" in onboarding.LOCAL_MODE_INSTRUCTIONS
-        assert "hermes setup" in onboarding.LOCAL_MODE_INSTRUCTIONS
+        assert "hermes setup" not in onboarding.LOCAL_MODE_INSTRUCTIONS
         assert onboarding.LOCAL_MODE_INSTRUCTIONS.startswith("Run: ")
 
     def test_remote_instructions_contents(self) -> None:
         r = onboarding.REMOTE_MODE_INSTRUCTIONS
         assert r == r.strip()
-        # 2.3.1rc2: now mentions both totalreclaw setup and hermes setup.
+        # 2.3.1rc4: canonical `totalreclaw setup` only (see test_local_instructions).
         assert "totalreclaw setup" in r
-        assert "hermes setup" in r
+        assert "hermes setup" not in r
         # The load-bearing security claim.
         assert "never leaves this machine" in r
 

--- a/python/tests/test_pair_crypto.py
+++ b/python/tests/test_pair_crypto.py
@@ -1,0 +1,263 @@
+"""Tests for ``totalreclaw.pair.crypto`` (2.3.1rc4 phrase-safety port).
+
+Parity with the TypeScript gateway: a ciphertext produced by the Python
+side with the same (sk, pk, sid) as a Node-side test vector must decrypt
+back to the original plaintext. End-to-end round trips are tested here;
+cross-language vectors live in the TS test file (``pair-crypto.test.ts``)
+and match the constants we emit.
+"""
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from totalreclaw.pair.crypto import (
+    AEAD_KEY_BYTES,
+    AEAD_NONCE_BYTES,
+    AEAD_TAG_BYTES,
+    HKDF_INFO,
+    X25519_KEY_BYTES,
+    _b64url_decode,
+    _b64url_encode,
+    _hkdf_sha256,
+    aead_decrypt,
+    aead_encrypt_with_session_key,
+    compare_secondary_codes_ct,
+    compute_shared_secret,
+    decrypt_pairing_payload,
+    derive_aead_key_from_ecdh,
+    derive_public_from_private,
+    derive_session_keys,
+    encrypt_pairing_payload,
+    generate_gateway_keypair,
+)
+
+
+class TestConstants:
+    def test_parity_with_ts_module(self):
+        """These values MUST equal the TS module's exports. Any drift
+        breaks cross-stack ciphertext interop."""
+        assert HKDF_INFO == "totalreclaw-pair-v1"
+        assert AEAD_KEY_BYTES == 32
+        assert AEAD_NONCE_BYTES == 12
+        assert AEAD_TAG_BYTES == 16
+        assert X25519_KEY_BYTES == 32
+
+
+class TestBase64url:
+    def test_encode_no_padding(self):
+        """Python's urlsafe_b64 emits ``=`` padding; we strip it for
+        Node ``Buffer.toString('base64url')`` parity."""
+        raw = b"\x01" * 32
+        encoded = _b64url_encode(raw)
+        assert "=" not in encoded
+        assert len(encoded) == 43  # 32 bytes → 43 chars unpadded
+
+    def test_decode_accepts_optional_padding(self):
+        raw = b"\x02" * 16
+        encoded_unpadded = _b64url_encode(raw)
+        encoded_padded = encoded_unpadded + "=" * ((-len(encoded_unpadded)) % 4)
+        assert _b64url_decode(encoded_unpadded) == raw
+        assert _b64url_decode(encoded_padded) == raw
+
+    def test_roundtrip(self):
+        raw = bytes(range(256))
+        assert _b64url_decode(_b64url_encode(raw)) == raw
+
+
+class TestKeypairGeneration:
+    def test_generate_keypair_has_correct_sizes(self):
+        kp = generate_gateway_keypair()
+        assert len(_b64url_decode(kp.sk_b64)) == X25519_KEY_BYTES
+        assert len(_b64url_decode(kp.pk_b64)) == X25519_KEY_BYTES
+
+    def test_keypairs_are_unique(self):
+        kp_a = generate_gateway_keypair()
+        kp_b = generate_gateway_keypair()
+        assert kp_a.sk_b64 != kp_b.sk_b64
+        assert kp_a.pk_b64 != kp_b.pk_b64
+
+    def test_derive_public_matches_keypair(self):
+        kp = generate_gateway_keypair()
+        derived = derive_public_from_private(kp.sk_b64)
+        assert derived == kp.pk_b64
+
+
+class TestECDH:
+    def test_shared_secret_is_symmetric(self):
+        """Swapped (local, remote) pairs MUST produce the same secret."""
+        a = generate_gateway_keypair()
+        b = generate_gateway_keypair()
+        s1 = compute_shared_secret(a.sk_b64, b.pk_b64)
+        s2 = compute_shared_secret(b.sk_b64, a.pk_b64)
+        assert s1 == s2
+        assert len(s1) == X25519_KEY_BYTES
+
+    def test_shared_secret_differs_with_different_peers(self):
+        a = generate_gateway_keypair()
+        b = generate_gateway_keypair()
+        c = generate_gateway_keypair()
+        assert compute_shared_secret(a.sk_b64, b.pk_b64) != compute_shared_secret(a.sk_b64, c.pk_b64)
+
+
+class TestHKDF:
+    def test_rfc5869_vector(self):
+        """Spot-check against the RFC 5869 Test Case 1.
+
+        IKM  = 0x0b*22
+        salt = 0x00..0x0c
+        info = 0xf0..0xf9
+        L    = 42 → PRK, OKM from RFC.
+        """
+        ikm = b"\x0b" * 22
+        salt = bytes(range(0x0D))
+        info = bytes(range(0xF0, 0xFA))
+        okm = _hkdf_sha256(salt=salt, ikm=ikm, info=info, length=42)
+        expected = bytes.fromhex(
+            "3cb25f25faacd57a90434f64d0362f2a"
+            "2d2d0a90cf1a5a4c5db02d56ecc4c5bf"
+            "34007208d5b887185865"
+        )
+        assert okm == expected
+
+
+class TestSessionKeys:
+    def test_session_keys_length(self):
+        shared = b"\x33" * X25519_KEY_BYTES
+        keys = derive_session_keys(shared, "deadbeef" * 4)
+        assert len(keys.k_enc) == AEAD_KEY_BYTES
+
+    def test_sid_binding_changes_key(self):
+        """Different sid → different key (enforces HKDF salt binding)."""
+        shared = b"\x33" * X25519_KEY_BYTES
+        a = derive_session_keys(shared, "session-a").k_enc
+        b = derive_session_keys(shared, "session-b").k_enc
+        assert a != b
+
+    def test_reject_wrong_shared_length(self):
+        with pytest.raises(ValueError):
+            derive_session_keys(b"\x00" * 16, "sid")
+
+    def test_reject_empty_sid(self):
+        with pytest.raises(ValueError):
+            derive_session_keys(b"\x00" * 32, "")
+
+
+class TestRoundTrip:
+    def test_encrypt_decrypt_known_plaintext(self):
+        """Gateway encrypts → gateway decrypts back. Sanity round-trip."""
+        gw = generate_gateway_keypair()
+        dev = generate_gateway_keypair()
+        sid = "abcdef" * 5  # 30 chars
+        plaintext = b"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+        # Device encrypts for gateway.
+        nonce_b64, ct_b64 = encrypt_pairing_payload(
+            sk_local_b64=dev.sk_b64,
+            pk_remote_b64=gw.pk_b64,
+            sid=sid,
+            plaintext=plaintext,
+        )
+
+        # Gateway decrypts with its sk and the device's pk.
+        recovered = decrypt_pairing_payload(
+            sk_gateway_b64=gw.sk_b64,
+            pk_device_b64=dev.pk_b64,
+            sid=sid,
+            nonce_b64=nonce_b64,
+            ciphertext_b64=ct_b64,
+        )
+        assert recovered == plaintext
+
+    def test_tamper_in_ciphertext_fails(self):
+        """Flipped bit in ct MUST make AEAD tag check fail."""
+        from cryptography.exceptions import InvalidTag
+
+        gw = generate_gateway_keypair()
+        dev = generate_gateway_keypair()
+        sid = "deadbeef" * 4
+
+        nonce_b64, ct_b64 = encrypt_pairing_payload(
+            sk_local_b64=dev.sk_b64,
+            pk_remote_b64=gw.pk_b64,
+            sid=sid,
+            plaintext=b"some plaintext",
+        )
+
+        # Flip a byte in the middle of the ciphertext.
+        raw = bytearray(_b64url_decode(ct_b64))
+        raw[5] ^= 0x01
+        tampered = _b64url_encode(bytes(raw))
+
+        with pytest.raises(InvalidTag):
+            decrypt_pairing_payload(
+                sk_gateway_b64=gw.sk_b64,
+                pk_device_b64=dev.pk_b64,
+                sid=sid,
+                nonce_b64=nonce_b64,
+                ciphertext_b64=tampered,
+            )
+
+    def test_sid_mismatch_fails(self):
+        """AEAD additional-data binding: decrypt under wrong sid rejects."""
+        from cryptography.exceptions import InvalidTag
+
+        gw = generate_gateway_keypair()
+        dev = generate_gateway_keypair()
+
+        nonce_b64, ct_b64 = encrypt_pairing_payload(
+            sk_local_b64=dev.sk_b64,
+            pk_remote_b64=gw.pk_b64,
+            sid="session-A" * 4,
+            plaintext=b"secret",
+        )
+
+        with pytest.raises(InvalidTag):
+            decrypt_pairing_payload(
+                sk_gateway_b64=gw.sk_b64,
+                pk_device_b64=dev.pk_b64,
+                sid="session-B" * 4,
+                nonce_b64=nonce_b64,
+                ciphertext_b64=ct_b64,
+            )
+
+    def test_wrong_gateway_key_fails(self):
+        """Decrypt under a different gateway private key must fail."""
+        from cryptography.exceptions import InvalidTag
+
+        gw = generate_gateway_keypair()
+        other = generate_gateway_keypair()
+        dev = generate_gateway_keypair()
+        sid = "s" * 16
+
+        nonce_b64, ct_b64 = encrypt_pairing_payload(
+            sk_local_b64=dev.sk_b64,
+            pk_remote_b64=gw.pk_b64,
+            sid=sid,
+            plaintext=b"payload",
+        )
+
+        with pytest.raises(InvalidTag):
+            decrypt_pairing_payload(
+                sk_gateway_b64=other.sk_b64,
+                pk_device_b64=dev.pk_b64,
+                sid=sid,
+                nonce_b64=nonce_b64,
+                ciphertext_b64=ct_b64,
+            )
+
+
+class TestPinCompare:
+    def test_matching_pins_return_true(self):
+        assert compare_secondary_codes_ct("123456", "123456") is True
+
+    def test_mismatched_pins_return_false(self):
+        assert compare_secondary_codes_ct("123456", "123457") is False
+
+    def test_different_lengths_return_false(self):
+        assert compare_secondary_codes_ct("123456", "12345") is False
+
+    def test_non_str_returns_false(self):
+        assert compare_secondary_codes_ct("123456", None) is False  # type: ignore[arg-type]
+        assert compare_secondary_codes_ct(None, "123456") is False  # type: ignore[arg-type]

--- a/python/tests/test_pair_http.py
+++ b/python/tests/test_pair_http.py
@@ -1,0 +1,343 @@
+"""Tests for ``totalreclaw.pair.http_server``.
+
+Spins up the embedded pair HTTP server on ``127.0.0.1`` with an ephemeral
+port, posts well-formed encrypted payloads, verifies credentials.json
+gets written via the injected completion handler. Error paths:
+PIN-mismatch → 403, expired session → 410, unknown token → 404, tamper
+→ 400.
+
+No real gateway is spun up; no real credentials.json is touched. Tests
+use pytest's ``tmp_path`` fixture for the pair-sessions.json + mock the
+completion handler so the flow exercises only the pair module.
+"""
+from __future__ import annotations
+
+import http.client
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from totalreclaw.pair.crypto import (
+    encrypt_pairing_payload,
+    generate_gateway_keypair,
+    _b64url_encode,
+)
+from totalreclaw.pair.http_server import (
+    CompletePairingResult,
+    PairHttpConfig,
+    _validate_respond_body,
+    build_pair_http_server,
+)
+from totalreclaw.pair.session_store import (
+    create_pair_session,
+    default_pair_sessions_path,
+)
+
+
+@pytest.fixture
+def sessions_dir(tmp_path: Path) -> Path:
+    """Hermetic per-test pair-sessions directory."""
+    d = tmp_path / "totalreclaw"
+    d.mkdir(mode=0o700)
+    return d
+
+
+@pytest.fixture
+def sessions_path(sessions_dir: Path) -> Path:
+    return default_pair_sessions_path(sessions_dir)
+
+
+class FakeCompletionSink:
+    """Captures the phrase for assertion + returns an ``active`` result.
+
+    Scope: test-only. Real callers use
+    ``hermes.pair_tool_completion.complete_pairing`` which wires through
+    :class:`PluginState`.
+    """
+
+    def __init__(self) -> None:
+        self.phrase: str | None = None
+        self.called = False
+
+    def __call__(self, phrase: str, session):
+        self.phrase = phrase
+        self.called = True
+        return CompletePairingResult(state="active", account_id="0xabc")
+
+
+def _start_server(sessions_path: Path, sink: FakeCompletionSink):
+    cfg = PairHttpConfig(
+        sessions_path=sessions_path,
+        complete_pairing=sink,
+        bind_host="127.0.0.1",
+        bind_port=0,  # ephemeral
+    )
+    server = build_pair_http_server(cfg)
+    server.start()
+    return server
+
+
+def _http_post(server, path: str, body: dict) -> tuple[int, dict | None]:
+    conn = http.client.HTTPConnection(server.host, server.port, timeout=5)
+    try:
+        payload = json.dumps(body).encode("utf-8")
+        conn.request(
+            "POST",
+            path,
+            payload,
+            headers={"Content-Type": "application/json", "Content-Length": str(len(payload))},
+        )
+        resp = conn.getresponse()
+        data = resp.read()
+        try:
+            parsed = json.loads(data) if data else None
+        except json.JSONDecodeError:
+            parsed = None
+        return resp.status, parsed
+    finally:
+        conn.close()
+
+
+def _http_get(server, path: str) -> tuple[int, bytes, dict[str, str]]:
+    conn = http.client.HTTPConnection(server.host, server.port, timeout=5)
+    try:
+        conn.request("GET", path)
+        resp = conn.getresponse()
+        body = resp.read()
+        headers = {k.lower(): v for k, v in resp.getheaders()}
+        return resp.status, body, headers
+    finally:
+        conn.close()
+
+
+class TestValidateBody:
+    def test_accepts_well_formed(self):
+        body = {
+            "v": 1,
+            "sid": "a" * 32,
+            "pk_d": "A" * 43,
+            "nonce": "N" * 16,
+            "ct": "C" * 100,
+            "pin": "123456",
+        }
+        assert _validate_respond_body(body) is not None
+
+    def test_rejects_wrong_version(self):
+        body = {"v": 2, "sid": "a" * 32, "pk_d": "A" * 43, "nonce": "N" * 16, "ct": "C" * 100, "pin": "123456"}
+        assert _validate_respond_body(body) is None
+
+    def test_rejects_bad_pin(self):
+        body = {"v": 1, "sid": "a" * 32, "pk_d": "A" * 43, "nonce": "N" * 16, "ct": "C" * 100, "pin": "12345"}
+        assert _validate_respond_body(body) is None
+        body["pin"] = "abcdef"
+        assert _validate_respond_body(body) is None
+
+    def test_rejects_non_dict(self):
+        assert _validate_respond_body("not a dict") is None  # type: ignore[arg-type]
+        assert _validate_respond_body(None) is None
+
+
+class TestHappyPath:
+    def test_post_with_valid_payload_writes_credentials(
+        self, sessions_path: Path
+    ):
+        kp = generate_gateway_keypair()
+        session = create_pair_session(
+            sessions_path,
+            mode="import",
+            sk_b64=kp.sk_b64,
+            pk_b64=kp.pk_b64,
+            secondary_code="482914",
+        )
+        sink = FakeCompletionSink()
+        server = _start_server(sessions_path, sink)
+        try:
+            # Device side: generate an ephemeral keypair + encrypt the phrase.
+            dev = generate_gateway_keypair()
+            plaintext = (
+                "abandon abandon abandon abandon abandon abandon "
+                "abandon abandon abandon abandon abandon about"
+            ).encode("utf-8")
+            nonce_b64, ct_b64 = encrypt_pairing_payload(
+                sk_local_b64=dev.sk_b64,
+                pk_remote_b64=kp.pk_b64,
+                sid=session.sid,
+                plaintext=plaintext,
+            )
+            body = {
+                "v": 1,
+                "sid": session.sid,
+                "pk_d": dev.pk_b64,
+                "nonce": nonce_b64,
+                "ct": ct_b64,
+                "pin": "482914",
+            }
+            status, _ = _http_post(server, f"/pair/{session.sid}", body)
+            assert status == 204
+            assert sink.called is True
+            assert sink.phrase is not None
+            assert sink.phrase.split() == plaintext.decode("utf-8").split()
+        finally:
+            server.stop()
+
+
+class TestErrorPaths:
+    def test_unknown_token_returns_404(self, sessions_path: Path):
+        sink = FakeCompletionSink()
+        server = _start_server(sessions_path, sink)
+        try:
+            body = {
+                "v": 1,
+                "sid": "x" * 32,
+                "pk_d": "A" * 43,
+                "nonce": "N" * 16,
+                "ct": "C" * 100,
+                "pin": "123456",
+            }
+            status, parsed = _http_post(server, f"/pair/{'x' * 32}", body)
+            assert status == 404
+        finally:
+            server.stop()
+
+    def test_wrong_pin_returns_403(self, sessions_path: Path):
+        kp = generate_gateway_keypair()
+        session = create_pair_session(
+            sessions_path,
+            mode="generate",
+            sk_b64=kp.sk_b64,
+            pk_b64=kp.pk_b64,
+            secondary_code="111111",
+        )
+        sink = FakeCompletionSink()
+        server = _start_server(sessions_path, sink)
+        try:
+            body = {
+                "v": 1,
+                "sid": session.sid,
+                "pk_d": "A" * 43,
+                "nonce": "N" * 16,
+                "ct": "C" * 100,
+                "pin": "222222",  # wrong
+            }
+            status, parsed = _http_post(server, f"/pair/{session.sid}", body)
+            assert status == 403
+            assert parsed is not None
+            assert parsed.get("error") == "wrong_pin"
+            assert sink.called is False
+        finally:
+            server.stop()
+
+    def test_expired_session_returns_410(self, sessions_path: Path):
+        kp = generate_gateway_keypair()
+        # Create a session with a clock that places creation in the distant past.
+        t_then = 1_000_000_000
+        session = create_pair_session(
+            sessions_path,
+            mode="generate",
+            sk_b64=kp.sk_b64,
+            pk_b64=kp.pk_b64,
+            secondary_code="333333",
+            now=lambda: t_then,
+        )
+        sink = FakeCompletionSink()
+
+        # Build the server with a ``now`` that's past expiry.
+        future_now_ms = session.expires_at_ms + 60_000
+        cfg = PairHttpConfig(
+            sessions_path=sessions_path,
+            complete_pairing=sink,
+            bind_host="127.0.0.1",
+            bind_port=0,
+            now=lambda: future_now_ms,
+        )
+        server = build_pair_http_server(cfg)
+        server.start()
+        try:
+            body = {
+                "v": 1,
+                "sid": session.sid,
+                "pk_d": "A" * 43,
+                "nonce": "N" * 16,
+                "ct": "C" * 100,
+                "pin": "333333",
+            }
+            status, _ = _http_post(server, f"/pair/{session.sid}", body)
+            assert status == 410
+            assert sink.called is False
+        finally:
+            server.stop()
+
+    def test_tampered_ciphertext_returns_400(self, sessions_path: Path):
+        kp = generate_gateway_keypair()
+        session = create_pair_session(
+            sessions_path,
+            mode="import",
+            sk_b64=kp.sk_b64,
+            pk_b64=kp.pk_b64,
+            secondary_code="555555",
+        )
+        sink = FakeCompletionSink()
+        server = _start_server(sessions_path, sink)
+        try:
+            dev = generate_gateway_keypair()
+            nonce_b64, ct_b64 = encrypt_pairing_payload(
+                sk_local_b64=dev.sk_b64,
+                pk_remote_b64=kp.pk_b64,
+                sid=session.sid,
+                plaintext=b"valid phrase doesnt matter here",
+            )
+            # Flip a byte in ciphertext.
+            from totalreclaw.pair.crypto import _b64url_decode
+            raw = bytearray(_b64url_decode(ct_b64))
+            raw[3] ^= 0x01
+            tampered = _b64url_encode(bytes(raw))
+
+            body = {
+                "v": 1,
+                "sid": session.sid,
+                "pk_d": dev.pk_b64,
+                "nonce": nonce_b64,
+                "ct": tampered,
+                "pin": "555555",
+            }
+            status, parsed = _http_post(server, f"/pair/{session.sid}", body)
+            assert status == 400
+            assert parsed is not None
+            assert parsed.get("error") == "decrypt_failed"
+            assert sink.called is False
+        finally:
+            server.stop()
+
+
+class TestGetPairPage:
+    def test_get_returns_html_with_csp(self, sessions_path: Path):
+        kp = generate_gateway_keypair()
+        session = create_pair_session(
+            sessions_path,
+            mode="generate",
+            sk_b64=kp.sk_b64,
+            pk_b64=kp.pk_b64,
+        )
+        sink = FakeCompletionSink()
+        server = _start_server(sessions_path, sink)
+        try:
+            status, body, headers = _http_get(server, f"/pair/{session.sid}")
+            assert status == 200
+            assert b"TotalReclaw pairing" in body
+            assert "text/html" in headers.get("content-type", "")
+            assert "no-store" in headers.get("cache-control", "")
+            assert "default-src 'none'" in headers.get("content-security-policy", "")
+        finally:
+            server.stop()
+
+    def test_get_unknown_token_returns_404(self, sessions_path: Path):
+        sink = FakeCompletionSink()
+        server = _start_server(sessions_path, sink)
+        try:
+            status, _, _ = _http_get(server, f"/pair/{'z' * 32}")
+            assert status == 404
+        finally:
+            server.stop()

--- a/python/tests/test_upgrade_tool.py
+++ b/python/tests/test_upgrade_tool.py
@@ -63,7 +63,9 @@ class TestUpgradeTool:
         state = _make_state()
         result = json.loads(await upgrade({}, state))
         assert "error" in result
-        assert "totalreclaw_setup" in result["error"]
+        # 2.3.1rc4 — error messages now point to totalreclaw_pair (the
+        # phrase-safe replacement), not totalreclaw_setup (removed).
+        assert "totalreclaw_pair" in result["error"]
 
     @pytest.mark.asyncio
     async def test_happy_path_returns_url_and_message(self) -> None:

--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1-rc.4] — 2026-04-22
+
+Phrase-safety hardening: `totalreclaw_onboard` agent tool removed. Paired with Hermes Python `2.3.1rc4` (which ports the QR-pair flow to Python so Hermes users gain a phrase-safe agent setup path too).
+
+### Removed (phrase-safety enforcement — BREAKING for agent tool callers)
+
+- **`totalreclaw_onboard` agent tool — REMOVED.** rc.3 shipped a `totalreclaw_onboard` tool that generated a fresh BIP-39 mnemonic in-process, wrote it to `credentials.json`, and returned `{scope_address, credentials_path}`. `emitPhrase: false` kept the mnemonic out of the tool's return payload, but NOTHING ARCHITECTURALLY PREVENTED leakage — a future patch could regress the flag, a different code path could echo the mnemonic in a log/error, or the mere existence of the tool signalled to agents that phrase generation inside chat is fine (it isn't). Per `project_phrase_safety_rule.md`: "recovery phrase MUST NEVER cross the LLM context in ANY form." rc.4 removes the registration. The underlying `runNonInteractiveOnboard` code path stays reachable via the CLI `openclaw totalreclaw onboard` — that path runs in the user's own terminal, OUTSIDE any agent shell, so phrase stdout never feeds back into LLM context.
+
+### Changed
+
+- **`SKILL.md` — setup section rewritten.** `totalreclaw_pair` is now the canonical setup surface for all users (local or remote). The CLI wizard (`openclaw totalreclaw onboard`) is explicitly documented as user-terminal-only — agents MUST NOT invoke it via their shell tool. Tool surface table updated: `totalreclaw_onboard` removed, `totalreclaw_pair` promoted to canonical. `totalreclaw_onboarding_start` remains as a pointer-only tool for users who explicitly prefer local-terminal setup.
+- **`index.ts` — `totalreclaw_pair` tool description updated.** Removed backref to `totalreclaw_onboard`; now instructs agents to always prefer pair, with `totalreclaw_onboarding_start` as the fallback pointer for local-terminal-only users.
+- **`docs/guides/openclaw-setup.md` — QR pairing is now documented as the default setup flow.** CLI wizard moved to a user-terminal-only subsection with a prominent "do NOT run this through an agent shell" warning.
+
+### Tests
+
+- **`phrase-safety-registry.test.ts`** — new. Text-scans `index.ts` for `api.registerTool({ name: '...' })` literals and asserts: (a) `totalreclaw_onboard` is NOT in the list; (b) `totalreclaw_pair` IS in the list; (c) no name contains phrase-adjacent tokens (`onboard_generate`, `generate_phrase`, `generate_mnemonic`, `restore_phrase`, `restore_mnemonic`, `mnemonic`). Runs as part of `npm test`.
+
 ## [3.3.1-rc.3] — 2026-04-22
 
 Patch RC bundling two stability fixes, one new RC-gated tool, two SKILL.md addendums, and a configurable LLM retry budget. All prior rc.1 + rc.2 fixes are preserved.

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext."
-version: 3.3.1-rc.3
+version: 3.3.1-rc.4
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz
@@ -30,14 +30,26 @@ You are operating inside a host that has the TotalReclaw memory plugin loaded. T
 
 Before any memory tool, check `~/.totalreclaw/credentials.json`:
 
-- **Missing, empty, malformed, or no `mnemonic` key** -> NOT set up. You MUST NOT generate a phrase in chat, and you MUST NOT ask the user to paste one. Route:
-  - Local gateway: call `totalreclaw_onboarding_start` (or `totalreclaw_onboard` if available); both return a pointer to `openclaw totalreclaw onboard`.
-  - Remote gateway (VPS / Docker / no TTY): call `totalreclaw_pair` (v3.3.1+), OR instruct the user to run `openclaw totalreclaw pair generate --json`. Present the returned `{url, pin, qr_ascii}` to the user. The phrase is entered in their browser, never in this conversation.
+- **Missing, empty, malformed, or no `mnemonic` key** -> NOT set up. Follow the "Setting up a user's TotalReclaw recovery phrase" section below. You MUST NOT generate a phrase in chat, and you MUST NOT ask the user to paste one.
 - **Present with a valid `mnemonic`** -> active. Use the tools below.
+
+## Setting up a user's TotalReclaw recovery phrase
+
+**Agent path (default, only secure path): call the `totalreclaw_pair` tool.** It returns a URL + 6-digit PIN. Tell the user:
+
+> "Open <URL> in your browser, enter your phrase (or let the browser generate one), and confirm PIN <PIN>. Your phrase is encrypted in the browser and uploaded end-to-end-encrypted to this gateway — it never crosses this chat."
+
+Browser-side crypto handles the phrase; this chat never sees it. After the user confirms "pairing complete" in their browser, the credentials are already on disk — no gateway restart needed for OpenClaw because routes are registered on plugin install and the pair HTTP handler writes credentials in-process.
+
+**NEVER** invoke `openclaw totalreclaw onboard`, `totalreclaw setup`, or any phrase-generating CLI via your shell tool. Those commands are for users to run in their own terminal — not for you. Agent shell stdout is captured into LLM context; running them leaks the phrase.
+
+**NEVER** ask the user to paste their phrase into chat. If they do, immediately tell them to rotate by generating a new wallet via `totalreclaw_pair` with `mode=generate`; the pasted phrase is compromised.
+
+**If the user explicitly prefers local-terminal setup** (no browser, no QR URL to open), point them at `totalreclaw_onboarding_start` — which returns a pointer to the CLI wizard they run THEMSELVES. You do not run it.
 
 ## Core rules
 
-1. **Phrase safety (NON-NEGOTIABLE).** The recovery phrase is a secret. Never generate one in chat, never echo one back, never log one in reasoning / tool payloads, never pass one to another tool. Direct users to `cat ~/.totalreclaw/credentials.json | jq -r .mnemonic`.
+1. **Phrase safety (NON-NEGOTIABLE, ABSOLUTE).** The recovery phrase is a secret. Never generate one in chat, never echo one back, never log one in reasoning / tool payloads, never pass one to another tool, never invoke a phrase-generating CLI via your shell tool. A leaked phrase = compromised vault, no rotation possible. Governed by `project_phrase_safety_rule.md` (memory file in p-diogo/totalreclaw-internal).
 2. **Use the tools, not inline state.** `totalreclaw_remember` stores; `totalreclaw_recall` retrieves. Don't re-ask the user for past facts; don't paraphrase memories as your own recollection.
 3. **Gateway restart is required after install.** If tools fail right after `openclaw plugins install @totalreclaw/totalreclaw`, tell the user to run `openclaw restart` or `docker restart openclaw-qa`.
 
@@ -87,8 +99,8 @@ Tools work only when credentials are active AND the gateway has been restarted p
 | `totalreclaw_migrate` | optional `confirm` (dry-run by default) |
 | `totalreclaw_import_from` / `totalreclaw_import_batch` | `source`, `file_path` or `content`, `dry_run` |
 | `totalreclaw_consolidate` | optional `dry_run` |
-| `totalreclaw_onboarding_start` / `totalreclaw_onboard` | (none) — returns CLI pointer |
-| `totalreclaw_pair` | optional `mode` (`generate` / `import`) — returns `{url, pin, qr_ascii, expires_at_ms}` |
+| `totalreclaw_onboarding_start` | (none) — returns CLI pointer for users who prefer local-terminal setup |
+| `totalreclaw_pair` | optional `mode` (`generate` / `import`) — returns `{url, pin, qr_ascii, expires_at_ms}`. CANONICAL setup surface |
 
 ## Taxonomy
 

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -5049,143 +5049,34 @@ const plugin = {
     );
 
     // ---------------------------------------------------------------
-    // Tool: totalreclaw_onboard (3.3.1-rc.2 — agent-callable onboard)
+    // Tool: totalreclaw_onboard — REMOVED in 3.3.1-rc.4 (phrase-safety).
     //
-    // Lets the agent drive the non-interactive onboard flow without
-    // shelling out to `openclaw totalreclaw onboard` (subprocess work
-    // is not available inside the plugin runtime and the OpenClaw
-    // security scanner blocks the standard subprocess module).
+    // rc.3 shipped a `totalreclaw_onboard` agent tool that generated a
+    // fresh BIP-39 mnemonic in-process, wrote it to credentials.json,
+    // and returned `{scope_address, credentials_path}` to the agent.
+    // `emitPhrase: false` kept the mnemonic OUT of the tool's return
+    // payload, but NOTHING ARCHITECTURALLY PREVENTED leakage — a future
+    // patch could regress the flag, a different code path could echo
+    // the mnemonic in a log/error message the agent captures, or the
+    // mere existence of the tool implied to agents that "generating a
+    // phrase here is fine" (it isn't).
     //
-    // Security envelope (same as the CLI path):
-    //   - NEVER accepts a recovery phrase through chat (mode=restore
-    //     is rejected here — that still requires the local CLI wizard).
-    //   - The generated phrase is written to ~/.totalreclaw/credentials.json
-    //     (mode 0600) by `runNonInteractiveOnboard`. We explicitly pass
-    //     `emitPhrase: false` so the phrase NEVER appears in the tool
-    //     return value.
-    //   - Returns only: scope_address + credentials_path + ok/error.
+    // Per ``project_phrase_safety_rule.md``
+    // (memory file in p-diogo/totalreclaw-internal — absolute rule:
+    // "recovery phrase MUST NEVER cross the LLM context in ANY form"),
+    // phrase-generating agent tools are forbidden. The ONLY approved
+    // agent-facilitated setup surface is ``totalreclaw_pair`` (browser-
+    // side crypto keeps the phrase out of the LLM round-trip by
+    // construction). The underlying ``runNonInteractiveOnboard`` code
+    // path is still reachable via the CLI ``openclaw totalreclaw onboard``
+    // — that path runs in the user's own terminal, OUTSIDE any agent
+    // shell, so phrase stdout never feeds back into LLM context.
+    //
+    // Audit assertion: ``tool-gating.test.ts`` enforces the removal —
+    // any future re-registration of ``totalreclaw_onboard`` (or any
+    // phrase-generating variant like ``totalreclaw_onboard_generate``,
+    // ``totalreclaw_restore_phrase``) fails CI.
     // ---------------------------------------------------------------
-    api.registerTool(
-      {
-        name: 'totalreclaw_onboard',
-        label: 'Onboard (generate new recovery phrase)',
-        description:
-          'Generate a NEW TotalReclaw recovery phrase on this machine without the user ' +
-          'leaving chat. The phrase is written ONLY to ~/.totalreclaw/credentials.json (mode ' +
-          '0600) and NEVER returned through this tool — the response contains just the derived ' +
-          'Smart Account (scope) address and the credentials path so the user can retrieve ' +
-          'their phrase locally (e.g. `cat ~/.totalreclaw/credentials.json | jq -r .mnemonic`).\n\n' +
-          'Use when a fresh user asks you to set up TotalReclaw or enable memory. Refuses if ' +
-          'onboarding is already active (the user can delete the credentials file to re-onboard, ' +
-          'but we will NOT silently overwrite). For RESTORE (import an existing phrase), tell ' +
-          'the user to run `openclaw totalreclaw onboard --mode restore` in their local ' +
-          'terminal — this tool refuses to accept phrases through chat.',
-        parameters: {
-          type: 'object',
-          properties: {
-            mode: {
-              type: 'string',
-              enum: ['generate'],
-              description:
-                'Only "generate" is supported via this tool (creates a fresh 12-word BIP-39 ' +
-                'phrase). "restore" requires the local CLI wizard because pasting a phrase ' +
-                'through chat ships it to the LLM provider, defeating end-to-end encryption.',
-              default: 'generate',
-            },
-          },
-          additionalProperties: false,
-        },
-        async execute(_toolCallId: string, params: Record<string, unknown>) {
-          const mode = params?.mode;
-          if (mode !== undefined && mode !== 'generate') {
-            return {
-              content: [{
-                type: 'text',
-                text:
-                  'Only mode="generate" is supported through chat. For RESTORE (import an ' +
-                  'existing recovery phrase), ask the user to run `openclaw totalreclaw onboard ' +
-                  '--mode restore` in their local terminal — the phrase is read from stdin and ' +
-                  'never touches the LLM provider or the transcript.',
-              }],
-            };
-          }
-          try {
-            const result: NonInteractiveOnboardResult = await runNonInteractiveOnboard({
-              credentialsPath: CREDENTIALS_PATH,
-              statePath: CONFIG.onboardingStatePath,
-              mode: 'generate',
-              emitPhrase: false, // NEVER include the phrase in agent-visible output.
-              deriveScopeAddress: async (mnemonic: string) => {
-                try {
-                  return await deriveSmartAccountAddress(mnemonic, CONFIG.chainId);
-                } catch (err) {
-                  api.logger.warn(
-                    `totalreclaw_onboard: scope-address derivation failed: ${
-                      err instanceof Error ? err.message : String(err)
-                    }`,
-                  );
-                  return undefined;
-                }
-              },
-            });
-            if (!result.ok) {
-              // already-active, write-failed, etc. Never leaks the phrase.
-              api.logger.info(`totalreclaw_onboard: ok=false error=${result.error}`);
-              return {
-                content: [{
-                  type: 'text',
-                  text:
-                    result.error === 'already-active'
-                      ? 'TotalReclaw is already set up on this machine. Memory tools are unblocked. To re-onboard, delete ~/.totalreclaw/credentials.json first.'
-                      : `Onboard failed: ${result.error_detail ?? result.error}`,
-                }],
-                details: {
-                  ok: false,
-                  error: result.error,
-                  action: result.action,
-                },
-              };
-            }
-            api.logger.info(
-              `totalreclaw_onboard: generated phrase, scope=${result.scope_address?.slice(0, 10) ?? 'unknown'}…, credentials=${result.credentials_path}`,
-            );
-            // Crucially: the mnemonic field is NEVER emitted in details
-            // (emitPhrase=false enforces that on the result object).
-            return {
-              content: [{
-                type: 'text',
-                text:
-                  `TotalReclaw setup complete. A new 12-word recovery phrase was generated and ` +
-                  `saved to ${result.credentials_path} (mode 0600). ` +
-                  (result.scope_address
-                    ? `Your on-chain scope (Smart Account) address is ${result.scope_address}. `
-                    : '') +
-                  `To view your recovery phrase, run on the user's local terminal:\n\n` +
-                  `    cat ${result.credentials_path} | jq -r .mnemonic\n\n` +
-                  `IMPORTANT: the recovery phrase is the ONLY way to recover memories on another ` +
-                  `device. Tell the user to store it safely — a password manager or a paper backup. ` +
-                  `TotalReclaw cannot recover it if lost.`,
-              }],
-              details: {
-                ok: true,
-                action: 'generate',
-                scope_address: result.scope_address,
-                credentials_path: result.credentials_path,
-                // Deliberately NO mnemonic field.
-              },
-            };
-          } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            api.logger.error(`totalreclaw_onboard failed: ${message}`);
-            return {
-              content: [{ type: 'text', text: `Onboard failed: ${humanizeError(message)}` }],
-              details: { ok: false, error: 'unexpected', error_detail: message },
-            };
-          }
-        },
-      },
-      { name: 'totalreclaw_onboard' },
-    );
 
     // ---------------------------------------------------------------
     // Tool: totalreclaw_pair (3.3.1-rc.2 — agent-callable pair-generate)
@@ -5206,10 +5097,12 @@ const plugin = {
           '6-digit PIN, and an ASCII QR code that the agent relays to the user. The recovery ' +
           'phrase itself is generated/entered in the BROWSER and uploaded end-to-end encrypted ' +
           'to this gateway — it NEVER touches the LLM provider or the chat transcript.\n\n' +
-          'Use when a user wants to set up TotalReclaw on a machine they don\'t have terminal ' +
-          'access to (a VPS, a friend\'s computer), or when they prefer a phone-mediated flow. ' +
-          'For local-machine setup with a terminal, prefer `totalreclaw_onboard` (generate) or ' +
-          '`totalreclaw_onboarding_start` (pointer to local CLI for restore).',
+          'This is the CANONICAL agent-facilitated setup surface — use it whenever the user ' +
+          'asks you to set up TotalReclaw, regardless of whether they have terminal access. ' +
+          'Browser-side crypto keeps the recovery phrase out of the LLM context entirely. ' +
+          'If a user explicitly prefers local-terminal setup with no browser, point them at ' +
+          '`totalreclaw_onboarding_start` (a pointer to the CLI wizard they run on their own ' +
+          'terminal, NOT through your shell tool).',
         parameters: {
           type: 'object',
           properties: {

--- a/skill/plugin/package-lock.json
+++ b/skill/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.1-rc.2",
+  "version": "3.3.1-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/totalreclaw",
-      "version": "3.3.1-rc.2",
+      "version": "3.3.1-rc.4",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.0.1",
@@ -1686,70 +1686,6 @@
       "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
       "license": "MIT"
     },
-    "node_modules/ox": {
-      "version": "0.14.17",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.17.tgz",
-      "integrity": "sha512-jOzNb2Wlfzsr8z/GoCtd1bf6OSRuWuysvbhnHGD+7fV1WRbcBR6B0RYoe3xWnUedF7zp4l5APmS7CzAhUok/lA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "^1.11.0",
-        "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "1.9.1",
-        "@noble/hashes": "^1.8.0",
-        "@scure/bip32": "^1.7.0",
-        "@scure/bip39": "^1.6.0",
-        "abitype": "^1.2.3",
-        "eventemitter3": "5.0.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ox/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/ox/node_modules/@scure/base": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
-      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/ox/node_modules/@scure/bip39": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
-      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "~1.8.0",
-        "@scure/base": "~1.2.5"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -2288,6 +2224,36 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/ox": {
+      "version": "0.14.17",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.17.tgz",
+      "integrity": "sha512-jOzNb2Wlfzsr8z/GoCtd1bf6OSRuWuysvbhnHGD+7fV1WRbcBR6B0RYoe3xWnUedF7zp4l5APmS7CzAhUok/lA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/webidl-conversions": {

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.1-rc.3",
+  "version": "3.3.1-rc.4",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [
@@ -50,7 +50,7 @@
     "skill.json"
   ],
   "scripts": {
-    "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx llm-client-retry.test.ts && npx tsx gateway-url.test.ts && npx tsx retype-setscope.test.ts && npx tsx tool-gating.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts && npx tsx qa-bug-report.test.ts && npx tsx nonce-serialization.test.ts",
+    "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx llm-client-retry.test.ts && npx tsx gateway-url.test.ts && npx tsx retype-setscope.test.ts && npx tsx tool-gating.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts && npx tsx qa-bug-report.test.ts && npx tsx nonce-serialization.test.ts && npx tsx phrase-safety-registry.test.ts",
     "check-scanner": "node ../scripts/check-scanner.mjs",
     "prepublishOnly": "node ../scripts/check-scanner.mjs"
   },

--- a/skill/plugin/phrase-safety-registry.test.ts
+++ b/skill/plugin/phrase-safety-registry.test.ts
@@ -1,0 +1,146 @@
+/**
+ * 3.3.1-rc.4 — phrase-safety contract tests.
+ *
+ * Contract: NO agent tool registered by the TotalReclaw plugin may
+ * generate, return, or accept a recovery phrase. The ONLY approved
+ * agent-facilitated setup surface is `totalreclaw_pair` (browser-side
+ * crypto keeps the phrase out of the LLM round-trip by construction).
+ *
+ * Governed by:
+ *   ~/.claude/projects/-Users-pdiogo-Documents-code-totalreclaw-internal/
+ *     memory/project_phrase_safety_rule.md
+ *
+ * Absolute rule: "recovery phrase MUST NEVER cross the LLM context in
+ * ANY form — not echoed, not in tool-call stdout, not in tool-result
+ * payloads, not in agent reasoning."
+ *
+ * What this test asserts:
+ *   1. `totalreclaw_onboard` is NOT present as a `registerTool` name
+ *      anywhere in `index.ts`. (rc.3 registered it; rc.4 removed it.)
+ *   2. `totalreclaw_pair` IS present (the approved replacement).
+ *   3. No tool name containing a phrase-adjacent token (`onboard_generate`,
+ *      `restore_phrase`, `mnemonic`, `generate_phrase`) is registered.
+ *   4. The scan is defense-in-depth — a text search, not an AST walk —
+ *      because a new registration that accidentally ships a phrase
+ *      surface would almost always include one of these tokens.
+ *
+ * Scan strategy: read index.ts as text and search for the
+ * `api.registerTool({ name: '...' }` pattern and `{ name: '...' }` tool
+ * registrations. We match on the `name:` literal inside the object
+ * passed to `registerTool`. This is a coarser scan than parsing TS but
+ * sufficient for catching an accidental re-registration.
+ *
+ * Run with: `npx tsx phrase-safety-registry.test.ts`
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, name: string): void {
+  const n = passed + failed + 1;
+  if (condition) {
+    console.log(`ok ${n} - ${name}`);
+    passed++;
+  } else {
+    console.log(`not ok ${n} - ${name}`);
+    failed++;
+  }
+}
+
+const INDEX_PATH = path.resolve(import.meta.dirname, 'index.ts');
+const src = fs.readFileSync(INDEX_PATH, 'utf-8');
+
+/**
+ * Extract the set of tool names passed to `api.registerTool({ name: '<name>', ... })`.
+ *
+ * Matches both single and double-quoted string literals. The regex is
+ * anchored to the `registerTool(` opening so literals elsewhere in the
+ * file (descriptions, comments, error messages) are not counted.
+ */
+function extractRegisteredToolNames(source: string): string[] {
+  const names: string[] = [];
+  // Find every `api.registerTool(` call and the next `name: '...'`
+  // literal inside the same call block. We approximate "inside the same
+  // call block" by taking the first `name:` literal within 2000 chars
+  // of the opening paren — registerTool blocks are big (schemas + execute
+  // bodies) but 2000 chars is enough for all current ones.
+  const openerRe = /api\.registerTool\s*\(\s*\{/g;
+  let m: RegExpExecArray | null;
+  while ((m = openerRe.exec(source)) !== null) {
+    const start = m.index + m[0].length;
+    const window = source.slice(start, start + 3000);
+    const nameRe = /\bname:\s*['"]([a-zA-Z0-9_]+)['"]/;
+    const nm = nameRe.exec(window);
+    if (nm) names.push(nm[1]);
+  }
+  return names;
+}
+
+const registered = extractRegisteredToolNames(src);
+
+// ---------------------------------------------------------------------------
+// 1. totalreclaw_onboard is NOT registered
+// ---------------------------------------------------------------------------
+assert(
+  !registered.includes('totalreclaw_onboard'),
+  'phrase-safety: totalreclaw_onboard is NOT registered (removed in rc.4)',
+);
+
+// ---------------------------------------------------------------------------
+// 2. totalreclaw_pair IS registered (the approved replacement)
+// ---------------------------------------------------------------------------
+assert(
+  registered.includes('totalreclaw_pair'),
+  'phrase-safety: totalreclaw_pair IS registered',
+);
+
+// ---------------------------------------------------------------------------
+// 3. No other phrase-adjacent tool name is registered
+// ---------------------------------------------------------------------------
+const FORBIDDEN_SUBSTRINGS = [
+  'onboard_generate',
+  'generate_phrase',
+  'generate_mnemonic',
+  'restore_phrase',
+  'restore_mnemonic',
+  'mnemonic',
+];
+
+for (const forbidden of FORBIDDEN_SUBSTRINGS) {
+  const hits = registered.filter((n) => n.toLowerCase().includes(forbidden));
+  assert(
+    hits.length === 0,
+    `phrase-safety: no registered tool name contains "${forbidden}" (hits: ${JSON.stringify(hits)})`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Known-safe tool names ARE registered (regression guard — if this
+// count drops unexpectedly the scan logic broke, not the registry)
+// ---------------------------------------------------------------------------
+const EXPECTED_SAFE = [
+  'totalreclaw_remember',
+  'totalreclaw_recall',
+  'totalreclaw_forget',
+  'totalreclaw_pair',
+];
+for (const t of EXPECTED_SAFE) {
+  assert(
+    registered.includes(t),
+    `sanity: ${t} is registered (regression guard)`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 5. Summary
+// ---------------------------------------------------------------------------
+console.log(`# fail: ${failed}`);
+console.log(`# ${passed}/${passed + failed} passed`);
+if (failed > 0) {
+  console.log('SOME TESTS FAILED');
+  process.exit(1);
+}
+console.log('ALL TESTS PASSED');


### PR DESCRIPTION
## Phrase-safety rule (top of PR — governs this whole change)

> **Rule (absolute):** the recovery phrase MUST NEVER cross the LLM context in ANY form — not echoed, not in tool-call stdout, not in tool-result payloads, not in agent reasoning.
>
> **Only two paths** are allowed to generate / enter / restore a phrase:
> 1. **User's own terminal, OUTSIDE any agent shell tool.** User SSHs / opens terminal on the gateway host + runs `totalreclaw setup` OR `openclaw totalreclaw onboard` directly. Phrase stays in that terminal's stdout.
> 2. **QR-pair flow.** Browser fetches pair page, user enters phrase in browser, browser-side x25519 ECDH, encrypted POST to gateway, gateway decrypts + writes `credentials.json`.
>
> **Enforcement:** remove phrase-generating agent tools from the runtime tool list (CLI entry points stay for the user's own terminal; they just aren't exposed as agent tools). `totalreclaw_pair` is the ONLY setup-related agent tool. Failure-mode tolerance: zero. Phrase leakage = vault compromise. No rotation after the fact.

Source: `~/.claude/projects/-Users-pdiogo-Documents-code-totalreclaw-internal/memory/project_phrase_safety_rule.md`.

## Summary

Bundled rc.4 addresses two rc.3 QA blockers:

- **The fix (console-script collision).** rc.3 shipped a `hermes` console script in `python/pyproject.toml` that overwrote the upstream `hermes-agent` CLI on `pip install totalreclaw`. `hermes gateway` then failed with `argument command: invalid choice: 'gateway'`, the Docker container restart-looped, the TR plugin never loaded, zero memories extracted. rc.4 drops the colliding line. Only the canonical `totalreclaw = "totalreclaw.cli:main"` remains.

- **The feature (Hermes QR-pair).** Ported `skill/plugin/pair-*.ts` to Python under `python/totalreclaw/pair/` so Hermes gains a phrase-safe agent-facilitated setup path. Same cipher suite as the TS side: x25519 ECDH + HKDF-SHA256 + ChaCha20-Poly1305 AEAD, 12-byte nonce, 16-byte tag, sid-as-AD binding. Pure x25519 in rc.4 (matches TS); ML-KEM hybrid deferred to rc.5 in lockstep across both stacks.

- **The hardening (onboard tool removal, both sides).** Removed the `totalreclaw_onboard` agent tool from OpenClaw (TS) and the `totalreclaw_setup` agent tool from Hermes (Python). Both accepted or returned phrase material through the LLM tool-call payload. `totalreclaw_pair` is now the CANONICAL agent-facilitated setup surface on both sides. CLI commands (`openclaw totalreclaw onboard`, `totalreclaw setup`) stay functional but are documented as user-terminal-only.

## Files changed

### Python (Hermes) — `python/`

**New modules:**
- `src/totalreclaw/pair/__init__.py` — public re-exports
- `src/totalreclaw/pair/crypto.py` — x25519 + HKDF + ChaCha20-Poly1305 via `cryptography`
- `src/totalreclaw/pair/session_store.py` — atomic TTL-evicted JSON store + `.lock` sentinel
- `src/totalreclaw/pair/http_server.py` — stdlib `http.server` on 127.0.0.1; GET pair page, POST respond
- `src/totalreclaw/pair/pair_page.py` — self-contained HTML + inline WebCrypto JS
- `src/totalreclaw/hermes/pair_tool.py` — `totalreclaw_pair` agent-tool handler
- `src/totalreclaw/hermes/pair_tool_completion.py` — post-decrypt completion callback

**Modified:**
- `pyproject.toml` — removed `hermes` console script; version 2.3.1rc3 → 2.3.1rc4; added `cryptography>=42.0` dep
- `src/totalreclaw/__init__.py` — version fallback 2.3.1rc3 → 2.3.1rc4
- `src/totalreclaw/hermes/__init__.py` — removed `totalreclaw_setup` tool registration; added `totalreclaw_pair`
- `src/totalreclaw/hermes/plugin.yaml` — tool list: -setup -onboarding_start +pair; version bump
- `src/totalreclaw/hermes/SKILL.md` — RULE 0/1a/5 rewritten around QR pair; forbidden patterns enumerated
- `src/totalreclaw/hermes/tools.py` — `setup()` function retained for CLI delegation; docstring warning added; "Run totalreclaw_setup first" error messages changed to "Call totalreclaw_pair to set up"
- `src/totalreclaw/onboarding.py` — removed `hermes setup` alt hint from setup instructions
- `CHANGELOG.md` — new `[2.3.1rc4]` section

**Tests:**
- `tests/test_pair_crypto.py` (22 tests — new)
- `tests/test_pair_http.py` (11 tests — new)
- `tests/test_agent_tools_phrase_safety.py` (5 tests — new)
- `tests/test_hermes_plugin.py` — updated registration assertions, added phrase-safety test
- `tests/test_onboarding.py` — updated instructions-hint assertions
- `tests/test_debrief_tool.py`, `tests/test_upgrade_tool.py` — updated error-string assertions

### TypeScript (OpenClaw plugin) — `skill/plugin/`

- `index.ts` — `totalreclaw_onboard` registration DELETED (replaced by inline explanatory comment); `totalreclaw_pair` description updated to remove back-ref to onboard
- `package.json` — version 3.3.1-rc.3 → 3.3.1-rc.4; test script adds `phrase-safety-registry.test.ts`
- `package-lock.json` — version bump + npm install cleanup
- `SKILL.md` — setup section rewritten; tool-surface table updated
- `CHANGELOG.md` — new `[3.3.1-rc.4]` section
- `phrase-safety-registry.test.ts` (12 tests — new)

### Docs — `docs/guides/`

- `hermes-setup.md` — QR pair flow is default; CLI relegated to user-terminal-only subsection
- `openclaw-setup.md` — QR pair promoted to canonical agent surface; CLI moved to user-terminal-only subsection

## Test plan

- [x] `PYTHONPATH=src python3 -m pytest tests/` — 843 passed, 10 skipped, 1 xfailed (Hermes)
- [x] `npm test` under `skill/plugin/` — all test files green, zero fails
- [x] `npm run check-scanner` — scanner clean, 88 files, 0 flags
- [x] `pip install -e python/` creates ONLY the `totalreclaw` binary, NOT `hermes`
- [x] Python crypto round-trip: encrypt on device → decrypt on gateway → recovered plaintext matches

## Not run (explicit constraints)

- No end-to-end QA against a live gateway (constraint: do NOT invoke any phrase-generating command during testing).
- No ML-KEM hybrid port (deferred to rc.5 across both TS + Python in lockstep — documented in `python/CHANGELOG.md`).
- Internal repo's `docs/release-pipeline.md` left untouched per constraints — user updates after this PR opens.

## Assumptions flagged for user

1. **Hermes tool-registration entry-point group** — reused the existing `totalreclaw.hermes.register(ctx)` pattern that Hermes already calls. No new entry-point group added.
2. **Pair server binding** — defaults to `127.0.0.1:<ephemeral-port>`. Operators running Hermes in Docker need `TOTALRECLAW_PAIR_BIND_HOST` / `TOTALRECLAW_PAIR_BIND_PORT` env vars to publish the port, OR SSH-port-forward. Documented in the setup guide.
3. **ML-KEM hybrid parity** — both TS and Python are pure x25519 in rc.4. The phrase-safety rule's carve-out (ship pure x25519 for rc.4 + TODO for hybrid in rc.5) is followed.
4. **`schemas.SETUP`** is retained in `hermes/schemas.py` even though the tool is no longer registered — in case in-process callers reference the shape. Security invariant is enforced at registration time (see `test_agent_tools_phrase_safety.py`).

**Do NOT auto-merge.** User reviews before promote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)