### PR TITLE
docs(guides): simplify Approach B prompts — post-install context only

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -33,9 +33,9 @@ hermes gateway restart    # or `docker restart tr-hermes` for Docker Hermes
 
 Then in your Hermes chat:
 
-> **TotalReclaw is installed at 'totalreclaw' on PyPI. Install it, restart the gateway, and walk me through the QR pairing flow**
+> **TotalReclaw is already installed. Use the totalreclaw_pair tool to walk me through the QR recovery-phrase setup.**
 
-The agent reads the explicit directive, runs `pip install --pre totalreclaw` (no-op if already installed), asks you to restart the gateway if needed, calls `totalreclaw_pair`, and guides you through the QR flow.
+The agent reads the explicit directive, calls `totalreclaw_pair`, and guides you through the QR flow.
 
 </details>
 
@@ -84,7 +84,7 @@ Paste the same canonical prompt. When the pair page loads, choose "import" and e
 ## Canonical prompts (these match the QA harness scenario contracts)
 
 - Approach A: `Set up TotalReclaw`
-- Approach B: `TotalReclaw is installed at 'totalreclaw' on PyPI. Install it, restart the gateway, and walk me through the QR pairing flow`
+- Approach B: `TotalReclaw is already installed. Use the totalreclaw_pair tool to walk me through the QR recovery-phrase setup.`
 
 ## See also
 

--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -35,7 +35,7 @@ openclaw gateway restart  # or `docker restart tr-openclaw` for Docker
 
 Then in your OpenClaw chat:
 
-> **TotalReclaw is a skill at 'totalreclaw' on ClawHub. Install it, then install the plugin, restart the gateway, and walk me through the QR pairing flow**
+> **TotalReclaw is a skill at 'totalreclaw' on ClawHub. Please install the plugin (openclaw plugins install totalreclaw), then use the totalreclaw_pair tool to walk me through the QR recovery-phrase setup.**
 
 The agent reads the explicit directive, installs the plugin (`openclaw plugins install totalreclaw`), asks you to restart the gateway, calls `totalreclaw_pair`, and guides you through the QR flow.
 
@@ -165,7 +165,7 @@ Both tiers have unlimited memories and reads. Upgrade: *"Upgrade my TotalReclaw 
 ## Canonical prompts (these match the QA harness scenario contracts)
 
 - Approach A: `Install totalreclaw`
-- Approach B: `TotalReclaw is a skill at 'totalreclaw' on ClawHub. Install it, then install the plugin, restart the gateway, and walk me through the QR pairing flow`
+- Approach B: `TotalReclaw is a skill at 'totalreclaw' on ClawHub. Please install the plugin (openclaw plugins install totalreclaw), then use the totalreclaw_pair tool to walk me through the QR recovery-phrase setup.`
 
 ---
 


### PR DESCRIPTION
## Summary

- Approach B prompts assumed the agent would drive install + restart, but in practice the QA harness (and any user following the instructions verbatim) runs install + restart out of band. Having the agent retry them triggers Hermes's dangerous-command approval prompt, which stalls unattended runs.
- New Hermes Approach B prompt focuses on the agent-drivable step only: `TotalReclaw is already installed. Use the totalreclaw_pair tool to walk me through the QR recovery-phrase setup.`
- New OpenClaw Approach B prompt keeps agent-driven plugin install (that one the agent must do) but drops restart-the-gateway (user-driven): `TotalReclaw is a skill at 'totalreclaw' on ClawHub. Please install the plugin (openclaw plugins install totalreclaw), then use the totalreclaw_pair tool to walk me through the QR recovery-phrase setup.`

Canonical-prompt list at the bottom of each guide synced to match.

## Test plan

- [ ] Paired internal PR p-diogo/totalreclaw-internal#<qa-harness/yolo-plus-prompt-sync PR> syncs the harness scenario YAMLs + contract test to these exact strings
- [ ] Autonomous QA loop no longer 124-timeouts on Approach B runs
- [ ] Approach A prompts unchanged, still end-to-end green

No auto-merge.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)