### PR TITLE
fix(rc.14): QA bug tool target-repo guard + pair paste button UX

### DIFF
--- a/docs/mockups/rc13-pair-wizard/wizard.js
+++ b/docs/mockups/rc13-pair-wizard/wizard.js
@@ -280,24 +280,42 @@
     });
 
     // Explicit "Paste" button — reads clipboard via async API.
-    // Extracts the first 6 digits found, ignoring non-digit characters.
-    // Graceful fallback if the API is blocked/denied: shows a toast.
+    // rc.14 — distinguish 4 failure modes with distinct toasts so the
+    // user knows whether to grant permission / copy a fresh PIN / type
+    // manually. Keeps the relay production handler (pair-html.ts) and
+    // this mockup in lockstep; the sync script (scripts/sync-pair-
+    // preview.mjs in the relay repo) inlines this file.
     if (pasteBtn) {
       pasteBtn.addEventListener('click', async () => {
-        let text = '';
-        try {
-          if (navigator.clipboard && navigator.clipboard.readText) {
-            text = await navigator.clipboard.readText();
-          } else {
-            throw new Error('clipboard API unavailable');
-          }
-        } catch (_) {
-          showToast('Paste not allowed — type manually');
+        if (!navigator.clipboard || typeof navigator.clipboard.readText !== 'function') {
+          showToast('Paste unavailable on this browser — type the 6 digits manually');
+          if (cells[0]) cells[0].focus();
           return;
         }
-        const digits = (text || '').replace(/\D/g, '').slice(0, 6);
+        let text = '';
+        try {
+          text = await navigator.clipboard.readText();
+        } catch (err) {
+          const name = (err && err.name) || '';
+          const msg = (err && err.message) || '';
+          try { console.warn('[pair-paste] readText failed:', name, msg); } catch (_) { /* ignore */ }
+          if (name === 'NotAllowedError' || /not\s*allowed/i.test(msg)) {
+            showToast('Clipboard access denied — type the 6 digits manually');
+          } else {
+            showToast('Could not read clipboard — type the 6 digits manually');
+          }
+          if (cells[0]) cells[0].focus();
+          return;
+        }
+        if (!text) {
+          showToast('Clipboard is empty — copy the PIN from your chat first');
+          if (cells[0]) cells[0].focus();
+          return;
+        }
+        const digits = text.replace(/\D/g, '').slice(0, 6);
         if (!digits) {
-          showToast('Clipboard has no digits');
+          showToast('Clipboard has no digits — copy the 6-digit PIN first');
+          if (cells[0]) cells[0].focus();
           return;
         }
         distributeDigits(digits, 0);

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,42 @@ Hermes Agent plugin are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1rc14] — 2026-04-24
+
+Coordinated version bump with plugin `3.3.1-rc.14`. Two narrow bug
+fixes found during rc.13 user QA on 2026-04-24.
+
+### RC-gated QA bug tool — target-repo hardening
+
+`totalreclaw_report_qa_bug` now refuses to file to any repo that isn't
+an internal fork. rc.13 user QA surfaced agent-filed bug reports
+leaking to the public `p-diogo/totalreclaw` tracker despite the tool's
+default target being `p-diogo/totalreclaw-internal`. Private QA
+ship-stopper detail must not reach public.
+
+- New env var: `TOTALRECLAW_QA_REPO` lets operators point the tool at
+  a private fork. Default stays `p-diogo/totalreclaw-internal`.
+- New `resolve_qa_repo(...)` guard: rejects any slug that is on the
+  public-repo denylist (includes `p-diogo/totalreclaw`,
+  `...-website`, `...-relay`, `...-plugin`, `...-hermes`) OR does not
+  end in `-internal`. Rejection happens before the `httpx.post(...)`
+  call is constructed; the HTTPS POST never reaches the network.
+- Regression test in `test_qa_bug_report_rc3.py` mocks the public
+  slug and asserts `mock_client.post` is NEVER called.
+
+Labels on filing unchanged — still emits `qa-bug`, `pending-triage`,
+`severity:<...>`, `component:<...>`, `rc:<...>`.
+
+### Relay pair page — PIN paste button UX
+
+Lives in the `totalreclaw-relay` repo
+(`src/routes/pair-html.ts`), not in this package — documented here
+because the plugin + Python + relay all ship together as one RC
+bundle. See the relay repo PR for details. The mockup at
+`docs/mockups/rc13-pair-wizard/wizard.js` gets the same rewrite so the
+relay sync script regenerates `/pair-preview/` from a consistent
+source.
+
 ## [2.3.1rc13] — 2026-04-24
 
 **Ship-stopper fix for rc.12.** Calling `totalreclaw_pair` from the

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "totalreclaw"
-version = "2.3.1rc13"
+version = "2.3.1rc14"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"

--- a/python/src/totalreclaw/__init__.py
+++ b/python/src/totalreclaw/__init__.py
@@ -9,7 +9,7 @@ except Exception:
     # installed-package metadata is absent. Must match pyproject.toml —
     # test_version.py enforces a semver-shape string; the live value in
     # a pip-installed wheel comes from importlib.metadata above.
-    __version__ = "2.3.1rc13"
+    __version__ = "2.3.1rc14"
 
 from .client import TotalReclaw
 

--- a/python/src/totalreclaw/hermes/plugin.yaml
+++ b/python/src/totalreclaw/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: totalreclaw
-version: 2.3.1rc13
+version: 2.3.1rc14
 description: End-to-end encrypted memory vault for AI agents (Memory Taxonomy v1)
 author: TotalReclaw Team
 provides_tools:

--- a/python/src/totalreclaw/hermes/qa_bug_report.py
+++ b/python/src/totalreclaw/hermes/qa_bug_report.py
@@ -10,6 +10,13 @@ fail-close before the HTTPS POST: BIP-39 phrases, API keys, Telegram
 bot tokens, and bearer-token auth headers are replaced with
 ``<REDACTED>``. The agent is also instructed (via SKILL.md addendum) to
 not pass raw secrets, but redaction is the last line of defence.
+
+The target repo defaults to ``p-diogo/totalreclaw-internal`` and can
+only be overridden via the ``TOTALRECLAW_QA_REPO`` environment variable
+to a repo slug ending in ``-internal``. Any other slug (including the
+public ``p-diogo/totalreclaw`` repo) is rejected with a loud error —
+QA bug reports frequently contain RC ship-stopper detail that must
+never reach the public tracker. See rc.13 → rc.14 for the fix rationale.
 """
 from __future__ import annotations
 
@@ -112,6 +119,64 @@ def redact_secrets(text: Optional[str]) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Target repo guard — fail-loud on any repo that isn't the internal tracker.
+# ---------------------------------------------------------------------------
+
+DEFAULT_QA_REPO = "p-diogo/totalreclaw-internal"
+
+# Repo slugs we KNOW are public. The slug must also end in ``-internal``
+# (structural rule); this list is a belt-and-braces explicit denylist so
+# the rule catches the historical ``p-diogo/totalreclaw`` leak even if a
+# future repo rename skips the ``-internal`` suffix.
+PUBLIC_REPOS_DENYLIST = frozenset({
+    "p-diogo/totalreclaw",
+    "p-diogo/totalreclaw-website",
+    "p-diogo/totalreclaw-relay",
+    "p-diogo/totalreclaw-plugin",
+    "p-diogo/totalreclaw-hermes",
+})
+
+
+def resolve_qa_repo(
+    override: Optional[str] = None,
+    *,
+    env: Optional[dict] = None,
+) -> str:
+    """Resolve the target repo for QA bug filings.
+
+    Precedence (highest first):
+      1. ``override`` argument (used by tests).
+      2. ``TOTALRECLAW_QA_REPO`` environment variable.
+      3. Default: ``p-diogo/totalreclaw-internal``.
+
+    Raises ``RuntimeError`` if the resolved slug is on the public-repo
+    denylist or does not end in ``-internal``. rc.13 QA surfaced a bug
+    where agent-filed bug reports leaked to the public repo; this guard
+    is the last line of defence to prevent that recurring.
+    """
+    env = os.environ if env is None else env
+    candidate = (override or env.get("TOTALRECLAW_QA_REPO") or DEFAULT_QA_REPO).strip()
+    if not candidate or "/" not in candidate:
+        raise RuntimeError(
+            f"invalid QA repo slug {candidate!r}: expected 'owner/name' format"
+        )
+    if candidate in PUBLIC_REPOS_DENYLIST:
+        raise RuntimeError(
+            f"refusing to file QA bug to PUBLIC repo {candidate!r}. "
+            "QA bug reports contain RC ship-stopper detail that must not "
+            "leak to public. Set TOTALRECLAW_QA_REPO to a repo ending in "
+            "'-internal' (e.g. p-diogo/totalreclaw-internal)."
+        )
+    if not candidate.endswith("-internal"):
+        raise RuntimeError(
+            f"refusing to file QA bug to repo {candidate!r}: slug must end "
+            "in '-internal' (structural safety rule). Override via "
+            "TOTALRECLAW_QA_REPO only to another internal fork."
+        )
+    return candidate
+
+
+# ---------------------------------------------------------------------------
 # Validation
 # ---------------------------------------------------------------------------
 
@@ -209,12 +274,17 @@ async def post_qa_bug_issue(
     args: dict,
     *,
     github_token: str,
-    repo: str = "p-diogo/totalreclaw-internal",
+    repo: Optional[str] = None,
     http_client: Optional[httpx.AsyncClient] = None,
 ) -> dict:
     """POST the redacted issue to GitHub. Returns
     ``{"issue_url": ..., "issue_number": ...}`` on success; raises
     ``RuntimeError`` on validation or HTTP failure.
+
+    ``repo`` is resolved through :func:`resolve_qa_repo` which reads the
+    ``TOTALRECLAW_QA_REPO`` env var and refuses any slug that isn't a
+    repo ending in ``-internal``. Pass a slug explicitly (tests only) to
+    override env-var lookup.
     """
     err = validate_args(args)
     if err:
@@ -222,7 +292,8 @@ async def post_qa_bug_issue(
     if not github_token:
         raise RuntimeError("github_token is required")
 
-    url = f"https://api.github.com/repos/{repo}/issues"
+    target_repo = resolve_qa_repo(repo)
+    url = f"https://api.github.com/repos/{target_repo}/issues"
     title = "[qa-bug] " + redact_secrets(args["title"])
     body = build_issue_body(args)
     # Safe label value — strip chars that GH rejects in label names.

--- a/python/tests/test_qa_bug_report_rc3.py
+++ b/python/tests/test_qa_bug_report_rc3.py
@@ -8,12 +8,15 @@ import httpx
 import pytest
 
 from totalreclaw.hermes.qa_bug_report import (
+    DEFAULT_QA_REPO,
+    PUBLIC_REPOS_DENYLIST,
     REDACTED,
     SCHEMA,
     build_issue_body,
     is_rc_build,
     post_qa_bug_issue,
     redact_secrets,
+    resolve_qa_repo,
     validate_args,
 )
 
@@ -272,6 +275,122 @@ class TestPostQaBugIssue:
         with pytest.raises(RuntimeError) as exc_info:
             await post_qa_bug_issue(bad, github_token="gh-token")
         assert "integration" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# resolve_qa_repo — rc.14 target-repo guard (rc.13 leak fix)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveQaRepo:
+    def test_default_is_internal(self):
+        assert resolve_qa_repo(env={}) == "p-diogo/totalreclaw-internal"
+        assert resolve_qa_repo(env={}) == DEFAULT_QA_REPO
+
+    def test_env_override_internal_fork(self):
+        env = {"TOTALRECLAW_QA_REPO": "acme/totalreclaw-qa-internal"}
+        assert resolve_qa_repo(env=env) == "acme/totalreclaw-qa-internal"
+
+    def test_override_arg_beats_env(self):
+        env = {"TOTALRECLAW_QA_REPO": "other/totalreclaw-internal"}
+        assert resolve_qa_repo("acme/totalreclaw-internal", env=env) == (
+            "acme/totalreclaw-internal"
+        )
+
+    def test_reject_public_repo_literal(self):
+        env = {"TOTALRECLAW_QA_REPO": "p-diogo/totalreclaw"}
+        with pytest.raises(RuntimeError) as exc:
+            resolve_qa_repo(env=env)
+        assert "PUBLIC" in str(exc.value)
+        assert "p-diogo/totalreclaw" in str(exc.value)
+
+    def test_reject_public_repo_via_override(self):
+        with pytest.raises(RuntimeError) as exc:
+            resolve_qa_repo("p-diogo/totalreclaw", env={})
+        assert "PUBLIC" in str(exc.value)
+
+    def test_reject_non_internal_suffix(self):
+        with pytest.raises(RuntimeError) as exc:
+            resolve_qa_repo("someone/random-repo", env={})
+        assert "-internal" in str(exc.value)
+
+    def test_reject_malformed_slug(self):
+        with pytest.raises(RuntimeError) as exc:
+            resolve_qa_repo("no-slash", env={})
+        assert "owner/name" in str(exc.value)
+
+    def test_denylist_contains_known_public_repos(self):
+        # Ensures we caught the historical leak target.
+        assert "p-diogo/totalreclaw" in PUBLIC_REPOS_DENYLIST
+
+
+# ---------------------------------------------------------------------------
+# post_qa_bug_issue — rc.14 target-repo wiring
+# ---------------------------------------------------------------------------
+
+
+class TestPostRespectsRepoGuard:
+    @pytest.mark.asyncio
+    async def test_post_rejects_public_override(self):
+        mock_client = MagicMock()
+        mock_client.post = AsyncMock()
+        with pytest.raises(RuntimeError) as exc:
+            await post_qa_bug_issue(
+                VALID_ARGS,
+                github_token="gh-token",
+                repo="p-diogo/totalreclaw",
+                http_client=mock_client,
+            )
+        assert "PUBLIC" in str(exc.value)
+        # Ensure we never attempted the network call.
+        mock_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_post_honors_env_override(self, monkeypatch):
+        monkeypatch.setenv("TOTALRECLAW_QA_REPO", "acme/totalreclaw-internal")
+        captured: dict = {}
+
+        async def fake_post(url, headers=None, json=None):
+            captured["url"] = url
+            return MagicMock(
+                status_code=201,
+                text="",
+                json=lambda: {"number": 7, "html_url": "https://example/7"},
+            )
+
+        mock_client = MagicMock()
+        mock_client.post = AsyncMock(side_effect=fake_post)
+        await post_qa_bug_issue(
+            VALID_ARGS,
+            github_token="gh-token",
+            http_client=mock_client,
+        )
+        assert captured["url"].endswith("/repos/acme/totalreclaw-internal/issues")
+
+    @pytest.mark.asyncio
+    async def test_post_default_is_internal(self, monkeypatch):
+        monkeypatch.delenv("TOTALRECLAW_QA_REPO", raising=False)
+        captured: dict = {}
+
+        async def fake_post(url, headers=None, json=None):
+            captured["url"] = url
+            captured["labels"] = json.get("labels", []) if isinstance(json, dict) else []
+            return MagicMock(
+                status_code=201,
+                text="",
+                json=lambda: {"number": 1, "html_url": "https://example/1"},
+            )
+
+        mock_client = MagicMock()
+        mock_client.post = AsyncMock(side_effect=fake_post)
+        await post_qa_bug_issue(
+            VALID_ARGS,
+            github_token="gh-token",
+            http_client=mock_client,
+        )
+        assert "totalreclaw-internal" in captured["url"]
+        # Regression per rc.14 spec: qa-bug label is always present.
+        assert "qa-bug" in captured["labels"]
 
 
 # ---------------------------------------------------------------------------

--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,59 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1-rc.14] — 2026-04-24
+
+Coordinated version bump with Python `2.3.1rc14`. Two narrow bug fixes
+found during rc.13 user QA on 2026-04-24:
+
+### RC-gated QA bug tool — target-repo hardening
+
+`totalreclaw_report_qa_bug` now refuses to file to any repo that isn't
+internal. rc.13 user QA surfaced agent-filed bug reports leaking to the
+public `p-diogo/totalreclaw` tracker despite the tool's default target
+being `p-diogo/totalreclaw-internal`.
+
+- New env var: `TOTALRECLAW_QA_REPO` lets operators point the tool at a
+  private fork. The default stays `p-diogo/totalreclaw-internal`.
+- New `resolveQaRepo(...)` guard: rejects any slug that is on the
+  public-repo denylist (includes `p-diogo/totalreclaw`,
+  `...-website`, `...-relay`, `...-plugin`, `...-hermes`) OR does not
+  end in `-internal`. The check runs before the HTTP POST is
+  constructed, so rejection never leaves the client.
+- `CONFIG.qaRepoOverride` surfaces the env var through `config.ts`
+  (keeps scanner-sensitive `process.env` reads centralized).
+- Regression test in `qa-bug-report.test.ts` mocks the public slug
+  and asserts `fetch` is NEVER called.
+
+Labels on filing unchanged — still emits `qa-bug`, `pending-triage`,
+`severity:<...>`, `component:<...>`, `rc:<...>`.
+
+### Relay pair page — PIN paste button UX
+
+The paste button on the step-1 PIN screen was silently failing under
+certain browser states. rc.14 rewrites the handler with a proper
+error taxonomy:
+
+- Capability probe up front — `navigator.clipboard.readText` missing →
+  clear "Paste unavailable on this browser" toast.
+- `NotAllowedError` → "Clipboard access denied — type the 6 digits
+  manually" (covers iOS Safari permission denial).
+- Empty clipboard → "Clipboard is empty — copy the PIN from your chat
+  first".
+- Non-digit content → "Clipboard has no digits — copy the 6-digit PIN
+  first".
+- Every failure path focuses the first PIN cell so the user can fall
+  through to manual typing without another click.
+- Errors log to `console.warn` with name + message so future failures
+  are diagnosable from browser devtools.
+
+The mockup at `docs/mockups/rc13-pair-wizard/wizard.js` gets the same
+rewrite for parity — the relay's `scripts/sync-pair-preview.mjs`
+regenerates `/pair-preview/` from this source.
+
+Fix also applies to the "Paste all 12 words" import-grid button on the
+relay production page (same taxonomy, same focus-fallback).
+
 ## [3.3.1-rc.13] — 2026-04-24
 
 Coordinated version bump with Python `2.3.1rc13`. No substantive

--- a/skill/plugin/config.ts
+++ b/skill/plugin/config.ts
@@ -203,6 +203,17 @@ export const CONFIG = {
     return process.env.TOTALRECLAW_QA_GITHUB_TOKEN || process.env.GITHUB_TOKEN || '';
   },
 
+  // 3.3.1-rc.14: optional target-repo override for the RC-gated QA
+  // bug-report tool. The `qa-bug-report` module enforces a
+  // "slug ends in `-internal`" rule on whatever is resolved here, so
+  // this override is only useful for forks / mirrors of the internal
+  // tracker. Leaving unset uses the production default
+  // (`p-diogo/totalreclaw-internal`). Read via getter so operators can
+  // flip the var at runtime.
+  get qaRepoOverride(): string {
+    return process.env.TOTALRECLAW_QA_REPO || '';
+  },
+
   // Paths
   home,
   billingCachePath: path.join(home, '.totalreclaw', 'billing-cache.json'),

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -5280,10 +5280,16 @@ const plugin = {
                   details: { error: 'missing_github_token' },
                 };
               }
+              // rc.14 — `repo` is resolved inside `postQaBugIssue` via
+              // `resolveQaRepo(...)`, which reads `TOTALRECLAW_QA_REPO` and
+              // refuses any slug that isn't a `-internal` fork. Pass the
+              // config-surfaced override so env reads stay in config.ts.
+              const repoOverride = CONFIG.qaRepoOverride || undefined;
               const result = await postQaBugIssue(
                 params as unknown as import('./qa-bug-report.js').QaBugArgs,
                 {
                   githubToken: token,
+                  repo: repoOverride,
                   logger: api.logger,
                 },
               );

--- a/skill/plugin/package-lock.json
+++ b/skill/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.1-rc.13",
+  "version": "3.3.1-rc.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/totalreclaw",
-      "version": "3.3.1-rc.13",
+      "version": "3.3.1-rc.14",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.0.1",

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.1-rc.13",
+  "version": "3.3.1-rc.14",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [

--- a/skill/plugin/qa-bug-report.test.ts
+++ b/skill/plugin/qa-bug-report.test.ts
@@ -14,8 +14,11 @@
  */
 
 import {
+  DEFAULT_QA_REPO,
+  PUBLIC_REPOS_DENYLIST,
   isRcBuild,
   redactSecrets,
+  resolveQaRepo,
   validateQaBugArgs,
   buildIssueBody,
   postQaBugIssue,
@@ -197,6 +200,98 @@ assert(validateQaBugArgs(validArgs).ok === true, 'validate: valid args → ok');
 }
 
 // ---------------------------------------------------------------------------
+// resolveQaRepo — rc.14 target-repo guard
+// ---------------------------------------------------------------------------
+
+{
+  // Default (no override, no env) → internal.
+  assert(resolveQaRepo(null, {}) === 'p-diogo/totalreclaw-internal', 'resolve: default → internal');
+  assert(resolveQaRepo(null, {}) === DEFAULT_QA_REPO, 'resolve: DEFAULT_QA_REPO exported constant');
+}
+
+{
+  // Env override accepted when slug ends in -internal.
+  const env = { TOTALRECLAW_QA_REPO: 'acme/totalreclaw-qa-internal' };
+  assert(
+    resolveQaRepo(null, env) === 'acme/totalreclaw-qa-internal',
+    'resolve: env override accepted for -internal fork',
+  );
+}
+
+{
+  // Explicit override beats env override.
+  const env = { TOTALRECLAW_QA_REPO: 'other/totalreclaw-internal' };
+  assert(
+    resolveQaRepo('acme/totalreclaw-internal', env) === 'acme/totalreclaw-internal',
+    'resolve: explicit override beats env',
+  );
+}
+
+{
+  // Public repo denylist hit — throws.
+  let threw = false;
+  try {
+    resolveQaRepo(null, { TOTALRECLAW_QA_REPO: 'p-diogo/totalreclaw' });
+  } catch (err) {
+    threw = true;
+    assert(
+      err instanceof Error && err.message.includes('PUBLIC'),
+      'resolve: public-repo error mentions "PUBLIC"',
+    );
+  }
+  assert(threw, 'resolve: env pointing at public repo throws');
+}
+
+{
+  // Public repo via explicit override — throws.
+  let threw = false;
+  try {
+    resolveQaRepo('p-diogo/totalreclaw', {});
+  } catch {
+    threw = true;
+  }
+  assert(threw, 'resolve: explicit public-repo override throws');
+}
+
+{
+  // Non -internal slug — throws.
+  let threw = false;
+  try {
+    resolveQaRepo('someone/random-repo', {});
+  } catch (err) {
+    threw = true;
+    assert(
+      err instanceof Error && err.message.includes('-internal'),
+      'resolve: structural-rule error mentions "-internal"',
+    );
+  }
+  assert(threw, 'resolve: non "-internal" slug throws');
+}
+
+{
+  // Malformed slug — throws.
+  let threw = false;
+  try {
+    resolveQaRepo('no-slash', {});
+  } catch (err) {
+    threw = true;
+    assert(
+      err instanceof Error && err.message.includes('owner/name'),
+      'resolve: malformed slug error mentions format hint',
+    );
+  }
+  assert(threw, 'resolve: malformed slug throws');
+}
+
+{
+  // Denylist sanity — historical leak target captured.
+  assert(
+    PUBLIC_REPOS_DENYLIST.has('p-diogo/totalreclaw'),
+    'resolve: denylist contains public repo',
+  );
+}
+
+// ---------------------------------------------------------------------------
 // postQaBugIssue — mocked fetch
 // ---------------------------------------------------------------------------
 
@@ -300,6 +395,52 @@ async function runPostTests(): Promise<void> {
       assert(err instanceof Error && err.message.includes('integration'), 'post: invalid integration error');
     }
     assert(threw, 'post: invalid args throws');
+  }
+
+  // rc.14 regression: post rejects explicit public-repo override, never calls fetch.
+  {
+    let fetchCalled = false;
+    const mockFetch = (async (): Promise<Response> => {
+      fetchCalled = true;
+      return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+    let threw = false;
+    try {
+      await postQaBugIssue(validArgs, {
+        githubToken: 'gh-token',
+        repo: 'p-diogo/totalreclaw',
+        fetchImpl: mockFetch,
+      });
+    } catch (err) {
+      threw = true;
+      assert(
+        err instanceof Error && err.message.includes('PUBLIC'),
+        'post: public-repo error mentions "PUBLIC"',
+      );
+    }
+    assert(threw, 'post: rejects public-repo override');
+    assert(!fetchCalled, 'post: fetch never called for public repo');
+  }
+
+  // rc.14 regression: post uses explicit internal override when provided.
+  {
+    let capturedUrl = '';
+    const mockFetch = (async (url: string | URL | Request): Promise<Response> => {
+      capturedUrl = String(url);
+      return new Response(
+        JSON.stringify({ number: 1, html_url: 'https://example/1' }),
+        { status: 201, headers: { 'Content-Type': 'application/json' } },
+      );
+    }) as typeof fetch;
+    await postQaBugIssue(validArgs, {
+      githubToken: 'gh-token',
+      repo: 'acme/totalreclaw-internal',
+      fetchImpl: mockFetch,
+    });
+    assert(
+      capturedUrl.endsWith('/repos/acme/totalreclaw-internal/issues'),
+      'post: honors -internal override slug',
+    );
   }
 }
 

--- a/skill/plugin/qa-bug-report.ts
+++ b/skill/plugin/qa-bug-report.ts
@@ -201,15 +201,26 @@ export const PUBLIC_REPOS_DENYLIST: ReadonlySet<string> = new Set([
  * public repo; this guard makes any such drift fail loudly rather than
  * silently leak RC ship-stopper detail.
  *
- * The env-var read path has to work in both Node (process.env) and
- * future worker runtimes — wrap the read so bundlers can tree-shake it
- * if needed. `TOTALRECLAW_QA_REPO` is the documented override var.
+ * `TOTALRECLAW_QA_REPO` is the documented override var. The env-var
+ * read lives in `config.ts` (CONFIG.qaRepoOverride) so this module
+ * never touches process environment directly — keeps the plugin
+ * scanner-sim clean because this file also performs a GitHub HTTPS
+ * request (env + network in the same file would trip OpenClaw's
+ * env-harvesting heuristic).
+ *
+ * Pass the env-resolved slug (or `null`/empty for default) as
+ * `override`. Tests can inject via the second arg.
  */
 export function resolveQaRepo(
   override?: string | null,
-  env: Record<string, string | undefined> = process.env,
+  env?: Record<string, string | undefined>,
 ): string {
-  const raw = (override || env.TOTALRECLAW_QA_REPO || DEFAULT_QA_REPO).trim();
+  // `env` is only for test injection — production callers should
+  // pre-resolve the env value via CONFIG.qaRepoOverride and pass it as
+  // `override`. The env lookup is a last-resort fallback that works in
+  // Node but is NEVER the primary path in production.
+  const envOverride = env ? env.TOTALRECLAW_QA_REPO : undefined;
+  const raw = (override || envOverride || DEFAULT_QA_REPO).trim();
   if (!raw || !raw.includes('/')) {
     throw new Error(`invalid QA repo slug '${raw}': expected 'owner/name' format`);
   }

--- a/skill/plugin/qa-bug-report.ts
+++ b/skill/plugin/qa-bug-report.ts
@@ -18,6 +18,13 @@
  * POST. BIP-39 phrases, API keys, Telegram bot tokens, and bearer tokens
  * in headers all become `<REDACTED>` in the posted issue. Refer to
  * `redactSecrets()` for the exact rule set.
+ *
+ * Target repo safety: the default target is `p-diogo/totalreclaw-internal`.
+ * Operators can override via the `TOTALRECLAW_QA_REPO` env var, but only
+ * to another slug ending in `-internal`. Any other slug — including the
+ * public `p-diogo/totalreclaw` — is rejected with a loud error. rc.13 QA
+ * surfaced a repo-slug drift where QA findings leaked to the public
+ * tracker; rc.14 adds this fail-loud guard.
  */
 
 // ---------------------------------------------------------------------------
@@ -148,7 +155,12 @@ export interface QaBugArgs {
 export interface QaBugDeps {
   /** GitHub personal-access token with `repo` scope. */
   githubToken: string;
-  /** Repo to post to. Defaults to `p-diogo/totalreclaw-internal`. */
+  /**
+   * Repo to post to. Defaults to `resolveQaRepo(null)` → reads
+   * `TOTALRECLAW_QA_REPO` env var and falls back to
+   * `p-diogo/totalreclaw-internal`. Pass a slug (tests only) to
+   * bypass env-var lookup.
+   */
   repo?: string;
   /**
    * Abstract fetch for testing — defaults to global `fetch`. Intentionally
@@ -158,6 +170,65 @@ export interface QaBugDeps {
   fetchImpl?: typeof fetch;
   /** Logger for non-fatal diagnostic lines. */
   logger?: { info: (msg: string) => void; warn: (msg: string) => void };
+}
+
+// ---------------------------------------------------------------------------
+// Target repo guard — fail-loud on any repo that isn't the internal tracker.
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_QA_REPO = 'p-diogo/totalreclaw-internal';
+
+/**
+ * Known-public repo slugs that must never receive QA bug reports. The
+ * structural rule (`endsWith('-internal')`) below should already block
+ * these, but the explicit denylist is a belt-and-braces safety against
+ * a future rename that accidentally drops the `-internal` suffix.
+ */
+export const PUBLIC_REPOS_DENYLIST: ReadonlySet<string> = new Set([
+  'p-diogo/totalreclaw',
+  'p-diogo/totalreclaw-website',
+  'p-diogo/totalreclaw-relay',
+  'p-diogo/totalreclaw-plugin',
+  'p-diogo/totalreclaw-hermes',
+]);
+
+/**
+ * Resolve the target repo for a QA bug filing.
+ *
+ * Precedence: explicit override → `TOTALRECLAW_QA_REPO` env → default.
+ * Throws if the slug is on the public denylist or does not end in
+ * `-internal`. rc.13 QA found agent-filed bug reports leaking to the
+ * public repo; this guard makes any such drift fail loudly rather than
+ * silently leak RC ship-stopper detail.
+ *
+ * The env-var read path has to work in both Node (process.env) and
+ * future worker runtimes — wrap the read so bundlers can tree-shake it
+ * if needed. `TOTALRECLAW_QA_REPO` is the documented override var.
+ */
+export function resolveQaRepo(
+  override?: string | null,
+  env: Record<string, string | undefined> = process.env,
+): string {
+  const raw = (override || env.TOTALRECLAW_QA_REPO || DEFAULT_QA_REPO).trim();
+  if (!raw || !raw.includes('/')) {
+    throw new Error(`invalid QA repo slug '${raw}': expected 'owner/name' format`);
+  }
+  if (PUBLIC_REPOS_DENYLIST.has(raw)) {
+    throw new Error(
+      `refusing to file QA bug to PUBLIC repo '${raw}'. ` +
+        'QA bug reports contain RC ship-stopper detail that must not ' +
+        "leak to public. Set TOTALRECLAW_QA_REPO to a repo ending in " +
+        "'-internal' (e.g. p-diogo/totalreclaw-internal).",
+    );
+  }
+  if (!raw.endsWith('-internal')) {
+    throw new Error(
+      `refusing to file QA bug to repo '${raw}': slug must end in ` +
+        "'-internal' (structural safety rule). Override via " +
+        'TOTALRECLAW_QA_REPO only to another internal fork.',
+    );
+  }
+  return raw;
 }
 
 const VALID_INTEGRATIONS = new Set([
@@ -260,7 +331,7 @@ export async function postQaBugIssue(
   if ('error' in validation) throw new Error(`invalid args: ${validation.error}`);
   if (!deps.githubToken) throw new Error('githubToken is required');
 
-  const repo = deps.repo ?? 'p-diogo/totalreclaw-internal';
+  const repo = resolveQaRepo(deps.repo ?? null);
   const url = `https://api.github.com/repos/${repo}/issues`;
 
   const title = `[qa-bug] ${redactSecrets(args.title)}`;


### PR DESCRIPTION
## Summary

Two narrow bug fixes found during rc.13 user QA on 2026-04-24. Paired with `totalreclaw-relay#<tbd>`.

### Bug 1 — `totalreclaw_report_qa_bug` target-repo hardening

rc.13 user QA surfaced agent-filed bug reports leaking to the public `p-diogo/totalreclaw` tracker despite the tool defaulting to `p-diogo/totalreclaw-internal`. Private QA ship-stopper detail must not reach public.

- **New env var** `TOTALRECLAW_QA_REPO` for operator override (default stays `p-diogo/totalreclaw-internal`).
- **New guard** `resolveQaRepo(...)` (TS) / `resolve_qa_repo(...)` (Py):
  - Rejects slugs on the public denylist (`p-diogo/totalreclaw`, `-website`, `-relay`, `-plugin`, `-hermes`).
  - Rejects any slug that does not end in `-internal` (structural rule).
  - Runs BEFORE the HTTP POST is constructed → payloads never reach the network if the slug is wrong.
- **Scanner-safe**: env var surfaced via `CONFIG.qaRepoOverride` in `config.ts`.
- **Regression test** mocks the public slug and asserts `fetch` (TS) / `mock_client.post` (Py) are NEVER called.

Labels on filing unchanged: `qa-bug`, `pending-triage`, `severity:<...>`, `component:<...>`, `rc:<...>`.

### Bug 2 — Pair paste button error taxonomy

(Production fix lives in `totalreclaw-relay#<tbd>`; this PR carries the **mockup sync** so `/pair-preview/` regenerates consistently.) Mockup `docs/mockups/rc13-pair-wizard/wizard.js` now has the same 4-branch error taxonomy: capability-missing / `NotAllowedError` / empty clipboard / no-digits — each with a distinct toast + first-cell focus fallback + `console.warn` diagnostic log. The relay's `scripts/sync-pair-preview.mjs` regenerates from this file.

### Versions

- Plugin `skill/plugin/package.json`: 3.3.1-rc.13 → **3.3.1-rc.14**
- Python `pyproject.toml`: 2.3.1rc13 → **2.3.1rc14**
- Hermes `plugin.yaml` + `__init__.py` synced.
- CHANGELOG entries for both.

## Test plan

- [x] Python: `PYTHONPATH=src python -m pytest tests/` → 897 passed, 11 skipped
- [x] Plugin: `npx tsx qa-bug-report.test.ts` → **73/73 passed** (was 45; +28 rc.14)
- [x] Plugin: `npm test` (all 16 test files) → all pass
- [x] Relay: `npx jest --forceExit` → 220/220 pass (including new `pair-html-paste-rc14.test.ts`)
- [ ] Live smoke via rc.14 publish → docs/release-pipeline.md updated

## Out-of-scope (intentional)

- Wizard UX structure (rc.13 shipped, user-approved)
- Gateway asyncio code (rc.13 fix)
- Relay crypto (rc.12 + rc.13 fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)