### PR TITLE
docs(#90): surface @rc npm tag for RC plugin installs

### DIFF
--- a/docs/guides/beta-tester-guide-detailed.md
+++ b/docs/guides/beta-tester-guide-detailed.md
@@ -71,6 +71,15 @@ This registers the plugin with your gateway under the ID `totalreclaw` and sets 
 
 > **TotalReclaw is distributed via npm.** Future CLI resolvers may surface it via additional registries.
 
+> **Beta tester note — installing an RC.** The bare spec above resolves to npm's `latest` dist-tag, which is always the current **stable** build. If you installed the skill via `openclaw skills install totalreclaw`, ClawHub may have handed you a release-candidate skill — in that case install the matching RC plugin explicitly with the `@rc` tag (or pin a specific candidate):
+>
+> ```
+> openclaw plugins install @totalreclaw/totalreclaw@rc          # latest RC
+> openclaw plugins install @totalreclaw/totalreclaw@3.3.1-rc.13 # pinned RC
+> ```
+>
+> Run `npm view @totalreclaw/totalreclaw dist-tags` to see what `latest` and `rc` currently resolve to. Keeping the skill and plugin on the same version family (both stable or both RC) avoids skill-instruction / plugin-behavior drift.
+
 <details>
 <summary>Developer / from-source install (plugin contributors only)</summary>
 

--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -73,11 +73,21 @@ The recovery phrase never crosses the LLM context — not the chat transcript, n
 If you'd rather run every command yourself without any agent involvement:
 
 ```bash
-openclaw plugins install @totalreclaw/totalreclaw
+openclaw plugins install @totalreclaw/totalreclaw            # stable
 openclaw gateway restart              # or: docker restart tr-openclaw
 ```
 
 Then ask the agent "set up TotalReclaw for me" — it will call `totalreclaw_pair` and hand you the URL + PIN.
+
+> **Installing an RC build.** `openclaw skills install totalreclaw` pulls the latest release-candidate skill from ClawHub, but the bare npm spec `@totalreclaw/totalreclaw` resolves to the `latest` dist-tag, which is always the current **stable** build. To install the matching RC plugin, explicitly tag the npm spec:
+>
+> ```bash
+> openclaw plugins install @totalreclaw/totalreclaw@rc        # latest RC
+> # or pin a specific candidate:
+> openclaw plugins install @totalreclaw/totalreclaw@3.3.1-rc.13
+> ```
+>
+> Check what each tag currently resolves to with `npm view @totalreclaw/totalreclaw dist-tags`. Keep the skill and plugin on the same version family (both stable or both RC) to avoid skill instructions and plugin behavior drifting apart.
 
 <details>
 <summary>From-source install (for plugin development)</summary>


### PR DESCRIPTION
## What broke
Users installing via the RC path got mismatched versions: `openclaw skills install totalreclaw` pulled the RC skill (3.3.1-rc.13) from ClawHub, but the documented `openclaw plugins install @totalreclaw/totalreclaw` resolved to stable (3.2.3) with no warning.

## What's fixed
`docs/guides/openclaw-setup.md` and `docs/guides/beta-tester-guide-detailed.md` now explicitly document the `@rc` npm dist-tag (and `@<rc-version>` pin form) as the way to install the matching RC plugin, including the `npm view @totalreclaw/totalreclaw dist-tags` command to inspect registry state.

## Impact after fix
RC-flavor beta testers following the public guides see both the bare stable-install command and the `@rc`/pinned-version install commands, and are told to keep skill + plugin on the same version family. No registry/code behavior change — `latest` correctly stays on stable.

## Verification
Verified npm registry state (`{ latest: '3.2.3', rc: '3.3.1-rc.14' }`) confirms the mismatch is deterministic from dist-tag assignment. The in-plugin `skill/plugin/SKILL.md` already carries the `@rc` guidance; this PR brings the two public guides in sync.

Closes #90
Note: CLI-level mismatch detection belongs in the OpenClaw CLI resolver (upstream) and is out of scope here. Consider filing a separate upstream issue if that behavior is desired.