### PR TITLE
feat(mockup): rc.13 pair wizard — 5 UX fixes from 2026-04-23 review

### DIFF
--- a/docs/mockups/rc13-pair-wizard/README.md
+++ b/docs/mockups/rc13-pair-wizard/README.md
@@ -2,13 +2,46 @@
 
 Open `index.html` in any browser. Clickable rc.13 UX mockup. No backend needed.
 
-Three screens: PIN → phrase (import / generate) → paired. Pure HTML/CSS/JS, no
+Three screens: PIN → phrase (Set up / Log in) → done. Pure HTML/CSS/JS, no
 build step, no dependencies. Purpose: gather taste-test feedback before we
 implement for real in rc.13 against `src/routes/pair-html.ts` in the relay.
 
 ## Live preview
 
 `https://api-staging.totalreclaw.xyz/pair-preview/` (served by the relay).
+
+## Preview mode
+
+When the page is loaded under `/pair-preview/` or with `?preview=1`, the
+mockup:
+
+- shows a small orange **PREVIEW** badge at the top,
+- leaves both primary CTAs (**Continue**, **Set up TotalReclaw** / **Log in**)
+  always clickable so a reviewer can click through the whole flow without
+  typing anything.
+
+The detection is path + query based (see `isPreviewMode()` in `wizard.js`). The
+production pair page — served from a different route entirely — never matches
+this check and keeps strict validation.
+
+## Copy decisions (2026-04-23)
+
+- "Setup" replaces "Pair" in user-facing copy. The tool name
+  `totalreclaw_pair` and internal routes stay as-is.
+- Default tab on step 2 is **Set up** (generate). **Log in** is the returning
+  user branch (restore from existing phrase).
+- Step 3 heading stays "You're all set"; subheading now reads "TotalReclaw
+  account created. Your memories are encrypted to your recovery phrase."
+
+## PIN input UX
+
+- Cell 1 carries `autocomplete="one-time-code"` so iOS can surface
+  SMS-autofill suggestions. The input handler detects multi-digit writes
+  and distributes them across the 6 cells.
+- A **Paste** button under the cells reads the clipboard via
+  `navigator.clipboard.readText()` and drops the first six digits into the
+  cells. If the browser blocks the API, a toast appears ("Paste not allowed —
+  type manually") and the user types in each cell manually.
 
 ## What this is not
 

--- a/docs/mockups/rc13-pair-wizard/index.html
+++ b/docs/mockups/rc13-pair-wizard/index.html
@@ -6,13 +6,21 @@
   <meta name="referrer" content="no-referrer" />
   <meta name="robots" content="noindex, nofollow" />
   <meta name="theme-color" content="#0B0B1A" />
-  <title>Pair your device — TotalReclaw (rc.13 mockup)</title>
+  <title>Set up TotalReclaw (rc.13 mockup)</title>
   <link rel="stylesheet" href="wizard.css" />
 </head>
 <body>
   <a href="#main" class="skip-link">Skip to content</a>
 
   <main id="main" class="wizard" aria-live="polite">
+    <!-- Preview-mode badge (shown only when served from /pair-preview/ or ?preview=1).
+         JS toggles the [hidden] attribute at boot; see wizard.js isPreviewMode(). -->
+    <div class="preview-badge" id="preview-badge" hidden>
+      <span class="preview-badge-dot" aria-hidden="true"></span>
+      <span class="preview-badge-label">PREVIEW</span>
+      <span class="preview-badge-help">mockup only — crypto mocked, validation relaxed</span>
+    </div>
+
     <!-- Top bar: logo + step meter + countdown -->
     <header class="topbar">
       <a class="brand" href="#" aria-label="TotalReclaw">
@@ -63,17 +71,25 @@
         <div class="screen-inner">
           <p class="eyebrow">Step 1 of 3</p>
           <h1 id="pin-heading" class="heading">Enter your PIN</h1>
-          <p class="subheading">Your agent showed you this PIN. It's there so only you can complete pairing.</p>
+          <p class="subheading">This sets up your TotalReclaw account. Your agent showed you a PIN — enter it here so only you can finish setup.</p>
 
           <div class="pin-wrap">
             <div class="pin-cells" role="group" aria-label="6-digit PIN">
-              <input class="pin-cell" type="tel" inputmode="numeric" pattern="[0-9]*" maxlength="1" autocomplete="off" aria-label="Digit 1" data-index="0" />
+              <!-- autocomplete="one-time-code" on cell 1 triggers iOS SMS-autofill and will
+                   distribute the 6 digits across cells via the paste handler. -->
+              <input class="pin-cell" type="tel" inputmode="numeric" pattern="[0-9]*" maxlength="1" autocomplete="one-time-code" aria-label="Digit 1" data-index="0" />
               <input class="pin-cell" type="tel" inputmode="numeric" pattern="[0-9]*" maxlength="1" autocomplete="off" aria-label="Digit 2" data-index="1" />
               <input class="pin-cell" type="tel" inputmode="numeric" pattern="[0-9]*" maxlength="1" autocomplete="off" aria-label="Digit 3" data-index="2" />
               <span class="pin-sep" aria-hidden="true"></span>
               <input class="pin-cell" type="tel" inputmode="numeric" pattern="[0-9]*" maxlength="1" autocomplete="off" aria-label="Digit 4" data-index="3" />
               <input class="pin-cell" type="tel" inputmode="numeric" pattern="[0-9]*" maxlength="1" autocomplete="off" aria-label="Digit 5" data-index="4" />
               <input class="pin-cell" type="tel" inputmode="numeric" pattern="[0-9]*" maxlength="1" autocomplete="off" aria-label="Digit 6" data-index="5" />
+            </div>
+            <div class="pin-actions">
+              <button type="button" class="btn-ghost btn-ghost-inline" id="pin-paste" aria-label="Paste 6-digit PIN from clipboard">
+                <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="8" y="3" width="8" height="4" rx="1" fill="none" stroke="currentColor" stroke-width="1.6"/><rect x="5" y="6" width="14" height="15" rx="2" fill="none" stroke="currentColor" stroke-width="1.6"/></svg>
+                Paste
+              </button>
             </div>
             <p class="pin-error" id="pin-error" role="alert" aria-live="assertive"></p>
           </div>
@@ -88,37 +104,27 @@
         </footer>
       </article>
 
-      <!-- ============ STEP 2 — PHRASE ============ -->
+      <!-- ============ STEP 2 — PHRASE ============
+           Default tab = Generate ("Set up"). New-user flow: generate phrase → create account.
+           The "Log in" tab is the returning-user branch (paste existing recovery phrase). -->
       <article class="screen" id="screen-phrase" data-step="2" role="group" aria-labelledby="phrase-heading" hidden>
         <div class="screen-inner">
           <p class="eyebrow">Step 2 of 3</p>
           <h1 id="phrase-heading" class="heading">Your recovery phrase</h1>
 
-          <div class="tabs" role="tablist" aria-label="Phrase source">
-            <button type="button" class="tab active" role="tab" id="tab-import" aria-selected="true" aria-controls="panel-import" data-mode="import">
-              Import existing
+          <div class="tabs mode-generate" role="tablist" aria-label="Account action">
+            <button type="button" class="tab active" role="tab" id="tab-generate" aria-selected="true" aria-controls="panel-generate" data-mode="generate">
+              Set up
             </button>
-            <button type="button" class="tab" role="tab" id="tab-generate" aria-selected="false" aria-controls="panel-generate" data-mode="generate">
-              Generate new
+            <button type="button" class="tab" role="tab" id="tab-import" aria-selected="false" aria-controls="panel-import" data-mode="import">
+              Log in
             </button>
             <span class="tab-indicator" aria-hidden="true"></span>
           </div>
 
-          <!-- Import panel (default) -->
-          <div id="panel-import" class="tab-panel" role="tabpanel" aria-labelledby="tab-import">
-            <p class="helper">Enter the 12 words of your existing recovery phrase.</p>
-            <div class="phrase-grid" id="phrase-grid-import" role="group" aria-label="12-word recovery phrase input">
-              <!-- JS populates 12 slots -->
-            </div>
-            <button type="button" class="btn-ghost" id="paste-all">
-              <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="8" y="3" width="8" height="4" rx="1" fill="none" stroke="currentColor" stroke-width="1.6"/><rect x="5" y="6" width="14" height="15" rx="2" fill="none" stroke="currentColor" stroke-width="1.6"/></svg>
-              Paste all 12 words
-            </button>
-          </div>
-
-          <!-- Generate panel -->
-          <div id="panel-generate" class="tab-panel" role="tabpanel" aria-labelledby="tab-generate" hidden>
-            <p class="helper">We generated a fresh 12-word phrase for you. Write it down before continuing.</p>
+          <!-- Generate panel (default — new-user flow) -->
+          <div id="panel-generate" class="tab-panel" role="tabpanel" aria-labelledby="tab-generate">
+            <p class="helper">Generate your recovery phrase. This phrase IS your account — write it down. You can restore your memories on any agent with it.</p>
             <div class="phrase-grid readonly" id="phrase-grid-generate" role="group" aria-label="Generated 12-word recovery phrase">
               <!-- JS populates 12 slots (readonly) -->
             </div>
@@ -138,6 +144,18 @@
             </label>
           </div>
 
+          <!-- Import panel (returning-user flow) -->
+          <div id="panel-import" class="tab-panel" role="tabpanel" aria-labelledby="tab-import" hidden>
+            <p class="helper">Enter your recovery phrase to restore your memories on this device.</p>
+            <div class="phrase-grid" id="phrase-grid-import" role="group" aria-label="12-word recovery phrase input">
+              <!-- JS populates 12 slots -->
+            </div>
+            <button type="button" class="btn-ghost" id="paste-all">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="8" y="3" width="8" height="4" rx="1" fill="none" stroke="currentColor" stroke-width="1.6"/><rect x="5" y="6" width="14" height="15" rx="2" fill="none" stroke="currentColor" stroke-width="1.6"/></svg>
+              Paste all 12 words
+            </button>
+          </div>
+
           <p class="security-note">
             <svg class="lock" viewBox="0 0 24 24" aria-hidden="true"><path d="M7 10V7a5 5 0 1 1 10 0v3" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><rect x="5" y="10" width="14" height="10" rx="2" fill="none" stroke="currentColor" stroke-width="1.6"/></svg>
             Never share this phrase. TotalReclaw's relay never sees it &mdash; encrypted in your browser before transmission.
@@ -150,7 +168,7 @@
               <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15 6l-6 6 6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
             </button>
             <button type="button" class="btn-primary" id="phrase-pair" disabled>
-              <span class="btn-label">Pair</span>
+              <span class="btn-label" id="phrase-pair-label">Set up TotalReclaw</span>
               <span class="btn-spinner" aria-hidden="true"></span>
             </button>
           </div>
@@ -167,7 +185,7 @@
             </svg>
           </div>
           <h1 id="done-heading" class="heading">You're all set</h1>
-          <p class="subheading">Go back to your chat and try: <em>"remember I prefer Python over Go"</em></p>
+          <p class="subheading" id="done-subheading">TotalReclaw account created. Your memories are encrypted to your recovery phrase. Go back to your chat and try: <em>"remember I prefer Python over Go"</em></p>
           <a href="#" class="close-link" id="close-link">Close this page</a>
         </div>
       </article>

--- a/docs/mockups/rc13-pair-wizard/wizard.css
+++ b/docs/mockups/rc13-pair-wizard/wizard.css
@@ -447,6 +447,98 @@ em { font-style: normal; color: var(--fg); font-weight: 500; background: var(--p
 }
 .pin-error.show { opacity: 1; }
 
+/* ---------- PIN "Paste" button ----------
+   Small inline action under the cells. Compact, secondary visual weight so it
+   doesn't compete with the primary Continue CTA. */
+.pin-actions {
+  display: flex;
+  justify-content: center;
+  margin: 6px 0 2px;
+}
+.btn-ghost-inline {
+  width: auto;
+  min-height: 36px;
+  padding: 7px 14px;
+  font-size: 0.86rem;
+  font-weight: 500;
+  border-radius: 999px;
+  gap: 6px;
+}
+.btn-ghost-inline svg { width: 15px; height: 15px; }
+
+/* ==========================================================================
+   Preview-mode badge + toast
+   ========================================================================== */
+.preview-badge {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  margin: -4px 0 12px;
+  background: var(--orange-soft);
+  border: 1px solid var(--orange);
+  border-radius: 999px;
+  font-size: 0.76rem;
+  color: var(--orange);
+  letter-spacing: 0.02em;
+  align-self: flex-start;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.preview-badge[hidden] { display: none; }
+.preview-badge-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--orange);
+  flex-shrink: 0;
+  animation: preview-pulse 1.6s ease-in-out infinite;
+}
+.preview-badge-label {
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+.preview-badge-help {
+  color: var(--fg-dim);
+  font-weight: 400;
+  letter-spacing: 0.005em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+@keyframes preview-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.55; transform: scale(0.8); }
+}
+
+/* Floating toast (e.g. clipboard-denied hint). Centred above footer CTA. */
+.toast {
+  position: fixed;
+  left: 50%;
+  bottom: calc(88px + env(safe-area-inset-bottom));
+  transform: translateX(-50%) translateY(20px);
+  padding: 10px 16px;
+  background: var(--bg-elev-2);
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  color: var(--fg);
+  font-size: 0.86rem;
+  box-shadow: var(--shadow-soft);
+  opacity: 0;
+  pointer-events: none;
+  z-index: 10;
+  transition: opacity var(--transition), transform var(--transition);
+  max-width: calc(100% - 32px);
+  text-align: center;
+}
+.toast.show {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+@media (max-width: 420px) {
+  .preview-badge-help { display: none; }
+}
+
 /* ==========================================================================
    STEP 2 — tabs, phrase grid
    ========================================================================== */

--- a/docs/mockups/rc13-pair-wizard/wizard.js
+++ b/docs/mockups/rc13-pair-wizard/wizard.js
@@ -16,13 +16,32 @@
   const STATE = {
     step: 1,
     pin: ['', '', '', '', '', ''],
-    mode: 'import', // 'import' | 'generate'
+    // Default 'generate' — new-user flow. 'import' is the "I have a phrase" branch.
+    mode: 'generate', // 'import' | 'generate'
     words: new Array(12).fill(''),
     generated: null,
     ackChecked: false,
     expiresAtMs: Date.now() + 10 * 60 * 1000, // 10 minutes
     timerId: null,
   };
+
+  // Preview mode = served from /pair-preview/ path or ?preview=1 query.
+  // In preview mode, validation is relaxed (Continue/Set up always clickable)
+  // so the user can click through the whole flow without filling fields.
+  // Production path remains strict.
+  function isPreviewMode() {
+    try {
+      const path = window.location.pathname || '';
+      const search = window.location.search || '';
+      if (path.indexOf('/pair-preview') === 0) return true;
+      if (path.indexOf('/pair-preview/') === 0) return true;
+      if (/(^|[?&])preview=1(&|$)/.test(search)) return true;
+      return false;
+    } catch (_) {
+      return false;
+    }
+  }
+  const PREVIEW = isPreviewMode();
 
   // Deterministic demo phrase (NOT cryptographically generated — this is a
   // mockup). Real pair page uses WebCrypto entropy → BIP-39.
@@ -114,11 +133,45 @@
     STATE.timerId = setInterval(renderCountdown, 1000);
   }
 
+  // ---------- Toast (transient hint) ----------
+  // One toast element is reused. Primarily used when the clipboard API is
+  // blocked / denied so the user knows to type manually. Self-dismisses.
+  let toastEl = null;
+  let toastTimer = null;
+  function showToast(msg, ms) {
+    if (!toastEl) {
+      toastEl = document.createElement('div');
+      toastEl.className = 'toast';
+      toastEl.setAttribute('role', 'status');
+      toastEl.setAttribute('aria-live', 'polite');
+      document.body.appendChild(toastEl);
+    }
+    toastEl.textContent = msg;
+    // Force a reflow before toggling .show so the transition plays.
+    // eslint-disable-next-line no-unused-expressions
+    toastEl.offsetWidth;
+    toastEl.classList.add('show');
+    if (toastTimer) clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => {
+      if (toastEl) toastEl.classList.remove('show');
+    }, ms || 2400);
+  }
+
+  // ---------- Preview-mode badge ----------
+  function initPreviewBadge() {
+    const badge = $('preview-badge');
+    if (!badge) return;
+    if (PREVIEW) {
+      badge.hidden = false;
+    }
+  }
+
   // ---------- Step 1: PIN ----------
   function initPinStep() {
     const cells = $$('.pin-cell');
     const continueBtn = $('pin-continue');
     const errEl = $('pin-error');
+    const pasteBtn = $('pin-paste');
 
     function updateFilledClass() {
       cells.forEach((c, i) => {
@@ -128,7 +181,9 @@
 
     function updateContinueState() {
       const complete = STATE.pin.every((d) => /^\d$/.test(d));
-      continueBtn.disabled = !complete;
+      // Preview-mode relaxation: the mockup should be clickable with 0 digits.
+      // Production path stays strict — only enables when all 6 are entered.
+      continueBtn.disabled = PREVIEW ? false : !complete;
     }
 
     function clearError() {
@@ -141,6 +196,26 @@
       errEl.classList.add('show');
     }
 
+    // Shared distributor used by both the explicit Paste button and keyboard
+    // paste events. Takes up to 6 digits from anywhere in the string.
+    function distributeDigits(digits, startIdx) {
+      const start = Math.max(0, Math.min(startIdx || 0, cells.length - 1));
+      const toWrite = digits.slice(0, cells.length - start).split('');
+      toWrite.forEach((d, k) => {
+        const target = cells[start + k];
+        if (target) {
+          target.value = d;
+          STATE.pin[start + k] = d;
+        }
+      });
+      updateFilledClass();
+      updateContinueState();
+      const lastWritten = start + toWrite.length - 1;
+      const nextIdx = Math.min(lastWritten + 1, cells.length - 1);
+      if (cells[nextIdx]) cells[nextIdx].focus();
+      return toWrite.length;
+    }
+
     cells.forEach((cell, i) => {
       cell.addEventListener('input', (e) => {
         const raw = e.target.value.replace(/\D/g, '');
@@ -150,8 +225,16 @@
           updateContinueState();
           return;
         }
-        // Take only the first digit; handle paste of multi-char in keydown/paste instead
-        const digit = raw[raw.length - 1];
+        // iOS SMS-autofill (triggered by autocomplete="one-time-code") fires an
+        // `input` event with the full 6-char code on cell 1. Distribute across
+        // cells when we receive more than one digit at once.
+        if (raw.length > 1) {
+          e.target.value = '';
+          distributeDigits(raw, i);
+          clearError();
+          return;
+        }
+        const digit = raw;
         STATE.pin[i] = digit;
         e.target.value = digit;
         updateFilledClass();
@@ -189,24 +272,44 @@
       cell.addEventListener('paste', (e) => {
         e.preventDefault();
         const text = (e.clipboardData || window.clipboardData).getData('text') || '';
-        const digits = text.replace(/\D/g, '').slice(0, 6 - i).split('');
-        digits.forEach((d, k) => {
-          const target = cells[i + k];
-          if (target) {
-            target.value = d;
-            STATE.pin[i + k] = d;
-          }
-        });
-        updateFilledClass();
-        updateContinueState();
-        const next = Math.min(i + digits.length, cells.length - 1);
-        cells[next].focus();
+        const digits = text.replace(/\D/g, '');
+        if (!digits) return;
+        distributeDigits(digits, i);
+        clearError();
       });
     });
 
+    // Explicit "Paste" button — reads clipboard via async API.
+    // Extracts the first 6 digits found, ignoring non-digit characters.
+    // Graceful fallback if the API is blocked/denied: shows a toast.
+    if (pasteBtn) {
+      pasteBtn.addEventListener('click', async () => {
+        let text = '';
+        try {
+          if (navigator.clipboard && navigator.clipboard.readText) {
+            text = await navigator.clipboard.readText();
+          } else {
+            throw new Error('clipboard API unavailable');
+          }
+        } catch (_) {
+          showToast('Paste not allowed — type manually');
+          return;
+        }
+        const digits = (text || '').replace(/\D/g, '').slice(0, 6);
+        if (!digits) {
+          showToast('Clipboard has no digits');
+          return;
+        }
+        distributeDigits(digits, 0);
+        clearError();
+        // If we filled all 6, Continue auto-enables via updateContinueState.
+        // Don't auto-submit — let the user confirm by clicking Continue.
+      });
+    }
+
     continueBtn.addEventListener('click', () => {
       const complete = STATE.pin.every((d) => /^\d$/.test(d));
-      if (!complete) {
+      if (!complete && !PREVIEW) {
         // Subtle shake for the first empty cell
         const firstEmpty = cells.find((c, idx) => !STATE.pin[idx]);
         if (firstEmpty) {
@@ -222,8 +325,9 @@
       STATE.step = 2;
       setDots();
       transitionTo('screen-phrase', 'forward');
-      // Focus the first word input of the active panel
-      setTimeout(focusFirstWordOfActivePanel, 300);
+      // Focus the first word input of the active panel (import) or the ack
+      // checkbox (generate) — whichever is active.
+      setTimeout(focusFirstInteractiveOfActivePanel, 300);
     });
 
     // Autofocus first cell on load
@@ -267,13 +371,23 @@
     }
   }
 
+  // Swap the primary CTA label depending on the active tab:
+  //   'generate' → "Set up TotalReclaw"  (new user: create account)
+  //   'import'   → "Log in"              (returning user: restore from phrase)
+  function setPrimaryActionLabel(mode) {
+    const label = $('phrase-pair-label');
+    if (!label) return;
+    label.textContent = mode === 'import' ? 'Log in' : 'Set up TotalReclaw';
+  }
+
   function wireImportGrid() {
     const grid = $('phrase-grid-import');
     const inputs = $$('.word-input', grid);
 
     function updatePairState() {
+      if (STATE.mode !== 'import') return; // only care when import tab is active
       const complete = STATE.words.every((w) => w.trim().length > 0);
-      $('phrase-pair').disabled = !complete;
+      $('phrase-pair').disabled = PREVIEW ? false : !complete;
     }
 
     function setWord(i, val) {
@@ -351,8 +465,9 @@
     fill(DEMO_PHRASE);
 
     function updatePairState() {
+      if (STATE.mode !== 'generate') return; // only care when generate tab is active
       const ready = STATE.generated && STATE.generated.length === 12 && STATE.ackChecked;
-      $('phrase-pair').disabled = !ready;
+      $('phrase-pair').disabled = PREVIEW ? false : !ready;
     }
 
     $('gen-ack').addEventListener('change', (e) => {
@@ -386,10 +501,17 @@
     });
   }
 
-  function focusFirstWordOfActivePanel() {
-    const panelId = STATE.mode === 'import' ? 'panel-import' : 'panel-generate';
-    const input = $(panelId).querySelector('.word-input:not([readonly])');
-    if (input) input.focus();
+  // Focus the right element when the phrase screen opens:
+  //   generate tab → the ack checkbox (user's next action)
+  //   import tab   → the first word input
+  function focusFirstInteractiveOfActivePanel() {
+    if (STATE.mode === 'import') {
+      const input = $('panel-import').querySelector('.word-input:not([readonly])');
+      if (input) input.focus();
+    } else {
+      const ack = $('gen-ack');
+      if (ack) ack.focus();
+    }
   }
 
   function wireTabs() {
@@ -407,8 +529,13 @@
       $('panel-import').hidden = mode !== 'import';
       $('panel-generate').hidden = mode !== 'generate';
 
-      // Re-evaluate Pair button
-      if (mode === 'import') {
+      // Update the primary CTA label for the new tab
+      setPrimaryActionLabel(mode);
+
+      // Re-evaluate primary button state for the active tab (preview mode always clickable)
+      if (PREVIEW) {
+        $('phrase-pair').disabled = false;
+      } else if (mode === 'import') {
         $('phrase-pair').disabled = !STATE.words.every((w) => w.trim().length > 0);
       } else {
         $('phrase-pair').disabled = !(STATE.generated && STATE.ackChecked);
@@ -425,6 +552,9 @@
         }
       });
     });
+
+    // Apply initial mode so label + button state are in sync with the default tab.
+    setMode(STATE.mode);
   }
 
   function initPhraseStep() {
@@ -480,6 +610,7 @@
   function resetWizard() {
     STATE.step = 1;
     STATE.pin = ['', '', '', '', '', ''];
+    STATE.mode = 'generate';
     STATE.words = new Array(12).fill('');
     STATE.generated = null;
     STATE.ackChecked = false;
@@ -495,8 +626,11 @@
       el.parentElement.classList.remove('filled');
     });
     $('gen-ack').checked = false;
-    $('pin-continue').disabled = true;
-    $('phrase-pair').disabled = true;
+    // In preview mode both primary buttons stay clickable; in production they
+    // start disabled until their respective validation is satisfied.
+    $('pin-continue').disabled = !PREVIEW;
+    $('phrase-pair').disabled = !PREVIEW;
+    setPrimaryActionLabel(STATE.mode);
     const cd = $('countdown');
     if (cd) {
       cd.style.visibility = '';
@@ -506,6 +640,20 @@
     // Rebuild generated panel so it re-fills with demo phrase cleanly
     buildWordGrid($('phrase-grid-generate'), { prefix: 'g', readonly: true });
     wireGenerateGrid();
+
+    // Restore the default "Set up" tab (generate) so a fresh click-through
+    // starts on the new-user flow every time.
+    const tabsRow = document.querySelector('.tabs');
+    if (tabsRow) {
+      tabsRow.classList.add('mode-generate');
+      $$('.tab').forEach((t) => {
+        const isGenerate = t.dataset.mode === 'generate';
+        t.classList.toggle('active', isGenerate);
+        t.setAttribute('aria-selected', isGenerate ? 'true' : 'false');
+      });
+      $('panel-import').hidden = true;
+      $('panel-generate').hidden = false;
+    }
 
     // Back to step 1
     const currentActive = document.querySelector('.screen.active');
@@ -522,6 +670,7 @@
 
   // ---------- Boot ----------
   document.addEventListener('DOMContentLoaded', () => {
+    initPreviewBadge();
     setDots();
     startTimer();
     initPinStep();


### PR DESCRIPTION
## Summary

User feedback on the rc.13 pair-wizard mockup (2026-04-23). Five fixes, one commit set. Preview at `https://api-staging.totalreclaw.xyz/pair-preview/` after the relay PR merges.

### 1. PIN "Paste" button
Small pill-shaped ghost button under the 6 cells. Reads clipboard via `navigator.clipboard.readText()`, extracts first 6 digits found (ignoring non-digits), distributes across cells. Graceful fallback: if the API is blocked/denied a toast shows "Paste not allowed — type manually". Does NOT auto-submit — user still clicks Continue.

### 2. PIN auto-advance + SMS-autofill
- Cell 1 now carries `autocomplete="one-time-code"` so iOS can surface SMS-autofill suggestions.
- The `input` handler detects multi-digit writes (iOS autofill fires a single event with all 6 chars) and distributes them across cells.
- Typing, backspace-on-empty, and Ctrl/Cmd+V were already working; kept behavior identical on production + preview.

### 3. Preview mode
When the URL path starts with `/pair-preview` OR the query has `?preview=1`, both primary CTAs ("Continue", "Set up TotalReclaw"/"Log in") stay clickable with zero input so reviewers can click through the full flow. An orange **PREVIEW** badge at the top of the page makes the relaxed state obvious.

Detection: `isPreviewMode()` in `wizard.js` — path + query only, no cookie or storage. Production pair page (a different route entirely) never matches, strict validation preserved there.

### 4. Default tab: Generate → first
Step 2 now opens on the **Set up** tab (generate a fresh phrase = new user flow). **Log in** tab is the returning-user branch (paste existing phrase).

### 5. "Pair" → "Setup" copy pass
- Page title: `Set up TotalReclaw`
- Step 1 subheading: "This sets up your TotalReclaw account. Your agent showed you a PIN..."
- Step 2 generate helper: "Generate your recovery phrase. This phrase IS your account — write it down. You can restore your memories on any agent with it."
- Step 2 import helper: "Enter your recovery phrase to restore your memories on this device."
- Primary CTA: "Set up TotalReclaw" (generate) / "Log in" (import) — swaps on tab change
- Step 3 subheading: "TotalReclaw account created. Your memories are encrypted to your recovery phrase."

Tool name `totalreclaw_pair`, internal `/pair` routes, and the `/pair-preview` URL path stay the same.

## Deploy

This is the source-of-truth mockup. The relay-served inline copy is updated by a companion PR at `p-diogo/totalreclaw-relay` (regenerates `src/routes/pair-preview.ts` via `scripts/sync-pair-preview.mjs`). Railway auto-deploys the relay PR once it merges.

## Test plan

- [ ] Open `docs/mockups/rc13-pair-wizard/index.html` directly (no query): PREVIEW badge is hidden, Continue disabled until 6 digits, strict validation preserved.
- [ ] Open `...index.html?preview=1`: PREVIEW badge visible, Continue always clickable, all 3 screens navigable with zero input.
- [ ] Step 2 opens on the "Set up" tab by default.
- [ ] Click Paste button with 6 digits in clipboard → cells fill, Continue enables.
- [ ] Click Paste with no clipboard digits → toast shows.
- [ ] Denied clipboard permission → toast shows, no crash.
- [ ] Tab the 6 PIN cells and type — auto-advance works; backspace-on-empty returns to previous cell.
- [ ] iOS (real device): trigger SMS autofill with a 6-digit code → all 6 cells fill.
- [ ] Copy changes: "Setup" appears in the title / subheadings / CTA label; no leftover "Pair" in user-facing copy.

## Scope guard

- Does NOT touch production pair flow at `totalreclaw-relay/src/routes/pair-html.ts`.
- Does NOT add dependencies or a build step — still vanilla HTML/CSS/JS.
- Does NOT modify the phrase step's encryption/scrub behavior (still no real crypto in the mockup).
- Phrase-safety rule preserved: the mockup never touches real entropy.

DO NOT auto-merge — user wants to click through the Railway-deployed preview first.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>