### PR TITLE
fix(plugin): lazy-load ONNX / transformers (partial — see PR body)

### DIFF
--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1-rc.15] — 2026-04-24
+
+Install-time unblock for bandwidth-constrained hosts. Lazy-loads the ONNX
+runtime instead of forcing a ~216MB download during `openclaw plugins
+install`.
+
+### Lazy-loaded ONNX / `@huggingface/transformers`
+
+`openclaw plugins install @totalreclaw/totalreclaw` on slow hosts (VPNs,
+CI containers with limited bandwidth, metered connections) was exceeding
+the plugin-install timeout mid-download and getting SIGTERM'd, leaving
+the plugin partially installed. Root cause: `@huggingface/transformers`
+was a direct `dependency`, which transitively pulled
+`onnxruntime-node`'s postinstall binary fetch (~216MB from GitHub
+Releases).
+
+- `@huggingface/transformers` and `onnxruntime-node` moved from
+  `dependencies` to optional `peerDependencies`
+  (`peerDependenciesMeta.<name>.optional: true`). npm v7+ and the
+  OpenClaw install path (`--legacy-peer-deps`) both skip these by
+  default — plugin install is now lean.
+- `embedding.ts` converts the static
+  `import { AutoTokenizer, AutoModel, pipeline } from
+  '@huggingface/transformers'` into a dynamic `await import(...)` on
+  the first `generateEmbedding` call. If the optional peer is missing,
+  the error surfaces a clear install hint:
+  `npm install @huggingface/transformers`.
+- New regression test `lazy-load-embedding.test.ts` asserts the
+  invariants (no top-level static runtime import; heavy packages not in
+  `dependencies`; peer-dep `optional` flag set) so a future refactor
+  can't silently reintroduce the install-time block.
+
+**User impact:** users on constrained hosts can now install the plugin
+without the 216MB download. Users who want semantic memory (recall /
+search over encrypted facts) install `@huggingface/transformers`
+separately — one-time, resumable if it times out.
+
+Fixes [issue #92][i92] (QA bug 6 of 10, split from #84).
+
+[i92]: https://github.com/p-diogo/totalreclaw-internal/issues/92
+
 ## [3.3.1-rc.14] — 2026-04-24
 
 Coordinated version bump with Python `2.3.1rc14`. Two narrow bug fixes

--- a/skill/plugin/embedding.ts
+++ b/skill/plugin/embedding.ts
@@ -8,11 +8,44 @@
  * embedding model breaks search across an existing vault, so the
  * `TOTALRECLAW_EMBEDDING_MODEL` user-facing env var was removed in v1.
  *
- * Dependencies: @huggingface/transformers
+ * Dependencies: @huggingface/transformers is declared as an optional peer
+ * dependency. It is lazy-loaded on the first `generateEmbedding` call so
+ * `openclaw plugins install @totalreclaw/totalreclaw` does not block on the
+ * ~216MB onnxruntime-node native-binary download. Install it separately to
+ * enable semantic search: `npm install @huggingface/transformers`.
  */
 
+// Type-only import — erased at compile time, no runtime dep on the package.
 // @ts-ignore - @huggingface/transformers types may not be perfect
-import { AutoTokenizer, AutoModel, pipeline, type FeatureExtractionPipeline } from '@huggingface/transformers';
+import type { FeatureExtractionPipeline } from '@huggingface/transformers';
+
+type HFTransformers = typeof import('@huggingface/transformers');
+
+/** Cached module handle after first successful dynamic import. */
+let transformersModule: HFTransformers | null = null;
+
+/**
+ * Lazily import @huggingface/transformers. The package is declared as an
+ * optional peer dependency so the plugin installs on bandwidth-constrained
+ * hosts without pulling the onnxruntime-node native binary (~216MB). On first
+ * use, try to load it; if the user never installed it, surface a clear
+ * actionable error with the install command.
+ */
+async function loadTransformers(): Promise<HFTransformers> {
+  if (transformersModule) return transformersModule;
+  try {
+    // @ts-ignore - dynamic import target is the optional peer dep
+    transformersModule = (await import('@huggingface/transformers')) as HFTransformers;
+    return transformersModule;
+  } catch (err) {
+    const hint =
+      '[TotalReclaw] @huggingface/transformers is not installed. ' +
+      'Semantic memory requires it (one-time ~216MB download of ONNX runtime + model). ' +
+      'Install with: npm install @huggingface/transformers';
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(`${hint}\nUnderlying load error: ${detail}`);
+  }
+}
 
 interface ModelConfig {
   id: string;
@@ -45,14 +78,17 @@ let activeModel: ModelConfig | null = null;
 /**
  * Generate an embedding vector for the given text.
  *
- * On first call, downloads and loads the ONNX model (cached after download).
- * Subsequent calls reuse the loaded model and run in ~100ms.
+ * On first call, dynamically imports @huggingface/transformers (requires it
+ * to be installed — see module docstring) and downloads the ONNX model
+ * (cached after download). Subsequent calls reuse the loaded module + model
+ * and run in ~100ms.
  */
 export async function generateEmbedding(
   text: string,
   options?: { isQuery?: boolean },
 ): Promise<number[]> {
   if (!activeModel) {
+    const { AutoTokenizer, AutoModel, pipeline } = await loadTransformers();
     activeModel = getModelConfig();
     console.error(`[TotalReclaw] Downloading embedding model (${activeModel.size}, one-time setup)...`);
     console.error('[TotalReclaw] This enables semantic search across your encrypted memories.');

--- a/skill/plugin/lazy-load-embedding.test.ts
+++ b/skill/plugin/lazy-load-embedding.test.ts
@@ -1,0 +1,158 @@
+/**
+ * lazy-load-embedding.test.ts — Regression guard for the deferred
+ * onnxruntime-node / @huggingface/transformers install path introduced in
+ * 3.3.1-rc.15.
+ *
+ * Background (install-time SIGTERM on bandwidth-constrained hosts):
+ *   `openclaw plugins install @totalreclaw/totalreclaw` invoked `npm install`,
+ *   which fetched `@huggingface/transformers` (direct dep) and transitively
+ *   `onnxruntime-node`, whose postinstall downloads a ~216MB native binary
+ *   from GitHub Releases. Slow / constrained hosts (CI containers with
+ *   limited bandwidth, throttled VPNs) exceeded the plugin-install timeout
+ *   and got SIGTERM'd mid-download, leaving the plugin partially installed.
+ *
+ *   Fix: demote `@huggingface/transformers` + `onnxruntime-node` from
+ *   `dependencies` to optional peer dependencies, and convert
+ *   `embedding.ts`'s static `import { AutoTokenizer, ... } from
+ *   '@huggingface/transformers'` to a dynamic `await import(...)` inside the
+ *   first-call code path.
+ *
+ *   Users who want semantic memory install the extras explicitly:
+ *     npm install @huggingface/transformers
+ *   Users who do not (chat-only flows) get a clean, lean install.
+ *
+ * This test asserts the invariants that make the lazy-load safe:
+ *   1. package.json does NOT declare the heavy packages as regular deps.
+ *   2. package.json DOES declare them as peer deps marked `optional: true`.
+ *   3. embedding.ts uses a dynamic `import()` — NOT a static top-level
+ *      runtime import — for `@huggingface/transformers`.
+ *   4. A type-only `import type` from `@huggingface/transformers` is fine
+ *      (erased at compile time, no runtime dep).
+ *
+ * Source-level text inspection is used here (rather than a child-process
+ * require-cache sniff) because `embedding.ts` is an ESM module with a
+ * dynamic `import()` whose behavior depends on whether the optional peer is
+ * actually installed on the test host. A deterministic regex check of the
+ * source is precise and unambiguous, and fails loudly if a future refactor
+ * reintroduces a top-level static import.
+ *
+ * Run with: npx tsx lazy-load-embedding.test.ts
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, name: string): void {
+  const n = passed + failed + 1;
+  if (condition) {
+    console.log(`ok ${n} - ${name}`);
+    passed++;
+  } else {
+    console.log(`not ok ${n} - ${name}`);
+    failed++;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 1. package.json: heavy packages must be optional peer deps, not direct deps
+// ---------------------------------------------------------------------------
+
+const pkgPath = path.join(__dirname, 'package.json');
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as {
+  dependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+};
+
+const HEAVY_PACKAGES = ['@huggingface/transformers', 'onnxruntime-node'] as const;
+
+for (const name of HEAVY_PACKAGES) {
+  assert(
+    !(pkg.dependencies ?? {})[name],
+    `package.json: "${name}" is NOT in "dependencies" (would force 216MB ONNX download at plugin install)`,
+  );
+  assert(
+    !!(pkg.peerDependencies ?? {})[name],
+    `package.json: "${name}" is declared in "peerDependencies"`,
+  );
+  assert(
+    (pkg.peerDependenciesMeta ?? {})[name]?.optional === true,
+    `package.json: "peerDependenciesMeta.${name}.optional" === true (npm v7+ will not auto-install)`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 2. embedding.ts: no static top-level runtime import of the heavy package
+// ---------------------------------------------------------------------------
+
+const embeddingPath = path.join(__dirname, 'embedding.ts');
+const embeddingSrc = fs.readFileSync(embeddingPath, 'utf8');
+
+{
+  // 2a. No top-level, non-type, static import from @huggingface/transformers.
+  //     Matches lines like: import { X } from '@huggingface/transformers';
+  //     but NOT: import type { X } from '@huggingface/transformers';
+  //     The check is source-line-scoped so the `import type` line below
+  //     doesn't trigger a false positive.
+  const staticRuntimeImport = embeddingSrc
+    .split('\n')
+    .some(
+      (line) =>
+        /^\s*import\s/.test(line) &&
+        !/^\s*import\s+type\s/.test(line) &&
+        /from\s+['"]@huggingface\/transformers['"]/.test(line),
+    );
+  assert(
+    !staticRuntimeImport,
+    'embedding.ts does NOT have a static top-level runtime import of @huggingface/transformers',
+  );
+}
+
+{
+  // 2b. Must contain a dynamic `await import('@huggingface/transformers')`.
+  const hasDynamicImport =
+    /await\s+import\s*\(\s*['"]@huggingface\/transformers['"]\s*\)/.test(embeddingSrc);
+  assert(
+    hasDynamicImport,
+    'embedding.ts uses a dynamic `await import("@huggingface/transformers")` (lazy-loaded on first use)',
+  );
+}
+
+{
+  // 2c. Regression guard: no top-level `require('@huggingface/transformers')`
+  //     either — would equally defeat lazy loading.
+  const hasRequire =
+    /require\s*\(\s*['"]@huggingface\/transformers['"]\s*\)/.test(embeddingSrc);
+  assert(
+    !hasRequire,
+    'embedding.ts does NOT use `require("@huggingface/transformers")` at module scope',
+  );
+}
+
+{
+  // 2d. Module docstring mentions the optional-peer install command so users
+  //     have a pointer when they hit the "module not installed" error.
+  const mentionsInstallCommand = /npm install @huggingface\/transformers/.test(embeddingSrc);
+  assert(
+    mentionsInstallCommand,
+    'embedding.ts documents the `npm install @huggingface/transformers` opt-in command',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log(`# fail: ${failed}`);
+console.log(`# ${passed}/${passed + failed} passed`);
+if (failed > 0) {
+  console.log('SOME TESTS FAILED');
+  process.exit(1);
+}
+console.log('ALL TESTS PASSED');

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.1-rc.14",
+  "version": "3.3.1-rc.15",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [
@@ -31,15 +31,25 @@
   "author": "TotalReclaw Team",
   "license": "MIT",
   "dependencies": {
-    "@huggingface/transformers": "^4.0.1",
     "@totalreclaw/client": "^1.2.0",
     "@totalreclaw/core": "^2.1.1",
     "@types/qrcode": "^1.5.6",
     "@types/ws": "^8.5.12",
-    "onnxruntime-node": "^1.24.0",
     "qrcode": "^1.5.4",
     "qrcode-terminal": "^0.12.0",
     "ws": "^8.18.3"
+  },
+  "peerDependencies": {
+    "@huggingface/transformers": "^4.0.1",
+    "onnxruntime-node": "^1.24.0"
+  },
+  "peerDependenciesMeta": {
+    "@huggingface/transformers": {
+      "optional": true
+    },
+    "onnxruntime-node": {
+      "optional": true
+    }
   },
   "files": [
     "*.ts",
@@ -54,7 +64,7 @@
     "skill.json"
   ],
   "scripts": {
-    "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx llm-client-retry.test.ts && npx tsx gateway-url.test.ts && npx tsx retype-setscope.test.ts && npx tsx tool-gating.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts && npx tsx pair-qr.test.ts && npx tsx pair-remote-client.test.ts && npx tsx qa-bug-report.test.ts && npx tsx nonce-serialization.test.ts && npx tsx phrase-safety-registry.test.ts",
+    "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx llm-client-retry.test.ts && npx tsx gateway-url.test.ts && npx tsx retype-setscope.test.ts && npx tsx tool-gating.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts && npx tsx pair-qr.test.ts && npx tsx pair-remote-client.test.ts && npx tsx qa-bug-report.test.ts && npx tsx nonce-serialization.test.ts && npx tsx phrase-safety-registry.test.ts && npx tsx lazy-load-embedding.test.ts",
     "check-scanner": "node ../scripts/check-scanner.mjs",
     "prepublishOnly": "node ../scripts/check-scanner.mjs"
   },


### PR DESCRIPTION
## What broke
`openclaw plugins install @totalreclaw/totalreclaw` downloaded ~216MB of ONNX runtime during `npm install`, SIGTERM-ing on bandwidth-constrained Docker hosts (issue #92 in totalreclaw-internal).

## What's fixed (partial)
Plugin side: `@huggingface/transformers` + `onnxruntime-node` moved from `dependencies` → optional `peerDependencies`; static `import` in `skill/plugin/embedding.ts` → dynamic `await import(...)` with a clear install-hint error; regression test `lazy-load-embedding.test.ts` pins the invariant.

## Impact after fix
Plugin-side eager import is gone. **But install-size is unchanged** — see "Known gap" below.

## Verification
Install-topology QA against published rc.15 → **NO-GO** for the bug at hand. Report: `docs/notes/QA-plugin-RC-3.3.1-rc.15-20260424.md` (totalreclaw-internal).

---

## :warning: Known gap — draft, not ready to merge

`@totalreclaw/client@1.2.0` (a regular `dependencies` entry of the plugin) **also** lists `@huggingface/transformers` as a regular dep and statically imports it in `client/src/embedding/onnx.ts`. So the plugin-side change alone does not reduce `npm install`'s transitive pull of `onnxruntime-node`.

Concrete numbers from the rc.15 sanity install (node 22.22.2, npm 10.9.7, no flags):

| RC | Packages | Install time | `node_modules` | `onnxruntime-node` |
| --- | ---:| ---:| ---:| ---:|
| rc.14 (pre-fix) | 191 | 29s | 782MB | 513MB |
| rc.15 (post-fix) | 191 | 30s | 782MB | 513MB |

Tree trace:

```
@totalreclaw/totalreclaw@3.3.1-rc.15
├─┬ @huggingface/transformers@4.2.0
│ └── onnxruntime-node@1.24.3 deduped
├─┬ @totalreclaw/client@1.2.0
│ └── @huggingface/transformers@4.2.0 deduped   ← REGULAR dep in client/package.json
└── onnxruntime-node@1.24.3
```

## To complete the fix

Apply the same pattern to `@totalreclaw/client`:

1. `client/package.json` — demote `@huggingface/transformers` → optional peer.
2. `client/src/embedding/onnx.ts` — static → dynamic import with install-hint.
3. Publish `@totalreclaw/client@1.3.0` (or 1.2.1).
4. Bump `skill/plugin/package.json`'s client dep to the new version, re-publish as `rc.16`.

Cross-package + new client version that `@totalreclaw/mcp-server` would also pick up → pushes past the tr-triage-and-fix 5-file rail and has broader consumer impact. Escalated to owner for direction.

Closes #92 once the client-side work lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)