### PR TITLE
chore(rc.10): TypeScript QR display + stub removal

### DIFF
--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -6,7 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [3.3.1-rc.10] — 2026-04-23
 
-Coordinated version bump with Hermes Python `2.3.1rc10`. rc.10 ships the relay-brokered pair flow — see `python/CHANGELOG.md` (the `2.3.1rc10` entry) for the full design. Plugin code in this release is unchanged from rc.9; the `totalreclaw_pair` pair URL on the OpenClaw plugin side still uses the gateway-loopback HTTP server (the OpenClaw plugin runs in-process alongside a browser on the same host for most deployments, so the loopback URL actually reaches the user). The relay-brokered path is currently Hermes-side only — the OpenClaw plugin can pick it up in a later RC if the same universal-reachability problem starts biting OpenClaw users.
+Coordinated version bump with Hermes Python `2.3.1rc10`. rc.10 ships the relay-brokered pair flow — see `python/CHANGELOG.md` (the `2.3.1rc10` entry) for the full design. The `totalreclaw_pair` pair URL on the OpenClaw plugin side still uses the gateway-loopback HTTP server (the OpenClaw plugin runs in-process alongside a browser on the same host for most deployments, so the loopback URL actually reaches the user). The relay-brokered path is currently Hermes-side only — the OpenClaw plugin can pick it up in a later RC if the same universal-reachability problem starts biting OpenClaw users.
+
+Bundled into rc.10: the previously-parked rc.5 QR display layer from PR #76 (`pair-qr.ts` + `pair-qr.test.ts`, tool-payload `qr_png_b64` + `qr_unicode` fields, `totalreclaw_setup` / `totalreclaw_onboarding_start` stub removal). All rebased onto main via the chore/rc.10-qr-rebase-pr76 branch.
+
+### Added (rebased from PR #76)
+
+- **`skill/plugin/pair-qr.ts`** — new. QR encoder module wrapping `qrcode` (PNG) + `qrcode-terminal` (Unicode block). Same contract as the Python side (`totalreclaw.pair.qr`).
+- **`totalreclaw_pair` tool payload** — the `details` block now carries `qr_png_b64` (base64 PNG for image transports) and `qr_unicode` (terminal block-char string) alongside the existing `qr_ascii`. URL + PIN unchanged.
+- **SKILL.md "Rendering the QR on your transport" section** — per-transport agent rendering guidance (Telegram attachment, terminal inline, web chat `<img>` embed).
+- **`qrcode` + `@types/qrcode`** runtime deps.
+
+### Removed (rc.5 phrase-safety carve-out closure, rebased)
+
+- **`totalreclaw_setup` + `totalreclaw_onboarding_start`** agent tools — both were neutered pointer stubs in rc.4; rc.5 auto-QA flagged them as future-regression surface and their mere presence signalled to agents that "phrase handling happens here". Deleted outright in rc.5, preserved through rc.10. `skill/plugin/phrase-safety-registry.test.ts` now asserts neither name is registered.
 
 Version bump reason: rc cadence keeps Python + plugin aligned so the release-pipeline tracker carries them through QA as one artifact set.
 

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "Install + set up TotalReclaw encrypted memory for OpenClaw, then use totalreclaw_remember / totalreclaw_recall. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', or any remember / recall request."
-version: 3.3.1-rc.6
+version: 3.3.1-rc.10
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz
@@ -34,7 +34,7 @@ If the user says "install totalreclaw" (or any variant) AND no `totalreclaw_*` t
 2. Tell the user: *"Plugin installed. Restarting the gateway so the tools bind."* Then ask the user to restart the gateway: `openclaw gateway restart` (native) or `docker restart tr-openclaw` (Docker). The agent-facing shell CANNOT self-restart the gateway it's running inside of — this step has to be a user action. Wait for the user to confirm the restart is done.
 3. After restart: verify `totalreclaw_pair` is now in your toolset. If not, tell the user the restart didn't take effect and to retry the restart command. Do not loop the install.
 4. Check `~/.totalreclaw/credentials.json` (via `test -s ~/.totalreclaw/credentials.json`). If it exists, confirm *"TotalReclaw is already set up."* and stop.
-5. Call `totalreclaw_pair`. Returns `{url, pin, qr_ascii, expires_at_ms}`.
+5. Call `totalreclaw_pair`. Returns `{url, pin, qr_ascii, qr_png_b64, qr_unicode, expires_at_ms}` (see "Rendering the QR on your transport" below for the rc.5+ additions).
 6. Relay verbatim: *"Open <url> in your browser. Enter your 12-word recovery phrase (or let the browser generate one). Confirm PIN <pin>. I'll wait for you to say done."*
 7. After user says done: verify `~/.totalreclaw/credentials.json`. If missing, call `totalreclaw_pair` again (PIN likely expired) and resend.
 8. Confirm: *"TotalReclaw set up ✓. Ask me to remember or recall anything — try `totalreclaw_remember` or ask me to remember something."*
@@ -47,10 +47,22 @@ Used when the user pastes a verbose prompt describing skill install + plugin ins
 
 1. `openclaw plugins install @totalreclaw/totalreclaw` (stable). For RC: `@totalreclaw/totalreclaw@rc`.
 2. Restart gateway so plugin routes + tools bind. Docker: `docker restart tr-openclaw`. Native: `openclaw gateway restart`. Wait ~5s; confirm the gateway is back up. (If you are running inside the gateway, ask the user to run the restart command and wait for confirmation.)
-3. Call `totalreclaw_pair`. Returns `{url, pin, qr_ascii, expires_at_ms}`.
+3. Call `totalreclaw_pair`. Returns `{url, pin, qr_ascii, qr_png_b64, qr_unicode, expires_at_ms}` (see "Rendering the QR on your transport" below for the rc.5+ additions).
 4. Relay to user verbatim: *"Open <url> in your browser. Enter your 12-word recovery phrase (or let the browser generate one). Confirm PIN <pin>. I'll wait for you to say done."*
 5. After user says done: verify `~/.totalreclaw/credentials.json` exists and is non-empty. If missing, call `totalreclaw_pair` again (PIN likely expired) and resend.
 6. Confirm: *"TotalReclaw is set up. Ask me to remember or recall anything."*
+
+## Rendering the QR on your transport (rc.5+)
+
+When you call `totalreclaw_pair` and receive the payload, tell the user: *"Open the URL below or scan this QR code from your phone. PIN: <pin>."*
+
+Then render the QR based on your chat transport:
+
+- **Transport supports image attachments** (Telegram, Slack, web chat, any transport with file/image upload): decode `qr_png_b64` from base64 to bytes, save to a tempfile with a `.png` suffix, and attach the tempfile as an image in your reply. Also show the URL + PIN as text so users who prefer clicking can still do so.
+- **Terminal-only transport** (OpenClaw native CLI chat, bare SSH shell): emit the `qr_unicode` string inline in your reply. It renders as block characters that display correctly in most terminal fonts; the user scans from their phone.
+- **Web chat with inline-image support**: embed as `<img src="data:image/png;base64,<qr_png_b64>" alt="Pair QR">` if the chat client renders HTML; otherwise fall back to attachment.
+
+The QR encodes ONLY the pair URL. The 6-digit PIN is a separate out-of-band confirmation — it is deliberately NOT baked into the QR (dual-channel design: scan + type). Never log, print, or re-emit the PIN outside of the user-facing reply. The PIN is a shared secret between you and the user; it must NOT end up in any other tool call, any log file, or any memory store.
 
 ## Phrase safety (HARD — never break)
 

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -4891,162 +4891,36 @@ const plugin = {
     );
 
     // ---------------------------------------------------------------
-    // Tool: totalreclaw_setup (DEPRECATED in 3.2.0)
+    // Tools: totalreclaw_setup + totalreclaw_onboarding_start —
+    //   REMOVED in 3.3.1-rc.5 (phrase-safety carve-out closure).
     // ---------------------------------------------------------------
     //
-    // Pre-3.2.0 behaviour: auto-generate a mnemonic + return it in the tool
-    // response body so the LLM surfaces it to the user. That path shipped
-    // the recovery phrase to the LLM provider's logs — incompatible with
-    // TotalReclaw's "server cannot read your memories" pitch. 3.2.0
-    // replaces it with a pointer-only stub.
+    // rc.4 left these two registrations in place as *neutered* stubs —
+    // ``totalreclaw_setup`` rejected any ``recovery_phrase`` argument
+    // and returned a CLI-pointer message; ``totalreclaw_onboarding_start``
+    // was already pointer-only. Neither path could leak a phrase in
+    // rc.4, but the rc.4 auto-QA (2026-04-22) flagged them as future-
+    // regression surface: any future patch that re-enables phrase
+    // acceptance (e.g. a flag-driven "power-user" path) would silently
+    // re-open the leak, and their mere presence in the tool registry
+    // keeps signalling to agents that "phrase handling happens here".
     //
-    // Kept registered (rather than deleted) for back-compat — LLMs that
-    // learned the old tool name from training data won't silently succeed
-    // if the user asks them to set up memory. They'll call this tool,
-    // receive a pointer to `openclaw totalreclaw onboard`, and the flow
-    // continues on the user's TTY.
+    // Per ``project_phrase_safety_rule.md`` the ONLY approved agent-
+    // facilitated setup surface is ``totalreclaw_pair`` (browser-side
+    // crypto keeps the phrase out of the LLM round-trip by construction).
+    // rc.5 deletes both registrations outright. The underlying CLI
+    // wizard (``openclaw totalreclaw onboard``) is unchanged — users
+    // run it in their own terminal, outside any agent shell.
     //
-    // The `recovery_phrase` param is kept in the schema so existing tool
-    // calls parse — but ANY phrase the caller passes is rejected, and the
-    // tool NEVER writes credentials.json. All real setup happens in the
-    // CLI wizard.
-    api.registerTool(
-      {
-        name: 'totalreclaw_setup',
-        label: 'TotalReclaw setup (deprecated — redirect to CLI)',
-        description:
-          'DEPRECATED in 3.2.0. This tool no longer accepts recovery phrases or performs ' +
-          'setup. It returns a pointer to `openclaw totalreclaw onboard` — the secure CLI ' +
-          'wizard that runs on the user\'s terminal so the phrase never touches the LLM ' +
-          'provider. Prefer calling `totalreclaw_onboarding_start` for the same pointer.',
-        parameters: {
-          type: 'object',
-          properties: {
-            recovery_phrase: {
-              type: 'string',
-              description:
-                'Legacy parameter — IGNORED in 3.2.0. If provided, the tool returns a ' +
-                'security warning explaining that phrases must never be pasted through ' +
-                'chat. Use the `openclaw totalreclaw onboard` CLI wizard to import an ' +
-                'existing phrase safely.',
-            },
-          },
-          additionalProperties: false,
-        },
-        async execute(_toolCallId: string, params: { recovery_phrase?: string }) {
-          // Phrase-passing is a security boundary violation in 3.2.0. Reject
-          // with a message that explains WHY — the LLM might try again with
-          // a different shape otherwise.
-          if (typeof params?.recovery_phrase === 'string' && params.recovery_phrase.trim().length > 0) {
-            api.logger.warn(
-              'totalreclaw_setup: rejected phrase-passing call (3.2.0 deprecation).',
-            );
-            return {
-              content: [{
-                type: 'text',
-                text:
-                  'For security, TotalReclaw no longer accepts a recovery phrase through ' +
-                  'chat. Pasting a phrase into this tool would ship it to the LLM provider, ' +
-                  'which defeats the whole point of end-to-end encryption.\n\n' +
-                  'Ask the user to open a terminal on their machine and run:\n\n' +
-                  '    openclaw totalreclaw onboard\n\n' +
-                  'The wizard imports an existing phrase via a hidden stdin prompt that ' +
-                  'never touches the LLM, the transcript, or the network.',
-              }],
-            };
-          }
-
-          // No-arg call against an already-active state: confirm + move on.
-          const state = resolveOnboardingState(CREDENTIALS_PATH, CONFIG.onboardingStatePath);
-          if (state.onboardingState === 'active') {
-            return {
-              content: [{
-                type: 'text',
-                text:
-                  'TotalReclaw is already set up and active on this machine. Memory tools ' +
-                  'are unblocked — you can call `totalreclaw_remember` and `totalreclaw_recall` ' +
-                  'directly. If the user wants to rotate phrases, have them delete ' +
-                  '`~/.totalreclaw/credentials.json` and run `openclaw totalreclaw onboard` again.',
-              }],
-            };
-          }
-
-          // Fresh state, no phrase: redirect to the CLI wizard.
-          return {
-            content: [{
-              type: 'text',
-              text:
-                'TotalReclaw setup must run on the user\'s local terminal so the recovery ' +
-                'phrase never touches the LLM. Ask the user to open a terminal and run:\n\n' +
-                '    openclaw totalreclaw onboard\n\n' +
-                'The wizard walks through generate-new-phrase or import-existing-phrase. ' +
-                'After it completes, memory tools become available automatically. See the ' +
-                '`totalreclaw_onboarding_start` tool for the same pointer in a more ' +
-                'discoverable shape.',
-            }],
-          };
-        },
-      },
-      { name: 'totalreclaw_setup' },
-    );
-
-    // ---------------------------------------------------------------
-    // Tool: totalreclaw_onboarding_start (3.2.0 pointer-only tool)
-    // ---------------------------------------------------------------
+    // Audit assertion: ``phrase-safety-registry.test.ts`` asserts
+    // neither name is present in the ``api.registerTool`` call list.
+    // Re-adding either fails CI.
     //
-    // When the user asks the LLM to set up TotalReclaw, this tool directs
-    // them to the CLI wizard. The response body is a non-secret pointer —
-    // it NEVER contains a recovery phrase — so it can safely flow through
-    // the LLM provider and the transcript.
-    api.registerTool(
-      {
-        name: 'totalreclaw_onboarding_start',
-        label: 'TotalReclaw — start onboarding',
-        description:
-          'Call this when the user wants to set up TotalReclaw memory or asks about ' +
-          'enabling memory features. This tool does NOT generate, display, or accept ' +
-          'a recovery phrase — it returns a short pointer that tells the user to run ' +
-          'the onboarding wizard in their local terminal. All phrase handling happens ' +
-          'outside the LLM. If TotalReclaw is already active, the tool returns a ' +
-          'confirmation.',
-        parameters: {
-          type: 'object',
-          properties: {},
-          additionalProperties: false,
-        },
-        async execute() {
-          const state = resolveOnboardingState(CREDENTIALS_PATH, CONFIG.onboardingStatePath);
-          if (state.onboardingState === 'active') {
-            return {
-              content: [{
-                type: 'text',
-                text:
-                  'TotalReclaw is already set up on this machine. Your encryption keys are ' +
-                  'ready — `totalreclaw_remember`, `totalreclaw_recall`, and the other memory ' +
-                  'tools are unblocked. Run `openclaw totalreclaw status` in a terminal for ' +
-                  'more detail.',
-              }],
-            };
-          }
-          return {
-            content: [{
-              type: 'text',
-              text:
-                'TotalReclaw onboarding requires a local terminal so your recovery phrase ' +
-                'never touches the LLM provider. On the same machine as your OpenClaw ' +
-                'gateway, open a terminal and run:\n\n' +
-                '    openclaw totalreclaw onboard\n\n' +
-                'The wizard will ask whether you want to generate a new phrase or import an ' +
-                'existing TotalReclaw phrase. Both paths display/accept the phrase only on ' +
-                'your terminal — nothing crosses the network. After the wizard completes, ' +
-                'come back here and I\'ll be able to use `totalreclaw_remember` and ' +
-                '`totalreclaw_recall`.',
-            }],
-          };
-        },
-      },
-      { name: 'totalreclaw_onboarding_start' },
-    );
+    // Historical tombstone (so LLM-assisted contributors don't re-add
+    // the former shape from training-data memory): rc.4 registered two
+    // tools by the names "totalreclaw_setup" and
+    // "totalreclaw_onboarding_start" as pointer-only stubs. Both were
+    // deleted in rc.5. Do not re-introduce.
 
     // ---------------------------------------------------------------
     // Tool: totalreclaw_onboard — REMOVED in 3.3.1-rc.4 (phrase-safety).
@@ -5156,8 +5030,34 @@ const plugin = {
                 resolve('');
               }
             });
+
+            // 3.3.1-rc.5 — render the same pair URL as (a) a PNG for
+            // image-capable transports (Telegram / Slack / web chat)
+            // and (b) a Unicode block string for terminal transports.
+            // The PIN is NEVER encoded into the QR; the QR carries
+            // ONLY the URL. Best-effort — if encoding fails (unlikely
+            // with the pure-TS `qrcode` lib) we ship empty strings so
+            // the URL-copy flow keeps working.
+            let qrPngB64 = '';
+            let qrUnicode = '';
+            try {
+              const { encodePng, encodeUnicode } = await import('./pair-qr.js');
+              const [pngBuf, uni] = await Promise.all([
+                encodePng(url),
+                encodeUnicode(url),
+              ]);
+              qrPngB64 = pngBuf.toString('base64');
+              qrUnicode = uni;
+            } catch (qrErr: unknown) {
+              api.logger.warn(
+                `totalreclaw_pair: QR encode failed (non-fatal): ${
+                  qrErr instanceof Error ? qrErr.message : String(qrErr)
+                }`,
+              );
+            }
+
             api.logger.info(
-              `totalreclaw_pair: session ${session.sid.slice(0, 8)}… mode=${mode} url=${url}`,
+              `totalreclaw_pair: session ${session.sid.slice(0, 8)}… mode=${mode} url=${url} qr_png=${qrPngB64.length} qr_unicode=${qrUnicode.length}`,
             );
             return {
               content: [{
@@ -5185,6 +5085,10 @@ const plugin = {
                 mode,
                 expires_at_ms: session.expiresAtMs,
                 qr_ascii: qrAscii,
+                // rc.5 additions — see SKILL.md "Rendering the QR on
+                // your transport" section for the agent-side logic.
+                qr_png_b64: qrPngB64,
+                qr_unicode: qrUnicode,
               },
             };
           } catch (err: unknown) {

--- a/skill/plugin/package-lock.json
+++ b/skill/plugin/package-lock.json
@@ -1,18 +1,20 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.1-rc.9",
+  "version": "3.3.1-rc.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/totalreclaw",
-      "version": "3.3.1-rc.9",
+      "version": "3.3.1-rc.10",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.0.1",
         "@totalreclaw/client": "^1.2.0",
         "@totalreclaw/core": "^2.1.1",
+        "@types/qrcode": "^1.5.6",
         "onnxruntime-node": "^1.24.0",
+        "qrcode": "^1.5.4",
         "qrcode-terminal": "^0.12.0"
       }
     },
@@ -769,6 +771,15 @@
         "undici-types": "~7.19.0"
       }
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -824,6 +835,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/aproba": {
@@ -942,6 +968,15 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chownr": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
@@ -950,6 +985,35 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -987,6 +1051,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/decompress-response": {
@@ -1070,6 +1143,12 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "license": "MIT"
     },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -1138,6 +1217,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/flatbuffers": {
       "version": "25.9.23",
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
@@ -1200,6 +1292,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/github-from-package": {
@@ -1405,6 +1506,18 @@
       "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/long": {
       "version": "5.3.2",
@@ -1686,6 +1799,51 @@
       "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
       "license": "MIT"
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -1715,6 +1873,15 @@
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
       "license": "MIT"
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
@@ -1779,6 +1946,23 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/qrcode-terminal": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
@@ -1816,6 +2000,21 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -2272,6 +2471,12 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/wide-align": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
@@ -2279,6 +2484,20 @@
       "license": "ISC",
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {
@@ -2308,11 +2527,52 @@
         }
       }
     },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     }
   }
 }

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -31,10 +31,12 @@
   "author": "TotalReclaw Team",
   "license": "MIT",
   "dependencies": {
+    "@huggingface/transformers": "^4.0.1",
     "@totalreclaw/client": "^1.2.0",
     "@totalreclaw/core": "^2.1.1",
-    "@huggingface/transformers": "^4.0.1",
+    "@types/qrcode": "^1.5.6",
     "onnxruntime-node": "^1.24.0",
+    "qrcode": "^1.5.4",
     "qrcode-terminal": "^0.12.0"
   },
   "files": [
@@ -50,7 +52,7 @@
     "skill.json"
   ],
   "scripts": {
-    "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx llm-client-retry.test.ts && npx tsx gateway-url.test.ts && npx tsx retype-setscope.test.ts && npx tsx tool-gating.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts && npx tsx qa-bug-report.test.ts && npx tsx nonce-serialization.test.ts && npx tsx phrase-safety-registry.test.ts",
+    "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx llm-client-retry.test.ts && npx tsx gateway-url.test.ts && npx tsx retype-setscope.test.ts && npx tsx tool-gating.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts && npx tsx pair-qr.test.ts && npx tsx qa-bug-report.test.ts && npx tsx nonce-serialization.test.ts && npx tsx phrase-safety-registry.test.ts",
     "check-scanner": "node ../scripts/check-scanner.mjs",
     "prepublishOnly": "node ../scripts/check-scanner.mjs"
   },

--- a/skill/plugin/pair-qr.test.ts
+++ b/skill/plugin/pair-qr.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for rc.5 pair-qr encoders.
+ *
+ * Covers:
+ *   - encodePng emits a valid PNG (magic header bytes).
+ *   - encodeUnicode emits a non-empty block-character string.
+ *   - Oversized, empty, and non-string inputs throw `QREncodeError`.
+ *   - The default ECC level produces QRs of a predictable size band for
+ *     a ~110-char URL (regression guard — if the library silently
+ *     changes defaults, we want to see it).
+ *
+ * Run with: `npx tsx pair-qr.test.ts`
+ */
+
+import { encodePng, encodeUnicode, QREncodeError } from './pair-qr.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond: boolean, name: string): void {
+  const n = passed + failed + 1;
+  if (cond) { console.log(`ok ${n} - ${name}`); passed++; }
+  else { console.log(`not ok ${n} - ${name}`); failed++; }
+}
+
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+const SAMPLE_URL =
+  'http://127.0.0.1:47321/pair/' +
+  'abc123def456abc123def456abc123de' +
+  '#pk=Nq7v3pQ8kL_wY1rZ-aXmPqT9yCvB6jH2kLgFeRzK';
+
+// ---------------------------------------------------------------------------
+// PNG emits valid header
+// ---------------------------------------------------------------------------
+{
+  const png = await encodePng(SAMPLE_URL);
+  assert(png.length > 500, `png: non-trivial size (${png.length} bytes)`);
+  assert(png.length < 20_000, `png: within sanity cap (${png.length} bytes)`);
+  assert(
+    Buffer.compare(png.subarray(0, 8), PNG_MAGIC) === 0,
+    `png: starts with PNG magic (got ${png.subarray(0, 8).toString('hex')})`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PNG respects scale option
+// ---------------------------------------------------------------------------
+{
+  const small = await encodePng(SAMPLE_URL, { boxSize: 4, border: 2 });
+  const big = await encodePng(SAMPLE_URL, { boxSize: 12, border: 4 });
+  assert(big.length > small.length, `png: bigger scale → larger PNG (${small.length} < ${big.length})`);
+}
+
+// ---------------------------------------------------------------------------
+// Unicode emits block chars
+// ---------------------------------------------------------------------------
+{
+  const uni = await encodeUnicode(SAMPLE_URL);
+  assert(uni.length > 0, 'unicode: non-empty');
+  const hasBlock = /[█▀▄]/.test(uni);
+  assert(hasBlock, `unicode: contains block glyphs (first 80 chars: ${JSON.stringify(uni.slice(0, 80))})`);
+  const lineCount = uni.split('\n').length;
+  assert(lineCount >= 10, `unicode: multi-line (${lineCount} lines)`);
+  assert(uni.length < 5000, `unicode: within sanity cap (${uni.length} chars)`);
+}
+
+// ---------------------------------------------------------------------------
+// Oversized input rejected
+// ---------------------------------------------------------------------------
+{
+  const oversized = 'http://x/' + 'a'.repeat(2050);
+  let thrownPng: unknown = null;
+  try { await encodePng(oversized); } catch (err) { thrownPng = err; }
+  assert(
+    thrownPng instanceof QREncodeError && /too large/.test((thrownPng as Error).message),
+    'png: rejects oversized URL with QREncodeError',
+  );
+
+  let thrownUni: unknown = null;
+  try { await encodeUnicode(oversized); } catch (err) { thrownUni = err; }
+  assert(
+    thrownUni instanceof QREncodeError && /too large/.test((thrownUni as Error).message),
+    'unicode: rejects oversized URL with QREncodeError',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Empty / non-string rejected
+// ---------------------------------------------------------------------------
+{
+  let thrown: unknown = null;
+  try { await encodePng(''); } catch (err) { thrown = err; }
+  assert(thrown instanceof QREncodeError, 'png: rejects empty string');
+
+  thrown = null;
+  try { await encodeUnicode(''); } catch (err) { thrown = err; }
+  assert(thrown instanceof QREncodeError, 'unicode: rejects empty string');
+
+  thrown = null;
+  try { await encodePng(null as unknown as string); } catch (err) { thrown = err; }
+  assert(
+    thrown instanceof QREncodeError && /must be a string/.test((thrown as Error).message),
+    'png: rejects null',
+  );
+
+  thrown = null;
+  try { await encodeUnicode(12345 as unknown as string); } catch (err) { thrown = err; }
+  assert(
+    thrown instanceof QREncodeError && /must be a string/.test((thrown as Error).message),
+    'unicode: rejects number',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log(`# fail: ${failed}`);
+console.log(`# ${passed}/${passed + failed} passed`);
+if (failed > 0) {
+  console.log('SOME TESTS FAILED');
+  process.exit(1);
+}
+console.log('ALL TESTS PASSED');

--- a/skill/plugin/pair-qr.ts
+++ b/skill/plugin/pair-qr.ts
@@ -1,0 +1,152 @@
+/**
+ * pair-qr — QR encoders for the rc.5 pair-tool payload.
+ *
+ * Two helpers that render the pair URL as either a PNG (for
+ * image-capable chat transports like Telegram) or a Unicode block
+ * string (for terminal-only transports like the OpenClaw native CLI).
+ *
+ * Phrase-safety invariant (see
+ * `project_phrase_safety_rule.md` in the internal repo):
+ *   The QR payload is ONLY the pair URL. The 6-digit PIN is a separate
+ *   out-of-band confirmation — it is NEVER baked into the QR. The URL
+ *   itself carries only the session token + gateway ephemeral pubkey
+ *   (fragment-encoded).
+ *
+ * Size profile for a typical ~110-char pair URL:
+ *   - `encodePng` defaults (scale=10, margin=4): ~4 KiB PNG, ~5.5 KiB
+ *     base64. Fits comfortably in a tool-call response.
+ *   - `encodeUnicode` (margin=2): ~1.1 KiB, 23 lines.
+ *
+ * We wrap the `qrcode` npm package (~50 KiB, pure TS, no native
+ * bindings) so neither tsx dev runs nor the published plugin depend on
+ * the bundler understanding CJS vs ESM subpath imports. All we use is
+ * the high-level `toBuffer` / `toString` surface.
+ */
+
+// Lazy import shape — avoids pulling `qrcode` into module load when the
+// tool is never invoked. The `qrcode` types ship with the package but
+// we describe the tiny surface we use here so a future type-drift in
+// upstream doesn't break the build.
+type QrCodeModule = {
+  toBuffer(
+    text: string,
+    options?: { errorCorrectionLevel?: 'L' | 'M' | 'Q' | 'H'; scale?: number; margin?: number },
+  ): Promise<Buffer>;
+  toString(
+    text: string,
+    options?: { type?: 'utf8'; errorCorrectionLevel?: 'L' | 'M' | 'Q' | 'H'; margin?: number },
+  ): Promise<string>;
+};
+
+/**
+ * Error class raised by the rc.5 QR encoders.
+ *
+ * Extends the built-in `Error` so `instanceof Error` checks in callers
+ * keep working.
+ */
+export class QREncodeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'QREncodeError';
+  }
+}
+
+// QR v40 maxes out at ~2953 alphanumeric bytes at ECC-L. We reject
+// payloads over 2 KiB — the pair URL should never approach this. This
+// is defence-in-depth against a caller accidentally feeding a
+// phrase-length blob.
+const MAX_PAYLOAD_BYTES = 2048;
+
+function validatePayload(url: unknown): asserts url is string {
+  if (typeof url !== 'string') {
+    throw new QREncodeError(`url must be a string, got ${typeof url}`);
+  }
+  if (url.length === 0) {
+    throw new QREncodeError('url must not be empty');
+  }
+  const bytes = Buffer.byteLength(url, 'utf-8');
+  if (bytes > MAX_PAYLOAD_BYTES) {
+    throw new QREncodeError(
+      `url too large for QR encoding: ${bytes} bytes (max ${MAX_PAYLOAD_BYTES}). ` +
+        'This limit prevents accidentally encoding phrase-length blobs; a pair ' +
+        'URL should be ~80-150 bytes.',
+    );
+  }
+}
+
+async function loadQrCodeModule(): Promise<QrCodeModule> {
+  const raw = (await import('qrcode' as string)) as unknown as
+    | (QrCodeModule & { default?: QrCodeModule })
+    | { default: QrCodeModule };
+  // qrcode ships CJS; the `default` export contains the surface under
+  // both Node's ESM interop and tsx's loader.
+  const mod = (raw as { default?: QrCodeModule }).default ?? (raw as QrCodeModule);
+  return mod;
+}
+
+export interface EncodePngOptions {
+  /** Error-correction level. Defaults to `'M'` (15%). */
+  ecc?: 'L' | 'M' | 'Q' | 'H';
+  /** Pixels per module. Defaults to 10 → ~300x300 px image. */
+  boxSize?: number;
+  /** Quiet-zone width in modules. Defaults to 4 (QR standard minimum). */
+  border?: number;
+}
+
+export interface EncodeUnicodeOptions {
+  /** Error-correction level. Defaults to `'M'`. */
+  ecc?: 'L' | 'M' | 'Q' | 'H';
+  /** Quiet-zone width in modules. Defaults to 2. */
+  border?: number;
+}
+
+/**
+ * Render `url` as a PNG QR code.
+ *
+ * @throws {QREncodeError} if the URL is empty, non-string, or exceeds
+ *   the 2 KiB safety cap.
+ */
+export async function encodePng(
+  url: string,
+  options: EncodePngOptions = {},
+): Promise<Buffer> {
+  validatePayload(url);
+  const qr = await loadQrCodeModule();
+  try {
+    return await qr.toBuffer(url, {
+      errorCorrectionLevel: options.ecc ?? 'M',
+      scale: Math.max(1, options.boxSize ?? 10),
+      margin: Math.max(0, options.border ?? 4),
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new QREncodeError(`QR encoding failed: ${msg}`);
+  }
+}
+
+/**
+ * Render `url` as a Unicode block QR string (for terminal output).
+ *
+ * Uses half-block glyphs so each character represents two vertical
+ * pixels — the resulting string renders square-ish in terminals with
+ * ~2:1 line-height. Emitted as a single newline-delimited string.
+ *
+ * @throws {QREncodeError} on invalid input.
+ */
+export async function encodeUnicode(
+  url: string,
+  options: EncodeUnicodeOptions = {},
+): Promise<string> {
+  validatePayload(url);
+  const qr = await loadQrCodeModule();
+  try {
+    return await qr.toString(url, {
+      type: 'utf8',
+      errorCorrectionLevel: options.ecc ?? 'M',
+      margin: Math.max(0, options.border ?? 2),
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new QREncodeError(`QR encoding failed: ${msg}`);
+  }
+}

--- a/skill/plugin/phrase-safety-registry.test.ts
+++ b/skill/plugin/phrase-safety-registry.test.ts
@@ -17,10 +17,13 @@
  * What this test asserts:
  *   1. `totalreclaw_onboard` is NOT present as a `registerTool` name
  *      anywhere in `index.ts`. (rc.3 registered it; rc.4 removed it.)
- *   2. `totalreclaw_pair` IS present (the approved replacement).
- *   3. No tool name containing a phrase-adjacent token (`onboard_generate`,
+ *   2. `totalreclaw_setup` and `totalreclaw_onboarding_start` are NOT
+ *      present either. (rc.4 kept them as neutered pointer stubs; rc.5
+ *      deletes both — see the rc.4 auto-QA carve-out in the PR body.)
+ *   3. `totalreclaw_pair` IS present (the approved replacement).
+ *   4. No tool name containing a phrase-adjacent token (`onboard_generate`,
  *      `restore_phrase`, `mnemonic`, `generate_phrase`) is registered.
- *   4. The scan is defense-in-depth — a text search, not an AST walk —
+ *   5. The scan is defense-in-depth — a text search, not an AST walk —
  *      because a new registration that accidentally ships a phrase
  *      surface would almost always include one of these tokens.
  *
@@ -87,6 +90,21 @@ const registered = extractRegisteredToolNames(src);
 assert(
   !registered.includes('totalreclaw_onboard'),
   'phrase-safety: totalreclaw_onboard is NOT registered (removed in rc.4)',
+);
+
+// ---------------------------------------------------------------------------
+// 1b. totalreclaw_setup and totalreclaw_onboarding_start are NOT
+//     registered (rc.5 removes the rc.4 neutered stubs — closes the
+//     auto-QA carve-out that flagged them as future-regression
+//     surface even though they couldn't leak a phrase today).
+// ---------------------------------------------------------------------------
+assert(
+  !registered.includes('totalreclaw_setup'),
+  'phrase-safety: totalreclaw_setup is NOT registered (removed in rc.5)',
+);
+assert(
+  !registered.includes('totalreclaw_onboarding_start'),
+  'phrase-safety: totalreclaw_onboarding_start is NOT registered (removed in rc.5)',
 );
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Reopening from rebased branch (old #88 closed due to stale state after #87 merged). TypeScript side of rc.10 QR + phrase-safety stub removal. Python side already in via #87.