### PR TITLE
docs(mockup): rc.13 typeform-style pair wizard — clickable UX preview

### DIFF
--- a/docs/mockups/rc13-pair-wizard/README.md
+++ b/docs/mockups/rc13-pair-wizard/README.md
@@ -1,0 +1,18 @@
+# rc.13 pair wizard — clickable mockup
+
+Open `index.html` in any browser. Clickable rc.13 UX mockup. No backend needed.
+
+Three screens: PIN → phrase (import / generate) → paired. Pure HTML/CSS/JS, no
+build step, no dependencies. Purpose: gather taste-test feedback before we
+implement for real in rc.13 against `src/routes/pair-html.ts` in the relay.
+
+## Live preview
+
+`https://api-staging.totalreclaw.xyz/pair-preview/` (served by the relay).
+
+## What this is not
+
+- Not production code. Does no crypto. Fake submit = `await 800ms`.
+- Never log or transmit a phrase from this file — it's a mockup.
+- Does not replace the production pair HTML at
+  `totalreclaw-relay/src/routes/pair-html.ts`. Runs alongside for review only.

--- a/docs/mockups/rc13-pair-wizard/index.html
+++ b/docs/mockups/rc13-pair-wizard/index.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="referrer" content="no-referrer" />
+  <meta name="robots" content="noindex, nofollow" />
+  <meta name="theme-color" content="#0B0B1A" />
+  <title>Pair your device — TotalReclaw (rc.13 mockup)</title>
+  <link rel="stylesheet" href="wizard.css" />
+</head>
+<body>
+  <a href="#main" class="skip-link">Skip to content</a>
+
+  <main id="main" class="wizard" aria-live="polite">
+    <!-- Top bar: logo + step meter + countdown -->
+    <header class="topbar">
+      <a class="brand" href="#" aria-label="TotalReclaw">
+        <svg class="brand-mark" viewBox="0 0 256 256" aria-hidden="true" focusable="false">
+          <defs>
+            <linearGradient id="shieldGrad" x1="30%" y1="0%" x2="70%" y2="100%">
+              <stop offset="0%" stop-color="#5040B0"/>
+              <stop offset="100%" stop-color="#7B5CFF"/>
+            </linearGradient>
+          </defs>
+          <path d="M128 18 L212 58 V162 C212 210 174 236 128 250 C82 236 44 210 44 162 V58 Z"
+                fill="rgba(75,55,170,0.05)" stroke="url(#shieldGrad)" stroke-width="5" stroke-linejoin="round"/>
+          <path d="M128 40 L196 74 V160 C196 200 164 222 128 234 C92 222 60 200 60 160 V74 Z"
+                fill="none" stroke="url(#shieldGrad)" stroke-width="2.5" stroke-linejoin="round" opacity="0.45"/>
+          <path d="M 116 186 C 96 162, 60 124, 72 92 C 76 78, 94 70, 108 82 C 118 90, 114 108, 100 116"
+                fill="none" stroke="url(#shieldGrad)" stroke-width="9" stroke-linecap="round"/>
+          <path d="M 140 186 C 160 162, 196 124, 184 92 C 180 78, 162 70, 148 82 C 138 90, 142 108, 156 116"
+                fill="none" stroke="url(#shieldGrad)" stroke-width="9" stroke-linecap="round"/>
+        </svg>
+        <span class="brand-text">TotalReclaw</span>
+      </a>
+
+      <div class="meta">
+        <div class="step-meter" aria-label="Progress">
+          <span class="step-label"><span id="step-current">1</span> / 3</span>
+          <div class="step-dots" role="presentation">
+            <span class="dot" data-step="1" aria-hidden="true"></span>
+            <span class="dot" data-step="2" aria-hidden="true"></span>
+            <span class="dot" data-step="3" aria-hidden="true"></span>
+          </div>
+        </div>
+        <div class="countdown" id="countdown" aria-live="polite">
+          <svg class="clock" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <circle cx="12" cy="13" r="8" fill="none" stroke="currentColor" stroke-width="1.6"/>
+            <path d="M12 9v4l2.5 2" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+            <path d="M9 3h6M12 3v2" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+          </svg>
+          <span id="countdown-text">10:00</span>
+        </div>
+      </div>
+    </header>
+
+    <!-- Stage contains exactly one active screen at a time -->
+    <section class="stage" id="stage">
+
+      <!-- ============ STEP 1 — PIN ============ -->
+      <article class="screen active" id="screen-pin" data-step="1" role="group" aria-labelledby="pin-heading">
+        <div class="screen-inner">
+          <p class="eyebrow">Step 1 of 3</p>
+          <h1 id="pin-heading" class="heading">Enter your PIN</h1>
+          <p class="subheading">Your agent showed you this PIN. It's there so only you can complete pairing.</p>
+
+          <div class="pin-wrap">
+            <div class="pin-cells" role="group" aria-label="6-digit PIN">
+              <input class="pin-cell" type="tel" inputmode="numeric" pattern="[0-9]*" maxlength="1" autocomplete="off" aria-label="Digit 1" data-index="0" />
+              <input class="pin-cell" type="tel" inputmode="numeric" pattern="[0-9]*" maxlength="1" autocomplete="off" aria-label="Digit 2" data-index="1" />
+              <input class="pin-cell" type="tel" inputmode="numeric" pattern="[0-9]*" maxlength="1" autocomplete="off" aria-label="Digit 3" data-index="2" />
+              <span class="pin-sep" aria-hidden="true"></span>
+              <input class="pin-cell" type="tel" inputmode="numeric" pattern="[0-9]*" maxlength="1" autocomplete="off" aria-label="Digit 4" data-index="3" />
+              <input class="pin-cell" type="tel" inputmode="numeric" pattern="[0-9]*" maxlength="1" autocomplete="off" aria-label="Digit 5" data-index="4" />
+              <input class="pin-cell" type="tel" inputmode="numeric" pattern="[0-9]*" maxlength="1" autocomplete="off" aria-label="Digit 6" data-index="5" />
+            </div>
+            <p class="pin-error" id="pin-error" role="alert" aria-live="assertive"></p>
+          </div>
+        </div>
+
+        <footer class="screen-cta">
+          <button type="button" class="btn-primary" id="pin-continue" disabled>Continue</button>
+          <p class="security-note">
+            <svg class="lock" viewBox="0 0 24 24" aria-hidden="true"><path d="M7 10V7a5 5 0 1 1 10 0v3" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><rect x="5" y="10" width="14" height="10" rx="2" fill="none" stroke="currentColor" stroke-width="1.6"/></svg>
+            This flow is the only secure way to set up your recovery phrase without the LLM provider ever seeing it.
+          </p>
+        </footer>
+      </article>
+
+      <!-- ============ STEP 2 — PHRASE ============ -->
+      <article class="screen" id="screen-phrase" data-step="2" role="group" aria-labelledby="phrase-heading" hidden>
+        <div class="screen-inner">
+          <p class="eyebrow">Step 2 of 3</p>
+          <h1 id="phrase-heading" class="heading">Your recovery phrase</h1>
+
+          <div class="tabs" role="tablist" aria-label="Phrase source">
+            <button type="button" class="tab active" role="tab" id="tab-import" aria-selected="true" aria-controls="panel-import" data-mode="import">
+              Import existing
+            </button>
+            <button type="button" class="tab" role="tab" id="tab-generate" aria-selected="false" aria-controls="panel-generate" data-mode="generate">
+              Generate new
+            </button>
+            <span class="tab-indicator" aria-hidden="true"></span>
+          </div>
+
+          <!-- Import panel (default) -->
+          <div id="panel-import" class="tab-panel" role="tabpanel" aria-labelledby="tab-import">
+            <p class="helper">Enter the 12 words of your existing recovery phrase.</p>
+            <div class="phrase-grid" id="phrase-grid-import" role="group" aria-label="12-word recovery phrase input">
+              <!-- JS populates 12 slots -->
+            </div>
+            <button type="button" class="btn-ghost" id="paste-all">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="8" y="3" width="8" height="4" rx="1" fill="none" stroke="currentColor" stroke-width="1.6"/><rect x="5" y="6" width="14" height="15" rx="2" fill="none" stroke="currentColor" stroke-width="1.6"/></svg>
+              Paste all 12 words
+            </button>
+          </div>
+
+          <!-- Generate panel -->
+          <div id="panel-generate" class="tab-panel" role="tabpanel" aria-labelledby="tab-generate" hidden>
+            <p class="helper">We generated a fresh 12-word phrase for you. Write it down before continuing.</p>
+            <div class="phrase-grid readonly" id="phrase-grid-generate" role="group" aria-label="Generated 12-word recovery phrase">
+              <!-- JS populates 12 slots (readonly) -->
+            </div>
+            <div class="gen-actions">
+              <button type="button" class="btn-ghost" id="gen-copy">
+                <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="9" y="9" width="11" height="11" rx="2" fill="none" stroke="currentColor" stroke-width="1.6"/><path d="M5 15V5a2 2 0 0 1 2-2h10" fill="none" stroke="currentColor" stroke-width="1.6"/></svg>
+                <span id="gen-copy-label">Copy</span>
+              </button>
+              <button type="button" class="btn-ghost" id="gen-regen">
+                <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 12a8 8 0 0 1 14-5.3M20 12a8 8 0 0 1-14 5.3M18 3v4h-4M6 21v-4h4" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                Regenerate
+              </button>
+            </div>
+            <label class="ack" for="gen-ack">
+              <input type="checkbox" id="gen-ack" />
+              <span>I've written this down and stored it somewhere safe.</span>
+            </label>
+          </div>
+
+          <p class="security-note">
+            <svg class="lock" viewBox="0 0 24 24" aria-hidden="true"><path d="M7 10V7a5 5 0 1 1 10 0v3" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><rect x="5" y="10" width="14" height="10" rx="2" fill="none" stroke="currentColor" stroke-width="1.6"/></svg>
+            Never share this phrase. TotalReclaw's relay never sees it &mdash; encrypted in your browser before transmission.
+          </p>
+        </div>
+
+        <footer class="screen-cta">
+          <div class="cta-row">
+            <button type="button" class="btn-secondary" id="back-to-pin" aria-label="Back to PIN">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15 6l-6 6 6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </button>
+            <button type="button" class="btn-primary" id="phrase-pair" disabled>
+              <span class="btn-label">Pair</span>
+              <span class="btn-spinner" aria-hidden="true"></span>
+            </button>
+          </div>
+        </footer>
+      </article>
+
+      <!-- ============ STEP 3 — DONE ============ -->
+      <article class="screen" id="screen-done" data-step="3" role="group" aria-labelledby="done-heading" hidden>
+        <div class="screen-inner center">
+          <div class="check-wrap" aria-hidden="true">
+            <svg class="check" viewBox="0 0 100 100">
+              <circle class="check-ring" cx="50" cy="50" r="44" fill="none" stroke-width="3"/>
+              <path class="check-tick" d="M30 52 L45 67 L72 36" fill="none" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </div>
+          <h1 id="done-heading" class="heading">You're all set</h1>
+          <p class="subheading">Go back to your chat and try: <em>"remember I prefer Python over Go"</em></p>
+          <a href="#" class="close-link" id="close-link">Close this page</a>
+        </div>
+      </article>
+
+    </section>
+
+    <p class="build-note" aria-hidden="true">rc.13 mockup &middot; clickable preview &middot; no backend</p>
+  </main>
+
+  <script src="wizard.js"></script>
+</body>
+</html>

--- a/docs/mockups/rc13-pair-wizard/wizard.css
+++ b/docs/mockups/rc13-pair-wizard/wizard.css
@@ -1,0 +1,704 @@
+/* ==========================================================================
+   TotalReclaw rc.13 pair wizard — mockup styles
+   Mobile-first. Real CSS, no framework, no build step.
+   Brand reference: totalreclaw-website/index.html
+     --bg: #0B0B1A, --purple: #7B5CFF, --orange: #D4943A
+   Font: system stack (no CDN per brief; brand font Euclid Circular A
+         lives in website repo but we stay dependency-free here).
+   ========================================================================== */
+
+:root {
+  /* Dark (default) */
+  --bg: #0B0B1A;
+  --bg-elev: #141329;
+  --bg-elev-2: #1B1A36;
+  --fg: #F0EDF8;
+  --fg-dim: rgba(240, 237, 248, 0.70);
+  --fg-faint: rgba(240, 237, 248, 0.42);
+  --border: rgba(255, 255, 255, 0.08);
+  --border-strong: rgba(255, 255, 255, 0.16);
+  --purple: #7B5CFF;
+  --purple-soft: rgba(123, 92, 255, 0.14);
+  --purple-softer: rgba(123, 92, 255, 0.08);
+  --purple-ring: rgba(123, 92, 255, 0.32);
+  --orange: #D4943A;
+  --orange-soft: rgba(212, 148, 58, 0.16);
+  --danger: #FF5A6A;
+  --success: #45D178;
+  --success-soft: rgba(69, 209, 120, 0.12);
+  --shadow-soft: 0 1px 2px rgba(0, 0, 0, 0.2), 0 8px 32px rgba(0, 0, 0, 0.28);
+  --shadow-lift: 0 4px 16px rgba(123, 92, 255, 0.22);
+
+  --radius-sm: 8px;
+  --radius: 12px;
+  --radius-lg: 16px;
+  --radius-xl: 24px;
+
+  --transition-fast: 140ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  --transition: 240ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  --transition-slow: 420ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+/* Light mode — keeps brand character, comfortable on laptops */
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #F7F6FB;
+    --bg-elev: #FFFFFF;
+    --bg-elev-2: #F0EEF8;
+    --fg: #18182B;
+    --fg-dim: rgba(24, 24, 43, 0.70);
+    --fg-faint: rgba(24, 24, 43, 0.48);
+    --border: rgba(24, 24, 43, 0.10);
+    --border-strong: rgba(24, 24, 43, 0.18);
+    --purple: #6B48FF;
+    --purple-soft: rgba(107, 72, 255, 0.10);
+    --purple-softer: rgba(107, 72, 255, 0.05);
+    --purple-ring: rgba(107, 72, 255, 0.28);
+    --orange: #B87320;
+    --orange-soft: rgba(184, 115, 32, 0.12);
+    --shadow-soft: 0 1px 2px rgba(24, 24, 43, 0.05), 0 8px 32px rgba(24, 24, 43, 0.08);
+  }
+}
+
+/* ---------- Reset ---------- */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html {
+  font-size: 16px;
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
+body {
+  min-height: 100vh;
+  min-height: 100dvh;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: "Euclid Circular A", -apple-system, BlinkMacSystemFont, "SF Pro Text",
+               "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-size: 1rem;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  letter-spacing: -0.005em;
+  overflow-x: hidden;
+}
+
+/* Ambient backdrop glow for depth (subtle) */
+body::before {
+  content: "";
+  position: fixed;
+  inset: -20vmax 0 auto 0;
+  height: 60vmax;
+  background:
+    radial-gradient(60% 60% at 50% 30%, var(--purple-softer), transparent 70%),
+    radial-gradient(50% 50% at 80% 10%, var(--orange-soft), transparent 70%);
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.8;
+}
+
+a { color: var(--purple); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+button { font: inherit; color: inherit; background: transparent; border: 0; cursor: pointer; }
+
+em { font-style: normal; color: var(--fg); font-weight: 500; background: var(--purple-softer); padding: 0.1em 0.4em; border-radius: 6px; }
+
+.skip-link {
+  position: absolute; left: -9999px; top: 0;
+  padding: 8px 12px; background: var(--purple); color: #fff; border-radius: 6px;
+}
+.skip-link:focus { left: 12px; top: 12px; z-index: 999; }
+
+/* ---------- Shell ---------- */
+.wizard {
+  position: relative;
+  z-index: 1;
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 18px 20px calc(24px + env(safe-area-inset-bottom));
+  min-height: 100vh;
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ---------- Topbar ---------- */
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 4px 2px 20px;
+}
+
+.brand {
+  display: inline-flex; align-items: center; gap: 10px;
+  color: var(--fg); font-weight: 600; letter-spacing: -0.01em;
+  text-decoration: none;
+}
+.brand:hover { text-decoration: none; }
+.brand-mark { width: 28px; height: 28px; flex-shrink: 0; }
+.brand-text { font-size: 0.98rem; letter-spacing: 0.005em; }
+
+.meta { display: flex; align-items: center; gap: 14px; }
+
+.step-meter {
+  display: flex; align-items: center; gap: 10px;
+  padding: 6px 10px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: 0.78rem;
+  color: var(--fg-dim);
+  font-variant-numeric: tabular-nums;
+}
+.step-label { letter-spacing: 0.04em; }
+.step-dots { display: flex; gap: 4px; }
+.step-dots .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--border-strong);
+  transition: background var(--transition), transform var(--transition);
+}
+.step-dots .dot.done { background: var(--purple); }
+.step-dots .dot.active { background: var(--purple); transform: scale(1.4); box-shadow: 0 0 0 3px var(--purple-ring); }
+
+.countdown {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 10px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--fg-dim);
+  transition: color var(--transition-fast), border-color var(--transition-fast), background var(--transition-fast);
+}
+.countdown .clock { width: 14px; height: 14px; }
+.countdown.warn { color: var(--orange); border-color: var(--orange); background: var(--orange-soft); }
+.countdown.warn .clock { animation: pulse 1s ease-in-out infinite; }
+.countdown.expired { color: var(--danger); border-color: var(--danger); }
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.45; }
+}
+
+/* ---------- Stage ---------- */
+.stage {
+  position: relative;
+  flex: 1;
+  display: flex;
+}
+
+.screen {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 6px 2px 0;
+  opacity: 0;
+  transform: translateX(24px);
+  transition: opacity var(--transition), transform var(--transition);
+  pointer-events: none;
+}
+.screen.active {
+  position: relative;
+  inset: auto;
+  opacity: 1;
+  transform: translateX(0);
+  pointer-events: auto;
+  width: 100%;
+}
+.screen.exit-left {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transform: translateX(-32px);
+  pointer-events: none;
+}
+.screen.enter-right {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transform: translateX(32px);
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .screen { transition: opacity 0.1s linear; transform: none !important; }
+  .screen.exit-left, .screen.enter-right { transform: none !important; }
+}
+
+.screen-inner { flex: 1; display: flex; flex-direction: column; gap: 14px; }
+.screen-inner.center { align-items: center; justify-content: center; text-align: center; padding-top: 24px; }
+
+.eyebrow {
+  font-size: 0.78rem;
+  color: var(--fg-faint);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-weight: 500;
+}
+
+.heading {
+  font-size: clamp(1.6rem, 5.8vw, 2.1rem);
+  font-weight: 600;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  color: var(--fg);
+}
+
+.subheading {
+  font-size: 1rem;
+  color: var(--fg-dim);
+  line-height: 1.55;
+}
+
+.helper {
+  font-size: 0.92rem;
+  color: var(--fg-dim);
+  margin: 4px 0 8px;
+}
+
+/* ---------- CTA footer ---------- */
+.screen-cta {
+  position: sticky;
+  bottom: 0;
+  padding: 18px 0 2px;
+  background: linear-gradient(to top, var(--bg) 65%, transparent);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.cta-row { display: flex; gap: 10px; }
+
+.btn-primary,
+.btn-secondary,
+.btn-ghost {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 52px;
+  padding: 14px 20px;
+  border-radius: var(--radius);
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.005em;
+  transition: transform var(--transition-fast), background var(--transition-fast),
+              box-shadow var(--transition-fast), border-color var(--transition-fast),
+              opacity var(--transition-fast);
+  -webkit-tap-highlight-color: transparent;
+  user-select: none;
+}
+
+.btn-primary {
+  flex: 1;
+  background: var(--purple);
+  color: #fff;
+  border: 1px solid var(--purple);
+  box-shadow: var(--shadow-lift);
+  position: relative;
+}
+.btn-primary:hover:not(:disabled) { transform: translateY(-1px); box-shadow: 0 6px 22px rgba(123, 92, 255, 0.36); }
+.btn-primary:active:not(:disabled) { transform: translateY(0); }
+.btn-primary:disabled {
+  background: var(--bg-elev-2);
+  border-color: var(--border);
+  color: var(--fg-faint);
+  box-shadow: none;
+  cursor: not-allowed;
+}
+.btn-primary:focus-visible {
+  outline: 2px solid var(--purple);
+  outline-offset: 3px;
+}
+.btn-primary.loading .btn-label { opacity: 0; }
+.btn-primary.loading .btn-spinner { opacity: 1; }
+
+.btn-spinner {
+  position: absolute;
+  width: 20px; height: 20px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  border-top-color: #fff;
+  opacity: 0;
+  animation: spin 0.85s linear infinite;
+  transition: opacity var(--transition-fast);
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.btn-secondary {
+  flex: 0 0 56px;
+  padding: 14px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  color: var(--fg-dim);
+}
+.btn-secondary:hover { border-color: var(--border-strong); color: var(--fg); }
+.btn-secondary:focus-visible { outline: 2px solid var(--purple); outline-offset: 3px; }
+.btn-secondary svg { width: 20px; height: 20px; }
+
+.btn-ghost {
+  width: 100%;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  color: var(--fg-dim);
+  font-weight: 500;
+  min-height: 44px;
+  padding: 10px 16px;
+}
+.btn-ghost:hover { border-color: var(--border-strong); color: var(--fg); }
+.btn-ghost:focus-visible { outline: 2px solid var(--purple); outline-offset: 2px; }
+.btn-ghost svg { width: 18px; height: 18px; }
+
+/* ---------- Security note ---------- */
+.security-note {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  font-size: 0.85rem;
+  color: var(--fg-dim);
+  line-height: 1.5;
+  padding: 12px 14px;
+  background: var(--purple-softer);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+.security-note .lock {
+  width: 16px; height: 16px;
+  flex-shrink: 0;
+  margin-top: 2px;
+  color: var(--purple);
+}
+
+/* ==========================================================================
+   STEP 1 — PIN cells
+   ========================================================================== */
+.pin-wrap { margin-top: 10px; }
+
+.pin-cells {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  max-width: 360px;
+  margin: 4px auto 10px;
+}
+
+.pin-cell {
+  flex: 1;
+  width: 100%;
+  max-width: 54px;
+  aspect-ratio: 1 / 1.15;
+  text-align: center;
+  font-size: 1.6rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--fg);
+  background: var(--bg-elev);
+  border: 1.5px solid var(--border-strong);
+  border-radius: var(--radius);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast),
+              background var(--transition-fast), transform var(--transition-fast);
+  caret-color: var(--purple);
+}
+.pin-cell:focus {
+  outline: none;
+  border-color: var(--purple);
+  background: var(--bg-elev-2);
+  box-shadow: 0 0 0 4px var(--purple-ring);
+  transform: translateY(-1px);
+}
+.pin-cell.filled {
+  border-color: var(--purple);
+  background: var(--purple-soft);
+}
+.pin-cell.shake { animation: shake 0.4s ease-in-out; }
+
+@keyframes shake {
+  10%, 90% { transform: translateX(-1px); }
+  20%, 80% { transform: translateX(2px); }
+  30%, 50%, 70% { transform: translateX(-3px); }
+  40%, 60% { transform: translateX(3px); }
+}
+
+.pin-sep {
+  display: inline-block;
+  width: 10px;
+  height: 2px;
+  background: var(--border-strong);
+  border-radius: 2px;
+  margin: 0 2px;
+  flex: 0 0 auto;
+}
+
+.pin-error {
+  min-height: 20px;
+  font-size: 0.85rem;
+  color: var(--danger);
+  text-align: center;
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+.pin-error.show { opacity: 1; }
+
+/* ==========================================================================
+   STEP 2 — tabs, phrase grid
+   ========================================================================== */
+.tabs {
+  position: relative;
+  display: flex;
+  gap: 0;
+  padding: 4px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin: 8px 0 4px;
+}
+.tab {
+  flex: 1;
+  padding: 11px 8px;
+  font-size: 0.92rem;
+  font-weight: 500;
+  color: var(--fg-dim);
+  border-radius: calc(var(--radius) - 4px);
+  transition: color var(--transition-fast);
+  position: relative;
+  z-index: 2;
+}
+.tab[aria-selected="true"] { color: var(--fg); }
+.tab:focus-visible { outline: 2px solid var(--purple); outline-offset: -2px; border-radius: calc(var(--radius) - 4px); }
+
+.tab-indicator {
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  left: 4px;
+  width: calc(50% - 4px);
+  background: var(--bg-elev-2);
+  border: 1px solid var(--border-strong);
+  border-radius: calc(var(--radius) - 4px);
+  transition: transform var(--transition), background var(--transition);
+  z-index: 1;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+}
+.tabs.mode-generate .tab-indicator { transform: translateX(100%); }
+
+.tab-panel[hidden] { display: none; }
+
+/* Phrase grid — 2 columns on mobile (better for 12-word readability at 375px),
+   3 columns at 420px+, 4 columns wide screens */
+.phrase-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+  padding: 14px 12px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin: 4px 0 10px;
+}
+
+@media (min-width: 420px) {
+  .phrase-grid { grid-template-columns: repeat(3, 1fr); gap: 10px; padding: 16px; }
+}
+@media (min-width: 720px) {
+  .phrase-grid { grid-template-columns: repeat(4, 1fr); }
+}
+
+.word-cell {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px 10px 10px;
+  background: var(--bg-elev-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+  min-height: 48px;
+}
+.word-cell:focus-within {
+  border-color: var(--purple);
+  background: var(--bg-elev);
+  box-shadow: 0 0 0 3px var(--purple-ring);
+}
+.word-cell.filled { border-color: var(--purple-ring); }
+
+.word-idx {
+  color: var(--fg-faint);
+  font-size: 0.74rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  width: 18px;
+  flex-shrink: 0;
+  text-align: right;
+  letter-spacing: 0.02em;
+}
+
+.word-input {
+  flex: 1;
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  color: var(--fg);
+  font-size: 0.98rem;
+  font-weight: 500;
+  font-family: inherit;
+  letter-spacing: 0.002em;
+  outline: none;
+  padding: 0;
+}
+.word-input::placeholder { color: var(--fg-faint); font-weight: 400; }
+
+.phrase-grid.readonly .word-cell { background: var(--bg-elev); border-color: var(--border); }
+.phrase-grid.readonly .word-input {
+  color: var(--fg);
+  font-weight: 600;
+  cursor: default;
+  user-select: all;
+}
+
+.gen-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin: 4px 0 10px;
+}
+
+.ack {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 14px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin: 4px 0 10px;
+  cursor: pointer;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+}
+.ack:hover { border-color: var(--border-strong); }
+.ack:has(input:checked) { border-color: var(--purple); background: var(--purple-softer); }
+
+.ack input {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 22px; height: 22px;
+  flex-shrink: 0;
+  margin-top: 1px;
+  border: 1.5px solid var(--border-strong);
+  border-radius: 6px;
+  background: var(--bg);
+  cursor: pointer;
+  position: relative;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+.ack input:checked {
+  background: var(--purple);
+  border-color: var(--purple);
+}
+.ack input:checked::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'><polyline points='5 12 10 17 19 7'/></svg>") center / 14px no-repeat;
+}
+.ack input:focus-visible { outline: 2px solid var(--purple); outline-offset: 3px; }
+
+.ack span { font-size: 0.92rem; color: var(--fg-dim); line-height: 1.5; }
+.ack:has(input:checked) span { color: var(--fg); }
+
+/* ==========================================================================
+   STEP 3 — Done
+   ========================================================================== */
+.check-wrap {
+  width: 112px; height: 112px;
+  margin: 8px auto 10px;
+  position: relative;
+}
+.check-wrap::before {
+  content: "";
+  position: absolute;
+  inset: -16px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(69, 209, 120, 0.22), transparent 70%);
+  animation: halo 1.6s ease-out forwards;
+}
+@keyframes halo {
+  0% { transform: scale(0.6); opacity: 0; }
+  30% { opacity: 1; }
+  100% { transform: scale(1.3); opacity: 0; }
+}
+
+.check { width: 100%; height: 100%; display: block; }
+.check-ring {
+  stroke: var(--success);
+  stroke-dasharray: 276;
+  stroke-dashoffset: 276;
+  animation: draw-ring 0.55s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+.check-tick {
+  stroke: var(--success);
+  stroke-dasharray: 80;
+  stroke-dashoffset: 80;
+  animation: draw-tick 0.5s cubic-bezier(0.2, 0.8, 0.2, 1) 0.45s forwards;
+}
+@keyframes draw-ring { to { stroke-dashoffset: 0; } }
+@keyframes draw-tick { to { stroke-dashoffset: 0; } }
+
+@media (prefers-reduced-motion: reduce) {
+  .check-wrap::before { animation: none; opacity: 0; }
+  .check-ring, .check-tick { animation: none; stroke-dashoffset: 0; }
+}
+
+.close-link {
+  display: inline-block;
+  margin-top: 22px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  color: var(--fg-dim);
+  font-size: 0.9rem;
+  font-weight: 500;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+}
+.close-link:hover { color: var(--fg); border-color: var(--border-strong); text-decoration: none; }
+
+/* ---------- Build note (bottom) ---------- */
+.build-note {
+  margin-top: 28px;
+  text-align: center;
+  font-size: 0.72rem;
+  color: var(--fg-faint);
+  letter-spacing: 0.08em;
+  opacity: 0.6;
+}
+
+/* ==========================================================================
+   Responsive — larger screens
+   ========================================================================== */
+@media (min-width: 600px) {
+  .wizard { padding: 36px 24px 40px; max-width: 560px; }
+  .heading { font-size: 2.1rem; }
+  .pin-cell { max-width: 60px; font-size: 1.8rem; }
+  .topbar { padding-bottom: 28px; }
+}
+
+@media (min-width: 900px) {
+  .wizard { max-width: 600px; }
+}
+
+/* Very small phones */
+@media (max-width: 360px) {
+  .wizard { padding: 14px 14px calc(20px + env(safe-area-inset-bottom)); }
+  .pin-cells { gap: 4px; }
+  .pin-cell { font-size: 1.4rem; }
+  .brand-text { display: none; }
+  .step-meter { padding: 5px 8px; }
+}

--- a/docs/mockups/rc13-pair-wizard/wizard.js
+++ b/docs/mockups/rc13-pair-wizard/wizard.js
@@ -1,0 +1,531 @@
+/**
+ * TotalReclaw rc.13 pair-wizard mockup — vanilla JS.
+ *
+ * No dependencies. No storage. No network. No crypto. Pure UX.
+ *
+ * Step machine: 1 = PIN, 2 = phrase (import | generate), 3 = done.
+ * A "fake submit" resolves after 800ms and advances to the done screen.
+ *
+ * NOTE: this is a mockup. Never log or transmit any word entered here.
+ *       All input buffers are scrubbed on screen leave.
+ */
+(function () {
+  'use strict';
+
+  // ---------- State ----------
+  const STATE = {
+    step: 1,
+    pin: ['', '', '', '', '', ''],
+    mode: 'import', // 'import' | 'generate'
+    words: new Array(12).fill(''),
+    generated: null,
+    ackChecked: false,
+    expiresAtMs: Date.now() + 10 * 60 * 1000, // 10 minutes
+    timerId: null,
+  };
+
+  // Deterministic demo phrase (NOT cryptographically generated — this is a
+  // mockup). Real pair page uses WebCrypto entropy → BIP-39.
+  const DEMO_PHRASE = [
+    'anchor', 'velvet', 'ridge', 'harbor',
+    'meadow', 'pilot', 'echo', 'falcon',
+    'quiet', 'amber', 'cobalt', 'summit',
+  ];
+
+  // ---------- Helpers ----------
+  const $ = (id) => document.getElementById(id);
+  const $$ = (sel, root) => Array.from((root || document).querySelectorAll(sel));
+
+  function pad2(n) { return n < 10 ? '0' + n : String(n); }
+
+  function setDots() {
+    const dots = $$('.step-dots .dot');
+    dots.forEach((d) => {
+      const n = Number(d.dataset.step);
+      d.classList.toggle('done', n < STATE.step);
+      d.classList.toggle('active', n === STATE.step);
+    });
+    const cur = $('step-current');
+    if (cur) cur.textContent = STATE.step <= 3 ? String(STATE.step) : '3';
+  }
+
+  function transitionTo(nextId, direction) {
+    // direction: 'forward' | 'back'
+    const all = $$('.screen');
+    const current = all.find((s) => s.classList.contains('active'));
+    const next = $(nextId);
+    if (!current || !next || current === next) return;
+
+    const forward = direction !== 'back';
+    const exitClass = forward ? 'exit-left' : 'enter-right';
+    const enterClass = forward ? 'enter-right' : 'exit-left';
+
+    // Prep next off-screen to the correct side
+    next.hidden = false;
+    next.classList.remove('active');
+    next.classList.remove('exit-left', 'enter-right');
+    next.classList.add(forward ? 'enter-right' : 'exit-left');
+
+    // Force reflow so the browser registers the starting transform
+    // eslint-disable-next-line no-unused-expressions
+    next.offsetWidth;
+
+    current.classList.remove('active');
+    current.classList.add(exitClass);
+
+    next.classList.remove('enter-right', 'exit-left');
+    next.classList.add('active');
+
+    const onDone = () => {
+      current.hidden = true;
+      current.classList.remove('exit-left', 'enter-right');
+      next.removeEventListener('transitionend', onDone);
+    };
+    next.addEventListener('transitionend', onDone);
+
+    // Fallback in case transitionend doesn't fire (reduced-motion, etc.)
+    setTimeout(onDone, 400);
+  }
+
+  // ---------- Countdown ----------
+  function renderCountdown() {
+    const remaining = Math.max(0, STATE.expiresAtMs - Date.now());
+    const m = Math.floor(remaining / 60000);
+    const s = Math.floor((remaining % 60000) / 1000);
+    const el = $('countdown');
+    const txt = $('countdown-text');
+    if (!el || !txt) return;
+
+    if (remaining <= 0) {
+      txt.textContent = 'Expired';
+      el.classList.remove('warn');
+      el.classList.add('expired');
+      $$('.btn-primary').forEach((b) => (b.disabled = true));
+      if (STATE.timerId) { clearInterval(STATE.timerId); STATE.timerId = null; }
+      return;
+    }
+
+    txt.textContent = pad2(m) + ':' + pad2(s);
+    el.classList.toggle('warn', remaining < 60 * 1000);
+  }
+
+  function startTimer() {
+    renderCountdown();
+    STATE.timerId = setInterval(renderCountdown, 1000);
+  }
+
+  // ---------- Step 1: PIN ----------
+  function initPinStep() {
+    const cells = $$('.pin-cell');
+    const continueBtn = $('pin-continue');
+    const errEl = $('pin-error');
+
+    function updateFilledClass() {
+      cells.forEach((c, i) => {
+        c.classList.toggle('filled', !!STATE.pin[i]);
+      });
+    }
+
+    function updateContinueState() {
+      const complete = STATE.pin.every((d) => /^\d$/.test(d));
+      continueBtn.disabled = !complete;
+    }
+
+    function clearError() {
+      errEl.classList.remove('show');
+      errEl.textContent = '';
+    }
+
+    function showError(msg) {
+      errEl.textContent = msg;
+      errEl.classList.add('show');
+    }
+
+    cells.forEach((cell, i) => {
+      cell.addEventListener('input', (e) => {
+        const raw = e.target.value.replace(/\D/g, '');
+        if (!raw) {
+          STATE.pin[i] = '';
+          updateFilledClass();
+          updateContinueState();
+          return;
+        }
+        // Take only the first digit; handle paste of multi-char in keydown/paste instead
+        const digit = raw[raw.length - 1];
+        STATE.pin[i] = digit;
+        e.target.value = digit;
+        updateFilledClass();
+        updateContinueState();
+        clearError();
+        // Auto-advance
+        if (i < cells.length - 1) {
+          cells[i + 1].focus();
+        } else {
+          cell.blur();
+        }
+      });
+
+      cell.addEventListener('keydown', (e) => {
+        if (e.key === 'Backspace' && !cell.value && i > 0) {
+          e.preventDefault();
+          cells[i - 1].focus();
+          cells[i - 1].value = '';
+          STATE.pin[i - 1] = '';
+          updateFilledClass();
+          updateContinueState();
+        } else if (e.key === 'ArrowLeft' && i > 0) {
+          e.preventDefault();
+          cells[i - 1].focus();
+        } else if (e.key === 'ArrowRight' && i < cells.length - 1) {
+          e.preventDefault();
+          cells[i + 1].focus();
+        } else if (e.key === 'Enter') {
+          if (!continueBtn.disabled) continueBtn.click();
+        }
+      });
+
+      cell.addEventListener('focus', () => cell.select());
+
+      cell.addEventListener('paste', (e) => {
+        e.preventDefault();
+        const text = (e.clipboardData || window.clipboardData).getData('text') || '';
+        const digits = text.replace(/\D/g, '').slice(0, 6 - i).split('');
+        digits.forEach((d, k) => {
+          const target = cells[i + k];
+          if (target) {
+            target.value = d;
+            STATE.pin[i + k] = d;
+          }
+        });
+        updateFilledClass();
+        updateContinueState();
+        const next = Math.min(i + digits.length, cells.length - 1);
+        cells[next].focus();
+      });
+    });
+
+    continueBtn.addEventListener('click', () => {
+      const complete = STATE.pin.every((d) => /^\d$/.test(d));
+      if (!complete) {
+        // Subtle shake for the first empty cell
+        const firstEmpty = cells.find((c, idx) => !STATE.pin[idx]);
+        if (firstEmpty) {
+          firstEmpty.classList.add('shake');
+          setTimeout(() => firstEmpty.classList.remove('shake'), 420);
+          firstEmpty.focus();
+        }
+        showError('Enter all 6 digits to continue.');
+        return;
+      }
+      clearError();
+      // Advance to step 2
+      STATE.step = 2;
+      setDots();
+      transitionTo('screen-phrase', 'forward');
+      // Focus the first word input of the active panel
+      setTimeout(focusFirstWordOfActivePanel, 300);
+    });
+
+    // Autofocus first cell on load
+    setTimeout(() => cells[0] && cells[0].focus(), 150);
+  }
+
+  // ---------- Step 2: Phrase ----------
+  function buildWordGrid(gridEl, options) {
+    gridEl.innerHTML = '';
+    const readonly = !!options.readonly;
+    for (let i = 0; i < 12; i++) {
+      const cell = document.createElement('label');
+      cell.className = 'word-cell';
+      cell.setAttribute('for', `word-${options.prefix}-${i}`);
+
+      const idx = document.createElement('span');
+      idx.className = 'word-idx';
+      idx.textContent = String(i + 1) + '.';
+      idx.setAttribute('aria-hidden', 'true');
+
+      const input = document.createElement('input');
+      input.className = 'word-input';
+      input.id = `word-${options.prefix}-${i}`;
+      input.type = 'text';
+      input.autocomplete = 'off';
+      input.autocapitalize = 'none';
+      input.spellcheck = false;
+      input.dataset.index = String(i);
+      input.setAttribute('aria-label', `Word ${i + 1}`);
+      input.placeholder = '';
+      if (readonly) {
+        input.readOnly = true;
+        input.tabIndex = -1;
+      } else {
+        input.placeholder = 'word';
+      }
+
+      cell.appendChild(idx);
+      cell.appendChild(input);
+      gridEl.appendChild(cell);
+    }
+  }
+
+  function wireImportGrid() {
+    const grid = $('phrase-grid-import');
+    const inputs = $$('.word-input', grid);
+
+    function updatePairState() {
+      const complete = STATE.words.every((w) => w.trim().length > 0);
+      $('phrase-pair').disabled = !complete;
+    }
+
+    function setWord(i, val) {
+      const trimmed = val.trim().toLowerCase();
+      STATE.words[i] = trimmed;
+      inputs[i].parentElement.classList.toggle('filled', trimmed.length > 0);
+      updatePairState();
+    }
+
+    inputs.forEach((input, i) => {
+      input.addEventListener('input', (e) => {
+        setWord(i, e.target.value);
+      });
+
+      input.addEventListener('keydown', (e) => {
+        if (e.key === ' ' || e.key === 'Enter' || e.key === 'Tab') {
+          if (e.key !== 'Tab') e.preventDefault();
+          // Auto-advance on space/enter
+          if (inputs[i + 1]) inputs[i + 1].focus();
+          else input.blur();
+        } else if (e.key === 'Backspace' && !input.value && i > 0) {
+          e.preventDefault();
+          inputs[i - 1].focus();
+        }
+      });
+
+      input.addEventListener('paste', (e) => {
+        const text = (e.clipboardData || window.clipboardData).getData('text') || '';
+        const words = text.trim().split(/\s+/).filter(Boolean);
+        if (words.length < 2) return; // single-word paste — let browser handle
+        e.preventDefault();
+        const remaining = 12 - i;
+        const toInsert = words.slice(0, remaining);
+        toInsert.forEach((w, k) => {
+          const idx = i + k;
+          inputs[idx].value = w.toLowerCase();
+          setWord(idx, w);
+        });
+        const next = Math.min(i + toInsert.length, inputs.length - 1);
+        inputs[next].focus();
+      });
+    });
+
+    $('paste-all').addEventListener('click', async () => {
+      // Try clipboard API first
+      let text = '';
+      if (navigator.clipboard && navigator.clipboard.readText) {
+        try { text = await navigator.clipboard.readText(); } catch (_) { /* ignore */ }
+      }
+      if (!text) {
+        // Fallback: demo-prefill with the demo phrase to let reviewer click through
+        text = DEMO_PHRASE.join(' ');
+      }
+      const words = text.trim().split(/\s+/).slice(0, 12);
+      words.forEach((w, k) => {
+        inputs[k].value = w.toLowerCase();
+        setWord(k, w);
+      });
+      inputs[Math.min(words.length, 11)].focus();
+    });
+  }
+
+  function wireGenerateGrid() {
+    const grid = $('phrase-grid-generate');
+    const inputs = $$('.word-input', grid);
+
+    function fill(phrase) {
+      STATE.generated = phrase.slice();
+      phrase.forEach((w, i) => {
+        inputs[i].value = w;
+        inputs[i].parentElement.classList.add('filled');
+      });
+    }
+
+    fill(DEMO_PHRASE);
+
+    function updatePairState() {
+      const ready = STATE.generated && STATE.generated.length === 12 && STATE.ackChecked;
+      $('phrase-pair').disabled = !ready;
+    }
+
+    $('gen-ack').addEventListener('change', (e) => {
+      STATE.ackChecked = !!e.target.checked;
+      updatePairState();
+    });
+
+    $('gen-copy').addEventListener('click', async () => {
+      const label = $('gen-copy-label');
+      if (!STATE.generated) return;
+      try {
+        await navigator.clipboard.writeText(STATE.generated.join(' '));
+        label.textContent = 'Copied';
+        setTimeout(() => { label.textContent = 'Copy'; }, 1600);
+      } catch (_) {
+        label.textContent = 'Copy blocked';
+        setTimeout(() => { label.textContent = 'Copy'; }, 1600);
+      }
+    });
+
+    $('gen-regen').addEventListener('click', () => {
+      // Mockup — rotate demo phrase so user sees it "regenerate"
+      const shifted = DEMO_PHRASE.slice();
+      // Cheap deterministic rotate so reviewer sees a change
+      shifted.push(shifted.shift());
+      fill(shifted);
+      // Ack resets on regenerate
+      STATE.ackChecked = false;
+      $('gen-ack').checked = false;
+      updatePairState();
+    });
+  }
+
+  function focusFirstWordOfActivePanel() {
+    const panelId = STATE.mode === 'import' ? 'panel-import' : 'panel-generate';
+    const input = $(panelId).querySelector('.word-input:not([readonly])');
+    if (input) input.focus();
+  }
+
+  function wireTabs() {
+    const tabs = $$('.tab');
+    const tabsRow = document.querySelector('.tabs');
+
+    function setMode(mode) {
+      STATE.mode = mode;
+      tabs.forEach((t) => {
+        const active = t.dataset.mode === mode;
+        t.classList.toggle('active', active);
+        t.setAttribute('aria-selected', active ? 'true' : 'false');
+      });
+      tabsRow.classList.toggle('mode-generate', mode === 'generate');
+      $('panel-import').hidden = mode !== 'import';
+      $('panel-generate').hidden = mode !== 'generate';
+
+      // Re-evaluate Pair button
+      if (mode === 'import') {
+        $('phrase-pair').disabled = !STATE.words.every((w) => w.trim().length > 0);
+      } else {
+        $('phrase-pair').disabled = !(STATE.generated && STATE.ackChecked);
+      }
+    }
+
+    tabs.forEach((t) => {
+      t.addEventListener('click', () => setMode(t.dataset.mode));
+      t.addEventListener('keydown', (e) => {
+        if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+          e.preventDefault();
+          const next = tabs.find((x) => x !== t);
+          if (next) { next.focus(); setMode(next.dataset.mode); }
+        }
+      });
+    });
+  }
+
+  function initPhraseStep() {
+    buildWordGrid($('phrase-grid-import'), { prefix: 'i', readonly: false });
+    buildWordGrid($('phrase-grid-generate'), { prefix: 'g', readonly: true });
+    wireImportGrid();
+    wireGenerateGrid();
+    wireTabs();
+
+    $('back-to-pin').addEventListener('click', () => {
+      STATE.step = 1;
+      setDots();
+      transitionTo('screen-pin', 'back');
+    });
+
+    $('phrase-pair').addEventListener('click', async () => {
+      const btn = $('phrase-pair');
+      if (btn.disabled) return;
+      btn.disabled = true;
+      btn.classList.add('loading');
+      // Fake submit — 800ms
+      await new Promise((r) => setTimeout(r, 800));
+
+      // Scrub inputs in-memory (mockup — no real phrase, but keep the habit)
+      STATE.words = STATE.words.map(() => '');
+      STATE.generated = null;
+      $$('.word-input').forEach((el) => { el.value = ''; });
+      // Also clear PIN buffer
+      STATE.pin = ['', '', '', '', '', ''];
+      $$('.pin-cell').forEach((el) => { el.value = ''; });
+
+      btn.classList.remove('loading');
+      btn.disabled = false;
+      STATE.step = 3;
+      setDots();
+      transitionTo('screen-done', 'forward');
+      // Stop timer — session consumed
+      if (STATE.timerId) { clearInterval(STATE.timerId); STATE.timerId = null; }
+      const cd = $('countdown');
+      if (cd) cd.style.visibility = 'hidden';
+    });
+  }
+
+  // ---------- Step 3: Done ----------
+  function initDoneStep() {
+    $('close-link').addEventListener('click', (e) => {
+      e.preventDefault();
+      // Demo-only: reset wizard so reviewer can click through again
+      resetWizard();
+    });
+  }
+
+  function resetWizard() {
+    STATE.step = 1;
+    STATE.pin = ['', '', '', '', '', ''];
+    STATE.words = new Array(12).fill('');
+    STATE.generated = null;
+    STATE.ackChecked = false;
+    STATE.expiresAtMs = Date.now() + 10 * 60 * 1000;
+    setDots();
+
+    $$('.pin-cell').forEach((el) => {
+      el.value = '';
+      el.classList.remove('filled', 'shake');
+    });
+    $$('.word-input').forEach((el) => {
+      if (!el.readOnly) el.value = '';
+      el.parentElement.classList.remove('filled');
+    });
+    $('gen-ack').checked = false;
+    $('pin-continue').disabled = true;
+    $('phrase-pair').disabled = true;
+    const cd = $('countdown');
+    if (cd) {
+      cd.style.visibility = '';
+      cd.classList.remove('warn', 'expired');
+    }
+
+    // Rebuild generated panel so it re-fills with demo phrase cleanly
+    buildWordGrid($('phrase-grid-generate'), { prefix: 'g', readonly: true });
+    wireGenerateGrid();
+
+    // Back to step 1
+    const currentActive = document.querySelector('.screen.active');
+    if (currentActive && currentActive.id !== 'screen-pin') {
+      transitionTo('screen-pin', 'back');
+    }
+
+    // Restart timer
+    if (STATE.timerId) clearInterval(STATE.timerId);
+    startTimer();
+
+    setTimeout(() => $$('.pin-cell')[0] && $$('.pin-cell')[0].focus(), 320);
+  }
+
+  // ---------- Boot ----------
+  document.addEventListener('DOMContentLoaded', () => {
+    setDots();
+    startTimer();
+    initPinStep();
+    initPhraseStep();
+    initDoneStep();
+  });
+})();


### PR DESCRIPTION
## Summary

- Three-screen HTML/CSS/JS mockup at `docs/mockups/rc13-pair-wizard/` so we can taste-test the new pair flow before implementing for real in rc.13.
- **Step 1:** 6-digit PIN, auto-advance cells, mobile numeric keyboard (`pattern="[0-9]*"` + `inputmode="numeric"`).
- **Step 2:** 12-word phrase — tabbed [Import existing] / [Generate new]. Import default. 2-col grid at 375px, 3 at 420px, 4 at 720px+.
- **Step 3:** success screen with CSS-only checkmark animation (stroke-dashoffset + halo fade).
- Visible MM:SS countdown (orange at <1min, red on expire). One-line security note on each step.
- `prefers-color-scheme` dark + light. `prefers-reduced-motion` respected.

## Design rationale

- **Type scale:** heading `clamp(1.6rem, 5.8vw, 2.1rem)` — fluid. PIN cells `1.6rem` (mobile) → `1.8rem` (≥600px). 12-word grid words at `0.98rem` bold so 8-char words don't truncate at 375px — fixing the rc.11 mobile rendering bug.
- **Colors:** matches the landing page brand (`totalreclaw-website/index.html`). `--purple: #7B5CFF`, `--orange: #D4943A` (countdown warn), `--bg: #0B0B1A`. Light-mode mirror with darker purple for contrast.
- **Transitions:** `240ms cubic-bezier(0.2, 0.8, 0.2, 1)` for screen slide/fade. `140ms` for hover/focus. Intentionally snappy — pair flow is a funnel, not a reading experience.
- **Brand font:** Euclid Circular A if locally available, else system stack. No CDN.

## Deviation from the drafted 3-step structure — none

Kept exactly 3 steps. I made the import tab the default (not generate) because existing-phrase import is the error-prone path that benefits most from being front-and-center; the brief left this open so calling it out here for feedback.

## Preview URL

Paired relay PR: [p-diogo/totalreclaw-relay#4](https://github.com/p-diogo/totalreclaw-relay/pull/4) serves the mockup at `https://api-staging.totalreclaw.xyz/pair-preview/` once merged and deployed.

## Test plan

- [ ] Open `docs/mockups/rc13-pair-wizard/index.html` locally — all 3 steps advance
- [ ] Open preview URL on iPhone — 12-word grid readable at 375px
- [ ] Open on laptop — light + dark auto based on system setting
- [ ] Tab-through keyboard nav: PIN cells, tabs, word inputs, CTAs
- [ ] Countdown ticks down; reload to reset to 10:00
- [ ] "Paste all 12 words" demo-fills when clipboard denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)