### PR TITLE
fix(rc.13): pair asyncio lifecycle + wizard UX as production page

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,107 @@ Hermes Agent plugin are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1rc13] — 2026-04-24
+
+**Ship-stopper fix for rc.12.** Calling `totalreclaw_pair` from the
+Hermes chat agent returned `{url, pin}` successfully, but the follow-up
+browser submit hit a 502 every time. Gateway container logs surfaced
+the root cause:
+
+```
+ERROR asyncio: Task was destroyed but it is pending!
+task: <Task pending name='Task-56' coro=<_spawn_relay_completion_task
+       .<locals>._runner() running at
+       totalreclaw/hermes/pair_tool.py:209>>
+Exception ignored in: <coroutine object
+       WebSocketCommonProtocol.close_connection>
+RuntimeError: no running event loop
+```
+
+The rc.10–rc.12 implementation opened the relay WebSocket on Hermes's
+tool-invocation event loop, then used `loop.create_task(...)` to keep
+awaiting on it after the tool returned. Hermes tears that loop down
+as soon as the tool returns, so the background task was destroyed
+mid-`ws.recv()`. The relay received no ack, timed out after 15s, and
+the browser got a 502.
+
+### Fix
+
+The full relay pair session (WebSocket open + opened + forward +
+decrypt + credentials write + ack + close) now runs on a dedicated OS
+thread that owns its own `asyncio.new_event_loop()`. The WebSocket is
+created **inside** the thread loop, so it is never bound to a loop
+that closes. The tool body blocks only on the fast
+`session/open` handshake — the browser-flow wait that follows (user
+types PIN + paste phrase, ~30s median) runs fully inside the worker
+thread with no dependency on the Hermes tool-call loop.
+
+Design note: threading was chosen over "block the tool for up to the
+5-minute TTL" (Option 1, unusable UX — user's chat would stall) and
+over "register a persistent-task hook on plugin startup" (Option 3,
+requires hermes-agent core changes, out of rc.13 scope).
+
+### Observability
+
+Four new structured log events trace the background thread's
+lifecycle for debuggability in `docker compose logs`:
+
+- `pair.relay_completion_started` — waiter thread spawned.
+- `pair.relay_opened` — relay answered `session/open`.
+- `pair.relay_decrypt_ok` / `pair.relay_decrypt_failed` — decrypt +
+  `state.configure(phrase)` outcome.
+- `pair.relay_ack_sent` / `pair.relay_ack_failed` — ack frame written
+  to the WS.
+- `pair.relay_completion_done` — thread exit, carries terminal outcome.
+
+### Pair page UX
+
+The pair HTML page served at `/pair/<token>` is replaced with the
+rc.13 wizard UX: a typeform-style 3-step flow (PIN → phrase → done)
+with 2/3/4-column responsive phrase grids, step dots, countdown, and
+the preview-mode split (`/pair-preview/` stays a mockup). Local-mode
+(`TOTALRECLAW_PAIR_MODE=local`) also adopts the wizard UX so a user
+who hops between relay and local sees identical UX.
+
+Four user-ratified design decisions baked in:
+
+1. 6-cell PIN input (not a single text field) — better affordance +
+   iOS `autocomplete="one-time-code"` on cell 1.
+2. Returning-user tab label is "Log in" (not "Import existing").
+3. Step-1 subheading is agent-generic: "Enter the 6-digit code from
+   your chat to continue." — no "your agent" / "Claude" reference.
+4. Paste into PIN auto-advances + auto-submits Continue when all 6
+   digits are present.
+
+Each is controlled by a single constant at the top of the wizard
+script so a later UX review can flip them without hunting.
+
+### Changed
+- `totalreclaw.hermes.pair_tool`: `_spawn_relay_completion_task`
+  (asyncio-task) replaced by `_run_relay_pair_on_thread`
+  (thread + dedicated event loop). Tool body now uses
+  `asyncio.to_thread(...)` to await the session-open handshake while
+  keeping the completion phase off the caller loop.
+- `totalreclaw.pair.remote_client`: ack emit logs structured
+  `pair.relay_ack_sent` / `_failed` events alongside the existing
+  session-completed log for grep-ability.
+- `totalreclaw.pair.pair_page`: full rewrite on the wizard UX with
+  parity to the relay-served page. Same crypto path (x25519 + HKDF
+  + AES-GCM + `HKDF_INFO = "totalreclaw-pair-v2"`).
+
+### Tests
+
+- New `tests/test_pair_tool_asyncio_lifecycle.py` — regression shield
+  for the rc.10–rc.12 lifecycle bug. Drives `_run_relay_pair_on_thread`
+  against a delayed relay stub + asserts the ack arrives even after
+  the caller-side handshake has returned. 3 test cases.
+- `tests/test_pair_generate_mode.py` — rewired to mock
+  `_run_relay_pair_on_thread` rather than the removed
+  `_spawn_relay_completion_task`.
+- `tests/test_pair_http.py` — page-title assertion updated to
+  match the wizard UX ("Set up TotalReclaw" vs. the rc.12
+  "TotalReclaw pairing").
+
 ## [2.3.1rc12] — 2026-04-23
 
 **Ship-stopper fix for rc.11.** The relay-served pair page's submit

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "totalreclaw"
-version = "2.3.1rc12"
+version = "2.3.1rc13"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"

--- a/python/src/totalreclaw/__init__.py
+++ b/python/src/totalreclaw/__init__.py
@@ -9,7 +9,7 @@ except Exception:
     # installed-package metadata is absent. Must match pyproject.toml —
     # test_version.py enforces a semver-shape string; the live value in
     # a pip-installed wheel comes from importlib.metadata above.
-    __version__ = "2.3.1rc10"
+    __version__ = "2.3.1rc13"
 
 from .client import TotalReclaw
 

--- a/python/src/totalreclaw/hermes/pair_tool.py
+++ b/python/src/totalreclaw/hermes/pair_tool.py
@@ -20,7 +20,9 @@ import base64
 import json
 import logging
 import os
+import queue
 import threading
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional
@@ -29,6 +31,22 @@ if TYPE_CHECKING:
     from .state import PluginState
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Relay-session handshake result — returned from the worker thread to the
+# tool body once the relay has acknowledged ``session/open``. Kept tiny so
+# we can push it through a threading.Queue without risking phrase material.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _OpenedSession:
+    """Metadata the tool needs to return to the agent."""
+
+    url: str
+    pin: str
+    expires_at: str
 
 
 # ---------------------------------------------------------------------------
@@ -161,63 +179,227 @@ def _pair_mode() -> str:
 
 
 # ---------------------------------------------------------------------------
-# Relay-mode: a background task completes the pairing after the tool returns.
+# Relay-mode: a background THREAD runs the entire pair session.
+#
+# rc.13 asyncio-lifecycle fix. Earlier RCs (rc.10–rc.12) opened the relay
+# WebSocket on the Hermes tool-invocation loop, then used
+# ``loop.create_task(...)`` to keep waiting on it after the tool
+# returned. Hermes tears that loop down as soon as the tool returns, so
+# the background task was destroyed mid-``ws.recv()`` — logged as::
+#
+#     Task was destroyed but it is pending!
+#     RuntimeError: no running event loop
+#
+# during ``WebSocketCommonProtocol.close_connection``. The relay saw no
+# ack, timed out at 15s, and returned 502 to the browser.
+#
+# Fix (Option 2 from the rc.13 design notes): run the ENTIRE pair
+# session — open + opened + forward + decrypt + configure + ack + close
+# — on a dedicated OS thread that owns its own ``asyncio`` event loop.
+# The WebSocket is created INSIDE the thread loop, not on the caller
+# loop, so it is never bound to a loop that closes.
+#
+# The tool body still needs ``{url, pin, expires_at}`` to return to the
+# agent synchronously. We use a small ``queue.Queue`` handshake: the
+# thread runs ``open_remote_pair_session`` to completion, pushes the
+# metadata, then proceeds to ``await_phrase_upload`` without the tool
+# body being involved. The tool blocks briefly (a few hundred ms — just
+# the TCP / TLS handshake + one WS round-trip) on the queue before
+# returning.
+#
+# Why NOT Option 1 (block synchronously up to the 5-minute TTL):
+#   Option 1 would pin the user's chat for up to 5 minutes while the
+#   browser flow runs. The whole point of the pair tool returning
+#   ``{url, pin}`` fast is so the agent can relay those to the user
+#   verbatim and the user can go open the URL without the chat
+#   stalling.
+#
+# Why NOT Option 3 (plugin lifecycle hook holding a long-lived task):
+#   Hermes's plugin runtime doesn't expose a persistent background-task
+#   hook. Option 3 would have required hermes-agent core changes,
+#   which is out of rc.13 scope (gateway-side hotfix).
+#
+# Observability: the worker thread emits structured lifecycle events so
+# the next layer of failure (decrypt error, credential-write error, ack
+# send error) is debuggable at a glance in ``docker compose logs``:
+#
+#   - pair.relay_completion_started  → waiter thread spawned
+#   - pair.relay_opened              → relay ACK'd session/open
+#   - pair.relay_decrypt_ok / _failed → decrypt + complete-pairing
+#   - pair.relay_ack_sent / _failed  → ack frame written to WS
+#   - pair.relay_completion_done     → thread exit (with outcome)
 # ---------------------------------------------------------------------------
 
 
-def _spawn_relay_completion_task(
-    session,
+# Queue sentinel — pushed by the worker thread if ``open_remote_pair_session``
+# raises before it can report a URL+PIN back. Carries the exception so
+# the tool body can re-raise it to the agent.
+@dataclass
+class _OpenFailed:
+    error: BaseException
+
+
+def _run_relay_pair_on_thread(
     state: "PluginState",
-) -> None:
-    """Schedule the phrase-upload-wait as a detached asyncio task.
+    mode: Optional[str],
+    handshake_timeout_s: float = 15.0,
+) -> _OpenedSession:
+    """Spawn a worker thread that runs the FULL relay pair session.
 
-    Called synchronously from the tool body. The tool returns the
-    {url, pin, ...} payload to the agent, then this task blocks on the
-    WebSocket until the user completes the browser flow (or the 5-minute
-    TTL lapses).
+    Blocks the caller only until the relay returns ``opened``. After
+    that, the thread runs ``await_phrase_upload`` independently and the
+    tool body is free to return to the agent.
+
+    Returns ``_OpenedSession(url, pin, expires_at)``. Raises on
+    relay open failure (rate-limit, bad gateway, etc).
     """
-    from ..pair.remote_client import await_phrase_upload
+    from ..pair.remote_client import await_phrase_upload, open_remote_pair_session
 
-    async def _complete_pairing(phrase: str) -> dict:
-        # Run the synchronous state.configure in a thread so we don't stall
-        # the asyncio loop while credentials.json + EOA derivation happens.
-        loop = asyncio.get_running_loop()
+    handshake_q: "queue.Queue[Any]" = queue.Queue(maxsize=1)
 
-        def _do() -> dict:
-            try:
-                state.configure(phrase)
-                client = state.get_client()
-                eoa = getattr(client, "_eoa_address", None)
-                logger.info(
-                    "pair-tool(relay): credentials configured for EOA %s (token %s…)",
-                    eoa or "unknown",
-                    session.token[:8],
-                )
-                return {"state": "active", "account_id": eoa}
-            except Exception as err:
-                logger.error(
-                    "pair-tool(relay): complete_pairing failed token=%s…: %r",
-                    session.token[:8],
-                    err,
-                )
-                return {"state": "error", "error": str(err)}
+    # Thread name uses the short relay host so the thread is identifiable
+    # in ``pstack`` / py-spy dumps. Will be appended with the token once
+    # the relay opens the session.
+    thread_name = "totalreclaw-pair-relay"
 
-        return await loop.run_in_executor(None, _do)
-
-    async def _runner() -> None:
+    def _configure_from_phrase(token_tag: str, phrase: str) -> dict:
+        """Synchronous credential write — runs on the thread's executor."""
         try:
-            await await_phrase_upload(session, complete_pairing=_complete_pairing)
+            state.configure(phrase)
+            client = state.get_client()
+            eoa = getattr(client, "_eoa_address", None)
+            logger.info(
+                "pair.relay_decrypt_ok token=%s… eoa=%s",
+                token_tag,
+                eoa or "unknown",
+            )
+            return {"state": "active", "account_id": eoa}
         except Exception as err:
-            logger.warning(
-                "pair-tool(relay): background task failed token=%s…: %r",
-                session.token[:8] if session.token else "?",
+            logger.error(
+                "pair.relay_decrypt_failed token=%s… stage=configure err=%r",
+                token_tag,
                 err,
             )
+            return {"state": "error", "error": str(err)}
 
-    # Fire-and-forget task on the current event loop. Hermes tool handlers
-    # run under asyncio so ``get_running_loop`` succeeds.
-    loop = asyncio.get_running_loop()
-    loop.create_task(_runner())
+    def _thread_main() -> None:
+        logger.info("pair.relay_completion_started")
+        loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(loop)
+
+            async def _drive_full_session() -> None:
+                """Open + opened + forward + decrypt + ack + close — all
+                under a SINGLE ``run_until_complete`` on the thread loop.
+
+                Splitting this across two ``run_until_complete`` calls
+                (open first, then await_phrase_upload) leaves the WS
+                protocol's keepalive tasks suspended between calls;
+                websockets then sends close 1001 (going away) when the
+                second run_until_complete starts, so ack fails. Keeping
+                it in one coroutine holds the loop in continuous drive.
+                """
+                token_tag_local = "?"
+                try:
+                    session = await open_remote_pair_session(mode=mode)
+                except BaseException as err:
+                    handshake_q.put(_OpenFailed(err))
+                    return
+
+                token_tag_local = session.token[:8] if session.token else "?"
+                logger.info(
+                    "pair.relay_opened token=%s… url_host=%s",
+                    token_tag_local,
+                    _safe_host(session.url),
+                )
+                handshake_q.put(
+                    _OpenedSession(
+                        url=session.url,
+                        pin=session.pin,
+                        expires_at=session.expires_at,
+                    )
+                )
+
+                async def _complete_pairing_async(phrase: str) -> dict:
+                    return await loop.run_in_executor(
+                        None, _configure_from_phrase, token_tag_local, phrase
+                    )
+
+                try:
+                    result = await await_phrase_upload(
+                        session,
+                        complete_pairing=_complete_pairing_async,
+                    )
+                    logger.info(
+                        "pair.relay_completion_done token=%s… outcome=ok state=%s",
+                        token_tag_local,
+                        result.get("state") if isinstance(result, dict) else "unknown",
+                    )
+                except Exception as err:
+                    logger.warning(
+                        "pair.relay_completion_done token=%s… outcome=error err=%r",
+                        token_tag_local,
+                        err,
+                    )
+
+            loop.run_until_complete(_drive_full_session())
+        finally:
+            # Drain stray tasks so websockets' close_connection coroutine
+            # doesn't emit a "task was destroyed but pending" warning on
+            # loop close — the same class of log line that gave rc.12
+            # away.
+            try:
+                pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
+                for t in pending:
+                    t.cancel()
+                if pending:
+                    loop.run_until_complete(
+                        asyncio.gather(*pending, return_exceptions=True)
+                    )
+            except Exception:
+                pass
+            try:
+                loop.close()
+            except Exception:
+                pass
+
+    t = threading.Thread(
+        target=_thread_main,
+        name=thread_name,
+        daemon=True,
+    )
+    t.start()
+
+    # Block the tool body until the relay answers ``opened`` — or a
+    # 15-second ceiling elapses (same as the relay's own respond-side
+    # timeout, so we don't accidentally hold the tool open longer than
+    # the browser will).
+    try:
+        handshake = handshake_q.get(timeout=handshake_timeout_s)
+    except queue.Empty:
+        raise RuntimeError(
+            "pair.relay: handshake did not complete within "
+            f"{handshake_timeout_s:.0f}s — relay unreachable?"
+        ) from None
+
+    if isinstance(handshake, _OpenFailed):
+        raise handshake.error  # propagate the open-time error to the agent
+
+    return handshake
+
+
+def _safe_host(url: str) -> str:
+    """Extract the host portion of ``url`` for logging.
+
+    Strips scheme + path + fragment — the fragment carries the gateway
+    pubkey, which we never want in logs even though it's public.
+    """
+    try:
+        from urllib.parse import urlparse
+
+        return urlparse(url).netloc or "?"
+    except Exception:
+        return "?"
 
 
 # ---------------------------------------------------------------------------
@@ -363,10 +545,21 @@ async def _pair_relay(state: "PluginState", mode: str):
 
     The ``mode`` is passed to the relay via the ``open`` frame so the
     server-rendered HTML only shows the panel(s) the caller asked for.
+
+    rc.13 asyncio-lifecycle fix: the WebSocket + completion waiter both
+    run on a dedicated worker thread. The tool body blocks only on the
+    fast ``session/open`` handshake, then returns to the agent. The
+    browser-side flow that follows (user types PIN + paste phrase, ~30s
+    median) runs fully inside the worker thread — the Hermes tool-call
+    event loop can close immediately after this function returns.
     """
-    from ..pair.remote_client import open_remote_pair_session
-
-    session = await open_remote_pair_session(mode=mode)
-    _spawn_relay_completion_task(session, state)
-
-    return session.url, session.pin, session.expires_at
+    # Offload to a thread-owned event loop — the WS never gets tied to
+    # the Hermes tool-invocation loop. See ``_run_relay_pair_on_thread``
+    # for the full design rationale + observability contract.
+    #
+    # ``to_thread`` is a thin wrapper around the default executor; it
+    # keeps this coroutine awaitable while the heavy lifting is on a
+    # real OS thread. The callee itself is synchronous — it blocks
+    # internally on the worker thread's handshake queue.
+    opened = await asyncio.to_thread(_run_relay_pair_on_thread, state, mode)
+    return opened.url, opened.pin, opened.expires_at

--- a/python/src/totalreclaw/hermes/plugin.yaml
+++ b/python/src/totalreclaw/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: totalreclaw
-version: 2.3.1rc9
+version: 2.3.1rc13
 description: End-to-end encrypted memory vault for AI agents (Memory Taxonomy v1)
 author: TotalReclaw Team
 provides_tools:

--- a/python/src/totalreclaw/pair/__init__.py
+++ b/python/src/totalreclaw/pair/__init__.py
@@ -1,4 +1,4 @@
-"""TotalReclaw Hermes QR-pair flow (2.3.1rc12+).
+"""TotalReclaw Hermes QR-pair flow (2.3.1rc13+).
 
 Browser-side crypto handoff that keeps the recovery phrase out of the
 LLM context. The gateway publishes an ephemeral x25519 public key via a

--- a/python/src/totalreclaw/pair/pair_page.py
+++ b/python/src/totalreclaw/pair/pair_page.py
@@ -1,43 +1,42 @@
 """pair.pair_page — self-contained HTML + inline JS + CSS for the browser
-side of the QR-pair handshake.
+side of the local-mode pair flow (``TOTALRECLAW_PAIR_MODE=local``).
 
-Python parity of ``skill/plugin/pair-page.ts``. The browser loads this
-page at ``GET /pair/<token>``, reads the gateway's ephemeral pubkey from
-the URL fragment (``#pk=<b64url>``), does x25519 ECDH + HKDF +
-AES-256-GCM encrypt against the user's typed / generated phrase, and
-POSTs the ciphertext to ``POST /pair/<token>``.
+rc.13 UX refresh: mirrors the relay's production "wizard" UX (see
+``p-diogo/totalreclaw-relay:src/routes/pair-html.ts``). Three-step
+typeform-style flow — PIN → phrase → done — with the 4 user-ratified
+design decisions baked in:
 
-UI mirrors the TS page's UX:
+  1. 6-cell PIN input + ``autocomplete="one-time-code"`` on cell 1.
+  2. Returning-user tab label is "Log in".
+  3. Step-1 subheading is agent-generic.
+  4. Paste into PIN auto-advances + auto-submits.
 
-- Brand-consistent copy ("your TotalReclaw account key", "Use it ONLY
-  with TotalReclaw", etc).
-- Consequence blocks ("With it you can" / "Without it").
-- Two modes: ``generate`` (browser generates BIP-39) and ``import`` (user
-  pastes).
-- PIN entry (6-digit) + acknowledge-gate BEFORE reveal.
+Shape parity with the relay ensures a user who pairs on one install
+sees the exact same UX regardless of whether they're in default
+relay-mode or air-gapped local-mode.
+
+Crypto is unchanged from rc.12: x25519 + HKDF-SHA256 + AES-256-GCM
+with ``HKDF_INFO = "totalreclaw-pair-v2"``. The browser derives a
+shared key against the gateway's ephemeral pubkey in the URL fragment,
+encrypts the phrase + POSTs the ciphertext to ``api_base`` on the
+gateway's loopback HTTP server.
 
 Security properties:
 
-- Entirely self-contained (no CDN, no external fetch). Inline CSS + JS.
-- No ``console.log`` of phrase / PIN / key material.
-- Memory scrubbed after submit (best-effort — browser GC is not
-  guaranteed).
-- ``cache-control: no-store`` + strict CSP on the response (set by the
-  HTTP server, not this module).
+  - Entirely self-contained (no CDN, no external fetch). Inline CSS + JS.
+  - No ``console.log`` of phrase / PIN / key material.
+  - Memory scrubbed after submit (best-effort — browser GC is not
+    guaranteed).
+  - ``cache-control: no-store`` + strict CSP on the response (set by the
+    HTTP server, not this module).
 
 BIP-39 wordlist: kept out of this module to reduce the Python wheel's
-size; on ``generate`` mode the page uses the browser's ``crypto.getRandomValues``
-+ a compact 2048-word list compiled from the ``mnemonic`` package at
-build time. See :func:`_bip39_words` for the lazy loader.
-
-ML-KEM hybrid port: NOT in rc.4. Both TS and Python pages use pure
-x25519 + AES-256-GCM (rc.12; was ChaCha20-Poly1305 in rc.4..rc.11 but
-that cipher is not exposed by WebCrypto). Hybrid KEM lands later in
-lockstep across both stacks.
+size; ``generate`` mode uses the ``mnemonic`` package's wordlist if
+available. See :func:`_bip39_words`.
 """
 from __future__ import annotations
 
-import html
+import html as _html
 import json
 from functools import lru_cache
 from typing import List
@@ -46,14 +45,13 @@ from typing import List
 @lru_cache(maxsize=1)
 def _bip39_words() -> List[str]:
     """Load the BIP-39 English wordlist from the ``mnemonic`` package if
-    available; otherwise return an empty list and let the browser skip
-    ``generate`` mode (``import`` still works).
+    available; otherwise return an empty list and the browser falls back
+    to ``import`` mode only (``generate`` mode displays an error).
 
     The ``mnemonic`` package is a ``dev`` extra, not a core dep — we
     don't want to pull it into every ``pip install totalreclaw``. If a
     user runs the pair flow without it, they can still use ``import``
-    mode to paste an existing phrase; ``generate`` mode falls back to
-    a "please install ``mnemonic`` to generate" error page.
+    mode to paste an existing phrase.
     """
     try:
         from mnemonic import Mnemonic  # type: ignore
@@ -68,12 +66,7 @@ def _bip39_words() -> List[str]:
 
 
 def _escape_js_string(s: str) -> str:
-    """JSON-encode a string for safe ``<script>`` embedding.
-
-    ``json.dumps`` produces a valid JS string literal. We still escape
-    ``<``, ``>``, ``&``, and U+2028/U+2029 because ``</script>`` in the
-    payload would close the script block.
-    """
+    """JSON-encode a string for safe ``<script>`` embedding."""
     encoded = json.dumps(s, ensure_ascii=False)
     return (
         encoded.replace("<", "\\u003c")
@@ -92,12 +85,13 @@ def render_pair_page(
     api_base: str,
     now_ms: int,
 ) -> str:
-    """Render the self-contained pair HTML page.
+    """Render the self-contained wizard-style pair HTML page.
 
-    ``api_base`` is the prefix that the pair respond endpoint lives under
-    (e.g. ``/pair/<token>``). The browser POSTs the encrypted payload to
-    the same URL it was served from, so the page embeds ``api_base``
-    verbatim.
+    ``api_base`` is the full path the browser POSTs ciphertext to
+    (e.g. ``/pair/<token>``). Local-mode uses POST to ``api_base``
+    directly (no ``/respond`` suffix — the relay and local-mode differ
+    in wire shape here; local-mode's handler accepts the POST body at
+    exactly the URL the page was served from).
     """
     if mode not in ("generate", "import"):
         raise ValueError(f"pair.pair_page: invalid mode '{mode}'")
@@ -108,456 +102,825 @@ def render_pair_page(
     bip39 = _bip39_words()
     bip39_js = json.dumps(bip39)
     expires_safe = int(expires_at_ms)
-    now_safe = int(now_ms)
+    sid_html = _html.escape(sid)
 
-    sid_html = html.escape(sid)
-    mode_html = html.escape(mode)
+    # Panel rendering: local-mode is single-mode (generate XOR import),
+    # so no tab switcher. The PIN screen + done screen are always there.
+    if mode == "generate":
+        panels_html = _GENERATE_PANEL_HTML
+        default_mode_js = "generate"
+    else:
+        panels_html = _IMPORT_PANEL_HTML
+        default_mode_js = "import"
 
-    # The HTML template is big; we compose it in pieces to keep line
-    # length reasonable.
-    script = _PAIR_PAGE_SCRIPT.format(
-        sid_js=sid_js,
-        mode_js=mode_js,
-        api_base_js=api_base_js,
-        expires_at_ms=expires_safe,
-        now_ms=now_safe,
-        bip39_js=bip39_js,
+    script = (
+        _PAIR_SCRIPT
+        .replace("__SID_JS__", sid_js)
+        .replace("__MODE_JS__", mode_js)
+        .replace("__API_BASE_JS__", api_base_js)
+        .replace("__EXPIRES_AT_MS__", str(expires_safe))
+        .replace("__BIP39_JS__", bip39_js)
+        .replace("__DEFAULT_MODE_JS__", _escape_js_string(default_mode_js))
     )
 
-    return _PAIR_PAGE_HTML.format(
-        sid_html=sid_html,
-        mode_html=mode_html,
-        style=_PAIR_PAGE_STYLE,
-        script=script,
+    return (
+        _PAIR_PAGE_HTML
+        .replace("__SID_HTML__", sid_html)
+        .replace("__PANELS__", panels_html)
+        .replace("__STYLE__", _PAIR_STYLE)
+        .replace("__SCRIPT__", script)
     )
 
 
 # ---------------------------------------------------------------------------
-# HTML / CSS / JS templates
+# CSS — derived from docs/mockups/rc13-pair-wizard/wizard.css. Mirrors the
+# relay's pair-html.ts PAGE_STYLE bit-for-bit. Keep them in sync when the
+# mockup is iterated so local-mode and relay look identical.
 # ---------------------------------------------------------------------------
 
-_PAIR_PAGE_STYLE = """
+_PAIR_STYLE = r"""
+:root {
+  --bg: #0B0B1A; --bg-elev: #141329; --bg-elev-2: #1B1A36;
+  --fg: #F0EDF8; --fg-dim: rgba(240, 237, 248, 0.70); --fg-faint: rgba(240, 237, 248, 0.42);
+  --border: rgba(255, 255, 255, 0.08); --border-strong: rgba(255, 255, 255, 0.16);
+  --purple: #7B5CFF; --purple-soft: rgba(123, 92, 255, 0.14);
+  --purple-softer: rgba(123, 92, 255, 0.08); --purple-ring: rgba(123, 92, 255, 0.32);
+  --orange: #D4943A; --orange-soft: rgba(212, 148, 58, 0.16);
+  --danger: #FF5A6A; --success: #45D178; --success-soft: rgba(69, 209, 120, 0.12);
+  --shadow-soft: 0 1px 2px rgba(0, 0, 0, 0.2), 0 8px 32px rgba(0, 0, 0, 0.28);
+  --shadow-lift: 0 4px 16px rgba(123, 92, 255, 0.22);
+  --radius-sm: 8px; --radius: 12px; --radius-lg: 16px; --radius-xl: 24px;
+  --transition-fast: 140ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  --transition: 240ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+@media (prefers-color-scheme: light) {
   :root {
-    --bg: #0b0d12;
-    --fg: #f4f4f7;
-    --muted: #9aa2b4;
-    --accent: #7c66ff;
-    --warn: #ffb84d;
-    --danger: #ff5a6a;
-    --card: #14181f;
-    --border: #242936;
+    --bg: #F7F6FB; --bg-elev: #FFFFFF; --bg-elev-2: #F0EEF8;
+    --fg: #18182B; --fg-dim: rgba(24, 24, 43, 0.70); --fg-faint: rgba(24, 24, 43, 0.48);
+    --border: rgba(24, 24, 43, 0.10); --border-strong: rgba(24, 24, 43, 0.18);
+    --purple: #6B48FF; --purple-soft: rgba(107, 72, 255, 0.10);
+    --purple-softer: rgba(107, 72, 255, 0.05); --purple-ring: rgba(107, 72, 255, 0.28);
+    --orange: #B87320; --orange-soft: rgba(184, 115, 32, 0.12);
+    --shadow-soft: 0 1px 2px rgba(24, 24, 43, 0.05), 0 8px 32px rgba(24, 24, 43, 0.08);
   }
-  * { box-sizing: border-box; }
-  html, body {
-    margin: 0; padding: 0;
-    background: var(--bg); color: var(--fg);
-    font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-    font-size: 16px; line-height: 1.5;
-    min-height: 100vh;
-  }
-  .page {
-    max-width: 640px; margin: 0 auto;
-    padding: 24px 20px 40px;
-  }
-  h1 { font-size: 1.6rem; margin: 0 0 8px; letter-spacing: -0.01em; }
-  h2 { font-size: 1.15rem; margin: 24px 0 8px; }
-  p { margin: 0 0 12px; }
-  .muted { color: var(--muted); }
-  .card {
-    background: var(--card);
-    border: 1px solid var(--border);
-    border-radius: 14px;
-    padding: 20px;
-    margin: 16px 0;
-  }
-  .warn-card { border-color: var(--warn); }
-  .danger-card { border-color: var(--danger); }
-  button {
-    background: var(--accent); color: #fff; border: 0;
-    font-size: 1rem; font-weight: 600;
-    padding: 14px 20px; border-radius: 10px;
-    cursor: pointer; width: 100%;
-  }
-  button:disabled { opacity: 0.4; cursor: not-allowed; }
-  .secondary-button {
-    background: transparent; color: var(--accent);
-    border: 1px solid var(--accent);
-  }
-  label { display: block; font-weight: 600; margin: 12px 0 6px; }
-  input[type="text"], input[type="password"], textarea {
-    width: 100%; padding: 12px 14px;
-    background: var(--bg); color: var(--fg);
-    border: 1px solid var(--border); border-radius: 8px;
-    font-size: 1rem; font-family: inherit;
-  }
-  textarea { min-height: 120px; resize: vertical; font-family: ui-monospace, Menlo, Consolas, monospace; }
-  .pin-input { letter-spacing: 0.3em; text-align: center; font-size: 1.4rem; font-family: ui-monospace, Menlo, monospace; }
-  .phrase-box {
-    background: #000; color: #a6d0ff;
-    border: 1px solid var(--border); border-radius: 10px;
-    padding: 16px; font-family: ui-monospace, Menlo, Consolas, monospace;
-    font-size: 1.05rem; line-height: 1.7;
-    word-spacing: 0.15em;
-    user-select: text;
-  }
-  ol { padding-left: 24px; }
-  ol li { margin: 6px 0; }
-  .consequence { display: flex; gap: 16px; margin: 12px 0; }
-  .consequence > div { flex: 1; padding: 14px; border-radius: 10px; border: 1px solid var(--border); }
-  .hidden { display: none; }
-  #status { margin: 20px 0; padding: 14px; border-radius: 10px; font-weight: 600; text-align: center; }
-  #status.info { background: rgba(124,102,255,0.12); color: var(--accent); }
-  #status.ok { background: rgba(69,209,120,0.12); color: #45d178; }
-  #status.err { background: rgba(255,90,106,0.12); color: var(--danger); }
-  .countdown { font-variant-numeric: tabular-nums; color: var(--muted); font-size: 0.9rem; }
+}
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { font-size: 16px; -webkit-text-size-adjust: 100%; }
+body {
+  min-height: 100vh; min-height: 100dvh; background: var(--bg); color: var(--fg);
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-size: 1rem; line-height: 1.5;
+  -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale;
+  letter-spacing: -0.005em; overflow-x: hidden;
+}
+body::before {
+  content: ""; position: fixed; inset: -20vmax 0 auto 0; height: 60vmax;
+  background:
+    radial-gradient(60% 60% at 50% 30%, var(--purple-softer), transparent 70%),
+    radial-gradient(50% 50% at 80% 10%, var(--orange-soft), transparent 70%);
+  pointer-events: none; z-index: 0; opacity: 0.8;
+}
+a { color: var(--purple); text-decoration: none; }
+a:hover { text-decoration: underline; }
+button { font: inherit; color: inherit; background: transparent; border: 0; cursor: pointer; }
+em { font-style: normal; color: var(--fg); font-weight: 500; background: var(--purple-softer); padding: 0.1em 0.4em; border-radius: 6px; }
+.skip-link { position: absolute; left: -9999px; top: 0; padding: 8px 12px; background: var(--purple); color: #fff; border-radius: 6px; }
+.skip-link:focus { left: 12px; top: 12px; z-index: 999; }
+.wizard {
+  position: relative; z-index: 1; max-width: 520px; margin: 0 auto;
+  padding: 18px 20px calc(24px + env(safe-area-inset-bottom));
+  min-height: 100vh; min-height: 100dvh; display: flex; flex-direction: column;
+}
+.topbar { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 4px 2px 20px; }
+.brand { display: inline-flex; align-items: center; gap: 10px; color: var(--fg); font-weight: 600; text-decoration: none; }
+.brand-mark { width: 28px; height: 28px; flex-shrink: 0; }
+.brand-text { font-size: 0.98rem; letter-spacing: 0.005em; }
+.meta { display: flex; align-items: center; gap: 14px; }
+.step-meter { display: flex; align-items: center; gap: 10px; padding: 6px 10px; background: var(--bg-elev); border: 1px solid var(--border); border-radius: 999px; font-size: 0.78rem; color: var(--fg-dim); font-variant-numeric: tabular-nums; }
+.step-dots { display: flex; gap: 4px; }
+.step-dots .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--border-strong); transition: background var(--transition), transform var(--transition); }
+.step-dots .dot.done { background: var(--purple); }
+.step-dots .dot.active { background: var(--purple); transform: scale(1.4); box-shadow: 0 0 0 3px var(--purple-ring); }
+.countdown { display: inline-flex; align-items: center; gap: 6px; padding: 6px 10px; background: var(--bg-elev); border: 1px solid var(--border); border-radius: 999px; font-size: 0.82rem; font-variant-numeric: tabular-nums; color: var(--fg-dim); transition: color var(--transition-fast), border-color var(--transition-fast), background var(--transition-fast); }
+.countdown .clock { width: 14px; height: 14px; }
+.countdown.warn { color: var(--orange); border-color: var(--orange); background: var(--orange-soft); }
+.countdown.warn .clock { animation: pulse 1s ease-in-out infinite; }
+.countdown.expired { color: var(--danger); border-color: var(--danger); }
+@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.45; } }
+.stage { position: relative; flex: 1; display: flex; }
+.screen { position: absolute; inset: 0; display: flex; flex-direction: column; gap: 18px; padding: 6px 2px 0; opacity: 0; transform: translateX(24px); transition: opacity var(--transition), transform var(--transition); pointer-events: none; }
+.screen.active { position: relative; inset: auto; opacity: 1; transform: translateX(0); pointer-events: auto; width: 100%; }
+.screen.exit-left { position: absolute; inset: 0; opacity: 0; transform: translateX(-32px); pointer-events: none; }
+.screen.enter-right { position: absolute; inset: 0; opacity: 0; transform: translateX(32px); pointer-events: none; }
+@media (prefers-reduced-motion: reduce) { .screen { transition: opacity 0.1s linear; transform: none !important; } .screen.exit-left, .screen.enter-right { transform: none !important; } }
+.screen-inner { flex: 1; display: flex; flex-direction: column; gap: 14px; }
+.screen-inner.center { align-items: center; justify-content: center; text-align: center; padding-top: 24px; }
+.eyebrow { font-size: 0.78rem; color: var(--fg-faint); letter-spacing: 0.14em; text-transform: uppercase; font-weight: 500; }
+.heading { font-size: clamp(1.6rem, 5.8vw, 2.1rem); font-weight: 600; line-height: 1.15; letter-spacing: -0.02em; color: var(--fg); }
+.subheading { font-size: 1rem; color: var(--fg-dim); line-height: 1.55; }
+.helper { font-size: 0.92rem; color: var(--fg-dim); margin: 4px 0 8px; }
+.screen-cta { position: sticky; bottom: 0; padding: 18px 0 2px; background: linear-gradient(to top, var(--bg) 65%, transparent); display: flex; flex-direction: column; gap: 14px; }
+.cta-row { display: flex; gap: 10px; }
+.btn-primary, .btn-secondary, .btn-ghost { display: inline-flex; align-items: center; justify-content: center; gap: 8px; min-height: 52px; padding: 14px 20px; border-radius: var(--radius); font-size: 1rem; font-weight: 600; transition: transform var(--transition-fast), background var(--transition-fast), box-shadow var(--transition-fast), border-color var(--transition-fast), opacity var(--transition-fast); -webkit-tap-highlight-color: transparent; user-select: none; }
+.btn-primary { flex: 1; background: var(--purple); color: #fff; border: 1px solid var(--purple); box-shadow: var(--shadow-lift); position: relative; }
+.btn-primary:hover:not(:disabled) { transform: translateY(-1px); box-shadow: 0 6px 22px rgba(123, 92, 255, 0.36); }
+.btn-primary:active:not(:disabled) { transform: translateY(0); }
+.btn-primary:disabled { background: var(--bg-elev-2); border-color: var(--border); color: var(--fg-faint); box-shadow: none; cursor: not-allowed; }
+.btn-primary:focus-visible { outline: 2px solid var(--purple); outline-offset: 3px; }
+.btn-primary.loading .btn-label { opacity: 0; }
+.btn-primary.loading .btn-spinner { opacity: 1; }
+.btn-spinner { position: absolute; width: 20px; height: 20px; border-radius: 50%; border: 2px solid rgba(255,255,255,0.35); border-top-color: #fff; opacity: 0; animation: spin 0.85s linear infinite; transition: opacity var(--transition-fast); }
+@keyframes spin { to { transform: rotate(360deg); } }
+.btn-secondary { flex: 0 0 56px; padding: 14px; background: var(--bg-elev); border: 1px solid var(--border); color: var(--fg-dim); }
+.btn-secondary:hover { border-color: var(--border-strong); color: var(--fg); }
+.btn-secondary svg { width: 20px; height: 20px; }
+.btn-ghost { width: 100%; background: var(--bg-elev); border: 1px solid var(--border); color: var(--fg-dim); font-weight: 500; min-height: 44px; padding: 10px 16px; }
+.btn-ghost:hover { border-color: var(--border-strong); color: var(--fg); }
+.btn-ghost svg { width: 18px; height: 18px; }
+.btn-ghost-inline { width: auto; min-height: 36px; padding: 7px 14px; font-size: 0.86rem; font-weight: 500; border-radius: 999px; gap: 6px; }
+.btn-ghost-inline svg { width: 15px; height: 15px; }
+.security-note { display: flex; gap: 10px; align-items: flex-start; font-size: 0.85rem; color: var(--fg-dim); line-height: 1.5; padding: 12px 14px; background: var(--purple-softer); border: 1px solid var(--border); border-radius: var(--radius); }
+.security-note .lock { width: 16px; height: 16px; flex-shrink: 0; margin-top: 2px; color: var(--purple); }
+.pin-wrap { margin-top: 10px; }
+.pin-cells { display: flex; align-items: center; justify-content: space-between; gap: 6px; max-width: 360px; margin: 4px auto 10px; }
+.pin-cell { flex: 1; width: 100%; max-width: 54px; aspect-ratio: 1 / 1.15; text-align: center; font-size: 1.6rem; font-weight: 600; font-variant-numeric: tabular-nums; color: var(--fg); background: var(--bg-elev); border: 1.5px solid var(--border-strong); border-radius: var(--radius); transition: border-color var(--transition-fast), box-shadow var(--transition-fast), background var(--transition-fast), transform var(--transition-fast); caret-color: var(--purple); }
+.pin-cell:focus { outline: none; border-color: var(--purple); background: var(--bg-elev-2); box-shadow: 0 0 0 4px var(--purple-ring); transform: translateY(-1px); }
+.pin-cell.filled { border-color: var(--purple); background: var(--purple-soft); }
+.pin-cell.shake { animation: shake 0.4s ease-in-out; }
+@keyframes shake { 10%, 90% { transform: translateX(-1px); } 20%, 80% { transform: translateX(2px); } 30%, 50%, 70% { transform: translateX(-3px); } 40%, 60% { transform: translateX(3px); } }
+.pin-sep { display: inline-block; width: 10px; height: 2px; background: var(--border-strong); border-radius: 2px; margin: 0 2px; flex: 0 0 auto; }
+.pin-error { min-height: 20px; font-size: 0.85rem; color: var(--danger); text-align: center; opacity: 0; transition: opacity var(--transition-fast); }
+.pin-error.show { opacity: 1; }
+.pin-actions { display: flex; justify-content: center; margin: 6px 0 2px; }
+.phrase-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; padding: 14px 12px; background: var(--bg-elev); border: 1px solid var(--border); border-radius: var(--radius); margin: 4px 0 10px; }
+@media (min-width: 420px) { .phrase-grid { grid-template-columns: repeat(3, 1fr); gap: 10px; padding: 16px; } }
+.word-cell { display: flex; align-items: center; gap: 8px; padding: 10px 12px 10px 10px; background: var(--bg-elev-2); border: 1px solid var(--border); border-radius: var(--radius-sm); transition: border-color var(--transition-fast), background var(--transition-fast); min-height: 48px; }
+.word-cell:focus-within { border-color: var(--purple); background: var(--bg-elev); box-shadow: 0 0 0 3px var(--purple-ring); }
+.word-cell.filled { border-color: var(--purple-ring); }
+.word-idx { color: var(--fg-faint); font-size: 0.74rem; font-variant-numeric: tabular-nums; font-weight: 600; width: 18px; flex-shrink: 0; text-align: right; }
+.word-input { flex: 1; min-width: 0; border: 0; background: transparent; color: var(--fg); font-size: 0.98rem; font-weight: 500; font-family: inherit; outline: none; padding: 0; }
+.word-input::placeholder { color: var(--fg-faint); font-weight: 400; }
+.phrase-grid.readonly .word-cell { background: var(--bg-elev); border-color: var(--border); }
+.phrase-grid.readonly .word-input { color: var(--fg); font-weight: 600; cursor: default; user-select: all; }
+.gen-actions { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin: 4px 0 10px; }
+.ack { display: flex; gap: 12px; align-items: flex-start; padding: 14px; background: var(--bg-elev); border: 1px solid var(--border); border-radius: var(--radius); margin: 4px 0 10px; cursor: pointer; transition: border-color var(--transition-fast), background var(--transition-fast); }
+.ack:hover { border-color: var(--border-strong); }
+.ack:has(input:checked) { border-color: var(--purple); background: var(--purple-softer); }
+.ack input { appearance: none; -webkit-appearance: none; width: 22px; height: 22px; flex-shrink: 0; margin-top: 1px; border: 1.5px solid var(--border-strong); border-radius: 6px; background: var(--bg); cursor: pointer; position: relative; transition: background var(--transition-fast), border-color var(--transition-fast); }
+.ack input:checked { background: var(--purple); border-color: var(--purple); }
+.ack input:checked::after { content: ""; position: absolute; inset: 0; background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'><polyline points='5 12 10 17 19 7'/></svg>") center / 14px no-repeat; }
+.ack span { font-size: 0.92rem; color: var(--fg-dim); line-height: 1.5; }
+.ack:has(input:checked) span { color: var(--fg); }
+.check-wrap { width: 112px; height: 112px; margin: 8px auto 10px; position: relative; }
+.check-wrap::before { content: ""; position: absolute; inset: -16px; border-radius: 50%; background: radial-gradient(circle, rgba(69, 209, 120, 0.22), transparent 70%); animation: halo 1.6s ease-out forwards; }
+@keyframes halo { 0% { transform: scale(0.6); opacity: 0; } 30% { opacity: 1; } 100% { transform: scale(1.3); opacity: 0; } }
+.check { width: 100%; height: 100%; display: block; }
+.check-ring { stroke: var(--success); stroke-dasharray: 276; stroke-dashoffset: 276; animation: draw-ring 0.55s cubic-bezier(0.2, 0.8, 0.2, 1) forwards; }
+.check-tick { stroke: var(--success); stroke-dasharray: 80; stroke-dashoffset: 80; animation: draw-tick 0.5s cubic-bezier(0.2, 0.8, 0.2, 1) 0.45s forwards; }
+@keyframes draw-ring { to { stroke-dashoffset: 0; } }
+@keyframes draw-tick { to { stroke-dashoffset: 0; } }
+.close-link { display: inline-block; margin-top: 22px; padding: 10px 18px; border-radius: 999px; background: var(--bg-elev); border: 1px solid var(--border); color: var(--fg-dim); font-size: 0.9rem; font-weight: 500; }
+.err-banner { display: flex; gap: 10px; align-items: flex-start; padding: 12px 14px; background: rgba(255,90,106,0.08); border: 1px solid var(--danger); border-radius: var(--radius); color: var(--danger); font-size: 0.9rem; line-height: 1.5; margin-top: 8px; }
+.err-banner[hidden] { display: none; }
+.toast { position: fixed; left: 50%; bottom: calc(88px + env(safe-area-inset-bottom)); transform: translateX(-50%) translateY(20px); padding: 10px 16px; background: var(--bg-elev-2); border: 1px solid var(--border-strong); border-radius: 999px; color: var(--fg); font-size: 0.86rem; box-shadow: var(--shadow-soft); opacity: 0; pointer-events: none; z-index: 10; transition: opacity var(--transition), transform var(--transition); max-width: calc(100% - 32px); text-align: center; }
+.toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
+@media (min-width: 600px) { .wizard { padding: 36px 24px 40px; max-width: 560px; } .heading { font-size: 2.1rem; } .pin-cell { max-width: 60px; font-size: 1.8rem; } }
+@media (max-width: 360px) { .wizard { padding: 14px 14px calc(20px + env(safe-area-inset-bottom)); } .pin-cell { font-size: 1.4rem; } .brand-text { display: none; } }
 """
 
 
-_PAIR_PAGE_SCRIPT = r"""
-  "use strict";
-  (function() {{
-    const SID = {sid_js};
-    const MODE = {mode_js};
-    const API_BASE = {api_base_js};
-    const EXPIRES_AT_MS = {expires_at_ms};
-    const NOW_MS = {now_ms};
-    const BIP39 = {bip39_js};
+# ---------------------------------------------------------------------------
+# Panel HTML — rendered based on the pinned mode. Local-mode is single-mode
+# (no tab switcher); the full tab-switcher UX lives in the relay page.
+# ---------------------------------------------------------------------------
 
-    // rc.12: v2 after cipher-suite swap (ChaCha20-Poly1305 -> AES-256-GCM).
-    const HKDF_INFO = "totalreclaw-pair-v2";
-    const AEAD_KEY_BYTES = 32;
-    const AEAD_NONCE_BYTES = 12;
-    const AEAD_TAG_BITS = 128;
+_GENERATE_PANEL_HTML = r"""
+  <div id="panel-generate" class="tab-panel" role="tabpanel">
+    <p class="helper">This phrase IS your account — write it down. You can restore your memories on any agent with it.</p>
+    <div class="phrase-grid readonly" id="phrase-grid-generate" role="group" aria-label="Generated 12-word recovery phrase"></div>
+    <div class="gen-actions">
+      <button type="button" class="btn-ghost" id="gen-copy">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="9" y="9" width="11" height="11" rx="2" fill="none" stroke="currentColor" stroke-width="1.6"/><path d="M5 15V5a2 2 0 0 1 2-2h10" fill="none" stroke="currentColor" stroke-width="1.6"/></svg>
+        <span id="gen-copy-label">Copy</span>
+      </button>
+      <button type="button" class="btn-ghost" id="gen-regen">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 12a8 8 0 0 1 14-5.3M20 12a8 8 0 0 1-14 5.3M18 3v4h-4M6 21v-4h4" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        Regenerate
+      </button>
+    </div>
+    <label class="ack" for="gen-ack">
+      <input type="checkbox" id="gen-ack" />
+      <span>I've written this down and stored it somewhere safe.</span>
+    </label>
+  </div>
+"""
 
-    // ---- Base64url helpers (matching Node / Python side) ----
-    function b64url(buf) {{
-      const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
-      let s = "";
-      for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
-      return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-    }}
-    function b64urlDecode(s) {{
-      const pad = "=".repeat((4 - (s.length % 4)) % 4);
-      const b64 = (s + pad).replace(/-/g, "+").replace(/_/g, "/");
-      const raw = atob(b64);
-      const out = new Uint8Array(raw.length);
-      for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i);
-      return out;
-    }}
+_IMPORT_PANEL_HTML = r"""
+  <div id="panel-import" class="tab-panel" role="tabpanel">
+    <p class="helper">Enter your recovery phrase to restore your memories on this device.</p>
+    <div class="phrase-grid" id="phrase-grid-import" role="group" aria-label="12-word recovery phrase input"></div>
+    <button type="button" class="btn-ghost" id="paste-all">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="8" y="3" width="8" height="4" rx="1" fill="none" stroke="currentColor" stroke-width="1.6"/><rect x="5" y="6" width="14" height="15" rx="2" fill="none" stroke="currentColor" stroke-width="1.6"/></svg>
+      Paste all 12 words
+    </button>
+  </div>
+"""
 
-    // ---- URL fragment → gateway pubkey ----
-    function readGatewayPubkeyFromHash() {{
-      const h = window.location.hash || "";
-      const m = /#pk=([A-Za-z0-9_\-]+)/.exec(h);
-      if (!m) return null;
-      try {{ return b64urlDecode(m[1]); }} catch (_e) {{ return null; }}
-    }}
+# ---------------------------------------------------------------------------
+# JavaScript — wizard logic + real crypto + real POST. Mirrors the relay's
+# pair-html.ts script. Local-mode POSTs directly to ``api_base`` (no
+# ``/respond`` suffix — the wire shape differs slightly from the relay).
+# ---------------------------------------------------------------------------
 
-    // ---- Web Crypto: x25519 ECDH + HKDF-SHA256 + AES-256-GCM ----
-    // rc.12: cipher suite swapped from ChaCha20-Poly1305 (not supported
-    // in WebCrypto) to AES-256-GCM (universal). Older browsers lacking
-    // X25519 still fall back to a fail-closed error page.
-    async function deriveKey(gatewayPub, sid) {{
-      // Generate an ephemeral x25519 keypair for the device side.
-      const kp = await crypto.subtle.generateKey({{ name: "X25519" }}, true, ["deriveBits"]);
-      const pkRaw = await crypto.subtle.exportKey("raw", kp.publicKey);
+_PAIR_SCRIPT = r"""
+"use strict";
+(function(){
+  const SID = __SID_JS__;
+  const INITIAL_MODE = __MODE_JS__;
+  const API_BASE = __API_BASE_JS__;
+  const EXPIRES_AT_MS = __EXPIRES_AT_MS__;
+  const HKDF_INFO = "totalreclaw-pair-v2";
+  const AEAD_KEY_BYTES = 32;
+  const AEAD_NONCE_BYTES = 12;
+  const AEAD_TAG_BITS = 128;
+  const BIP39 = __BIP39_JS__;
+  const DEFAULT_MODE = __DEFAULT_MODE_JS__;
 
-      const pubCrypto = await crypto.subtle.importKey(
-        "raw", gatewayPub, {{ name: "X25519" }}, false, []
-      );
-      const sharedBits = await crypto.subtle.deriveBits(
-        {{ name: "X25519", public: pubCrypto }}, kp.privateKey, 256
-      );
-      const shared = new Uint8Array(sharedBits);
+  // UX constants (see rc.13 design decisions in pair-html.ts).
+  const PASTE_PIN_AUTOSUBMIT = true;
+  const STEP1_SUBHEADING = "Enter the 6-digit code from your chat to continue.";
 
-      // HKDF: extract with salt=sid, expand with info="totalreclaw-pair-v2".
-      const baseKey = await crypto.subtle.importKey(
-        "raw", shared, "HKDF", false, ["deriveBits"]
-      );
-      const keyBits = await crypto.subtle.deriveBits(
-        {{
-          name: "HKDF",
-          hash: "SHA-256",
-          salt: new TextEncoder().encode(sid),
-          info: new TextEncoder().encode(HKDF_INFO),
-        }},
-        baseKey,
-        AEAD_KEY_BYTES * 8
-      );
-      return {{ kEnc: new Uint8Array(keyBits), pkRaw: new Uint8Array(pkRaw) }};
-    }}
+  const STATE = {
+    step: 1,
+    pin: ['', '', '', '', '', ''],
+    mode: DEFAULT_MODE,
+    words: new Array(12).fill(''),
+    generated: null,
+    ackChecked: false,
+    timerId: null,
+    submitting: false,
+  };
 
-    async function aeadEncrypt(kEnc, sid, plaintext) {{
-      const key = await crypto.subtle.importKey(
-        "raw", kEnc, {{ name: "AES-GCM" }}, false, ["encrypt"]
-      );
-      const nonce = crypto.getRandomValues(new Uint8Array(AEAD_NONCE_BYTES));
-      const ct = await crypto.subtle.encrypt(
-        {{ name: "AES-GCM", iv: nonce, additionalData: new TextEncoder().encode(sid), tagLength: AEAD_TAG_BITS }},
-        key,
-        plaintext
-      );
-      return {{ nonce, ct: new Uint8Array(ct) }};
-    }}
+  const $ = (id) => document.getElementById(id);
+  const $$ = (sel, root) => Array.from((root || document).querySelectorAll(sel));
+  function pad2(n) { return n < 10 ? '0' + n : String(n); }
 
-    // ---- BIP-39 generate (browser side) ----
-    function bytesToBits(bytes) {{
-      const bits = [];
-      for (let i = 0; i < bytes.length; i++) {{
-        const b = bytes[i];
-        for (let j = 7; j >= 0; j--) bits.push((b >> j) & 1);
-      }}
-      return bits;
-    }}
-    async function sha256(data) {{
-      const d = await crypto.subtle.digest("SHA-256", data);
-      return new Uint8Array(d);
-    }}
-    async function generateMnemonic12() {{
-      if (!BIP39 || BIP39.length !== 2048) {{
-        throw new Error("BIP-39 wordlist unavailable. Use 'import' mode or install the 'mnemonic' Python package on the gateway.");
-      }}
-      const entropy = crypto.getRandomValues(new Uint8Array(16));
-      const digest = await sha256(entropy);
-      const checksumBits = bytesToBits(digest).slice(0, 4);
-      const bits = bytesToBits(entropy).concat(checksumBits);
-      const words = [];
-      for (let i = 0; i < bits.length; i += 11) {{
-        let v = 0;
-        for (let j = 0; j < 11; j++) v = (v << 1) | bits[i + j];
-        words.push(BIP39[v]);
-      }}
-      return words.join(" ");
-    }}
+  function b64url(buf) {
+    const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+    let s = "";
+    for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+    return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  }
+  function b64urlDecode(s) {
+    const pad = "=".repeat((4 - (s.length % 4)) % 4);
+    const b64 = (s + pad).replace(/-/g, "+").replace(/_/g, "/");
+    const raw = atob(b64);
+    const out = new Uint8Array(raw.length);
+    for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i);
+    return out;
+  }
+  function readGatewayPubkeyFromHash() {
+    const h = window.location.hash || "";
+    const m = /#pk=([A-Za-z0-9_\-]+)/.exec(h);
+    if (!m) return null;
+    try { return b64urlDecode(m[1]); } catch(_e) { return null; }
+  }
+  async function deriveKey(gatewayPub, sid) {
+    const kp = await crypto.subtle.generateKey({ name: "X25519" }, true, ["deriveBits"]);
+    const pkRaw = await crypto.subtle.exportKey("raw", kp.publicKey);
+    const pubCrypto = await crypto.subtle.importKey("raw", gatewayPub, { name: "X25519" }, false, []);
+    const sharedBits = await crypto.subtle.deriveBits({ name: "X25519", public: pubCrypto }, kp.privateKey, 256);
+    const shared = new Uint8Array(sharedBits);
+    const baseKey = await crypto.subtle.importKey("raw", shared, "HKDF", false, ["deriveBits"]);
+    const keyBits = await crypto.subtle.deriveBits(
+      { name: "HKDF", hash: "SHA-256", salt: new TextEncoder().encode(sid), info: new TextEncoder().encode(HKDF_INFO) },
+      baseKey, AEAD_KEY_BYTES * 8
+    );
+    return { kEnc: new Uint8Array(keyBits), pkRaw: new Uint8Array(pkRaw) };
+  }
+  async function aeadEncrypt(kEnc, sid, plaintext) {
+    const key = await crypto.subtle.importKey("raw", kEnc, { name: "AES-GCM" }, false, ["encrypt"]);
+    const nonce = crypto.getRandomValues(new Uint8Array(AEAD_NONCE_BYTES));
+    const ct = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv: nonce, additionalData: new TextEncoder().encode(sid), tagLength: AEAD_TAG_BITS },
+      key, plaintext
+    );
+    return { nonce, ct: new Uint8Array(ct) };
+  }
 
-    // ---- DOM helpers ----
-    const $ = (id) => document.getElementById(id);
-    function setStatus(text, kind) {{
-      const el = $("status");
-      el.textContent = text;
-      el.className = kind || "info";
-      el.classList.remove("hidden");
-    }}
-    function hide(id) {{ $(id).classList.add("hidden"); }}
-    function show(id) {{ $(id).classList.remove("hidden"); }}
+  function bytesToBits(bytes) {
+    const bits = [];
+    for (let i = 0; i < bytes.length; i++) {
+      const b = bytes[i];
+      for (let j = 7; j >= 0; j--) bits.push((b >> j) & 1);
+    }
+    return bits;
+  }
+  async function sha256(data) {
+    const d = await crypto.subtle.digest("SHA-256", data);
+    return new Uint8Array(d);
+  }
+  async function entropyToMnemonic(entropy) {
+    if (!BIP39 || BIP39.length !== 2048) {
+      throw new Error("BIP-39 wordlist unavailable on gateway — use import mode or install the 'mnemonic' Python package.");
+    }
+    const digest = await sha256(entropy);
+    const checksumBits = bytesToBits(digest).slice(0, 4);
+    const bits = bytesToBits(entropy).concat(checksumBits);
+    const words = [];
+    for (let i = 0; i < bits.length; i += 11) {
+      let v = 0;
+      for (let j = 0; j < 11; j++) v = (v << 1) | bits[i + j];
+      words.push(BIP39[v]);
+    }
+    return words;
+  }
+  async function generateMnemonic12() {
+    const entropy = crypto.getRandomValues(new Uint8Array(16));
+    try { return await entropyToMnemonic(entropy); }
+    finally { entropy.fill(0); }
+  }
 
-    // ---- Countdown ----
-    function renderCountdown() {{
-      const remaining = Math.max(0, EXPIRES_AT_MS - Date.now());
-      const m = Math.floor(remaining / 60000);
-      const s = Math.floor((remaining % 60000) / 1000);
-      $("countdown").textContent = remaining > 0
-        ? `Expires in ${{m}}:${{String(s).padStart(2,"0")}}`
-        : "Session expired. Ask the agent for a fresh URL.";
-      if (remaining <= 0) {{
-        document.querySelectorAll("button").forEach(b => b.disabled = true);
-      }}
-    }}
-    setInterval(renderCountdown, 1000); renderCountdown();
+  function setDots() {
+    $$('.step-dots .dot').forEach((d) => {
+      const n = Number(d.dataset.step);
+      d.classList.toggle('done', n < STATE.step);
+      d.classList.toggle('active', n === STATE.step);
+    });
+    const cur = $('step-current');
+    if (cur) cur.textContent = STATE.step <= 3 ? String(STATE.step) : '3';
+  }
+  function transitionTo(nextId, direction) {
+    const all = $$('.screen');
+    const current = all.find((s) => s.classList.contains('active'));
+    const next = $(nextId);
+    if (!current || !next || current === next) return;
+    const forward = direction !== 'back';
+    next.hidden = false;
+    next.classList.remove('active', 'exit-left', 'enter-right');
+    next.classList.add(forward ? 'enter-right' : 'exit-left');
+    next.offsetWidth;
+    current.classList.remove('active');
+    current.classList.add(forward ? 'exit-left' : 'enter-right');
+    next.classList.remove('enter-right', 'exit-left');
+    next.classList.add('active');
+    const onDone = () => {
+      current.hidden = true;
+      current.classList.remove('exit-left', 'enter-right');
+      next.removeEventListener('transitionend', onDone);
+    };
+    next.addEventListener('transitionend', onDone);
+    setTimeout(onDone, 400);
+  }
 
-    // ---- PIN gate → unlock phrase flow ----
-    $("pin-submit").addEventListener("click", () => {{
-      const pin = ($("pin").value || "").trim();
-      if (!/^\d{{6}}$/.test(pin)) {{
-        setStatus("Enter the 6-digit PIN the agent showed you.", "err");
+  function renderCountdown() {
+    const remaining = Math.max(0, EXPIRES_AT_MS - Date.now());
+    const m = Math.floor(remaining / 60000);
+    const s = Math.floor((remaining % 60000) / 1000);
+    const el = $('countdown');
+    const txt = $('countdown-text');
+    if (!el || !txt) return;
+    if (remaining <= 0) {
+      txt.textContent = 'Expired';
+      el.classList.remove('warn');
+      el.classList.add('expired');
+      $$('.btn-primary').forEach((b) => (b.disabled = true));
+      if (STATE.timerId) { clearInterval(STATE.timerId); STATE.timerId = null; }
+      return;
+    }
+    txt.textContent = pad2(m) + ':' + pad2(s);
+    el.classList.toggle('warn', remaining < 60 * 1000);
+  }
+  function startTimer() {
+    renderCountdown();
+    STATE.timerId = setInterval(renderCountdown, 1000);
+  }
+
+  let toastEl = null;
+  let toastTimer = null;
+  function showToast(msg, ms) {
+    if (!toastEl) {
+      toastEl = document.createElement('div');
+      toastEl.className = 'toast';
+      toastEl.setAttribute('role', 'status');
+      document.body.appendChild(toastEl);
+    }
+    toastEl.textContent = msg;
+    toastEl.offsetWidth;
+    toastEl.classList.add('show');
+    if (toastTimer) clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => { if (toastEl) toastEl.classList.remove('show'); }, ms || 2400);
+  }
+
+  function setError(msg) {
+    const el = $('err-banner');
+    if (!el) return;
+    if (!msg) { el.hidden = true; el.textContent = ''; return; }
+    el.hidden = false;
+    el.textContent = msg;
+  }
+
+  function initPinStep() {
+    const cells = $$('.pin-cell');
+    const continueBtn = $('pin-continue');
+    const errEl = $('pin-error');
+    const pasteBtn = $('pin-paste');
+    function updateFilledClass() { cells.forEach((c, i) => c.classList.toggle('filled', !!STATE.pin[i])); }
+    function updateContinueState() {
+      const complete = STATE.pin.every((d) => /^\d$/.test(d));
+      continueBtn.disabled = !complete;
+    }
+    function clearError() { errEl.classList.remove('show'); errEl.textContent = ''; }
+    function showError(msg) { errEl.textContent = msg; errEl.classList.add('show'); }
+    function distributeDigits(digits, startIdx, autoSubmit) {
+      const start = Math.max(0, Math.min(startIdx || 0, cells.length - 1));
+      const toWrite = digits.slice(0, cells.length - start).split('');
+      toWrite.forEach((d, k) => { const t = cells[start + k]; if (t) { t.value = d; STATE.pin[start + k] = d; } });
+      updateFilledClass(); updateContinueState();
+      const nextIdx = Math.min(start + toWrite.length, cells.length - 1);
+      if (cells[nextIdx]) cells[nextIdx].focus();
+      if (autoSubmit && PASTE_PIN_AUTOSUBMIT && STATE.pin.every((d) => /^\d$/.test(d))) {
+        setTimeout(() => { if (!continueBtn.disabled) continueBtn.click(); }, 120);
+      }
+    }
+    cells.forEach((cell, i) => {
+      cell.addEventListener('input', (e) => {
+        const raw = e.target.value.replace(/\D/g, '');
+        if (!raw) { STATE.pin[i] = ''; updateFilledClass(); updateContinueState(); return; }
+        if (raw.length > 1) { e.target.value = ''; distributeDigits(raw, i, true); clearError(); return; }
+        STATE.pin[i] = raw; e.target.value = raw;
+        updateFilledClass(); updateContinueState(); clearError();
+        if (i < cells.length - 1) cells[i + 1].focus(); else cell.blur();
+      });
+      cell.addEventListener('keydown', (e) => {
+        if (e.key === 'Backspace' && !cell.value && i > 0) {
+          e.preventDefault(); cells[i - 1].focus(); cells[i - 1].value = '';
+          STATE.pin[i - 1] = ''; updateFilledClass(); updateContinueState();
+        } else if (e.key === 'Enter') { if (!continueBtn.disabled) continueBtn.click(); }
+      });
+      cell.addEventListener('focus', () => cell.select());
+      cell.addEventListener('paste', (e) => {
+        e.preventDefault();
+        const text = (e.clipboardData || window.clipboardData).getData('text') || '';
+        const digits = text.replace(/\D/g, '');
+        if (!digits) return;
+        distributeDigits(digits, i, true); clearError();
+      });
+    });
+    if (pasteBtn) {
+      pasteBtn.addEventListener('click', async () => {
+        let text = '';
+        try { if (navigator.clipboard && navigator.clipboard.readText) text = await navigator.clipboard.readText(); else throw new Error(''); }
+        catch (_) { showToast('Paste not allowed — type manually'); return; }
+        const digits = (text || '').replace(/\D/g, '').slice(0, 6);
+        if (!digits) { showToast('Clipboard has no digits'); return; }
+        distributeDigits(digits, 0, true); clearError();
+      });
+    }
+    continueBtn.addEventListener('click', () => {
+      const complete = STATE.pin.every((d) => /^\d$/.test(d));
+      if (!complete) {
+        const firstEmpty = cells.find((c, idx) => !STATE.pin[idx]);
+        if (firstEmpty) { firstEmpty.classList.add('shake'); setTimeout(() => firstEmpty.classList.remove('shake'), 420); firstEmpty.focus(); }
+        showError('Enter all 6 digits to continue.'); return;
+      }
+      clearError();
+      STATE.step = 2; setDots();
+      transitionTo('screen-phrase', 'forward');
+    });
+    setTimeout(() => cells[0] && cells[0].focus(), 150);
+  }
+
+  function buildWordGrid(gridEl, options) {
+    gridEl.innerHTML = '';
+    const readonly = !!options.readonly;
+    for (let i = 0; i < 12; i++) {
+      const cell = document.createElement('label'); cell.className = 'word-cell';
+      const idx = document.createElement('span'); idx.className = 'word-idx'; idx.textContent = (i + 1) + '.';
+      const input = document.createElement('input');
+      input.className = 'word-input'; input.type = 'text'; input.autocomplete = 'off';
+      input.autocapitalize = 'none'; input.spellcheck = false; input.dataset.index = String(i);
+      input.setAttribute('aria-label', 'Word ' + (i + 1));
+      if (readonly) { input.readOnly = true; input.tabIndex = -1; } else { input.placeholder = 'word'; }
+      cell.appendChild(idx); cell.appendChild(input); gridEl.appendChild(cell);
+    }
+  }
+
+  function wireImportGrid() {
+    const grid = $('phrase-grid-import'); if (!grid) return;
+    const inputs = $$('.word-input', grid);
+    function updatePairState() {
+      const complete = STATE.words.every((w) => w.trim().length > 0);
+      $('phrase-pair').disabled = !complete || STATE.submitting;
+    }
+    function setWord(i, val) {
+      const trimmed = val.trim().toLowerCase();
+      STATE.words[i] = trimmed;
+      inputs[i].parentElement.classList.toggle('filled', trimmed.length > 0);
+      updatePairState();
+    }
+    inputs.forEach((input, i) => {
+      input.addEventListener('input', (e) => setWord(i, e.target.value));
+      input.addEventListener('keydown', (e) => {
+        if (e.key === ' ' || e.key === 'Enter' || e.key === 'Tab') {
+          if (e.key !== 'Tab') e.preventDefault();
+          if (inputs[i + 1]) inputs[i + 1].focus(); else input.blur();
+        } else if (e.key === 'Backspace' && !input.value && i > 0) { e.preventDefault(); inputs[i - 1].focus(); }
+      });
+      input.addEventListener('paste', (e) => {
+        const text = (e.clipboardData || window.clipboardData).getData('text') || '';
+        const words = text.trim().split(/\s+/).filter(Boolean);
+        if (words.length < 2) return;
+        e.preventDefault();
+        const toInsert = words.slice(0, 12 - i);
+        toInsert.forEach((w, k) => { const idx = i + k; inputs[idx].value = w.toLowerCase(); setWord(idx, w); });
+        const next = Math.min(i + toInsert.length, inputs.length - 1);
+        inputs[next].focus();
+      });
+    });
+    const pasteAll = $('paste-all');
+    if (pasteAll) {
+      pasteAll.addEventListener('click', async () => {
+        let text = '';
+        if (navigator.clipboard && navigator.clipboard.readText) {
+          try { text = await navigator.clipboard.readText(); } catch (_) {}
+        }
+        if (!text) { showToast('Clipboard blocked — type manually'); return; }
+        const words = text.trim().split(/\s+/).slice(0, 12);
+        words.forEach((w, k) => { inputs[k].value = w.toLowerCase(); setWord(k, w); });
+        inputs[Math.min(words.length, 11)].focus();
+      });
+    }
+  }
+
+  function wireGenerateGrid() {
+    const grid = $('phrase-grid-generate'); if (!grid) return;
+    const inputs = $$('.word-input', grid);
+    function fill(words) {
+      STATE.generated = words.slice();
+      words.forEach((w, i) => { inputs[i].value = w; inputs[i].parentElement.classList.add('filled'); });
+    }
+    async function generateAndFill() {
+      try { const words = await generateMnemonic12(); fill(words); }
+      catch (err) { setError('Could not generate phrase: ' + (err && err.message ? err.message : String(err))); }
+    }
+    generateAndFill();
+    function updatePairState() {
+      const ready = STATE.generated && STATE.generated.length === 12 && STATE.ackChecked;
+      $('phrase-pair').disabled = !ready || STATE.submitting;
+    }
+    $('gen-ack').addEventListener('change', (e) => { STATE.ackChecked = !!e.target.checked; updatePairState(); });
+    $('gen-copy').addEventListener('click', async () => {
+      const label = $('gen-copy-label');
+      if (!STATE.generated) return;
+      try { await navigator.clipboard.writeText(STATE.generated.join(' ')); label.textContent = 'Copied'; setTimeout(() => { label.textContent = 'Copy'; }, 1600); }
+      catch (_) { label.textContent = 'Copy blocked'; setTimeout(() => { label.textContent = 'Copy'; }, 1600); }
+    });
+    $('gen-regen').addEventListener('click', async () => {
+      if (STATE.generated) { for (let i = 0; i < STATE.generated.length; i++) STATE.generated[i] = ''; STATE.generated = null; }
+      STATE.ackChecked = false; $('gen-ack').checked = false;
+      updatePairState(); await generateAndFill();
+    });
+  }
+
+  async function submitPhrase(phrase) {
+    STATE.submitting = true;
+    const btn = $('phrase-pair'); btn.disabled = true; btn.classList.add('loading');
+    setError('');
+    let phase = 'init';
+    try {
+      const gw = readGatewayPubkeyFromHash();
+      if (!gw) { setError('Gateway key missing from URL. Ask for a fresh pair URL.'); return; }
+      phase = 'derive';
+      const { kEnc, pkRaw } = await deriveKey(gw, SID);
+      phase = 'encrypt';
+      const plaintext = new TextEncoder().encode(phrase);
+      const { nonce, ct } = await aeadEncrypt(kEnc, SID, plaintext);
+      plaintext.fill(0);
+      if (STATE.generated) { for (let i = 0; i < STATE.generated.length; i++) STATE.generated[i] = ''; STATE.generated = null; }
+      STATE.words = STATE.words.map(() => '');
+      $$('.word-input').forEach((el) => { if (!el.readOnly) el.value = ''; });
+
+      phase = 'post';
+      // Local-mode wire shape — matches http_server.py's POST handler:
+      // { v:1, sid, pk_d, pin, nonce, ct }
+      const body = JSON.stringify({
+        v: 1, sid: SID,
+        pk_d: b64url(pkRaw),
+        pin: STATE.pin.join(''),
+        nonce: b64url(nonce),
+        ct: b64url(ct),
+      });
+      STATE.pin = ['', '', '', '', '', ''];
+      const res = await fetch(API_BASE, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body, cache: 'no-store',
+      });
+      if (res.status === 204 || res.status === 200) {
+        STATE.step = 3; setDots();
+        transitionTo('screen-done', 'forward');
+        if (STATE.timerId) { clearInterval(STATE.timerId); STATE.timerId = null; }
+        const cd = $('countdown'); if (cd) cd.style.visibility = 'hidden';
         return;
-      }}
-      // Store the PIN locally; we'll send it with the encrypted payload.
-      window.__PAIR_PIN = pin;
-      hide("pin-step");
-      if (MODE === "generate") show("gen-step"); else show("import-step");
-      setStatus("PIN accepted. Continue below.", "ok");
-    }});
+      }
+      if (res.status === 403) { setError('PIN mismatch or too many failed attempts. Ask the agent for a fresh URL.'); return; }
+      if (res.status === 410) { setError('Session expired. Ask the agent for a fresh URL.'); return; }
+      let detail = '';
+      try { detail = await res.text(); } catch (_) {}
+      setError('Pairing failed (HTTP ' + res.status + '): ' + (detail || 'unknown error'));
+    } catch (err) {
+      const label = phase === 'derive' ? 'Key derivation failed' :
+                    phase === 'encrypt' ? 'Encryption failed' :
+                    phase === 'post' ? 'Submit failed' : 'Pair failed';
+      setError(label + ': ' + (err && err.message ? err.message : String(err)));
+    } finally {
+      STATE.submitting = false;
+      btn.classList.remove('loading');
+      if (STATE.step !== 3) btn.disabled = false;
+    }
+  }
 
-    // ---- Generate flow ----
-    let generatedPhrase = null;
-    $("gen-button").addEventListener("click", async () => {{
-      try {{
-        generatedPhrase = await generateMnemonic12();
-        $("phrase-display").textContent = generatedPhrase;
-        show("phrase-display-box");
-        hide("gen-button");
-        show("gen-ack-step");
-      }} catch (err) {{
-        setStatus("Could not generate phrase: " + err.message, "err");
-      }}
-    }});
-    $("gen-confirm").addEventListener("click", async () => {{
-      if (!$("gen-ack").checked) {{
-        setStatus("Check the acknowledgment before continuing.", "err");
-        return;
-      }}
-      if (!generatedPhrase) {{
-        setStatus("No phrase to submit. Retry generate.", "err");
-        return;
-      }}
-      await submitPhrase(generatedPhrase);
-    }});
+  function initPhraseStep() {
+    if ($('phrase-grid-import')) { buildWordGrid($('phrase-grid-import'), { readonly: false }); wireImportGrid(); }
+    if ($('phrase-grid-generate')) { buildWordGrid($('phrase-grid-generate'), { readonly: true }); wireGenerateGrid(); }
+    $('back-to-pin').addEventListener('click', () => { STATE.step = 1; setDots(); transitionTo('screen-pin', 'back'); });
+    $('phrase-pair').addEventListener('click', async () => {
+      const btn = $('phrase-pair');
+      if (btn.disabled || STATE.submitting) return;
+      if (STATE.mode === 'generate') {
+        if (!STATE.generated || STATE.generated.length !== 12) { setError('No phrase to submit. Tap Regenerate.'); return; }
+        if (!STATE.ackChecked) { setError('Confirm you have written down the phrase before continuing.'); return; }
+        await submitPhrase(STATE.generated.join(' '));
+      } else {
+        if (!STATE.words.every((w) => w.trim().length > 0)) { setError('Enter all 12 words to continue.'); return; }
+        await submitPhrase(STATE.words.join(' '));
+      }
+    });
+  }
 
-    // ---- Import flow ----
-    $("import-submit").addEventListener("click", async () => {{
-      const raw = ($("import-phrase").value || "").trim().toLowerCase().replace(/\s+/g, " ");
-      if (!raw) {{
-        setStatus("Paste your 12 or 24-word phrase.", "err");
-        return;
-      }}
-      const n = raw.split(" ").length;
-      if (n !== 12 && n !== 24) {{
-        setStatus("Phrase must be exactly 12 or 24 words.", "err");
-        return;
-      }}
-      await submitPhrase(raw);
-    }});
+  function initDoneStep() {
+    const closeLink = $('close-link');
+    if (closeLink) closeLink.addEventListener('click', (e) => { e.preventDefault(); try { window.close(); } catch (_) {} });
+  }
 
-    // ---- Submit: encrypt + POST ----
-    async function submitPhrase(phrase) {{
-      try {{
-        const gw = readGatewayPubkeyFromHash();
-        if (!gw) {{
-          setStatus("Gateway key missing from URL. Ask for a fresh pair URL.", "err");
-          return;
-        }}
-        setStatus("Encrypting phrase end-to-end…", "info");
-        const {{ kEnc, pkRaw }} = await deriveKey(gw, SID);
-        const plaintext = new TextEncoder().encode(phrase);
-        const {{ nonce, ct }} = await aeadEncrypt(kEnc, SID, plaintext);
+  async function probeCrypto() {
+    const ok = crypto && crypto.subtle && typeof crypto.subtle.generateKey === "function";
+    if (!ok) throw new Error("no webcrypto");
+    await crypto.subtle.generateKey({ name: "X25519" }, true, ["deriveBits"]);
+    const rawKey = new Uint8Array(AEAD_KEY_BYTES);
+    const aesKey = await crypto.subtle.importKey("raw", rawKey, { name: "AES-GCM" }, false, ["encrypt"]);
+    const probeNonce = new Uint8Array(AEAD_NONCE_BYTES);
+    await crypto.subtle.encrypt({ name: "AES-GCM", iv: probeNonce, additionalData: new Uint8Array(0), tagLength: AEAD_TAG_BITS }, aesKey, new Uint8Array(0));
+    await crypto.subtle.importKey("raw", rawKey, "HKDF", false, ["deriveBits"]);
+  }
 
-        // Zero the plaintext buffer — best-effort (browser GC is not
-        // guaranteed; but we at least drop our reference).
-        plaintext.fill(0);
-
-        const body = JSON.stringify({{
-          v: 1,
-          sid: SID,
-          pk_d: b64url(pkRaw),
-          pin: window.__PAIR_PIN,
-          nonce: b64url(nonce),
-          ct: b64url(ct),
-        }});
-        window.__PAIR_PIN = null; // drop reference
-        const res = await fetch(API_BASE, {{
-          method: "POST",
-          headers: {{ "Content-Type": "application/json" }},
-          body,
-          cache: "no-store",
-        }});
-        if (res.status === 204 || res.status === 200) {{
-          hide("gen-step"); hide("import-step"); hide("gen-ack-step");
-          show("done-step");
-          setStatus("Pairing complete. Tell the agent you're done; it will confirm on its side.", "ok");
-          return;
-        }}
-        if (res.status === 403) {{
-          setStatus("PIN mismatch or too many failed attempts. Ask the agent for a fresh URL.", "err");
-          return;
-        }}
-        if (res.status === 410) {{
-          setStatus("Session expired. Ask the agent for a fresh URL.", "err");
-          return;
-        }}
-        const detail = await res.text();
-        setStatus(`Pairing failed (${{res.status}}): ${{detail || "unknown error"}}`, "err");
-      }} catch (err) {{
-        setStatus("Encryption failed: " + (err && err.message ? err.message : String(err)), "err");
-      }}
-    }}
-
-    // Capability gate: probe X25519 + AES-GCM + HKDF end-to-end. rc.10/rc.11
-    // only probed X25519, missed that the browser didn't implement
-    // ChaCha20-Poly1305 — submit failed silently with "Algorithm:
-    // Unrecognized name". rc.12 probes every call this page will make.
-    (async () => {{
-      try {{
-        const ok = crypto && crypto.subtle && typeof crypto.subtle.generateKey === "function";
-        if (!ok) throw new Error("no webcrypto");
-        await crypto.subtle.generateKey({{ name: "X25519" }}, true, ["deriveBits"]);
-        const rawKey = new Uint8Array(AEAD_KEY_BYTES);
-        const aesKey = await crypto.subtle.importKey("raw", rawKey, {{ name: "AES-GCM" }}, false, ["encrypt"]);
-        const probeNonce = new Uint8Array(AEAD_NONCE_BYTES);
-        await crypto.subtle.encrypt(
-          {{ name: "AES-GCM", iv: probeNonce, additionalData: new Uint8Array(0), tagLength: AEAD_TAG_BITS }},
-          aesKey,
-          new Uint8Array(0)
-        );
-        await crypto.subtle.importKey("raw", rawKey, "HKDF", false, ["deriveBits"]);
-      }} catch (err) {{
-        setStatus(
-          "This browser lacks x25519 + AES-GCM + HKDF support required to pair securely. " +
-            "Use an up-to-date Safari 17.2+ or Chromium 133+ browser. (" +
-            (err && err.message ? err.message : String(err)) + ")",
-          "err"
-        );
-        document.querySelectorAll("button").forEach(b => b.disabled = true);
-      }}
-    }})();
-  }})();
+  document.addEventListener('DOMContentLoaded', async () => {
+    const sub = document.getElementById('pin-subheading');
+    if (sub) sub.textContent = STEP1_SUBHEADING;
+    setDots(); startTimer();
+    try { await probeCrypto(); }
+    catch (err) {
+      setError('This browser lacks x25519 + AES-GCM + HKDF support required to pair securely. Use an up-to-date Safari 17.2+ or Chromium 133+ browser. (' + (err && err.message ? err.message : String(err)) + ')');
+      $$('.btn-primary').forEach((b) => (b.disabled = true));
+      return;
+    }
+    initPinStep(); initPhraseStep(); initDoneStep();
+  });
+})();
 """
 
 
-_PAIR_PAGE_HTML = """<!DOCTYPE html>
+# ---------------------------------------------------------------------------
+# HTML template — single-mode (local-mode doesn't show the tab switcher).
+# The PANELS placeholder is replaced with either GENERATE or IMPORT panel.
+# ---------------------------------------------------------------------------
+
+_PAIR_PAGE_HTML = r"""<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 <meta name="referrer" content="no-referrer" />
 <meta name="robots" content="noindex, nofollow" />
-<title>TotalReclaw Pair</title>
-<style>{style}</style>
+<meta name="theme-color" content="#0B0B1A" />
+<title>Set up TotalReclaw</title>
+<style>__STYLE__</style>
 </head>
 <body>
-<main class="page">
-  <h1>TotalReclaw pairing</h1>
-  <p class="muted">Mode: <strong>{mode_html}</strong>. Session: <code>{sid_html}</code>.</p>
-  <p class="countdown" id="countdown">Loading…</p>
-
-  <div id="status" class="info hidden"></div>
-
-  <section class="card" id="pin-step">
-    <h2>Step 1. Verify PIN</h2>
-    <p>The TotalReclaw agent showed you a 6-digit PIN. Type it here so the gateway knows you're the right browser.</p>
-    <label for="pin">6-digit PIN</label>
-    <input id="pin" class="pin-input" type="text" inputmode="numeric" pattern="\\d{{6}}" maxlength="6" autocomplete="off" />
-    <p></p>
-    <button id="pin-submit">Verify</button>
-  </section>
-
-  <section class="card hidden" id="gen-step">
-    <h2>Step 2. Generate your TotalReclaw account key</h2>
-    <p>This is your <strong>one and only</strong> key to your encrypted memory vault. Treat it like a master password — it cannot be reset if lost.</p>
-    <div class="consequence">
-      <div><strong>With it you can:</strong> recover access from any device, export your memories, switch agents.</div>
-      <div><strong>Without it:</strong> your memories are permanently unrecoverable. There is no "forgot password".</div>
+<a href="#main" class="skip-link">Skip to content</a>
+<main id="main" class="wizard" aria-live="polite">
+  <header class="topbar">
+    <a class="brand" href="#" aria-label="TotalReclaw">
+      <svg class="brand-mark" viewBox="0 0 256 256" aria-hidden="true" focusable="false">
+        <defs>
+          <linearGradient id="shieldGrad" x1="30%" y1="0%" x2="70%" y2="100%">
+            <stop offset="0%" stop-color="#5040B0"/>
+            <stop offset="100%" stop-color="#7B5CFF"/>
+          </linearGradient>
+        </defs>
+        <path d="M128 18 L212 58 V162 C212 210 174 236 128 250 C82 236 44 210 44 162 V58 Z"
+              fill="rgba(75,55,170,0.05)" stroke="url(#shieldGrad)" stroke-width="5" stroke-linejoin="round"/>
+        <path d="M128 40 L196 74 V160 C196 200 164 222 128 234 C92 222 60 200 60 160 V74 Z"
+              fill="none" stroke="url(#shieldGrad)" stroke-width="2.5" stroke-linejoin="round" opacity="0.45"/>
+        <path d="M 116 186 C 96 162, 60 124, 72 92 C 76 78, 94 70, 108 82 C 118 90, 114 108, 100 116"
+              fill="none" stroke="url(#shieldGrad)" stroke-width="9" stroke-linecap="round"/>
+        <path d="M 140 186 C 160 162, 196 124, 184 92 C 180 78, 162 70, 148 82 C 138 90, 142 108, 156 116"
+              fill="none" stroke="url(#shieldGrad)" stroke-width="9" stroke-linecap="round"/>
+      </svg>
+      <span class="brand-text">TotalReclaw</span>
+    </a>
+    <div class="meta">
+      <div class="step-meter" aria-label="Progress">
+        <span class="step-label"><span id="step-current">1</span> / 3</span>
+        <div class="step-dots">
+          <span class="dot" data-step="1" aria-hidden="true"></span>
+          <span class="dot" data-step="2" aria-hidden="true"></span>
+          <span class="dot" data-step="3" aria-hidden="true"></span>
+        </div>
+      </div>
+      <div class="countdown" id="countdown">
+        <svg class="clock" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="13" r="8" fill="none" stroke="currentColor" stroke-width="1.6"/><path d="M12 9v4l2.5 2" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><path d="M9 3h6M12 3v2" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg>
+        <span id="countdown-text">5:00</span>
+      </div>
     </div>
-    <p class="muted">Store it in a password manager, encrypted notes, or on paper in a safe. <strong>Never</strong> share it with anyone. <strong>Use it ONLY with TotalReclaw</strong> — never paste it into other apps, not even ones that ask nicely.</p>
-    <button id="gen-button">Generate now</button>
-    <div id="phrase-display-box" class="hidden">
-      <label>Your account key (write this down)</label>
-      <div class="phrase-box" id="phrase-display"></div>
-    </div>
-  </section>
+  </header>
 
-  <section class="card hidden warn-card" id="gen-ack-step">
-    <h2>Step 3. Acknowledge</h2>
-    <p>Before we seal the key into your TotalReclaw account on this gateway, confirm:</p>
-    <label><input type="checkbox" id="gen-ack" /> I have written down or securely stored the 12 words above. I understand losing them means losing access to my memories forever.</label>
-    <p></p>
-    <button id="gen-confirm">Seal key and finish</button>
-  </section>
+  <section class="stage" id="stage">
+    <article class="screen active" id="screen-pin" data-step="1">
+      <div class="screen-inner">
+        <p class="eyebrow">Step 1 of 3</p>
+        <h1 class="heading">Enter your PIN</h1>
+        <p id="pin-subheading" class="subheading">Enter the 6-digit code from your chat to continue.</p>
+        <div class="pin-wrap">
+          <div class="pin-cells" role="group" aria-label="6-digit PIN">
+            <input class="pin-cell" type="tel" inputmode="numeric" pattern="[0-9]*" maxlength="1" autocomplete="one-time-code" aria-label="Digit 1" data-index="0" />
+            <input class="pin-cell" type="tel" inputmode="numeric" pattern="[0-9]*" maxlength="1" autocomplete="off" aria-label="Digit 2" data-index="1" />
+            <input class="pin-cell" type="tel" inputmode="numeric" pattern="[0-9]*" maxlength="1" autocomplete="off" aria-label="Digit 3" data-index="2" />
+            <span class="pin-sep" aria-hidden="true"></span>
+            <input class="pin-cell" type="tel" inputmode="numeric" pattern="[0-9]*" maxlength="1" autocomplete="off" aria-label="Digit 4" data-index="3" />
+            <input class="pin-cell" type="tel" inputmode="numeric" pattern="[0-9]*" maxlength="1" autocomplete="off" aria-label="Digit 5" data-index="4" />
+            <input class="pin-cell" type="tel" inputmode="numeric" pattern="[0-9]*" maxlength="1" autocomplete="off" aria-label="Digit 6" data-index="5" />
+          </div>
+          <div class="pin-actions">
+            <button type="button" class="btn-ghost btn-ghost-inline" id="pin-paste" aria-label="Paste 6-digit PIN from clipboard">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="8" y="3" width="8" height="4" rx="1" fill="none" stroke="currentColor" stroke-width="1.6"/><rect x="5" y="6" width="14" height="15" rx="2" fill="none" stroke="currentColor" stroke-width="1.6"/></svg>
+              Paste
+            </button>
+          </div>
+          <p class="pin-error" id="pin-error" role="alert"></p>
+        </div>
+      </div>
+      <footer class="screen-cta">
+        <button type="button" class="btn-primary" id="pin-continue" disabled>Continue</button>
+        <p class="security-note">
+          <svg class="lock" viewBox="0 0 24 24" aria-hidden="true"><path d="M7 10V7a5 5 0 1 1 10 0v3" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><rect x="5" y="10" width="14" height="10" rx="2" fill="none" stroke="currentColor" stroke-width="1.6"/></svg>
+          This flow is the only secure way to set up your recovery phrase without the LLM provider ever seeing it.
+        </p>
+      </footer>
+    </article>
 
-  <section class="card hidden" id="import-step">
-    <h2>Step 2. Paste your existing TotalReclaw account key</h2>
-    <p>Paste your 12 or 24-word phrase below. The phrase is encrypted in this browser tab before leaving — it never crosses the LLM context.</p>
-    <label for="import-phrase">Your 12 or 24-word phrase</label>
-    <textarea id="import-phrase" autocomplete="off" spellcheck="false"></textarea>
-    <button id="import-submit">Seal key and finish</button>
-  </section>
+    <article class="screen" id="screen-phrase" data-step="2" hidden>
+      <div class="screen-inner">
+        <p class="eyebrow">Step 2 of 3</p>
+        <h1 class="heading">Your recovery phrase</h1>
+__PANELS__
+        <p class="security-note">
+          <svg class="lock" viewBox="0 0 24 24" aria-hidden="true"><path d="M7 10V7a5 5 0 1 1 10 0v3" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><rect x="5" y="10" width="14" height="10" rx="2" fill="none" stroke="currentColor" stroke-width="1.6"/></svg>
+          Never share this phrase. Encrypted in your browser before transmission.
+        </p>
+        <div class="err-banner" id="err-banner" hidden role="alert"></div>
+      </div>
+      <footer class="screen-cta">
+        <div class="cta-row">
+          <button type="button" class="btn-secondary" id="back-to-pin" aria-label="Back to PIN">
+            <svg viewBox="0 0 24 24"><path d="M15 6l-6 6 6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </button>
+          <button type="button" class="btn-primary" id="phrase-pair" disabled>
+            <span class="btn-label">Seal key and finish</span>
+            <span class="btn-spinner" aria-hidden="true"></span>
+          </button>
+        </div>
+      </footer>
+    </article>
 
-  <section class="card hidden" id="done-step">
-    <h2>Pairing complete</h2>
-    <p>Your key is sealed into this TotalReclaw gateway. You can close this tab and go back to the agent. If the agent asks, tell it "pairing complete" — it will verify and restart the memory plugin if needed.</p>
+    <article class="screen" id="screen-done" data-step="3" hidden>
+      <div class="screen-inner center">
+        <div class="check-wrap" aria-hidden="true">
+          <svg class="check" viewBox="0 0 100 100">
+            <circle class="check-ring" cx="50" cy="50" r="44" fill="none" stroke-width="3"/>
+            <path class="check-tick" d="M30 52 L45 67 L72 36" fill="none" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </div>
+        <h1 class="heading">You're all set</h1>
+        <p class="subheading">TotalReclaw account created. Go back to your chat and try: <em>"remember I prefer Python over Go"</em></p>
+        <a href="#" class="close-link" id="close-link">Close this page</a>
+      </div>
+    </article>
   </section>
+  <p style="text-align:center;margin-top:28px;font-size:.72rem;color:var(--fg-faint);letter-spacing:.08em;opacity:.6">Session: __SID_HTML__</p>
 </main>
-<script>{script}</script>
+<script>__SCRIPT__</script>
 </body>
 </html>
 """

--- a/python/src/totalreclaw/pair/remote_client.py
+++ b/python/src/totalreclaw/pair/remote_client.py
@@ -330,11 +330,21 @@ async def await_phrase_upload(
         phrase = ""  # noqa: F841 — drop our reference
 
     # Ack the relay so the browser gets a 204.
+    ack_sent = False
     try:
         await ws.send(json.dumps({"type": "ack"}))
+        ack_sent = True
+        # Structured event — makes rc.13 gateway-side pair successes
+        # grep-able in ``docker compose logs`` alongside the relay's
+        # ``pair.respond_success`` event.
+        logger.info(
+            "pair.relay_ack_sent token=%s… mode=%s",
+            session.token[:8],
+            forward_mode or "unspecified",
+        )
     except Exception as err:
         logger.warning(
-            "pair.remote_client: ack send failed for token=%s…: %r",
+            "pair.relay_ack_failed token=%s… err=%r",
             session.token[:8],
             err,
         )
@@ -345,9 +355,10 @@ async def await_phrase_upload(
             pass
 
     logger.info(
-        "pair.remote_client: session completed token=%s… mode=%s",
+        "pair.remote_client: session completed token=%s… mode=%s ack=%s",
         session.token[:8],
         forward_mode or "unspecified",
+        "ok" if ack_sent else "failed",
     )
     return result
 

--- a/python/tests/test_pair_generate_mode.py
+++ b/python/tests/test_pair_generate_mode.py
@@ -365,39 +365,37 @@ def test_pair_tool_schema_advertises_either():
 
 @pytest.mark.asyncio
 async def test_relay_mode_passes_ui_mode_to_open_session(tmp_path, monkeypatch):
-    """Verify relay path forwards UI mode to ``open_remote_pair_session``.
+    """Verify relay path forwards UI mode to the thread-based pair
+    supervisor.
 
-    This test uses a spy wrapper on ``open_remote_pair_session`` to make
-    sure the ``mode`` kwarg threads through ``pair_tool.pair`` -> ``_pair_relay``
-    -> ``open_remote_pair_session``. No live network.
+    rc.13 replaced the ``_spawn_relay_completion_task`` asyncio-task
+    helper with ``_run_relay_pair_on_thread``, which runs the entire
+    relay session on a dedicated worker thread (fixes the
+    tool-invocation loop-teardown bug where ack frames were never
+    sent). This test stubs out the thread-helper entirely and asserts
+    the ``mode`` kwarg threads through ``pair_tool.pair`` →
+    ``_pair_relay`` → ``_run_relay_pair_on_thread``. No network.
     """
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.delenv("TOTALRECLAW_PAIR_MODE", raising=False)  # default (relay)
 
     from totalreclaw.hermes import pair_tool as _pair_tool_mod
-    from totalreclaw.pair import remote_client as _rc
 
     captured: dict = {}
 
-    class _FakeSession:
-        url = "https://example.invalid/pair/p/x#pk=y"
-        pin = "123456"
-        expires_at = "2026-04-23T12:00:00Z"
-        token = "x"
-        keypair = MagicMock(pk_b64="y")
-        _ws = MagicMock()
-
-    async def _fake_open_remote_pair_session(**kwargs):
-        captured.update(kwargs)
-        return _FakeSession()
+    def _fake_run_relay_pair_on_thread(state, mode, **kwargs):
+        captured["mode"] = mode
+        captured["state"] = state
+        return _pair_tool_mod._OpenedSession(
+            url="https://example.invalid/pair/p/x#pk=y",
+            pin="123456",
+            expires_at="2026-04-23T12:00:00Z",
+        )
 
     monkeypatch.setattr(
-        _rc, "open_remote_pair_session", _fake_open_remote_pair_session
-    )
-
-    # Skip the background task — we're only testing pair_tool wiring.
-    monkeypatch.setattr(
-        _pair_tool_mod, "_spawn_relay_completion_task", lambda s, st: None
+        _pair_tool_mod,
+        "_run_relay_pair_on_thread",
+        _fake_run_relay_pair_on_thread,
     )
 
     state = MagicMock()

--- a/python/tests/test_pair_http.py
+++ b/python/tests/test_pair_http.py
@@ -326,7 +326,8 @@ class TestGetPairPage:
         try:
             status, body, headers = _http_get(server, f"/pair/{session.sid}")
             assert status == 200
-            assert b"TotalReclaw pairing" in body
+            # rc.13 UX refresh: page title is "Set up TotalReclaw" now.
+            assert b"Set up TotalReclaw" in body
             assert "text/html" in headers.get("content-type", "")
             assert "no-store" in headers.get("cache-control", "")
             assert "default-src 'none'" in headers.get("content-security-policy", "")

--- a/python/tests/test_pair_tool_asyncio_lifecycle.py
+++ b/python/tests/test_pair_tool_asyncio_lifecycle.py
@@ -1,0 +1,326 @@
+"""rc.13 regression test for the tool-invocation-loop asyncio lifecycle fix.
+
+Prior RCs (rc.10–rc.12) opened the relay WebSocket on Hermes's
+tool-invocation loop, then used ``loop.create_task(...)`` to keep
+awaiting on it after the tool returned. That loop is torn down as soon
+as the tool returns, so the background task was destroyed mid-
+``ws.recv()`` — logged as::
+
+    Task was destroyed but it is pending!
+    RuntimeError: no running event loop
+
+during ``WebSocketCommonProtocol.close_connection``. The relay saw no
+ack, timed out after 15s, and returned 502 to the browser.
+
+rc.13 runs the ENTIRE relay session on a dedicated OS thread with its
+own ``asyncio.new_event_loop()``. The WebSocket is created INSIDE the
+thread, so it's never bound to a loop that closes mid-session.
+
+This test proves the fix end-to-end:
+
+1. Call ``_run_relay_pair_on_thread`` (the rc.13 helper used by the
+   tool body via ``asyncio.to_thread``).
+2. The relay stub delays the ``forward`` frame by 400ms — long enough
+   that rc.12's tool-loop-destroyed bug would have fired.
+3. Assert the ack frame is received + ``state.configure(phrase)`` is
+   called with the decrypted phrase.
+
+If the fix regresses (WS gets bound to the caller loop again, or the
+waiter runs off the tool loop), the ack never arrives because the loop
+closes before ``recv()`` wakes.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+from typing import List, Optional
+from unittest.mock import MagicMock
+
+import pytest
+import websockets
+
+from totalreclaw.pair.crypto import (
+    encrypt_pairing_payload,
+    generate_gateway_keypair,
+)
+
+
+TEST_PHRASE = (
+    "abandon abandon abandon abandon abandon abandon "
+    "abandon abandon abandon abandon abandon about"
+)
+
+
+class _DelayedRelayStub:
+    """WebSocket server that impersonates the relay with a delay between
+    ``opened`` and ``forward`` — mirroring real usage where the browser
+    takes human time to type the PIN + paste the phrase.
+
+    The delay proves the fix: without the rc.13 thread-loop isolation,
+    the tool loop closes before the delay elapses and the waiter dies.
+    """
+
+    def __init__(self, token: str, phrase: str, forward_delay_s: float) -> None:
+        self.token = token
+        self.phrase = phrase
+        self.forward_delay_s = forward_delay_s
+        self.open_received: Optional[dict] = None
+        self.ack_received: Optional[dict] = None
+        self._server: Optional[websockets.Server] = None
+        self._port: int = 0
+        self._ack_event = threading.Event()
+
+    @property
+    def url(self) -> str:
+        return f"ws://127.0.0.1:{self._port}"
+
+    async def start(self) -> None:
+        async def handler(ws):
+            raw = await ws.recv()
+            self.open_received = json.loads(raw)
+            await ws.send(
+                json.dumps(
+                    {
+                        "type": "opened",
+                        "token": self.token,
+                        "short_url": f"/pair/p/{self.token}",
+                        "expires_at": "2026-04-30T00:00:00Z",
+                    }
+                )
+            )
+
+            # Hold before pushing forward. In rc.10–rc.12 the gateway's
+            # tool loop would have closed by this point; waiter destroyed
+            # mid-recv and ack never goes out.
+            await asyncio.sleep(self.forward_delay_s)
+
+            kp_device = generate_gateway_keypair()
+            gateway_pubkey = self.open_received["gateway_pubkey"]
+            nonce_b64, ct_b64 = encrypt_pairing_payload(
+                sk_local_b64=kp_device.sk_b64,
+                pk_remote_b64=gateway_pubkey,
+                sid=self.token,
+                plaintext=self.phrase.encode("utf-8"),
+            )
+            await ws.send(
+                json.dumps(
+                    {
+                        "type": "forward",
+                        "client_pubkey": kp_device.pk_b64,
+                        "nonce": nonce_b64,
+                        "ciphertext": ct_b64,
+                    }
+                )
+            )
+
+            try:
+                raw2 = await asyncio.wait_for(ws.recv(), timeout=10)
+                msg = json.loads(raw2)
+                if msg.get("type") == "ack":
+                    self.ack_received = msg
+                    self._ack_event.set()
+            except asyncio.TimeoutError:
+                pass
+
+        self._server = await websockets.serve(handler, "127.0.0.1", 0)
+        self._port = self._server.sockets[0].getsockname()[1]
+
+    async def wait_for_ack_async(self, timeout_s: float) -> bool:
+        """Async wait — keeps the pytest loop running so the server
+        handler coroutine can progress.
+
+        ``_ack_event`` is threading.Event (set from the server handler
+        coroutine), so we poll it with ``asyncio.sleep`` yields. A
+        purely sync ``wait()`` call would block the pytest loop and
+        the handler couldn't read the ack frame at all.
+        """
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            if self._ack_event.is_set():
+                return True
+            await asyncio.sleep(0.02)
+        return False
+
+    async def stop(self) -> None:
+        if self._server:
+            self._server.close()
+            await self._server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_relay_pair_survives_tool_loop_teardown(monkeypatch):
+    """End-to-end: the tool returns {url, pin} fast, the browser
+    uploads the phrase after a delay, and the worker thread still acks
+    the relay + writes credentials.
+
+    Regression shield for the rc.10–rc.12 bug where Hermes's tool-
+    invocation loop closed mid-``ws.recv`` and the ack was never sent.
+    """
+    # Real relay-stub with a 400ms delay between opened + forward — long
+    # enough to exercise the lifecycle bug if it regressed.
+    relay = _DelayedRelayStub(
+        token="rc13-lifecycle-tok",
+        phrase=TEST_PHRASE,
+        forward_delay_s=0.4,
+    )
+    await relay.start()
+
+    # Point the remote_client at the stub.
+    monkeypatch.setenv("TOTALRECLAW_PAIR_RELAY_URL", relay.url)
+
+    # Side-effect bucket so we can inspect what the worker thread did.
+    captured_phrases: List[str] = []
+    configure_called = threading.Event()
+
+    class FakeState:
+        """Plugin-state double — ``_spawn_relay_completion_task`` closes
+        over this and invokes ``.configure()`` when the relay forwards a
+        valid ciphertext."""
+
+        def configure(self, phrase: str) -> None:
+            captured_phrases.append(phrase)
+            configure_called.set()
+
+        def get_client(self):
+            mock = MagicMock()
+            mock._eoa_address = "0xdeadbeef0123"
+            return mock
+
+    state = FakeState()
+
+    # Exercise the actual code path used by the tool body
+    # (``_pair_relay`` → ``asyncio.to_thread(_run_relay_pair_on_thread,
+    # ...)``). Using the exact helper covers both the handshake path
+    # AND the background-completion path in one go.
+    from totalreclaw.hermes.pair_tool import _run_relay_pair_on_thread
+
+    t_start = time.monotonic()
+    opened = await asyncio.to_thread(
+        _run_relay_pair_on_thread, state, "either"
+    )
+    t_handshake = time.monotonic() - t_start
+
+    # Handshake should complete in well under 1s (local loopback).
+    # The forward delay is 400ms AFTER opened — if we accidentally wait
+    # for forward here, t_handshake would be >400ms.
+    assert t_handshake < 1.0, (
+        f"handshake took {t_handshake:.2f}s — did we accidentally "
+        "block on the forward frame instead of returning fast?"
+    )
+
+    # Sanity on the opened metadata.
+    assert opened.url.startswith("http://")
+    assert relay.token in opened.url
+    assert opened.pin and len(opened.pin) == 6
+    assert opened.expires_at
+
+    # Wait for the worker thread to drive the whole pairing.
+    # 5s budget — the forward delay is 400ms, decrypt + ack is <50ms
+    # in practice, so 5s is slack for slow CI machines.
+    ack_arrived = await relay.wait_for_ack_async(timeout_s=5.0)
+
+    try:
+        await relay.stop()
+    except Exception:
+        pass
+
+    # Hard assertions on the rc.13 fix.
+    assert ack_arrived, (
+        "relay never received ack — the worker thread failed to "
+        "complete the pair session (lifecycle regression)"
+    )
+    assert relay.ack_received is not None
+    assert relay.ack_received.get("type") == "ack"
+
+    # The worker thread invoked the plugin-state configure callback with
+    # the decrypted phrase — proves decrypt succeeded end-to-end.
+    assert configure_called.wait(timeout=2.0), (
+        "state.configure was never called — decrypt or credential-write "
+        "path broken"
+    )
+    assert captured_phrases == [TEST_PHRASE]
+
+
+@pytest.mark.asyncio
+async def test_relay_pair_returns_before_forward(monkeypatch):
+    """The tool body MUST return ``{url, pin, expires_at}`` before the
+    browser completes its side.
+
+    If the fix accidentally waits for the forward frame before
+    returning, the tool would block the agent chat for up to the 5-min
+    TTL — the exact UX regression Option 2 was chosen to avoid.
+    """
+    relay = _DelayedRelayStub(
+        token="rc13-return-fast-tok",
+        phrase=TEST_PHRASE,
+        forward_delay_s=5.0,  # deliberately long — would block if buggy
+    )
+    await relay.start()
+    monkeypatch.setenv("TOTALRECLAW_PAIR_RELAY_URL", relay.url)
+
+    class NoopState:
+        def configure(self, phrase: str) -> None:  # pragma: no cover
+            pass
+
+        def get_client(self):  # pragma: no cover
+            return MagicMock(_eoa_address="0x0")
+
+    try:
+        from totalreclaw.hermes.pair_tool import _run_relay_pair_on_thread
+
+        t_start = time.monotonic()
+        opened = await asyncio.to_thread(
+            _run_relay_pair_on_thread, NoopState(), "either"
+        )
+        t_elapsed = time.monotonic() - t_start
+
+        # The handshake must return in well under the forward delay (5s).
+        # 1s is generous — in practice it's <100ms on loopback.
+        assert t_elapsed < 1.0, (
+            f"_run_relay_pair_on_thread blocked for {t_elapsed:.2f}s "
+            "— it must return after ``opened``, not after ``forward``"
+        )
+        assert opened.pin
+        assert opened.url
+    finally:
+        try:
+            await relay.stop()
+        except Exception:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_relay_pair_surfaces_open_failure(monkeypatch):
+    """If the relay rejects the ``open`` with ``{type:error}``, the
+    handshake helper must propagate the error to the tool body so it
+    can report a sane message to the agent (not a 15s timeout).
+    """
+
+    async def handler(ws):
+        _ = await ws.recv()  # consume the open frame
+        await ws.send(json.dumps({"type": "error", "error": "rate_limited"}))
+        await ws.close()
+
+    server = await websockets.serve(handler, "127.0.0.1", 0)
+    try:
+        port = server.sockets[0].getsockname()[1]
+        monkeypatch.setenv("TOTALRECLAW_PAIR_RELAY_URL", f"ws://127.0.0.1:{port}")
+
+        class NoopState:
+            def configure(self, phrase: str) -> None:  # pragma: no cover
+                pass
+
+            def get_client(self):  # pragma: no cover
+                return MagicMock(_eoa_address="0x0")
+
+        from totalreclaw.hermes.pair_tool import _run_relay_pair_on_thread
+
+        with pytest.raises(RuntimeError, match="rate_limited"):
+            await asyncio.to_thread(
+                _run_relay_pair_on_thread, NoopState(), "either"
+            )
+    finally:
+        server.close()
+        await server.wait_closed()

--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1-rc.13] — 2026-04-24
+
+Coordinated version bump with Python `2.3.1rc13`. No substantive
+changes to the plugin's own TypeScript — the rc.13 fix lands on the
+Hermes-side (`python/src/totalreclaw/hermes/pair_tool.py`) where the
+asyncio lifecycle regression lived. We keep plugin + Python RC
+numbers in lockstep so the release-pipeline tracker and
+`qa-totalreclaw` skill carry both artifacts through QA as one
+bundle.
+
+See the corresponding entry in `python/CHANGELOG.md` for the full
+design: the relay-pair WebSocket is now owned by a dedicated worker
+thread (with its own event loop) so it survives the Hermes
+tool-invocation loop teardown that destroyed the rc.10–rc.12 waiter
+mid-recv and caused every pair attempt to 502.
+
+The relay-served production pair page is also replaced with the
+rc.13 wizard UX — a typeform-style 3-step flow (PIN → phrase → done)
+mirroring the `docs/mockups/rc13-pair-wizard/` design. This lands in
+the `totalreclaw-relay` repo PR, not here, but surfaces to every
+OpenClaw user via the default relay pair flow.
+
+### Plugin local-mode pair page
+
+`skill/plugin/pair-page.ts` (the local-mode fallback served when a
+user sets `TOTALRECLAW_PAIR_MODE=local`) retains its rc.10–rc.12 UX
+shape. The wizard UX port for this file is deferred to rc.14 pending
+a design decision on whether to share a single CSS+JS asset across
+all three pair pages (relay / Python local / plugin local) or keep
+them independently inlined. Local-mode is rarely exercised — the
+plugin defaults to the relay flow via the Hermes Python sidecar and
+only falls back here for air-gapped setups.
+
 ## [3.3.1-rc.12] — 2026-04-23
 
 **Ship-stopper fix for rc.11.** The relay-served pair page's submit

--- a/skill/plugin/package-lock.json
+++ b/skill/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.1-rc.12",
+  "version": "3.3.1-rc.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/totalreclaw",
-      "version": "3.3.1-rc.12",
+      "version": "3.3.1-rc.13",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.0.1",

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.1-rc.12",
+  "version": "3.3.1-rc.13",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [

--- a/skill/plugin/pair-page.ts
+++ b/skill/plugin/pair-page.ts
@@ -5,6 +5,17 @@
  * the URL fragment (`#pk=...`), runs the client-side pairing flow
  * ENTIRELY in the browser, and POSTs the encrypted payload back.
  *
+ * rc.13 status: this OpenClaw-plugin local-mode page has NOT been
+ * ported to the wizard UX used by the relay (production) and the
+ * Python local-mode pages. Local-mode on the OpenClaw plugin is rarely
+ * exercised — the plugin defaults to a relay flow via the Hermes
+ * Python sidecar and only falls back here for air-gapped setups. The
+ * wizard UX port for this file is tracked for rc.14 alongside the
+ * design decision on whether to share a single CSS+JS asset across
+ * all three pair pages (relay / Python / plugin) or keep them
+ * independently inlined. For now, this file retains its rc.10–rc.12
+ * UX shape and the rc.12 AES-GCM cipher swap.
+ *
  * Brand tokens imported from the v5b.html public site (colors, font
  * stack). Typography falls back to system fonts for mobile parity —
  * we don't ship Euclid Circular A bytes over the pairing HTTP surface.


### PR DESCRIPTION
## Summary

Ship-stopper fix for rc.12 — calling \`totalreclaw_pair\` returned the URL + PIN but every browser submit hit a 502. Gateway logs showed \`Task was destroyed but it is pending!\` followed by \`RuntimeError: no running event loop\` during WebSocket close. Hermes's tool-invocation loop was tearing down before the waiter task could ack the relay.

**Root cause:** rc.10–rc.12 opened the relay WebSocket on Hermes's tool-invocation event loop and used \`loop.create_task(...)\` to keep awaiting on it after the tool returned. Hermes tears that loop down as soon as the tool returns.

**Fix:** the full relay pair session (open + opened + forward + decrypt + configure + ack + close) now runs on a dedicated OS thread with its own \`asyncio.new_event_loop()\`. The WebSocket is created INSIDE the thread loop so it is never bound to a loop that closes. The tool body blocks only on the fast session/open handshake, then returns \`{url, pin, expires_at}\` to the agent.

## Wizard UX for production pair page (scope expansion)

Local-mode \`pair_page.py\` rewritten on the rc.13 wizard design (docs/mockups/rc13-pair-wizard/): typeform-style 3-step flow with step dots, 6-cell PIN input, responsive phrase grid. Matches the relay-served production page (see paired totalreclaw-relay PR) so local-mode and relay-mode look identical.

Four user-ratified UX decisions baked in:
1. 6-cell PIN input + \`autocomplete="one-time-code"\` on cell 1
2. Returning-user tab label is "Log in"
3. Step-1 subheading is agent-generic
4. Paste into PIN auto-advances + auto-submits

Plugin local-mode \`pair-page.ts\` deferred to rc.14 — rarely-exercised path.

## Observability

5 new structured lifecycle log events emitted from the worker thread:
- \`pair.relay_completion_started\`
- \`pair.relay_opened\`
- \`pair.relay_decrypt_ok\` / \`_failed\`
- \`pair.relay_ack_sent\` / \`_failed\`
- \`pair.relay_completion_done\`

## Versions

- python/pyproject.toml: 2.3.1rc12 → 2.3.1rc13
- skill/plugin/package.json: 3.3.1-rc.12 → 3.3.1-rc.13
- plugin.yaml: 2.3.1rc9 → 2.3.1rc13 (was stale)

## Paired infra

- totalreclaw-relay PR: https://github.com/p-diogo/totalreclaw-relay/pull/new/fix/rc13-wizard-prod (wizard UX at /pair/p/:token)

## Test plan

- [x] New \`tests/test_pair_tool_asyncio_lifecycle.py\` passes — regression shield for the rc.10–rc.12 lifecycle bug (delayed relay stub + ack-arrival assertion)
- [x] Full python test suite: 837 passed, 11 skipped, 1 xfailed
- [x] \`test_pair_generate_mode.py\` rewired to mock \`_run_relay_pair_on_thread\`
- [x] \`test_pair_http.py\` page-title assertion updated for wizard UX
- [ ] After publish: end-to-end verify on pop-os tr-hermes — \`hermes chat -q "Set up TotalReclaw"\` → agent returns URL+PIN → simulate browser POST → gateway logs \`pair.relay_ack_sent\` → POST /respond returns 204

🤖 Generated with [Claude Code](https://claude.com/claude-code)