### PR TITLE
ci: pin wasm-pack-action to eliminate "latest"-tag flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
       # `Build @totalreclaw/core (WASM)` steps can be removed in a cleanup PR.
       - uses: dtolnay/rust-toolchain@stable
       - uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: 'v0.14.0'  # pinned to stop `latest`-tag flake; v0.9.1 lacks --features
       - name: Build @totalreclaw/core (WASM) [transitional — safe to drop once core@2.x is on npm]
         run: |
           cd rust/totalreclaw-core

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -62,6 +62,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: 'v0.14.0'  # pinned to stop `latest`-tag flake; v0.9.1 lacks --features
 
       - name: Build WASM
         run: cd rust/totalreclaw-core && wasm-pack build --target nodejs --out-dir pkg --features wasm
@@ -197,6 +199,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: 'v0.14.0'  # pinned to stop `latest`-tag flake; v0.9.1 lacks --features
 
       # NOTE: `mcp/package.json` used to depend on `@totalreclaw/core` via a
       # `file:` dep, which required building the WASM pkg locally. It now


### PR DESCRIPTION
## Summary

`jetli/wasm-pack-action@v0.4.0` with no explicit `version:` input falls back to installing the latest wasm-pack release. That tag is not deterministic across runners, and on 2026-04-24 the same workflow resolved to two different wasm-pack versions on sibling runs:

- **`main` branch** (green): wasm-pack **v0.14.0** — supports `--features`, build succeeds.
- **PR #100** (red, MCP Server Tests): wasm-pack **v0.9.1** — predates the `--features` flag (added in wasm-pack 0.10), so `wasm-pack build --target nodejs --out-dir pkg --features wasm` fails with a CLI parse error.

This is a pure CI-infra flake: the PR code itself was fine, but the job failed because the action happened to resolve to an older wasm-pack that weekend. Pinning eliminates the flake class entirely.

## Change

Before:
```yaml
- uses: jetli/wasm-pack-action@v0.4.0
```
(implicit `version: latest`)

After:
```yaml
- uses: jetli/wasm-pack-action@v0.4.0
  with:
    version: 'v0.14.0'  # pinned to stop `latest`-tag flake; v0.9.1 lacks --features
```

`v0.14.0` is what recent green runs on `main` have been resolving to (confirmed via `gh run view` logs on run `24893181451`). It is >= 0.10, so `--features` continues to work.

## Files changed

- `.github/workflows/ci.yml` — `build-and-test` job (1 call site)
- `.github/workflows/npm-publish.yml` — `publish-core` + `publish-mcp` jobs (2 call sites)

Total: **3 call sites pinned**, matching the grep scope across `.github/workflows/`.

## Why pinning helps

1. **Determinism**: the exact wasm-pack binary is identical on every run.
2. **Bisectable regressions**: any future `wasm-pack` behavior change lands in a dedicated bump PR, not as a silent CI flake.
3. **No downside**: the action still downloads the same binary from the same release URL; we just tell it which release.

## Discovery context

Noticed on PR #100 run on 2026-04-24 — the MCP Server Tests job failed on a PR whose code changes had nothing to do with wasm-pack invocation. Diffing main's green run log vs. PR #100's red run log showed different `Installing wasm-pack vX.Y.Z ...` lines, which pointed at the `latest`-tag drift.

## Test plan

- [x] `git diff` shows only the 3 expected additions (verified locally)
- [ ] CI build-and-test job on this PR passes with wasm-pack v0.14.0 explicitly installed
- [ ] After merge, re-run PR #100's failed `MCP Server Tests` job to confirm the fix unblocks it

🤖 Generated with [Claude Code](https://claude.com/claude-code)