### PR TITLE
feat(rc.11): plugin relay-brokered pair flow + Python version bump

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,16 @@ Hermes Agent plugin are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1rc11] — 2026-04-23
+
+Version-bump-only on the Python side — the substantive rc.11 change is in the OpenClaw plugin, which ports the universal-reachability relay-brokered pair flow from Python rc.10 to TypeScript. See `skill/plugin/CHANGELOG.md` (the `3.3.1-rc.11` entry) for the full design. The Python client's own relay client (`totalreclaw.pair.remote_client`) is unchanged from rc.10 and continues to back the Hermes `totalreclaw_pair` tool.
+
+We coordinate the Python + plugin version bumps so the release-pipeline tracker carries both artifacts through QA as one RC bundle.
+
+### Why a Python bump when only plugin changed
+
+Our RC cadence publishes both registries from the same bundle. Out-of-sync version tags cause downstream confusion (the `qa-totalreclaw` skill and the release-pipeline tracker both key on a single RC-number per wave). Skipping the Python bump would leave rc.11 documented on the plugin side only; a later Hermes regression would then have to skip to rc.12 to catch up. Much simpler to bump both in lockstep.
+
 ## [2.3.1rc10] — 2026-04-23
 
 rc.10 relay-brokered pair flow — default `totalreclaw_pair` now routes through `wss://api-staging.totalreclaw.xyz/pair/*` instead of a gateway-loopback HTTP server. Universal pair reachability: users can complete the pair flow from any browser on any device (phone, laptop, split-network setups) — no more `127.0.0.1` URL that only works when the browser shares a loopback with the gateway.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "totalreclaw"
-version = "2.3.1rc10"
+version = "2.3.1rc11"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"

--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1-rc.11] — 2026-04-23
+
+OpenClaw-side universal pair reachability — the plugin's `totalreclaw_pair` tool now routes through the relay WebSocket by default, mirroring the Python `2.3.1rc10` pivot on the Hermes side. The URL returned to the user is `https://api-staging.totalreclaw.xyz/pair/p/<token>#pk=<gateway_pubkey>` instead of the previous `http://<gateway-host>:<port>/plugin/totalreclaw/pair/finish?sid=<sid>#pk=…`. Managed hosts, Docker-in-cloud setups, phone-scan-QR flows, and split-network operators can now complete pairing without the browser needing loopback or LAN access to the gateway.
+
+Paired with Hermes Python `2.3.1rc11` — both clients now reach for the relay by default, and `TOTALRECLAW_PAIR_MODE=local` on either side restores the rc.4–rc.10 loopback flow for air-gapped / self-hosted deployments.
+
+### Added
+
+- **`skill/plugin/pair-remote-client.ts`** — new. TypeScript mirror of `python/src/totalreclaw/pair/remote_client.py` (rc.10 Hermes):
+  - `openRemotePairSession({ relayBaseUrl?, pin?, clientId?, mode? })` — generates an ephemeral x25519 keypair via the existing `pair-crypto.ts` module, opens a WebSocket to `/pair/session/open`, sends `{type:"open", gateway_pubkey, pin, client_id, mode}`, and returns a `RemotePairSession` handle containing the user-facing URL (with `#pk=` fragment), PIN, token, expiry, and the live WebSocket.
+  - `awaitPhraseUpload(session, { completePairing, phraseValidator?, timeoutMs? })` — blocks on the kept-open WebSocket until the relay pushes `{type:"forward", client_pubkey, nonce, ciphertext}`. Decrypts locally via `decryptPairingPayload` using the gateway's private key (same ECDH + HKDF + ChaCha20-Poly1305 primitives as rc.10's loopback flow — byte-compatible with Python's `pair.crypto`). Runs the caller-supplied `completePairing` handler and sends `{type:"ack"}` back on success or `{type:"nack", error}` on validator / decrypt / completion failure.
+  - `pairViaRelay(...)` — one-shot convenience wrapper for tests and simple callers.
+- **`ws` runtime dep** (`^8.18.3`) + **`@types/ws`** — pure-JS WebSocket client. Transitive already via `@totalreclaw/core`; rc.11 promotes it to a direct dep so the plugin's own import graph is explicit.
+- **`TOTALRECLAW_PAIR_MODE`** env (plugin side) — mirrors the Python env. Unset or any non-`local` value routes through the relay; `local` preserves the rc.4–rc.10 loopback HTTP server served by `pair-http.ts` (`/plugin/totalreclaw/pair/{finish,start,respond,status}`).
+- **`TOTALRECLAW_PAIR_RELAY_URL`** env (plugin side) — self-hosters can point at their own relay. Defaults to `wss://api-staging.totalreclaw.xyz`.
+- **`skill/plugin/pair-remote-client.test.ts`** — 20 assertions across 5 scenarios: happy-path round-trip, invalid-phrase nack, relay open error, decrypt failure, https-to-wss scheme conversion. Runs against a local `ws` server stub — no network dependency.
+
+### Changed
+
+- **`totalreclaw_pair` tool** now branches on `CONFIG.pairMode`. In relay mode it returns the URL + PIN immediately and schedules a background task that blocks on the WebSocket until the browser completes (or the TTL lapses). Credentials-write happens in that background task via the same `loadCredentialsJson` / `writeCredentialsJson` / `setRecoveryPhraseOverride` / `writeOnboardingState` side-effect chain that the loopback `pair-http.respond` handler uses — so the onboarding-state flip remains identical. Tool payload shape unchanged (`{url, pin, expires_at_ms, qr_ascii, qr_png_b64, qr_unicode, mode}`) except for a new `transport: 'relay' | 'local'` field that tooling (QA harness, telemetry) can use to confirm which path served a given URL.
+
+### Phrase-safety invariants (preserved)
+
+- Relay is blind: the gateway's ephemeral x25519 private key never leaves the plugin host. The relay forwards opaque ciphertext; it cannot derive the symmetric key.
+- PIN is out-of-band: the user reads the PIN from agent chat and types it into the browser. The relay stores the PIN in memory only; logs carry no PIN, no ciphertext, no pubkey, no phrase.
+- Session state is in-memory on the relay with a 5-minute TTL. Redis deferred to Phase 2 per the design blueprint.
+- Backwards-compat: `TOTALRECLAW_PAIR_MODE=local` preserves every bit of the rc.4–rc.10 flow — same loopback HTTP server, same session store, same browser page, same decrypt handler.
+
+### Mechanism / byte-compat
+
+The crypto is a literal TypeScript binding against the same `pair-crypto.ts` module `pair-http.ts` already imports. No new cipher suite, no new wire format — only the transport (WebSocket to relay + relay-served HTML page) differs from the loopback path. A ciphertext produced by the relay-served `pair-html.ts` page decrypts under the same gateway private key using the same `decryptPairingPayload(...)` call path. This is deliberate: `pair-crypto.ts` is the byte-compat anchor shared with Python's `pair.crypto`, and rc.11 extends that anchor to the relay wire.
+
 ## [3.3.1-rc.10] — 2026-04-23
 
 Coordinated version bump with Hermes Python `2.3.1rc10`. rc.10 ships the relay-brokered pair flow — see `python/CHANGELOG.md` (the `2.3.1rc10` entry) for the full design. The `totalreclaw_pair` pair URL on the OpenClaw plugin side still uses the gateway-loopback HTTP server (the OpenClaw plugin runs in-process alongside a browser on the same host for most deployments, so the loopback URL actually reaches the user). The relay-brokered path is currently Hermes-side only — the OpenClaw plugin can pick it up in a later RC if the same universal-reachability problem starts biting OpenClaw users.

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "Install + set up TotalReclaw encrypted memory for OpenClaw, then use totalreclaw_remember / totalreclaw_recall. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', or any remember / recall request."
-version: 3.3.1-rc.10
+version: 3.3.1-rc.11
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz

--- a/skill/plugin/config.ts
+++ b/skill/plugin/config.ts
@@ -105,6 +105,21 @@ export const CONFIG = {
   // for 15-min TTL windows; 0600 mode.
   pairSessionsPath: process.env.TOTALRECLAW_PAIR_SESSIONS_PATH || path.join(home, '.totalreclaw', 'pair-sessions.json'),
 
+  // 3.3.1-rc.11 — pair-flow transport selector. Mirrors the Python-side
+  // `TOTALRECLAW_PAIR_MODE` env (rc.10). `'relay'` (default) routes
+  // `totalreclaw_pair` through the universal-reachability WebSocket relay at
+  // `TOTALRECLAW_PAIR_RELAY_URL`. `'local'` preserves the rc.4–rc.10 loopback
+  // HTTP flow (the plugin serves `/plugin/totalreclaw/pair/*` via
+  // `pair-http.ts`). Air-gapped / self-hosted users can pin `'local'` here.
+  pairMode: (() => {
+    const v = (process.env.TOTALRECLAW_PAIR_MODE ?? '').trim().toLowerCase();
+    return v === 'local' ? 'local' : 'relay';
+  })() as 'relay' | 'local',
+  // 3.3.1-rc.11 — relay base URL for the WebSocket-brokered pair flow.
+  // `wss://` preferred; `https://` is rewritten in the remote-client.
+  pairRelayUrl: (process.env.TOTALRECLAW_PAIR_RELAY_URL
+    || 'wss://api-staging.totalreclaw.xyz').replace(/\/+$/, ''),
+
   // Chain — chainId is no longer user-configurable. It is auto-detected from
   // the relay billing response (free = Base Sepolia / 84532, Pro = Gnosis /
   // 100). The default here is used only before the first billing lookup

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -4996,18 +4996,99 @@ const plugin = {
           const rawMode = params?.mode;
           const mode: 'generate' | 'import' =
             rawMode === 'import' ? 'import' : 'generate';
+          const pairMode = CONFIG.pairMode;
           try {
-            const { createPairSession } = await import('./pair-session-store.js');
-            const { generateGatewayKeypair } = await import('./pair-crypto.js');
+            // 3.3.1-rc.11 — relay-brokered pair by default (universal reachability).
+            // `TOTALRECLAW_PAIR_MODE=local` preserves the rc.4–rc.10 loopback flow
+            // for air-gapped / self-hosted setups. Both paths return the same
+            // tool payload (`{url, pin, expires_at_ms, qr_*, mode, instructions}`);
+            // only the URL origin differs.
+            let url: string;
+            let pin: string;
+            let sidOrToken: string;
+            let expiresAtMs: number;
+            let localSession: import('./pair-session-store.js').PairSession | undefined;
+
+            if (pairMode === 'relay') {
+              const { openRemotePairSession, awaitPhraseUpload } = await import(
+                './pair-remote-client.js'
+              );
+              const remoteSession = await openRemotePairSession({
+                relayBaseUrl: CONFIG.pairRelayUrl,
+                mode: mode === 'generate' ? 'generate' : 'import',
+              });
+              url = remoteSession.url;
+              pin = remoteSession.pin;
+              sidOrToken = remoteSession.token;
+              // Relay sends ISO-8601; convert to ms for tool payload parity.
+              const parsed = Date.parse(remoteSession.expiresAt);
+              expiresAtMs = Number.isFinite(parsed)
+                ? parsed
+                : Date.now() + 5 * 60_000;
+              // Background task — writes credentials.json + flips state when
+              // the browser completes the flow. Tool handler returns
+              // immediately so the agent can tell the user the URL + PIN.
+              void (async () => {
+                try {
+                  await awaitPhraseUpload(remoteSession, {
+                    phraseValidator: (p: string) =>
+                      validateMnemonic(p, wordlist),
+                    completePairing: async ({ mnemonic }) => {
+                      try {
+                        const creds =
+                          loadCredentialsJson(CREDENTIALS_PATH) ?? {};
+                        const next = { ...creds, mnemonic };
+                        if (!writeCredentialsJson(CREDENTIALS_PATH, next)) {
+                          return { state: 'error', error: 'credentials_write_failed' };
+                        }
+                        setRecoveryPhraseOverride(mnemonic);
+                        writeOnboardingState(CONFIG.onboardingStatePath, {
+                          onboardingState: 'active',
+                          createdBy: mode === 'generate' ? 'generate' : 'import',
+                          credentialsCreatedAt: new Date().toISOString(),
+                          version: '3.3.1-rc.11',
+                        });
+                        api.logger.info(
+                          `totalreclaw_pair(relay): session ${remoteSession.token.slice(0, 8)}… completed; credentials written`,
+                        );
+                        return { state: 'active' };
+                      } catch (err: unknown) {
+                        const msg = err instanceof Error ? err.message : String(err);
+                        api.logger.error(
+                          `totalreclaw_pair(relay): completePairing failed: ${msg}`,
+                        );
+                        return { state: 'error', error: msg };
+                      }
+                    },
+                  });
+                } catch (bgErr: unknown) {
+                  // Expected on TTL expiry / user-aborts — log at warn, not error.
+                  const bgMsg = bgErr instanceof Error ? bgErr.message : String(bgErr);
+                  api.logger.warn(
+                    `totalreclaw_pair(relay): background task ended for token=${remoteSession.token.slice(0, 8)}…: ${bgMsg}`,
+                  );
+                }
+              })();
+            } else {
+              // Local loopback path (rc.10 behaviour).
+              const { createPairSession } = await import('./pair-session-store.js');
+              const { generateGatewayKeypair } = await import('./pair-crypto.js');
+              const kp = generateGatewayKeypair();
+              const session = await createPairSession(CONFIG.pairSessionsPath, {
+                mode,
+                operatorContext: { channel: 'agent' },
+                rngPrivateKey: () => Buffer.from(kp.skB64, 'base64url'),
+                rngPublicKey: () => Buffer.from(kp.pkB64, 'base64url'),
+              });
+              url = buildPairingUrl(api, session);
+              pin = session.secondaryCode;
+              sidOrToken = session.sid;
+              expiresAtMs = session.expiresAtMs;
+              localSession = session;
+            }
+
+            // QR renderers — same for both modes; input is the URL string.
             const { defaultRenderQr } = await import('./pair-cli.js');
-            const kp = generateGatewayKeypair();
-            const session = await createPairSession(CONFIG.pairSessionsPath, {
-              mode,
-              operatorContext: { channel: 'agent' },
-              rngPrivateKey: () => Buffer.from(kp.skB64, 'base64url'),
-              rngPublicKey: () => Buffer.from(kp.pkB64, 'base64url'),
-            });
-            const url = buildPairingUrl(api, session);
             const qrAscii = await new Promise<string>((resolve) => {
               let settled = false;
               const t = setTimeout(() => {
@@ -5031,13 +5112,7 @@ const plugin = {
               }
             });
 
-            // 3.3.1-rc.5 — render the same pair URL as (a) a PNG for
-            // image-capable transports (Telegram / Slack / web chat)
-            // and (b) a Unicode block string for terminal transports.
-            // The PIN is NEVER encoded into the QR; the QR carries
-            // ONLY the URL. Best-effort — if encoding fails (unlikely
-            // with the pure-TS `qrcode` lib) we ship empty strings so
-            // the URL-copy flow keeps working.
+            // 3.3.1-rc.5 — PNG + Unicode QR for multi-transport rendering.
             let qrPngB64 = '';
             let qrUnicode = '';
             try {
@@ -5057,15 +5132,19 @@ const plugin = {
             }
 
             api.logger.info(
-              `totalreclaw_pair: session ${session.sid.slice(0, 8)}… mode=${mode} url=${url} qr_png=${qrPngB64.length} qr_unicode=${qrUnicode.length}`,
+              `totalreclaw_pair: session ${sidOrToken.slice(0, 8)}… mode=${mode} transport=${pairMode} url=${url} qr_png=${qrPngB64.length} qr_unicode=${qrUnicode.length}`,
             );
+            // Voidly reference localSession so TS does not flag the unused
+            // local-branch binding. Future rc.12 diagnostics can expose
+            // `session.mode` / `session.status` separately.
+            void localSession;
             return {
               content: [{
                 type: 'text',
                 text:
                   `Pairing session started.\n\n` +
                   `URL: ${url}\n\n` +
-                  `PIN (type this into the browser): ${session.secondaryCode}\n\n` +
+                  `PIN (type this into the browser): ${pin}\n\n` +
                   (qrAscii ? `QR code:\n\n${qrAscii}\n\n` : '') +
                   `Instructions for the user:\n` +
                   `1. Open the URL above on their phone or another browser (scan the QR or copy-paste).\n` +
@@ -5079,16 +5158,18 @@ const plugin = {
                   `This session expires in ~5 minutes. Run this tool again if you need a fresh URL.`,
               }],
               details: {
-                sid: session.sid,
+                sid: sidOrToken,
                 url,
-                pin: session.secondaryCode,
+                pin,
                 mode,
-                expires_at_ms: session.expiresAtMs,
+                expires_at_ms: expiresAtMs,
                 qr_ascii: qrAscii,
-                // rc.5 additions — see SKILL.md "Rendering the QR on
-                // your transport" section for the agent-side logic.
                 qr_png_b64: qrPngB64,
                 qr_unicode: qrUnicode,
+                // rc.11 — surface the transport so downstream tooling (QA
+                // harness asserters, telemetry) can confirm which path
+                // served the URL. Either 'relay' or 'local'.
+                transport: pairMode,
               },
             };
           } catch (err: unknown) {

--- a/skill/plugin/package-lock.json
+++ b/skill/plugin/package-lock.json
@@ -1,21 +1,23 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.1-rc.10",
+  "version": "3.3.1-rc.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/totalreclaw",
-      "version": "3.3.1-rc.10",
+      "version": "3.3.1-rc.11",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.0.1",
         "@totalreclaw/client": "^1.2.0",
         "@totalreclaw/core": "^2.1.1",
         "@types/qrcode": "^1.5.6",
+        "@types/ws": "^8.5.12",
         "onnxruntime-node": "^1.24.0",
         "qrcode": "^1.5.4",
-        "qrcode-terminal": "^0.12.0"
+        "qrcode-terminal": "^0.12.0",
+        "ws": "^8.18.3"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -775,6 +777,15 @@
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
       "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.1-rc.10",
+  "version": "3.3.1-rc.11",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [
@@ -35,9 +35,11 @@
     "@totalreclaw/client": "^1.2.0",
     "@totalreclaw/core": "^2.1.1",
     "@types/qrcode": "^1.5.6",
+    "@types/ws": "^8.5.12",
     "onnxruntime-node": "^1.24.0",
     "qrcode": "^1.5.4",
-    "qrcode-terminal": "^0.12.0"
+    "qrcode-terminal": "^0.12.0",
+    "ws": "^8.18.3"
   },
   "files": [
     "*.ts",
@@ -52,7 +54,7 @@
     "skill.json"
   ],
   "scripts": {
-    "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx llm-client-retry.test.ts && npx tsx gateway-url.test.ts && npx tsx retype-setscope.test.ts && npx tsx tool-gating.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts && npx tsx pair-qr.test.ts && npx tsx qa-bug-report.test.ts && npx tsx nonce-serialization.test.ts && npx tsx phrase-safety-registry.test.ts",
+    "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx llm-client-retry.test.ts && npx tsx gateway-url.test.ts && npx tsx retype-setscope.test.ts && npx tsx tool-gating.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts && npx tsx pair-qr.test.ts && npx tsx pair-remote-client.test.ts && npx tsx qa-bug-report.test.ts && npx tsx nonce-serialization.test.ts && npx tsx phrase-safety-registry.test.ts",
     "check-scanner": "node ../scripts/check-scanner.mjs",
     "prepublishOnly": "node ../scripts/check-scanner.mjs"
   },

--- a/skill/plugin/pair-remote-client.test.ts
+++ b/skill/plugin/pair-remote-client.test.ts
@@ -1,0 +1,438 @@
+/**
+ * Tests for `pair-remote-client` — relay-brokered pair flow (plugin rc.11).
+ *
+ * Runs a local WebSocket server that mimics the relay's open/forward/ack
+ * protocol so the test covers the full TS <-> relay wire with no network
+ * dependency. Encryption vectors are produced with the same `pair-crypto`
+ * primitives the gateway would use — so the round-trip proves:
+ *
+ *   1. open frame shape is correct
+ *   2. opened reply drives the user URL / PIN / token plumbing
+ *   3. forward frame is decrypted locally + completion handler is invoked
+ *   4. ack is sent back on success; nack carries a typed error on failure
+ *
+ * Does NOT run against the real staging relay — that is covered by the
+ * auto-QA harness after publish.
+ */
+import { WebSocketServer, WebSocket } from 'ws';
+import { createServer, type Server as HttpServer } from 'node:http';
+import { AddressInfo } from 'node:net';
+
+import {
+  awaitPhraseUpload,
+  openRemotePairSession,
+} from './pair-remote-client.js';
+import {
+  encryptPairingPayload,
+  generateGatewayKeypair,
+  type GatewayKeypair,
+} from './pair-crypto.js';
+
+// Minimal tap-style harness — matches the rest of this plugin's test style.
+let _passed = 0;
+let _failed = 0;
+let _seq = 0;
+function ok(name: string, cond: boolean, detail?: string): void {
+  const status = cond ? 'ok' : 'fail';
+  const tail = detail ? ` -- ${detail}` : '';
+  _seq += 1;
+  // eslint-disable-next-line no-console
+  console.log(`${status} ${_seq} - ${name}${tail}`);
+  if (cond) _passed += 1;
+  else _failed += 1;
+}
+
+/** The phrase the "browser" side will encrypt + upload in these tests. */
+const TEST_PHRASE =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+/** Non-BIP-39 lowercase ASCII — still matches the 12-word regex. */
+const INVALID_PHRASE =
+  'foo foo foo foo foo foo foo foo foo foo foo foo';
+
+// ---------------------------------------------------------------------------
+// Relay stub
+// ---------------------------------------------------------------------------
+
+interface RelayStubOptions {
+  /** Override the default `token` the stub issues. */
+  token?: string;
+  /** Override the `expires_at` ISO string. */
+  expiresAt?: string;
+  /** If true, send an `{type:"error"}` frame instead of `opened`. */
+  errorOnOpen?: string;
+  /** Delay (ms) before sending the forward frame. Default 10. */
+  forwardAfterMs?: number;
+  /** If true, mimic a nonce/ciphertext built for the WRONG session id. */
+  corruptSid?: boolean;
+  /**
+   * Phrase the stub-browser encrypts + uploads. Default TEST_PHRASE. Set
+   * to something non-BIP-39 to exercise validator failure paths.
+   */
+  phrase?: string;
+  /**
+   * Force a device keypair so the test can verify the exact client pubkey
+   * that reaches the gateway side.
+   */
+  forceDeviceKeypair?: GatewayKeypair;
+}
+
+interface RelayStub {
+  wssUrl: string;
+  /** Resolves with whatever frame the stub last received from the gateway. */
+  lastGatewayFrame: () => Record<string, unknown> | null;
+  /** Resolves when the `ack` or `nack` from the gateway arrives (or when the WS closes). */
+  awaitAck: () => Promise<'ack' | 'nack' | 'closed'>;
+  close: () => Promise<void>;
+}
+
+async function startRelayStub(opts: RelayStubOptions = {}): Promise<RelayStub> {
+  const token = opts.token ?? 'testtoken12345678';
+  const expiresAt =
+    opts.expiresAt ?? new Date(Date.now() + 60_000).toISOString();
+  const forwardDelay = opts.forwardAfterMs ?? 10;
+  const phrase = opts.phrase ?? TEST_PHRASE;
+
+  const http: HttpServer = createServer();
+  const wss = new WebSocketServer({ server: http });
+
+  let lastFrame: Record<string, unknown> | null = null;
+  let ackResolver: ((v: 'ack' | 'nack' | 'closed') => void) | null = null;
+  const ackPromise: Promise<'ack' | 'nack' | 'closed'> = new Promise(
+    (resolve) => {
+      ackResolver = resolve;
+    },
+  );
+
+  wss.on('connection', (ws) => {
+    ws.on('message', async (raw) => {
+      try {
+        const text =
+          typeof raw === 'string'
+            ? raw
+            : Buffer.from(raw as ArrayBuffer).toString('utf-8');
+        const msg = JSON.parse(text) as Record<string, unknown>;
+        lastFrame = msg;
+
+        // First frame must be `open`. Reply with `opened` (or `error`).
+        if (msg.type === 'open') {
+          if (opts.errorOnOpen) {
+            ws.send(JSON.stringify({ type: 'error', error: opts.errorOnOpen }));
+            return;
+          }
+          ws.send(
+            JSON.stringify({
+              type: 'opened',
+              token,
+              short_url: `/pair/p/${token}`,
+              expires_at: expiresAt,
+            }),
+          );
+
+          // Simulate the browser POST: encrypt the phrase for the gateway's
+          // public key + push a `forward` frame.
+          setTimeout(() => {
+            const gatewayPubkey = String(msg.gateway_pubkey);
+            const deviceKp =
+              opts.forceDeviceKeypair ?? generateGatewayKeypair();
+            const sid = opts.corruptSid ? 'wrong-sid' : token;
+            const { nonceB64, ciphertextB64 } = encryptPairingPayload({
+              skLocalB64: deviceKp.skB64,
+              pkRemoteB64: gatewayPubkey,
+              sid,
+              plaintext: Buffer.from(phrase, 'utf-8'),
+            });
+            ws.send(
+              JSON.stringify({
+                type: 'forward',
+                client_pubkey: deviceKp.pkB64,
+                nonce: nonceB64,
+                ciphertext: ciphertextB64,
+              }),
+            );
+          }, forwardDelay);
+          return;
+        }
+
+        if (msg.type === 'ack') {
+          ackResolver?.('ack');
+          ackResolver = null;
+          try {
+            ws.close();
+          } catch {
+            /* noop */
+          }
+          return;
+        }
+        if (msg.type === 'nack') {
+          ackResolver?.('nack');
+          ackResolver = null;
+          try {
+            ws.close();
+          } catch {
+            /* noop */
+          }
+          return;
+        }
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('relay-stub: message handler error', err);
+      }
+    });
+
+    ws.on('close', () => {
+      if (ackResolver) {
+        ackResolver('closed');
+        ackResolver = null;
+      }
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    http.listen(0, '127.0.0.1', () => resolve());
+  });
+
+  const addr = http.address() as AddressInfo;
+  const wssUrl = `ws://127.0.0.1:${addr.port}`;
+
+  return {
+    wssUrl,
+    lastGatewayFrame: () => lastFrame,
+    awaitAck: () => ackPromise,
+    close: () =>
+      new Promise<void>((resolve) => {
+        try {
+          wss.close(() => {
+            http.close(() => resolve());
+          });
+        } catch {
+          resolve();
+        }
+      }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+async function testHappyPath(): Promise<void> {
+  const stub = await startRelayStub({ token: 'abc12345' });
+  try {
+    const session = await openRemotePairSession({
+      relayBaseUrl: stub.wssUrl,
+      pin: '123456',
+      clientId: 'gw-test-1',
+      mode: 'either',
+      webSocketImpl: WebSocket,
+    });
+
+    // Assertions against the open-side plumbing.
+    ok(
+      'happy: URL contains the token',
+      session.url.includes('/pair/p/abc12345'),
+      session.url,
+    );
+    ok(
+      'happy: URL uses https scheme (stub serves ws://)',
+      session.url.startsWith('http://'),
+      session.url,
+    );
+    ok(
+      'happy: URL carries #pk= fragment',
+      /#pk=[A-Za-z0-9_-]{40,48}$/.test(session.url),
+      session.url,
+    );
+    ok('happy: PIN echoes', session.pin === '123456');
+    ok('happy: token echoes', session.token === 'abc12345');
+
+    const firstFrame = stub.lastGatewayFrame();
+    ok(
+      'happy: open frame has correct shape',
+      !!firstFrame &&
+        firstFrame.type === 'open' &&
+        typeof firstFrame.gateway_pubkey === 'string' &&
+        firstFrame.pin === '123456' &&
+        firstFrame.client_id === 'gw-test-1' &&
+        firstFrame.mode === 'either',
+      JSON.stringify(firstFrame),
+    );
+
+    // Block on phrase upload.
+    let completed = false;
+    const result = await awaitPhraseUpload(session, {
+      completePairing: async ({ mnemonic }) => {
+        completed = true;
+        // MUST NOT log the phrase — but we can assert on its shape for the test.
+        ok(
+          'happy: completion received full 12-word phrase',
+          mnemonic.split(' ').length === 12 && mnemonic === TEST_PHRASE,
+          `len=${mnemonic.split(' ').length}`,
+        );
+        return { state: 'active', accountId: '0xdeadbeef' };
+      },
+    });
+
+    ok('happy: completePairing called', completed);
+    ok('happy: result.state active', result.state === 'active');
+    ok(
+      'happy: result.accountId echoed',
+      result.accountId === '0xdeadbeef',
+    );
+
+    const ack = await stub.awaitAck();
+    ok('happy: gateway sent ack', ack === 'ack');
+  } finally {
+    await stub.close();
+  }
+}
+
+async function testInvalidPhraseSendsNack(): Promise<void> {
+  const stub = await startRelayStub({ phrase: INVALID_PHRASE });
+  try {
+    const session = await openRemotePairSession({
+      relayBaseUrl: stub.wssUrl,
+      pin: '654321',
+    });
+
+    let called = false;
+    let threw = false;
+    try {
+      await awaitPhraseUpload(session, {
+        completePairing: async () => {
+          called = true;
+          return { state: 'active' };
+        },
+        phraseValidator: (_p) => false,
+      });
+    } catch (err) {
+      threw =
+        err instanceof Error &&
+        /failed BIP-39 validation/.test(err.message);
+    }
+
+    ok(
+      'invalid-phrase: completePairing NOT invoked',
+      !called,
+    );
+    ok(
+      'invalid-phrase: awaitPhraseUpload threw validation error',
+      threw,
+    );
+
+    const ack = await stub.awaitAck();
+    ok('invalid-phrase: gateway sent nack', ack === 'nack');
+  } finally {
+    await stub.close();
+  }
+}
+
+async function testOpenErrorPropagates(): Promise<void> {
+  const stub = await startRelayStub({ errorOnOpen: 'rate_limited' });
+  try {
+    let threw = false;
+    try {
+      await openRemotePairSession({
+        relayBaseUrl: stub.wssUrl,
+        pin: '000000',
+      });
+    } catch (err) {
+      threw =
+        err instanceof Error && /rate_limited/.test(err.message);
+    }
+    ok('open-error: error propagates with relay error code', threw);
+  } finally {
+    await stub.close();
+  }
+}
+
+async function testDecryptFailureSendsNack(): Promise<void> {
+  const stub = await startRelayStub({ corruptSid: true });
+  try {
+    const session = await openRemotePairSession({
+      relayBaseUrl: stub.wssUrl,
+      pin: '999999',
+    });
+
+    let called = false;
+    let threw = false;
+    try {
+      await awaitPhraseUpload(session, {
+        completePairing: async () => {
+          called = true;
+          return { state: 'active' };
+        },
+      });
+    } catch {
+      threw = true;
+    }
+    ok('decrypt-fail: completePairing NOT invoked', !called);
+    ok('decrypt-fail: awaitPhraseUpload threw', threw);
+    const ack = await stub.awaitAck();
+    ok('decrypt-fail: gateway sent nack', ack === 'nack');
+  } finally {
+    await stub.close();
+  }
+}
+
+async function testHttpsInputConvertedToWss(): Promise<void> {
+  // The caller passes a https:// URL (as most config plumbing will produce
+  // in production); the client should still hit wss://host/pair/session/open.
+  const stub = await startRelayStub({ token: 'https-test' });
+  try {
+    const httpsStyle = stub.wssUrl.replace(/^ws:/, 'http:');
+    const session = await openRemotePairSession({
+      relayBaseUrl: httpsStyle,
+      pin: '111111',
+    });
+    ok(
+      'scheme-convert: URL uses http scheme (because stub is http://)',
+      session.url.startsWith('http://'),
+      session.url,
+    );
+    ok(
+      'scheme-convert: URL contains token',
+      session.url.includes('/pair/p/https-test'),
+      session.url,
+    );
+    // Clean shutdown — cancel the awaiting phrase upload.
+    try {
+      session._ws.close();
+    } catch {
+      /* noop */
+    }
+  } finally {
+    await stub.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  await testHappyPath();
+  await testInvalidPhraseSendsNack();
+  await testOpenErrorPropagates();
+  await testDecryptFailureSendsNack();
+  await testHttpsInputConvertedToWss();
+
+  // eslint-disable-next-line no-console
+  console.log(`# fail: ${_failed}`);
+  // eslint-disable-next-line no-console
+  console.log(`# ${_passed}/${_passed + _failed} passed`);
+  if (_failed > 0) {
+    // eslint-disable-next-line no-console
+    console.log('TESTS FAILED');
+    process.exit(1);
+  } else {
+    // eslint-disable-next-line no-console
+    console.log('ALL TESTS PASSED');
+  }
+}
+
+main().catch((err) => {
+  // eslint-disable-next-line no-console
+  console.error('Test runner crashed:', err);
+  process.exit(1);
+});

--- a/skill/plugin/pair-remote-client.ts
+++ b/skill/plugin/pair-remote-client.ts
@@ -1,0 +1,540 @@
+/**
+ * pair-remote-client — gateway-side WebSocket client for the relay-brokered
+ * pair flow (plugin rc.11).
+ *
+ * TypeScript mirror of ``python/src/totalreclaw/pair/remote_client.py``. Wire
+ * formats (WebSocket frame shapes, URL layout, base64url encoding) match the
+ * Python implementation byte-for-byte so either side can open a session that
+ * the relay (`totalreclaw-relay`) + browser page (`pair-html.ts`) already
+ * understand. Crypto primitives come from the shared ``pair-crypto.ts``
+ * module — the same ECDH + HKDF + ChaCha20-Poly1305 stack the loopback HTTP
+ * server uses.
+ *
+ * Flow (this file implements the gateway half):
+ *
+ *   1. Generate an ephemeral x25519 keypair (`generateGatewayKeypair`).
+ *   2. Open a short-lived WebSocket to `wss://<relay>/pair/session/open`.
+ *   3. Send `{type: "open", gateway_pubkey, pin, client_id, mode?}`.
+ *   4. Receive `{type: "opened", token, short_url, expires_at}` — use these
+ *      to build the user-facing pair URL (token + `#pk=<gateway_pubkey>`).
+ *   5. Block on the WebSocket until the relay pushes
+ *      `{type: "forward", client_pubkey, nonce, ciphertext}`.
+ *   6. Decrypt locally via `decryptPairingPayload` using the gateway private
+ *      key. If decrypt succeeds and phrase is valid, call the caller's
+ *      `completePairing` handler (writes credentials.json).
+ *   7. Send `{type: "ack"}` back; close the WebSocket.
+ *
+ * Phrase-safety invariants preserved:
+ *   - Relay sees only ciphertext; it cannot derive the symmetric key without
+ *     the gateway's private key.
+ *   - The gateway pubkey transits the relay as a label in the open frame so
+ *     the relay can display the session, but is ALSO bound into the URL
+ *     fragment the user opens — the fragment never hits the relay.
+ *   - Phrase NEVER enters any logs. PIN is never logged.
+ *   - No relay credentials are required — auth is the single-use PIN +
+ *     5-minute TTL + gateway ECDH private key.
+ *
+ * Scope / scanner surface:
+ *   - NO `fs.*` primitives (delegates credentials writes to the caller via
+ *     `completePairing`). Safe for the check-scanner cross-rule guard.
+ *   - NO env-var reads. Caller passes `relayBaseUrl` explicitly; the plugin
+ *     sources it from the `TOTALRECLAW_PAIR_RELAY_URL` env (via `config.ts`)
+ *     or falls back to the staging default.
+ */
+
+import { randomBytes, randomInt } from 'node:crypto';
+
+import WebSocket from 'ws';
+
+import {
+  decryptPairingPayload,
+  generateGatewayKeypair,
+  type GatewayKeypair,
+} from './pair-crypto.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default relay endpoint. Caller passes `TOTALRECLAW_PAIR_RELAY_URL` via config. */
+export const DEFAULT_RELAY_URL = 'wss://api-staging.totalreclaw.xyz';
+
+/** WebSocket connect + handshake timeout (ms). */
+const OPEN_TIMEOUT_MS = 10_000;
+
+/** Default blocking-await-for-forward timeout (5 minutes — matches relay TTL). */
+const DEFAULT_AWAIT_TIMEOUT_MS = 5 * 60_000;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Pair mode forwarded in the open frame. Relay uses it to pick the HTML panel. */
+export type PairRelayMode = 'generate' | 'import' | 'either';
+
+/**
+ * Handle returned by `openRemotePairSession`. Carries the user-facing URL
+ * + PIN + keypair + a live WebSocket. The caller normally hands the URL /
+ * PIN to the user via chat, then calls `awaitPhraseUpload(session, ...)` to
+ * block until the browser completes.
+ */
+export interface RemotePairSession {
+  /** User-facing pair URL (https://… plus `#pk=` fragment). */
+  url: string;
+  /** 6-digit PIN the user types into the browser. */
+  pin: string;
+  /** Opaque session token issued by the relay. */
+  token: string;
+  /** ISO-8601 timestamp when the relay will drop the session. */
+  expiresAt: string;
+  /** Ephemeral gateway keypair for this session. `skB64` stays in-process. */
+  keypair: GatewayKeypair;
+  /** Relay mode forwarded in the open frame. */
+  mode: PairRelayMode;
+  /** Live WebSocket. Internal — the caller does not interact with it. */
+  _ws: WebSocket;
+}
+
+/** Outcome of the caller-supplied completion handler. */
+export interface RelayCompletionResult {
+  state: 'active' | 'error';
+  accountId?: string;
+  error?: string;
+}
+
+/**
+ * Completion handler signature. Receives the decrypted recovery phrase as a
+ * plain string + the live session. Expected to write credentials.json + flip
+ * onboarding state. MUST NOT log or return the phrase. The returned
+ * `RelayCompletionResult` decides whether the relay sees `ack` or `nack`.
+ */
+export type RelayCompletePairingHandler = (inputs: {
+  mnemonic: string;
+  session: RemotePairSession;
+}) => Promise<RelayCompletionResult>;
+
+/** Optional phrase validator — caller can pass `validateMnemonic` from `@scure/bip39`. */
+export type PhraseValidator = (phrase: string) => boolean;
+
+/** Default validator — 12 or 24 lowercase ASCII words. Matches pair-http default. */
+function defaultBip39CountValidator(phrase: string): boolean {
+  const words = phrase.split(' ');
+  if (words.length !== 12 && words.length !== 24) return false;
+  return words.every((w) => /^[a-z]+$/.test(w));
+}
+
+/** 6-digit uniform PIN. Uses `node:crypto.randomInt` (cryptographically random). */
+function defaultPin(): string {
+  const n = randomInt(0, 1_000_000);
+  return n.toString(10).padStart(6, '0');
+}
+
+/** Random hex client id. Opaque to the relay. */
+function defaultClientId(): string {
+  return 'gw-' + randomBytes(8).toString('hex');
+}
+
+/**
+ * Assemble the user-facing pair URL. Converts `wss://` → `https://` and
+ * `ws://` → `http://` for the URL the user opens in a browser. The gateway
+ * pubkey lives in the URL fragment so it never hits relay logs.
+ */
+function buildUserUrl(relayBase: string, token: string, pkB64: string): string {
+  let httpBase = relayBase;
+  if (httpBase.startsWith('wss://')) {
+    httpBase = 'https://' + httpBase.slice('wss://'.length);
+  } else if (httpBase.startsWith('ws://')) {
+    httpBase = 'http://' + httpBase.slice('ws://'.length);
+  }
+  return `${httpBase}/pair/p/${token}#pk=${pkB64}`;
+}
+
+/**
+ * Normalise the relay base URL for the WebSocket connect. We always hit
+ * `wss://` for the open-frame WS even if the caller passed an `https://`
+ * browser-facing URL in the config (most self-hosters will pass one URL for
+ * both). Strips trailing slashes.
+ */
+function wsConnectBase(relayBase: string): string {
+  let base = relayBase.replace(/\/+$/, '');
+  if (base.startsWith('https://')) {
+    base = 'wss://' + base.slice('https://'.length);
+  } else if (base.startsWith('http://')) {
+    base = 'ws://' + base.slice('http://'.length);
+  }
+  return base;
+}
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface OpenRemotePairOptions {
+  /** Relay base URL. Defaults to `DEFAULT_RELAY_URL`. */
+  relayBaseUrl?: string;
+  /** Override the auto-generated PIN (tests). */
+  pin?: string;
+  /** Override the auto-generated client id (tests). */
+  clientId?: string;
+  /** Pair mode advertised in the open frame. Defaults to 'either'. */
+  mode?: PairRelayMode;
+  /** Override the random keypair generator (tests). */
+  keypair?: GatewayKeypair;
+  /** Override the WebSocket constructor (tests inject a stub). */
+  webSocketImpl?: typeof WebSocket;
+  /** Override `Date.now` for deterministic expiry strings (tests). */
+  now?: () => number;
+}
+
+export interface AwaitPhraseUploadOptions {
+  /** Completion handler — writes credentials and returns state. */
+  completePairing: RelayCompletePairingHandler;
+  /** Optional phrase validator. Defaults to 12/24-word lowercase-ASCII. */
+  phraseValidator?: PhraseValidator;
+  /** Timeout for the forward frame arrival (ms). Default 5 min. */
+  timeoutMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Open
+// ---------------------------------------------------------------------------
+
+/**
+ * Open a pair session on the relay. Returns a handle with the user-facing
+ * URL, 6-digit PIN, expiry, keypair, and a live WebSocket the caller holds
+ * until `awaitPhraseUpload` resolves.
+ *
+ * Throws if the relay responds with `{type: "error"}` or an unexpected frame.
+ */
+export async function openRemotePairSession(
+  opts: OpenRemotePairOptions = {},
+): Promise<RemotePairSession> {
+  const relayBase = (opts.relayBaseUrl ?? DEFAULT_RELAY_URL).replace(/\/+$/, '');
+  const wsBase = wsConnectBase(relayBase);
+  const wsUrl = `${wsBase}/pair/session/open`;
+  const WebSocketImpl = opts.webSocketImpl ?? WebSocket;
+  const keypair = opts.keypair ?? generateGatewayKeypair();
+  const pin = opts.pin ?? defaultPin();
+  const clientId = opts.clientId ?? defaultClientId();
+  const mode: PairRelayMode = opts.mode ?? 'either';
+
+  const ws: WebSocket = new WebSocketImpl(wsUrl, {
+    handshakeTimeout: OPEN_TIMEOUT_MS,
+  });
+
+  // Wait for the WS to open (so `send` doesn't race the handshake).
+  try {
+    await waitOpen(ws, OPEN_TIMEOUT_MS);
+  } catch (err) {
+    safeClose(ws);
+    throw err;
+  }
+
+  // Send the open frame.
+  try {
+    ws.send(
+      JSON.stringify({
+        type: 'open',
+        gateway_pubkey: keypair.pkB64,
+        pin,
+        client_id: clientId,
+        mode,
+      }),
+    );
+  } catch (err) {
+    safeClose(ws);
+    throw err instanceof Error ? err : new Error(String(err));
+  }
+
+  // Wait for the opened frame.
+  let raw: Buffer | ArrayBuffer | string;
+  try {
+    raw = await waitNextMessage(ws, OPEN_TIMEOUT_MS);
+  } catch (err) {
+    safeClose(ws);
+    throw err;
+  }
+
+  let msg: { type?: string; [k: string]: unknown };
+  try {
+    const text = typeof raw === 'string' ? raw : Buffer.from(raw as ArrayBuffer).toString('utf-8');
+    msg = JSON.parse(text);
+  } catch {
+    safeClose(ws);
+    throw new Error('pair-remote-client: opened frame not valid JSON');
+  }
+
+  if (msg.type === 'error') {
+    const errStr = typeof msg.error === 'string' ? msg.error : 'relay_error';
+    safeClose(ws);
+    throw new Error(`pair-remote-client: session/open failed: ${errStr}`);
+  }
+
+  if (msg.type !== 'opened') {
+    safeClose(ws);
+    throw new Error(`pair-remote-client: unexpected response type '${String(msg.type)}'`);
+  }
+
+  const token = typeof msg.token === 'string' ? msg.token : '';
+  const expiresAt = typeof msg.expires_at === 'string' ? msg.expires_at : '';
+  if (!token || !expiresAt) {
+    safeClose(ws);
+    throw new Error('pair-remote-client: opened frame missing token or expires_at');
+  }
+
+  const url = buildUserUrl(relayBase, token, keypair.pkB64);
+
+  return {
+    url,
+    pin,
+    token,
+    expiresAt,
+    keypair,
+    mode,
+    _ws: ws,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Await + decrypt + ack
+// ---------------------------------------------------------------------------
+
+/**
+ * Block on the WebSocket until the relay pushes the encrypted phrase, then
+ * decrypt and invoke `completePairing`. Sends `{type: "ack"}` on success or
+ * `{type: "nack", error: "..."}` on failure, then closes the WebSocket.
+ *
+ * Returns the `RelayCompletionResult` produced by the caller's handler.
+ *
+ * Caller semantics: most plugin callers schedule this as a background task so
+ * the `totalreclaw_pair` tool handler can return the URL + PIN to the agent
+ * immediately, and the phrase-upload wait happens asynchronously while the
+ * agent chats with the user.
+ */
+export async function awaitPhraseUpload(
+  session: RemotePairSession,
+  opts: AwaitPhraseUploadOptions,
+): Promise<RelayCompletionResult> {
+  const validate = opts.phraseValidator ?? defaultBip39CountValidator;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_AWAIT_TIMEOUT_MS;
+  const ws = session._ws;
+
+  let raw: Buffer | ArrayBuffer | string;
+  try {
+    raw = await waitNextMessage(ws, timeoutMs);
+  } catch (err) {
+    safeClose(ws);
+    throw err;
+  }
+
+  let msg: { type?: string; [k: string]: unknown };
+  try {
+    const text = typeof raw === 'string' ? raw : Buffer.from(raw as ArrayBuffer).toString('utf-8');
+    msg = JSON.parse(text);
+  } catch {
+    safeSend(ws, { type: 'nack', error: 'bad_json' });
+    safeClose(ws);
+    throw new Error('pair-remote-client: forward frame not valid JSON');
+  }
+
+  if (msg.type !== 'forward') {
+    safeSend(ws, { type: 'nack', error: 'expected_forward' });
+    safeClose(ws);
+    throw new Error(`pair-remote-client: unexpected frame '${String(msg.type)}'`);
+  }
+
+  const clientPubkey = typeof msg.client_pubkey === 'string' ? msg.client_pubkey : '';
+  const nonce = typeof msg.nonce === 'string' ? msg.nonce : '';
+  const ciphertext = typeof msg.ciphertext === 'string' ? msg.ciphertext : '';
+  if (!clientPubkey || !nonce || !ciphertext) {
+    safeSend(ws, { type: 'nack', error: 'bad_forward_body' });
+    safeClose(ws);
+    throw new Error('pair-remote-client: forward frame missing required fields');
+  }
+
+  // Decrypt locally (ciphertext + shared-secret derivation never leave this host).
+  let plaintext: Buffer;
+  try {
+    plaintext = decryptPairingPayload({
+      skGatewayB64: session.keypair.skB64,
+      pkDeviceB64: clientPubkey,
+      sid: session.token,
+      nonceB64: nonce,
+      ciphertextB64: ciphertext,
+    });
+  } catch (err) {
+    safeSend(ws, { type: 'nack', error: 'decrypt_failed' });
+    safeClose(ws);
+    throw err instanceof Error ? err : new Error(String(err));
+  }
+
+  // Decode + normalize. Match pair-http's BIP-39 norm: NFKC → lowercase → trim → single-space.
+  let mnemonic: string;
+  try {
+    mnemonic = plaintext
+      .toString('utf-8')
+      .normalize('NFKC')
+      .toLowerCase()
+      .trim()
+      .split(/\s+/)
+      .join(' ');
+  } catch (err) {
+    safeSend(ws, { type: 'nack', error: 'bad_utf8' });
+    safeClose(ws);
+    throw err instanceof Error ? err : new Error(String(err));
+  } finally {
+    // Best-effort: scrub the raw plaintext buffer.
+    plaintext.fill(0);
+  }
+
+  if (!validate(mnemonic)) {
+    safeSend(ws, { type: 'nack', error: 'invalid_mnemonic' });
+    safeClose(ws);
+    throw new Error('pair-remote-client: phrase failed BIP-39 validation');
+  }
+
+  // Hand off to the caller-supplied completion handler. Wrapped in try/finally
+  // so we always drop our own reference to the mnemonic.
+  let result: RelayCompletionResult;
+  try {
+    result = await opts.completePairing({ mnemonic, session });
+  } catch (err) {
+    safeSend(ws, { type: 'nack', error: 'completion_failed' });
+    safeClose(ws);
+    throw err instanceof Error ? err : new Error(String(err));
+  } finally {
+    // Drop our reference. JS strings are immutable so we can't zero them;
+    // rebinding at least drops the reference from this closure.
+    mnemonic = '';
+  }
+
+  if (result.state !== 'active') {
+    safeSend(ws, { type: 'nack', error: result.error ?? 'completion_failed' });
+    safeClose(ws);
+    return result;
+  }
+
+  safeSend(ws, { type: 'ack' });
+  safeClose(ws);
+  return result;
+}
+
+/**
+ * One-shot convenience: open session + await phrase upload + run completion.
+ * Tool handlers normally split this into two calls so the agent can tell the
+ * user the URL + PIN before blocking. This helper exists for tests and for
+ * simpler callers.
+ */
+export async function pairViaRelay(opts: {
+  completePairing: RelayCompletePairingHandler;
+  relayBaseUrl?: string;
+  pin?: string;
+  mode?: PairRelayMode;
+  phraseValidator?: PhraseValidator;
+  timeoutMs?: number;
+}): Promise<RelayCompletionResult> {
+  const session = await openRemotePairSession({
+    relayBaseUrl: opts.relayBaseUrl,
+    pin: opts.pin,
+    mode: opts.mode,
+  });
+  return awaitPhraseUpload(session, {
+    completePairing: opts.completePairing,
+    phraseValidator: opts.phraseValidator,
+    timeoutMs: opts.timeoutMs,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// WS helpers
+// ---------------------------------------------------------------------------
+
+function waitOpen(ws: WebSocket, timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (ws.readyState === WebSocket.OPEN) {
+      resolve();
+      return;
+    }
+    const onOpen = (): void => {
+      cleanup();
+      resolve();
+    };
+    const onError = (err: Error): void => {
+      cleanup();
+      reject(err instanceof Error ? err : new Error(String(err)));
+    };
+    const onClose = (code: number): void => {
+      cleanup();
+      reject(new Error(`pair-remote-client: ws closed before open (${code})`));
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error('pair-remote-client: ws open timeout'));
+    }, timeoutMs);
+    const cleanup = (): void => {
+      clearTimeout(timer);
+      ws.off('open', onOpen);
+      ws.off('error', onError);
+      ws.off('close', onClose);
+    };
+    ws.on('open', onOpen);
+    ws.on('error', onError);
+    ws.on('close', onClose);
+  });
+}
+
+function waitNextMessage(
+  ws: WebSocket,
+  timeoutMs: number,
+): Promise<Buffer | ArrayBuffer | string> {
+  return new Promise((resolve, reject) => {
+    const onMessage = (data: Buffer | ArrayBuffer | string): void => {
+      cleanup();
+      resolve(data);
+    };
+    const onError = (err: Error): void => {
+      cleanup();
+      reject(err instanceof Error ? err : new Error(String(err)));
+    };
+    const onClose = (code: number): void => {
+      cleanup();
+      reject(new Error(`pair-remote-client: ws closed before message (${code})`));
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error('pair-remote-client: ws message timeout'));
+    }, timeoutMs);
+    const cleanup = (): void => {
+      clearTimeout(timer);
+      ws.off('message', onMessage);
+      ws.off('error', onError);
+      ws.off('close', onClose);
+    };
+    ws.on('message', onMessage);
+    ws.on('error', onError);
+    ws.on('close', onClose);
+  });
+}
+
+function safeSend(ws: WebSocket, msg: unknown): void {
+  try {
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(msg));
+    }
+  } catch {
+    /* swallow */
+  }
+}
+
+function safeClose(ws: WebSocket): void {
+  try {
+    if (
+      ws.readyState === WebSocket.OPEN ||
+      ws.readyState === WebSocket.CONNECTING
+    ) {
+      ws.close();
+    }
+  } catch {
+    /* swallow */
+  }
+}


### PR DESCRIPTION
## Summary

- **rc.11** ports the rc.10 relay-brokered pair flow from Python to the OpenClaw plugin — `totalreclaw_pair` now returns a relay URL (`https://api-staging.totalreclaw.xyz/pair/p/<token>#pk=…`) by default, matching the Hermes rc.10 behaviour. Universal reachability: managed hosts, Docker-in-cloud, phone-scan-QR, and split-network setups can complete pairing without the browser needing loopback to the gateway.
- **Preserves `TOTALRECLAW_PAIR_MODE=local`** for air-gapped / self-hosted users (rc.4–rc.10 loopback HTTP flow unchanged).
- **Python `2.3.1rc11`** is a version-bump-only coordination — RC cadence keeps both registries aligned for the release-pipeline tracker.

### Byte-compat anchor

The TypeScript `pair-remote-client` uses the same `pair-crypto.ts` module (`decryptPairingPayload`, `generateGatewayKeypair`) that the loopback `pair-http.respond` handler already uses — which is itself the byte-compat anchor shared with Python's `pair.crypto`. So a ciphertext produced by the relay-served `pair-html.ts` page decrypts under the gateway private key the same way on both clients.

## Files

- NEW `skill/plugin/pair-remote-client.ts` — TypeScript mirror of `python/src/totalreclaw/pair/remote_client.py`.
- NEW `skill/plugin/pair-remote-client.test.ts` — 20 assertions across 5 scenarios. Runs against a local `ws` server stub — no network dep.
- `skill/plugin/index.ts` — `totalreclaw_pair` tool branches on `CONFIG.pairMode`. Relay mode returns URL + PIN immediately, schedules a background task to write credentials when the browser completes.
- `skill/plugin/config.ts` — `pairMode` + `pairRelayUrl` config (mirrors Python env vars).
- `skill/plugin/package.json` — `ws ^8.18.3` + `@types/ws ^8.5.12` promoted to direct deps.
- `skill/plugin/CHANGELOG.md` + `skill/plugin/SKILL.md` — version bump + entry.
- `python/pyproject.toml` + `python/CHANGELOG.md` — version-bump-only for RC cadence alignment.

## Phrase-safety invariants (preserved)

- Relay is blind: ephemeral x25519 private key never leaves the plugin host.
- PIN is out-of-band: user reads from agent chat, types into the browser.
- Scanner clean: `pair-remote-client.ts` passes `check-scanner.mjs` (0 flags).

## Test plan

- [x] `npx tsx pair-remote-client.test.ts` — 20/20 passing.
- [x] `npx tsx phrase-safety-registry.test.ts` — 14/14 passing, `totalreclaw_pair` still registered, no phrase-generating tools present.
- [x] `npx tsx config-schema.test.ts` — 18/18 passing.
- [x] `npx tsx pair-cli-json.test.ts` — 17/17 passing (loopback flow unchanged).
- [x] `node ../scripts/check-scanner.mjs` — 0 flags across 92 files.
- [ ] **Real-user QA gate (auto-QA on staging after publish)** — RC auto-QA will invoke `qa-totalreclaw` against `3.3.1-rc.11` from the public registry + staging relay. Relay URL must surface in the agent's chat response.

## Ship line

- DO NOT auto-promote stable. After rc.11 auto-QA returns GO on both Hermes + OpenClaw, stop and wait for user review per the release-pipeline tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)