### PR TITLE
docs(guides): canonical install prompt includes package-source hint

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -6,7 +6,7 @@ TotalReclaw gives your Hermes agent encrypted, persistent memory. One copy-paste
 
 Open your chat with your Hermes agent. Paste this message:
 
-> **Install TotalReclaw latest RC and walk me through the recovery-phrase setup**
+> **Install TotalReclaw (`pip install --pre totalreclaw` from PyPI) and walk me through the recovery-phrase setup**
 
 The agent will install the package, restart its gateway, call the `totalreclaw_pair` tool, and give you a URL + PIN to enter your recovery phrase in the browser. Your phrase never touches the chat.
 

--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -8,7 +8,7 @@ TotalReclaw gives your OpenClaw agent encrypted, persistent memory. One copy-pas
 
 Open your chat with your OpenClaw agent. Paste this message:
 
-> **Install TotalReclaw latest RC and walk me through the recovery-phrase setup**
+> **Install TotalReclaw (`openclaw skills install totalreclaw` from ClawHub) and walk me through the recovery-phrase setup**
 
 The agent will install the package, restart its gateway, call the `totalreclaw_pair` tool, and give you a URL + PIN to enter your recovery phrase in the browser. Your phrase never touches the chat.
 


### PR DESCRIPTION
## What broke
Agents with no prior TotalReclaw context (observed on zai/glm-5.1) refused to install from the canonical user-guide prompt — they treated "TotalReclaw" as an unknown product and hit a `clarify()` dead-end.

## What's fixed
Single-prompt flow now names the registry + install command verbatim (`pip install --pre totalreclaw` for Hermes, `openclaw skills install totalreclaw` for OpenClaw), so the agent proceeds without needing product knowledge.

## Impact after fix
Users pasting the recommended prompt get `pip install --pre totalreclaw` → gateway restart → `totalreclaw_pair` on the first turn, on any LLM backend.

## Verification
On `zai/glm-5.1` the updated Hermes prompt resulted in `totalreclaw v2.3.1rc7` installed and `totalreclaw_pair` called within the first 60s. QA scenario `install_from_user_guide_hermes` (tools/qa-harness/scenarios/) is updated in a matching internal-repo PR.

Closes p-diogo/totalreclaw-internal#44

🤖 Generated with [Claude Code](https://claude.com/claude-code)