### PR TITLE
fix(plugin): rc.18 tarball + Docker pair URL + tool-injection logging (closes #110)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,20 @@ jobs:
       # openclaw.plugin.json does NOT have "kind":"memory" (startup registry fix)
       # AND that index.ts still declares kind:'memory' as const (memory-slot
       # matching preserved). Uses npx tsx — available without a devDependency.
-      - name: Plugin manifest shape tests
+      # Includes import-time-smoke.test.ts (issue #110 fix 2) which asserts
+      # plugin module load completes in <5s with no eager network I/O.
+      - name: Plugin manifest shape + smoke tests
         run: cd skill/plugin && npm test
+
+      # Issue #110 fix 1: build the plugin's TS to dist/.js, and verify the
+      # tarball would ship a complete set of `.js` artifacts. PR-time check
+      # so a broken build (e.g. missing import target, syntax error) doesn't
+      # reach the publish workflow.
+      - name: Build plugin (.ts -> dist/.js)
+        run: cd skill/plugin && npm run build
+
+      - name: Verify tarball ships built `.js` artifacts (issue #110)
+        run: cd skill/plugin && npm run verify-tarball
 
   mcp-tests:
     name: MCP Server Tests

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -358,12 +358,44 @@ jobs:
       - name: Scanner-sim (env-harvesting false-positive check)
         run: cd skill/plugin && npm run check-scanner
 
-      # Tests intentionally skipped at this step: this plugin publishes
-      # `.ts` source (no build step), and `skill/plugin/package.json` has
-      # no `test` script defined. Per-file `*.test.ts` suites are run in
-      # other workflows; gating publish on them here would require wiring
-      # a runner that isn't currently present. Mirrors the nanoclaw
-      # rationale above.
+      # Issue #110 fix 1 (rc.18 manual QA): plugin used to ship raw `.ts`
+      # source — `index.ts` did `import './crypto.js'` but only `crypto.ts`
+      # existed. Gateway TS-loader masked this, but CLI subcommand paths
+      # that resolved literal `./crypto.js` failed. Build + verify gates
+      # below ensure every `.js` import target ships as a real file.
+      - name: Build plugin (.ts -> dist/.js)
+        run: cd skill/plugin && npm run build
+
+      - name: Run plugin tests (asserts manifest, phrase-safety registry, import-time budget)
+        run: cd skill/plugin && npm test
+
+      - name: Verify tarball ships built `.js` artifacts (issue #110)
+        run: cd skill/plugin && npm run verify-tarball
+
+      - name: Smoke-import the plugin module from a clean Node env
+        run: |
+          cd skill/plugin
+          # Pack and install to /tmp to verify the published shape works
+          # the way an end-user `openclaw plugins install` would see it.
+          TARBALL=$(npm pack 2>/dev/null | tail -1)
+          mkdir -p /tmp/plugin-smoke && cd /tmp/plugin-smoke
+          npm init -y >/dev/null
+          npm install "${GITHUB_WORKSPACE}/skill/plugin/${TARBALL}" --no-save --legacy-peer-deps
+          # Import the entry — must complete in <5s and not require network.
+          timeout 10 node --input-type=module -e "
+            const start = Date.now();
+            const mod = await import('@totalreclaw/totalreclaw');
+            const elapsed = Date.now() - start;
+            if (typeof mod.default !== 'object' || mod.default?.id !== 'totalreclaw') {
+              console.error('Expected default export with id=totalreclaw, got:', mod.default);
+              process.exit(1);
+            }
+            if (elapsed > 5000) {
+              console.error('Plugin import took', elapsed, 'ms (>5000ms budget) — possible eager ONNX regression (issue #110 fix 2)');
+              process.exit(1);
+            }
+            console.log('OK: plugin imports cleanly from clean Node env in', elapsed, 'ms');
+          " || { echo 'ERROR: plugin tarball failed clean-Node smoke import'; exit 1; }
 
       - name: Apply RC version suffix (rc mode only)
         if: inputs.release-type == 'rc'

--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -71,6 +71,19 @@ jobs:
       - name: Scanner-sim (env-harvesting false-positive check)
         run: node skill/scripts/check-scanner.mjs
 
+      # Issue #110 fix 1: build the plugin's TS to dist/.js before publish.
+      # The plugin uses ` /* */ from './X.js'` Node-ESM-style imports; the
+      # tarball must ship matching dist/X.js files, otherwise CLI subcommand
+      # paths fail (gateway TS-loader was masking this on the runtime path).
+      - name: Install plugin dependencies (for tsc)
+        run: cd skill/plugin && rm -f package-lock.json && npm install --legacy-peer-deps
+
+      - name: Build plugin (.ts -> dist/.js)
+        run: cd skill/plugin && npm run build
+
+      - name: Verify tarball ships built `.js` artifacts (issue #110)
+        run: cd skill/plugin && npm run verify-tarball
+
       - name: Install ClawHub CLI
         run: npm install -g clawhub
 

--- a/skill/plugin/gateway-url.test.ts
+++ b/skill/plugin/gateway-url.test.ts
@@ -15,7 +15,7 @@
  */
 
 import type os from 'node:os';
-import { detectTailscaleHost, detectLanHost, detectGatewayHost } from './gateway-url.js';
+import { detectTailscaleHost, detectLanHost, detectGatewayHost, isDockerInternalIp } from './gateway-url.js';
 
 let passed = 0;
 let failed = 0;
@@ -207,6 +207,71 @@ function iface(addr: string, family: 'IPv4' | 'IPv6', internal = false): os.Netw
   assert(r === null, 'meta: detectGatewayHost returns sync null on empty NIC table');
   // If detectGatewayHost returned a Promise, the assertion above would be
   // `Promise<null>` which is truthy — so `r === null` catches it.
+}
+
+// ---------------------------------------------------------------------------
+// Issue #110 fix 4: Docker container internal IP detection
+// ---------------------------------------------------------------------------
+
+{
+  // isDockerInternalIp — 172.16/12 range
+  assert(isDockerInternalIp('172.17.0.1') === true, 'docker: 172.17.0.1 (default-bridge) recognized');
+  assert(isDockerInternalIp('172.18.0.2') === true, 'docker: 172.18.0.2 (issue #110 user IP) recognized');
+  assert(isDockerInternalIp('172.31.255.255') === true, 'docker: 172.31.255.255 (top of /12) recognized');
+  assert(isDockerInternalIp('172.16.0.1') === true, 'docker: 172.16.0.1 (bottom of /12) recognized');
+  assert(isDockerInternalIp('172.15.0.1') === false, 'docker: 172.15.x outside /12 not flagged');
+  assert(isDockerInternalIp('172.32.0.1') === false, 'docker: 172.32.x outside /12 not flagged');
+  assert(isDockerInternalIp('192.168.1.1') === false, 'docker: 192.168.x not flagged');
+  assert(isDockerInternalIp('10.0.0.1') === false, 'docker: 10.x not flagged (rare for Docker default)');
+  assert(isDockerInternalIp('not-an-ip') === false, 'docker: malformed input safe');
+}
+
+{
+  // detectLanHost with isDocker=true skips 172.18.x
+  const result = detectLanHost({
+    networkInterfaces: fakeNetifs({
+      lo0: [iface('127.0.0.1', 'IPv4', true)],
+      eth0: [iface('172.18.0.2', 'IPv4')], // Docker bridge IP — must be skipped
+    }),
+    isDocker: true,
+  });
+  assert(result === null, 'docker-aware LAN: 172.18.0.2 on eth0 skipped when isDocker=true (issue #110)');
+}
+
+{
+  // detectLanHost with isDocker=false KEEPS 172.18.x (could be a real LAN)
+  const result = detectLanHost({
+    networkInterfaces: fakeNetifs({
+      lo0: [iface('127.0.0.1', 'IPv4', true)],
+      eth0: [iface('172.18.0.2', 'IPv4')],
+    }),
+    isDocker: false,
+  });
+  assert(result !== null && result.host === '172.18.0.2', 'docker-aware LAN: 172.18.0.2 kept when isDocker=false (legitimate corporate LAN)');
+}
+
+{
+  // detectLanHost with isDocker=true skips Docker IP but picks up a non-Docker LAN
+  const result = detectLanHost({
+    networkInterfaces: fakeNetifs({
+      lo0: [iface('127.0.0.1', 'IPv4', true)],
+      eth0: [iface('172.18.0.2', 'IPv4')], // Docker bridge — skip
+      eth1: [iface('192.168.1.50', 'IPv4')], // real LAN — keep
+    }),
+    isDocker: true,
+  });
+  assert(result?.host === '192.168.1.50', 'docker-aware LAN: skips Docker IP, picks real LAN if present');
+}
+
+{
+  // detectGatewayHost forwards isDocker to detectLanHost
+  const result = detectGatewayHost({
+    networkInterfaces: fakeNetifs({
+      eth0: [iface('172.18.0.2', 'IPv4')],
+    }),
+    isDocker: true,
+  });
+  assert(result === null, 'composed: detectGatewayHost returns null in Docker when only Docker-internal IP found');
 }
 
 // ---------------------------------------------------------------------------

--- a/skill/plugin/gateway-url.ts
+++ b/skill/plugin/gateway-url.ts
@@ -127,26 +127,65 @@ function shouldSkipIface(name: string): boolean {
 }
 
 /**
+ * Docker container internal IP detection — issue #110 fix 4.
+ *
+ * From INSIDE a Docker container, `eth0` carries the container's bridge IP
+ * (e.g. `172.18.0.2`). That IP is reachable from other containers on the
+ * SAME Docker network but NOT from the host browser, the user's phone, or
+ * any external device. Surfacing it as the pairing URL produces a hard-
+ * dead user experience: "scan QR" yields connection-refused.
+ *
+ * Docker default-bridge ranges:
+ *   - 172.17.0.0/16 — `bridge` (default)
+ *   - 172.18.0.0/16 .. 172.31.0.0/16 — user-defined networks
+ *
+ * We use the conservative test: 172.16.0.0/12 (the full RFC-1918 172.x
+ * range, which is what Docker draws from). If the host is clearly Docker
+ * (`/.dockerenv`), we treat 172.16-31.x.x AS Docker-internal and skip it.
+ *
+ * Outside Docker, 172.16.x.x can be a legitimate corporate LAN, so we
+ * only apply the rule when we have positive Docker evidence.
+ */
+export function isDockerInternalIp(addr: string): boolean {
+  if (!/^\d{1,3}(?:\.\d{1,3}){3}$/.test(addr)) return false;
+  const parts = addr.split('.').map((p) => Number.parseInt(p, 10));
+  if (parts[0] !== 172) return false;
+  return parts[1] >= 16 && parts[1] <= 31;
+}
+
+/**
  * Pick the first non-loopback, non-virtual IPv4 address. Returns null if
  * none found (headless VPS with only lo + tailscale, for example).
+ *
+ * issue #110 fix 4: when the host is detected as Docker (caller passes
+ * `isDocker: true`), skip Docker-bridge IPs in the 172.16/12 range — they
+ * are container-internal and useless for any external browser. Returning
+ * null from this function in that scenario lets `buildPairingUrl` fall
+ * through to the localhost-with-relay-fallback warning rather than handing
+ * the user a dead URL.
  */
 export function detectLanHost(options?: {
   /** Override os.networkInterfaces for tests. */
   networkInterfaces?: () => NodeJS.Dict<os.NetworkInterfaceInfo[]>;
+  /** True when the host is Docker — skips 172.16/12 bridge IPs. */
+  isDocker?: boolean;
 }): DetectedGatewayHost | null {
   const nif = (options?.networkInterfaces ?? os.networkInterfaces)();
   for (const [name, addrs] of Object.entries(nif)) {
     if (shouldSkipIface(name)) continue;
     if (!addrs) continue;
     for (const a of addrs) {
-      if (a.family === 'IPv4' && !a.internal) {
-        return {
-          kind: 'lan',
-          host: a.address,
-          tls: false,
-          note: `LAN IPv4 on interface ${name} — only reachable from the same network.`,
-        };
-      }
+      if (a.family !== 'IPv4' || a.internal) continue;
+      // issue #110 fix 4 — Docker container internal IP is unreachable
+      // from any external browser. Skip it so the caller falls back to
+      // the relay-brokered URL.
+      if (options?.isDocker && isDockerInternalIp(a.address)) continue;
+      return {
+        kind: 'lan',
+        host: a.address,
+        tls: false,
+        note: `LAN IPv4 on interface ${name} — only reachable from the same network.`,
+      };
     }
   }
   return null;
@@ -162,13 +201,22 @@ export function detectLanHost(options?: {
  *
  * Sync: no I/O, no subprocess, no network. Safe in sync callers like
  * `buildPairingUrl` in index.ts.
+ *
+ * issue #110 fix 4: the `isDocker` option, when true, skips the 172.16/12
+ * Docker-bridge range during LAN detection. The caller (index.ts) passes
+ * `isRunningInDocker()` so we don't surface a container-internal IP that
+ * no external browser can reach.
  */
 export function detectGatewayHost(options?: {
   networkInterfaces?: () => NodeJS.Dict<os.NetworkInterfaceInfo[]>;
+  isDocker?: boolean;
 }): DetectedGatewayHost | null {
   const ts = detectTailscaleHost({ networkInterfaces: options?.networkInterfaces });
   if (ts) return ts;
-  const lan = detectLanHost({ networkInterfaces: options?.networkInterfaces });
+  const lan = detectLanHost({
+    networkInterfaces: options?.networkInterfaces,
+    isDocker: options?.isDocker,
+  });
   if (lan) return lan;
   return null;
 }

--- a/skill/plugin/import-time-smoke.test.ts
+++ b/skill/plugin/import-time-smoke.test.ts
@@ -1,0 +1,57 @@
+/**
+ * import-time-smoke.test.ts — regression guard for issue #110 fix 2.
+ *
+ * Background
+ *   rc.18 manual QA (issue #110): "Plugin init blocks CLI for ~2hr (likely
+ *   ONNX 216MB synchronous download on module-load)". `embedding.ts` is
+ *   already lazy (model loads on first generateEmbedding call), but this
+ *   test asserts the GUARANTEE: importing the plugin's default-export
+ *   completes in well under 5 seconds with no network access required.
+ *
+ * What this catches
+ *   - Future regression that adds eager `await Auto*.from_pretrained(...)`
+ *     to module-top-level (fetches ONNX, blocks for minutes on slow links).
+ *   - Eager subgraph queries / api-staging round-trips at import.
+ *   - Sync `fs.readFileSync` of large credentials on every import.
+ *
+ * Bound: 5000ms is generous (cold node + jiti + 6kLoC plugin); typical
+ * macOS dev box is ~150ms. CI Linux runners are ~300-500ms. If this test
+ * starts timing out without an obvious heavy-init culprit, look at new
+ * top-level `await import('./...')` in index.ts.
+ *
+ * Runtime
+ *   `npx tsx import-time-smoke.test.ts` (matches the rest of the suite).
+ *
+ * NOTE: this test imports the SOURCE `./index.ts` via tsx — it does NOT
+ * exercise the built `dist/index.js` (the actual shipped artifact). The
+ * publish workflow runs a separate `node --check dist/index.js` step in
+ * `verify-tarball.mjs` that catches dist-side regressions.
+ */
+
+import assert from 'node:assert/strict';
+
+const START = Date.now();
+const mod = await import('./index.js');
+const ELAPSED = Date.now() - START;
+
+const BUDGET_MS = 5000;
+
+assert.ok(
+  typeof mod.default === 'object' && mod.default !== null,
+  'plugin default export must be an object',
+);
+assert.equal(
+  (mod.default as { id?: string }).id,
+  'totalreclaw',
+  'plugin id must be "totalreclaw"',
+);
+assert.ok(
+  ELAPSED < BUDGET_MS,
+  `plugin module import took ${ELAPSED}ms, budget is ${BUDGET_MS}ms — possible regression to eager ONNX load (issue #110 fix 2)`,
+);
+
+console.log(`ok 1 - plugin import took ${ELAPSED}ms (< ${BUDGET_MS}ms budget)`);
+console.log('ok 2 - plugin default export is an object with id="totalreclaw"');
+console.log('# fail: 0');
+console.log('# 2/2 passed');
+console.log('ALL TESTS PASSED');

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -341,8 +341,17 @@ function buildPairingUrl(
   // Layers 4 + 5 — auto-detect via gateway-url helper (Tailscale CGNAT, then LAN)
   else {
     let detected: ReturnType<typeof detectGatewayHost> = null;
+    // issue #110 fix 4 — pass `isDocker` so LAN detection skips
+    // 172.16/12 bridge IPs that no external browser can reach.
+    let isDocker = false;
     try {
-      detected = detectGatewayHost();
+      isDocker = isRunningInDocker();
+    } catch {
+      // Defensive: never block URL building on Docker sniff errors.
+      isDocker = false;
+    }
+    try {
+      detected = detectGatewayHost({ isDocker });
     } catch (err) {
       api.logger.warn(
         `TotalReclaw: host autodetect crashed: ${err instanceof Error ? err.message : String(err)} — falling back to localhost`,
@@ -368,9 +377,27 @@ function buildPairingUrl(
           `Set plugins.entries.totalreclaw.config.publicUrl for remote access.`,
       );
     } else {
-      // Layer 6 — localhost fallback
+      // Layer 6 — localhost fallback (or Docker-aware relay-pointer warning)
       const bind = cfg?.gateway?.bind;
-      if (bind === 'lan' || bind === 'tailnet') {
+      if (isDocker) {
+        // issue #110 fix 4: inside Docker the LAN IP is container-internal
+        // and useless. Loopback localhost only works for `docker exec`
+        // tests. The CORRECT pair URL for Docker is the relay-brokered
+        // path served by the `totalreclaw_pair` agent tool (CONFIG.pairMode
+        // === 'relay' since rc.11). The CLI-only path here cannot mint a
+        // relay session synchronously (the relay handshake needs a WS
+        // round-trip), so we emit the loopback URL with a LOUD warning
+        // pointing the operator at the agent tool / publicUrl override.
+        api.logger.warn(
+          `TotalReclaw: Docker container detected — pairing URL falling back to ` +
+            `http://localhost:${port}, which is unreachable from the host browser. ` +
+            `Use the totalreclaw_pair AGENT TOOL (relay-brokered, universally reachable) ` +
+            `instead of the CLI fallback, OR set plugins.entries.totalreclaw.config.publicUrl ` +
+            `to your gateway's host-reachable URL (e.g. http://<host-ip>:${port} when the ` +
+            `Docker port is published). Setting TOTALRECLAW_PAIR_MODE=relay is the default; ` +
+            `air-gapped operators on TOTALRECLAW_PAIR_MODE=local must publish a port + set publicUrl.`,
+        );
+      } else if (bind === 'lan' || bind === 'tailnet') {
         api.logger.warn(
           `TotalReclaw: pairing URL falling back to localhost because gateway.bind=${bind} could not be autodetected. ` +
             'Set plugins.entries.totalreclaw.config.publicUrl to override.',
@@ -5189,6 +5216,16 @@ const plugin = {
         },
       },
       { name: 'totalreclaw_pair' },
+    );
+    // 3.3.1-rc.20 (issue #110): explicit post-registration breadcrumb so
+    // ops/QA can grep gateway logs for definitive proof the tool was
+    // declared. If the agent then reports the tool is missing from its
+    // tool list, the gap is upstream OpenClaw tool propagation, not our
+    // plugin — see issue #110 fix 3 + PR #102 (CLI fallback).
+    api.logger.info(
+      'TotalReclaw: registerTool(totalreclaw_pair) returned. If the agent does not see it in its tool list ' +
+        'after gateway restart, the issue is upstream tool injection (containerized agents) — fall back to ' +
+        '`openclaw totalreclaw pair generate --url-pin-only` (PR #102) or `openclaw totalreclaw onboard --pair-only`.',
     );
 
     // ---------------------------------------------------------------

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -41,7 +41,13 @@
     "qrcode-terminal": "^0.12.0",
     "ws": "^8.18.3"
   },
+  "devDependencies": {
+    "typescript": "^5.5.0"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "files": [
+    "dist/",
     "*.ts",
     "import-adapters/",
     "!**/*.test.ts",
@@ -54,13 +60,16 @@
     "skill.json"
   ],
   "scripts": {
-    "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx llm-client-retry.test.ts && npx tsx gateway-url.test.ts && npx tsx retype-setscope.test.ts && npx tsx tool-gating.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts && npx tsx pair-qr.test.ts && npx tsx pair-remote-client.test.ts && npx tsx qa-bug-report.test.ts && npx tsx nonce-serialization.test.ts && npx tsx phrase-safety-registry.test.ts && npx tsx test_issue_92_onnx_download_ux.test.ts && npx tsx onboard-pair-only.test.ts",
+    "build": "rm -rf dist && tsc -p tsconfig.json --noCheck",
+    "verify-tarball": "node ../scripts/verify-tarball.mjs",
+    "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx llm-client-retry.test.ts && npx tsx gateway-url.test.ts && npx tsx retype-setscope.test.ts && npx tsx tool-gating.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts && npx tsx pair-qr.test.ts && npx tsx pair-remote-client.test.ts && npx tsx qa-bug-report.test.ts && npx tsx nonce-serialization.test.ts && npx tsx phrase-safety-registry.test.ts && npx tsx test_issue_92_onnx_download_ux.test.ts && npx tsx onboard-pair-only.test.ts && npx tsx import-time-smoke.test.ts",
     "check-scanner": "node ../scripts/check-scanner.mjs",
+    "prepack": "npm run build",
     "prepublishOnly": "node ../scripts/check-scanner.mjs"
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ]
   }
 }

--- a/skill/plugin/tsconfig.json
+++ b/skill/plugin/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "declaration": false,
+    "sourceMap": false,
+    "noEmitOnError": false,
+    "isolatedModules": false,
+    "forceConsistentCasingInFileNames": true,
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"]
+  },
+  "include": [
+    "*.ts",
+    "import-adapters/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "pocv2-e2e-test.ts"
+  ]
+}

--- a/skill/scripts/verify-tarball.mjs
+++ b/skill/scripts/verify-tarball.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * verify-tarball.mjs — Pre-publish gate for the @totalreclaw/totalreclaw plugin.
+ *
+ * Purpose
+ *   Issue #110 (rc.18 manual QA): the published npm tarball shipped raw
+ *   .ts source — `index.ts` did `import './crypto.js'` but only `crypto.ts`
+ *   existed. Gateway loaded fine via OpenClaw's TS loader; CLI subcommand
+ *   path that resolved literal `./crypto.js` couldn't find the file.
+ *
+ *   This gate runs RIGHT BEFORE `npm publish` and asserts:
+ *
+ *     (1) `dist/` exists in the project tree (built artifact dir).
+ *     (2) Every `import './X.js'` referenced in shipped TS sources has a
+ *         matching `dist/X.js` file. Tarball ships both `*.ts` AND `dist/`,
+ *         so anything that resolves `.js` literally MUST find a built file.
+ *     (3) `package.json:openclaw.extensions[0]` points at a file that
+ *         exists in `dist/` (the entry the OpenClaw loader will mount).
+ *
+ *   Failing any check exits non-zero — the publish workflow fails fast
+ *   instead of putting a broken tarball on the registry.
+ *
+ * Wiring
+ *   - `npm run verify-tarball` from skill/plugin/ (runs after `prepack`'s build)
+ *   - Re-run from `.github/workflows/npm-publish.yml` `publish-plugin` job
+ *     as a defense-in-depth step.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+
+const HERE = path.dirname(url.fileURLToPath(import.meta.url));
+// skill/scripts/ -> skill/plugin/
+const PLUGIN_DIR = path.resolve(HERE, '..', 'plugin');
+const DIST_DIR = path.join(PLUGIN_DIR, 'dist');
+const PKG_PATH = path.join(PLUGIN_DIR, 'package.json');
+
+function fail(msg) {
+  console.error('verify-tarball: FAIL —', msg);
+  process.exit(1);
+}
+
+function ok(msg) {
+  console.log('verify-tarball: OK —', msg);
+}
+
+// ---- Check 1: dist/ exists -------------------------------------------------
+if (!fs.existsSync(DIST_DIR) || !fs.statSync(DIST_DIR).isDirectory()) {
+  fail(
+    `dist/ directory missing at ${DIST_DIR}. Run \`npm run build\` from skill/plugin/ before publishing. ` +
+      `The npm tarball must contain compiled .js files so CLI subcommand paths can resolve literal './X.js' imports ` +
+      `(see issue #110 — rc.18 shipped only .ts and broke gateway-CLI subcommand resolution).`,
+  );
+}
+
+// ---- Check 2: every '.js' import target has a corresponding dist/X.js ------
+function readSourceImports(dir, prefix = '') {
+  const out = new Map(); // basename without ext -> [referencing file]
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+    if (entry.name.startsWith('.')) continue;
+    const full = path.join(dir, entry.name);
+    const rel = prefix ? path.posix.join(prefix, entry.name) : entry.name;
+    if (entry.isDirectory()) {
+      for (const [k, v] of readSourceImports(full, rel)) {
+        out.set(k, [...(out.get(k) ?? []), ...v]);
+      }
+      continue;
+    }
+    if (!entry.name.endsWith('.ts')) continue;
+    if (entry.name.endsWith('.test.ts')) continue;
+    if (entry.name === 'pocv2-e2e-test.ts') continue;
+    const src = fs.readFileSync(full, 'utf8');
+    // Match `from './foo.js'`, `import('./foo.js')`, `from './sub/foo.js'`, etc.
+    const re = /(?:from|import\()\s*['"](\.\/[^'"]+\.js)['"]\)?/g;
+    let m;
+    while ((m = re.exec(src)) !== null) {
+      const importPath = m[1]; // e.g. './crypto.js' or './import-adapters/types.js'
+      // Resolve relative to the file's own dir (so subdir imports are correct)
+      const fileDir = path.dirname(rel);
+      const resolved = path.posix.normalize(
+        path.posix.join(fileDir, importPath.replace(/^\.\//, '')),
+      );
+      const distRel = resolved; // already relative to PLUGIN_DIR root
+      const arr = out.get(distRel) ?? [];
+      arr.push(rel);
+      out.set(distRel, arr);
+    }
+  }
+  return out;
+}
+
+const imports = readSourceImports(PLUGIN_DIR);
+const missing = [];
+for (const [importTarget, refs] of imports.entries()) {
+  const distFile = path.join(DIST_DIR, importTarget);
+  if (!fs.existsSync(distFile)) {
+    missing.push({ importTarget, refs });
+  }
+}
+if (missing.length > 0) {
+  console.error('verify-tarball: FAIL — missing dist/ artifacts for these .js imports:');
+  for (const { importTarget, refs } of missing.slice(0, 20)) {
+    console.error(`  - dist/${importTarget}  (referenced by ${refs.slice(0, 3).join(', ')}${refs.length > 3 ? ', ...' : ''})`);
+  }
+  if (missing.length > 20) {
+    console.error(`  ... and ${missing.length - 20} more`);
+  }
+  console.error('');
+  console.error(
+    'Run `npm run build` from skill/plugin/ to regenerate dist/. The TS source uses ` /* */ from \'./X.js\'` style ' +
+      'imports (Node ESM convention); the .js extension MUST resolve to a real file at runtime, ' +
+      'and OpenClaw\'s `jiti` loader is not guaranteed to be available on every plugin entry path.',
+  );
+  process.exit(1);
+}
+ok(`${imports.size} '.js' import targets — all resolve to dist/`);
+
+// ---- Check 3: openclaw.extensions[0] points at an existing dist/ file ------
+const pkg = JSON.parse(fs.readFileSync(PKG_PATH, 'utf8'));
+const exts = pkg?.openclaw?.extensions;
+if (!Array.isArray(exts) || exts.length === 0) {
+  fail('package.json has no openclaw.extensions entry');
+}
+const entry = exts[0];
+const entryAbs = path.resolve(PLUGIN_DIR, entry);
+if (!fs.existsSync(entryAbs)) {
+  fail(
+    `openclaw.extensions[0] = "${entry}" but ${entryAbs} does not exist. ` +
+      `Run \`npm run build\` to regenerate dist/, or update openclaw.extensions to point at a built file.`,
+  );
+}
+ok(`openclaw.extensions[0] (${entry}) resolves to a built file`);
+
+// ---- Check 4: smoke-load the entry to catch syntax errors ------------------
+//
+// This catches TS-emitted JS that node refuses to parse (rare but possible
+// when --noCheck masks a syntax-level problem). We `node --check` the
+// file rather than executing it, so we don't trigger the heavy module-load
+// side effects.
+import { execSync } from 'node:child_process';
+try {
+  execSync(`node --check ${JSON.stringify(entryAbs)}`, { stdio: 'pipe' });
+  ok(`node --check ${path.relative(PLUGIN_DIR, entryAbs)} — syntax valid`);
+} catch (err) {
+  const stderr = err?.stderr?.toString?.() ?? String(err);
+  fail(`node --check failed on ${entry}:\n${stderr}`);
+}
+
+console.log('verify-tarball: all checks passed.');


### PR DESCRIPTION
## Summary

User-reported manual QA on `@totalreclaw/totalreclaw@rc` (rc.18) hit four blocker-class issues during install + pairing. This PR addresses all four cohesively.

- **Fix 1 (tarball ships built `.js`)** — rc.18 npm tarball shipped raw `.ts`. `index.ts` did `import './crypto.js'` but only `crypto.ts` existed. Gateway loaded fine via OpenClaw's `jiti` TS loader; CLI subcommand path that resolved literal `./crypto.js` failed. Now ships `dist/.js` alongside `*.ts`; `openclaw.extensions[0] = './dist/index.js'`. Pre-publish `verify-tarball` gate asserts every `'./X.js'` import has a real `dist/X.js`.
- **Fix 2 (lazy-load smoke regression guard)** — `embedding.ts` is already lazy (Issue #92 / PR #105); added an `import-time-smoke.test.ts` that fails CI if the default-export import takes >5s, plus a clean-Node tarball smoke step in `npm-publish.yml` that catches eager-load regressions before publish.
- **Fix 3 (`totalreclaw_pair` tool-injection)** — root cause is upstream OpenClaw containerized-agent tool propagation. PR #102 already shipped the `--url-pin-only` CLI fallback. Added a post-registration `api.logger.info(...)` breadcrumb so gateway-log greps definitively confirm our side did register the tool. No upstream blocker on our end; the CLI fallback IS the canonical workaround until OpenClaw fixes container injection.
- **Fix 4 (pair URL ≠ Docker container IP)** — user got `172.18.0.2:18789` (Docker bridge IP, useless from host browser). Added `isDockerInternalIp` (172.16.0.0/12) + plumbed `isDocker` (via `isRunningInDocker()`) into `detectGatewayHost` / `detectLanHost`. Inside Docker, container-bridge IPs are now skipped; `buildPairingUrl` falls through to localhost with a LOUD warning that points the operator at the `totalreclaw_pair` agent tool (relay-brokered since rc.11) or at setting `publicUrl`.

## Pre-publish gates added

- `.github/workflows/ci.yml` (PR-time)
- `.github/workflows/npm-publish.yml` (publish-plugin job)
- `.github/workflows/publish-clawhub.yml` (publish job)

Each runs: `npm run check-scanner` (existing) → `npm run build` (new) → `npm test` → `npm run verify-tarball` (new). The npm publish step adds a clean-Node tarball install + `await import(...)` smoke check that asserts <5s import.

## Test plan

- [x] `npm test` (skill/plugin) — 18 suites, all green; new `import-time-smoke` (2/2) and Docker IP detection (13 new cases in `gateway-url.test.ts`, 30/30 total)
- [x] `npm run build` clean exit; emits 37 `.js` files
- [x] `npm run verify-tarball` clean exit; 42 `.js` import targets resolve
- [x] `npm run check-scanner` clean exit; 96 files, 0 flags
- [x] `node --input-type=module -e "import('./dist/index.js')"` returns `default.id === 'totalreclaw'` in 143ms cold
- [ ] CI green
- [ ] Auto-QA on the next RC publish exercises the Docker container case end-to-end (the existing QA-VPS Docker setup will surface the new warning copy and validate the agent tool path is taken)

## Constraints respected

- No crypto / phrase-handling / paymaster code changed
- No version bump (next RC publish appends `-rc.<N>` in workflow)
- No install-command changes (only build artifacts)
- Phrase-safety registry test still passes — no tool registration changes

Closes p-diogo/totalreclaw#110.

🤖 Auto-triage Phase 3 (issue #110 fix bundle).