### PR TITLE
fix(rc.12): swap pair AEAD ChaCha20-Poly1305 -> AES-256-GCM

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -60,7 +60,7 @@ The agent reads the explicit directive, calls `totalreclaw_pair`, and guides you
 2. Agent checks `~/.totalreclaw/credentials.json`; if absent, calls the `totalreclaw_pair` tool.
 3. A pair URL + 6-digit PIN is surfaced back to you in chat.
 4. You open the URL in your browser. The pair page offers two tabs: **Generate new** (the browser creates a fresh 12-word recovery phrase using the canonical BIP-39 wordlist) and **Import existing** (paste a phrase you already have). Pick one, confirm the 6-digit PIN, and continue.
-5. The browser performs x25519 ECDH against the gateway's ephemeral pubkey, derives a ChaCha20-Poly1305 key via HKDF-SHA256, encrypts the phrase locally, and POSTs ciphertext + nonce + its pubkey to the gateway.
+5. The browser performs x25519 ECDH against the gateway's ephemeral pubkey, derives an AES-256-GCM key via HKDF-SHA256, encrypts the phrase locally, and POSTs ciphertext + nonce + its pubkey to the gateway.
 6. The gateway decrypts server-side and writes `~/.totalreclaw/credentials.json` (mode `0600`).
 7. The agent confirms setup and your memory tools are live.
 
@@ -73,7 +73,7 @@ The recovery phrase never crosses the LLM context — not the chat transcript, n
 - Hermes Agent v0.5.0+ (https://github.com/NousResearch/hermes-agent)
 - An LLM provider configured in Hermes (zai / openai / anthropic / gemini)
 - Python 3.11+
-- An up-to-date browser with WebCrypto x25519 + ChaCha20-Poly1305 (Safari 17.2+ or Chromium 118+)
+- An up-to-date browser with WebCrypto x25519 + AES-GCM (Safari 17.2+ or Chromium 133+)
 
 ## Notes on `--pre`
 

--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -51,7 +51,7 @@ The agent reads the explicit directive, installs the plugin (`openclaw plugins i
 5. Agent calls the `totalreclaw_pair` tool.
 6. A pair URL + 6-digit PIN is surfaced back to you in chat.
 7. You open the URL in your browser. The pair page offers two tabs: **Generate new** (the browser creates a fresh 12-word recovery phrase using the canonical BIP-39 wordlist) and **Import existing** (paste a phrase you already have). Pick one, confirm the 6-digit PIN, and continue.
-8. The browser performs x25519 ECDH against the gateway's ephemeral pubkey, derives a ChaCha20-Poly1305 key via HKDF-SHA256, encrypts the phrase locally, and POSTs ciphertext + nonce + its pubkey to the gateway.
+8. The browser performs x25519 ECDH against the gateway's ephemeral pubkey, derives an AES-256-GCM key via HKDF-SHA256, encrypts the phrase locally, and POSTs ciphertext + nonce + its pubkey to the gateway.
 9. The gateway decrypts server-side and writes `~/.totalreclaw/credentials.json` (mode `0600`).
 10. The agent confirms setup and your memory tools are live. First real interaction downloads a ~216 MB embedding model (cached locally, one-time).
 
@@ -64,7 +64,7 @@ The recovery phrase never crosses the LLM context — not the chat transcript, n
 ## Prerequisites
 
 - OpenClaw v3.2.0+ with the gateway running
-- An up-to-date browser with WebCrypto x25519 + ChaCha20-Poly1305 (Safari 17.2+ or Chromium 118+)
+- An up-to-date browser with WebCrypto x25519 + AES-GCM (Safari 17.2+ or Chromium 133+)
 
 ---
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,38 @@ Hermes Agent plugin are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1rc12] — 2026-04-23
+
+**Ship-stopper fix for rc.11.** The relay-served pair page's submit
+button threw `NotSupportedError: Failed to execute 'importKey' on
+'SubtleCrypto': Algorithm: Unrecognized name` when the user clicked
+"Seal key and finish". Root cause: `ChaCha20-Poly1305` is NOT implemented
+in the Web Crypto API of Chrome / Safari / Edge (AES-GCM is the only
+AEAD the spec currently exposes). rc.10/rc.11 never worked end-to-end
+for any user; every pair attempt failed silently and the token expired
+without logging a failure — GH issue #79.
+
+rc.12 swaps the cipher suite from ChaCha20-Poly1305 to AES-256-GCM on
+both sides (browser + gateway). Wire shape unchanged — still 12-byte
+nonce, 16-byte tag, sid-bound AAD, base64url encoding. HKDF info bumped
+from `totalreclaw-pair-v1` to `totalreclaw-pair-v2` so rc.11 ciphertexts
+cannot collide with rc.12 keys.
+
+### Changed
+- `totalreclaw.pair.crypto`: AEAD cipher swapped from `ChaCha20Poly1305`
+  to `AESGCM` (same `cryptography` package). HKDF info constant bumped.
+- `totalreclaw.pair.pair_page`: browser-side AEAD call and capability
+  probe updated to AES-GCM; HKDF info bumped.
+
+### Observability
+- Pair page emits phase-labelled error messages ("Key derivation failed",
+  "Encryption failed", "Submit failed", "Network error", "Gateway could
+  not finish pairing") instead of a single generic "Encryption failed"
+  that masked the browser crypto unsupported error.
+- Capability gate on page load now probes X25519 + AES-GCM + HKDF
+  end-to-end (rc.10/rc.11 only probed X25519, which passed in browsers
+  that still couldn't do AEAD).
+
 ## [2.3.1rc11] — 2026-04-23
 
 Version-bump-only on the Python side — the substantive rc.11 change is in the OpenClaw plugin, which ports the universal-reachability relay-brokered pair flow from Python rc.10 to TypeScript. See `skill/plugin/CHANGELOG.md` (the `3.3.1-rc.11` entry) for the full design. The Python client's own relay client (`totalreclaw.pair.remote_client`) is unchanged from rc.10 and continues to back the Hermes `totalreclaw_pair` tool.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "totalreclaw"
-version = "2.3.1rc11"
+version = "2.3.1rc12"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"

--- a/python/src/totalreclaw/pair/__init__.py
+++ b/python/src/totalreclaw/pair/__init__.py
@@ -1,21 +1,26 @@
-"""TotalReclaw Hermes QR-pair flow (2.3.1rc4).
+"""TotalReclaw Hermes QR-pair flow (2.3.1rc12+).
 
 Browser-side crypto handoff that keeps the recovery phrase out of the
 LLM context. The gateway publishes an ephemeral x25519 public key via a
 local-loopback HTTP endpoint; the user's browser does x25519 ECDH +
-ChaCha20-Poly1305 AEAD encryption of the phrase against that key and
-POSTs the ciphertext back. The gateway decrypts, writes
+AES-256-GCM AEAD encryption of the phrase against that key and POSTs
+the ciphertext back. The gateway decrypts, writes
 ``~/.totalreclaw/credentials.json`` (0600), and the agent never sees the
 plaintext at any point.
 
-Parity with the TypeScript plugin's ``skill/plugin/pair-*.ts`` modules
-(3.3.0). Cipher-suite wire format is identical:
+Parity with the TypeScript plugin's ``skill/plugin/pair-*.ts`` modules.
+Cipher-suite wire format is identical:
 
 - x25519 ECDH key agreement (32-byte raw keys).
 - HKDF-SHA256 with ``salt = sid`` (UTF-8 bytes) and
-  ``info = "totalreclaw-pair-v1"`` (UTF-8) -> 32-byte AEAD key.
-- ChaCha20-Poly1305 AEAD, 12-byte nonce, 16-byte tag, ``AD = sid`` bytes.
+  ``info = "totalreclaw-pair-v2"`` (UTF-8) -> 32-byte AEAD key.
+- AES-256-GCM AEAD, 12-byte nonce, 16-byte tag, ``AD = sid`` bytes.
 - Base64url encoding for every wire field.
+
+Cipher-suite history: rc.4..rc.11 used ChaCha20-Poly1305 but the Web
+Crypto API doesn't implement it in Chrome/Safari/Edge — rc.12 swapped
+to AES-GCM. HKDF info bumped v1 → v2 to fail closed on cross-version
+mixes.
 
 ML-KEM hybrid parity (per ``project_phrase_safety_rule.md``) is DEFERRED
 to rc.5 — pure x25519 ships in rc.4 so Hermes gains *some* phrase-safe

--- a/python/src/totalreclaw/pair/crypto.py
+++ b/python/src/totalreclaw/pair/crypto.py
@@ -1,20 +1,29 @@
-"""pair.crypto — gateway-side x25519 + ChaCha20-Poly1305 primitives.
+"""pair.crypto — gateway-side x25519 + AES-256-GCM primitives.
 
-Python parity of ``skill/plugin/pair-crypto.ts`` (v3.3.0). Every wire
+Python parity of ``skill/plugin/pair-crypto.ts`` (v3.3.1-rc.12). Every wire
 constant (HKDF info, salt binding, tag length, key length) matches the
 TS module so a ciphertext produced by one side decrypts on the other
 unchanged.
 
-Cipher suite (per design doc section 3a-3b, ratified 2026-04-20):
+Cipher suite (per design doc section 3a-3b; cipher swap ratified 2026-04-23):
 
 - ECDH on x25519 for key agreement.
 - HKDF-SHA256 for symmetric-key derivation from the shared secret.
-- ChaCha20-Poly1305 AEAD for the ciphertext payload, with the sid
-  bound as associated data (``AD = sid UTF-8 bytes``).
+- AES-256-GCM AEAD for the ciphertext payload, with the sid bound as
+  associated data (``AD = sid UTF-8 bytes``).
 
 Every primitive is provided by the ``cryptography`` package (OpenSSL-
 backed). No phrase material, private keys, or secondary codes EVER flow
 through logs or return values.
+
+RC.12 cipher-suite swap
+-----------------------
+rc.4..rc.11 specified ChaCha20-Poly1305, but WebCrypto (Chrome / Safari
+/ Edge) does NOT implement ChaCha20-Poly1305 as of 2026-04-23 — the spec
+exposes AES-GCM as the only AEAD. The pair-page submit silently failed
+on encrypt with "Algorithm: Unrecognized name". rc.12 swaps the browser
+side to AES-256-GCM and bumps ``HKDF_INFO`` to ``totalreclaw-pair-v2``
+so mixed-version ciphertexts fail closed rather than silently garble.
 
 Byte encoding: every wire field is base64url (``urlsafe_b64``) with
 ``"="`` padding stripped, matching Node's ``Buffer.toString('base64url')``
@@ -38,7 +47,7 @@ from cryptography.hazmat.primitives.asymmetric.x25519 import (
     X25519PrivateKey,
     X25519PublicKey,
 )
-from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.serialization import (
     Encoding,
     PrivateFormat,
@@ -53,15 +62,17 @@ from cryptography.hazmat.primitives.serialization import (
 
 #: HKDF "info" parameter — fixes the domain separation for this protocol.
 #: MUST match the browser-side constant in the pair-page bundle.
-HKDF_INFO = "totalreclaw-pair-v1"
+#: rc.12: bumped to v2 after cipher-suite swap from ChaCha20-Poly1305 to
+#: AES-256-GCM. v1 ciphertexts will fail closed under v2 HKDF.
+HKDF_INFO = "totalreclaw-pair-v2"
 
-#: HKDF output length — 32 bytes = 256-bit ChaCha20-Poly1305 key.
+#: HKDF output length — 32 bytes = 256-bit AES-256-GCM key.
 AEAD_KEY_BYTES = 32
 
-#: ChaCha20-Poly1305 nonce length — 12 bytes per RFC 7539.
+#: AES-GCM nonce length — 12 bytes (recommended per SP 800-38D).
 AEAD_NONCE_BYTES = 12
 
-#: ChaCha20-Poly1305 auth-tag length — 16 bytes standard.
+#: AES-GCM auth-tag length — 16 bytes (128 bits, standard).
 AEAD_TAG_BYTES = 16
 
 #: Raw x25519 public/private key length — 32 bytes per RFC 7748.
@@ -242,15 +253,16 @@ def derive_aead_key_from_ecdh(sk_local_b64: str, pk_remote_b64: str, sid: str) -
 
 
 def aead_decrypt(k_enc: bytes, nonce_b64: str, sid: str, ciphertext_b64: str) -> bytes:
-    """Decrypt a ChaCha20-Poly1305 ciphertext.
+    """Decrypt an AES-256-GCM ciphertext.
 
-    The ``cryptography`` library's ``ChaCha20Poly1305.decrypt`` expects
-    the ciphertext in combined ``plaintext || tag`` form and takes the
-    AD bytes directly — matching the Node API's ``setAAD`` behaviour.
+    The ``cryptography`` library's ``AESGCM.decrypt`` expects the
+    ciphertext in combined ``plaintext || tag`` form and takes the AD
+    bytes directly — matching both the Node ``setAAD`` API and the
+    WebCrypto ``additionalData`` parameter.
 
     Raises ``cryptography.exceptions.InvalidTag`` on tag mismatch (either
-    tampering or wrong key), which the HTTP handler catches and maps to
-    a 400 response.
+    tampering or wrong key), which the relay respond handler catches and
+    maps to a gateway nack → 502 response.
     """
     nonce = _b64url_decode(nonce_b64)
     if len(nonce) != AEAD_NONCE_BYTES:
@@ -263,7 +275,7 @@ def aead_decrypt(k_enc: bytes, nonce_b64: str, sid: str, ciphertext_b64: str) ->
     if len(combined) < AEAD_TAG_BYTES:
         raise ValueError("pair.crypto: ciphertext too short to contain tag")
 
-    aead = ChaCha20Poly1305(k_enc)
+    aead = AESGCM(k_enc)
     return aead.decrypt(nonce, combined, sid.encode("utf-8"))
 
 
@@ -315,7 +327,7 @@ def aead_encrypt_with_session_key(
         raise ValueError(f"pair.crypto: nonce must be {AEAD_NONCE_BYTES} bytes")
 
     pt = bytes(plaintext)
-    aead = ChaCha20Poly1305(k_enc)
+    aead = AESGCM(k_enc)
     ct = aead.encrypt(nonce, pt, sid.encode("utf-8"))
     return (_b64url_encode(nonce), _b64url_encode(ct))
 

--- a/python/src/totalreclaw/pair/pair_page.py
+++ b/python/src/totalreclaw/pair/pair_page.py
@@ -4,8 +4,8 @@ side of the QR-pair handshake.
 Python parity of ``skill/plugin/pair-page.ts``. The browser loads this
 page at ``GET /pair/<token>``, reads the gateway's ephemeral pubkey from
 the URL fragment (``#pk=<b64url>``), does x25519 ECDH + HKDF +
-ChaCha20-Poly1305 encrypt against the user's typed / generated phrase,
-and POSTs the ciphertext to ``POST /pair/<token>``.
+AES-256-GCM encrypt against the user's typed / generated phrase, and
+POSTs the ciphertext to ``POST /pair/<token>``.
 
 UI mirrors the TS page's UX:
 
@@ -31,8 +31,9 @@ size; on ``generate`` mode the page uses the browser's ``crypto.getRandomValues`
 build time. See :func:`_bip39_words` for the lazy loader.
 
 ML-KEM hybrid port: NOT in rc.4. Both TS and Python pages use pure
-x25519 + ChaCha20-Poly1305. Hybrid KEM lands in rc.5 in lockstep across
-both stacks.
+x25519 + AES-256-GCM (rc.12; was ChaCha20-Poly1305 in rc.4..rc.11 but
+that cipher is not exposed by WebCrypto). Hybrid KEM lands later in
+lockstep across both stacks.
 """
 from __future__ import annotations
 
@@ -222,9 +223,11 @@ _PAIR_PAGE_SCRIPT = r"""
     const NOW_MS = {now_ms};
     const BIP39 = {bip39_js};
 
-    const HKDF_INFO = "totalreclaw-pair-v1";
+    // rc.12: v2 after cipher-suite swap (ChaCha20-Poly1305 -> AES-256-GCM).
+    const HKDF_INFO = "totalreclaw-pair-v2";
     const AEAD_KEY_BYTES = 32;
     const AEAD_NONCE_BYTES = 12;
+    const AEAD_TAG_BITS = 128;
 
     // ---- Base64url helpers (matching Node / Python side) ----
     function b64url(buf) {{
@@ -250,10 +253,10 @@ _PAIR_PAGE_SCRIPT = r"""
       try {{ return b64urlDecode(m[1]); }} catch (_e) {{ return null; }}
     }}
 
-    // ---- Web Crypto: x25519 ECDH + HKDF-SHA256 + ChaCha20-Poly1305 ----
-    // WebCrypto's x25519 + ChaCha20-Poly1305 support lands in Safari 17.2
-    // and Chromium 118. Older browsers fall back to a fail-closed error
-    // page ("update your browser to pair securely"). No polyfill ship.
+    // ---- Web Crypto: x25519 ECDH + HKDF-SHA256 + AES-256-GCM ----
+    // rc.12: cipher suite swapped from ChaCha20-Poly1305 (not supported
+    // in WebCrypto) to AES-256-GCM (universal). Older browsers lacking
+    // X25519 still fall back to a fail-closed error page.
     async function deriveKey(gatewayPub, sid) {{
       // Generate an ephemeral x25519 keypair for the device side.
       const kp = await crypto.subtle.generateKey({{ name: "X25519" }}, true, ["deriveBits"]);
@@ -267,7 +270,7 @@ _PAIR_PAGE_SCRIPT = r"""
       );
       const shared = new Uint8Array(sharedBits);
 
-      // HKDF: extract with salt=sid, expand with info="totalreclaw-pair-v1".
+      // HKDF: extract with salt=sid, expand with info="totalreclaw-pair-v2".
       const baseKey = await crypto.subtle.importKey(
         "raw", shared, "HKDF", false, ["deriveBits"]
       );
@@ -286,11 +289,11 @@ _PAIR_PAGE_SCRIPT = r"""
 
     async function aeadEncrypt(kEnc, sid, plaintext) {{
       const key = await crypto.subtle.importKey(
-        "raw", kEnc, {{ name: "ChaCha20-Poly1305" }}, false, ["encrypt"]
+        "raw", kEnc, {{ name: "AES-GCM" }}, false, ["encrypt"]
       );
       const nonce = crypto.getRandomValues(new Uint8Array(AEAD_NONCE_BYTES));
       const ct = await crypto.subtle.encrypt(
-        {{ name: "ChaCha20-Poly1305", iv: nonce, additionalData: new TextEncoder().encode(sid) }},
+        {{ name: "AES-GCM", iv: nonce, additionalData: new TextEncoder().encode(sid), tagLength: AEAD_TAG_BITS }},
         key,
         plaintext
       );
@@ -459,15 +462,31 @@ _PAIR_PAGE_SCRIPT = r"""
       }}
     }}
 
-    // Capability gate: refuse to run on browsers without x25519 + ChaCha.
+    // Capability gate: probe X25519 + AES-GCM + HKDF end-to-end. rc.10/rc.11
+    // only probed X25519, missed that the browser didn't implement
+    // ChaCha20-Poly1305 — submit failed silently with "Algorithm:
+    // Unrecognized name". rc.12 probes every call this page will make.
     (async () => {{
       try {{
         const ok = crypto && crypto.subtle && typeof crypto.subtle.generateKey === "function";
         if (!ok) throw new Error("no webcrypto");
-        // Probe X25519 support without actually using a key.
         await crypto.subtle.generateKey({{ name: "X25519" }}, true, ["deriveBits"]);
+        const rawKey = new Uint8Array(AEAD_KEY_BYTES);
+        const aesKey = await crypto.subtle.importKey("raw", rawKey, {{ name: "AES-GCM" }}, false, ["encrypt"]);
+        const probeNonce = new Uint8Array(AEAD_NONCE_BYTES);
+        await crypto.subtle.encrypt(
+          {{ name: "AES-GCM", iv: probeNonce, additionalData: new Uint8Array(0), tagLength: AEAD_TAG_BITS }},
+          aesKey,
+          new Uint8Array(0)
+        );
+        await crypto.subtle.importKey("raw", rawKey, "HKDF", false, ["deriveBits"]);
       }} catch (err) {{
-        setStatus("This browser lacks x25519 + ChaCha20-Poly1305 support. Please use an up-to-date Safari (17.2+) or Chromium (118+) browser to pair securely.", "err");
+        setStatus(
+          "This browser lacks x25519 + AES-GCM + HKDF support required to pair securely. " +
+            "Use an up-to-date Safari 17.2+ or Chromium 133+ browser. (" +
+            (err && err.message ? err.message : String(err)) + ")",
+          "err"
+        );
         document.querySelectorAll("button").forEach(b => b.disabled = true);
       }}
     }})();

--- a/python/tests/test_pair_crypto.py
+++ b/python/tests/test_pair_crypto.py
@@ -38,7 +38,8 @@ class TestConstants:
     def test_parity_with_ts_module(self):
         """These values MUST equal the TS module's exports. Any drift
         breaks cross-stack ciphertext interop."""
-        assert HKDF_INFO == "totalreclaw-pair-v1"
+        # rc.12: bumped to v2 after cipher-suite swap to AES-256-GCM.
+        assert HKDF_INFO == "totalreclaw-pair-v2"
         assert AEAD_KEY_BYTES == 32
         assert AEAD_NONCE_BYTES == 12
         assert AEAD_TAG_BYTES == 16

--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1-rc.12] — 2026-04-23
+
+**Ship-stopper fix for rc.11.** The relay-served pair page's submit
+button threw `NotSupportedError: Failed to execute 'importKey' on
+'SubtleCrypto': Algorithm: Unrecognized name` when the user clicked
+"Seal key and finish". Root cause: `ChaCha20-Poly1305` is NOT
+implemented in the Web Crypto API of Chrome / Safari / Edge — the
+spec exposes `AES-GCM` as the only AEAD. rc.10/rc.11 never worked
+end-to-end for any user; every pair attempt failed silently and the
+token expired without logging a failure — GH issue #79.
+
+rc.12 swaps the cipher suite from ChaCha20-Poly1305 to AES-256-GCM on
+both sides (browser + gateway). Wire shape unchanged — still 12-byte
+nonce, 16-byte tag, sid-bound AAD, base64url encoding. HKDF info bumped
+from `totalreclaw-pair-v1` to `totalreclaw-pair-v2` so rc.11 ciphertexts
+cannot collide with rc.12 keys (fail-closed on any version skew).
+
+### Changed
+- `skill/plugin/pair-crypto.ts`: `aeadDecrypt` / `aeadEncryptWithSessionKey`
+  switched from `chacha20-poly1305` to `aes-256-gcm`. `HKDF_INFO` bumped
+  to `totalreclaw-pair-v2`.
+- `skill/plugin/pair-page.ts` (local-mode pair page): WebCrypto
+  `ChaCha20-Poly1305` calls swapped to `AES-GCM`. Capability probe
+  function renamed `chaChaSupported` → `aesGcmSupported`.
+
+### Observability
+- The relay's `pair-html.ts` (user-facing page) now reports phase-labelled
+  error messages so a network / encrypt / submit failure no longer masks
+  as a silent "stuck on acknowledge screen". Relay PR (fix/pair-aes-gcm-rc12)
+  is the canonical fix for the issue reported in #79.
+
 ## [3.3.1-rc.11] — 2026-04-23
 
 OpenClaw-side universal pair reachability — the plugin's `totalreclaw_pair` tool now routes through the relay WebSocket by default, mirroring the Python `2.3.1rc10` pivot on the Hermes side. The URL returned to the user is `https://api-staging.totalreclaw.xyz/pair/p/<token>#pk=<gateway_pubkey>` instead of the previous `http://<gateway-host>:<port>/plugin/totalreclaw/pair/finish?sid=<sid>#pk=…`. Managed hosts, Docker-in-cloud setups, phone-scan-QR flows, and split-network operators can now complete pairing without the browser needing loopback or LAN access to the gateway.

--- a/skill/plugin/package-lock.json
+++ b/skill/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.1-rc.11",
+  "version": "3.3.1-rc.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/totalreclaw",
-      "version": "3.3.1-rc.11",
+      "version": "3.3.1-rc.12",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.0.1",

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.1-rc.11",
+  "version": "3.3.1-rc.12",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [

--- a/skill/plugin/pair-crypto.test.ts
+++ b/skill/plugin/pair-crypto.test.ts
@@ -369,7 +369,8 @@ function assert(condition: boolean, name: string): void {
 // 16. Constant sanity
 // ---------------------------------------------------------------------------
 {
-  assert(HKDF_INFO === 'totalreclaw-pair-v1', 'const: HKDF info tag matches spec');
+  // rc.12: bumped to v2 after cipher-suite swap to AES-256-GCM.
+  assert(HKDF_INFO === 'totalreclaw-pair-v2', 'const: HKDF info tag matches spec (v2)');
   assert(AEAD_KEY_BYTES === 32, 'const: AEAD key 32 bytes');
   assert(AEAD_NONCE_BYTES === 12, 'const: AEAD nonce 12 bytes');
   assert(AEAD_TAG_BYTES === 16, 'const: AEAD tag 16 bytes');

--- a/skill/plugin/pair-crypto.ts
+++ b/skill/plugin/pair-crypto.ts
@@ -1,19 +1,24 @@
 /**
- * pair-crypto — gateway-side cryptographic primitives for the v3.3.0
- * QR-pairing flow.
+ * pair-crypto — gateway-side cryptographic primitives for the v3.3.x
+ * relay-brokered pair flow.
  *
- * Cipher suite (per design doc section 3a-3b, ratified 2026-04-20):
+ * Cipher suite (design doc 3a-3b, cipher swap ratified 2026-04-23 / rc.12):
  *   - ECDH on x25519 for key agreement.
  *   - HKDF-SHA256 for symmetric-key derivation from the shared secret.
- *   - ChaCha20-Poly1305 AEAD for the ciphertext payload, with the sid
- *     bound as associated data (AD = sid UTF-8 bytes).
+ *   - AES-256-GCM AEAD for the ciphertext payload, with the sid bound as
+ *     associated data (AD = sid UTF-8 bytes, 12-byte nonce, 16-byte tag).
+ *
+ * rc.4..rc.11 used ChaCha20-Poly1305, but the Web Crypto API does NOT
+ * implement ChaCha20-Poly1305 in Chrome / Safari / Edge. The pair-page
+ * submit path silently threw `Algorithm: Unrecognized name` before
+ * reaching the network. rc.12 swaps the cipher suite to AES-256-GCM
+ * (universally supported in WebCrypto) and bumps HKDF_INFO to v2 so
+ * cross-version mis-pairs fail closed rather than garble.
  *
  * Every primitive is provided by the Node built-in `node:crypto` module
  * on Node 18.19+ and above. NO third-party crypto dependency is added
- * to the plugin for the gateway side. (The BROWSER side of the flow in
- * P2 uses WebCrypto with a `@noble/curves` + `@noble/ciphers` fallback
- * for older Safari — those ship as part of the served pairing page and
- * do NOT affect the plugin's server-side dep tree.)
+ * to the plugin for the gateway side. (The BROWSER side of the flow uses
+ * WebCrypto's AES-GCM directly — no shim needed.)
  *
  * Scope and guarantees
  * --------------------
@@ -33,11 +38,11 @@
  *
  * Interoperability with browser WebCrypto
  * ---------------------------------------
- *   The WebCrypto x25519 + HKDF + ChaCha20-Poly1305 APIs are bit-for-bit
- *   compatible with Node's `crypto` as long as:
+ *   The WebCrypto x25519 + HKDF + AES-GCM APIs are bit-for-bit compatible
+ *   with Node's `crypto` as long as:
  *     - Raw 32-byte public/private keys are used (not DER/SPKI).
  *     - HKDF parameters are (hash=SHA-256, salt=sid bytes, info fixed
- *       ASCII string, length=32 bytes → 256-bit AEAD key).
+ *       ASCII string "totalreclaw-pair-v2", length=32 bytes).
  *     - AEAD uses a 12-byte random nonce + 16-byte tag, AD = sid bytes.
  *   See tests for fixed test vectors.
  */
@@ -60,18 +65,23 @@ import {
 
 /**
  * HKDF "info" parameter — fixes the domain separation for this protocol.
- * MUST match the browser-side constant in the pair-page bundle (P2).
- * Versioned so we can roll to a new KDF without breaking old ciphertexts.
+ * MUST match the browser-side constant in the pair-page bundle + the
+ * relay-served pair-html page.
+ *
+ * Versioned so we can roll to a new KDF or cipher suite without silently
+ * producing garbage with old ciphertexts. rc.12: bumped from v1 to v2
+ * after cipher-suite swap from ChaCha20-Poly1305 → AES-256-GCM (see
+ * module header comment for context).
  */
-export const HKDF_INFO = 'totalreclaw-pair-v1';
+export const HKDF_INFO = 'totalreclaw-pair-v2';
 
-/** HKDF output length — 32 bytes = 256-bit ChaCha20-Poly1305 key. */
+/** HKDF output length — 32 bytes = 256-bit AES-256-GCM key. */
 export const AEAD_KEY_BYTES = 32;
 
-/** ChaCha20-Poly1305 nonce length — 12 bytes per RFC 7539. */
+/** AES-GCM nonce length — 12 bytes (SP 800-38D recommendation). */
 export const AEAD_NONCE_BYTES = 12;
 
-/** ChaCha20-Poly1305 auth tag length — 16 bytes standard. */
+/** AES-GCM auth tag length — 16 bytes (128 bits, standard). */
 export const AEAD_TAG_BYTES = 16;
 
 /** Raw x25519 public/private key length — 32 bytes per RFC 7748. */
@@ -101,7 +111,7 @@ export interface GatewayKeypair {
 
 /** Fully-derived session keys — caller uses kEnc for AEAD ops. */
 export interface SessionKeys {
-  /** 32-byte ChaCha20-Poly1305 key. */
+  /** 32-byte AES-256-GCM key. */
   kEnc: Buffer;
 }
 
@@ -323,9 +333,9 @@ export function deriveAeadKeyFromEcdh(opts: {
 // ---------------------------------------------------------------------------
 
 /**
- * Decrypt a ChaCha20-Poly1305 AEAD ciphertext. Returns the plaintext
- * on success; throws if the tag is invalid (which includes both
- * tampering and wrong-key attempts).
+ * Decrypt an AES-256-GCM AEAD ciphertext. Returns the plaintext on
+ * success; throws if the tag is invalid (which includes both tampering
+ * and wrong-key attempts).
  *
  * Ciphertext is expected in the combined form `plaintext || tag`, where
  * tag is the trailing 16 bytes. The caller MUST supply the same
@@ -351,7 +361,7 @@ export function aeadDecrypt(opts: {
   const ct = combined.subarray(0, combined.length - AEAD_TAG_BYTES);
   const tag = combined.subarray(combined.length - AEAD_TAG_BYTES);
 
-  const decipher = createDecipheriv('chacha20-poly1305', opts.kEnc, nonce, {
+  const decipher = createDecipheriv('aes-256-gcm', opts.kEnc, nonce, {
     authTagLength: AEAD_TAG_BYTES,
   });
   decipher.setAAD(Buffer.from(opts.sid, 'utf-8'), { plaintextLength: ct.length });
@@ -409,7 +419,7 @@ export function aeadEncryptWithSessionKey(opts: {
   }
 
   const pt = Buffer.isBuffer(opts.plaintext) ? opts.plaintext : Buffer.from(opts.plaintext);
-  const cipher = createCipheriv('chacha20-poly1305', opts.kEnc, nonceBuf, {
+  const cipher = createCipheriv('aes-256-gcm', opts.kEnc, nonceBuf, {
     authTagLength: AEAD_TAG_BYTES,
   });
   cipher.setAAD(Buffer.from(opts.sid, 'utf-8'), { plaintextLength: pt.length });

--- a/skill/plugin/pair-page.test.ts
+++ b/skill/plugin/pair-page.test.ts
@@ -8,7 +8,7 @@
  *   4. Contains the required security copy blocks (design doc + user
  *      ratification 2026-04-20 phone-page wave).
  *   5. Uses the brand tokens from v5b.html (--purple, --bg, etc.).
- *   6. Uses WebCrypto X25519 + ChaCha20-Poly1305 + HKDF.
+ *   6. Uses WebCrypto X25519 + AES-GCM + HKDF (rc.12 cipher swap).
  *   7. Reads pk from `window.location.hash` (design doc section 5c).
  *   8. Does NOT reference any external CDN / host.
  *   9. Escapes potentially-dangerous sid/apiBase injections via
@@ -127,9 +127,12 @@ function assert(cond: boolean, name: string): void {
     sid: 's', mode: 'generate', expiresAtMs: 0, apiBase: '/', nowMs: 0,
   });
   assert(html.includes('X25519'), 'crypto: X25519 algorithm referenced');
-  assert(html.includes('ChaCha20-Poly1305'), 'crypto: ChaCha20-Poly1305 referenced');
+  // rc.12: AEAD is AES-GCM (WebCrypto-supported). ChaCha20-Poly1305 is NOT
+  // implemented in browser WebCrypto; see pair-crypto.ts header for context.
+  assert(html.includes('AES-GCM'), 'crypto: AES-GCM referenced');
+  assert(!html.includes('ChaCha20-Poly1305'), 'crypto: no stale ChaCha20-Poly1305 ref');
   assert(html.includes('HKDF'), 'crypto: HKDF referenced');
-  assert(html.includes('totalreclaw-pair-v1'), 'crypto: HKDF info matches server');
+  assert(html.includes('totalreclaw-pair-v2'), 'crypto: HKDF info matches server (v2)');
   assert(html.includes('deriveBits'), 'crypto: WebCrypto deriveBits API used');
 }
 

--- a/skill/plugin/pair-page.ts
+++ b/skill/plugin/pair-page.ts
@@ -364,7 +364,9 @@ button.secondary:hover:not(:disabled) { border-color: var(--border-accent); colo
   // Client-observed time at page load (used to adjust for clock skew).
   const CLIENT_EPOCH_AT_LOAD = Date.now();
 
-  const HKDF_INFO = "totalreclaw-pair-v1";
+  // v2: cipher-suite swap in rc.12 (see pair-crypto.ts header). Keep
+  // this constant in lockstep with the gateway-side pair-crypto.ts.
+  const HKDF_INFO = "totalreclaw-pair-v2";
 
   // ---------- Small utilities ----------
   function $(sel, root) { return (root || document).querySelector(sel); }
@@ -473,10 +475,9 @@ button.secondary:hover:not(:disabled) { border-color: var(--border-accent); colo
   }
 
   // ---------- Crypto shims: prefer WebCrypto; fall back to JS path ----------
-  // WebCrypto's x25519 + HKDF + ChaCha20-Poly1305 availability is Safari 17+
-  // and modern Chromium / Firefox. If absent we render an error — the page
-  // is self-contained, and we elect not to bundle @noble/curves + ciphers
-  // for the MVP (tracked as Wave 3.1 polish follow-up).
+  // WebCrypto's x25519 + HKDF + AES-GCM availability is Safari 17+ and
+  // modern Chromium 133+ / Firefox 130+. If absent we render an error
+  // — the page is self-contained and we do not bundle any JS crypto shim.
   async function ensureWebCryptoSupport() {
     if (!window.crypto || !crypto.subtle) return false;
     try {
@@ -505,29 +506,28 @@ button.secondary:hover:not(:disabled) { border-color: var(--border-accent); colo
     );
     return new Uint8Array(bits);
   }
-  // AEAD: WebCrypto offers AES-GCM universally; ChaCha20-Poly1305 support is
-  // newer. We attempt chacha first; if it throws, we abort (do NOT silently
-  // swap ciphers — that would mismatch the gateway).
-  async function aeadEncryptChaCha(keyBytes, nonce, sid, plaintext) {
+  // AEAD: AES-256-GCM (universal in WebCrypto). Cipher swap rationale
+  // lives in pair-crypto.ts header comment (rc.12 changelog entry).
+  async function aeadEncryptAesGcm(keyBytes, nonce, sid, plaintext) {
     const key = await crypto.subtle.importKey(
       "raw", keyBytes,
-      { name: "ChaCha20-Poly1305" },
+      { name: "AES-GCM" },
       false, ["encrypt"],
     );
     const adBytes = new TextEncoder().encode(sid);
     const ct = new Uint8Array(await crypto.subtle.encrypt(
-      { name: "ChaCha20-Poly1305", iv: nonce, additionalData: adBytes, tagLength: 128 },
+      { name: "AES-GCM", iv: nonce, additionalData: adBytes, tagLength: 128 },
       key, plaintext,
     ));
     return ct;
   }
 
-  async function chaChaSupported() {
+  async function aesGcmSupported() {
     try {
       const k = new Uint8Array(32);
       const n = new Uint8Array(12);
-      const key = await crypto.subtle.importKey("raw", k, { name: "ChaCha20-Poly1305" }, false, ["encrypt"]);
-      await crypto.subtle.encrypt({ name: "ChaCha20-Poly1305", iv: n, additionalData: new Uint8Array(0), tagLength: 128 }, key, new Uint8Array(0));
+      const key = await crypto.subtle.importKey("raw", k, { name: "AES-GCM" }, false, ["encrypt"]);
+      await crypto.subtle.encrypt({ name: "AES-GCM", iv: n, additionalData: new Uint8Array(0), tagLength: 128 }, key, new Uint8Array(0));
       return true;
     } catch (e) { return false; }
   }
@@ -742,8 +742,8 @@ button.secondary:hover:not(:disabled) { border-color: var(--border-accent); colo
       render(renderError("Your browser does not support modern cryptographic APIs (X25519). Please update your browser and try again, or use a different device. Supported: Chrome 123+, Firefox 130+, Safari 17+."));
       return;
     }
-    if (!(await chaChaSupported())) {
-      render(renderError("Your browser does not support ChaCha20-Poly1305. Update your browser or use a different device."));
+    if (!(await aesGcmSupported())) {
+      render(renderError("Your browser does not support AES-GCM. Update your browser or use a different device."));
       return;
     }
 
@@ -762,7 +762,7 @@ button.secondary:hover:not(:disabled) { border-color: var(--border-accent); colo
       const nonce = new Uint8Array(12);
       crypto.getRandomValues(nonce);
       const ptBytes = new TextEncoder().encode(mnemonic);
-      const ct = await aeadEncryptChaCha(kEnc, nonce, SID, ptBytes);
+      const ct = await aeadEncryptAesGcm(kEnc, nonce, SID, ptBytes);
 
       // 6. Zero sensitive buffers BEFORE sending. The JS GC will run
       //    whenever it runs; explicit zeroing is best-effort but honours

--- a/skill/plugin/pair-remote-client.ts
+++ b/skill/plugin/pair-remote-client.ts
@@ -7,7 +7,7 @@
  * Python implementation byte-for-byte so either side can open a session that
  * the relay (`totalreclaw-relay`) + browser page (`pair-html.ts`) already
  * understand. Crypto primitives come from the shared ``pair-crypto.ts``
- * module — the same ECDH + HKDF + ChaCha20-Poly1305 stack the loopback HTTP
+ * module — the same ECDH + HKDF + AES-256-GCM stack the loopback HTTP
  * server uses.
  *
  * Flow (this file implements the gateway half):


### PR DESCRIPTION
## Summary

- rc.10/rc.11 pair flow silently failed on submit: `ChaCha20-Poly1305` is NOT implemented in any browser's WebCrypto (Chrome 147 + Safari 18.2 both throw `NotSupportedError: Algorithm: Unrecognized name`). 100% submit failure for every user — issue [totalreclaw-internal#79](https://github.com/p-diogo/totalreclaw-internal/issues/79).
- Swap gateway-side crypto to AES-256-GCM to match browser. Wire shape unchanged (12-byte nonce, 16-byte tag, sid-bound AAD, base64url). HKDF info bumped `totalreclaw-pair-v1` → `v2`.
- Python client bumped `2.3.1rc11` → `2.3.1rc12`. Plugin bumped `3.3.1-rc.11` → `3.3.1-rc.12`.

## Changed

**Python (`totalreclaw.pair.crypto`)**:
- AEAD swapped from `cryptography.ChaCha20Poly1305` to `AESGCM` (same `cryptography` package)
- HKDF info bumped to v2
- Local-mode `pair_page.py` browser side: WebCrypto AES-GCM; new end-to-end capability probe (X25519 + AES-GCM + HKDF)

**Plugin (`skill/plugin/pair-crypto.ts`)**:
- `createCipheriv`/`createDecipheriv` switched `chacha20-poly1305` → `aes-256-gcm`
- `HKDF_INFO` bumped to v2; tests updated
- Local-mode `pair-page.ts`: WebCrypto AES-GCM; capability probe renamed

Companion relay PR: [totalreclaw-relay#5](https://github.com/p-diogo/totalreclaw-relay/pull/5) — user-facing browser page (the one served by the staging relay).

## Test plan

- [x] 22 Python pair-crypto tests pass (`pytest tests/test_pair_crypto.py`)
- [x] 883 total Python tests pass (`pytest tests/`)
- [x] 39 plugin pair-crypto tests pass (`npx tsx pair-crypto.test.ts`)
- [x] 58 plugin pair-page tests pass (`npx tsx pair-page.test.ts`)
- [x] All pair-* plugin tests pass (pair-cli, pair-crypto, pair-http, pair-page, pair-qr, pair-remote-client, pair-session-store)
- [x] End-to-end: headless Chrome → relay (with rc.12 fix) → gateway decrypt succeeds
- [ ] Post-merge: full auto-QA against rc.12 bundle via `qa-totalreclaw`

Fixes p-diogo/totalreclaw-internal#79.