### PR TITLE
fix(plugin): add --pair-only flag for safe agent invocation (closes #95)

### DIFF
--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -66,7 +66,7 @@ The QR encodes ONLY the pair URL. The 6-digit PIN is a separate out-of-band conf
 
 ## Phrase safety (HARD — never break)
 
-NEVER echo / generate / ask the user to paste a recovery phrase in chat. NEVER invoke `openclaw totalreclaw onboard`, `totalreclaw setup`, or any phrase-touching CLI via your shell tool (stdout enters LLM context). The ONLY agent-facilitated setup paths are (in order of preference): (1) `totalreclaw_pair` tool; (2) if the tool is missing from your tool list — a known gap for some container-based agents, issue #87 — shell out to `openclaw totalreclaw pair generate --url-pin-only`, which emits a single-line JSON `{v,url,pin,expires_at_ms}` with zero phrase material on stdout (pair-crypto is x25519-only, not BIP-39). If the user pastes a phrase anyway: tell them it is compromised, call `totalreclaw_pair` with `mode=generate` for a fresh wallet.
+NEVER echo / generate / ask the user to paste a recovery phrase in chat. NEVER invoke `openclaw totalreclaw onboard` (the bare interactive form), `totalreclaw setup`, or any phrase-touching CLI via your shell tool (stdout enters LLM context). The ONLY agent-facilitated setup paths are (in order of preference): (1) `totalreclaw_pair` tool; (2) if the tool is missing from your tool list — a known gap for some container-based agents, issue #87 — shell out to EITHER `openclaw totalreclaw pair generate --url-pin-only` (single-line JSON `{v,url,pin,expires_at_ms}`) OR `openclaw totalreclaw onboard --pair-only` (single-line JSON `{v,pair_url,pin,expires_at_ms}`, issue #95 — same pair flow, `pair_url` key naming). Both have zero phrase material on stdout (pair-crypto is x25519-only, not BIP-39). If the user pastes a phrase anyway: tell them it is compromised, call `totalreclaw_pair` with `mode=generate` for a fresh wallet.
 
 ## Usage (post-setup)
 
@@ -78,7 +78,7 @@ NEVER echo / generate / ask the user to paste a recovery phrase in chat. NEVER i
 
 ## Diagnostics
 
-- `totalreclaw_*` tools not visible → plugin not installed or gateway not restarted. Verify via `openclaw plugins list | grep totalreclaw`. If listed but tools still absent (container-agent gap, issue #87), shell out to `openclaw totalreclaw pair generate --url-pin-only` on the gateway host and hand the user the `url` + `pin` from the JSON payload — do NOT suggest `openclaw totalreclaw onboard` (leaks phrase on stdout).
+- `totalreclaw_*` tools not visible → plugin not installed or gateway not restarted. Verify via `openclaw plugins list | grep totalreclaw`. If listed but tools still absent (container-agent gap, issue #87), shell out to `openclaw totalreclaw pair generate --url-pin-only` on the gateway host and hand the user the `url` + `pin` from the JSON payload — OR `openclaw totalreclaw onboard --pair-only` (same flow, returns `pair_url` instead of `url`, issue #95). Do NOT suggest the bare `openclaw totalreclaw onboard` (leaks phrase on stdout — deprecated in rc.18, removed next RC).
 - User says done but `credentials.json` missing → PIN expired or entered wrong phrase; call `totalreclaw_pair` again.
 - `onboarding required` → credentials missing; redo from the pair step.
 - `quota exceeded` → `totalreclaw_status`, then offer `totalreclaw_upgrade`.

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -2902,6 +2902,12 @@ const plugin = {
             credentialsPath: CREDENTIALS_PATH,
             statePath: CONFIG.onboardingStatePath,
             logger: api.logger,
+            // 3.3.1-rc.18 — wire the pair flow into onboard so the
+            // `--pair-only` flag (issue #95) can delegate to it without
+            // duplicating session-store / URL-builder logic. Same deps
+            // as the standalone `pair` subcommand.
+            pairSessionsPath: CONFIG.pairSessionsPath,
+            renderPairingUrl: (session) => buildPairingUrl(api, session),
             // 3.3.1 — supplied to the non-interactive --json onboard path
             // so the emitted payload includes the derived Smart Account
             // (scope) address. Uses the chain-id default; Pro-tier

--- a/skill/plugin/onboard-pair-only.test.ts
+++ b/skill/plugin/onboard-pair-only.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Tests for `openclaw totalreclaw onboard --pair-only` (3.3.1-rc.18, issue #95).
+ *
+ * Phrase-safety contract: when the onboard CLI is invoked with
+ * `--pair-only`, the stdout/stderr captured during the run MUST contain
+ * ZERO phrase / mnemonic / recovery material — by construction the
+ * pair flow delegated to is x25519-only and never imports BIP-39.
+ *
+ * Strategy: drive `runPairCli` directly with `outputMode: 'pair-only'`
+ * (the same wiring `registerOnboardingCli`'s `--pair-only` branch uses
+ * via dynamic import) and assert on:
+ *   1. Single JSON line on stdout with the {v,pair_url,pin,expires_at_ms}
+ *      shape — no `url`, no `sid`, no `mode`, no `qr_ascii`.
+ *   2. `pair_url` is the rendered pairing URL (the `pk=` fragment is
+ *      x25519 — no phrase material).
+ *   3. `pin` is 6 digits.
+ *   4. The captured stdout buffer contains NO phrase-adjacent token
+ *      (`phrase`, `mnemonic`, `recovery`, `seed`, `bip39`).
+ *   5. The captured stdout buffer contains NO BIP-39 wordlist word
+ *      (sample-checked across 10 random wordlist entries).
+ *   6. The captured stdout buffer contains NO 12-word run of lowercase
+ *      alpha tokens — defense against a future regression that prints
+ *      the phrase grid by accident.
+ *   7. Status transitions DO NOT surface on stdout (silent after the
+ *      single payload line).
+ *   8. Stderr from the pair flow contains no phrase material either.
+ *
+ * Run with: npx tsx onboard-pair-only.test.ts
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { wordlist } from '@scure/bip39/wordlists/english.js';
+
+import {
+  transitionPairSession,
+} from './pair-session-store.js';
+import {
+  runPairCli,
+  type PairCliIo,
+  type PairCliPairOnlyPayload,
+} from './pair-cli.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond: boolean, name: string): void {
+  const n = passed + failed + 1;
+  if (cond) { console.log(`ok ${n} - ${name}`); passed++; }
+  else { console.log(`not ok ${n} - ${name}`); failed++; }
+}
+
+function mkTmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'tr-onboard-pair-only-'));
+}
+
+class CaptureStream {
+  buf: string[] = [];
+  write(data: string | Uint8Array): boolean {
+    this.buf.push(data.toString());
+    return true;
+  }
+  end() { /* noop */ }
+  text(): string { return this.buf.join(''); }
+}
+
+function buildTestIo(): { stdout: CaptureStream; stderr: CaptureStream; io: PairCliIo; triggerInterrupt: () => void } {
+  const stdout = new CaptureStream();
+  const stderr = new CaptureStream();
+  let interruptCb: (() => void) | null = null;
+  const io: PairCliIo = {
+    stdout: stdout as unknown as NodeJS.WritableStream,
+    stderr: stderr as unknown as NodeJS.WritableStream,
+    onInterrupt(cb) {
+      interruptCb = cb;
+      return () => { interruptCb = null; };
+    },
+  };
+  return {
+    stdout,
+    stderr,
+    io,
+    triggerInterrupt: () => { interruptCb?.(); },
+  };
+}
+
+function mkFakeQrRenderer(): (payload: string, cb: (ascii: string) => void) => void {
+  return (payload, cb) => cb(`[QR:${payload.length}]`);
+}
+
+// ---------------------------------------------------------------------------
+// test_issue_95_pair_only_emits_pair_url_payload
+// ---------------------------------------------------------------------------
+
+{
+  const sessionsPath = path.join(mkTmp(), 'pair-sessions.json');
+  const t = buildTestIo();
+  let qrRendererCalled = false;
+
+  const runPromise = runPairCli('generate', {
+    sessionsPath,
+    renderPairingUrl: (s) =>
+      `http://test/pair/finish?sid=${s.sid}#pk=${s.pkGatewayB64}`,
+    // pair-only mode MUST NOT invoke the QR renderer (no qrcode-terminal
+    // load, no ASCII on stdout) — same invariant as url-pin mode.
+    renderQr: (_, cb) => {
+      qrRendererCalled = true;
+      cb('[QR:should-not-appear]');
+    },
+    pollIntervalMs: 30,
+    io: t.io,
+    outputMode: 'pair-only',
+  });
+
+  await new Promise<void>((r) => setTimeout(r, 100));
+
+  const firstOutput = t.stdout.text().split('\n')[0];
+  let payload: PairCliPairOnlyPayload | null = null;
+  try {
+    payload = JSON.parse(firstOutput) as PairCliPairOnlyPayload;
+  } catch {
+    /* payload stays null */
+  }
+
+  assert(payload !== null, 'test_issue_95_pair_only: stdout parses as JSON');
+  assert(payload?.v === 1, 'test_issue_95_pair_only: v=1');
+  assert(
+    typeof payload?.pair_url === 'string' && payload.pair_url.includes('#pk='),
+    'test_issue_95_pair_only: pair_url has pk fragment',
+  );
+  assert(typeof payload?.pin === 'string' && /^\d{6}$/.test(payload.pin), 'test_issue_95_pair_only: pin is 6 digits');
+  assert(
+    typeof payload?.expires_at_ms === 'number' && payload.expires_at_ms > Date.now(),
+    'test_issue_95_pair_only: expires_at_ms is future',
+  );
+
+  // Slim payload shape: exactly these four keys, nothing more. The spec
+  // names `pair_url` (not `url`) — assert that explicitly so a future
+  // regression can't silently rename without breaking this test.
+  const keys = Object.keys(payload as object).sort();
+  assert(
+    keys.length === 4 &&
+      keys[0] === 'expires_at_ms' &&
+      keys[1] === 'pair_url' &&
+      keys[2] === 'pin' &&
+      keys[3] === 'v',
+    `test_issue_95_pair_only: keys = [expires_at_ms,pair_url,pin,v] (got [${keys.join(',')}])`,
+  );
+
+  // Forbidden fields from json / url-pin modes that must NOT appear here.
+  const p2 = payload as unknown as Record<string, unknown>;
+  assert(!('url' in p2), 'test_issue_95_pair_only: no url field (must be pair_url)');
+  assert(!('sid' in p2), 'test_issue_95_pair_only: no sid field');
+  assert(!('mode' in p2), 'test_issue_95_pair_only: no mode field');
+  assert(!('qr_ascii' in p2), 'test_issue_95_pair_only: no qr_ascii field');
+  assert(!('mnemonic' in p2), 'test_issue_95_pair_only: no mnemonic field');
+  assert(!('phrase' in p2), 'test_issue_95_pair_only: no phrase field');
+
+  assert(!qrRendererCalled, 'test_issue_95_pair_only: QR renderer NOT invoked');
+
+  // Drive the session through state transitions; in pair-only mode
+  // these MUST NOT surface on stdout.
+  const raw = fs.readFileSync(sessionsPath, 'utf-8');
+  const parsed = JSON.parse(raw) as { sessions?: Array<{ sid: string }> };
+  const sid = parsed.sessions?.[0]?.sid as string;
+  await transitionPairSession(sessionsPath, sid, 'device_connected', Date.now);
+  await new Promise<void>((r) => setTimeout(r, 80));
+  await transitionPairSession(sessionsPath, sid, 'consumed', Date.now);
+  await transitionPairSession(sessionsPath, sid, 'completed', Date.now);
+
+  const outcome = await runPromise;
+  assert(outcome.status === 'completed', 'test_issue_95_pair_only: outcome completed');
+
+  const fullStdout = t.stdout.text();
+  const fullStderr = t.stderr.text();
+
+  // Stdout must remain a single JSON line + trailing newline.
+  const nonEmptyLines = fullStdout.split('\n').filter((l) => l.length > 0);
+  assert(nonEmptyLines.length === 1, `test_issue_95_pair_only: single stdout line (got ${nonEmptyLines.length})`);
+
+  // No human-readable banner / status copy at any point.
+  assert(!fullStdout.includes('Remote pairing'), 'test_issue_95_pair_only: no intro copy on stdout');
+  assert(!fullStdout.includes('Browser connected'), 'test_issue_95_pair_only: no "Browser connected" on stdout');
+  assert(!fullStdout.includes('Pairing complete'), 'test_issue_95_pair_only: no "Pairing complete" on stdout');
+  assert(!fullStdout.includes('Security:'), 'test_issue_95_pair_only: no security warning on stdout');
+  assert(!fullStdout.includes('[QR:'), 'test_issue_95_pair_only: no QR ASCII on stdout');
+
+  // ---------------------------------------------------------------
+  // STRICT INVARIANT (issue #95 spec): phrase string MUST NOT appear
+  // in captured stdout/stderr in --pair-only mode. Defense-in-depth
+  // since pair-cli does not import any mnemonic code, but this test
+  // catches a regression that accidentally inlines phrase material.
+  // ---------------------------------------------------------------
+  assert(!/\bphrase\b/i.test(fullStdout), 'STRICT: no "phrase" on stdout');
+  assert(!/\bmnemonic\b/i.test(fullStdout), 'STRICT: no "mnemonic" on stdout');
+  assert(!/\brecovery\b/i.test(fullStdout), 'STRICT: no "recovery" on stdout');
+  assert(!/\bseed\b/i.test(fullStdout), 'STRICT: no "seed" on stdout');
+  assert(!/\bbip-?39\b/i.test(fullStdout), 'STRICT: no "bip39" on stdout');
+
+  assert(!/\bphrase\b/i.test(fullStderr), 'STRICT: no "phrase" on stderr');
+  assert(!/\bmnemonic\b/i.test(fullStderr), 'STRICT: no "mnemonic" on stderr');
+  assert(!/\brecovery\b/i.test(fullStderr), 'STRICT: no "recovery" on stderr');
+  assert(!/\bseed\b/i.test(fullStderr), 'STRICT: no "seed" on stderr');
+  assert(!/\bbip-?39\b/i.test(fullStderr), 'STRICT: no "bip39" on stderr');
+
+  // Assert no BIP-39 wordlist word appears on stdout. We sample 10
+  // random wordlist entries — if any are present, fail. (Full-list
+  // scan is overkill: the assertion above already rules out every
+  // scenario where a phrase would leak; this is belt-and-braces.)
+  const sampleWords = ['ability', 'absurd', 'access', 'banana', 'cargo', 'dance', 'eager', 'fabric', 'galaxy', 'hammer'];
+  for (const w of sampleWords) {
+    assert(
+      wordlist.includes(w),
+      `setup: sample word "${w}" is in the BIP-39 wordlist`,
+    );
+    assert(
+      !new RegExp(`\\b${w}\\b`).test(fullStdout),
+      `STRICT: BIP-39 word "${w}" not on stdout`,
+    );
+  }
+
+  // Defense against a future regression that accidentally prints a
+  // phrase grid: scan stdout for any 12-word run of lowercase alpha
+  // tokens of length >=3. The pair-only payload's URL contains no such
+  // structure (it's hex / base64url + URL-encoded chars), so this is
+  // a clean proxy for a leaked phrase.
+  const tokens = fullStdout.toLowerCase().match(/\b[a-z]{3,}\b/g) ?? [];
+  let maxRun = 0;
+  let cur = 0;
+  for (const _t of tokens) {
+    cur++;
+    if (cur > maxRun) maxRun = cur;
+  }
+  // Tokens come from JSON keys/values; even concatenated, a legitimate
+  // payload should produce far fewer than 12 contiguous lowercase
+  // tokens. (`{"v":1,"pair_url":"http://...","pin":"123456","expires_at_ms":...}`
+  // has 4-6 lowercase tokens depending on URL).
+  assert(
+    maxRun < 12,
+    `STRICT: stdout has fewer than 12 contiguous lowercase tokens (got ${maxRun}) — phrase-grid regression check`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log(`# fail: ${failed}`);
+console.log(`# ${passed}/${passed + failed} passed`);
+if (failed > 0) {
+  console.log('SOME TESTS FAILED');
+  process.exit(1);
+}
+console.log('ALL TESTS PASSED');

--- a/skill/plugin/onboarding-cli.ts
+++ b/skill/plugin/onboarding-cli.ts
@@ -59,6 +59,23 @@ import {
 // has one place to grow into later).
 // ---------------------------------------------------------------------------
 
+/**
+ * 3.3.1-rc.18 (issue #95) — deprecation warning for the interactive
+ * phrase-print branch. Emitted to STDERR (never stdout) so it is visible
+ * to humans but does not pollute any pipe consuming the wizard's output.
+ *
+ * The phrase-print branch will be REMOVED in the next RC after rc.18.
+ * Users running on a TTY can still complete the flow in rc.18; agents
+ * MUST use `--pair-only` or the `totalreclaw_pair` tool today.
+ */
+export const PHRASE_PRINT_DEPRECATION_WARNING =
+  '\nDEPRECATION (issue #95): the interactive `openclaw totalreclaw onboard` flow\n' +
+  '  prints your recovery phrase to this terminal. This is being removed in the\n' +
+  '  next release candidate. For agent / scripted invocation, use:\n' +
+  '    openclaw totalreclaw onboard --pair-only\n' +
+  '  which emits ONLY {pair_url, pin} JSON and routes the phrase through the\n' +
+  '  browser flow (never on stdout).\n\n';
+
 export const COPY = {
   welcome:
     '\nTotalReclaw — Secure onboarding\n\n' +
@@ -403,6 +420,11 @@ export async function runOnboardingWizard(deps: WizardDeps): Promise<WizardResul
   }
 
   if (choice === 'generate') {
+    // 3.3.1-rc.18 (issue #95) — deprecation banner on stderr ONLY.
+    // The phrase-print branch is scheduled for removal in the RC after
+    // rc.18; we keep it functional in rc.18 for back-compat with users
+    // running the wizard on a real TTY today.
+    io.stderr.write(PHRASE_PRINT_DEPRECATION_WARNING);
     io.stdout.write(COPY.generateWarning);
     io.stdout.write(COPY.importRemoteLimitation);
     const mnemonic = genMnemonic();
@@ -674,6 +696,22 @@ export async function runNonInteractiveOnboard(
  *   --emit-phrase          Include the plaintext phrase in the JSON payload
  *                          (NOT recommended — the phrase lives in
  *                          credentials.json; prefer reading it there).
+ *
+ * 3.3.1-rc.18 — `onboard` accepts:
+ *   --pair-only            Phrase-safe agent-shell flag (issue #95).
+ *                          Delegates to the pair flow and emits a single
+ *                          line of JSON `{v, pair_url, pin, expires_at_ms}`
+ *                          to stdout. Phrase NEVER touches stdout, stderr,
+ *                          or the logger in this mode. Use this for any
+ *                          agent-driven setup; it is the recommended path
+ *                          when a container-based agent does not have the
+ *                          `totalreclaw_pair` tool injected.
+ *
+ *                          Requires `pairSessionsPath` + `renderPairingUrl`
+ *                          to be supplied to `registerOnboardingCli`. If
+ *                          absent, `--pair-only` exits non-zero with a
+ *                          clear message instead of falling through to the
+ *                          phrase-print branch.
  */
 export function registerOnboardingCli(
   program: import('commander').Command,
@@ -683,6 +721,10 @@ export function registerOnboardingCli(
     logger: { info(msg: string): void; warn(msg: string): void; error(msg: string): void };
     /** Caller-supplied helper for scope-address derivation. Optional — when absent, JSON output omits `scope_address`. */
     deriveScopeAddress?: (mnemonic: string) => Promise<string | undefined>;
+    /** Caller-supplied path to the pair-session store. Required for `--pair-only`. */
+    pairSessionsPath?: string;
+    /** Caller-supplied URL renderer for the pair flow. Required for `--pair-only`. */
+    renderPairingUrl?: (session: import('./pair-session-store.js').PairSession) => string;
   },
 ): void {
   const tr = program
@@ -690,12 +732,13 @@ export function registerOnboardingCli(
     .description('TotalReclaw encrypted memory — secure onboarding + status');
 
   tr.command('onboard')
-    .description('Interactive onboarding: generate or import a recovery phrase (runs locally, no LLM)')
+    .description('Interactive onboarding: generate or import a recovery phrase (runs locally, no LLM). For agent-driven setup prefer --pair-only.')
     .option('--non-interactive', 'Exit non-zero if any input would be prompted for (agent-driven use)')
     .option('--json', 'Emit the result as a structured JSON payload. Only valid with --non-interactive.')
     .option('--mode <mode>', 'generate | restore — skip the menu prompt')
     .option('--phrase <phrase>', 'Recovery phrase for --mode restore. `-` reads from stdin.')
     .option('--emit-phrase', 'Include the plaintext phrase in the JSON payload (not recommended). Default: false.')
+    .option('--pair-only', 'Phrase-safe agent-invocation mode (issue #95). Emits ONLY {v,pair_url,pin,expires_at_ms} JSON to stdout via the pair flow. Phrase never touches stdout/stderr/logger. RECOMMENDED for any agent or scripted invocation.')
     .action(async (...actionArgs: unknown[]) => {
       // commander: (options, cmd)
       const cliOpts = (actionArgs[0] ?? {}) as {
@@ -704,7 +747,69 @@ export function registerOnboardingCli(
         mode?: string;
         phrase?: string;
         emitPhrase?: boolean;
+        pairOnly?: boolean;
       };
+
+      // ---------------------------------------------------------------
+      // 3.3.1-rc.18 — `--pair-only` (issue #95)
+      //
+      // Phrase-safe agent-shell flag. Delegates to the pair flow and
+      // emits a single line of JSON `{v, pair_url, pin, expires_at_ms}`
+      // to stdout. By construction:
+      //   - The pair flow is x25519-only — pair-crypto.ts does NOT
+      //     import @scure/bip39 and never touches a recovery phrase.
+      //   - No interactive prompts, no readline, no @scure/bip39 import
+      //     in this code path. Phrase never enters stdout/stderr/logger.
+      //   - Stays silent on status transitions (the runPairCli
+      //     `pair-only` output mode suppresses banners, spinners, and
+      //     all human-readable copy).
+      //
+      // This MUST be the path agents take when they need to set up
+      // TotalReclaw via a shell. The interactive phrase-print branch
+      // below is deprecated for that use case and emits a warning when
+      // the user falls through to it.
+      // ---------------------------------------------------------------
+      if (cliOpts.pairOnly) {
+        if (!opts.pairSessionsPath || !opts.renderPairingUrl) {
+          process.stderr.write(
+            '--pair-only is unavailable: this OpenClaw build did not wire the pair flow into the onboard CLI. ' +
+              'Use `openclaw totalreclaw pair generate --url-pin-only` instead.\n',
+          );
+          process.exit(1);
+        }
+        // Resolve mode. --mode restore is incompatible with --pair-only
+        // since pair flow's "import" mode runs in the browser, not in
+        // the CLI. Default to 'generate' silently.
+        const pairMode = cliOpts.mode === 'restore' || cliOpts.mode === 'import' ? 'import' : 'generate';
+
+        // Lazy import — keeps pair-cli + qrcode-terminal off the
+        // onboarding hot path when --pair-only is not used.
+        const { runPairCli, defaultRenderQr, buildDefaultPairCliIo } = await import('./pair-cli.js');
+        const io = buildDefaultPairCliIo();
+        try {
+          const outcome = await runPairCli(pairMode, {
+            sessionsPath: opts.pairSessionsPath,
+            renderPairingUrl: opts.renderPairingUrl,
+            renderQr: defaultRenderQr,
+            io,
+            outputMode: 'pair-only',
+          });
+          if (outcome.status !== 'completed') {
+            process.exit(outcome.status === 'canceled' ? 130 : 1);
+          }
+          process.exit(0);
+        } catch (err) {
+          // CRITICAL: this catch MUST NOT include the phrase, the
+          // mnemonic, or any user secret in the message. The pair flow
+          // does not produce phrase material, so this is structurally
+          // safe — but defense-in-depth: emit a fixed error string.
+          opts.logger.error(
+            `pair-only delegation crashed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          process.stderr.write('--pair-only failed (see logs).\n');
+          process.exit(2);
+        }
+      }
 
       if (cliOpts.nonInteractive) {
         // Non-interactive path — no readline, no prompts.
@@ -744,10 +849,18 @@ export function registerOnboardingCli(
         });
 
         if (cliOpts.json) {
+          // 3.3.1-rc.18 (issue #95) — emit deprecation on stderr when
+          // the JSON payload is about to include the plaintext phrase.
+          // stderr is intentional: stdout must remain a single
+          // machine-parseable JSON line.
+          if (cliOpts.emitPhrase && result.ok && result.mnemonic) {
+            process.stderr.write(PHRASE_PRINT_DEPRECATION_WARNING);
+          }
           process.stdout.write(JSON.stringify(result) + '\n');
         } else {
           if (result.ok) {
             if (result.mnemonic) {
+              process.stderr.write(PHRASE_PRINT_DEPRECATION_WARNING);
               process.stderr.write(
                 'WARNING: --emit-phrase was set. The plaintext recovery phrase was returned.\n' +
                   'For agent-driven flows, prefer reading ~/.totalreclaw/credentials.json directly ' +

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -54,7 +54,7 @@
     "skill.json"
   ],
   "scripts": {
-    "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx llm-client-retry.test.ts && npx tsx gateway-url.test.ts && npx tsx retype-setscope.test.ts && npx tsx tool-gating.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts && npx tsx pair-qr.test.ts && npx tsx pair-remote-client.test.ts && npx tsx qa-bug-report.test.ts && npx tsx nonce-serialization.test.ts && npx tsx phrase-safety-registry.test.ts && npx tsx test_issue_92_onnx_download_ux.test.ts",
+    "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx llm-client-retry.test.ts && npx tsx gateway-url.test.ts && npx tsx retype-setscope.test.ts && npx tsx tool-gating.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts && npx tsx pair-qr.test.ts && npx tsx pair-remote-client.test.ts && npx tsx qa-bug-report.test.ts && npx tsx nonce-serialization.test.ts && npx tsx phrase-safety-registry.test.ts && npx tsx test_issue_92_onnx_download_ux.test.ts && npx tsx onboard-pair-only.test.ts",
     "check-scanner": "node ../scripts/check-scanner.mjs",
     "prepublishOnly": "node ../scripts/check-scanner.mjs"
   },

--- a/skill/plugin/pair-cli.ts
+++ b/skill/plugin/pair-cli.ts
@@ -92,8 +92,15 @@ export interface PairCliOutcome {
  *     gap) and must shell out to the CLI. Guarantees zero phrase material
  *     on stdout by construction — pair-crypto is x25519-only and the slim
  *     payload carries nothing BIP-39-adjacent.
+ *   - 'pair-only': (3.3.1-rc.18, issue #95) the same surface as 'url-pin',
+ *     but the URL field is named `pair_url` (matching the spec wording
+ *     for `openclaw totalreclaw onboard --pair-only`). Used by the
+ *     onboard CLI's `--pair-only` flag to provide a phrase-safe
+ *     alternative to the interactive phrase-print path. Emits ONLY
+ *     `{ v, pair_url, pin, expires_at_ms }`. Same zero-phrase invariant
+ *     as 'url-pin' — the underlying pair flow does no BIP-39 work.
  */
-export type PairCliOutputMode = 'human' | 'json' | 'url-pin';
+export type PairCliOutputMode = 'human' | 'json' | 'url-pin' | 'pair-only';
 
 /**
  * JSON payload emitted by runPairCli when outputMode === 'json'. Printed
@@ -117,6 +124,20 @@ export interface PairCliJsonPayload {
 export interface PairCliUrlPinPayload {
   v: 1;
   url: string;
+  pin: string;
+  expires_at_ms: number;
+}
+
+/**
+ * Slim payload for outputMode === 'pair-only'. Same shape as
+ * `PairCliUrlPinPayload` but with `pair_url` instead of `url` — the
+ * key name matches the spec for `onboard --pair-only` (issue #95).
+ * Phrase invariant: zero BIP-39 material on stdout by construction
+ * (the pair flow is x25519-only).
+ */
+export interface PairCliPairOnlyPayload {
+  v: 1;
+  pair_url: string;
   pin: string;
   expires_at_ms: number;
 }
@@ -232,10 +253,12 @@ export async function runPairCli(
   }
 
   // 2. Build the URL unconditionally, but only render the QR for modes
-  //    that actually emit it. url-pin mode skips the renderer entirely —
-  //    no CPU cost, no qrcode-terminal import, no ASCII on stdout.
+  //    that actually emit it. url-pin and pair-only modes skip the
+  //    renderer entirely — no CPU cost, no qrcode-terminal import, no
+  //    ASCII on stdout.
   const url = deps.renderPairingUrl(session);
-  const qrAscii = outputMode === 'url-pin' ? '' : await new Promise<string>((resolve) => {
+  const skipsQr = outputMode === 'url-pin' || outputMode === 'pair-only';
+  const qrAscii = skipsQr ? '' : await new Promise<string>((resolve) => {
     // Guard against QR renderers that never fire their callback (shouldn't
     // happen with qrcode-terminal, but defensive): a 10-second timeout
     // returns an empty string so we never hang the pairing flow.
@@ -261,11 +284,20 @@ export async function runPairCli(
     }
   });
 
-  // 3. Emit the visible surface (JSON/url-pin first — single line — or human copy).
+  // 3. Emit the visible surface (JSON/url-pin/pair-only first — single
+  //    line — or human copy).
   if (outputMode === 'url-pin') {
     const payload: PairCliUrlPinPayload = {
       v: 1,
       url,
+      pin: session.secondaryCode,
+      expires_at_ms: session.expiresAtMs,
+    };
+    stdout.write(JSON.stringify(payload) + '\n');
+  } else if (outputMode === 'pair-only') {
+    const payload: PairCliPairOnlyPayload = {
+      v: 1,
+      pair_url: url,
       pin: session.secondaryCode,
       expires_at_ms: session.expiresAtMs,
     };
@@ -304,9 +336,10 @@ export async function runPairCli(
     canceled = true;
   });
 
-  // 5. Poll — status transitions only surface in human mode; json/url-pin
-  //    modes stay silent after the single payload line so agents parsing
-  //    stdout get one JSON line and an exit code, nothing else.
+  // 5. Poll — status transitions only surface in human mode; json /
+  //    url-pin / pair-only modes stay silent after the single payload
+  //    line so agents parsing stdout get one JSON line and an exit
+  //    code, nothing else.
   const emitStatus = (text: string): void => {
     if (outputMode === 'human') stdout.write(text);
   };


### PR DESCRIPTION
## Summary

Implements owner-authorized phrase-safety fix per `p-diogo/totalreclaw-internal#95` (owner directive 2026-04-25: *"the plan for this is to indeed go with pair only and deprecate stdout printing"*).

- **New `--pair-only` flag** on `openclaw totalreclaw onboard` — emits ONLY `{v, pair_url, pin, expires_at_ms}` JSON to stdout via the existing pair flow. Phrase NEVER touches stdout, stderr, or the logger in this mode.
- **Deprecation warning** on the existing interactive phrase-print branch (the path that prints the 12-word grid). Stays functional in rc.18 for back-compat; flagged for removal in the next RC.
- **Strict regression test** asserts phrase / mnemonic / recovery / seed / bip39 substrings — and a sample of BIP-39 wordlist words — are absent from captured stdout AND stderr when `--pair-only` is used.
- **Help text + SKILL.md** updated to recommend `--pair-only` for agent / scripted invocation.

This is the structural fix for the CLI path that complements the `totalreclaw_pair` tool (the preferred agent-facing surface) and the existing `pair generate --url-pin-only` (issue #87, rc.15+). The new flag is functionally identical to `pair --url-pin-only` but uses the spec's `pair_url` key naming.

## Phrase-safety construction

Why this is structurally safe (independent of test coverage):

1. `--pair-only` delegates to `runPairCli` with `outputMode: 'pair-only'`.
2. `runPairCli` lives in `pair-cli.ts`, which imports `pair-session-store` + `pair-crypto` only — neither touches `@scure/bip39`, the BIP-39 wordlist, or any mnemonic surface.
3. The `'pair-only'` output mode emits a single JSON line and stays silent on every status transition — no banner, no spinner, no human copy.
4. The pairing URL is x25519 public-key + base64url session ID; it carries zero phrase material by construction.

## Before / after stdout

**Before** (`openclaw totalreclaw onboard`, interactive):
```
TotalReclaw — Secure onboarding
...
Your recovery phrase (WRITE THIS DOWN):

  1. ability     2. absurd      3. access      4. ...
  ...
```
(Phrase grid lands on stdout. If invoked from an agent shell, lands in LLM context.)

**After** (`openclaw totalreclaw onboard --pair-only`):
```
{"v":1,"pair_url":"https://gateway.example.com/plugin/totalreclaw/pair/finish?sid=abc123#pk=...","pin":"483921","expires_at_ms":1745609123000}
```
(Single line of JSON. Zero phrase material. Agent-shell safe.)

## Deprecation path

The interactive phrase-print branch in `runOnboardingWizard` (and the `--non-interactive --emit-phrase` path) now emit a stderr-only deprecation banner pointing users at `--pair-only`. The banner content:

> DEPRECATION (issue #95): the interactive `openclaw totalreclaw onboard` flow prints your recovery phrase to this terminal. This is being removed in the next release candidate. For agent / scripted invocation, use:
>     openclaw totalreclaw onboard --pair-only
> which emits ONLY {pair_url, pin} JSON and routes the phrase through the browser flow (never on stdout).

Removal of the phrase-print branch entirely is a separate next-RC PR (per spec — this PR only deprecates).

## Test plan

- [x] `npm test` in `skill/plugin/` — all 17 test files pass (including new `onboard-pair-only.test.ts` with 51 assertions)
- [x] `npx tsc --noEmit -p skill/tsconfig.json` — no new type errors in `skill/plugin/`
- [x] `node skill/scripts/check-scanner.mjs` — scanner-sim clean (95 files, 0 flags)
- [x] Existing `pair-cli-json.test.ts` (issue #87 url-pin-only test) — unchanged, still passes
- [x] Existing `phrase-safety-registry.test.ts` — still passes (no agent tools added)
- [ ] Real-user QA against rc.18 — to be run by the rc.18 dispatch (see timing note below)

## rc.18 timing

The rc.18 dispatch is currently being prepared. If this PR merges to `main` BEFORE the `publish-clawhub.yml` workflow checks out the source for rc.18 build, rc.18 will ship with `--pair-only`. Otherwise it lands in the rc following rc.18.

## Constraints honoured

- Did NOT modify the phrase-generation crypto path (BIP-39 generation, mnemonic-to-seed, x25519 derivation). Only the OUTPUT path.
- Did NOT remove the phrase-print branch. Only deprecated it.
- Did NOT modify pair flow internals — `--pair-only` delegates to `runPairCli` with a new `'pair-only'` output mode that just renames the URL key from `url` to `pair_url` for spec compliance.

## Authorization

Owner-authorized in `p-diogo/totalreclaw-internal#95` 2026-04-25 (verbatim: *"the plan for this is to indeed go with pair only and deprecate stdout printing"*). This PR is an explicit, owner-directed phrase-safety code change executed manually outside the auto-triage skill (which has structural rails preventing it from touching phrase paths even with comment-level unlock).

Closes [p-diogo/totalreclaw-internal#95](https://github.com/p-diogo/totalreclaw-internal/issues/95).

🤖 Generated with [Claude Code](https://claude.com/claude-code)