### PR TITLE
fix(first-run): suppress welcome banner in agent context — unblocks harness + removes phrase-unsafe CLI hint

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,40 @@ Hermes Agent plugin are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1rc9] — 2026-04-23
+
+Ship-stopper fix for two problems in the first-run welcome banner that surfaced during the rc.8 Hermes auto-QA run against the Git-plugin install path. Both rooted in `totalreclaw.onboarding.maybe_emit_welcome`:
+
+1. **Chat-breaker (harness regression).** When `~/.totalreclaw/credentials.json` was absent (the clean-machine case every fresh user hits), `import totalreclaw.hermes` wrote a multi-paragraph welcome banner to stdout. The QA harness invokes `hermes chat -q` and parses `session_id` from the response — the banner dominated stdout, the parser failed, every chat step in the scenario failed, the run returned NO-GO.
+2. **Phrase-safety violation.** The banner told the user to `Run: totalreclaw setup`. That CLI runs an interactive prompt that echoes the recovery phrase to stdout. In an agent-driven context (`hermes chat -q`, `openclaw chat`, etc.) the agent reads stdout back into its LLM context — so the phrase would cross the LLM boundary, a vault-compromise-class violation of `project_phrase_safety_rule.md` ("recovery phrase MUST NEVER cross the LLM context in ANY form").
+
+### Fixed (ship-stopper)
+
+- **`python/src/totalreclaw/onboarding.py::maybe_emit_welcome` — now a no-op by default.** Preserves the function signature so existing callers (`totalreclaw.client.TotalReclaw.__init__`, `totalreclaw.hermes.register`) don't break on upgrade, but it never writes to `stream` and always returns `False`. Agent-driven setup flows through `totalreclaw_pair` (browser-side crypto, phrase-safe); user-in-terminal setup still happens via the `totalreclaw setup` CLI wizard, which emits its own prompts directly OUTSIDE any agent context.
+- **`LOCAL_MODE_INSTRUCTIONS` / `REMOTE_MODE_INSTRUCTIONS` rewrite.** The constants are still exported (the CLI wizard consumes them, and cross-client parity tests lock their shape), but the `Run: totalreclaw setup` CLI hint is gone. New copy routes users to the pair flow via their agent: `"Ask your agent to 'Set up TotalReclaw' — it will walk you through a QR pairing flow. Your recovery phrase never crosses the chat."` The remote variant additionally retains the "never leaves this machine" guarantee.
+
+### Added
+
+- **`python/tests/test_no_stdout_on_first_run_in_agent_context.py`** — regression shield. Pins the post-fix invariants:
+  - `test_maybe_emit_welcome_writes_nothing_in_agent_context` — simulates `sys.stdout.isatty() is False` + missing credentials; asserts both the explicit stream and `sys.stdout` receive zero bytes and the function returns `False`.
+  - `test_maybe_emit_welcome_writes_nothing_when_explicit_stream_passed` — harness-compat scenario: an agent runtime passes its own buffer; the no-op must honour the contract regardless of stream target.
+  - `test_import_totalreclaw_does_not_write_to_stdout` — reloads `totalreclaw.onboarding` under a captured `sys.stdout` and asserts bare import writes nothing.
+  - `test_no_print_statement_at_module_init_time` — AST scan of `onboarding.py` body; fails on any `print(...)` / `sys.stdout.write(...)` at module scope (belt-and-suspenders against future regressions that sneak in a module-level emit).
+  - `TestBannerCopyIsPhraseSafe` (3 tests) — locks the copy constants against re-introducing `Run: totalreclaw setup` / `Run: hermes setup` and asserts both still reference the pair flow.
+
+### Changed
+
+- **`python/tests/test_onboarding.py::TestMaybeEmitWelcome`** — rewritten to assert the new no-op contract: `test_no_op_on_first_run`, `test_no_op_when_onboarded`, `test_no_op_on_repeat_calls`. Previously these asserted the banner DID emit (which is now the thing we want to prevent).
+- **`python/tests/test_onboarding.py::TestCopyConstants::test_local_instructions` / `::test_remote_instructions_contents`** — updated to assert the pair-flow copy + the `Run:` CLI hint is absent. The `recovery phrase` terminology and "never leaves this machine" security claim are preserved.
+
+### Why auto-QA missed this earlier
+
+rc.6 auto-QA ran against a staging relay that happened to have a populated `credentials.json` on the QA host (seeded from the rc.4 QA run), so `detect_first_run` returned `False` and the banner never emitted. rc.7 and rc.8 QA ran on a freshly re-imaged host, hit the first-run path for the first time since the welcome banner shipped in rc.1, and surfaced both problems. The new regression test exercises the first-run path directly regardless of host state.
+
+## [2.3.1rc7, 2.3.1rc8] — SKIPPED
+
+rc.7 and rc.8 were registry-only bumps from 2026-04-22 workflow dispatches; the git repo on `main` carried rc.6 code unchanged through both publishes. rc.9 is the first RC with a functional change after rc.6.
+
 ## [2.3.1rc6] — 2026-04-22
 
 Ship-stopper fix for the rc.4 regression that shipped to manual QA: Hermes chat agent could not see the `totalreclaw_*` tools in its toolset even though the plugin loaded cleanly (SKILL.md surfaced, module imported). Root cause was a long-latent drift between `plugin.yaml::provides_tools` and the `ctx.register_tool()` calls in `totalreclaw.hermes.register()` — the manifest advertised `totalreclaw_pin` / `totalreclaw_unpin` as agent-facing but `register()` never wired them. The drift had been in the codebase since pin/unpin landed in 2.2.2; rc.4's phrase-safety hardening surfaced it because the user's first contact with the plugin was a fresh install hunting for `totalreclaw_pair` (which IS wired), which made the narrower missing-pin/unpin symptom mis-attributable to pair.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "totalreclaw"
-version = "2.3.1rc6"
+version = "2.3.1rc9"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"

--- a/python/src/totalreclaw/__init__.py
+++ b/python/src/totalreclaw/__init__.py
@@ -9,7 +9,7 @@ except Exception:
     # installed-package metadata is absent. Must match pyproject.toml —
     # test_version.py enforces a semver-shape string; the live value in
     # a pip-installed wheel comes from importlib.metadata above.
-    __version__ = "2.3.1rc6"
+    __version__ = "2.3.1rc9"
 
 from .client import TotalReclaw
 

--- a/python/src/totalreclaw/hermes/plugin.yaml
+++ b/python/src/totalreclaw/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: totalreclaw
-version: 2.3.1rc6
+version: 2.3.1rc9
 description: End-to-end encrypted memory vault for AI agents (Memory Taxonomy v1)
 author: TotalReclaw Team
 provides_tools:

--- a/python/src/totalreclaw/onboarding.py
+++ b/python/src/totalreclaw/onboarding.py
@@ -19,20 +19,52 @@ What this module owns:
   strings.
 * :data:`CANONICAL_CREDENTIALS_PATH` — the ``~/.totalreclaw/credentials.json``
   path shared across Hermes, OpenClaw, and MCP.
-* :func:`maybe_emit_welcome` — emits the welcome once-per-process. Uses
-  a module-level flag (``_emitted_this_process``) plus a best-effort
-  sentinel file so repeat imports within the same session stay quiet.
+* :func:`maybe_emit_welcome` — historically emitted a first-run welcome
+  banner to stdout. **As of 2.3.1rc9 this is a no-op by default** (see
+  "Banner suppression" below). The signature is preserved for
+  backwards-compat with existing call sites.
 
 What this module deliberately does NOT do:
 
 * Never prints or logs the recovery phrase itself — welcome copy only.
 * No network calls. No env var reads beyond what's needed to classify
   local-vs-remote mode.
-* No blocking prompts. The wizard (``hermes setup``) lives in
-  :mod:`totalreclaw.hermes.cli`; this module only emits the welcome
-  surface + detection helper.
+* No blocking prompts. Agent-driven setup runs through
+  ``totalreclaw_pair`` (browser-side crypto, phrase-safe); user-in-
+  terminal setup runs through the ``totalreclaw setup`` CLI wizard
+  OUTSIDE any agent context.
 
-Added 2.3.1 (2026-04-20).
+Banner suppression (2.3.1rc9):
+    Earlier RCs wrote a multi-paragraph welcome banner to stdout on
+    every ``import totalreclaw.hermes`` / ``TotalReclaw(...)`` call
+    when ``~/.totalreclaw/credentials.json`` was absent. Two problems
+    surfaced during the rc.8 Hermes auto-QA run with the Git-plugin
+    install path:
+
+    1. Chat-breaker: banner dominated ``hermes chat -q`` stdout in
+       agent contexts, so the QA harness could not parse the
+       ``session_id`` from the response and the chat step failed.
+    2. Phrase-safety violation: the banner told the user to
+       ``Run: totalreclaw setup``. When an agent reads that hint and
+       invokes the CLI through its shell tool, the CLI's interactive
+       prompts echo the recovery phrase through the agent's stdout /
+       LLM context — which violates the absolute phrase-safety rule
+       (``recovery phrase MUST NEVER cross the LLM context``).
+
+    Fix: suppress the banner entirely. Agent-driven setup flows via
+    the ``totalreclaw_pair`` tool, which SKILL.md routes to on a
+    "Set up TotalReclaw" prompt. The pair flow runs entirely in a
+    browser-side crypto handshake — no phrase ever touches stdout
+    or the LLM context. The ``totalreclaw setup`` CLI wizard still
+    exists for user-in-terminal setup and emits its own prompts
+    directly; it is not supposed to be invoked from an agent shell.
+
+    Copy constants (``WELCOME_MESSAGE``, ``BRANCH_QUESTION``,
+    ``STORAGE_GUIDANCE``, etc.) remain exported — the CLI wizard and
+    cross-client parity tests still consume them — but
+    ``maybe_emit_welcome`` no longer renders them to any stream.
+
+Added 2.3.1 (2026-04-20); banner suppressed 2.3.1rc9 (2026-04-23).
 """
 from __future__ import annotations
 
@@ -79,12 +111,13 @@ BRANCH_QUESTION = """
 Let's set up your account. Do you already have a recovery phrase, or should we generate a new one?
 """.strip()
 
-LOCAL_MODE_INSTRUCTIONS = "Run: totalreclaw setup"
+LOCAL_MODE_INSTRUCTIONS = (
+    "Ask your agent to 'Set up TotalReclaw' — it will walk you through a QR "
+    "pairing flow. Your recovery phrase never crosses the chat."
+)
 
 REMOTE_MODE_INSTRUCTIONS = """
-Run: totalreclaw setup
-
-You'll be prompted to either restore from an existing recovery phrase or generate a new one. Your phrase never leaves this machine.
+Ask your agent to 'Set up TotalReclaw' — it will walk you through a QR pairing flow. Scan the QR on your phone, enter the 6-digit PIN the agent shows you, and pick "Generate new" or "Restore existing". Your recovery phrase never crosses the chat. Your recovery phrase never leaves this machine.
 """.strip()
 
 STORAGE_GUIDANCE = """
@@ -264,74 +297,40 @@ def maybe_emit_welcome(
     *,
     use_sentinel: bool = True,
 ) -> bool:
-    """Emit the welcome message to ``stream`` iff this is first-run + we
-    haven't emitted in this process yet.
+    """Historically emitted a first-run welcome banner to ``stream``.
 
-    Returns ``True`` if the welcome was emitted, ``False`` otherwise
-    (already onboarded, already emitted in this process, or
-    sentinel-suppressed).
+    **As of 2.3.1rc9 this is a no-op.** The function is preserved so
+    existing callers (``totalreclaw.client.TotalReclaw.__init__``,
+    ``totalreclaw.hermes.register``) don't break on upgrade, but it
+    never writes to ``stream`` and always returns ``False``. See the
+    module docstring "Banner suppression" section for rationale.
 
-    Suppression strategy:
+    Why a no-op instead of a removal:
 
-    * Per-process: a module-level flag. Prevents double-emission when
-      both the client and the Hermes plugin import the onboarding
-      module during the same session.
-    * Per-host (best-effort): a sentinel file at
-      ``~/.totalreclaw/.welcome_shown``. Prevents re-emission on every
-      command invocation for a first-run user who's chosen to defer
-      setup. Pass ``use_sentinel=False`` to disable (useful for tests).
+    * Two in-tree callers still invoke it. Removing the function would
+      force a coordinated plugin + client update. A no-op is strictly
+      safer.
+    * The banner text violated the absolute phrase-safety rule: it
+      suggested ``Run: totalreclaw setup``, a CLI that emits the
+      recovery phrase to stdout. In an agent-driven context
+      (``hermes chat -q``, ``openclaw chat``, etc.) the agent reads
+      stdout back into its own LLM context, so the phrase would cross
+      the LLM boundary. Suppressing the banner removes the hint.
+    * The banner ALSO broke the ``hermes chat -q`` stdout format in
+      agent harnesses: multi-paragraph output dominated the session-id
+      response, so QA harnesses could not parse it and the chat step
+      failed. Suppression unblocks the harness immediately.
 
-    Never emits the recovery phrase itself. Only ever writes the
-    welcome + branch-question copy + the instructions for the detected
-    mode.
+    Parameters are retained byte-for-byte so call sites don't have to
+    change. They are all ignored.
     """
+    # Mark as "emitted" so any subsequent caller that treats a prior
+    # emission as a signal (e.g. an integration smoke test) still sees
+    # the once-per-process semantics it expects. This is cheap and
+    # preserves the existing observable flag behaviour.
     global _emitted_this_process
-
-    if _emitted_this_process:
-        return False
-
-    if not detect_first_run(credentials_path):
-        return False
-
-    if use_sentinel:
-        try:
-            if _WELCOME_SENTINEL_PATH.exists():
-                _emitted_this_process = True  # still mark to avoid repeat probes
-                return False
-        except OSError:
-            pass
-
-    mode = detect_mode(relay_url)
-    message = build_welcome_message(mode)
-
-    out = stream if stream is not None else _default_stream()
-    try:
-        out.write(message + "\n")
-        try:
-            out.flush()
-        except Exception:
-            pass
-    except Exception:
-        # Never block the client on a broken stdout — just log and move on.
-        logger.debug("totalreclaw.onboarding: welcome write failed", exc_info=True)
-        return False
-
     _emitted_this_process = True
-
-    if use_sentinel:
-        try:
-            _WELCOME_SENTINEL_PATH.parent.mkdir(parents=True, exist_ok=True)
-            _WELCOME_SENTINEL_PATH.write_text("")
-            try:
-                _WELCOME_SENTINEL_PATH.chmod(0o600)
-            except OSError:
-                pass
-        except OSError:
-            # Read-only home dir / perms — tolerate and rely on the
-            # per-process flag alone.
-            logger.debug("totalreclaw.onboarding: sentinel write failed", exc_info=True)
-
-    return True
+    return False
 
 
 def _default_stream() -> TextIO:

--- a/python/tests/test_no_stdout_on_first_run_in_agent_context.py
+++ b/python/tests/test_no_stdout_on_first_run_in_agent_context.py
@@ -1,0 +1,279 @@
+"""Regression shield: first-run must not emit anything to stdout in
+agent contexts.
+
+Added 2.3.1rc9 (2026-04-23).
+
+Context
+-------
+
+rc.8's Hermes auto-QA run with the Git-plugin install path surfaced a
+chat-breaker + a phrase-safety violation, both rooted in
+``totalreclaw.onboarding.maybe_emit_welcome``:
+
+1. **Chat-breaker.** When ``~/.totalreclaw/credentials.json`` was
+   missing (the clean-machine case that every fresh user hits),
+   ``import totalreclaw.hermes`` wrote a multi-paragraph welcome
+   banner to stdout. The QA harness invokes ``hermes chat -q`` and
+   parses ``session_id`` from the response — the banner dominated
+   stdout, the parser failed, every chat step in the scenario failed,
+   the run returned NO-GO.
+
+2. **Phrase-safety violation.** The banner suggested
+   ``Run: totalreclaw setup``. That CLI runs an interactive prompt
+   that echoes the recovery phrase to stdout. In an agent-driven
+   context (Hermes chat, OpenClaw chat, etc.) the agent reads stdout
+   back into its LLM context — which means the phrase crosses the
+   LLM boundary. That's a vault-compromise-class violation of the
+   absolute rule in ``project_phrase_safety_rule.md``: "recovery
+   phrase MUST NEVER cross the LLM context in ANY form."
+
+Fix: ``maybe_emit_welcome`` is a no-op as of 2.3.1rc9. Agent-driven
+setup flows through the ``totalreclaw_pair`` tool (browser-side
+crypto, phrase-safe); user-in-terminal setup happens OUTSIDE any
+agent context via ``totalreclaw setup`` directly.
+
+This test is the regression shield for both problems.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from io import StringIO
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from totalreclaw import onboarding
+
+
+class TestNoStdoutOnFirstRunInAgentContext:
+    """Simulate an agent-context first-run and assert zero stdout."""
+
+    def setup_method(self) -> None:
+        onboarding._reset_for_tests()
+
+    def test_maybe_emit_welcome_writes_nothing_in_agent_context(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Agent context: ``sys.stdout.isatty()`` returns False + no
+        credentials file.
+
+        Under those conditions ``maybe_emit_welcome`` MUST NOT write
+        anything to stdout (or to the passed-in stream, or anywhere
+        else observable by an agent harness).
+        """
+        # No credentials file → first-run.
+        creds = tmp_path / "does-not-exist.json"
+        sentinel = tmp_path / ".welcome_shown"
+
+        # Redirect the default stream so we can observe it — and
+        # separately redirect sys.stdout so even if the function
+        # ignored the explicit stream arg and reached for stdout, we'd
+        # catch it.
+        fake_default = StringIO()
+        fake_stdout = StringIO()
+        monkeypatch.setattr(onboarding, "_default_stream", lambda: fake_default)
+        monkeypatch.setattr(sys, "stdout", fake_stdout)
+
+        # Simulate "piped to another process" (the agent harness case).
+        # ``sys.stdout.isatty()`` on a StringIO returns False already,
+        # but we lock it in explicitly so the test expresses the
+        # agent-context invariant.
+        assert fake_stdout.isatty() is False
+
+        # Point the sentinel at tmp so we never touch the real home.
+        original_sentinel = onboarding._WELCOME_SENTINEL_PATH
+        onboarding._WELCOME_SENTINEL_PATH = sentinel
+        try:
+            result = onboarding.maybe_emit_welcome(credentials_path=creds)
+        finally:
+            onboarding._WELCOME_SENTINEL_PATH = original_sentinel
+
+        # Contract:
+        assert result is False, (
+            "maybe_emit_welcome must be a no-op in agent contexts "
+            "(returns False, never True)"
+        )
+        assert fake_default.getvalue() == "", (
+            "maybe_emit_welcome wrote to its default stream — it must "
+            "not emit anything on first-run in an agent context"
+        )
+        assert fake_stdout.getvalue() == "", (
+            "maybe_emit_welcome wrote to sys.stdout — it must not emit "
+            "anything on first-run in an agent context"
+        )
+
+    def test_maybe_emit_welcome_writes_nothing_when_explicit_stream_passed(
+        self, tmp_path: Path
+    ) -> None:
+        """Even with an explicit ``stream`` arg and first-run conditions,
+        the function writes nothing.
+
+        This is the direct harness-compat scenario: an agent runtime
+        passes its own buffer in hopes of capturing the banner
+        separately. The no-op must honour the contract regardless of
+        where the stream points.
+        """
+        creds = tmp_path / "nope.json"
+        buf = StringIO()
+
+        result = onboarding.maybe_emit_welcome(
+            credentials_path=creds,
+            relay_url="https://api-staging.totalreclaw.xyz",
+            stream=buf,
+            use_sentinel=False,
+        )
+
+        assert result is False
+        assert buf.getvalue() == ""
+
+    def test_import_totalreclaw_does_not_write_to_stdout(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Module import must be side-effect-free on stdout.
+
+        Historically ``totalreclaw.hermes.register(ctx)`` called
+        ``maybe_emit_welcome()``, which in turn wrote the banner. The
+        no-op fix means any subsequent caller of register() also
+        inherits the silence guarantee — but the strongest shield is
+        to assert that bare ``import totalreclaw`` / ``import
+        totalreclaw.onboarding`` write nothing.
+
+        We capture stdout during a fresh module reload to approximate
+        a first-time import.
+        """
+        # Simulate no-credentials first-run env.
+        monkeypatch.setattr(
+            onboarding,
+            "CANONICAL_CREDENTIALS_PATH",
+            tmp_path / "absent-credentials.json",
+        )
+
+        buf = StringIO()
+        with mock.patch.object(sys, "stdout", buf):
+            # Re-run the module load side effects (no-op today, but
+            # future regressions that add a module-level print would
+            # get caught).
+            import importlib
+            importlib.reload(onboarding)
+
+        assert buf.getvalue() == "", (
+            "Importing totalreclaw.onboarding wrote to stdout — module "
+            "load must be silent in agent contexts"
+        )
+
+    def test_no_print_statement_at_module_init_time(self) -> None:
+        """AST scan: no top-level ``print(...)`` / ``sys.stdout.write``
+        at module-body scope in ``onboarding.py``.
+
+        Module-level prints would fire on every ``import`` regardless
+        of the ``maybe_emit_welcome`` gate. This scan is a belt-and-
+        suspenders shield: even if the gate is correct today, a future
+        patch that sneaks a ``print(...)`` onto the module body would
+        break agent contexts and fail this assertion.
+        """
+        import ast
+        import inspect
+
+        source = inspect.getsource(onboarding)
+        tree = ast.parse(source)
+
+        for node in tree.body:
+            # Skip imports, constants, function / class definitions —
+            # those don't emit at import time on their own.
+            if isinstance(
+                node,
+                (
+                    ast.Import,
+                    ast.ImportFrom,
+                    ast.FunctionDef,
+                    ast.AsyncFunctionDef,
+                    ast.ClassDef,
+                    ast.Assign,
+                    ast.AnnAssign,
+                    ast.AugAssign,
+                ),
+            ):
+                continue
+            # ``from __future__ import annotations``, docstring, etc.
+            # ``ast.Str`` was removed in Python 3.14; ``ast.Constant``
+            # covers string / number / None literals in 3.8+.
+            if isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant):
+                continue
+            if isinstance(node, ast.If):
+                # Allow ``if TYPE_CHECKING:`` and similar pure type-only
+                # branches. If a regression adds ``if x: print(y)`` at
+                # module scope, catch that below.
+                for sub in ast.walk(node):
+                    if isinstance(sub, ast.Call) and _is_stdout_call(sub):
+                        pytest.fail(
+                            "Module-level ``print`` / stdout write "
+                            "detected in totalreclaw.onboarding — this "
+                            "will fire on every import and break agent "
+                            "contexts. Wrap it in a function."
+                        )
+                continue
+
+            # Anything else at module scope that contains a stdout
+            # call is a regression.
+            for sub in ast.walk(node):
+                if isinstance(sub, ast.Call) and _is_stdout_call(sub):
+                    pytest.fail(
+                        "Module-level ``print`` / stdout write "
+                        "detected in totalreclaw.onboarding — this "
+                        "will fire on every import and break agent "
+                        "contexts."
+                    )
+
+
+def _is_stdout_call(call: "ast.Call") -> bool:
+    """Return True if ``call`` is a ``print(...)`` or
+    ``sys.stdout.write(...)`` / ``sys.stderr.write(...)`` invocation."""
+    import ast as _ast
+
+    func = call.func
+    if isinstance(func, _ast.Name) and func.id == "print":
+        return True
+    if isinstance(func, _ast.Attribute):
+        if func.attr == "write" and isinstance(func.value, _ast.Attribute):
+            inner = func.value
+            if inner.attr in ("stdout", "stderr"):
+                if isinstance(inner.value, _ast.Name) and inner.value.id == "sys":
+                    return True
+    return False
+
+
+class TestBannerCopyIsPhraseSafe:
+    """Even though the banner is no longer emitted, the copy constants
+    are still exported (the CLI wizard imports them). Assert they don't
+    carry phrase-unsafe CLI hints that a future regression could
+    re-emit.
+    """
+
+    def test_local_instructions_no_cli_run_hint(self) -> None:
+        li = onboarding.LOCAL_MODE_INSTRUCTIONS
+        assert "Run: totalreclaw setup" not in li
+        assert "Run: hermes setup" not in li
+
+    def test_remote_instructions_no_cli_run_hint(self) -> None:
+        r = onboarding.REMOTE_MODE_INSTRUCTIONS
+        assert "Run: totalreclaw setup" not in r
+        assert "Run: hermes setup" not in r
+
+    def test_pair_flow_is_the_documented_setup_path(self) -> None:
+        """The instructions must route users to the pair flow (which
+        runs through an agent tool + browser-side crypto) rather than
+        a shell CLI that would echo the phrase."""
+        for copy in (
+            onboarding.LOCAL_MODE_INSTRUCTIONS,
+            onboarding.REMOTE_MODE_INSTRUCTIONS,
+        ):
+            # Either an explicit "Set up TotalReclaw" agent prompt or
+            # a reference to QR / pairing is fine. The failure case is
+            # "no mention of the pair flow at all."
+            assert (
+                "Set up TotalReclaw" in copy
+                or "QR" in copy
+                or "pair" in copy.lower()
+            ), f"instructions lost the pair-flow hint: {copy!r}"

--- a/python/tests/test_onboarding.py
+++ b/python/tests/test_onboarding.py
@@ -128,7 +128,7 @@ class TestDetectFirstRun:
 
 class TestBuildWelcomeMessage:
     def test_welcome_message_local_mode(self) -> None:
-        """Local mode must include the short 'Run: hermes setup' instruction."""
+        """Local mode must include the short pair-flow instruction."""
         msg = onboarding.build_welcome_message("local")
         assert onboarding.WELCOME_MESSAGE in msg
         assert onboarding.BRANCH_QUESTION in msg
@@ -222,21 +222,34 @@ class TestCopyConstants:
         assert "generate" in q.lower()
 
     def test_local_instructions(self) -> None:
-        # 2.3.1rc4: the colliding `hermes` console script was removed to
-        # stop overwriting the upstream hermes-agent CLI on
-        # `pip install totalreclaw`. Only the canonical `totalreclaw setup`
-        # remains in the hint.
-        assert "totalreclaw setup" in onboarding.LOCAL_MODE_INSTRUCTIONS
-        assert "hermes setup" not in onboarding.LOCAL_MODE_INSTRUCTIONS
-        assert onboarding.LOCAL_MODE_INSTRUCTIONS.startswith("Run: ")
+        # 2.3.1rc9: instructions must NOT tell the user (or agent) to run
+        # ``totalreclaw setup`` directly. That CLI emits the recovery
+        # phrase to stdout; in an agent-driven context, stdout is echoed
+        # back into the LLM. The canonical setup surface is the
+        # ``totalreclaw_pair`` agent tool — a browser-side crypto
+        # handshake that never puts the phrase on stdout.
+        li = onboarding.LOCAL_MODE_INSTRUCTIONS
+        assert li == li.strip()
+        assert "Set up TotalReclaw" in li
+        # Phrase-safety invariant: no `Run: totalreclaw setup` / similar
+        # CLI-invocation hint, and no `hermes setup` either.
+        assert "Run: totalreclaw setup" not in li
+        assert "Run: hermes setup" not in li
+        assert "hermes setup" not in li
+        assert "recovery phrase" in li.lower()
 
     def test_remote_instructions_contents(self) -> None:
         r = onboarding.REMOTE_MODE_INSTRUCTIONS
         assert r == r.strip()
-        # 2.3.1rc4: canonical `totalreclaw setup` only (see test_local_instructions).
-        assert "totalreclaw setup" in r
+        # 2.3.1rc9: same phrase-safety invariants as local mode. The
+        # remote note still carries the "phrase never leaves this
+        # machine" guarantee because that's the key property the QR
+        # pair flow preserves.
+        assert "Set up TotalReclaw" in r
+        assert "Run: totalreclaw setup" not in r
+        assert "Run: hermes setup" not in r
         assert "hermes setup" not in r
-        # The load-bearing security claim.
+        # The load-bearing security claim, still true under pair flow.
         assert "never leaves this machine" in r
 
     def test_storage_guidance(self) -> None:
@@ -264,15 +277,24 @@ class TestCopyConstants:
 
 
 class TestMaybeEmitWelcome:
+    """``maybe_emit_welcome`` is a no-op as of 2.3.1rc9.
+
+    See the module docstring "Banner suppression" section and
+    :file:`test_no_stdout_on_first_run_in_agent_context.py` for the
+    full phrase-safety + harness-compat rationale. These tests pin the
+    new invariant so a future regression (re-enabling the banner) is
+    caught here as well as in the agent-context test.
+    """
+
     def setup_method(self) -> None:
         onboarding._reset_for_tests()
 
-    def test_emits_on_first_run(self, tmp_path: Path) -> None:
+    def test_no_op_on_first_run(self, tmp_path: Path) -> None:
+        """First-run (no credentials) no longer emits anything."""
         creds = tmp_path / "creds.json"
         sentinel = tmp_path / ".welcome_shown"
         buf = StringIO()
 
-        # Ensure we don't leak to the actual user home.
         original_sentinel = onboarding._WELCOME_SENTINEL_PATH
         onboarding._WELCOME_SENTINEL_PATH = sentinel
         try:
@@ -284,13 +306,11 @@ class TestMaybeEmitWelcome:
         finally:
             onboarding._WELCOME_SENTINEL_PATH = original_sentinel
 
-        assert emitted is True
-        output = buf.getvalue()
-        assert onboarding.WELCOME_MESSAGE in output
-        assert onboarding.BRANCH_QUESTION in output
-        assert onboarding.LOCAL_MODE_INSTRUCTIONS in output
+        assert emitted is False
+        assert buf.getvalue() == ""
 
-    def test_does_not_emit_when_onboarded(self, tmp_path: Path) -> None:
+    def test_no_op_when_onboarded(self, tmp_path: Path) -> None:
+        """Onboarded user still sees nothing (unchanged from pre-rc.9)."""
         creds = tmp_path / "creds.json"
         creds.write_text(json.dumps({"mnemonic": "abandon " * 11 + "about"}))
         buf = StringIO()
@@ -301,7 +321,8 @@ class TestMaybeEmitWelcome:
         assert emitted is False
         assert buf.getvalue() == ""
 
-    def test_does_not_emit_twice_in_same_process(self, tmp_path: Path) -> None:
+    def test_no_op_on_repeat_calls(self, tmp_path: Path) -> None:
+        """Repeat invocations are all no-ops; no banner on either call."""
         creds = tmp_path / "creds.json"
         buf1 = StringIO()
         buf2 = StringIO()
@@ -312,9 +333,9 @@ class TestMaybeEmitWelcome:
         second = onboarding.maybe_emit_welcome(
             credentials_path=creds, stream=buf2, use_sentinel=False
         )
-        assert first is True
+        assert first is False
         assert second is False
-        assert buf1.getvalue() != ""
+        assert buf1.getvalue() == ""
         assert buf2.getvalue() == ""
 
 

--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1-rc.9] — 2026-04-23
+
+Coordinated version bump with Hermes Python `2.3.1rc9`. Plugin code itself is unchanged from `3.3.1-rc.6` (the first-run banner fix lives entirely on the Python side — `totalreclaw.onboarding.maybe_emit_welcome`). The rc.9 bundle ships the Hermes-side banner suppression and keeps plugin + Python versions aligned so the release-pipeline tracker can carry them through QA as one artifact set.
+
+### Why a plugin bump when only Python changed
+
+Our RC cadence publishes both registries from the same bundle. Out-of-sync version tags cause downstream confusion (the `qa-totalreclaw` skill and the release-pipeline tracker both key on a single RC-number per wave). Skipping the plugin bump would leave rc.9 documented on the Python side only; a later plugin bug would then have to skip to rc.10 to catch up. Much simpler to bump both in lockstep.
+
+See `python/CHANGELOG.md` (the `2.3.1rc9` entry) for the underlying fix: suppress the first-run welcome banner emitted by `totalreclaw.onboarding.maybe_emit_welcome`. Two problems surfaced during the rc.8 Hermes auto-QA run:
+
+1. **Chat-breaker.** The banner dominated `hermes chat -q` stdout when credentials were absent, breaking the QA harness's `session_id` parsing on every fresh install.
+2. **Phrase-safety violation.** The banner told users to `Run: totalreclaw setup` — a CLI that emits the recovery phrase to stdout. In an agent-driven context, stdout is echoed back into LLM context, so the phrase would cross the LLM boundary in violation of `project_phrase_safety_rule.md`.
+
+Agent-driven setup now routes through the `totalreclaw_pair` tool (browser-side crypto, phrase-safe) per SKILL.md. User-in-terminal setup still runs through `totalreclaw setup` / `openclaw totalreclaw onboard` OUTSIDE any agent context.
+
+### Skipped
+
+- **`3.3.1-rc.7`** and **`3.3.1-rc.8`** — registry-only bumps from 2026-04-22 workflow dispatches; the git repo on `main` carried rc.6 code unchanged through both publishes.
+
 ## [3.3.1-rc.6] — 2026-04-22
 
 Coordinated version bump with Hermes Python `2.3.1rc6`. Plugin code itself is unchanged from `3.3.1-rc.4` (the OpenClaw plugin's `register()` path already wired every tool advertised in `skill.yaml`). The rc.6 bundle ships the Hermes-side tool-registration fix and keeps plugin + Python versions aligned so the release-pipeline tracker can carry them through QA as one artifact set.

--- a/skill/plugin/package-lock.json
+++ b/skill/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.1-rc.6",
+  "version": "3.3.1-rc.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/totalreclaw",
-      "version": "3.3.1-rc.6",
+      "version": "3.3.1-rc.9",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.0.1",

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.1-rc.6",
+  "version": "3.3.1-rc.9",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary

- **Ship-stopper fix for two problems** in the first-run welcome banner, both surfaced during the rc.8 Hermes auto-QA run against the Git-plugin install path. Rooted in `totalreclaw.onboarding.maybe_emit_welcome`.
- **`maybe_emit_welcome` is now a no-op by default.** Signature preserved so existing callers (`TotalReclaw.__init__`, `totalreclaw.hermes.register`) don't break on upgrade; it never writes to `stream` and always returns `False`.
- **Version bumps**: Python `2.3.1rc6 → 2.3.1rc9`; skill/plugin `3.3.1-rc.6 → 3.3.1-rc.9` (coordinated bump; plugin TS code unchanged — fix lives entirely on the Python side).
- **Do NOT auto-merge.** Pedro reviews + dispatches the rc.9 publish after merge.

## The two problems, one commit

### 1. Chat-breaker (harness regression)

When `~/.totalreclaw/credentials.json` was absent (the clean-machine case every fresh user hits), `import totalreclaw.hermes` wrote a multi-paragraph welcome banner to stdout. The QA harness invokes `hermes chat -q` and parses `session_id` from the response — the banner dominated stdout, the parser failed, every chat step in the scenario failed, the run returned NO-GO.

### 2. Phrase-safety violation

The banner told users to ```Run: totalreclaw setup```. That CLI runs an interactive prompt that echoes the recovery phrase to stdout. In an agent-driven context (`hermes chat -q`, `openclaw chat`, etc.) the agent reads stdout back into its LLM context — so the phrase would cross the LLM boundary, a vault-compromise-class violation of the absolute rule in `project_phrase_safety_rule.md`: "recovery phrase MUST NEVER cross the LLM context in ANY form."

## What changed

- **`python/src/totalreclaw/onboarding.py`**
  - `maybe_emit_welcome` → no-op by default. Returns `False`, writes nothing. Still marks `_emitted_this_process` so any once-per-process invariant downstream callers rely on still holds.
  - `LOCAL_MODE_INSTRUCTIONS` / `REMOTE_MODE_INSTRUCTIONS` rewritten to route users at the pair flow (`Ask your agent to 'Set up TotalReclaw' — it will walk you through a QR pairing flow. Your recovery phrase never crosses the chat.`). Dropped the `Run: totalreclaw setup` CLI hint entirely. Remote variant retains the `never leaves this machine` security claim.
  - Module docstring + function docstring document the rationale so a future regression is explicit.

- **`python/tests/test_no_stdout_on_first_run_in_agent_context.py`** (new)
  - `test_maybe_emit_welcome_writes_nothing_in_agent_context` — first-run + `sys.stdout.isatty() is False` → zero bytes emitted.
  - `test_maybe_emit_welcome_writes_nothing_when_explicit_stream_passed` — harness-compat scenario.
  - `test_import_totalreclaw_does_not_write_to_stdout` — reload-under-captured-stdout shield.
  - `test_no_print_statement_at_module_init_time` — AST scan of `onboarding.py` body for module-level `print(...)` / `sys.stdout.write(...)`.
  - `TestBannerCopyIsPhraseSafe` (3 tests) — locks `LOCAL_MODE_INSTRUCTIONS` / `REMOTE_MODE_INSTRUCTIONS` against re-introducing CLI hints + asserts pair-flow hint is still there.

- **`python/tests/test_onboarding.py`**
  - `TestMaybeEmitWelcome` rewritten to assert the new no-op contract (previously asserted the banner DID emit — which is now the thing we want to prevent).
  - `test_local_instructions` + `test_remote_instructions_contents` updated to assert new pair-flow copy + `Run:` CLI hint is absent.

- **Version bumps**: `python/pyproject.toml`, `python/src/totalreclaw/__init__.py` (fallback string), `python/src/totalreclaw/hermes/plugin.yaml`, `skill/plugin/package.json`, `skill/plugin/package-lock.json` — all bumped to rc.9.

- **CHANGELOGs**: `python/CHANGELOG.md` + `skill/plugin/CHANGELOG.md` — rc.9 entries + explicit `[rc.7, rc.8] — SKIPPED` note (those were registry-only bumps; git `main` carried rc.6 code unchanged).

## Out of scope (intentional)

- No Hermes or OpenClaw / plugin TS code changes. Fix lives entirely on the Python side. The plugin bump is for RC cadence coordination only (per the rc.6 precedent documented in `skill/plugin/CHANGELOG.md`).
- No SKILL.md edits — that's a separate concern.

## Line count delta on the banner-emitting file

`python/src/totalreclaw/onboarding.py`: **+76 / -77 = -1 net** (362 → 361 lines). The function body shrank from a ~75-line emission path to a 3-line no-op; the docstring grew proportionally to document the rationale.

## Test plan

- [x] `pytest python/tests/test_onboarding.py` — 30 passed (rewrites + new copy assertions land clean)
- [x] `pytest python/tests/test_no_stdout_on_first_run_in_agent_context.py` — 7 passed (new shield)
- [x] `pytest python/tests/test_hermes_plugin.py python/tests/test_hermes_plugin_manifest_parity.py python/tests/test_hermes_setup_cli.py python/tests/test_agent_tools_phrase_safety.py` — 109 passed total (no downstream regressions)
- [x] `pytest python/tests/test_version.py` — 4 passed (version bump lands clean)
- [ ] **After merge**: dispatch `publish-python-client.yml` (`release-type=rc`, `rc-number=9`) + `npm-publish.yml` (`release-type=rc`, `rc-number=9`)
- [ ] **After publish**: full real-user QA on the VPS against `totalreclaw==2.3.1rc9` with fresh `~/.totalreclaw/` — assert `hermes chat -q` stdout no longer carries the banner + session_id parses