### PR TITLE
docs+skill: two install/setup approaches (skill-driven + explicit two-step)

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -1,26 +1,54 @@
 # Hermes Agent + TotalReclaw
 
-TotalReclaw gives your Hermes agent encrypted, persistent memory. One copy-paste prompt to the agent installs the plugin, restarts the gateway, and walks you through pairing in your browser.
+TotalReclaw gives your Hermes agent encrypted, persistent memory. Two install approaches — pick whichever fits your workflow.
 
-## Install via chat (default)
+## Fastest — shell + chat (Approach A, preferred)
 
-Open your chat with your Hermes agent. Paste this message:
+Terminal:
 
-> **Install TotalReclaw (`pip install --pre totalreclaw` from PyPI) and walk me through the recovery-phrase setup**
+```bash
+pip install --pre totalreclaw
+hermes gateway restart    # or `docker restart tr-hermes` for Docker Hermes
+```
 
-The agent will install the package, restart its gateway, call the `totalreclaw_pair` tool, and give you a URL + PIN to enter your recovery phrase in the browser. Your phrase never touches the chat.
+Then in your Hermes chat:
+
+> **Set up TotalReclaw**
+
+The agent will call the pairing tool and give you a URL + PIN. Open the URL, enter your recovery phrase, confirm PIN. Done.
+
+Why this works: the Hermes pip package bundles both `SKILL.md` (agent instructions) and the plugin into the same wheel, so once pip + restart complete, the agent has everything it needs. The chat prompt triggers the skill's fast path: check for existing credentials, call `totalreclaw_pair`, relay URL + PIN.
+
+<details>
+<summary><strong>Approach B — explicit two-step (fallback)</strong></summary>
+
+If you'd rather spell out every step explicitly (useful if the agent doesn't know about TotalReclaw yet), install the same way but use this verbose chat prompt:
+
+Terminal:
+
+```bash
+pip install --pre totalreclaw
+hermes gateway restart    # or `docker restart tr-hermes` for Docker Hermes
+```
+
+Then in your Hermes chat:
+
+> **TotalReclaw is installed at 'totalreclaw' on PyPI. Install it, restart the gateway, and walk me through the QR pairing flow**
+
+The agent reads the explicit directive, runs `pip install --pre totalreclaw` (no-op if already installed), asks you to restart the gateway if needed, calls `totalreclaw_pair`, and guides you through the QR flow.
+
+</details>
 
 <details>
 <summary>What happens behind the scenes</summary>
 
-1. Agent runs `pip install --pre totalreclaw` (pip resolves to the latest RC on PyPI).
-2. Agent runs `hermes gateway restart` so the newly installed plugin is picked up.
-3. Agent calls the `totalreclaw_pair` tool.
-4. A pair URL + 6-digit PIN is surfaced back to you in chat.
-5. You open the URL in your browser and enter (or let the browser generate) your recovery phrase, then confirm the PIN.
-6. The browser performs x25519 ECDH against the gateway's ephemeral pubkey, derives a ChaCha20-Poly1305 key via HKDF-SHA256, encrypts the phrase locally, and POSTs ciphertext + nonce + its pubkey to the gateway.
-7. The gateway decrypts server-side and writes `~/.totalreclaw/credentials.json` (mode `0600`).
-8. The agent confirms setup and your memory tools are live.
+1. Agent reads its TotalReclaw skill, picks up that `totalreclaw_*` tools are (or should be) live.
+2. Agent checks `~/.totalreclaw/credentials.json`; if absent, calls the `totalreclaw_pair` tool.
+3. A pair URL + 6-digit PIN is surfaced back to you in chat.
+4. You open the URL in your browser and enter (or let the browser generate) your recovery phrase, then confirm the PIN.
+5. The browser performs x25519 ECDH against the gateway's ephemeral pubkey, derives a ChaCha20-Poly1305 key via HKDF-SHA256, encrypts the phrase locally, and POSTs ciphertext + nonce + its pubkey to the gateway.
+6. The gateway decrypts server-side and writes `~/.totalreclaw/credentials.json` (mode `0600`).
+7. The agent confirms setup and your memory tools are live.
 
 The recovery phrase never crosses the LLM context — not the chat transcript, not the agent's shell stdout, not any tool-call payload. Browser-side crypto keeps it isolated by construction.
 
@@ -33,18 +61,9 @@ The recovery phrase never crosses the LLM context — not the chat transcript, n
 - Python 3.11+
 - An up-to-date browser with WebCrypto x25519 + ChaCha20-Poly1305 (Safari 17.2+ or Chromium 118+)
 
-## Manual install (CLI)
-
-If you'd rather run the commands yourself:
-
-```bash
-pip install --pre totalreclaw
-hermes gateway restart
-```
+## Notes on `--pre`
 
 `--pre` lets pip resolve to the latest release candidate without pinning a version. Drop `--pre` once a stable is promoted. Ubuntu/Debian/Docker: add `--break-system-packages` or use a venv if you hit `externally-managed-environment`.
-
-Then ask the agent "set up TotalReclaw for me" — it will call `totalreclaw_pair` and hand you the URL + PIN.
 
 ## Upgrading
 
@@ -60,7 +79,12 @@ If you were on plugin 3.3.1-rc.2 or Hermes 2.3.1rc2, after upgrading also run `p
 
 ## Returning user (new machine)
 
-Paste the same prompt. When the pair page loads, choose "import" and enter your existing 12/24-word phrase. The browser encrypts it against the gateway's ephemeral key before uploading.
+Paste the same canonical prompt. When the pair page loads, choose "import" and enter your existing 12/24-word phrase. The browser encrypts it against the gateway's ephemeral key before uploading.
+
+## Canonical prompts (these match the QA harness scenario contracts)
+
+- Approach A: `Set up TotalReclaw`
+- Approach B: `TotalReclaw is installed at 'totalreclaw' on PyPI. Install it, restart the gateway, and walk me through the QR pairing flow`
 
 ## See also
 

--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -1,30 +1,61 @@
 # TotalReclaw for OpenClaw
 
-TotalReclaw gives your OpenClaw agent encrypted, persistent memory. One copy-paste prompt to the agent installs the plugin, restarts the gateway, and walks you through pairing in your browser.
+TotalReclaw gives your OpenClaw agent encrypted, persistent memory. Two install approaches — pick whichever fits your workflow.
 
 ---
 
-## Install via chat (default)
+## Fastest — skill + chat (Approach A, preferred)
 
-Open your chat with your OpenClaw agent. Paste this message:
+Terminal:
 
-> **Install TotalReclaw (`openclaw skills install totalreclaw` from ClawHub) and walk me through the recovery-phrase setup**
+```bash
+openclaw skills install totalreclaw
+openclaw gateway restart  # or `docker restart tr-openclaw` for Docker
+```
 
-The agent will install the package, restart its gateway, call the `totalreclaw_pair` tool, and give you a URL + PIN to enter your recovery phrase in the browser. Your phrase never touches the chat.
+Then in your OpenClaw chat:
+
+> **Install totalreclaw**
+
+The agent reads the skill, installs the plugin, asks you to restart the gateway once the plugin is in place, calls the pairing tool, and guides you through the QR flow.
+
+Why this works: ClawHub classifies `totalreclaw` as a skill. `openclaw skills install totalreclaw` registers the SKILL.md into agent context **before** the plugin itself is installed — so the agent has the instructions to bootstrap the rest. The one `openclaw gateway restart` in the terminal makes the skill discoverable; the plugin install happens via shell from the agent, and a second user-driven restart binds the tools.
+
+<details>
+<summary><strong>Approach B — explicit two-step (fallback)</strong></summary>
+
+If you'd rather spell out every step explicitly (useful if you prefer more control), install the skill the same way but use a verbose chat prompt:
+
+Terminal:
+
+```bash
+openclaw skills install totalreclaw
+openclaw gateway restart  # or `docker restart tr-openclaw` for Docker
+```
+
+Then in your OpenClaw chat:
+
+> **TotalReclaw is a skill at 'totalreclaw' on ClawHub. Install it, then install the plugin, restart the gateway, and walk me through the QR pairing flow**
+
+The agent reads the explicit directive, installs the plugin (`openclaw plugins install totalreclaw`), asks you to restart the gateway, calls `totalreclaw_pair`, and guides you through the QR flow.
+
+</details>
 
 <details>
 <summary>What happens behind the scenes</summary>
 
-1. Agent runs `openclaw skills install totalreclaw` (resolves to the latest RC on ClawHub).
-2. Agent restarts the gateway (`openclaw restart` native, or `docker restart tr-openclaw` in Docker) so HTTP routes and hooks bind.
-3. Agent calls the `totalreclaw_pair` tool.
-4. A pair URL + 6-digit PIN is surfaced back to you in chat.
-5. You open the URL in your browser and enter (or let the browser generate) your recovery phrase, then confirm the PIN.
-6. The browser performs x25519 ECDH against the gateway's ephemeral pubkey, derives a ChaCha20-Poly1305 key via HKDF-SHA256, encrypts the phrase locally, and POSTs ciphertext + nonce + its pubkey to the gateway.
-7. The gateway decrypts server-side and writes `~/.totalreclaw/credentials.json` (mode `0600`).
-8. The agent confirms setup and your memory tools are live.
+1. `openclaw skills install totalreclaw` places the skill metadata + SKILL.md under `~/.openclaw/workspace/skills/totalreclaw/`.
+2. The first gateway restart makes the skill visible to your agent's context.
+3. The chat prompt triggers the skill's fast path: the agent runs `openclaw plugins install totalreclaw` via its shell tool.
+4. The agent asks you to restart the gateway (`openclaw gateway restart` or `docker restart tr-openclaw`) so HTTP routes + hooks bind. The agent cannot self-restart the process it is running in.
+5. Agent calls the `totalreclaw_pair` tool.
+6. A pair URL + 6-digit PIN is surfaced back to you in chat.
+7. You open the URL in your browser, enter (or let the browser generate) your recovery phrase, confirm the PIN.
+8. The browser performs x25519 ECDH against the gateway's ephemeral pubkey, derives a ChaCha20-Poly1305 key via HKDF-SHA256, encrypts the phrase locally, and POSTs ciphertext + nonce + its pubkey to the gateway.
+9. The gateway decrypts server-side and writes `~/.totalreclaw/credentials.json` (mode `0600`).
+10. The agent confirms setup and your memory tools are live. First real interaction downloads a ~216 MB embedding model (cached locally, one-time).
 
-The recovery phrase never crosses the LLM context — not the chat transcript, not the agent's shell stdout, not any tool-call payload. Browser-side crypto keeps it isolated by construction. Your first real interaction will download a ~216 MB embedding model (cached locally, one-time).
+The recovery phrase never crosses the LLM context — not the chat transcript, not the agent's shell stdout, not any tool-call payload. Browser-side crypto keeps it isolated by construction.
 
 </details>
 
@@ -37,16 +68,16 @@ The recovery phrase never crosses the LLM context — not the chat transcript, n
 
 ---
 
-## Manual install (CLI)
+## Fully manual (CLI only)
 
-If you'd rather run the commands yourself:
+If you'd rather run every command yourself without any agent involvement:
 
 ```bash
-openclaw skills install totalreclaw
-openclaw restart              # or: docker restart tr-openclaw
+openclaw plugins install @totalreclaw/totalreclaw
+openclaw gateway restart              # or: docker restart tr-openclaw
 ```
 
-`openclaw skills install totalreclaw` resolves to the latest RC on ClawHub. Then ask the agent "set up TotalReclaw for me" — it will call `totalreclaw_pair` and hand you the URL + PIN.
+Then ask the agent "set up TotalReclaw for me" — it will call `totalreclaw_pair` and hand you the URL + PIN.
 
 <details>
 <summary>From-source install (for plugin development)</summary>
@@ -123,11 +154,18 @@ Both tiers have unlimited memories and reads. Upgrade: *"Upgrade my TotalReclaw 
 
 ## Troubleshooting
 
-- **Agent can't see TotalReclaw tools**: restart the gateway (`openclaw restart` or `docker restart tr-openclaw`).
+- **Agent can't see TotalReclaw tools**: restart the gateway (`openclaw gateway restart` or `docker restart tr-openclaw`).
 - **Pair URL returns 404**: check that `~/.totalreclaw/credentials.json` isn't locked by a previous process and that the gateway is running.
 - **Browser fails to POST the encrypted phrase**: check the pair page's Content-Security-Policy — older browsers without WebCrypto x25519 (pre-Safari 17.2 / Chromium 118) cannot run the AEAD crypto.
 - **Tool calls return "onboarding required"**: repeat the canonical prompt so the agent re-runs `totalreclaw_pair`.
 - **"Not authenticated" / 401**: check your phrase — exact words, exact order, lowercase, single spaces.
+
+---
+
+## Canonical prompts (these match the QA harness scenario contracts)
+
+- Approach A: `Install totalreclaw`
+- Approach B: `TotalReclaw is a skill at 'totalreclaw' on ClawHub. Install it, then install the plugin, restart the gateway, and walk me through the QR pairing flow`
 
 ---
 

--- a/python/src/totalreclaw/hermes/SKILL.md
+++ b/python/src/totalreclaw/hermes/SKILL.md
@@ -9,7 +9,21 @@ homepage: https://totalreclaw.xyz
 
 # TotalReclaw — Hermes
 
-## Setup flow (run on "install / set up TotalReclaw" OR any tool returning `onboarding required`)
+## Fast path — "set up TotalReclaw" (Approach A, preferred)
+
+If the user says "set up TotalReclaw" (or any variant) AND this SKILL.md is loaded, assume `totalreclaw_*` tools are already available (pip install + gateway restart atomically bundles SKILL.md + plugin for the Hermes pip package — if you are reading this, the plugin is loaded too).
+
+1. Check `~/.totalreclaw/credentials.json` exists and is non-empty (via a read-only shell `test -s ~/.totalreclaw/credentials.json`). If it exists, confirm *"TotalReclaw is already set up."* and stop.
+2. If credentials missing: call `totalreclaw_pair` immediately. It returns `{url, pin, expires_at_ms}`.
+3. Relay verbatim: *"Open <url> in your browser. Enter your 12-word recovery phrase (or let the browser generate one). Confirm PIN <pin>. I'll wait for you to say done."*
+4. After user says done: verify `~/.totalreclaw/credentials.json`. If missing, call `totalreclaw_pair` again (PIN likely expired) and resend.
+5. Confirm: *"TotalReclaw set up ✓. Ask me to remember or recall anything — try `totalreclaw_remember` or ask me to remember something."*
+
+If `totalreclaw_*` tools are NOT in your toolset: the gateway needs a restart. Tell the user once: *"Run `hermes gateway restart` (native) or `docker restart tr-hermes` (Docker), then come back."* Do not try to invoke missing tools.
+
+## Explicit two-step setup flow (Approach B, fallback)
+
+Used when the user pastes a verbose prompt describing install + restart + pair (e.g. *"TotalReclaw is installed at 'totalreclaw' on PyPI. Install it, restart the gateway, and walk me through the QR pairing flow"*) OR when a tool returns `onboarding required`.
 
 1. `pip install --pre totalreclaw` (latest pre-release on PyPI; pin a specific `rcN` from https://pypi.org/project/totalreclaw/#history if asked).
 2. Restart gateway so plugin loads. Docker: `docker restart tr-hermes`. Native: `hermes gateway restart`. Wait ~5s; confirm the gateway is back up.
@@ -32,9 +46,9 @@ NEVER echo / generate / ask the user to paste a recovery phrase in chat. NEVER i
 
 ## Diagnostics
 
-- `totalreclaw_*` tools not visible → gateway not restarted after install; redo step 2.
+- `totalreclaw_*` tools not visible → gateway not restarted after install; ask user once to run `hermes gateway restart` or `docker restart tr-hermes`.
 - User says done but `credentials.json` missing → PIN expired or entered wrong phrase; call `totalreclaw_pair` again.
-- `onboarding required` → credentials missing; redo from step 3.
+- `onboarding required` → credentials missing; redo from the pair step.
 - `quota exceeded` → `totalreclaw_status`, then offer `totalreclaw_upgrade`.
 
 ## Tool surface

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -24,10 +24,29 @@ metadata:
 
 # TotalReclaw — OpenClaw
 
-## Setup flow (run on "install / set up TotalReclaw" OR any tool returning `onboarding required`)
+## Fast path — "install totalreclaw" (Approach A, preferred)
 
-1. `openclaw plugins install @totalreclaw/totalreclaw` (stable). For RC: install `@totalreclaw/totalreclaw@rc` — the `rc` dist-tag on npm is the latest candidate.
-2. Restart gateway so plugin routes + tools bind. Docker: `docker restart tr-openclaw`. Native: `openclaw gateway restart`. Wait ~5s; confirm the gateway is back up.
+ClawHub classifies TotalReclaw as a skill. `openclaw skills install totalreclaw` registers this SKILL.md into your agent context BEFORE the plugin is installed (so you may be reading this with no `totalreclaw_*` tools yet).
+
+If the user says "install totalreclaw" (or any variant) AND no `totalreclaw_*` tools are in your toolset:
+
+1. Run via your shell tool: `openclaw plugins install totalreclaw`. (For RC candidates: `openclaw plugins install @totalreclaw/totalreclaw@rc` — the `rc` dist-tag on npm is the latest candidate.)
+2. Tell the user: *"Plugin installed. Restarting the gateway so the tools bind."* Then ask the user to restart the gateway: `openclaw gateway restart` (native) or `docker restart tr-openclaw` (Docker). The agent-facing shell CANNOT self-restart the gateway it's running inside of — this step has to be a user action. Wait for the user to confirm the restart is done.
+3. After restart: verify `totalreclaw_pair` is now in your toolset. If not, tell the user the restart didn't take effect and to retry the restart command. Do not loop the install.
+4. Check `~/.totalreclaw/credentials.json` (via `test -s ~/.totalreclaw/credentials.json`). If it exists, confirm *"TotalReclaw is already set up."* and stop.
+5. Call `totalreclaw_pair`. Returns `{url, pin, qr_ascii, expires_at_ms}`.
+6. Relay verbatim: *"Open <url> in your browser. Enter your 12-word recovery phrase (or let the browser generate one). Confirm PIN <pin>. I'll wait for you to say done."*
+7. After user says done: verify `~/.totalreclaw/credentials.json`. If missing, call `totalreclaw_pair` again (PIN likely expired) and resend.
+8. Confirm: *"TotalReclaw set up ✓. Ask me to remember or recall anything — try `totalreclaw_remember` or ask me to remember something."*
+
+If `totalreclaw_*` tools ARE already in your toolset when the user asks, SKIP the install step and jump to step 4.
+
+## Explicit two-step setup flow (Approach B, fallback)
+
+Used when the user pastes a verbose prompt describing skill install + plugin install + restart + pair (e.g. *"TotalReclaw is a skill at 'totalreclaw' on ClawHub. Install it, then install the plugin, restart the gateway, and walk me through the QR pairing flow"*) OR when a tool returns `onboarding required`.
+
+1. `openclaw plugins install @totalreclaw/totalreclaw` (stable). For RC: `@totalreclaw/totalreclaw@rc`.
+2. Restart gateway so plugin routes + tools bind. Docker: `docker restart tr-openclaw`. Native: `openclaw gateway restart`. Wait ~5s; confirm the gateway is back up. (If you are running inside the gateway, ask the user to run the restart command and wait for confirmation.)
 3. Call `totalreclaw_pair`. Returns `{url, pin, qr_ascii, expires_at_ms}`.
 4. Relay to user verbatim: *"Open <url> in your browser. Enter your 12-word recovery phrase (or let the browser generate one). Confirm PIN <pin>. I'll wait for you to say done."*
 5. After user says done: verify `~/.totalreclaw/credentials.json` exists and is non-empty. If missing, call `totalreclaw_pair` again (PIN likely expired) and resend.
@@ -47,9 +66,9 @@ NEVER echo / generate / ask the user to paste a recovery phrase in chat. NEVER i
 
 ## Diagnostics
 
-- `totalreclaw_*` tools not visible → gateway not restarted after install; redo step 2.
+- `totalreclaw_*` tools not visible → plugin not installed or gateway not restarted. Verify via `openclaw plugins list | grep totalreclaw`. If listed, ask the user to restart the gateway.
 - User says done but `credentials.json` missing → PIN expired or entered wrong phrase; call `totalreclaw_pair` again.
-- `onboarding required` → credentials missing; redo from step 3.
+- `onboarding required` → credentials missing; redo from the pair step.
 - `quota exceeded` → `totalreclaw_status`, then offer `totalreclaw_upgrade`.
 - `No LLM available for auto-extraction` at startup → provider key unreachable; check `~/.openclaw/agents/<agent>/agent/auth-profiles.json` or plugin config `extraction.llm`.
 


### PR DESCRIPTION
## Summary

- Introduces two canonical install paths (Approach A skill-driven + Approach B explicit two-step) so the QA harness can run both in parallel and pick the more reliable one.
- Updates `SKILL.md` (Hermes + OpenClaw) with a fast-path block for Approach A and keeps the explicit flow for Approach B.
- Updates `docs/guides/hermes-setup.md` and `docs/guides/openclaw-setup.md` with both approaches (Approach A top, Approach B in collapsed details).
- Pins canonical chat prompts to match the harness scenario contracts:
  - Hermes A: `Set up TotalReclaw`
  - Hermes B: `TotalReclaw is installed at 'totalreclaw' on PyPI. Install it, restart the gateway, and walk me through the QR pairing flow`
  - OpenClaw A: `Install totalreclaw`
  - OpenClaw B: `TotalReclaw is a skill at 'totalreclaw' on ClawHub. Install it, then install the plugin, restart the gateway, and walk me through the QR pairing flow`

No version bumps; docs + SKILL.md only. Phrase-safety rule is untouched — `totalreclaw_pair` remains the sole agent-facilitated setup path.

## Test plan

- [ ] Harness scenario `approach_a_hermes` drives `pip install --pre totalreclaw` + `docker restart tr-hermes` + chat "Set up TotalReclaw" → agent calls `totalreclaw_pair`.
- [ ] Harness scenario `approach_b_hermes` drives the same pre-shell + verbose chat prompt → agent calls `totalreclaw_pair`.
- [ ] Harness scenario `approach_a_openclaw` drives `openclaw skills install totalreclaw` + `docker restart tr-openclaw` + chat "Install totalreclaw" → agent drives plugin install + pair.
- [ ] Harness scenario `approach_b_openclaw` drives the same pre-shell + verbose chat prompt → agent drives plugin install + pair.
- [ ] No emoji added to code/config; no CHANGELOG/version bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)