### PR TITLE
skill(plugin+hermes): minimal agent-imperative SKILL.md rewrite

### DIFF
--- a/python/src/totalreclaw/hermes/SKILL.md
+++ b/python/src/totalreclaw/hermes/SKILL.md
@@ -1,221 +1,42 @@
 ---
 name: totalreclaw
-description: "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext. Python / Hermes edition."
+description: "Install + set up TotalReclaw encrypted memory for Hermes, then use totalreclaw_remember / totalreclaw_recall. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', or any remember / recall request."
 version: 2.3.1rc6
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz
 ---
 
-# TotalReclaw — Hermes Plugin Skill
+# TotalReclaw — Hermes
 
-**This document is directive for agents, not user-facing copy.** Follow the rules in order; every rule is a hard `MUST` unless stated otherwise.
+## Setup flow (run on "install / set up TotalReclaw" OR any tool returning `onboarding required`)
 
-## RULE 0 — Recovery-phrase handling (security boundary, ABSOLUTE)
+1. `pip install --pre totalreclaw` (latest pre-release on PyPI; pin a specific `rcN` from https://pypi.org/project/totalreclaw/#history if asked).
+2. Restart gateway so plugin loads. Docker: `docker restart tr-hermes`. Native: `hermes gateway restart`. Wait ~5s; confirm the gateway is back up.
+3. Call `totalreclaw_pair`. Returns `{url, pin, expires_at_ms}`.
+4. Relay to user verbatim: *"Open <url> in your browser. Enter your 12-word recovery phrase (or let the browser generate one). Confirm PIN <pin>. I'll wait for you to say done."*
+5. After user says done: verify `~/.totalreclaw/credentials.json` exists and is non-empty. If missing, call `totalreclaw_pair` again (PIN likely expired) and resend.
+6. Confirm: *"TotalReclaw is set up. Ask me to remember or recall anything."*
 
-The recovery phrase is the ONLY key to the user's encrypted memories. A single leaked phrase equals a fully compromised vault: the LLM provider (and anyone with access to its logs) can decrypt every memory the user has ever stored. Phrases do NOT rotate — once leaked, always leaked.
+## Phrase safety (HARD — never break)
 
-**Absolute rule:** the recovery phrase MUST NEVER cross the LLM context in ANY form — not in your replies, not in tool-call arguments, not in tool-call return values, not in your reasoning, not in shell-tool stdout.
+NEVER echo / generate / ask the user to paste a recovery phrase in chat. NEVER invoke `totalreclaw setup`, `hermes setup`, or any phrase-touching CLI via your shell tool (stdout enters LLM context). The ONLY agent-facilitated setup path is `totalreclaw_pair`. If the user pastes a phrase anyway: tell them it is compromised, call `totalreclaw_pair` with `mode=generate` for a fresh wallet.
 
-- **NEVER invoke `totalreclaw setup`, `hermes setup`, or any phrase-generating / phrase-restoring CLI via your shell tool.** Those commands print (or could print, with flags like `--emit-phrase`, or with a silent-save regression) the phrase. Your shell-tool stdout is captured into LLM context. Those CLIs exist for users to run in their OWN terminal, OUTSIDE any agent shell.
-- **NEVER pass a recovery phrase as a tool-call argument.** The entire tool-call payload is in LLM context. The `totalreclaw_setup` tool that accepted a `recovery_phrase` parameter in rc.3 has been REMOVED in rc.4 for this reason.
-- **NEVER generate a 12-word phrase yourself.** You cannot produce a valid BIP-39 checksum; any phrase you invent is garbage that can't recover real memories.
-- **NEVER display a phrase in chat.** LLM providers log transcripts; any phrase in a reply leaks to every hop.
-- **NEVER ask the user to paste their phrase.** If they do anyway, tell them immediately: "That was pasted into chat — please delete the message and generate a new wallet via `totalreclaw_pair` with `mode=generate`. The phrase you pasted is now compromised and cannot be un-leaked."
+## Usage (post-setup)
 
-The ONLY agent-facilitated setup path is `totalreclaw_pair` (see RULE 1a). Browser-side crypto keeps the phrase out of the LLM round-trip by construction.
+- Stable user facts / preferences / identity / "remember X" → `totalreclaw_remember` (don't ask permission).
+- First-person factual query ("do I / what's my / where do I …") → `totalreclaw_recall` FIRST, then answer from returned facts. If 0 results, say so.
+- "forget / pin / unpin X" → `totalreclaw_recall` first for `fact_id`, then `totalreclaw_forget` / `_pin` / `_unpin`.
+- "status" → `totalreclaw_status`. "upgrade" → `totalreclaw_upgrade` (paste Stripe URL verbatim).
+- "import from Mem0 / ChatGPT / Claude / Gemini / mcp-memory-server" → `totalreclaw_import_from` with `dry_run=True` first.
 
----
+## Diagnostics
 
-## RULE 1 — On plugin load, check setup state
+- `totalreclaw_*` tools not visible → gateway not restarted after install; redo step 2.
+- User says done but `credentials.json` missing → PIN expired or entered wrong phrase; call `totalreclaw_pair` again.
+- `onboarding required` → credentials missing; redo from step 3.
+- `quota exceeded` → `totalreclaw_status`, then offer `totalreclaw_upgrade`.
 
-Exactly one of these is true when your session starts:
+## Tool surface
 
-| State | Detection | Your action |
-|---|---|---|
-| Setup complete | `totalreclaw.agent.state.is_configured() == True` | Do nothing; memory tools are live. |
-| Setup pending | `is_configured() == False` (credentials.json missing/empty) | Proceed to RULE 1a. |
-
-### RULE 1a — Setting up a user's TotalReclaw recovery phrase
-
-**Agent path (default, only secure path): call the `totalreclaw_pair` tool.** It returns a URL + 6-digit PIN + `expires_at`. Tell the user:
-
-> "Open <URL> in your browser, enter your phrase (or let the browser generate a new one), and confirm PIN <PIN>. Your phrase is encrypted in the browser and uploaded end-to-end-encrypted to this gateway — it never crosses this chat."
-
-The browser does x25519 + ChaCha20-Poly1305 encryption against the gateway's ephemeral key. The gateway decrypts server-side and writes `~/.totalreclaw/credentials.json`. The LLM never sees the phrase at any point in the flow.
-
-**After the user confirms "pairing complete" in their browser:** tell them to restart the Hermes gateway so the plugin picks up the new credentials. Plugin routes and hooks only bind on fresh gateway start.
-
-**NEVER** invoke `totalreclaw setup`, `hermes setup`, `openclaw totalreclaw onboard`, or any phrase-generating CLI via your shell tool. Those commands are for users running them in their own terminal — not for you. Agent shell stdout is captured into LLM context; running them leaks the phrase.
-
-**NEVER** ask the user to paste their phrase into chat. If they do, immediately tell them to rotate by generating a new wallet via `totalreclaw_pair` with `mode=generate`; the pasted phrase is compromised and there is no rotation after-the-fact.
-
----
-
-## RULE 2 — Auto-storage (`totalreclaw_remember`)
-
-When the user says something worth remembering, call `totalreclaw_remember` WITHOUT asking for permission. Candidates include:
-
-- Explicit memory requests: "remember X", "note that Y", "don't forget Z"
-- Stable preferences: "I prefer PostgreSQL", "I always deploy to Vercel"
-- Long-lived context: "I'm working on a React app called Foobar", "my manager is Alice"
-- Corrections to earlier facts: "actually, my location is Porto, not Lisbon"
-
-Do NOT store:
-- Ephemeral state visible only this turn
-- Things the user flagged as temporary ("just for this session")
-- Generic knowledge not about the user
-
-Schema:
-```python
-await client.remember(
-    text="Pedro lives in Porto, Portugal",
-    type="claim",         # or "preference" | "directive" | "commitment" | "episode" | "summary"
-    source="user",        # or "user-inferred" | "assistant" | "external" | "derived"
-    scope="personal",     # or "work" | "health" | "family" | "creative" | "finance" | "misc"
-    importance=7,         # 1-10 (int) or 0-1 (float, auto-normalized)
-)
-```
-
----
-
-## RULE 3 — Recall (`totalreclaw_recall`)
-
-Call `totalreclaw_recall` when the user:
-
-- Asks "do you remember..." / "what did I tell you about..."
-- References past preferences, decisions, or history
-- Asks a question where prior context would help (e.g., "what's my default deploy target?")
-
-Use the user's natural phrasing as the `query`. Default `k=8` works well; bump to 20 for exhaustive searches (e.g., "list everything you know about me").
-
-**Start-of-session check (optional but recommended):** after RULE 1 passes, call `recall(query="")` with an empty-ish prompt or a broad term like `"user profile"` to surface the top memories before the user types their first real message. This lets you open with "hey Pedro, welcome back from Porto" rather than a cold hello.
-
-### RULE 3a — First-person queries ALWAYS trigger recall
-
-Any user message that references THEIR OWN facts triggers a recall call BEFORE you answer. Triggers (non-exhaustive — err on the side of calling recall):
-
-- "where do I live / work" / "what's my address / city"
-- "what do I prefer / like / hate / use"
-- "do I have / own / know"
-- "when did I / have I ever"
-- "who is my / my [relation/role]"
-- "what was my / my [object/preference]"
-- any question pattern containing "my / I / me" + a fact-shaped noun (address, job, favourite, project, partner, pet, etc.)
-
-Call `totalreclaw_recall(query=<semantic version of the question>)` FIRST, THEN answer based on returned facts. Do NOT answer from memory or invent. If recall returns 0 results, say "I don't have anything about that yet." rc.2 QA debug found 5/5 failures to call recall on "where do I live?" — the phrasing was enough to make agents skip the tool. This rule is hard: first-person factual queries are a recall trigger, full stop.
-
----
-
-## RULE 4 — Mutation tools
-
-### `totalreclaw_forget`
-
-When user says: "forget X", "delete the memory about Y", "remove Z from your memory".
-
-**Workflow:** if the user names the memory in natural language, FIRST call `totalreclaw_recall` with their phrase as the query, then pass the top result's `fact_id` to `totalreclaw_forget`. Never invent a fact_id; if you don't have one from recall, say so and ask the user to clarify which specific memory to delete.
-
-### `totalreclaw_pin` / `totalreclaw_unpin`
-
-When user says: "remember this permanently", "never forget that", "always keep", "this is important" → `pin`.
-When user says: "you can forget that", "it's no longer relevant" → `unpin`.
-
-Same recall-first workflow as forget: if no `fact_id`, recall first.
-
-### `totalreclaw_retype` (OpenClaw plugin 3.3.1-rc.2+)
-
-When user corrects a memory's category: "that's a preference, not a fact", "file this as a commitment instead of a claim". Valid types: `claim`, `preference`, `directive`, `commitment`, `episode`, `summary`. Recall first to find `fact_id`.
-
-### `totalreclaw_set_scope` (OpenClaw plugin 3.3.1-rc.2+)
-
-When user re-categorizes a memory's domain: "put that under work", "this is a health thing", "move this to personal". Valid scopes: `work`, `personal`, `health`, `family`, `creative`, `finance`, `misc`, `unspecified`. Recall first to find `fact_id`.
-
----
-
-## RULE 5 — QR pair is the canonical setup flow (RULE 1a applies to ALL users)
-
-RULE 1a's `totalreclaw_pair` flow is canonical for EVERY user, regardless of whether they have terminal access. Local users, remote users, Docker users, VPS users — all go through `totalreclaw_pair`. The browser-side crypto is what keeps the phrase out of the LLM context, and that protection matters whether the user is on the same machine or on a phone halfway around the world.
-
-If a user explicitly says they prefer to set up entirely in their own terminal (no browser, no URL to open), point them at the CLI `totalreclaw setup` — but tell them to run it IN THEIR OWN TERMINAL, not through you. Do NOT call that CLI via your shell tool. Your shell-tool stdout is captured into LLM context.
-
-Hermes Python 2.3.1rc4 ships a native `totalreclaw_pair` implementation (x25519 + ChaCha20-Poly1305). Use it directly — no fallback to external tools needed.
-
----
-
-## RULE 6 — Status + billing
-
-When user asks "how many memories do I have?", "am I over my quota?", or anything about their TotalReclaw subscription: call `totalreclaw_status`. Returns `{ tier, quota, usage, resetsAt, upgradeUrl? }`.
-
-When user asks to upgrade: call `totalreclaw_upgrade`. Returns a Stripe checkout URL — paste it verbatim; never summarize it.
-
----
-
-## RULE 7 — Import from other agents
-
-When user says "I used to use Mem0 / MCP Memory Server / ChatGPT Memory / Claude Projects / Gemini Memory / MemoClaw — can you bring those in?": call `totalreclaw_import_from`. Ask for the source name + API key (or file content) first. Use `dry_run=True` to preview before committing.
-
-Supported sources: `mem0`, `mcp-memory-server`, `chatgpt`, `claude`, `gemini`, `memoclaw`, `generic-json`, `generic-csv`.
-
----
-
-## RULE 8 — Consolidate
-
-When user notices duplicates or says "clean up my memory": call `totalreclaw_consolidate` with `dry_run=True` first to show proposed merges. If user approves, call again with `dry_run=False` to commit.
-
----
-
-## RULE 9 — Error handling
-
-- Tool returns `onboarding required`: re-run RULE 1 / RULE 1a.
-- Tool returns `quota exceeded`: call `totalreclaw_status` to confirm, then offer `totalreclaw_upgrade`.
-- Tool returns a generic error: surface the message, don't retry blindly — the backoff is inside the tool, not you.
-
-### zai provider configuration (2.3.1rc3+)
-
-zai exposes two endpoints:
-- **Coding plan (subscription)**: `https://api.z.ai/api/coding/paas/v4` — default.
-- **PAYG**: `https://api.z.ai/api/paas/v4` — for pay-as-you-go balances.
-
-A coding-plan key hitting the PAYG endpoint (or vice-versa) returns `Insufficient balance or no resource package. Please recharge.` rc.3 auto-detects this and flips to the other endpoint on one retry per call, but users can avoid the first-call tax by setting `ZAI_BASE_URL` in their `~/.hermes/.env` or environment:
-
-- GLM Coding Plan users: leave `ZAI_BASE_URL` unset, or set to `https://api.z.ai/api/coding/paas/v4`.
-- PAYG users: set `ZAI_BASE_URL=https://api.z.ai/api/paas/v4`.
-
-Retry budget: the extraction LLM retries up to 5 attempts with 2s→4s→8s→16s→32s backoff (total ~62s). Configurable via `TOTALRECLAW_LLM_RETRY_BUDGET_MS` (default 60000ms).
-
----
-
-## Memory Taxonomy v1 reference
-
-The on-chain v1 contract (as of plugin 3.0.0 / Hermes 2.3.0 / core 2.2.0):
-
-| Field | Required | Values |
-|---|---|---|
-| `text` | yes | 5-512 UTF-8 chars |
-| `type` | yes | `claim` / `preference` / `directive` / `commitment` / `episode` / `summary` |
-| `source` | yes | `user` / `user-inferred` / `assistant` / `external` / `derived` |
-| `scope` | no | `work` / `personal` / `health` / `family` / `creative` / `finance` / `misc` / `unspecified` |
-| `volatility` | no | `stable` / `updatable` / `ephemeral` |
-| `importance` | no | 1-10 (int) or 0-1 (float) |
-
-Retrieval v2 Tier 1 ranks user-sourced facts above assistant-sourced facts on tied BM25 + cosine scores. Use `source="user"` for verbatim user statements and `source="user-inferred"` when you're stating something the user implied but didn't say outright.
-
----
-
-## RULE 10 — Filing QA bugs (RC builds only)
-
-If the `totalreclaw_report_qa_bug` tool is registered (this means you're running an RC build — stable users never see the tool), OFFER to file a bug when ANY of these triggers fire. Never auto-file; always ask the user once per issue.
-
-Triggers:
-1. A tool call fails 2+ times in a row with the same error signature.
-2. User expresses friction: "this doesn't work" / "error" / "stuck" / "broken" / "not what I expected" / "wrong version" / explicit "file a bug".
-3. Setup flow hits an error that you can't resolve via the docs.
-4. Docs don't match reality (user guide says X; actual behavior is Y).
-
-Offer: "This looks worth reporting so the maintainer can fix it. Want me to file a QA bug? I'll capture the symptom + repro."
-
-On user yes → call `totalreclaw_report_qa_bug` with the redacted details. Required fields: `integration` (plugin/hermes/nanoclaw/mcp/relay/clawhub/docs/other), `rc_version` (exact version string, e.g. `2.3.1rc3`), `severity` (blocker/high/medium/low), `title` (<60 chars), `symptom`, `expected`, `repro`, `logs`, `environment`.
-
-On user no / ambiguous → proceed without filing.
-
-Do NOT offer the same bug twice in a session. Do NOT include secrets (recovery phrases, API keys, Telegram bot tokens, bearer tokens) in any field — the tool redacts automatically, but don't pass raw values anyway. The tool requires `TOTALRECLAW_QA_GITHUB_TOKEN` (or `GITHUB_TOKEN`) to be set on the host; if the tool returns a missing-token error, tell the user the operator needs to export one with `repo` scope.
+`totalreclaw_pair` (ONLY setup path) · `_remember` · `_recall` · `_forget` · `_pin` · `_unpin` · `_export` · `_status` · `_upgrade` · `_import_from` · `_import_batch` · `_debrief` · `_report_qa_bug` (RC only).

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: totalreclaw
-description: "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext."
+description: "Install + set up TotalReclaw encrypted memory for OpenClaw, then use totalreclaw_remember / totalreclaw_recall. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', or any remember / recall request."
 version: 3.3.1-rc.6
 author: TotalReclaw Team
 license: MIT
@@ -22,152 +22,37 @@ metadata:
       - persistent-context
 ---
 
-# TotalReclaw — Agent Guide
+# TotalReclaw — OpenClaw
 
-You are operating inside a host that has the TotalReclaw memory plugin loaded. This file tells you WHAT to call and WHEN. Every sentence is a rule.
+## Setup flow (run on "install / set up TotalReclaw" OR any tool returning `onboarding required`)
 
-## Setup state
+1. `openclaw plugins install @totalreclaw/totalreclaw` (stable). For RC: install `@totalreclaw/totalreclaw@rc` — the `rc` dist-tag on npm is the latest candidate.
+2. Restart gateway so plugin routes + tools bind. Docker: `docker restart tr-openclaw`. Native: `openclaw gateway restart`. Wait ~5s; confirm the gateway is back up.
+3. Call `totalreclaw_pair`. Returns `{url, pin, qr_ascii, expires_at_ms}`.
+4. Relay to user verbatim: *"Open <url> in your browser. Enter your 12-word recovery phrase (or let the browser generate one). Confirm PIN <pin>. I'll wait for you to say done."*
+5. After user says done: verify `~/.totalreclaw/credentials.json` exists and is non-empty. If missing, call `totalreclaw_pair` again (PIN likely expired) and resend.
+6. Confirm: *"TotalReclaw is set up. Ask me to remember or recall anything."*
 
-Before any memory tool, check `~/.totalreclaw/credentials.json`:
+## Phrase safety (HARD — never break)
 
-- **Missing, empty, malformed, or no `mnemonic` key** -> NOT set up. Follow the "Setting up a user's TotalReclaw recovery phrase" section below. You MUST NOT generate a phrase in chat, and you MUST NOT ask the user to paste one.
-- **Present with a valid `mnemonic`** -> active. Use the tools below.
+NEVER echo / generate / ask the user to paste a recovery phrase in chat. NEVER invoke `openclaw totalreclaw onboard`, `totalreclaw setup`, or any phrase-touching CLI via your shell tool (stdout enters LLM context). The ONLY agent-facilitated setup path is `totalreclaw_pair`. If the user pastes a phrase anyway: tell them it is compromised, call `totalreclaw_pair` with `mode=generate` for a fresh wallet.
 
-## Setting up a user's TotalReclaw recovery phrase
+## Usage (post-setup)
 
-**Agent path (default, only secure path): call the `totalreclaw_pair` tool.** It returns a URL + 6-digit PIN. Tell the user:
+- Stable user facts / preferences / identity / "remember X" → `totalreclaw_remember` (don't ask permission).
+- First-person factual query ("do I / what's my / where do I …") → `totalreclaw_recall` FIRST, then answer from returned facts. If 0 results, say so.
+- "forget / pin / unpin / retype / move to <scope>" X → `totalreclaw_recall` first for `factId`, then `totalreclaw_forget` / `_pin` / `_unpin` / `_retype` / `_set_scope`.
+- "status" → `totalreclaw_status`. "upgrade" → `totalreclaw_upgrade` (paste Stripe URL verbatim). Post-upgrade testnet → mainnet: `totalreclaw_migrate` with `dry_run` first.
+- "import / export / consolidate" → `totalreclaw_import_from` (`dry_run=true` first; `_import_batch` for >50 chunks) · `totalreclaw_export` · `totalreclaw_consolidate` (`dry_run` first).
 
-> "Open <URL> in your browser, enter your phrase (or let the browser generate one), and confirm PIN <PIN>. Your phrase is encrypted in the browser and uploaded end-to-end-encrypted to this gateway — it never crosses this chat."
+## Diagnostics
 
-Browser-side crypto handles the phrase; this chat never sees it. After the user confirms "pairing complete" in their browser, the credentials are already on disk — no gateway restart needed for OpenClaw because routes are registered on plugin install and the pair HTTP handler writes credentials in-process.
-
-**NEVER** invoke `openclaw totalreclaw onboard`, `totalreclaw setup`, or any phrase-generating CLI via your shell tool. Those commands are for users to run in their own terminal — not for you. Agent shell stdout is captured into LLM context; running them leaks the phrase.
-
-**NEVER** ask the user to paste their phrase into chat. If they do, immediately tell them to rotate by generating a new wallet via `totalreclaw_pair` with `mode=generate`; the pasted phrase is compromised.
-
-**If the user explicitly prefers local-terminal setup** (no browser, no QR URL to open), point them at `totalreclaw_onboarding_start` — which returns a pointer to the CLI wizard they run THEMSELVES. You do not run it.
-
-## Core rules
-
-1. **Phrase safety (NON-NEGOTIABLE, ABSOLUTE).** The recovery phrase is a secret. Never generate one in chat, never echo one back, never log one in reasoning / tool payloads, never pass one to another tool, never invoke a phrase-generating CLI via your shell tool. A leaked phrase = compromised vault, no rotation possible. Governed by `project_phrase_safety_rule.md` (memory file in p-diogo/totalreclaw-internal).
-2. **Use the tools, not inline state.** `totalreclaw_remember` stores; `totalreclaw_recall` retrieves. Don't re-ask the user for past facts; don't paraphrase memories as your own recollection.
-3. **Gateway restart is required after install.** If tools fail right after `openclaw plugins install @totalreclaw/totalreclaw`, tell the user to run `openclaw restart` or `docker restart openclaw-qa`.
-
-## Decision tree — which tool, when
-
-- **Fact-shaped content** (preferences, identity, commitments, decisions, directives, episodes): `totalreclaw_remember`. Don't ask permission for obvious user facts.
-- **Question about the past** ("what do you remember about…", "do I like…"): `totalreclaw_recall`.
-- **"Pin that" / "remember permanently"**: `totalreclaw_pin`. **"Unpin" / "can forget that"**: `totalreclaw_unpin`.
-- **"Forget X" / "delete that memory"**: `totalreclaw_forget` with the fact's id.
-- **"That's a preference, not a claim"**: `totalreclaw_retype`.
-- **"Put that under work"**: `totalreclaw_set_scope`.
-- **"Export my memories"**: `totalreclaw_export`.
-- **"What's my TotalReclaw status?"**: `totalreclaw_status`.
-- **"Set up TotalReclaw"** (no credentials): route per the Setup-state section above.
-- **"Import my Mem0 / ChatGPT / Claude / Gemini history"**: `totalreclaw_import_from` with `dry_run=true` first. Show the estimate, confirm, then run without `dry_run`. For >50 chunks, use `totalreclaw_import_batch` and report progress.
-- **"Upgrade" / "I want Pro"**: `totalreclaw_upgrade` returns a Stripe URL. After upgrade, offer `totalreclaw_migrate` (dry-run first) to move testnet memories to mainnet.
-
-### First-person queries — ALWAYS call `totalreclaw_recall` first
-
-Any user message that references THEIR OWN facts triggers a recall call BEFORE you answer. Triggers (non-exhaustive — err on the side of calling recall):
-
-- "where do I live / work" / "what's my address / city"
-- "what do I prefer / like / hate / use"
-- "do I have / own / know"
-- "when did I / have I ever"
-- "who is my / my [relation/role]"
-- "what was my / my [object/preference]"
-- any question pattern containing "my / I / me" + a fact-shaped noun (address, job, favourite, project, partner, pet, etc.)
-
-Call `totalreclaw_recall(query=<semantic version of the question>)` FIRST, THEN answer based on returned facts. Do NOT answer from memory or invent; if recall returns 0 results, say "I don't have anything about that yet." rc.2 QA debug found 5/5 failures to call recall on "where do I live?" — the phrasing was enough to make agents skip the tool. This rule is hard: first-person factual queries are a recall trigger, full stop.
+- `totalreclaw_*` tools not visible → gateway not restarted after install; redo step 2.
+- User says done but `credentials.json` missing → PIN expired or entered wrong phrase; call `totalreclaw_pair` again.
+- `onboarding required` → credentials missing; redo from step 3.
+- `quota exceeded` → `totalreclaw_status`, then offer `totalreclaw_upgrade`.
+- `No LLM available for auto-extraction` at startup → provider key unreachable; check `~/.openclaw/agents/<agent>/agent/auth-profiles.json` or plugin config `extraction.llm`.
 
 ## Tool surface
 
-Tools work only when credentials are active AND the gateway has been restarted post-install. If a tool returns "onboarding required", route back to onboarding.
-
-| Tool | Key params |
-|------|------------|
-| `totalreclaw_remember` | `text`, optional `type` (default `claim`), `importance` |
-| `totalreclaw_recall` | `query`, optional `k` (default 8, max 20) |
-| `totalreclaw_forget` | `factId` |
-| `totalreclaw_pin` / `totalreclaw_unpin` | `factId`, optional `reason` |
-| `totalreclaw_retype` | `factId`, `newType` |
-| `totalreclaw_set_scope` | `factId`, `scope` |
-| `totalreclaw_export` | optional `format` (`json` / `markdown`) |
-| `totalreclaw_status` | (none) |
-| `totalreclaw_upgrade` | (none) |
-| `totalreclaw_migrate` | optional `confirm` (dry-run by default) |
-| `totalreclaw_import_from` / `totalreclaw_import_batch` | `source`, `file_path` or `content`, `dry_run` |
-| `totalreclaw_consolidate` | optional `dry_run` |
-| `totalreclaw_onboarding_start` | (none) — returns CLI pointer for users who prefer local-terminal setup |
-| `totalreclaw_pair` | optional `mode` (`generate` / `import`) — returns `{url, pin, qr_ascii, expires_at_ms}`. CANONICAL setup surface |
-
-## Taxonomy
-
-**Types:** `claim` (default) / `preference` / `directive` (reusable rule) / `commitment` (future intent) / `episode` (event) / `summary` (derived synthesis).
-
-**Scopes:** `work` / `personal` (default) / `health` / `family` / `creative` / `finance` / `misc`.
-
-## If a tool fails
-
-- Tell the user plainly. Don't retry blindly.
-- "onboarding required" -> route per Setup-state above.
-- "No LLM available for auto-extraction" (startup only, v3.3.1+) -> provider key not reachable. Point at `~/.openclaw/agents/<agent>/agent/auth-profiles.json` or the `plugins.entries.totalreclaw.config.extraction.llm` override.
-- Silent extraction failures -> suggest `openclaw totalreclaw status` or check `~/.totalreclaw/billing-cache.json` for rate-limit signals.
-
-## zai provider configuration (3.3.1-rc.3+)
-
-zai exposes two endpoints:
-- **Coding plan (subscription)**: `https://api.z.ai/api/coding/paas/v4` — default.
-- **PAYG**: `https://api.z.ai/api/paas/v4` — for pay-as-you-go balances.
-
-A coding-plan key hitting the PAYG endpoint (or vice-versa) returns `Insufficient balance or no resource package. Please recharge.` rc.3 auto-detects this and flips to the other endpoint on one retry per call, but users can avoid the first-call tax by setting `ZAI_BASE_URL` explicitly:
-
-- GLM Coding Plan users: leave `ZAI_BASE_URL` unset, or set to `https://api.z.ai/api/coding/paas/v4`.
-- PAYG users: set `ZAI_BASE_URL=https://api.z.ai/api/paas/v4`.
-
-Retry budget: the extraction LLM retries up to 5 attempts with 2s→4s→8s→16s→32s backoff (total ~62s). Configurable via `TOTALRECLAW_LLM_RETRY_BUDGET_MS` (default 60000).
-
-## Minimum viable interaction pattern
-
-```
-User: "I live in Porto and prefer PostgreSQL."
--> totalreclaw_remember({text: "User lives in Porto", type: "claim"})
--> totalreclaw_remember({text: "User prefers PostgreSQL over MySQL", type: "preference"})
--> respond naturally, don't list what you just saved.
-
-User: "What do you remember about me?"
--> totalreclaw_recall({query: "user facts preferences identity"})
--> summarize returned facts in your reply.
-
-User: "Set me up for TotalReclaw."
--> check ~/.totalreclaw/credentials.json. If missing:
-   local:  totalreclaw_onboarding_start (or totalreclaw_onboard)
-   remote: totalreclaw_pair -> present URL + PIN + QR
--> follow the tool's instructions. Never invent a phrase.
-```
-
-## What NOT to do
-
-- Do NOT write memories to `MEMORY.md` or any cleartext file — that defeats E2EE.
-- Do NOT call `totalreclaw_remember` for transient in-session context.
-- Do NOT paste recovery phrases or API keys into chat.
-- Do NOT run `npx @totalreclaw/mcp-server setup` — deprecated path that corrupts credentials.
-
-## Filing QA bugs (RC builds only)
-
-If `totalreclaw_report_qa_bug` tool is available (this means you're in an RC build — stable users never see the tool), OFFER to file a bug when ANY of these triggers fire. Never auto-file; always ask the user once per issue.
-
-Triggers:
-1. A tool call fails 2+ times in a row with the same error signature.
-2. User expresses friction: "this doesn't work" / "error" / "stuck" / "broken" / "not what I expected" / "wrong version" / explicit "file a bug".
-3. Setup flow hits an error that you can't resolve via the docs.
-4. Docs don't match reality (user guide says X; actual behavior is Y).
-
-Offer: "This looks worth reporting so the maintainer can fix it. Want me to file a QA bug? I'll capture the symptom + repro."
-
-On user yes → call `totalreclaw_report_qa_bug` with the redacted details. Required fields: `integration` (plugin/hermes/nanoclaw/mcp/relay/clawhub/docs/other), `rc_version` (exact version string), `severity` (blocker/high/medium/low), `title` (<60 chars), `symptom`, `expected`, `repro`, `logs`, `environment`.
-
-On user no / ambiguous → proceed without filing.
-
-Do NOT offer the same bug twice in a session. Do NOT include secrets (recovery phrases, API keys, bot tokens) in any field — the tool redacts automatically, but don't pass raw values anyway. The tool requires `TOTALRECLAW_QA_GITHUB_TOKEN` (or `GITHUB_TOKEN`) to be set on the host; if the tool returns a missing-token error, tell the user the operator needs to export one with `repo` scope.
+`totalreclaw_pair` (ONLY setup path) · `_remember` · `_recall` · `_forget` · `_pin` · `_unpin` · `_retype` · `_set_scope` · `_export` · `_status` · `_upgrade` · `_migrate` · `_import_from` · `_import_batch` · `_consolidate` · `_onboarding_start` (pointer to local-terminal wizard, for users explicitly rejecting the browser flow) · `_report_qa_bug` (RC only).


### PR DESCRIPTION
## Summary
- Rewrites `python/src/totalreclaw/hermes/SKILL.md` (221 → 42 lines, 34-line body) and `skill/plugin/SKILL.md` (173 → 58 lines, 35-line body) as agent-imperative playbooks — every line tells the host LLM what to DO, not what TotalReclaw "is".
- 6-step numbered setup flow (`install → restart gateway → totalreclaw_pair → relay URL+PIN → verify credentials.json → confirm`) with both Docker (`docker restart tr-hermes` / `tr-openclaw`) and native (`hermes gateway restart` / `openclaw gateway restart`) restart variants, no inline RC version pins (say "latest pre-release on PyPI" / "`rc` dist-tag on npm" so the file doesn't go stale per-RC).
- Phrase-safety rule preserved as one hard paragraph; tool surface compressed to one line; diagnostics are one-liners each.

## Why
rc.6 user-QA (2026-04-22) showed agents repeatedly failed to find the install command, skipped the post-install gateway restart, didn't discover `totalreclaw_pair`, and couldn't walk the user through the QR pairing flow. User quote: *"can't even get to the point where I can set up the recovery phrase through the new QR flow…agents cannot even find the actual tools."* Root cause: the old SKILL.md mixed product marketing, multiple competing setup paths (`totalreclaw_setup` / `totalreclaw_onboarding_start` / `totalreclaw_pair`), per-tool reference prose, and v1-taxonomy schema tables — total ~400 lines for the two files. Agents could not extract a deterministic 6-step flow from it. This PR restores agent-first reliability while keeping the absolute phrase-safety invariant intact.

## What was cut (justification)
- **Verbose RULE 0-10 phrase-safety preamble (Hermes)** — collapsed to one "HARD — never break" paragraph. Same semantics, same CLIs banned.
- **First-person-recall elaboration list (5-bullet trigger catalog)** — compressed to one line referencing the pattern. Agents that follow "first-person factual → recall FIRST" need no list.
- **Memory Taxonomy v1 reference tables (type/source/scope/importance matrix)** — removed from SKILL.md. The schemas live in the tool's own JSONSchema and the taxonomy is enforced server-side, so the agent never needs to memorize the enum; the tool returns a validation error on any mismatch.
- **zai provider endpoint / retry budget addendum** — removed. It's operator configuration (`~/.hermes/.env`), not agent behavior. Lives in `docs/guides/hermes-setup.md`.
- **Minimum viable interaction pattern example block** — removed. The "Usage (post-setup)" bullets encode the same flow more compactly.
- **QA-bug-reporting trigger list (4 triggers + redaction guidance)** — removed from SKILL.md. The `totalreclaw_report_qa_bug` tool is still listed in the tool surface; its own schema documents triggers. This cut the most lines of any section; if QA-bug filing proves to be missed in practice, restore as a 2-line bullet under Usage.

None of these cuts remove a behavior that blocks the happy-path setup flow. If later QA surfaces an agent missing one of the cut rules, the fix is a 1-2 line addition, not restoration of the old structure.

## Test plan
- [ ] Read each file as if I were the host agent on prompt "install TotalReclaw" — can I execute all 6 steps without external docs? (Done; passes.)
- [ ] Confirm manifest-parity test still green (`python/tests/test_hermes_plugin_manifest_parity.py` only asserts `plugin.yaml` ⇄ `register(ctx)`, doesn't parse SKILL.md).
- [ ] Confirm the skill still publishes cleanly (frontmatter `name` / `version` unchanged; `SKILL.md` still listed in `skill/plugin/package.json` `files`).
- [ ] On next RC or stable, dispatch `qa-totalreclaw` and verify the install → pair → credentials flow works end-to-end without agent detours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)