### PR TITLE
fix(plugin): add headless --url-pin-only pair CLI for container agents (#87)

### DIFF
--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -66,7 +66,7 @@ The QR encodes ONLY the pair URL. The 6-digit PIN is a separate out-of-band conf
 
 ## Phrase safety (HARD — never break)
 
-NEVER echo / generate / ask the user to paste a recovery phrase in chat. NEVER invoke `openclaw totalreclaw onboard`, `totalreclaw setup`, or any phrase-touching CLI via your shell tool (stdout enters LLM context). The ONLY agent-facilitated setup path is `totalreclaw_pair`. If the user pastes a phrase anyway: tell them it is compromised, call `totalreclaw_pair` with `mode=generate` for a fresh wallet.
+NEVER echo / generate / ask the user to paste a recovery phrase in chat. NEVER invoke `openclaw totalreclaw onboard`, `totalreclaw setup`, or any phrase-touching CLI via your shell tool (stdout enters LLM context). The ONLY agent-facilitated setup paths are (in order of preference): (1) `totalreclaw_pair` tool; (2) if the tool is missing from your tool list — a known gap for some container-based agents, issue #87 — shell out to `openclaw totalreclaw pair generate --url-pin-only`, which emits a single-line JSON `{v,url,pin,expires_at_ms}` with zero phrase material on stdout (pair-crypto is x25519-only, not BIP-39). If the user pastes a phrase anyway: tell them it is compromised, call `totalreclaw_pair` with `mode=generate` for a fresh wallet.
 
 ## Usage (post-setup)
 
@@ -78,7 +78,7 @@ NEVER echo / generate / ask the user to paste a recovery phrase in chat. NEVER i
 
 ## Diagnostics
 
-- `totalreclaw_*` tools not visible → plugin not installed or gateway not restarted. Verify via `openclaw plugins list | grep totalreclaw`. If listed, ask the user to restart the gateway.
+- `totalreclaw_*` tools not visible → plugin not installed or gateway not restarted. Verify via `openclaw plugins list | grep totalreclaw`. If listed but tools still absent (container-agent gap, issue #87), shell out to `openclaw totalreclaw pair generate --url-pin-only` on the gateway host and hand the user the `url` + `pin` from the JSON payload — do NOT suggest `openclaw totalreclaw onboard` (leaks phrase on stdout).
 - User says done but `credentials.json` missing → PIN expired or entered wrong phrase; call `totalreclaw_pair` again.
 - `onboarding required` → credentials missing; redo from the pair step.
 - `quota exceeded` → `totalreclaw_status`, then offer `totalreclaw_upgrade`.

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -5412,11 +5412,18 @@ const plugin = {
                 '## TotalReclaw setup pending\n\n' +
                 'TotalReclaw encrypted memory is installed but not yet set up on this machine. ' +
                 'If the user asks about memory features or wants to configure TotalReclaw, ' +
-                'call the `totalreclaw_onboarding_start` tool for instructions.\n\n' +
+                'call the `totalreclaw_pair` tool — it returns a pairing URL + 6-digit PIN ' +
+                'the user opens in a browser (phrase is generated and encrypted in-browser, ' +
+                'never leaves their device in plaintext). If `totalreclaw_pair` is not in ' +
+                'your tool list (container-based agents sometimes miss it), shell out to ' +
+                '`openclaw totalreclaw pair generate --url-pin-only` on the gateway host — ' +
+                'it emits a single JSON line `{v,url,pin,expires_at_ms}` with no phrase ' +
+                'material; hand the user the `url` and `pin`.\n\n' +
                 '**Do NOT** attempt to generate, display, or relay a recovery phrase in chat. ' +
-                'All phrase handling happens on the user\'s local terminal via ' +
-                '`openclaw totalreclaw onboard` — this keeps the phrase out of the LLM ' +
-                'provider\'s logs.',
+                '**Do NOT** run `openclaw totalreclaw onboard` — that CLI emits the recovery ' +
+                'phrase on stdout and would leak it into the LLM transcript. Use `pair` ' +
+                '(tool or `--url-pin-only` CLI) instead; `onboard` is reserved for users ' +
+                'running it directly in their own local terminal.',
             };
           }
 

--- a/skill/plugin/package-lock.json
+++ b/skill/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.1-rc.14",
+  "version": "3.3.1-rc.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/totalreclaw",
-      "version": "3.3.1-rc.14",
+      "version": "3.3.1-rc.15",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.0.1",

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.1-rc.14",
+  "version": "3.3.1-rc.15",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [

--- a/skill/plugin/pair-cli-json.test.ts
+++ b/skill/plugin/pair-cli-json.test.ts
@@ -1,11 +1,14 @@
 /**
- * Tests for 3.3.1 pair-cli JSON mode.
+ * Tests for 3.3.1 pair-cli JSON mode + 3.3.1-rc.15 url-pin mode (issue #87).
  *
  * Covers:
  *   - outputMode: 'json' emits a single line of valid JSON to stdout
  *   - JSON payload contains sid, url, pin, qr_ascii, expires_at_ms
  *   - JSON mode never prints the human-readable intro / security warning
  *   - ttlSeconds is propagated to the pair session's expiresAtMs
+ *   - test_issue_87_url_pin_only_emits_slim_payload: url-pin mode emits
+ *     ONLY {v,url,pin,expires_at_ms}, skips QR rendering, stays silent
+ *     on status transitions, and has no phrase-adjacent material.
  *
  * Run with: npx tsx pair-cli-json.test.ts
  */
@@ -18,7 +21,7 @@ import {
   transitionPairSession,
   getPairSession,
 } from './pair-session-store.js';
-import { runPairCli, type PairCliIo, type PairCliJsonPayload } from './pair-cli.js';
+import { runPairCli, type PairCliIo, type PairCliJsonPayload, type PairCliUrlPinPayload } from './pair-cli.js';
 
 let passed = 0;
 let failed = 0;
@@ -167,6 +170,108 @@ function mkFakeQrRenderer(): (payload: string, cb: (ascii: string) => void) => v
   await new Promise<void>((r) => setTimeout(r, 200));
   const outcome = await runPromise;
   assert(outcome.status === 'canceled', 'human: canceled outcome on interrupt');
+}
+
+// ---------------------------------------------------------------------------
+// test_issue_87_url_pin_only_emits_slim_payload
+//
+// Headless container-agent fallback: when `totalreclaw_pair` tool is
+// missing from the agent's tool list (OpenClaw gateway-to-container
+// tool-injection gap), the agent shells out to
+// `openclaw totalreclaw pair generate --url-pin-only`. This mode MUST:
+//   - Emit ONLY {v,url,pin,expires_at_ms} on stdout — no qr_ascii,
+//     no sid, no mode echo, no banner, no spinner.
+//   - Skip QR rendering entirely (no CPU cost, no qrcode-terminal load).
+//   - Stay silent on status transitions (device_connected, completed).
+//   - Carry zero phrase-adjacent material on stdout (defense-in-depth
+//     check — pair-crypto is x25519-only and never imports BIP-39).
+// ---------------------------------------------------------------------------
+
+{
+  const sessionsPath = path.join(mkTmp(), 'pair-sessions.json');
+  const t = buildTestIo();
+  let qrRendererCalled = false;
+
+  const runPromise = runPairCli('generate', {
+    sessionsPath,
+    renderPairingUrl: (s) =>
+      `http://test/pair/finish?sid=${s.sid}#pk=${s.pkGatewayB64}`,
+    // If url-pin mode accidentally invokes the QR renderer, flip this
+    // and the test fails — url-pin mode MUST skip QR rendering.
+    renderQr: (_, cb) => {
+      qrRendererCalled = true;
+      cb('[QR:should-not-appear]');
+    },
+    pollIntervalMs: 30,
+    io: t.io,
+    outputMode: 'url-pin',
+  });
+
+  await new Promise<void>((r) => setTimeout(r, 100));
+
+  const firstOutput = t.stdout.text().split('\n')[0];
+  let payload: PairCliUrlPinPayload | null = null;
+  try {
+    payload = JSON.parse(firstOutput) as PairCliUrlPinPayload;
+  } catch {
+    /* payload stays null */
+  }
+  assert(payload !== null, 'test_issue_87_url_pin_only: stdout parses as JSON');
+  assert(payload?.v === 1, 'test_issue_87_url_pin_only: v=1');
+  assert(typeof payload?.url === 'string' && payload.url.includes('#pk='), 'test_issue_87_url_pin_only: url has pk fragment');
+  assert(typeof payload?.pin === 'string' && /^\d{6}$/.test(payload.pin), 'test_issue_87_url_pin_only: pin is 6 digits');
+  assert(typeof payload?.expires_at_ms === 'number' && payload.expires_at_ms > Date.now(), 'test_issue_87_url_pin_only: expires_at_ms is future');
+
+  // Slim payload shape: exactly these four keys, nothing more.
+  const keys = Object.keys(payload as object).sort();
+  assert(
+    keys.length === 4 &&
+      keys[0] === 'expires_at_ms' &&
+      keys[1] === 'pin' &&
+      keys[2] === 'url' &&
+      keys[3] === 'v',
+    `test_issue_87_url_pin_only: keys = [expires_at_ms,pin,url,v] (got [${keys.join(',')}])`,
+  );
+  // Forbidden fields from the json mode that must NOT appear here.
+  const p2 = payload as unknown as Record<string, unknown>;
+  assert(!('sid' in p2), 'test_issue_87_url_pin_only: no sid field');
+  assert(!('mode' in p2), 'test_issue_87_url_pin_only: no mode field');
+  assert(!('qr_ascii' in p2), 'test_issue_87_url_pin_only: no qr_ascii field');
+
+  assert(!qrRendererCalled, 'test_issue_87_url_pin_only: QR renderer NOT invoked');
+
+  // Drive the session through state transitions; in url-pin mode these
+  // must NOT surface on stdout.
+  const raw = fs.readFileSync(sessionsPath, 'utf-8');
+  const parsed = JSON.parse(raw) as { sessions?: Array<{ sid: string }> };
+  const sid = parsed.sessions?.[0]?.sid as string;
+  await transitionPairSession(sessionsPath, sid, 'device_connected', Date.now);
+  await new Promise<void>((r) => setTimeout(r, 80));
+  await transitionPairSession(sessionsPath, sid, 'consumed', Date.now);
+  await transitionPairSession(sessionsPath, sid, 'completed', Date.now);
+
+  const outcome = await runPromise;
+  assert(outcome.status === 'completed', 'test_issue_87_url_pin_only: outcome completed');
+
+  const fullText = t.stdout.text();
+
+  // Stdout must remain a single JSON line + trailing newline.
+  const nonEmptyLines = fullText.split('\n').filter((l) => l.length > 0);
+  assert(nonEmptyLines.length === 1, `test_issue_87_url_pin_only: single stdout line (got ${nonEmptyLines.length})`);
+
+  // No human-readable banner / status copy at any point.
+  assert(!fullText.includes('Remote pairing'), 'test_issue_87_url_pin_only: no intro copy leaked');
+  assert(!fullText.includes('Browser connected'), 'test_issue_87_url_pin_only: no "Browser connected" copy');
+  assert(!fullText.includes('Pairing complete'), 'test_issue_87_url_pin_only: no "Pairing complete" copy');
+  assert(!fullText.includes('Security:'), 'test_issue_87_url_pin_only: no security warning copy');
+  assert(!fullText.includes('[QR:'), 'test_issue_87_url_pin_only: no QR ASCII on stdout');
+
+  // Defense-in-depth: phrase-adjacent tokens must never surface on
+  // stdout — pair-cli does not import any mnemonic code, so these
+  // assertions can only fail if a regression accidentally inlines them.
+  assert(!/\bphrase\b/i.test(fullText), 'test_issue_87_url_pin_only: no "phrase" on stdout');
+  assert(!/\bmnemonic\b/i.test(fullText), 'test_issue_87_url_pin_only: no "mnemonic" on stdout');
+  assert(!/\brecovery\b/i.test(fullText), 'test_issue_87_url_pin_only: no "recovery" on stdout');
 }
 
 // ---------------------------------------------------------------------------

--- a/skill/plugin/pair-cli.ts
+++ b/skill/plugin/pair-cli.ts
@@ -85,8 +85,15 @@ export interface PairCliOutcome {
  *     as the session reaches a terminal state — same status-code
  *     semantics as 'human' (0 on completed, 1 on expired/rejected/error,
  *     130 on canceled).
+ *   - 'url-pin': (3.3.1-rc.15, issue #87) headless container-agent fallback.
+ *     Emits ONLY `{ v, url, pin, expires_at_ms }` — no QR ASCII, no SID,
+ *     no mode echo. Use when a container-based agent cannot see the
+ *     `totalreclaw_pair` tool (OpenClaw gateway-to-container tool-injection
+ *     gap) and must shell out to the CLI. Guarantees zero phrase material
+ *     on stdout by construction — pair-crypto is x25519-only and the slim
+ *     payload carries nothing BIP-39-adjacent.
  */
-export type PairCliOutputMode = 'human' | 'json';
+export type PairCliOutputMode = 'human' | 'json' | 'url-pin';
 
 /**
  * JSON payload emitted by runPairCli when outputMode === 'json'. Printed
@@ -101,6 +108,17 @@ export interface PairCliJsonPayload {
   mode: PairCliMode;
   expires_at_ms: number;
   qr_ascii: string;
+}
+
+/**
+ * Slim payload for outputMode === 'url-pin'. Intentionally a subset of
+ * `PairCliJsonPayload` with no QR ASCII, SID, or mode echo. Issue #87.
+ */
+export interface PairCliUrlPinPayload {
+  v: 1;
+  url: string;
+  pin: string;
+  expires_at_ms: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -213,9 +231,11 @@ export async function runPairCli(
     return { status: 'error', error: msg };
   }
 
-  // 2. Render the QR — promise-based so both human + json modes share it.
+  // 2. Build the URL unconditionally, but only render the QR for modes
+  //    that actually emit it. url-pin mode skips the renderer entirely —
+  //    no CPU cost, no qrcode-terminal import, no ASCII on stdout.
   const url = deps.renderPairingUrl(session);
-  const qrAscii = await new Promise<string>((resolve) => {
+  const qrAscii = outputMode === 'url-pin' ? '' : await new Promise<string>((resolve) => {
     // Guard against QR renderers that never fire their callback (shouldn't
     // happen with qrcode-terminal, but defensive): a 10-second timeout
     // returns an empty string so we never hang the pairing flow.
@@ -241,8 +261,16 @@ export async function runPairCli(
     }
   });
 
-  // 3. Emit the visible surface (JSON first — single line — or human copy).
-  if (outputMode === 'json') {
+  // 3. Emit the visible surface (JSON/url-pin first — single line — or human copy).
+  if (outputMode === 'url-pin') {
+    const payload: PairCliUrlPinPayload = {
+      v: 1,
+      url,
+      pin: session.secondaryCode,
+      expires_at_ms: session.expiresAtMs,
+    };
+    stdout.write(JSON.stringify(payload) + '\n');
+  } else if (outputMode === 'json') {
     const payload: PairCliJsonPayload = {
       v: 1,
       sid: session.sid,
@@ -276,7 +304,9 @@ export async function runPairCli(
     canceled = true;
   });
 
-  // 5. Poll
+  // 5. Poll — status transitions only surface in human mode; json/url-pin
+  //    modes stay silent after the single payload line so agents parsing
+  //    stdout get one JSON line and an exit code, nothing else.
   const emitStatus = (text: string): void => {
     if (outputMode === 'human') stdout.write(text);
   };
@@ -399,14 +429,19 @@ export function registerPairCli(
       'Pair a remote browser device to this gateway (mode = generate | import; default generate)',
     )
     .option('--json', 'Emit a single JSON payload (url/pin/sid/qr_ascii) instead of the human-readable banner. Enables agent-driven pairing.')
+    .option('--url-pin-only', 'Emit ONLY {v,url,pin,expires_at_ms} — no QR ASCII, no SID, no mode echo. Headless fallback for container-based agents where the totalreclaw_pair tool is not injected (issue #87). Zero phrase exposure on stdout.')
     .option('--timeout <sec>', 'Session TTL in seconds (default: 900 = 15 min, matches pair-session-store default)')
     .action(async (...args: unknown[]) => {
       // commander passes: [modeArg, options, cmd]
       const modeRaw = typeof args[0] === 'string' ? args[0] : undefined;
-      const opts = (args[1] ?? {}) as { json?: boolean; timeout?: string | number };
+      const opts = (args[1] ?? {}) as { json?: boolean; urlPinOnly?: boolean; timeout?: string | number };
       const mode: PairCliMode =
         modeRaw === 'import' || modeRaw === 'imp' ? 'import' : 'generate';
-      const outputMode: PairCliOutputMode = opts.json ? 'json' : 'human';
+      // --url-pin-only wins over --json when both are passed, since it is
+      // strictly the tighter surface (no QR, no SID). The flag is a subset.
+      const outputMode: PairCliOutputMode = opts.urlPinOnly
+        ? 'url-pin'
+        : opts.json ? 'json' : 'human';
       let ttlSeconds: number | undefined;
       if (typeof opts.timeout === 'number' && Number.isFinite(opts.timeout)) {
         ttlSeconds = opts.timeout;


### PR DESCRIPTION
## What broke
Container-based OpenClaw agents don't see the `totalreclaw_pair` tool (gateway-to-container tool-injection gap, issue #87). Affected agents fall back to `openclaw totalreclaw onboard`, which writes the recovery phrase to stdout — when the agent runs that, the phrase enters the LLM transcript and the E2EE threat model is broken.

## What's fixed
Adds `openclaw totalreclaw pair generate --url-pin-only` — a strict subset of the existing `--json` mode that emits ONLY `{v,url,pin,expires_at_ms}` (no `qr_ascii`, no `sid`, no mode echo, no banner, no spinner) and skips QR rendering entirely. The `before_agent_start` guidance now points containerized agents at this flag and explicitly forbids them from running `onboard` themselves. SKILL.md gets the same fallback in phrase-safety + diagnostics sections.

## Impact after fix
Container-based agents have a phrase-SAFE pairing fallback. `pair-crypto` is x25519-only and never imports BIP-39 — zero phrase material crosses stdout by construction. Existing `pair` (tool, `--json`, `human` modes) and `onboard` (local-TTY) flows unchanged.

## Verification
479/479 unit tests pass on this branch. New regression block `test_issue_87_url_pin_only_*` (20 assertions in `pair-cli-json.test.ts`) covers payload shape, key-set strictness, QR-renderer skip, silent status transitions, and phrase-token negative assertions. Phrase-safety registry test still passes — no new tool registration.

**Awaiting QA against published rc.15** — auto-triage stops at PR-open for `severity:blocker` per the skill's escalation rail. Pedro to merge + dispatch publish + run `qa-totalreclaw` (Scenario: container-agent pairing fallback). Closes #87 on merge via the trailer.

---

Path B per directive in https://github.com/p-diogo/totalreclaw-internal/issues/87#issuecomment-4315640585.

🤖 Auto-triage Phase 3 (fallback auth — GH App not yet configured). Closes p-diogo/totalreclaw-internal#87.