### PR TITLE
docs(hermes): pivot install to Git-plugin (hermes plugins install p-diogo/totalreclaw-hermes) + pip for backing package

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -7,7 +7,14 @@ TotalReclaw gives your Hermes agent encrypted, persistent memory. Two install ap
 Terminal:
 
 ```bash
-pip install --pre totalreclaw
+# Install the Hermes plugin (Git-based discovery in Hermes 2026.4.16+)
+hermes plugins install p-diogo/totalreclaw-hermes --enable
+
+# Ensure the backing Python package is in your Hermes venv
+/path/to/hermes/venv/bin/python3 -m pip install --pre totalreclaw
+# (or just `pip install --pre totalreclaw` if your pip resolves to hermes's venv)
+
+# Restart the gateway for the plugin to take effect
 hermes gateway restart    # or `docker restart tr-hermes` for Docker Hermes
 ```
 
@@ -17,7 +24,7 @@ Then in your Hermes chat:
 
 The agent will call the pairing tool and give you a URL + PIN. Open the URL, enter your recovery phrase, confirm PIN. Done.
 
-Why this works: the Hermes pip package bundles both `SKILL.md` (agent instructions) and the plugin into the same wheel, so once pip + restart complete, the agent has everything it needs. The chat prompt triggers the skill's fast path: check for existing credentials, call `totalreclaw_pair`, relay URL + PIN.
+Why two install commands? Hermes 2026.4.16+ uses Git-based plugin discovery. `hermes plugins install p-diogo/totalreclaw-hermes --enable` registers the plugin manifest from the Git repo; `pip install --pre totalreclaw` supplies the Python tool implementations in the Hermes venv. The chat prompt then triggers the skill's fast path: check for existing credentials, call `totalreclaw_pair`, relay URL + PIN.
 
 <details>
 <summary><strong>Approach B — explicit two-step (fallback)</strong></summary>
@@ -27,7 +34,14 @@ If you'd rather spell out every step explicitly (useful if the agent doesn't kno
 Terminal:
 
 ```bash
-pip install --pre totalreclaw
+# Install the Hermes plugin (Git-based discovery in Hermes 2026.4.16+)
+hermes plugins install p-diogo/totalreclaw-hermes --enable
+
+# Ensure the backing Python package is in your Hermes venv
+/path/to/hermes/venv/bin/python3 -m pip install --pre totalreclaw
+# (or just `pip install --pre totalreclaw` if your pip resolves to hermes's venv)
+
+# Restart the gateway for the plugin to take effect
 hermes gateway restart    # or `docker restart tr-hermes` for Docker Hermes
 ```
 
@@ -71,7 +85,7 @@ If you were on plugin 3.3.1-rc.2 or Hermes 2.3.1rc2, after upgrading also run `p
 
 ## Troubleshooting
 
-- **Agent can't see TotalReclaw tools**: `hermes gateway restart`.
+- **Agent can't see TotalReclaw tools**: confirm both install commands ran — `hermes plugins list` should show `p-diogo/totalreclaw-hermes` enabled, and `pip show totalreclaw` in the Hermes venv should resolve. Then `hermes gateway restart`.
 - **Pair URL returns 404**: check that `~/.totalreclaw/credentials.json` isn't locked by a previous process and that the gateway is running.
 - **Browser fails to POST the encrypted phrase**: check the pair page's Content-Security-Policy — older browsers without WebCrypto x25519 (pre-Safari 17.2 / Chromium 118) cannot run the AEAD crypto.
 - **"No LLM available for auto-extraction"**: configure a provider in Hermes (`hermes login` or set `ZAI_API_KEY` / `OPENAI_API_KEY` in `~/.hermes/.env`). TotalReclaw reuses it automatically.

--- a/python/src/totalreclaw/hermes/SKILL.md
+++ b/python/src/totalreclaw/hermes/SKILL.md
@@ -11,7 +11,7 @@ homepage: https://totalreclaw.xyz
 
 ## Fast path — "set up TotalReclaw" (Approach A, preferred)
 
-If the user says "set up TotalReclaw" (or any variant) AND this SKILL.md is loaded, assume `totalreclaw_*` tools are already available (pip install + gateway restart atomically bundles SKILL.md + plugin for the Hermes pip package — if you are reading this, the plugin is loaded too).
+If the user says "set up TotalReclaw" (or any variant) AND this SKILL.md is loaded, assume `totalreclaw_*` tools are already available (`hermes plugins install p-diogo/totalreclaw-hermes --enable` registers the plugin manifest, `pip install --pre totalreclaw` supplies the Python tool implementations, and gateway restart loads both together — if you are reading this, the plugin is loaded too).
 
 1. Check `~/.totalreclaw/credentials.json` exists and is non-empty (via a read-only shell `test -s ~/.totalreclaw/credentials.json`). If it exists, confirm *"TotalReclaw is already set up."* and stop.
 2. If credentials missing: call `totalreclaw_pair` immediately. It returns `{url, pin, expires_at_ms}`.
@@ -23,9 +23,9 @@ If `totalreclaw_*` tools are NOT in your toolset: the gateway needs a restart. T
 
 ## Explicit two-step setup flow (Approach B, fallback)
 
-Used when the user pastes a verbose prompt describing install + restart + pair (e.g. *"TotalReclaw is installed at 'totalreclaw' on PyPI. Install it, restart the gateway, and walk me through the QR pairing flow"*) OR when a tool returns `onboarding required`.
+Used when the user pastes a verbose prompt describing install + restart + pair (e.g. *"TotalReclaw is already installed. Use the totalreclaw_pair tool to walk me through the QR recovery-phrase setup."*) OR when a tool returns `onboarding required`.
 
-1. `pip install --pre totalreclaw` (latest pre-release on PyPI; pin a specific `rcN` from https://pypi.org/project/totalreclaw/#history if asked).
+1. Install both halves of the Hermes 2026.4.16+ plugin surface: `hermes plugins install p-diogo/totalreclaw-hermes --enable` (Git-based plugin manifest) AND `pip install --pre totalreclaw` (Python tool implementations; latest pre-release on PyPI — pin a specific `rcN` from https://pypi.org/project/totalreclaw/#history if asked).
 2. Restart gateway so plugin loads. Docker: `docker restart tr-hermes`. Native: `hermes gateway restart`. Wait ~5s; confirm the gateway is back up.
 3. Call `totalreclaw_pair`. Returns `{url, pin, expires_at_ms}`.
 4. Relay to user verbatim: *"Open <url> in your browser. Enter your 12-word recovery phrase (or let the browser generate one). Confirm PIN <pin>. I'll wait for you to say done."*


### PR DESCRIPTION
## Summary

- `pip install --pre totalreclaw` alone no longer registers the plugin in Hermes 2026.4.16+ (Git-based plugin discovery). Install now requires both `hermes plugins install p-diogo/totalreclaw-hermes --enable` (manifest) and `pip install --pre totalreclaw` (Python tool implementations).
- `docs/guides/hermes-setup.md` — both Approach A and Approach B terminal blocks now carry the 3-line install (plugin install + pip install + restart). "Why two install commands?" paragraph added. Troubleshooting entry updated to check both halves.
- `python/src/totalreclaw/hermes/SKILL.md` — fast-path preamble + explicit-setup step references both `hermes plugins install` and `pip install`. Agent-imperative flow unchanged.

Canonical chat prompts are unchanged:
- Approach A: `Set up TotalReclaw`
- Approach B: `TotalReclaw is already installed. Use the totalreclaw_pair tool to walk me through the QR recovery-phrase setup.`

## Test plan

- [ ] Verify `hermes plugins install p-diogo/totalreclaw-hermes --enable` + venv pip install on a fresh Hermes 2026.4.16+ install makes all 13 `totalreclaw_*` tools visible post-restart
- [ ] Run `approach_a_hermes` + `approach_b_hermes` scenarios in the qa-harness (companion PR in internal repo) against rc.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)