### PR TITLE
docs+skill: URL-driven install flow (single happy path)

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -1,76 +1,75 @@
-# Hermes Agent + TotalReclaw
+# TotalReclaw for Hermes
 
-TotalReclaw gives your Hermes agent encrypted, persistent memory. Two install approaches — pick whichever fits your workflow.
+TotalReclaw gives your Hermes agent encrypted, persistent memory. The fastest setup is a single chat message — the agent fetches this guide, runs the install for you, and walks you through pairing. **You do nothing in the terminal.**
 
-## Fastest — shell + chat (Approach A, preferred)
+If you already have Hermes running, paste this into your Hermes chat:
 
-Terminal:
+> **Install TotalReclaw, see <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md>**
 
-```bash
-# Install the Hermes plugin (Git-based discovery in Hermes 2026.4.16+)
-hermes plugins install p-diogo/totalreclaw-hermes --enable
+Your agent will fetch this page, run the install commands, ask you to restart the gateway once (Hermes doesn't auto-reload), and then hand you a pair URL + 6-digit PIN. You open the URL in your browser, generate or restore a 12-word recovery phrase there, confirm the PIN, and you're done.
 
-# Ensure the backing Python package is in your Hermes venv
-/path/to/hermes/venv/bin/python3 -m pip install --pre totalreclaw
-# (or just `pip install --pre totalreclaw` if your pip resolves to hermes's venv)
+---
 
-# Restart the gateway. Pick the line that matches your setup:
-hermes gateway restart                       # native install
-docker restart <your-hermes-container>       # Docker self-host (substitute your container name; `docker ps` shows it)
-# Managed Hermes service: use the service's restart control (web UI). See the "Managed Hermes service" section below.
-```
+## Agent instructions (read this if you are a Hermes agent that just fetched this URL)
 
-Then in your Hermes chat:
+You have been asked to install TotalReclaw. Run the steps below in order. Do not deviate, do not ask the user to run any terminal command other than the gateway restart in Step 2, do not echo or generate a recovery phrase.
 
-> **Set up TotalReclaw**
+### Step 1 — Install the plugin + Python package
 
-The agent will call the pairing tool and give you a URL + PIN. Open the URL, enter your recovery phrase, confirm PIN. Done.
-
-Why two install commands? Hermes 2026.4.16+ uses Git-based plugin discovery. `hermes plugins install p-diogo/totalreclaw-hermes --enable` registers the plugin manifest from the Git repo; `pip install --pre totalreclaw` supplies the Python tool implementations in the Hermes venv. The chat prompt then triggers the skill's fast path: check for existing credentials, call `totalreclaw_pair`, relay URL + PIN.
-
-<details>
-<summary><strong>Approach B — explicit two-step (fallback)</strong></summary>
-
-If you'd rather spell out every step explicitly (useful if the agent doesn't know about TotalReclaw yet), install the same way but use this verbose chat prompt:
-
-Terminal:
+Run via your shell tool, in this order:
 
 ```bash
-# Install the Hermes plugin (Git-based discovery in Hermes 2026.4.16+)
 hermes plugins install p-diogo/totalreclaw-hermes --enable
-
-# Ensure the backing Python package is in your Hermes venv
-/path/to/hermes/venv/bin/python3 -m pip install --pre totalreclaw
-# (or just `pip install --pre totalreclaw` if your pip resolves to hermes's venv)
-
-# Restart the gateway. Pick the line that matches your setup:
-hermes gateway restart                       # native install
-docker restart <your-hermes-container>       # Docker self-host (substitute your container name)
-# Managed Hermes service: use the service's restart control (web UI).
+pip install --pre totalreclaw
 ```
 
-Then in your Hermes chat:
+Notes:
+- Hermes 2026.4.16+ uses Git-based plugin discovery: the first command registers the plugin manifest, the second installs the Python tool implementations into the Hermes venv.
+- If Hermes runs in its own venv that your default `pip` doesn't resolve to, use the venv's pip directly: `/path/to/hermes/venv/bin/python3 -m pip install --pre totalreclaw`.
+- On Ubuntu / Debian / Docker you may hit `externally-managed-environment` — add `--break-system-packages` or use a venv.
+- If either command fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment), STOP and tell the user verbatim: *"Your environment doesn't expose the Hermes CLI / pip to me. Please install `p-diogo/totalreclaw-hermes` and the `totalreclaw` Python package via your service's plugins UI, then reply `done`."* Wait for `done` before continuing to Step 2.
 
-> **TotalReclaw is already installed. Use the totalreclaw_pair tool to walk me through the QR recovery-phrase setup.**
+### Step 2 — Ask the user to restart the gateway
 
-The agent reads the explicit directive, calls `totalreclaw_pair`, and guides you through the QR flow.
+Hermes does NOT auto-reload on plugin install. Tell the user verbatim:
 
-</details>
+> *Please restart your Hermes gateway: `hermes gateway restart` (native), `docker restart <your-container-name>` (Docker self-host — substitute the actual name; `docker ps` shows it), or your managed service's restart control. If supervised by systemd / launchd, `kill -USR1 $(cat ~/.hermes/gateway.pid)` triggers a graceful-drain restart. Reply `done` once it's back up.*
 
-<details>
-<summary>What happens behind the scenes</summary>
+Do NOT invoke the restart yourself — your shell runs inside the gateway you'd be restarting. Wait for the user's `done`.
 
-1. Agent reads its TotalReclaw skill, picks up that `totalreclaw_*` tools are (or should be) live.
-2. Agent checks `~/.totalreclaw/credentials.json`; if absent, calls the `totalreclaw_pair` tool.
-3. A pair URL + 6-digit PIN is surfaced back to you in chat.
-4. You open the URL in your browser. The pair page offers two tabs: **Generate new** (the browser creates a fresh 12-word recovery phrase using the canonical BIP-39 wordlist) and **Import existing** (paste a phrase you already have). Pick one, confirm the 6-digit PIN, and continue.
-5. The browser performs x25519 ECDH against the gateway's ephemeral pubkey, derives an AES-256-GCM key via HKDF-SHA256, encrypts the phrase locally, and POSTs ciphertext + nonce + its pubkey to the gateway.
-6. The gateway decrypts server-side and writes `~/.totalreclaw/credentials.json` (mode `0600`).
-7. The agent confirms setup and your memory tools are live.
+### Step 3 — Check for existing credentials
 
-The recovery phrase never crosses the LLM context — not the chat transcript, not the agent's shell stdout, not any tool-call payload. Browser-side crypto keeps it isolated by construction.
+Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, confirm *"TotalReclaw is already set up."* and stop. Otherwise continue.
 
-</details>
+### Step 4 — Pair (browser flow, NEVER ask the user to type their phrase in chat)
+
+Call the `totalreclaw_pair` tool. It returns `{url, pin, expires_at_ms}`.
+
+Relay to the user verbatim:
+
+> *Open <url> in your browser. Generate a new 12-word recovery phrase there or paste an existing one — the phrase stays in your browser, the relay only sees ciphertext. Confirm PIN <pin>. Reply `done` once the page says it's sealed.*
+
+### Step 5 — Verify and confirm
+
+After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN likely expired — call `totalreclaw_pair` again and resend. If present, confirm *"TotalReclaw is set up. Ask me to remember or recall anything."*
+
+### Phrase safety (HARD — never break)
+
+NEVER echo, generate, or ask the user to paste a recovery phrase in chat. NEVER invoke `totalreclaw setup`, `hermes setup`, or any phrase-touching CLI via your shell tool — stdout enters LLM context. The ONLY agent-facilitated setup path is the `totalreclaw_pair` tool. If the user pastes a phrase anyway: tell them it is compromised and call `totalreclaw_pair` with `mode=generate` for a fresh wallet.
+
+---
+
+## What's happening (for the human reader)
+
+1. `hermes plugins install p-diogo/totalreclaw-hermes --enable` — registers TotalReclaw's plugin manifest from its Git repo.
+2. `pip install --pre totalreclaw` — installs the Python tool implementations into the Hermes venv. `--pre` resolves to the latest release candidate; drop it once a stable is promoted.
+3. The agent asks you to restart the Hermes gateway. (Hermes does not yet auto-reload on plugin install — tracked upstream.) After restart, the new tools bind.
+4. The agent calls `totalreclaw_pair`, which generates an ephemeral x25519 keypair on the gateway and a 6-digit PIN. You get a URL + PIN.
+5. You open the URL. The pair page has two tabs: **Generate new** (the browser creates a fresh BIP-39 12-word phrase locally using `crypto.getRandomValues`) and **Import existing** (paste a phrase you already have). Pick one, confirm the 6-digit PIN, click seal.
+6. The browser performs x25519 ECDH against the gateway's ephemeral pubkey, derives an AES-256-GCM key via HKDF-SHA256, encrypts the phrase locally, and POSTs ciphertext + nonce + its pubkey back. The gateway decrypts server-side and writes `~/.totalreclaw/credentials.json` (mode `0600`).
+7. The recovery phrase never crosses the LLM context — not the chat transcript, not the agent's shell stdout, not any tool-call payload. Browser-side crypto keeps it isolated by construction.
+
+---
 
 ## Prerequisites
 
@@ -79,48 +78,76 @@ The recovery phrase never crosses the LLM context — not the chat transcript, n
 - Python 3.11+
 - An up-to-date browser with WebCrypto x25519 + AES-GCM (Safari 17.2+ or Chromium 133+)
 
-## Managed Hermes service (no terminal)
+---
 
-If you're on a managed / hosted Hermes service and don't have shell access to the gateway host, plugin installation typically happens through your service's web UI rather than the `hermes` CLI + `pip`. The flow is:
+## Managed Hermes service (no terminal, no agent shell)
+
+If you're on a managed / hosted Hermes service that doesn't expose host shell to the agent, install via the service's web UI instead:
 
 1. In your service's control panel, find the **Plugins** panel and search for `totalreclaw` (or `p-diogo/totalreclaw-hermes`). Install and enable it. Most managed Hermes deployments handle the underlying Python-package install transparently as part of plugin enable.
-2. If the service exposes a separate restart control, restart your agent through that. Many managed services apply plugin changes transparently and skip this step.
-3. Return to chat and say **`Set up TotalReclaw`**. Your agent will call `totalreclaw_pair` and walk you through the QR pairing flow — open the URL it returns, enter or generate your 12-word recovery phrase in the browser, and confirm the 6-digit PIN.
+2. If the service exposes a separate restart control, use it.
+3. Return to chat and paste the same canonical message:
 
-The browser-side crypto and pairing flow are identical to self-hosted setups; only the install + restart step differs.
+   > **Install TotalReclaw, see <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md>**
+
+   The agent will detect the plugin is already loaded, skip Steps 1-2, and jump straight to pairing.
+
+The browser-side crypto and pairing flow are identical to self-hosted setups.
 
 > Managed-Hermes coverage is still emerging — if your service doesn't expose `totalreclaw` in its plugins UI yet, ask their support to surface the `p-diogo/totalreclaw-hermes` Hermes plugin + `totalreclaw` Python package, or run a self-hosted Hermes instance for now.
 
-> The CLI-driven install commands above (`hermes plugins install`, `pip install --pre totalreclaw`) assume you have terminal access on the gateway host and a writable Hermes Python venv. They will not work on a managed service that doesn't expose the host shell — use the steps above instead.
+---
 
-## Notes on `--pre`
+## Fully manual (CLI only — last resort)
 
-`--pre` lets pip resolve to the latest release candidate without pinning a version. Drop `--pre` once a stable is promoted. Ubuntu/Debian/Docker: add `--break-system-packages` or use a venv if you hit `externally-managed-environment`.
+If you can't or won't use the chat flow (self-hosted only — managed services don't expose the host shell):
+
+```bash
+hermes plugins install p-diogo/totalreclaw-hermes --enable
+pip install --pre totalreclaw       # or your hermes venv's pip
+
+# Restart the gateway. Pick the line that matches your setup:
+hermes gateway restart                       # native install
+docker restart <your-hermes-container>       # Docker self-host (substitute your actual container name)
+# Managed service: use the service's restart control (web UI).
+```
+
+Then in chat: *"Set up TotalReclaw"* — the agent will call `totalreclaw_pair` and hand you the URL + PIN.
+
+---
 
 ## Upgrading
 
 If you were on plugin 3.3.1-rc.2 or Hermes 2.3.1rc2, after upgrading also run `pip install --force-reinstall hermes-agent` to restore the `hermes` CLI entrypoint that rc.2's console-script collision left stale. Fresh installs are unaffected.
 
+---
+
 ## Troubleshooting
 
-- **Agent can't see TotalReclaw tools**: confirm both install steps completed — on a self-host, `hermes plugins list` should show `p-diogo/totalreclaw-hermes` enabled and `pip show totalreclaw` in the Hermes venv should resolve; on a managed service, confirm `totalreclaw` is listed in your service's plugins UI. Then restart: `hermes gateway restart` (native), `docker restart <your-hermes-container>` (Docker self-host — substitute your actual container name), or your managed service's restart control. If your Hermes is supervised by systemd / launchd, sending `SIGUSR1` triggers a graceful-drain restart that's typically faster than `systemctl restart`: `kill -USR1 $(cat ~/.hermes/gateway.pid)`. The supervisor respawns the gateway cleanly. (Hermes does not yet auto-reload on plugin install — tracked upstream; for now manual restart is required.)
+- **Agent says "I'm not familiar with TotalReclaw"**: paste the canonical message above with the URL — the agent fetches the guide and follows the install steps.
+- **Agent can't see TotalReclaw tools after install**: confirm both install steps completed — on a self-host, `hermes plugins list` should show `p-diogo/totalreclaw-hermes` enabled and `pip show totalreclaw` in the Hermes venv should resolve; on a managed service, confirm `totalreclaw` is listed in your service's plugins UI. Then restart: `hermes gateway restart` (native), `docker restart <your-hermes-container>` (Docker self-host), or your managed service's restart control. If supervised by systemd / launchd, `kill -USR1 $(cat ~/.hermes/gateway.pid)` is faster than `systemctl restart`. (Hermes does not yet auto-reload on plugin install — tracked upstream.)
 - **Pair URL returns 404**: check that `~/.totalreclaw/credentials.json` isn't locked by a previous process and that the gateway is running.
 - **Browser fails to POST the encrypted phrase**: check the pair page's Content-Security-Policy — older browsers without WebCrypto x25519 (pre-Safari 17.2 / Chromium 118) cannot run the AEAD crypto.
 - **"No LLM available for auto-extraction"**: configure a provider in Hermes (`hermes login` or set `ZAI_API_KEY` / `OPENAI_API_KEY` in `~/.hermes/.env`). TotalReclaw reuses it automatically.
 - **Recovery phrase appeared in chat**: file a bug. Rotate by generating a new wallet via `totalreclaw_pair` with `mode=generate`. The leaked phrase is unrecoverable once shipped through LLM context.
 
+---
+
 ## Returning user (new machine)
 
-Paste the same canonical prompt. When the pair page loads, switch to the **Import existing** tab and enter your existing 12/24-word phrase. The browser encrypts it against the gateway's ephemeral key before uploading — the relay never sees plaintext.
+Paste the same canonical message. When the pair page loads, switch to the **Import existing** tab and enter your existing 12/24-word phrase. The browser encrypts it against the gateway's ephemeral key before uploading — the relay never sees plaintext.
 
 ## First-time user (no phrase yet)
 
-Paste the same canonical prompt. The **Generate new** tab is selected by default. Click **Generate new 12-word phrase** — the browser creates a BIP-39 phrase using its own `crypto.getRandomValues` against the inlined 2048-word wordlist. Write the 12 words down somewhere safe (a password manager is fine), tick the acknowledgment, and click **Seal key and finish**. That is your one and only recovery key — there is no reset.
+Paste the same canonical message. The **Generate new** tab is selected by default. Click **Generate new 12-word phrase** — the browser creates a BIP-39 phrase using its own `crypto.getRandomValues` against the inlined 2048-word wordlist. Write the 12 words down somewhere safe (a password manager is fine), tick the acknowledgment, and click **Seal key and finish**. That is your one and only recovery key — there is no reset.
 
-## Canonical prompts (these match the QA harness scenario contracts)
+---
 
-- Approach A: `Set up TotalReclaw`
-- Approach B: `TotalReclaw is already installed. Use the totalreclaw_pair tool to walk me through the QR recovery-phrase setup.`
+## Canonical prompt (matches the QA harness scenario contracts)
+
+> **Install TotalReclaw, see <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md>**
+
+---
 
 ## See also
 

--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -1,71 +1,73 @@
 # TotalReclaw for OpenClaw
 
-TotalReclaw gives your OpenClaw agent encrypted, persistent memory. Two install approaches — pick whichever fits your workflow.
+TotalReclaw gives your OpenClaw agent encrypted, persistent memory. The fastest setup is a single chat message — the agent fetches this guide, runs the install for you, and walks you through pairing. **You do nothing in the terminal.**
+
+If you already have OpenClaw running, paste this into your OpenClaw chat:
+
+> **Install TotalReclaw, see <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md>**
+
+Your agent will fetch this page, run the two install commands, and hand you a pair URL + 6-digit PIN. You open the URL in your browser, generate or restore a 12-word recovery phrase there, confirm the PIN, and you're done.
 
 ---
 
-## Fastest — skill + chat (Approach A, preferred)
+## Agent instructions (read this if you are an OpenClaw agent that just fetched this URL)
 
-Terminal:
+You have been asked to install TotalReclaw. Run the steps below in order. Do not deviate, do not ask the user to run terminal commands, do not echo or generate a recovery phrase.
 
-```bash
-openclaw skills install totalreclaw
+### Step 1 — Install the skill + plugin
 
-# Restart your gateway so the new skill is discoverable. Pick the line that matches your setup:
-openclaw gateway restart                       # native install
-docker restart <your-openclaw-container>       # Docker self-host (substitute your container name; `docker ps` shows it)
-# Managed OpenClaw service: use the service's restart control (web UI). See the "Managed OpenClaw service" section below.
-```
-
-Then in your OpenClaw chat:
-
-> **Install totalreclaw**
-
-The agent reads the skill, installs the plugin, waits for OpenClaw's auto-reload to bind the new tools (default `gateway.reload.mode = "hybrid"` triggers a graceful restart within 1-3s of the install), calls the pairing tool, and guides you through the QR flow. No second manual restart required for the common case.
-
-Why this works: ClawHub classifies `totalreclaw` as a skill. `openclaw skills install totalreclaw` registers the SKILL.md into agent context **before** the plugin itself is installed — so the agent has the instructions to bootstrap the rest. The one `openclaw gateway restart` in the terminal makes the skill discoverable; the plugin install happens via shell from the agent, and OpenClaw's config-watcher then auto-restarts the gateway to bind the new tools (no second user-driven restart needed unless `gateway.reload.mode = off`).
-
-<details>
-<summary><strong>Approach B — explicit two-step (fallback)</strong></summary>
-
-If you'd rather spell out every step explicitly (useful if you prefer more control), install the skill the same way but use a verbose chat prompt:
-
-Terminal:
+Run via your shell tool, in this order:
 
 ```bash
 openclaw skills install totalreclaw
-
-# Restart your gateway so the new skill is discoverable. Pick the line that matches your setup:
-openclaw gateway restart                       # native install
-docker restart <your-openclaw-container>       # Docker self-host (substitute your container name)
-# Managed OpenClaw service: use the service's restart control (web UI).
+openclaw plugins install @totalreclaw/totalreclaw
 ```
 
-Then in your OpenClaw chat:
+Notes:
+- For an RC build, replace the second command with `openclaw plugins install @totalreclaw/totalreclaw@rc` (or pin a version like `@totalreclaw/totalreclaw@3.3.1-rc.19`).
+- If either command fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment), STOP and tell the user verbatim: *"Your environment doesn't expose the OpenClaw CLI to me. Please install `totalreclaw` from your service's plugins / skills UI, then reply `done`."* Wait for `done` before continuing to Step 2.
 
-> **TotalReclaw is a skill at 'totalreclaw' on ClawHub. Please install the plugin (openclaw plugins install totalreclaw), then use the totalreclaw_pair tool to walk me through the QR recovery-phrase setup.**
+### Step 2 — Wait for auto-reload (do NOT restart the gateway yourself)
 
-The agent reads the explicit directive, installs the plugin (`openclaw plugins install totalreclaw`), waits for OpenClaw's config-watcher to auto-restart the gateway and bind the new tools (1-3s under default `gateway.reload.mode = "hybrid"`), calls `totalreclaw_pair`, and guides you through the QR flow.
+OpenClaw's default config (`gateway.reload.mode = "hybrid"`) auto-restarts the gateway via a file-watcher within 1-3 seconds of the plugin install. Wait ~5 seconds, then verify with `openclaw plugins list | grep totalreclaw` and confirm the `totalreclaw_pair` tool is in your toolset.
 
-</details>
+If `totalreclaw_pair` is not bound within 10 seconds, the user has `gateway.reload.mode = off`. Fall back: tell the user verbatim *"Auto-reload didn't fire. Please restart your OpenClaw gateway: `openclaw gateway restart` (native), `docker restart <your-container-name>` (Docker self-host — substitute the actual name; `docker ps` shows it), or your managed service's restart control. Reply `done` once it's back up."* Do NOT invoke the restart yourself — your shell runs inside the gateway you'd be restarting.
 
-<details>
-<summary>What happens behind the scenes</summary>
+### Step 3 — Check for existing credentials
 
-1. `openclaw skills install totalreclaw` places the skill metadata + SKILL.md under `~/.openclaw/workspace/skills/totalreclaw/`.
-2. The first gateway restart makes the skill visible to your agent's context.
-3. The chat prompt triggers the skill's fast path: the agent runs `openclaw plugins install totalreclaw` via its shell tool.
-4. OpenClaw's config-watcher (chokidar) detects the `plugins.*` change in `~/.openclaw/config.yaml` and, under the default `gateway.reload.mode = "hybrid"`, schedules a SIGUSR1 graceful-drain restart of the gateway. The new process re-reads config, re-imports the plugin, and the new HTTP routes + hooks + tools bind — typically within 1-3s. No human action required. (Fallback: if the user has set `gateway.reload.mode = off` in their config, auto-reload is disabled and the agent will instruct a manual restart instead. The agent cannot self-restart the process it is running in.)
-5. Agent calls the `totalreclaw_pair` tool.
-6. A pair URL + 6-digit PIN is surfaced back to you in chat.
-7. You open the URL in your browser. The pair page offers two tabs: **Generate new** (the browser creates a fresh 12-word recovery phrase using the canonical BIP-39 wordlist) and **Import existing** (paste a phrase you already have). Pick one, confirm the 6-digit PIN, and continue.
-8. The browser performs x25519 ECDH against the gateway's ephemeral pubkey, derives an AES-256-GCM key via HKDF-SHA256, encrypts the phrase locally, and POSTs ciphertext + nonce + its pubkey to the gateway.
-9. The gateway decrypts server-side and writes `~/.totalreclaw/credentials.json` (mode `0600`).
-10. The agent confirms setup and your memory tools are live. First real interaction downloads a ~216 MB embedding model (cached locally, one-time).
+Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, confirm *"TotalReclaw is already set up."* and stop. Otherwise continue.
 
-The recovery phrase never crosses the LLM context — not the chat transcript, not the agent's shell stdout, not any tool-call payload. Browser-side crypto keeps it isolated by construction.
+### Step 4 — Pair (browser flow, NEVER ask the user to type their phrase in chat)
 
-</details>
+Call the `totalreclaw_pair` tool. It returns `{url, pin, qr_ascii, qr_png_b64, qr_unicode, expires_at_ms}`.
+
+Relay to the user verbatim:
+
+> *Open <url> in your browser. Generate a new 12-word recovery phrase there or paste an existing one — the phrase stays in your browser, the relay only sees ciphertext. Confirm PIN <pin>. Reply `done` once the page says it's sealed.*
+
+Render the QR if your transport supports it: image-capable transports (Telegram, Slack, web chat) decode `qr_png_b64` to bytes and attach as an image; terminal-only transports (OpenClaw native CLI) emit `qr_unicode` inline. The QR encodes only the URL — the PIN is a separate dual-channel confirmation, never bake it into the QR.
+
+### Step 5 — Verify and confirm
+
+After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN likely expired — call `totalreclaw_pair` again and resend. If present, confirm *"TotalReclaw is set up. Ask me to remember or recall anything."*
+
+### Phrase safety (HARD — never break)
+
+NEVER echo, generate, or ask the user to paste a recovery phrase in chat. NEVER invoke `openclaw totalreclaw onboard` (bare interactive form), `totalreclaw setup`, or any phrase-touching CLI via your shell tool — stdout enters LLM context. The ONLY agent-facilitated setup path is the `totalreclaw_pair` tool. If the user pastes a phrase anyway: tell them it is compromised and call `totalreclaw_pair` with `mode=generate` for a fresh wallet.
+
+---
+
+## What's happening (for the human reader)
+
+1. `openclaw skills install totalreclaw` — fetches TotalReclaw's SKILL.md from ClawHub and registers it under `~/.openclaw/workspace/skills/totalreclaw/`. The agent picks it up on next config reload.
+2. `openclaw plugins install @totalreclaw/totalreclaw` — installs the plugin from npm (the `latest` dist-tag is always current stable; use `@rc` for the latest release candidate).
+3. OpenClaw's config-watcher detects the `plugins.*` change in `~/.openclaw/config.yaml` and (under default `gateway.reload.mode = "hybrid"`) triggers a graceful SIGUSR1 restart within 1-3s. The new tools bind automatically.
+4. The agent calls `totalreclaw_pair`, which generates an ephemeral x25519 keypair on the gateway and a 6-digit PIN. You get a URL + PIN.
+5. You open the URL. The pair page has two tabs: **Generate new** (the browser creates a fresh BIP-39 12-word phrase locally using `crypto.getRandomValues`) and **Import existing** (paste a phrase you already have). Pick one, confirm the 6-digit PIN, click seal.
+6. The browser performs x25519 ECDH against the gateway's ephemeral pubkey, derives an AES-256-GCM key via HKDF-SHA256, encrypts the phrase locally, and POSTs ciphertext + nonce + its pubkey back. The gateway decrypts server-side and writes `~/.totalreclaw/credentials.json` (mode `0600`).
+7. The recovery phrase never crosses the LLM context — not the chat transcript, not the agent's shell stdout, not any tool-call payload. Browser-side crypto keeps it isolated by construction.
+
+First real interaction downloads a ~216 MB embedding model (cached locally, one-time).
 
 ---
 
@@ -76,48 +78,41 @@ The recovery phrase never crosses the LLM context — not the chat transcript, n
 
 ---
 
-## Managed OpenClaw service (no terminal)
+## Managed OpenClaw service (no terminal, no agent shell)
 
-If you're on a managed / hosted OpenClaw service and don't have shell access to the gateway host, plugin installation typically happens through your service's web UI rather than the `openclaw` CLI. You can still use TotalReclaw — the flow is:
+If you're on a managed / hosted OpenClaw service that doesn't expose host shell to the agent, install via the service's web UI instead:
 
 1. In your service's control panel, find the **Plugins** (or **Skills**) panel and search for `totalreclaw`. Install and enable it.
-2. If the service exposes a separate restart control, restart your agent through that. Many managed services apply plugin changes transparently and skip this step.
-3. Return to chat and say **`Set up TotalReclaw`**. Your agent will pick up the skill and walk you through the QR pairing flow — open the URL it returns, enter or generate your 12-word recovery phrase in the browser, and confirm the 6-digit PIN.
+2. If the service exposes a separate restart control, use it. Many managed services apply plugin changes transparently.
+3. Return to chat and paste the same canonical message:
 
-The browser-side crypto and pairing flow are identical to self-hosted setups; only the install + restart step differs.
+   > **Install TotalReclaw, see <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md>**
 
-> The CLI-driven sections below (`openclaw skills install`, `openclaw plugins install`, `pip install`, `git clone`) assume you have terminal access on the gateway host. They will not work on a managed service that doesn't expose the host shell — use the steps above instead.
+   The agent will detect that the plugin is already loaded, skip Steps 1-2, and jump straight to pairing.
+
+The browser-side crypto and pairing flow are identical to self-hosted setups; only the install step differs.
 
 ---
 
-## Fully manual (CLI only)
+## Fully manual (CLI only — last resort)
 
-If you'd rather run every command yourself without any agent involvement (self-hosted only — managed services don't expose the host shell):
+If you can't or won't use the chat flow (self-hosted only — managed services don't expose the host shell):
 
 ```bash
 openclaw plugins install @totalreclaw/totalreclaw            # stable
+# Or for an RC: @totalreclaw/totalreclaw@rc
 # Under the default config (`gateway.reload.mode = "hybrid"`), OpenClaw's file-watcher
 # auto-restarts the gateway within 1-3s of the install — no manual restart needed.
 # Verify with: `openclaw plugins list | grep totalreclaw`.
 
-# If you have `gateway.reload.mode = off` (or auto-reload is otherwise disabled),
-# fall back to a manual restart. Pick the line that matches your setup:
+# If you have `gateway.reload.mode = off`, restart manually:
 # openclaw gateway restart                                   # native install
-# docker restart <your-openclaw-container>                   # Docker self-host (substitute your container name)
-# Managed OpenClaw service: use the service's restart control (web UI).
+# docker restart <your-openclaw-container>                   # Docker self-host
 ```
 
-Then ask the agent "set up TotalReclaw for me" — it will call `totalreclaw_pair` and hand you the URL + PIN.
+Then in chat: *"Set up TotalReclaw"* — the agent will call `totalreclaw_pair` and hand you the URL + PIN. Open the URL in your browser to enter or generate your phrase.
 
-> **Installing an RC build.** `openclaw skills install totalreclaw` pulls the latest release-candidate skill from ClawHub, but the bare npm spec `@totalreclaw/totalreclaw` resolves to the `latest` dist-tag, which is always the current **stable** build. To install the matching RC plugin, explicitly tag the npm spec:
->
-> ```bash
-> openclaw plugins install @totalreclaw/totalreclaw@rc        # latest RC
-> # or pin a specific candidate:
-> openclaw plugins install @totalreclaw/totalreclaw@3.3.1-rc.19
-> ```
->
-> Check what each tag currently resolves to with `npm view @totalreclaw/totalreclaw dist-tags`. Keep the skill and plugin on the same version family (both stable or both RC) to avoid skill instructions and plugin behavior drifting apart.
+> Pin a specific RC with `openclaw plugins install @totalreclaw/totalreclaw@3.3.1-rc.19`. Check what each tag resolves to: `npm view @totalreclaw/totalreclaw dist-tags`. Keep skill and plugin on the same version family (both stable or both RC).
 
 <details>
 <summary>From-source install (for plugin development — self-host only)</summary>
@@ -127,7 +122,7 @@ git clone https://github.com/p-diogo/totalreclaw.git
 openclaw plugins install ./totalreclaw/skill/plugin
 ```
 
-This path requires terminal access on the gateway host and is not available on managed services.
+Requires terminal access on the gateway host. Not available on managed services.
 
 </details>
 
@@ -196,18 +191,18 @@ Both tiers have unlimited memories and reads. Upgrade: *"Upgrade my TotalReclaw 
 
 ## Troubleshooting
 
-- **Agent can't see TotalReclaw tools**: under the default config OpenClaw auto-restarts the gateway within 1-3s of `openclaw plugins install` — wait 5-10s and check `openclaw plugins list`. If the plugin is listed but the agent still can't see the tools, your config likely has `gateway.reload.mode = off` (auto-reload disabled) — fall back to a manual restart. Native: `openclaw gateway restart`. Docker self-host: `docker restart <your-openclaw-container>` (substitute your actual container name; `docker ps` shows it). Managed service: use the service's restart control (web UI).
+- **Agent says "I'm not familiar with TotalReclaw"**: paste the canonical message above with the URL — the agent fetches the guide and follows the install steps.
+- **Agent can't see TotalReclaw tools after install**: under the default config OpenClaw auto-restarts the gateway within 1-3s of `openclaw plugins install` — wait 5-10s and check `openclaw plugins list`. If the plugin is listed but the agent still can't see the tools, your config likely has `gateway.reload.mode = off` — fall back to a manual restart. Native: `openclaw gateway restart`. Docker self-host: `docker restart <your-openclaw-container>`. Managed service: use the service's restart control.
 - **Pair URL returns 404**: check that `~/.totalreclaw/credentials.json` isn't locked by a previous process and that the gateway is running.
 - **Browser fails to POST the encrypted phrase**: check the pair page's Content-Security-Policy — older browsers without WebCrypto x25519 (pre-Safari 17.2 / Chromium 118) cannot run the AEAD crypto.
-- **Tool calls return "onboarding required"**: repeat the canonical prompt so the agent re-runs `totalreclaw_pair`.
+- **Tool calls return "onboarding required"**: paste the canonical message again so the agent re-runs `totalreclaw_pair`.
 - **"Not authenticated" / 401**: check your phrase — exact words, exact order, lowercase, single spaces.
 
 ---
 
-## Canonical prompts (these match the QA harness scenario contracts)
+## Canonical prompt (matches the QA harness scenario contracts)
 
-- Approach A: `Install totalreclaw`
-- Approach B: `TotalReclaw is a skill at 'totalreclaw' on ClawHub. Please install the plugin (openclaw plugins install totalreclaw), then use the totalreclaw_pair tool to walk me through the QR recovery-phrase setup.`
+> **Install TotalReclaw, see <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md>**
 
 ---
 

--- a/python/src/totalreclaw/hermes/SKILL.md
+++ b/python/src/totalreclaw/hermes/SKILL.md
@@ -9,28 +9,29 @@ homepage: https://totalreclaw.xyz
 
 # TotalReclaw — Hermes
 
-## Fast path — "set up TotalReclaw" (Approach A, preferred)
+> The canonical install flow lives at <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md>. If a user pastes that URL in chat, fetch it and follow its agent-instructions section. This SKILL.md mirrors the same steps so you can act even if the URL is unreachable.
 
-If the user says "set up TotalReclaw" (or any variant) AND this SKILL.md is loaded, assume `totalreclaw_*` tools are already available (`hermes plugins install p-diogo/totalreclaw-hermes --enable` registers the plugin manifest, `pip install --pre totalreclaw` supplies the Python tool implementations, and gateway restart loads both together — if you are reading this, the plugin is loaded too). On a managed Hermes service where your shell can't run `hermes plugins install` or `pip install`, expect that the user installed both via the service's plugins UI; this SKILL.md still applies.
+## Setup flow
 
-1. Check `~/.totalreclaw/credentials.json` exists and is non-empty (via a read-only shell `test -s ~/.totalreclaw/credentials.json`). If it exists, confirm *"TotalReclaw is already set up."* and stop.
-2. If credentials missing: call `totalreclaw_pair` immediately. It returns `{url, pin, expires_at_ms}`.
-3. Relay verbatim: *"Open <url> in your browser. Enter your 12-word recovery phrase (or let the browser generate one). Confirm PIN <pin>. I'll wait for you to say done."*
-4. After user says done: verify `~/.totalreclaw/credentials.json`. If missing, call `totalreclaw_pair` again (PIN likely expired) and resend.
-5. Confirm: *"TotalReclaw set up ✓. Ask me to remember or recall anything — try `totalreclaw_remember` or ask me to remember something."*
+If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jump to step 4. Otherwise run all steps in order.
 
-If `totalreclaw_*` tools are NOT in your toolset: the gateway needs a restart. Hermes does NOT auto-reload on plugin install — manual restart is required. Tell the user once: *"My memory tools didn't bind — the gateway needs a restart. Common patterns: `hermes gateway restart` (native install), `docker restart <your-container-name>` (Docker self-host — replace with your actual container name; `docker ps` shows it), or your managed Hermes service's restart control if you're on a hosted plan. If your Hermes is supervised by systemd / launchd, you can also send SIGUSR1 for a graceful-drain restart: `kill -USR1 $(cat ~/.hermes/gateway.pid)` — the supervisor will respawn cleanly. Reply `done` once it's back up."* Do not try to invoke missing tools yourself, and do NOT run the restart yourself — your shell is inside the gateway you're restarting.
+1. **Install plugin + Python package.** Hermes 2026.4.16+ uses Git-based plugin discovery and a separate Python tool implementation. Run via your shell tool:
+   ```
+   hermes plugins install p-diogo/totalreclaw-hermes --enable
+   pip install --pre totalreclaw
+   ```
+   (If Hermes runs in its own venv, use that venv's pip — e.g. `/path/to/hermes/venv/bin/python3 -m pip install --pre totalreclaw`.) If either shell call fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment): tell the user verbatim *"Your environment doesn't expose the Hermes CLI / pip to me. Please install `p-diogo/totalreclaw-hermes` and the `totalreclaw` Python package via your service's plugins UI, then reply `done`."* Wait for `done` and skip to step 3.
 
-## Explicit two-step setup flow (Approach B, fallback)
+2. **Restart the gateway — Hermes does NOT auto-reload on plugin install.** Tell the user verbatim: *"Please restart your Hermes gateway: `hermes gateway restart` (native), `docker restart <your-container-name>` (Docker self-host — substitute the actual name; `docker ps` shows it), or your managed service's restart control. If supervised by systemd / launchd, `kill -USR1 $(cat ~/.hermes/gateway.pid)` triggers a graceful-drain restart. Reply `done` once it's back up."* Do NOT run the restart yourself — your shell is inside the gateway you'd be restarting. Wait for the user's `done`.
 
-Used when the user pastes a verbose prompt describing install + restart + pair (e.g. *"TotalReclaw is already installed. Use the totalreclaw_pair tool to walk me through the QR recovery-phrase setup."*) OR when a tool returns `onboarding required`.
+3. **Verify `totalreclaw_pair` is bound.** If still missing after restart, tell the user the plugin didn't load and to retry. Do not loop the install.
 
-1. Install both halves of the Hermes 2026.4.16+ plugin surface: `hermes plugins install p-diogo/totalreclaw-hermes --enable` (Git-based plugin manifest) AND `pip install --pre totalreclaw` (Python tool implementations; latest pre-release on PyPI — pin a specific `rcN` from https://pypi.org/project/totalreclaw/#history if asked). If either shell call fails with `command not found` / ENOENT / "not authorized" / similar (managed-service or shell-restricted environment): tell the user *"Your environment doesn't expose the Hermes CLI / pip to me. Please install `p-diogo/totalreclaw-hermes` and the `totalreclaw` Python package via your service's plugins UI, then reply `done`."* Wait for `done` and skip to step 3.
-2. Restart gateway so plugin loads. Tell the user verbatim: *"Please restart your Hermes gateway: `hermes gateway restart` (native install), `docker restart <your-container-name>` (Docker self-host — replace with your actual container name), or your managed service's restart control. Reply `done` once it's back up."* Do NOT run the restart yourself — your shell is inside the gateway. Wait for the user's `done`.
-3. Call `totalreclaw_pair`. Returns `{url, pin, expires_at_ms}`.
-4. Relay to user verbatim: *"Open <url> in your browser. Enter your 12-word recovery phrase (or let the browser generate one). Confirm PIN <pin>. I'll wait for you to say done."*
-5. After user says done: verify `~/.totalreclaw/credentials.json` exists and is non-empty. If missing, call `totalreclaw_pair` again (PIN likely expired) and resend.
-6. Confirm: *"TotalReclaw is set up. Ask me to remember or recall anything."*
+4. **Check for existing credentials.** Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, confirm *"TotalReclaw is already set up."* and stop.
+
+5. **Pair.** Call `totalreclaw_pair`. Returns `{url, pin, expires_at_ms}`. Relay verbatim:
+   > *Open <url> in your browser. Generate a new 12-word recovery phrase there or paste an existing one — the phrase stays in your browser, the relay only sees ciphertext. Confirm PIN <pin>. Reply `done` once the page says it's sealed.*
+
+6. **Verify and confirm.** After user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN expired — call `totalreclaw_pair` again and resend. If present, confirm *"TotalReclaw is set up. Ask me to remember or recall anything."*
 
 ## Phrase safety (HARD — never break)
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -24,19 +24,17 @@ metadata:
 
 # TotalReclaw Skill
 
+> Canonical install + setup flow lives at <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md> (OpenClaw) and <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md> (Hermes). When a user pastes one of those URLs in chat, fetch it and follow its agent-instructions section verbatim. The "Post-Install Setup" section below mirrors the same pair-tool flow as a fallback.
+
 ## Recovery Phrase -- READ THIS FIRST
 
-**CRITICAL SAFETY WARNING:** TotalReclaw generates a NEW recovery phrase for the user. NEVER let the user enter a recovery phrase from an existing crypto wallet they own. TotalReclaw uses BIP-39 mnemonics (the same format as crypto wallets), but TotalReclaw recovery phrases must be SEPARATE from any funded wallet. If a user tries to import a phrase they already use for a crypto wallet, STOP and warn them: "Do NOT use a recovery phrase from an existing crypto wallet. TotalReclaw should have its own dedicated phrase to keep your funds safe."
+**CRITICAL SAFETY RULE:** The recovery phrase MUST NEVER cross the LLM context. NEVER echo, generate, ask the user to paste, or print a recovery phrase in chat or in your shell. The phrase is created and confirmed inside the user's browser via the `totalreclaw_pair` flow — the relay only receives ciphertext, and your tool calls must never carry a phrase payload.
 
-The recovery phrase is the user's ONLY identity in TotalReclaw. It derives all encryption keys. There is NO password reset, NO recovery mechanism, and NO support channel that can help if it is lost.
+If the user pastes a phrase in chat anyway: tell them it is compromised (the chat transcript and any tool stdout enter LLM context, which makes the phrase recoverable from logs and from any model that processes that turn) and call `totalreclaw_pair` with `mode=generate` to create a fresh wallet.
 
-**When showing the recovery phrase to the user, ALWAYS include this warning:**
+The recovery phrase is the user's ONLY identity in TotalReclaw. It derives all encryption keys. There is NO password reset, NO recovery mechanism, and NO support channel that can help if it is lost. The browser-side pair flow displays this warning automatically when a new phrase is generated.
 
-> Your recovery phrase is the ONLY way to access your encrypted memories. If you lose it, your memories are gone forever -- there is no password reset, no recovery, and no support that can help. Write it down and store it somewhere safe. Never share it with anyone.
->
-> IMPORTANT: This phrase is for TotalReclaw ONLY. Never use a recovery phrase from an existing crypto wallet -- keep your TotalReclaw phrase separate from any wallet that holds funds.
-
-If the user asks to see their recovery phrase, remind them to store it securely. If they mention losing it, be clear that recovery is impossible and they will need to start fresh with a new phrase.
+**Do NOT** import a phrase the user already uses for a funded crypto wallet. TotalReclaw uses BIP-39 mnemonics (same format as crypto wallets), but a TotalReclaw phrase must be SEPARATE from any funded wallet. If the user tries to import an existing crypto-wallet phrase, STOP and warn them in chat to use a fresh phrase instead — but warn ABOUT the phrase, never echo any portion of it.
 
 ---
 
@@ -486,44 +484,21 @@ When the user asks to import conversation history:
 
 ## Post-Install Setup
 
-After installing TotalReclaw, the agent MUST complete setup automatically. **Do NOT ask the user to set environment variables manually.**
+If `totalreclaw_*` tools are bound to your toolset, run these steps to pair. If they are NOT bound, the plugin isn't installed yet — follow the URL-driven install flow at <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md> first.
 
-### Step 1: Recovery phrase
+1. **Check for existing credentials.** Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, confirm *"TotalReclaw is already set up."* and stop.
 
-The recovery phrase is a **12-word BIP-39 mnemonic**. It derives all encryption keys. The server never sees it.
+2. **Pair via browser.** Call `totalreclaw_pair`. It returns `{url, pin, qr_ascii, qr_png_b64, qr_unicode, expires_at_ms}`. Relay verbatim:
+   > *Open <url> in your browser. Generate a new 12-word recovery phrase there or paste an existing one — the phrase stays in your browser, the relay only sees ciphertext. Confirm PIN <pin>. Reply `done` once the page says it's sealed.*
 
-Ask the user:
-> "Do you have an existing TotalReclaw recovery phrase you'd like to restore, or should I generate a new one?"
+   Render the QR if your transport supports image attachments (decode `qr_png_b64` to bytes and attach), or emit `qr_unicode` inline for terminal-only transports.
 
-- **New user:** Call `totalreclaw_setup` WITHOUT a recovery phrase — the tool generates a valid BIP-39 mnemonic automatically, derives encryption keys, and registers with the relay. Do NOT use `npx @totalreclaw/mcp-server setup` or `exec` to run CLI tools — this creates credentials in an incompatible format. Do NOT generate the phrase yourself — LLMs cannot compute BIP-39 checksums correctly. After setup, display the phrase prominently with a warning:
-  > "⚠️ SAVE YOUR RECOVERY PHRASE — it's the only way to recover your memories if you switch devices: `[phrase]`"
-- **Returning user:** Ask them to provide their existing 12-word phrase, then call `totalreclaw_setup` with `recovery_phrase` set to their phrase.
+3. **Verify and confirm.** After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN expired — call `totalreclaw_pair` again and resend. If present, confirm *"TotalReclaw is set up. Ask me to remember or recall anything."*
 
-When setup is required, the plugin will automatically detect the host environment (macOS, Linux, or Docker) and provide the exact commands or config snippets needed to set the env vars. Follow those instructions.
+4. **Mention the free tier.** After confirming setup:
+   > *You're on TotalReclaw's free tier — unlimited memories on Base Sepolia testnet (testnet may reset). For permanent storage on Gnosis mainnet, see https://totalreclaw.xyz/pricing.*
 
-### Step 2: Storage mode (optional)
-
-The managed service is the default -- no extra configuration needed. If you want to self-host instead, set `TOTALRECLAW_SELF_HOSTED=true` and `TOTALRECLAW_SERVER_URL` to your server URL.
-
-### Step 3: Set memory slot
-
-Register TotalReclaw as the memory plugin:
-```json
-{ "plugins": { "slots": { "memory": "totalreclaw" } } }
-```
-
-### Step 5: Restart and verify
-
-Restart the gateway, then confirm the plugin loaded by checking that `totalreclaw_remember`, `totalreclaw_recall`, `totalreclaw_forget`, `totalreclaw_export`, `totalreclaw_status`, `totalreclaw_upgrade`, `totalreclaw_migrate`, `totalreclaw_consolidate`, and `totalreclaw_import_from` tools are available.
-
-### Step 6: Explain the free tier
-
-After setup completes, inform the user about the free tier:
-> "You're on TotalReclaw's free tier — 500 memories per month, unlimited reads and searches.
-> I'll let you know if you're approaching the limit. For unlimited memories, visit
-> https://totalreclaw.xyz/pricing"
-
-The agent proactively warns when quota usage exceeds 80%. If the limit is reached, new writes are rejected but all existing memories remain searchable.
+**Never** call `totalreclaw_setup` or any phrase-touching CLI from your shell — those leak the phrase into LLM context. The ONLY agent-facilitated setup path is the `totalreclaw_pair` tool.
 
 ---
 

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -24,49 +24,43 @@ metadata:
 
 # TotalReclaw — OpenClaw
 
-## Fast path — "install totalreclaw" (Approach A, preferred)
+> The canonical install flow lives at <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md>. If a user pastes that URL in chat, fetch it and follow its agent-instructions section. This SKILL.md mirrors the same steps so you can act even if the URL is unreachable.
 
-ClawHub classifies TotalReclaw as a skill. `openclaw skills install totalreclaw` registers this SKILL.md into your agent context BEFORE the plugin is installed (so you may be reading this with no `totalreclaw_*` tools yet).
+## Setup flow
 
-If the user says "install totalreclaw" (or any variant) AND no `totalreclaw_*` tools are in your toolset:
+If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jump to step 4. Otherwise run all steps in order.
 
-1. Run via your shell tool: `openclaw plugins install totalreclaw`. (For RC candidates: `openclaw plugins install @totalreclaw/totalreclaw@rc` — the `rc` dist-tag on npm is the latest candidate.) If the shell call fails with `command not found` / ENOENT / "not authorized" / similar (managed-service or shell-restricted environment): tell the user *"Your environment doesn't expose the OpenClaw CLI to me. Please install `totalreclaw` from your service's plugins / skills UI, then reply `done`."* Wait for `done` and skip to step 3.
-2. Tell the user: *"Plugin installed. Verifying it loaded..."* OpenClaw's default config (`gateway.reload.mode = "hybrid"`) auto-restarts the gateway via a file-watcher when `plugins.*` config changes; this typically takes 1-3 seconds. Wait ~5 seconds, then run `openclaw plugins list` and confirm `totalreclaw` shows as enabled. If it does NOT appear within 10 seconds, the user has `gateway.reload.mode = off` (or another setup that disables auto-reload) — fall back to the manual-restart path: tell the user verbatim *"Auto-reload didn't fire. Please restart your OpenClaw gateway so the new tools bind. Common patterns: `openclaw gateway restart` (native install), `docker restart <your-container-name>` (Docker self-host — substitute your actual container name; `docker ps` will show it), or use your managed service's restart control if you're on a hosted plan. Once the gateway is back up, reply `done` and I'll continue."* Do NOT invoke any restart command yourself — your shell is running inside the gateway you're restarting (catch-22). Wait for the user's `done` before proceeding.
-3. Verify `totalreclaw_pair` is now in your toolset. If not (and you already fell back to manual restart and the user said `done`), tell the user the restart didn't take effect and to retry the restart command. Do not loop the install.
-4. Check `~/.totalreclaw/credentials.json` (via `test -s ~/.totalreclaw/credentials.json`). If it exists, confirm *"TotalReclaw is already set up."* and stop.
-5. Call `totalreclaw_pair`. Returns `{url, pin, qr_ascii, qr_png_b64, qr_unicode, expires_at_ms}` (see "Rendering the QR on your transport" below for the rc.5+ additions).
-6. Relay verbatim: *"Open <url> in your browser. Enter your 12-word recovery phrase (or let the browser generate one). Confirm PIN <pin>. I'll wait for you to say done."*
-7. After user says done: verify `~/.totalreclaw/credentials.json`. If missing, call `totalreclaw_pair` again (PIN likely expired) and resend.
-8. Confirm: *"TotalReclaw set up ✓. Ask me to remember or recall anything — try `totalreclaw_remember` or ask me to remember something."*
+1. **Install skill + plugin.** Run via your shell tool, in this order:
+   ```
+   openclaw skills install totalreclaw
+   openclaw plugins install @totalreclaw/totalreclaw
+   ```
+   For RC: replace the second command with `openclaw plugins install @totalreclaw/totalreclaw@rc`. If either shell call fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment), tell the user verbatim *"Your environment doesn't expose the OpenClaw CLI to me. Please install `totalreclaw` from your service's plugins / skills UI, then reply `done`."* Wait for `done` and skip to step 3.
 
-If `totalreclaw_*` tools ARE already in your toolset when the user asks, SKIP the install step and jump to step 4.
+2. **Wait for auto-reload — do NOT restart the gateway yourself.** OpenClaw's default config (`gateway.reload.mode = "hybrid"`) auto-restarts the gateway via a file-watcher within 1-3 seconds. Wait ~5s, then run `openclaw plugins list | grep totalreclaw` and confirm `totalreclaw_pair` is in your toolset. If it does NOT appear within 10s, the user has `gateway.reload.mode = off` — fall back: tell the user verbatim *"Auto-reload didn't fire. Please restart your OpenClaw gateway: `openclaw gateway restart` (native), `docker restart <your-container-name>` (Docker self-host — substitute the actual name; `docker ps` shows it), or your managed service's restart control. Reply `done` once it's back up."* Do NOT invoke the restart yourself — your shell is running inside the gateway you'd be restarting (catch-22). Wait for the user's `done`.
 
-## Explicit two-step setup flow (Approach B, fallback)
+3. **Verify `totalreclaw_pair` is bound.** If still missing after the user said `done`, tell them the restart didn't take effect and to retry. Do not loop the install.
 
-Used when the user pastes a verbose prompt describing skill install + plugin install + restart + pair (e.g. *"TotalReclaw is a skill at 'totalreclaw' on ClawHub. Install it, then install the plugin, restart the gateway, and walk me through the QR pairing flow"*) OR when a tool returns `onboarding required`.
+4. **Check for existing credentials.** Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, confirm *"TotalReclaw is already set up."* and stop.
 
-1. `openclaw plugins install @totalreclaw/totalreclaw` (stable). For RC: `@totalreclaw/totalreclaw@rc`. If the CLI isn't available to your shell (managed service / shell-restricted env): ask the user to install `totalreclaw` from their service's plugins UI and reply `done`.
-2. Wait ~5 seconds for OpenClaw's auto-reload to fire (default `gateway.reload.mode = "hybrid"` — file-watcher detects the plugin install and sends SIGUSR1 to the gateway, completing within 1-3s). Verify with `openclaw plugins list`; `totalreclaw` should show enabled. If it does NOT appear within 10s, the user has `gateway.reload.mode = off` (or auto-reload is otherwise disabled) — fall back to manual restart: tell the user verbatim *"Auto-reload didn't fire. Please restart your gateway: `openclaw gateway restart` (native), `docker restart <your-container-name>` (Docker self-host — replace with your actual container name), or your managed service's restart control. Reply `done` once it's back up."* Do NOT run the restart yourself — your shell is inside the gateway. Wait for the user's `done`.
-3. Call `totalreclaw_pair`. Returns `{url, pin, qr_ascii, qr_png_b64, qr_unicode, expires_at_ms}` (see "Rendering the QR on your transport" below for the rc.5+ additions).
-4. Relay to user verbatim: *"Open <url> in your browser. Enter your 12-word recovery phrase (or let the browser generate one). Confirm PIN <pin>. I'll wait for you to say done."*
-5. After user says done: verify `~/.totalreclaw/credentials.json` exists and is non-empty. If missing, call `totalreclaw_pair` again (PIN likely expired) and resend.
-6. Confirm: *"TotalReclaw is set up. Ask me to remember or recall anything."*
+5. **Pair.** Call `totalreclaw_pair`. Returns `{url, pin, qr_ascii, qr_png_b64, qr_unicode, expires_at_ms}` (see "Rendering the QR" below). Relay verbatim:
+   > *Open <url> in your browser. Generate a new 12-word recovery phrase there or paste an existing one — the phrase stays in your browser, the relay only sees ciphertext. Confirm PIN <pin>. Reply `done` once the page says it's sealed.*
+
+6. **Verify and confirm.** After user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN expired — call `totalreclaw_pair` again and resend. If present, confirm *"TotalReclaw is set up. Ask me to remember or recall anything."*
 
 ## Rendering the QR on your transport (rc.5+)
 
-When you call `totalreclaw_pair` and receive the payload, tell the user: *"Open the URL below or scan this QR code from your phone. PIN: <pin>."*
+When you receive the `totalreclaw_pair` payload, render the QR based on your chat transport:
 
-Then render the QR based on your chat transport:
-
-- **Transport supports image attachments** (Telegram, Slack, web chat, any transport with file/image upload): decode `qr_png_b64` from base64 to bytes, save to a tempfile with a `.png` suffix, and attach the tempfile as an image in your reply. Also show the URL + PIN as text so users who prefer clicking can still do so.
-- **Terminal-only transport** (OpenClaw native CLI chat, bare SSH shell): emit the `qr_unicode` string inline in your reply. It renders as block characters that display correctly in most terminal fonts; the user scans from their phone.
+- **Transport supports image attachments** (Telegram, Slack, web chat, any transport with file/image upload): decode `qr_png_b64` from base64 to bytes, save to a tempfile with a `.png` suffix, and attach the tempfile as an image. Also show the URL + PIN as text so users who prefer clicking can still do so.
+- **Terminal-only transport** (OpenClaw native CLI chat, bare SSH shell): emit `qr_unicode` inline in your reply. It renders as block characters in most terminal fonts; the user scans from their phone.
 - **Web chat with inline-image support**: embed as `<img src="data:image/png;base64,<qr_png_b64>" alt="Pair QR">` if the chat client renders HTML; otherwise fall back to attachment.
 
-The QR encodes ONLY the pair URL. The 6-digit PIN is a separate out-of-band confirmation — it is deliberately NOT baked into the QR (dual-channel design: scan + type). Never log, print, or re-emit the PIN outside of the user-facing reply. The PIN is a shared secret between you and the user; it must NOT end up in any other tool call, any log file, or any memory store.
+The QR encodes ONLY the pair URL. The 6-digit PIN is a separate out-of-band confirmation — deliberately NOT baked into the QR (dual-channel design: scan + type). Never log, print, or re-emit the PIN outside the user-facing reply. The PIN must NOT end up in any other tool call, log file, or memory store.
 
 ## Phrase safety (HARD — never break)
 
-NEVER echo / generate / ask the user to paste a recovery phrase in chat. NEVER invoke `openclaw totalreclaw onboard` (the bare interactive form), `totalreclaw setup`, or any phrase-touching CLI via your shell tool (stdout enters LLM context). The ONLY agent-facilitated setup paths are (in order of preference): (1) `totalreclaw_pair` tool; (2) if the tool is missing from your tool list — a known gap for some container-based agents, issue #87 — shell out to EITHER `openclaw totalreclaw pair generate --url-pin-only` (single-line JSON `{v,url,pin,expires_at_ms}`) OR `openclaw totalreclaw onboard --pair-only` (single-line JSON `{v,pair_url,pin,expires_at_ms}`, issue #95 — same pair flow, `pair_url` key naming). Both have zero phrase material on stdout (pair-crypto is x25519-only, not BIP-39). If the user pastes a phrase anyway: tell them it is compromised, call `totalreclaw_pair` with `mode=generate` for a fresh wallet.
+NEVER echo / generate / ask the user to paste a recovery phrase in chat. NEVER invoke `openclaw totalreclaw onboard` (bare interactive form), `totalreclaw setup`, or any phrase-touching CLI via your shell tool (stdout enters LLM context). The ONLY agent-facilitated setup paths are (in order of preference): (1) `totalreclaw_pair` tool; (2) if the tool is missing from your tool list — a known gap for some container-based agents, issue #87 — shell out to EITHER `openclaw totalreclaw pair generate --url-pin-only` (single-line JSON `{v,url,pin,expires_at_ms}`) OR `openclaw totalreclaw onboard --pair-only` (single-line JSON `{v,pair_url,pin,expires_at_ms}`, issue #95 — same pair flow, `pair_url` key naming). Both have zero phrase material on stdout (pair-crypto is x25519-only, not BIP-39). If the user pastes a phrase anyway: tell them it is compromised, call `totalreclaw_pair` with `mode=generate` for a fresh wallet.
 
 ## Usage (post-setup)
 
@@ -78,7 +72,7 @@ NEVER echo / generate / ask the user to paste a recovery phrase in chat. NEVER i
 
 ## Diagnostics
 
-- `totalreclaw_*` tools not visible → plugin not installed or auto-reload didn't fire. Verify via `openclaw plugins list | grep totalreclaw` (or, on a managed service that doesn't expose the CLI, ask the user to confirm via their service's plugins UI). If `totalreclaw` is listed but tools are still absent in your toolset, the gateway probably hasn't completed its auto-restart yet (give it 5-10s) OR `gateway.reload.mode = off` is set — instruct manual restart as fallback: `openclaw gateway restart` (native), `docker restart <your-container-name>` (Docker self-host), or the managed service's restart control. If the plugin is listed and the gateway has been restarted but tools are still missing (container-agent gap, issue #87), shell out to `openclaw totalreclaw pair generate --url-pin-only` on the gateway host and hand the user the `url` + `pin` from the JSON payload — OR `openclaw totalreclaw onboard --pair-only` (same flow, returns `pair_url` instead of `url`, issue #95). If your shell doesn't reach the gateway host (managed service), tell the user to install/enable the plugin via their service's plugins UI and restart the gateway via the service's restart control. Do NOT suggest the bare `openclaw totalreclaw onboard` (leaks phrase on stdout — deprecated in rc.18, removed next RC).
+- `totalreclaw_*` tools not visible → plugin not installed or auto-reload didn't fire. Verify via `openclaw plugins list | grep totalreclaw` (or, on a managed service that doesn't expose the CLI, ask the user to confirm via their service's plugins UI). If `totalreclaw` is listed but tools are still absent, the gateway probably hasn't completed its auto-restart yet (give it 5-10s) OR `gateway.reload.mode = off` is set — instruct manual restart as fallback: `openclaw gateway restart` (native), `docker restart <your-container-name>` (Docker self-host), or the managed service's restart control. If the plugin is listed and the gateway has been restarted but tools are still missing (container-agent gap, issue #87), shell out to `openclaw totalreclaw pair generate --url-pin-only` on the gateway host and hand the user the `url` + `pin` from the JSON payload — OR `openclaw totalreclaw onboard --pair-only` (same flow, returns `pair_url` instead of `url`, issue #95). If your shell doesn't reach the gateway host (managed service), tell the user to install/enable the plugin via their service's plugins UI and restart the gateway via the service's restart control. Do NOT suggest the bare `openclaw totalreclaw onboard` (leaks phrase on stdout — deprecated in rc.18, removed next RC).
 - User says done but `credentials.json` missing → PIN expired or entered wrong phrase; call `totalreclaw_pair` again.
 - `onboarding required` → credentials missing; redo from the pair step.
 - `quota exceeded` → `totalreclaw_status`, then offer `totalreclaw_upgrade`.


### PR DESCRIPTION
## Summary

- Collapse OpenClaw + Hermes setup guides from two-approach split → ONE canonical URL-driven flow
- New flow: user tells agent *"Install TotalReclaw, see <github URL>"* → agent fetches markdown + runs commands itself → zero terminal commands for end users
- **Critical fix caught during rewrite**: skill/SKILL.md "Post-Install Setup" section was telling the agent to display the recovery phrase prominently in chat — phrase-safety violation. Removed + replaced with browser-only pair flow language.
- Harmonized 5 doc/skill files for parity.

## Why

rc.19 brutal QA confirmed agent on fresh OpenClaw refuses to install unknown 3rd-party packages without context (same since rc.2). URL-driven flow gives the agent authoritative source via WebFetch — same pattern Hermes uses.

## Test plan

- [ ] Auto-QA against rc.20 fed only the URL prompt (no pre-bootstrap) returns GO
- [ ] No phrase / mnemonic / credentials surface text remaining in any SKILL.md
- [ ] Manual QA by Pedro on rc.20 confirms zero CLI required

🤖 Generated with [Claude Code](https://claude.com/claude-code)