### PR TITLE
fix(#97): Hermes 0.10.0 LLM-config drift + load-time validator

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "totalreclaw"
-version = "2.3.1rc14"
+version = "2.3.1rc15"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"

--- a/python/src/totalreclaw/__init__.py
+++ b/python/src/totalreclaw/__init__.py
@@ -9,7 +9,7 @@ except Exception:
     # installed-package metadata is absent. Must match pyproject.toml —
     # test_version.py enforces a semver-shape string; the live value in
     # a pip-installed wheel comes from importlib.metadata above.
-    __version__ = "2.3.1rc14"
+    __version__ = "2.3.1rc15"
 
 from .client import TotalReclaw
 

--- a/python/src/totalreclaw/agent/llm_client.py
+++ b/python/src/totalreclaw/agent/llm_client.py
@@ -27,6 +27,25 @@ import httpx
 logger = logging.getLogger(__name__)
 
 
+#: Per-provider canonical model-name env var candidates. Checked in order;
+#: first hit wins. ``HERMES_MODEL`` is Hermes 0.10.0's session-level setting
+#: that always reflects the active model regardless of provider. Generic
+#: fallbacks (``OPENAI_MODEL`` / ``ANTHROPIC_MODEL`` / ``LLM_MODEL``) keep
+#: pre-0.10.0 installs working.
+_PROVIDER_MODEL_ENV_VARS = {
+    "zai": ["HERMES_MODEL", "ZAI_MODEL", "GLM_MODEL"],
+    "openai": ["HERMES_MODEL", "OPENAI_MODEL"],
+    "anthropic": ["HERMES_MODEL", "ANTHROPIC_MODEL"],
+    "openrouter": ["HERMES_MODEL", "OPENROUTER_MODEL"],
+    "groq": ["HERMES_MODEL", "GROQ_MODEL"],
+    "deepseek": ["HERMES_MODEL", "DEEPSEEK_MODEL"],
+    "mistral": ["HERMES_MODEL", "MISTRAL_MODEL"],
+    "gemini": ["HERMES_MODEL", "GEMINI_MODEL", "GOOGLE_MODEL"],
+    "xai": ["HERMES_MODEL", "XAI_MODEL"],
+    "together": ["HERMES_MODEL", "TOGETHER_MODEL"],
+}
+
+
 @dataclass
 class LLMConfig:
     api_key: str
@@ -179,6 +198,159 @@ def _read_hermes_env_file(env_path: Path) -> dict[str, str]:
     return env_vars
 
 
+def _read_hermes_auth_json(auth_path: Path) -> Optional[dict]:
+    """Parse ``~/.hermes/auth.json`` into a dict, or return ``None``.
+
+    Hermes 0.10.0 moved active-provider credentials out of ``config.yaml``
+    and into ``auth.json::credential_pool``. We read the whole JSON and
+    let the caller pick what it needs; on any parse / IO error we return
+    ``None`` and the caller falls through to the next resolution path.
+    """
+    if not auth_path.exists():
+        return None
+    try:
+        return json.loads(auth_path.read_text())
+    except (OSError, ValueError) as e:
+        logger.debug("_read_hermes_auth_json: %s unparseable (%s)", auth_path, e)
+        return None
+
+
+def _pick_credential_from_pool(
+    auth: dict,
+) -> tuple[str, str, str]:
+    """Pick the first usable (provider, api_key, base_url) triple from
+    ``auth.json::credential_pool``.
+
+    Hermes 0.10.0 shape::
+
+        {
+          "credential_pool": {
+            "zai": [{"access_token": "...", "base_url": "...", ...}, ...],
+            ...
+          }
+        }
+
+    We walk providers in the order they appear in the dict (Python 3.7+
+    preserves insertion order → matches the order Hermes registered them).
+    Within each provider, the first credential with an ``access_token``
+    wins. Returns ``("", "", "")`` when nothing usable is found.
+    """
+    pool = auth.get("credential_pool")
+    if not isinstance(pool, dict):
+        return "", "", ""
+    for provider, creds in pool.items():
+        if not isinstance(creds, list):
+            continue
+        for cred in creds:
+            if not isinstance(cred, dict):
+                continue
+            token = cred.get("access_token")
+            if not isinstance(token, str) or not token:
+                continue
+            base_url = cred.get("base_url") if isinstance(cred.get("base_url"), str) else ""
+            return str(provider), token, base_url
+    return "", "", ""
+
+
+def _resolve_hermes_model_from_runtime_env(
+    provider_lower: str, env_vars: dict[str, str]
+) -> str:
+    """Resolve the active model name from Hermes runtime env vars.
+
+    Checks the provider-specific candidates from
+    :data:`_PROVIDER_MODEL_ENV_VARS` (e.g. ``ZAI_MODEL`` for zai) plus the
+    generic ``HERMES_MODEL`` fallback. ``env_vars`` is the parsed
+    ``~/.hermes/.env`` dict; it wins over process env so a stale
+    ``OPENAI_MODEL`` export from an earlier shell can't shadow the
+    current Hermes session model.
+    """
+    candidates = _PROVIDER_MODEL_ENV_VARS.get(
+        provider_lower,
+        # Unknown provider — fall back to generic vars only.
+        ["HERMES_MODEL", "LLM_MODEL"],
+    )
+    for name in candidates:
+        val = env_vars.get(name) or os.environ.get(name)
+        if val and val.strip():
+            return val.strip()
+    # Final generic fallback in case the provider table is out of date.
+    for name in ("HERMES_MODEL", "LLM_MODEL"):
+        val = env_vars.get(name) or os.environ.get(name)
+        if val and val.strip():
+            return val.strip()
+    return ""
+
+
+def _read_hermes_llm_config_from_auth_json(
+    hermes_dir: Path,
+) -> Optional[LLMConfig]:
+    """Build an :class:`LLMConfig` from ``hermes_dir/auth.json`` + ``.env``.
+
+    This is the Hermes 0.10.0 resolution path. ``auth.json`` supplies
+    provider + API key + base_url via ``credential_pool``; the active
+    model is read from the runtime-env vars Hermes writes to ``.env``
+    (``HERMES_MODEL`` / ``{PROVIDER}_MODEL``). Returns ``None`` on any
+    missing piece — callers fall through to the next resolver.
+    """
+    auth = _read_hermes_auth_json(hermes_dir / "auth.json")
+    if auth is None:
+        return None
+    provider, api_key, auth_base_url = _pick_credential_from_pool(auth)
+    if not provider or not api_key:
+        logger.debug(
+            "_read_hermes_llm_config_from_auth_json: no usable credential in %s",
+            hermes_dir / "auth.json",
+        )
+        return None
+
+    provider_lower = provider.lower()
+    env_vars = _read_hermes_env_file(hermes_dir / ".env")
+    model = _resolve_hermes_model_from_runtime_env(provider_lower, env_vars)
+    if not model:
+        logger.debug(
+            "_read_hermes_llm_config_from_auth_json: no model env var set "
+            "for provider %r (tried %s)",
+            provider,
+            ", ".join(
+                _PROVIDER_MODEL_ENV_VARS.get(
+                    provider_lower, ["HERMES_MODEL", "LLM_MODEL"]
+                )
+            ),
+        )
+        return None
+
+    # base_url precedence:
+    #   1. Explicit ZAI_BASE_URL override (matches the legacy path).
+    #   2. auth.json credential base_url (Hermes's own chosen endpoint).
+    #   3. Default for this provider.
+    if provider_lower == "zai":
+        zai_override = env_vars.get("ZAI_BASE_URL") or os.environ.get("ZAI_BASE_URL")
+        if zai_override and zai_override.strip():
+            base_url = zai_override.strip().rstrip("/")
+        elif auth_base_url:
+            base_url = auth_base_url.rstrip("/")
+        else:
+            base_url = get_zai_base_url()
+    else:
+        _, default_base_url = _HERMES_PROVIDER_KEY_MAP.get(provider_lower, ([], ""))
+        base_url = (
+            (auth_base_url.rstrip("/") if auth_base_url else "")
+            or env_vars.get("OPENAI_BASE_URL")
+            or os.environ.get("OPENAI_BASE_URL")
+            or default_base_url
+        )
+
+    api_format = "anthropic" if provider_lower == "anthropic" else "openai"
+    logger.info(
+        "TotalReclaw LLM config resolved from Hermes auth.json + .env "
+        "(provider=%s, model=%s, base_url=%s)",
+        provider, model, base_url,
+    )
+    return LLMConfig(
+        api_key=api_key, base_url=base_url, model=model, api_format=api_format
+    )
+
+
 def _extract_provider_and_model(cfg: dict) -> tuple[str, str]:
     """Accept BOTH top-level and nested shapes.
 
@@ -224,6 +396,13 @@ def read_hermes_llm_config() -> Optional[LLMConfig]:
     ``{provider: zai, model: glm-5-turbo}`` AND nested
     ``{model: {provider: zai, model: glm-5-turbo}}``.
 
+    Hermes 0.10.0 (2026-04-16) moved the active provider + API key out
+    of ``config.yaml`` into ``~/.hermes/auth.json::credential_pool`` and
+    the active model into runtime-set env vars (``HERMES_MODEL`` plus
+    provider-specific ``{PROVIDER}_MODEL``). After the legacy YAML path
+    fails, we fall through to an ``auth.json``-based resolver so 0.10.0
+    installs work without a TR-side config change. Fix for internal#97.
+
     Returns ``None`` if no config is found, if it can't be parsed, or
     if the required provider/model fields are missing. Logs a WARNING
     at the resolution point so operators can tell WHERE the model came
@@ -256,8 +435,17 @@ def read_hermes_llm_config() -> Optional[LLMConfig]:
 
         provider, model = _extract_provider_and_model(cfg)
         if not provider or not model:
+            # Legacy YAML shape empty — try the Hermes 0.10.0 auth.json
+            # path in the same directory before moving to the next YAML
+            # candidate. The YAML file still serves as the "this is a
+            # Hermes install" marker so we don't read auth.json from an
+            # unrelated directory.
+            hermes_010 = _read_hermes_llm_config_from_auth_json(config_path.parent)
+            if hermes_010 is not None:
+                return hermes_010
             logger.debug(
-                "read_hermes_llm_config: %s missing provider/model keys",
+                "read_hermes_llm_config: %s missing provider/model keys "
+                "(and auth.json fallback unavailable)",
                 config_path,
             )
             continue
@@ -340,17 +528,25 @@ def detect_llm_config(configured_model: Optional[str] = None) -> Optional[LLMCon
       2. Provider default
     """
     openai_base_url = os.environ.get("OPENAI_BASE_URL")
-    # Common env vars for configured model name
-    env_model = (
+    # Generic model-env vars, used as the last-resort fallback below when
+    # no provider-specific ``{PROVIDER}_MODEL`` / ``HERMES_MODEL`` is set.
+    env_model_generic = (
         os.environ.get("OPENAI_MODEL")
         or os.environ.get("ANTHROPIC_MODEL")
         or os.environ.get("LLM_MODEL")
+        or os.environ.get("HERMES_MODEL")
     )
 
     for _provider, env_vars, default_base_url, api_format in PROVIDERS:
         for env_var in env_vars:
             api_key = os.environ.get(env_var)
             if api_key:
+                # Provider-specific model vars (e.g. ``ZAI_MODEL``,
+                # ``GROQ_MODEL``) take precedence over the generic ones so
+                # Hermes 0.10.0 users with a single ``ZAI_MODEL=...`` in
+                # ``.env`` resolve here without needing an extra
+                # ``OPENAI_MODEL`` export. Fix for internal#97.
+                env_model = _resolve_hermes_model_from_runtime_env(_provider, {}) or env_model_generic
                 model = configured_model or env_model
                 if not model:
                     # No model configured via env — skip this provider so
@@ -398,6 +594,88 @@ def detect_llm_config(configured_model: Optional[str] = None) -> Optional[LLMCon
 
     logger.debug("detect_llm_config: no LLM config resolved from env or Hermes")
     return None
+
+
+def validate_llm_config_at_load(
+    context: str = "plugin-load",
+) -> tuple[Optional[LLMConfig], Optional[str]]:
+    """Resolve LLM config once at plugin load and loudly WARN if missing.
+
+    Prior to internal#97 (rc.15), TR's auto-extraction silently logged
+    one DEBUG line per turn when :func:`detect_llm_config` returned
+    ``None`` — users saw 27+ identical log lines for a 27-turn session
+    with zero memories written, and no hint as to why. Per Pedro's
+    directive ("fail loud"), this validator runs once at plugin
+    registration so operators see a single, actionable WARNING at
+    startup instead of a per-turn stream.
+
+    Returns ``(config, None)`` on success, ``(None, reason)`` on
+    failure. The reason string is a short diagnostic intended for
+    inclusion in the WARNING body and for surfacing via the
+    quota-warning channel on first turn.
+    """
+    config = detect_llm_config()
+    if config is not None:
+        logger.info(
+            "TotalReclaw [%s]: LLM config OK (provider_base=%s, model=%s).",
+            context, config.base_url, config.model,
+        )
+        return config, None
+
+    # Build an actionable reason by re-probing the two resolution paths.
+    hermes_dir = Path.home() / ".hermes"
+    auth_exists = (hermes_dir / "auth.json").exists()
+    env_exists = (hermes_dir / ".env").exists()
+    yaml_exists = (hermes_dir / "config.yaml").exists()
+    has_any_api_key = any(
+        os.environ.get(v) for v in (
+            "ZAI_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
+            "GROQ_API_KEY", "DEEPSEEK_API_KEY", "OPENROUTER_API_KEY",
+            "MISTRAL_API_KEY", "XAI_API_KEY", "TOGETHER_API_KEY",
+            "GEMINI_API_KEY", "GOOGLE_API_KEY", "GLM_API_KEY", "Z_AI_API_KEY",
+        )
+    )
+    has_any_model = any(
+        os.environ.get(v) for v in (
+            "HERMES_MODEL", "OPENAI_MODEL", "ANTHROPIC_MODEL", "LLM_MODEL",
+            "ZAI_MODEL", "GLM_MODEL", "OPENROUTER_MODEL", "GROQ_MODEL",
+            "DEEPSEEK_MODEL", "MISTRAL_MODEL", "XAI_MODEL", "TOGETHER_MODEL",
+            "GEMINI_MODEL", "GOOGLE_MODEL",
+        )
+    )
+    if not (yaml_exists or auth_exists):
+        reason = (
+            "no Hermes install detected at ~/.hermes (and no "
+            "{PROVIDER}_API_KEY + {PROVIDER}_MODEL in env)"
+        )
+    elif auth_exists and not has_any_model:
+        reason = (
+            "Hermes auth.json found but no model env var set — Hermes "
+            "0.10.0 writes HERMES_MODEL / {PROVIDER}_MODEL to "
+            "~/.hermes/.env at session start. Is the session running?"
+        )
+    elif not has_any_api_key and not auth_exists:
+        reason = (
+            "no provider API key found — set {PROVIDER}_API_KEY in env "
+            "or ~/.hermes/.env (e.g. ZAI_API_KEY, OPENAI_API_KEY)"
+        )
+    else:
+        reason = (
+            "config files exist but resolution failed — enable DEBUG "
+            "logging on 'totalreclaw.agent.llm_client' for details"
+        )
+
+    logger.warning(
+        "TotalReclaw [%s]: automatic memory extraction is DISABLED — %s. "
+        "Extraction will be skipped until this is fixed; explicit "
+        "totalreclaw_remember / totalreclaw_recall still work. Files checked: "
+        "~/.hermes/config.yaml=%s, ~/.hermes/auth.json=%s, ~/.hermes/.env=%s.",
+        context, reason,
+        "present" if yaml_exists else "missing",
+        "present" if auth_exists else "missing",
+        "present" if env_exists else "missing",
+    )
+    return None, reason
 
 
 # Retry/backoff settings for LLM calls — rc.3 lifts budget to 5 attempts

--- a/python/src/totalreclaw/hermes/__init__.py
+++ b/python/src/totalreclaw/hermes/__init__.py
@@ -197,4 +197,15 @@ def register(ctx):
     ctx.register_hook("post_llm_call", lambda **kw: hooks.post_llm_call(state, **kw))
     ctx.register_hook("on_session_end", lambda **kw: hooks.on_session_end(state, **kw))
 
+    # Fix for internal#97: validate LLM-config resolution once at plugin
+    # load and emit a single loud WARNING if it fails, so Hermes 0.10.0
+    # schema drift surfaces immediately instead of accumulating one
+    # silent DEBUG line per turn.
+    try:
+        from totalreclaw.agent.llm_client import validate_llm_config_at_load
+        _config, reason = validate_llm_config_at_load(context="hermes-plugin-load")
+        state._totalreclaw_llm_load_reason = reason
+    except Exception:  # pragma: no cover — validation must not crash plugin load
+        logger.debug("LLM-config load-time validation skipped", exc_info=True)
+
     logger.info("TotalReclaw plugin registered (12+ tools, 4 hooks)")

--- a/python/src/totalreclaw/hermes/plugin.yaml
+++ b/python/src/totalreclaw/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: totalreclaw
-version: 2.3.1rc14
+version: 2.3.1rc15
 description: End-to-end encrypted memory vault for AI agents (Memory Taxonomy v1)
 author: TotalReclaw Team
 provides_tools:

--- a/python/tests/test_extractor.py
+++ b/python/tests/test_extractor.py
@@ -254,8 +254,13 @@ class TestTruncateMessages:
 # ---------------------------------------------------------------------------
 
 class TestDetectLLMConfig:
-    def test_no_api_keys(self):
-        with patch.dict(os.environ, {}, clear=True):
+    def test_no_api_keys(self, tmp_path, monkeypatch):
+        # Point HOME at an empty tmp dir so the Hermes auth.json
+        # fallback (added in rc.15 for Hermes 0.10.0) doesn't resolve
+        # against the developer's real ~/.hermes — the test's intent
+        # is "no env, no config", so filesystem state must be empty too.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        with patch.dict(os.environ, {"HOME": str(tmp_path)}, clear=True):
             config = detect_llm_config()
             assert config is None
 
@@ -286,9 +291,14 @@ class TestDetectLLMConfig:
             assert config.model == "test-model"
             assert "groq.com" in config.base_url
 
-    def test_no_model_returns_none(self):
+    def test_no_model_returns_none(self, tmp_path, monkeypatch):
         """API key present but no model configured anywhere -> None."""
-        with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=True):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        with patch.dict(
+            os.environ,
+            {"OPENAI_API_KEY": "sk-test", "HOME": str(tmp_path)},
+            clear=True,
+        ):
             config = detect_llm_config()
             assert config is None
 
@@ -492,8 +502,9 @@ class TestChatCompletion:
 
 class TestExtractFactsLLM:
     @pytest.mark.asyncio
-    async def test_no_llm_returns_empty(self):
-        with patch.dict(os.environ, {}, clear=True):
+    async def test_no_llm_returns_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        with patch.dict(os.environ, {"HOME": str(tmp_path)}, clear=True):
             messages = [{"role": "user", "content": "I live in Lisbon"}]
             facts = await extract_facts_llm(messages)
             assert facts == []

--- a/python/tests/test_llm_client_hermes_0_10_schema.py
+++ b/python/tests/test_llm_client_hermes_0_10_schema.py
@@ -1,0 +1,425 @@
+"""Regression tests for internal#97 — Hermes 0.10.0 config-schema drift.
+
+Hermes 0.10.0 (2026-04-16) left ``~/.hermes/config.yaml`` with empty
+top-level ``provider`` + ``model`` keys and moved the active credentials
+into ``~/.hermes/auth.json::credential_pool`` + runtime-written env vars
+in ``~/.hermes/.env`` (``HERMES_MODEL`` / ``{PROVIDER}_MODEL``). Before
+rc.15, :func:`read_hermes_llm_config` only understood the legacy shape
+and returned ``None`` every turn, producing the silent extraction
+disable reported at
+https://github.com/p-diogo/totalreclaw-internal/issues/97.
+
+Shape of these tests:
+  - Build a throwaway ``~/.hermes``-like dir via ``tmp_path``.
+  - Point TR at it by setting ``HERMES_CONFIG=<tmp_path>/config.yaml``.
+  - Pin the exact JSON/YAML/.env shapes we observed on the VPS.
+  - Assert TR returns a valid :class:`LLMConfig` (not ``None``).
+"""
+from __future__ import annotations
+
+import json
+import os
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from totalreclaw.agent.llm_client import (
+    LLMConfig,
+    ZAI_CODING_BASE_URL,
+    _pick_credential_from_pool,
+    _read_hermes_auth_json,
+    _resolve_hermes_model_from_runtime_env,
+    detect_llm_config,
+    read_hermes_llm_config,
+    validate_llm_config_at_load,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_hermes_010_fixture(
+    root: Path,
+    *,
+    provider: str = "zai",
+    model_env_key: str = "HERMES_MODEL",
+    model_value: str = "glm-5-turbo",
+    include_zai_base_url_in_env: bool = False,
+    auth_base_url: str = "https://api.z.ai/api/coding/paas/v4",
+) -> Path:
+    """Write a minimal Hermes 0.10.0-shaped ``.hermes`` dir into ``root``.
+
+    Returns the path to ``config.yaml`` so callers can feed it to
+    ``HERMES_CONFIG`` for deterministic resolution without depending on
+    the real home directory.
+    """
+    hermes = root / ".hermes"
+    hermes.mkdir()
+    # 0.10.0-shaped config.yaml: blank model + empty providers block.
+    (hermes / "config.yaml").write_text(
+        textwrap.dedent("""\
+            model: ''
+            providers: {}
+            fallback_providers: []
+        """)
+    )
+    # auth.json with a single credential in credential_pool.
+    (hermes / "auth.json").write_text(
+        json.dumps({
+            "version": 1,
+            "providers": {},
+            "credential_pool": {
+                provider: [
+                    {
+                        "id": "abc",
+                        "label": f"{provider.upper()}_API_KEY",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": f"env:{provider.upper()}_API_KEY",
+                        "access_token": f"sk-fake-{provider}-key",
+                        "base_url": auth_base_url,
+                    }
+                ]
+            },
+        })
+    )
+    # .env: runtime-written model var (what Hermes 0.10.0 actually does).
+    env_lines = [f"{model_env_key}={model_value}"]
+    if include_zai_base_url_in_env:
+        env_lines.append("ZAI_BASE_URL=https://api.z.ai/api/paas/v4")
+    (hermes / ".env").write_text("\n".join(env_lines) + "\n")
+    return hermes / "config.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class TestReadHermesAuthJson:
+    def test_missing_file_returns_none(self, tmp_path):
+        assert _read_hermes_auth_json(tmp_path / "auth.json") is None
+
+    def test_unparseable_returns_none(self, tmp_path):
+        p = tmp_path / "auth.json"
+        p.write_text("not-json")
+        assert _read_hermes_auth_json(p) is None
+
+    def test_well_formed_returns_dict(self, tmp_path):
+        p = tmp_path / "auth.json"
+        p.write_text(json.dumps({"credential_pool": {"zai": []}}))
+        result = _read_hermes_auth_json(p)
+        assert isinstance(result, dict)
+        assert "credential_pool" in result
+
+
+class TestPickCredentialFromPool:
+    def test_empty_pool(self):
+        assert _pick_credential_from_pool({}) == ("", "", "")
+        assert _pick_credential_from_pool({"credential_pool": {}}) == ("", "", "")
+
+    def test_first_usable_wins(self):
+        auth = {
+            "credential_pool": {
+                "zai": [
+                    {"access_token": "key1", "base_url": "https://a"},
+                    {"access_token": "key2", "base_url": "https://b"},
+                ]
+            }
+        }
+        assert _pick_credential_from_pool(auth) == (
+            "zai", "key1", "https://a",
+        )
+
+    def test_skips_credential_without_token(self):
+        auth = {
+            "credential_pool": {
+                "zai": [
+                    {"access_token": "", "base_url": "https://a"},
+                    {"access_token": "keyok", "base_url": "https://b"},
+                ]
+            }
+        }
+        assert _pick_credential_from_pool(auth) == ("zai", "keyok", "https://b")
+
+    def test_multiple_providers_ordered(self):
+        # Dict insertion order preserved → first provider wins.
+        auth = {
+            "credential_pool": {
+                "openai": [{"access_token": "oai-key", "base_url": ""}],
+                "zai": [{"access_token": "zai-key", "base_url": ""}],
+            }
+        }
+        provider, _, _ = _pick_credential_from_pool(auth)
+        assert provider == "openai"
+
+
+class TestResolveHermesModelFromRuntimeEnv:
+    def test_provider_specific_env_var_wins(self, monkeypatch):
+        monkeypatch.delenv("HERMES_MODEL", raising=False)
+        monkeypatch.delenv("ZAI_MODEL", raising=False)
+        assert _resolve_hermes_model_from_runtime_env(
+            "zai", {"ZAI_MODEL": "glm-5-turbo"},
+        ) == "glm-5-turbo"
+
+    def test_hermes_model_fallback(self, monkeypatch):
+        monkeypatch.delenv("HERMES_MODEL", raising=False)
+        monkeypatch.delenv("ZAI_MODEL", raising=False)
+        assert _resolve_hermes_model_from_runtime_env(
+            "zai", {"HERMES_MODEL": "glm-5-turbo"},
+        ) == "glm-5-turbo"
+
+    def test_process_env_fallback(self, monkeypatch):
+        monkeypatch.setenv("ZAI_MODEL", "glm-4.5")
+        assert _resolve_hermes_model_from_runtime_env("zai", {}) == "glm-4.5"
+
+    def test_env_file_trumps_process_env(self, monkeypatch):
+        # ``.env`` from disk (dict passed in) should win over a stale
+        # process-env export — a user restarting Hermes with a new model
+        # should see the new model, not a shell export from before.
+        monkeypatch.setenv("ZAI_MODEL", "glm-old")
+        assert _resolve_hermes_model_from_runtime_env(
+            "zai", {"ZAI_MODEL": "glm-new"},
+        ) == "glm-new"
+
+    def test_unknown_provider_falls_back_to_generic(self, monkeypatch):
+        monkeypatch.delenv("HERMES_MODEL", raising=False)
+        monkeypatch.delenv("LLM_MODEL", raising=False)
+        assert _resolve_hermes_model_from_runtime_env(
+            "unknown-provider", {"LLM_MODEL": "gpt-generic"},
+        ) == "gpt-generic"
+
+
+# ---------------------------------------------------------------------------
+# Integration: read_hermes_llm_config() with Hermes 0.10.0 layout
+# ---------------------------------------------------------------------------
+
+
+class TestReadHermesLlmConfig010:
+    """Pins the regression for internal#97.
+
+    Pre-rc.15 these tests all failed (returned ``None``).
+    """
+
+    def test_issue_97_repro_zai_with_hermes_model(self, tmp_path, monkeypatch):
+        # Exactly the VPS shape: config.yaml blank, auth.json has one
+        # zai credential, .env has HERMES_MODEL.
+        cfg_path = _write_hermes_010_fixture(
+            tmp_path, provider="zai", model_env_key="HERMES_MODEL",
+            model_value="glm-5-turbo",
+        )
+        monkeypatch.setenv("HERMES_CONFIG", str(cfg_path))
+        # Clear any legacy env that might accidentally resolve first.
+        for v in ("ZAI_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
+                  "OPENAI_MODEL", "ANTHROPIC_MODEL", "LLM_MODEL",
+                  "HERMES_MODEL", "ZAI_MODEL", "XDG_CONFIG_HOME"):
+            monkeypatch.delenv(v, raising=False)
+
+        config = read_hermes_llm_config()
+        assert config is not None, "regression: returned None on Hermes 0.10.0 shape"
+        assert isinstance(config, LLMConfig)
+        assert config.model == "glm-5-turbo"
+        assert config.api_key == "sk-fake-zai-key"
+        assert config.api_format == "openai"
+        # auth.json's base_url should flow through.
+        assert config.base_url.rstrip("/") == "https://api.z.ai/api/coding/paas/v4"
+
+    def test_issue_97_provider_specific_model_env(self, tmp_path, monkeypatch):
+        cfg_path = _write_hermes_010_fixture(
+            tmp_path, provider="zai", model_env_key="ZAI_MODEL",
+            model_value="glm-4.5",
+        )
+        monkeypatch.setenv("HERMES_CONFIG", str(cfg_path))
+        for v in ("HERMES_MODEL", "OPENAI_MODEL", "LLM_MODEL", "XDG_CONFIG_HOME"):
+            monkeypatch.delenv(v, raising=False)
+
+        config = read_hermes_llm_config()
+        assert config is not None
+        assert config.model == "glm-4.5"
+
+    def test_openai_provider_via_auth_json(self, tmp_path, monkeypatch):
+        cfg_path = _write_hermes_010_fixture(
+            tmp_path, provider="openai", model_env_key="HERMES_MODEL",
+            model_value="gpt-5-mini", auth_base_url="https://api.openai.com/v1",
+        )
+        monkeypatch.setenv("HERMES_CONFIG", str(cfg_path))
+        for v in ("OPENAI_MODEL", "OPENAI_API_KEY", "XDG_CONFIG_HOME"):
+            monkeypatch.delenv(v, raising=False)
+
+        config = read_hermes_llm_config()
+        assert config is not None
+        assert config.model == "gpt-5-mini"
+        assert config.api_format == "openai"
+        assert config.base_url == "https://api.openai.com/v1"
+
+    def test_zai_base_url_env_still_wins(self, tmp_path, monkeypatch):
+        cfg_path = _write_hermes_010_fixture(
+            tmp_path, provider="zai", model_env_key="HERMES_MODEL",
+            model_value="glm-5-turbo",
+        )
+        monkeypatch.setenv("HERMES_CONFIG", str(cfg_path))
+        # Explicit env override trumps auth.json's base_url.
+        monkeypatch.setenv("ZAI_BASE_URL", "https://api.z.ai/api/paas/v4")
+        for v in ("HERMES_MODEL", "ZAI_MODEL", "XDG_CONFIG_HOME"):
+            monkeypatch.delenv(v, raising=False)
+
+        config = read_hermes_llm_config()
+        assert config is not None
+        assert config.base_url == "https://api.z.ai/api/paas/v4"
+
+    def test_no_auth_json_returns_none(self, tmp_path, monkeypatch):
+        # 0.10.0-shaped config.yaml but no auth.json — simulates a
+        # corrupted Hermes dir. Should return None rather than crash.
+        hermes = tmp_path / ".hermes"
+        hermes.mkdir()
+        (hermes / "config.yaml").write_text("model: ''\nproviders: {}\n")
+        (hermes / ".env").write_text("HERMES_MODEL=glm-5-turbo\n")
+        monkeypatch.setenv("HERMES_CONFIG", str(hermes / "config.yaml"))
+        # Point HOME at tmp_path so the fallback ~/.hermes candidate
+        # doesn't accidentally resolve against the developer's real dir.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        for v in ("ZAI_API_KEY", "OPENAI_API_KEY", "HERMES_MODEL",
+                  "XDG_CONFIG_HOME"):
+            monkeypatch.delenv(v, raising=False)
+
+        assert read_hermes_llm_config() is None
+
+    def test_auth_json_without_model_env_returns_none(self, tmp_path, monkeypatch):
+        # auth.json present but no .env / no model var set anywhere.
+        hermes = tmp_path / ".hermes"
+        hermes.mkdir()
+        (hermes / "config.yaml").write_text("model: ''\nproviders: {}\n")
+        (hermes / "auth.json").write_text(json.dumps({
+            "credential_pool": {
+                "zai": [{"access_token": "sk-x", "base_url": "https://a"}]
+            }
+        }))
+        monkeypatch.setenv("HERMES_CONFIG", str(hermes / "config.yaml"))
+        monkeypatch.setenv("HOME", str(tmp_path))
+        for v in ("HERMES_MODEL", "ZAI_MODEL", "OPENAI_MODEL", "LLM_MODEL",
+                  "XDG_CONFIG_HOME"):
+            monkeypatch.delenv(v, raising=False)
+
+        assert read_hermes_llm_config() is None
+
+    def test_legacy_yaml_shape_still_works(self, tmp_path, monkeypatch):
+        # Back-compat: old-style config.yaml should still resolve without
+        # touching auth.json.
+        hermes = tmp_path / ".hermes"
+        hermes.mkdir()
+        (hermes / "config.yaml").write_text(
+            "provider: zai\nmodel: glm-4.5\n"
+        )
+        (hermes / ".env").write_text("ZAI_API_KEY=sk-legacy\n")
+        monkeypatch.setenv("HERMES_CONFIG", str(hermes / "config.yaml"))
+        for v in ("ZAI_API_KEY", "HERMES_MODEL", "ZAI_MODEL", "XDG_CONFIG_HOME"):
+            monkeypatch.delenv(v, raising=False)
+
+        config = read_hermes_llm_config()
+        assert config is not None
+        assert config.model == "glm-4.5"
+        assert config.api_key == "sk-legacy"
+
+
+# ---------------------------------------------------------------------------
+# Integration: detect_llm_config() env path with provider-specific *_MODEL
+# ---------------------------------------------------------------------------
+
+
+class TestDetectLlmConfigProviderSpecificModel:
+    def test_zai_model_without_openai_model_resolves(self, monkeypatch, tmp_path):
+        # Only ZAI_MODEL + ZAI_API_KEY in env — pre-rc.15 this would miss
+        # because only OPENAI_MODEL / ANTHROPIC_MODEL / LLM_MODEL were
+        # consulted for model names.
+        for v in ("OPENAI_MODEL", "ANTHROPIC_MODEL", "LLM_MODEL",
+                  "HERMES_MODEL", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
+                  "GROQ_API_KEY", "DEEPSEEK_API_KEY", "OPENROUTER_API_KEY",
+                  "MISTRAL_API_KEY", "XAI_API_KEY", "TOGETHER_API_KEY",
+                  "GEMINI_API_KEY", "GOOGLE_API_KEY", "GLM_API_KEY",
+                  "Z_AI_API_KEY", "XDG_CONFIG_HOME", "HERMES_CONFIG"):
+            monkeypatch.delenv(v, raising=False)
+        monkeypatch.setenv("ZAI_API_KEY", "sk-zai-env")
+        monkeypatch.setenv("ZAI_MODEL", "glm-5-turbo")
+        # Neutralize any real ~/.hermes — point HOME at empty tmp_path
+        # so the Hermes fallback doesn't accidentally resolve.
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        config = detect_llm_config()
+        assert config is not None
+        assert config.model == "glm-5-turbo"
+        assert config.api_key == "sk-zai-env"
+
+
+# ---------------------------------------------------------------------------
+# Load-time validator
+# ---------------------------------------------------------------------------
+
+
+class TestValidateLlmConfigAtLoad:
+    def test_resolution_success_returns_config(self, tmp_path, monkeypatch):
+        cfg_path = _write_hermes_010_fixture(
+            tmp_path, provider="zai", model_env_key="HERMES_MODEL",
+            model_value="glm-5-turbo",
+        )
+        monkeypatch.setenv("HERMES_CONFIG", str(cfg_path))
+        monkeypatch.setenv("HOME", str(tmp_path))
+        for v in ("ZAI_API_KEY", "OPENAI_API_KEY", "OPENAI_MODEL",
+                  "ANTHROPIC_MODEL", "LLM_MODEL", "HERMES_MODEL", "ZAI_MODEL"):
+            monkeypatch.delenv(v, raising=False)
+
+        config, reason = validate_llm_config_at_load(context="test")
+        assert config is not None
+        assert reason is None
+
+    def test_resolution_failure_returns_reason(self, tmp_path, monkeypatch, caplog):
+        # Empty ~/.hermes dir → no config, no auth, no env vars.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        for v in ("ZAI_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
+                  "GROQ_API_KEY", "DEEPSEEK_API_KEY", "OPENROUTER_API_KEY",
+                  "MISTRAL_API_KEY", "XAI_API_KEY", "TOGETHER_API_KEY",
+                  "GEMINI_API_KEY", "GOOGLE_API_KEY", "GLM_API_KEY",
+                  "Z_AI_API_KEY", "HERMES_MODEL", "OPENAI_MODEL",
+                  "ANTHROPIC_MODEL", "LLM_MODEL", "ZAI_MODEL", "GLM_MODEL",
+                  "OPENROUTER_MODEL", "GROQ_MODEL", "DEEPSEEK_MODEL",
+                  "MISTRAL_MODEL", "XAI_MODEL", "TOGETHER_MODEL",
+                  "GEMINI_MODEL", "GOOGLE_MODEL", "HERMES_CONFIG",
+                  "XDG_CONFIG_HOME"):
+            monkeypatch.delenv(v, raising=False)
+
+        with caplog.at_level("WARNING", logger="totalreclaw.agent.llm_client"):
+            config, reason = validate_llm_config_at_load(context="test-fail")
+        assert config is None
+        assert reason and isinstance(reason, str)
+        # One loud WARNING, not per-turn DEBUG.
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert any("automatic memory extraction is DISABLED" in r.message
+                   for r in warnings), "no loud load-time WARNING emitted"
+
+    def test_reason_diagnoses_missing_model_env(self, tmp_path, monkeypatch):
+        # auth.json present but no model env → reason should point at
+        # the missing HERMES_MODEL / {PROVIDER}_MODEL.
+        hermes = tmp_path / ".hermes"
+        hermes.mkdir()
+        (hermes / "config.yaml").write_text("model: ''\nproviders: {}\n")
+        (hermes / "auth.json").write_text(json.dumps({
+            "credential_pool": {
+                "zai": [{"access_token": "sk-x", "base_url": "https://a"}]
+            }
+        }))
+        monkeypatch.setenv("HERMES_CONFIG", str(hermes / "config.yaml"))
+        monkeypatch.setenv("HOME", str(tmp_path))
+        for v in ("HERMES_MODEL", "ZAI_MODEL", "OPENAI_MODEL", "LLM_MODEL",
+                  "XDG_CONFIG_HOME"):
+            monkeypatch.delenv(v, raising=False)
+
+        config, reason = validate_llm_config_at_load(context="test-no-model")
+        assert config is None
+        assert reason is not None
+        # Wording is informational — pin the stable-ish substrings.
+        assert (
+            "model env var" in reason.lower()
+            or "config files exist" in reason.lower()
+        )

--- a/python/tests/test_v2_02_hermes_fixes.py
+++ b/python/tests/test_v2_02_hermes_fixes.py
@@ -193,8 +193,9 @@ class TestBug5VisibleLLMError:
     """
 
     @pytest.mark.asyncio
-    async def test_extract_facts_llm_warns_when_no_config(self, caplog):
-        with patch.dict(os.environ, {}, clear=True):
+    async def test_extract_facts_llm_warns_when_no_config(self, caplog, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        with patch.dict(os.environ, {"HOME": str(tmp_path)}, clear=True):
             with caplog.at_level(logging.WARNING, logger="totalreclaw.agent.extraction"):
                 result = await extract_facts_llm(
                     [{"role": "user", "content": "I like coffee"}],

--- a/python/tests/test_wave2a_hermes_fixes.py
+++ b/python/tests/test_wave2a_hermes_fixes.py
@@ -102,7 +102,12 @@ class TestBug4HermesConfigYaml:
         # No .env file at all.
 
         monkeypatch.setenv("HERMES_CONFIG", str(hermes_dir / "config.yaml"))
-        for k in ("ZAI_API_KEY", "OPENAI_API_KEY", "OPENAI_MODEL", "GLM_API_KEY"):
+        # rc.15: point HOME at tmp_path so the 0.10.0 auth.json fallback
+        # doesn't accidentally resolve against the developer's real
+        # ~/.hermes dir.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        for k in ("ZAI_API_KEY", "OPENAI_API_KEY", "OPENAI_MODEL", "GLM_API_KEY",
+                  "HERMES_MODEL", "ZAI_MODEL"):
             monkeypatch.delenv(k, raising=False)
 
         assert read_hermes_llm_config() is None


### PR DESCRIPTION
## What broke
Hermes 0.10.0 users saw zero automatic memory extraction — every turn logged "extraction disabled: no LLM config resolved" (27+ times in a typical session).

## What's fixed
Parser now reads Hermes 0.10.0's `auth.json::credential_pool` + runtime env vars (`HERMES_MODEL` / `{PROVIDER}_MODEL`), not just the legacy `config.yaml` top-level keys; plugin load emits a single loud WARNING if resolution still fails instead of silent per-turn DEBUG spam.

## Impact after fix
Auto-extraction wires through correctly on Hermes 0.10.0 installs without requiring users to re-export any env vars. Pre-0.10.0 Hermes + non-Hermes setups (plain `OPENAI_MODEL` + `OPENAI_API_KEY`) continue to work unchanged.

## Verification
Scenario (config resolution on real VPS Hermes 0.10.0 install): **GO** on rc15 path install. 23 new regression tests + full 920-test Python suite passing. Full pair-and-chat end-to-end flow deferred to Pedro's review (escalation per Stage 5.B: 9 files touched exceeds the 5-file auto-merge threshold).

---

**Root cause**: SDK drift. Hermes 0.10.0 (2026-04-16) moved the active provider + API key out of `~/.hermes/config.yaml` (now `model: ''` / `providers: {}`) into `~/.hermes/auth.json::credential_pool`, and the active model into runtime-written env vars in `~/.hermes/.env`. TR's `read_hermes_llm_config()` still only parsed the legacy top-level YAML keys, so `detect_llm_config()` returned `None` every turn → "extraction disabled" per-turn debug log.

**Approach**: Option β, per Pedro's directive in the issue (2026-04-24 19:10Z):
> go β for rc.15, fix parser for Hermes 0.10.0 schema (auth.json.credential_pool + runtime env) with load-time validation that fails loud.

**Changes**:

- `totalreclaw.agent.llm_client`: new `_read_hermes_auth_json`, `_pick_credential_from_pool`, `_resolve_hermes_model_from_runtime_env` helpers. `read_hermes_llm_config()` now falls through to an `auth.json`-based resolver when the YAML shape is empty. `detect_llm_config()` env-path now recognizes per-provider `{PROVIDER}_MODEL` + `HERMES_MODEL` vars.
- `totalreclaw.agent.llm_client.validate_llm_config_at_load`: new public entry point. Runs once at plugin load and emits a single loud WARNING with an actionable reason (not Hermes installed / auth.json present but no model env / API key missing / etc.) when resolution fails — replaces the per-turn silent DEBUG log pattern.
- `totalreclaw.hermes.__init__.register`: calls the validator at plugin load and stashes the reason on `state` for first-turn quota-warning surface.
- `tests/test_llm_client_hermes_0_10_schema.py`: 23 new regression tests pinning the exact 0.10.0 fixture shape.
- 3 pre-existing tests that implicitly assumed an empty `~/.hermes`: minor `HOME=tmp_path` isolation adjustments so the new `auth.json` fallback doesn't spuriously resolve against the developer's real dir.
- Version bump `2.3.1rc14 → 2.3.1rc15` (`pyproject.toml`, `__init__.py` fallback, `plugin.yaml`).

**File count**: 9 files. Over the 5-file auto-merge threshold, so this PR is opened in escalation mode — Pedro reviews + merges. Breakdown: 2 actual code files (`llm_client.py` + `hermes/__init__.py` wire-in), 3 mandatory version-metadata bumps, 3 one-to-three-line test-compat tweaks, 1 new regression test file.

**QA report**: `totalreclaw-internal/docs/notes/QA-hermes-RC-2.3.1rc15-20260424.md`.

Closes #97 (internal tracker: p-diogo/totalreclaw-internal#97).

🤖 Auto-triage pipeline (Phase 3).