### PR TITLE
docs(guides): bump hermes-setup + openclaw-setup to rc.6 + upgrade note

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -2,6 +2,14 @@
 
 TotalReclaw gives your Hermes agent encrypted, persistent memory. Install the plugin, pair your vault from your browser, chat.
 
+## Installing via chat with your agent
+
+If Hermes is already running and you want the agent to walk you through the rest of this guide, paste:
+
+> "Install TotalReclaw by following the guide at https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md"
+
+Your agent will install the package, restart its gateway, then walk you through the QR pairing flow. Your recovery phrase never touches the chat — it's entered in your browser during pairing.
+
 ## Prerequisites
 
 - Hermes Agent v0.5.0+ (https://github.com/NousResearch/hermes-agent)
@@ -20,12 +28,14 @@ Hermes auto-discovers the plugin via entry-point registration at next start. No 
 **Installing a release candidate (RC / pre-release)?** Pre-releases on PyPI are hidden from `pip install` by default. Use `--pre` and pin the version explicitly:
 
 ```bash
-pip install --pre totalreclaw==2.3.1rc4        # replace with the RC version you want
+pip install --pre totalreclaw==2.3.1rc6        # replace with the RC version you want
 ```
 
 Find the latest RC via `pip index versions totalreclaw --pre` or on [PyPI](https://pypi.org/project/totalreclaw/#history). Never install an RC on production — only for QA against staging.
 
-> **2.3.1rc4 changed the console-script list.** rc.3 and earlier shipped a `hermes` entry point that collided with the upstream `hermes-agent` CLI. rc.4 removes it — now `pip install totalreclaw` only creates the `totalreclaw` binary. If you upgraded from rc.3 and your `hermes` binary was overwritten, reinstall hermes-agent to restore it (`pip install --force-reinstall hermes-agent`).
+### Upgrading
+
+If you were on plugin 3.3.1-rc.2 or Hermes 2.3.1rc2, after `pip install --pre totalreclaw==2.3.1rc6` also run `pip install --force-reinstall hermes-agent` to restore the `hermes` CLI entrypoint that rc.2's console-script collision left stale. Fresh installs are unaffected.
 
 ## 2. Set up your vault (default: QR pair flow)
 

--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -4,6 +4,16 @@ TotalReclaw gives your OpenClaw agent encrypted, persistent memory. Facts, prefe
 
 ---
 
+## Installing via chat with your agent
+
+If OpenClaw is already running and you want the agent to walk you through the rest of this guide, paste:
+
+> "Install TotalReclaw by following the guide at https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md"
+
+Your agent will install the package, restart its gateway, then walk you through the QR pairing flow. Your recovery phrase never touches the chat — it's entered in your browser during pairing.
+
+---
+
 ## Install
 
 ```bash
@@ -20,10 +30,14 @@ First-run setup runs a secure CLI wizard (v3.2.0+); the plugin never auto-genera
 
 ```bash
 openclaw plugins install @totalreclaw/totalreclaw@rc               # always the latest RC
-openclaw plugins install @totalreclaw/totalreclaw@3.3.1-rc.2       # pin exact version
+openclaw plugins install @totalreclaw/totalreclaw@3.3.1-rc.6       # pin exact version
 ```
 
 Find the current RC via `npm view @totalreclaw/totalreclaw dist-tags` or the [npm page](https://www.npmjs.com/package/@totalreclaw/totalreclaw?activeTab=versions).
+
+### Upgrading
+
+If you were on plugin 3.3.1-rc.2 or Hermes 2.3.1rc2, after `pip install --pre totalreclaw==2.3.1rc6` also run `pip install --force-reinstall hermes-agent` to restore the `hermes` CLI entrypoint that rc.2's console-script collision left stale. Fresh installs are unaffected.
 
 <details>
 <summary>From-source install (for plugin development)</summary>
@@ -85,13 +99,13 @@ Check state any time: `openclaw totalreclaw status`.
 
 Ask the agent "set up TotalReclaw for me" and it should call `totalreclaw_pair` directly. For users who explicitly prefer local-terminal setup, the agent falls back to `totalreclaw_onboarding_start` — a pointer-only tool that tells YOU to run the CLI wizard yourself. The agent never runs the wizard for you.
 
-### rc.4 phrase-safety changes (3.3.1-rc.4+)
+### Phrase-safety model (3.3.1-rc.6+)
 
 Per `project_phrase_safety_rule.md`:
 
 - `totalreclaw_onboard` agent tool — **REMOVED**. Even with `emitPhrase: false`, nothing architecturally prevented leakage. Use `totalreclaw_pair`.
 - `totalreclaw setup` / `openclaw totalreclaw onboard` CLI commands — **KEPT but user-terminal only**. They MUST NOT be invoked via any agent shell tool.
-- `totalreclaw_pair` agent tool — **CANONICAL**. Browser-side x25519 + ChaCha20-Poly1305 + HKDF-SHA256 keeps the phrase out of the LLM round-trip by construction. Now ported to Hermes Python as well (v2.3.1rc4+).
+- `totalreclaw_pair` agent tool — **CANONICAL**. Browser-side x25519 + ChaCha20-Poly1305 + HKDF-SHA256 keeps the phrase out of the LLM round-trip by construction. Ported to Hermes Python as well (v2.3.1rc6+).
 
 ### Retrieving your phrase later
 


### PR DESCRIPTION
## Summary

- Bump pinned RC examples: Hermes `2.3.1rc4` -> `2.3.1rc6`, OpenClaw `3.3.1-rc.2` -> `3.3.1-rc.6`.
- Add an "Installing via chat with your agent" section near the top of both guides with a copy-pasteable prompt for Hermes / OpenClaw users.
- Add an "Upgrading" subsection covering the rc.2 console-script collision recovery (`pip install --force-reinstall hermes-agent`). Fresh installs unaffected.
- Reframe the OpenClaw phrase-safety section floor from rc.4 to rc.6; QR-pair (`totalreclaw_pair`) stays the canonical agent-facilitated setup path, CLI wizards remain user-terminal-only.

## Test plan

- [ ] User skims both guides to confirm version strings, install commands, and upgrade note read correctly.
- [ ] Paste the "Installing via chat with your agent" prompt into a fresh Hermes / OpenClaw chat and confirm the agent executes the full install + pair flow.

Generated with Claude Code