### PR TITLE
fix(hermes): debrief sees empty buffer — move session-end work to on_session_finalize (rc.16)

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "totalreclaw"
-version = "2.3.1rc15"
+version = "2.3.1rc16"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"

--- a/python/src/totalreclaw/hermes/__init__.py
+++ b/python/src/totalreclaw/hermes/__init__.py
@@ -191,11 +191,19 @@ def register(ctx):
     except Exception:  # pragma: no cover — registration must not crash plugin load
         logger.debug("QA bug-report tool registration skipped", exc_info=True)
 
-    # Register hooks
+    # Register hooks.
+    #
+    # ``on_session_end`` is registered as a no-op handler: hermes_cli
+    # dispatches it at the end of every ``run_conversation()`` (per user
+    # turn), not at true session end, so anything heavy belongs in
+    # ``on_session_finalize``. See ``hooks.on_session_end`` docstring +
+    # issue #101 for the failure mode this avoids.
     ctx.register_hook("on_session_start", lambda **kw: hooks.on_session_start(state, **kw))
     ctx.register_hook("pre_llm_call", lambda **kw: hooks.pre_llm_call(state, **kw))
     ctx.register_hook("post_llm_call", lambda **kw: hooks.post_llm_call(state, **kw))
     ctx.register_hook("on_session_end", lambda **kw: hooks.on_session_end(state, **kw))
+    ctx.register_hook("on_session_finalize", lambda **kw: hooks.on_session_finalize(state, **kw))
+    ctx.register_hook("on_session_reset", lambda **kw: hooks.on_session_reset(state, **kw))
 
     # Fix for internal#97: validate LLM-config resolution once at plugin
     # load and emit a single loud WARNING if it fails, so Hermes 0.10.0
@@ -208,4 +216,4 @@ def register(ctx):
     except Exception:  # pragma: no cover — validation must not crash plugin load
         logger.debug("LLM-config load-time validation skipped", exc_info=True)
 
-    logger.info("TotalReclaw plugin registered (12+ tools, 4 hooks)")
+    logger.info("TotalReclaw plugin registered (12+ tools, 6 hooks)")

--- a/python/src/totalreclaw/hermes/hooks.py
+++ b/python/src/totalreclaw/hermes/hooks.py
@@ -212,27 +212,54 @@ def post_llm_call(state: "PluginState", **kwargs) -> None:
 
 
 def on_session_end(state: "PluginState", **kwargs) -> None:
-    """Comprehensive flush of unprocessed messages + session debrief."""
-    if not state.is_configured():
-        return
+    """No-op. ``on_session_end`` is dispatched by hermes_cli at the end of
+    every ``run_conversation()`` call — i.e. once per user turn, NOT at
+    true session end. Session-end flush + debrief + message-buffer clear
+    have moved to ``on_session_finalize``.
 
-    if not state.has_unprocessed_messages():
+    Before 2.3.1rc15 this handler ran the flush + debrief and wiped
+    ``state._messages`` in its ``finally`` block. Because the hook fires
+    per-turn, the clear ran after every turn and ``totalreclaw_debrief``
+    always saw <8 messages even in 10+ turn sessions (issue #101, parent
+    #85 bug 5).
+    """
+    return None
+
+
+def on_session_finalize(state: "PluginState", **kwargs) -> None:
+    """Comprehensive flush of unprocessed messages + session debrief.
+
+    Fires at true session boundaries (hermes_cli atexit, gateway session
+    finalize). Per-turn auto-extraction runs from ``post_llm_call``; this
+    handler catches residual unprocessed messages and runs the session
+    debrief while the full conversation buffer is still intact.
+    """
+    if not state.is_configured():
         return
 
     try:
         stored_fact_texts: list[str] = []
-        try:
-            stored_fact_texts = _auto_extract(state, mode="full", llm_config=_get_hermes_llm_config())
-        except Exception as e:
-            logger.warning("TotalReclaw on_session_end flush failed: %s", e)
+        if state.has_unprocessed_messages():
+            try:
+                stored_fact_texts = _auto_extract(state, mode="full", llm_config=_get_hermes_llm_config())
+            except Exception as e:
+                logger.warning("TotalReclaw on_session_finalize flush failed: %s", e)
 
-        # Session debrief (after regular extraction)
         try:
             _session_debrief(state, stored_fact_texts=stored_fact_texts)
         except Exception as e:
-            logger.warning("TotalReclaw on_session_end debrief failed: %s", e)
+            logger.warning("TotalReclaw on_session_finalize debrief failed: %s", e)
     finally:
         state.clear_messages()
+
+
+def on_session_reset(state: "PluginState", **kwargs) -> None:
+    """User-initiated reset (``/reset``). Clean slate without the expensive
+    debrief — a finalize would have fired first if the conversation was
+    meant to be persisted.
+    """
+    state.clear_messages()
+    state.reset_turn_counter()
 
 
 # Backward-compatible alias used by tests

--- a/python/src/totalreclaw/hermes/hooks.py
+++ b/python/src/totalreclaw/hermes/hooks.py
@@ -217,7 +217,7 @@ def on_session_end(state: "PluginState", **kwargs) -> None:
     true session end. Session-end flush + debrief + message-buffer clear
     have moved to ``on_session_finalize``.
 
-    Before 2.3.1rc15 this handler ran the flush + debrief and wiped
+    Before 2.3.1rc16 this handler ran the flush + debrief and wiped
     ``state._messages`` in its ``finally`` block. Because the hook fires
     per-turn, the clear ran after every turn and ``totalreclaw_debrief``
     always saw <8 messages even in 10+ turn sessions (issue #101, parent

--- a/python/src/totalreclaw/hermes/plugin.yaml
+++ b/python/src/totalreclaw/hermes/plugin.yaml
@@ -20,3 +20,5 @@ provides_hooks:
   - pre_llm_call
   - post_llm_call
   - on_session_end
+  - on_session_finalize
+  - on_session_reset

--- a/python/src/totalreclaw/hermes/plugin.yaml
+++ b/python/src/totalreclaw/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: totalreclaw
-version: 2.3.1rc15
+version: 2.3.1rc16
 description: End-to-end encrypted memory vault for AI agents (Memory Taxonomy v1)
 author: TotalReclaw Team
 provides_tools:

--- a/python/tests/test_hermes_plugin.py
+++ b/python/tests/test_hermes_plugin.py
@@ -529,7 +529,10 @@ class TestRegister:
             f"expected {expected_tools} tools for version {__version__!r}, "
             f"got {ctx.register_tool.call_count}"
         )
-        assert ctx.register_hook.call_count == 4
+        assert ctx.register_hook.call_count == 6
+        hook_names = [call.args[0] for call in ctx.register_hook.call_args_list]
+        assert "on_session_finalize" in hook_names  # issue #101
+        assert "on_session_reset" in hook_names  # issue #101
 
         # Check tool names — every memory tool plus the new pair tool.
         tool_names = [call.kwargs["name"] for call in ctx.register_tool.call_args_list]

--- a/python/tests/test_issue_101_debrief_messages_survive_turns.py
+++ b/python/tests/test_issue_101_debrief_messages_survive_turns.py
@@ -1,0 +1,110 @@
+"""Regression test for issue #101.
+
+hermes_cli dispatches ``on_session_end`` at the end of every
+``run_conversation()`` (i.e. once per user turn), NOT at true session end.
+The plugin's ``on_session_end`` handler used to do a comprehensive flush +
+``state.clear_messages()`` in its ``finally`` block, which wiped the
+plugin message buffer after every turn. Result: ``totalreclaw_debrief``
+(and the on-finalize session debrief) always saw <8 messages even in
+long sessions and returned ``{"skipped": true, "session too short"}``.
+
+This test pins the fix: after 10 turns of simulated hermes_cli dispatch
+(post_llm_call + on_session_end per turn), the message buffer must
+contain >= 8 messages so the debrief guard does not trip. Clearing only
+happens at true session boundaries (``on_session_finalize`` /
+``on_session_reset``).
+"""
+from __future__ import annotations
+
+import pytest
+
+from totalreclaw.hermes.state import PluginState
+from totalreclaw.hermes import hooks as hhooks
+
+
+class _FakeState(PluginState):
+    """PluginState that skips real client auto-configure (no creds on disk)."""
+
+    def __init__(self):
+        self._client = object()
+        self._turn_count = 0
+        self._messages = []
+        self._last_processed_idx = 0
+        self._billing_cache = None
+        self._billing_cache_time = 0.0
+        self._extraction_interval = 3
+        self._max_facts = 15
+        self._min_importance = 6
+        self._quota_warning = None
+        self._server_url = None
+        self._env_interval_override = False
+        self._env_importance_override = False
+
+    def is_configured(self):
+        return True
+
+
+def _simulate_turn(state, i):
+    """Mirror hermes_cli run_agent.py dispatch: post_llm_call then
+    on_session_end fire once per ``run_conversation()`` call."""
+    hhooks.post_llm_call(
+        state,
+        session_id="s",
+        model="m",
+        platform="cli",
+        user_message=f"user msg turn {i}",
+        assistant_response=f"assistant msg turn {i}",
+        conversation_history=[],
+    )
+    hhooks.on_session_end(
+        state,
+        session_id="s",
+        completed=True,
+        interrupted=False,
+        model="m",
+        platform="cli",
+    )
+
+
+def test_issue_101_messages_survive_per_turn_dispatch():
+    state = _FakeState()
+    for i in range(1, 11):
+        _simulate_turn(state, i)
+
+    all_messages = state.get_all_messages()
+    assert len(all_messages) >= 8, (
+        "Per-turn on_session_end must not wipe the plugin message buffer — "
+        "totalreclaw_debrief's <8 guard depends on the 10-turn history "
+        "surviving across run_conversation() dispatches. "
+        f"Got len={len(all_messages)}."
+    )
+
+
+def test_issue_101_finalize_clears_buffer():
+    """Confirm the new on_session_finalize hook still performs the
+    session-end cleanup that was wrongly in on_session_end."""
+    state = _FakeState()
+    for i in range(1, 11):
+        _simulate_turn(state, i)
+
+    assert len(state.get_all_messages()) >= 8
+    hhooks.on_session_finalize(
+        state,
+        session_id="s",
+        completed=True,
+        interrupted=False,
+    )
+    assert state.get_all_messages() == []
+
+
+def test_issue_101_reset_clears_buffer_and_turn_counter():
+    state = _FakeState()
+    for i in range(1, 4):
+        _simulate_turn(state, i)
+
+    assert state.turn_count > 0
+    assert len(state.get_all_messages()) > 0
+
+    hhooks.on_session_reset(state, session_id="s")
+    assert state.get_all_messages() == []
+    assert state.turn_count == 0


### PR DESCRIPTION
## What broke
`totalreclaw_debrief` returned `{skipped: true, "session too short"}` in Hermes sessions of 10+ turns, silently skipping the debrief even when plenty of history existed.

## What's fixed
Moved the session-end flush + debrief + message-buffer clear from `on_session_end` (which hermes_cli fires once per `run_conversation()` — i.e. per user turn) to `on_session_finalize` (true session boundary). Added `on_session_reset` for /reset. `on_session_end` is now a no-op kept for back-compat.

## Impact after fix
`state._messages` survives across turns, so by the time a user invokes `totalreclaw_debrief` the `<8` guard no longer trips. Also unblocks a secondary symptom in the parent audit (#85 bug 1): the comprehensive "mode=full" flush now runs once at true session end rather than being starved by per-turn wipes.

## Verification
- New regression test `test_issue_101_debrief_messages_survive_turns.py` — 3 tests: simulates 10 turns of hermes_cli-pattern dispatch and asserts buffer survives (fails on pre-patch tree, passes post-patch); also pins `on_session_finalize` clearing + `on_session_reset` semantics.
- Full Python test suite: **900 passed, 11 skipped** (includes updated hook-count assertion in `test_hermes_plugin.py::TestRegister::test_register`).
- End-to-end tool smoke against patched package on VPS: `tools.debrief({}, state)` now proceeds past the guard after 10 simulated turns (previously short-circuited with "session too short").

## Version note
rc.15 is claimed by still-open PR #103 (Hermes 0.10.0 LLM-config drift fix for parent audit #85 bug 1). This lands as **2.3.1rc16** to avoid collision.

## QA note (severity:low shortcut)
Severity:low + plugin-hook-only scope + deterministic unit-test coverage. No on-chain, relay, or crypto code touched. Per the `tr-triage-and-fix` skill's polish-tier speed shortcut, a full `qa-totalreclaw` LLM-driven chat sweep was not run; the in-container smoke + unit suite already cover the exact bug path. RC publish will happen via normal CI on merge.

Closes p-diogo/totalreclaw-internal#101