### PR TITLE
fix(plugin): recall miss for short queries (closes #116)

### DIFF
--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -80,7 +80,7 @@ import {
   dedupeByProvider,
 } from './llm-profile-reader.js';
 import { LSHHasher } from './lsh.js';
-import { rerank, cosineSimilarity, detectQueryIntent, INTENT_WEIGHTS, type RerankerCandidate } from './reranker.js';
+import { rerank, cosineSimilarity, detectQueryIntent, INTENT_WEIGHTS, passesRelevanceGate, type RerankerCandidate } from './reranker.js';
 import { deduplicateBatch } from './semantic-dedup.js';
 import {
   findNearDuplicate,
@@ -3556,14 +3556,19 @@ const plugin = {
               };
             }
 
-            // 6b. Cosine similarity threshold gate — skip results when the
-            //     best match is below the minimum relevance threshold.
-            const maxCosine = Math.max(
-              ...reranked.map((r) => r.cosineSimilarity ?? 0),
-            );
-            if (maxCosine < COSINE_THRESHOLD) {
+            // 6b. Relevance gate — surface results when EITHER the top match
+            //     clears the cosine threshold OR every meaningful query token
+            //     appears in the top result's text (lexical override).
+            //     Issue #116 (rc.18 finding F1): short queries like
+            //     "favorite color" produce embeddings with low cosine sim
+            //     against the local Harrier-OSS-270m model even when the
+            //     stored fact text contains every query token.
+            if (!passesRelevanceGate(params.query, reranked, COSINE_THRESHOLD)) {
+              const maxCosine = Math.max(
+                ...reranked.map((r) => r.cosineSimilarity ?? 0),
+              );
               api.logger.info(
-                `Recall: cosine threshold gate filtered results (max=${maxCosine.toFixed(3)}, threshold=${COSINE_THRESHOLD})`,
+                `Recall: relevance gate filtered results (max cosine=${maxCosine.toFixed(3)}, threshold=${COSINE_THRESHOLD}, no lexical override)`,
               );
               return {
                 content: [{ type: 'text', text: 'No relevant memories found for this query.' }],
@@ -5733,14 +5738,14 @@ const plugin = {
 
             if (reranked.length === 0) return undefined;
 
-            // 6b. Cosine similarity threshold gate — skip injection when the
-            //     best match is below the minimum relevance threshold.
-            const hookMaxCosine = Math.max(
-              ...reranked.map((r) => r.cosineSimilarity ?? 0),
-            );
-            if (hookMaxCosine < COSINE_THRESHOLD) {
+            // 6b. Relevance gate — see recall tool above for the cosine +
+            //     lexical-override rule (issue #116).
+            if (!passesRelevanceGate(evt.prompt, reranked, COSINE_THRESHOLD)) {
+              const hookMaxCosine = Math.max(
+                ...reranked.map((r) => r.cosineSimilarity ?? 0),
+              );
               api.logger.info(
-                `Hook: cosine threshold gate filtered results (max=${hookMaxCosine.toFixed(3)}, threshold=${COSINE_THRESHOLD})`,
+                `Hook: relevance gate filtered results (max cosine=${hookMaxCosine.toFixed(3)}, threshold=${COSINE_THRESHOLD}, no lexical override)`,
               );
               return undefined;
             }
@@ -5848,14 +5853,14 @@ const plugin = {
 
           if (reranked.length === 0) return undefined;
 
-          // Cosine similarity threshold gate — skip injection when the
-          // best match is below the minimum relevance threshold.
-          const srvMaxCosine = Math.max(
-            ...reranked.map((r) => r.cosineSimilarity ?? 0),
-          );
-          if (srvMaxCosine < COSINE_THRESHOLD) {
+          // Relevance gate — see recall tool for the cosine + lexical-override
+          // rule (issue #116).
+          if (!passesRelevanceGate(evt.prompt, reranked, COSINE_THRESHOLD)) {
+            const srvMaxCosine = Math.max(
+              ...reranked.map((r) => r.cosineSimilarity ?? 0),
+            );
             api.logger.info(
-              `Hook: cosine threshold gate filtered results (max=${srvMaxCosine.toFixed(3)}, threshold=${COSINE_THRESHOLD})`,
+              `Hook: relevance gate filtered results (max cosine=${srvMaxCosine.toFixed(3)}, threshold=${COSINE_THRESHOLD}, no lexical override)`,
             );
             return undefined;
           }

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -62,7 +62,7 @@
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.json --noCheck",
     "verify-tarball": "node ../scripts/verify-tarball.mjs",
-    "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx llm-client-retry.test.ts && npx tsx gateway-url.test.ts && npx tsx retype-setscope.test.ts && npx tsx tool-gating.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts && npx tsx pair-qr.test.ts && npx tsx pair-remote-client.test.ts && npx tsx qa-bug-report.test.ts && npx tsx nonce-serialization.test.ts && npx tsx phrase-safety-registry.test.ts && npx tsx test_issue_92_onnx_download_ux.test.ts && npx tsx onboard-pair-only.test.ts && npx tsx import-time-smoke.test.ts",
+    "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx llm-client-retry.test.ts && npx tsx gateway-url.test.ts && npx tsx retype-setscope.test.ts && npx tsx tool-gating.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts && npx tsx pair-qr.test.ts && npx tsx pair-remote-client.test.ts && npx tsx qa-bug-report.test.ts && npx tsx nonce-serialization.test.ts && npx tsx phrase-safety-registry.test.ts && npx tsx test_issue_92_onnx_download_ux.test.ts && npx tsx onboard-pair-only.test.ts && npx tsx import-time-smoke.test.ts && npx tsx recall-relevance-gate.test.ts",
     "check-scanner": "node ../scripts/check-scanner.mjs",
     "prepack": "npm run build",
     "prepublishOnly": "node ../scripts/check-scanner.mjs"

--- a/skill/plugin/recall-relevance-gate.test.ts
+++ b/skill/plugin/recall-relevance-gate.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Regression test for issue #116 — recall miss for single-token / short
+ * query "favorite color" against a stored fact like
+ * "User's favorite color is cobalt blue".
+ *
+ * Root cause: the recall tool's relevance gate filtered results based on
+ * cosine similarity alone (`maxCosine < 0.15` → suppress all). Short
+ * queries embedded by the local Harrier-OSS-270m model produce low
+ * cosine similarity against longer fact embeddings even when every query
+ * token literally appears in the candidate text — an extreme false-negative
+ * with no semantic correlate. Hermes (Python client) has NO cosine gate
+ * and recalled the same fact for the same Smart Account in rc.18 QA, which
+ * pinned the bug to the OpenClaw plugin's gate logic.
+ *
+ * Fix: `passesRelevanceGate` accepts results when EITHER cosine clears the
+ * threshold OR every meaningful query token (post stop-word removal) appears
+ * as a stem-prefix substring in the top reranked result's text.
+ *
+ * This file documents both the failure mode (would-have-failed assertions
+ * against the baseline cosine-only gate) and the fix's expected behaviour.
+ *
+ * Run with: npx tsx recall-relevance-gate.test.ts
+ */
+
+import {
+  passesRelevanceGate,
+  type RerankerResult,
+} from './reranker.js';
+
+let passed = 0;
+let failed = 0;
+let testNum = 0;
+
+function assert(condition: boolean, message: string): void {
+  testNum++;
+  if (condition) {
+    passed++;
+    console.log(`ok ${testNum} - ${message}`);
+  } else {
+    failed++;
+    console.log(`not ok ${testNum} - ${message}`);
+  }
+}
+
+/**
+ * Build a synthetic reranked result. Cosine similarity is set explicitly to
+ * mimic the Harrier-OSS-270m output for short queries (typically below the
+ * 0.15 default threshold even when topical match is unambiguous).
+ */
+function makeResult(text: string, cosine: number, id = 't1'): RerankerResult {
+  return {
+    id,
+    text,
+    rrfScore: 0.5,
+    cosineSimilarity: cosine,
+  };
+}
+
+const COSINE_THRESHOLD = 0.15;
+
+// ---------------------------------------------------------------------------
+// Baseline failure mode (issue #116)
+// ---------------------------------------------------------------------------
+
+console.log('# Baseline cosine-only gate (the bug)');
+
+{
+  // Mimic the rc.18 finding directly: short query "favorite color" against
+  // a stored fact, with cosine 0.10 (below 0.15 threshold).
+  const reranked = [
+    makeResult("User's favorite color is cobalt blue", 0.10),
+  ];
+  // The pre-fix gate code would return false here (and the recall tool
+  // would say "No relevant memories found for this query."). Document
+  // that regression directly:
+  const bareCosineGate = (
+    Math.max(...reranked.map((r) => r.cosineSimilarity ?? 0)) >= COSINE_THRESHOLD
+  );
+  assert(
+    bareCosineGate === false,
+    'baseline cosine-only gate suppresses "favorite color" against the matching fact (the rc.18 bug)',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Lexical-override path (the fix)
+// ---------------------------------------------------------------------------
+
+console.log('# Fix — lexical override accepts on-target short queries');
+
+{
+  // Issue #116 reproduction.
+  const reranked = [
+    makeResult("User's favorite color is cobalt blue", 0.10),
+  ];
+  const ok = passesRelevanceGate('favorite color', reranked, COSINE_THRESHOLD);
+  assert(ok === true, 'short query "favorite color" passes via lexical override (issue #116 regression)');
+}
+
+{
+  // Single-token query: "color" alone, with the cosine still under the gate.
+  const reranked = [
+    makeResult("User's favorite color is cobalt blue", 0.08),
+  ];
+  const ok = passesRelevanceGate('color', reranked, COSINE_THRESHOLD);
+  assert(ok === true, 'single-token query "color" passes via lexical override');
+}
+
+{
+  // Longer natural-language query — same fact, but cosine higher because
+  // the query has more semantic content. Should clear the cosine path.
+  const reranked = [
+    makeResult("User's favorite color is cobalt blue", 0.42),
+  ];
+  const ok = passesRelevanceGate("what's my favorite color?", reranked, COSINE_THRESHOLD);
+  assert(ok === true, 'natural-language query passes via cosine path (no regression on the long-query case)');
+}
+
+{
+  // Stem-tolerance: query token "favorite" appears as "favorites" in fact text.
+  const reranked = [
+    makeResult("User has several favorites; the top one is mountains.", 0.05),
+  ];
+  const ok = passesRelevanceGate('favorite', reranked, COSINE_THRESHOLD);
+  assert(ok === true, '4-char-prefix substring match tolerates light morphology (favorite ↔ favorites)');
+}
+
+// ---------------------------------------------------------------------------
+// Precision — gate must still reject genuinely-irrelevant queries
+// ---------------------------------------------------------------------------
+
+console.log('# Fix — gate still rejects irrelevant queries');
+
+{
+  // Query terms have NO overlap with the top result text. Low cosine + no
+  // lexical match → the gate must suppress. This is the precision case the
+  // gate was originally introduced for; the fix must not break it.
+  const reranked = [
+    makeResult("User's favorite color is cobalt blue", 0.05),
+  ];
+  const ok = passesRelevanceGate('chess strategies', reranked, COSINE_THRESHOLD);
+  assert(ok === false, 'irrelevant query is still suppressed (precision preserved)');
+}
+
+{
+  // Partial-token match must NOT pass — the override requires ALL query
+  // tokens to appear, not just one. "favorite cars" against a "favorite
+  // color" fact: "favorite" matches but "cars" doesn't — should suppress.
+  const reranked = [
+    makeResult("User's favorite color is cobalt blue", 0.05),
+  ];
+  const ok = passesRelevanceGate('favorite cars', reranked, COSINE_THRESHOLD);
+  assert(ok === false, 'partial token overlap does NOT trigger the lexical override');
+}
+
+{
+  // Empty / all-stop-words query: no meaningful tokens to match. Falls back
+  // to cosine path — must suppress when cosine is also below threshold.
+  const reranked = [
+    makeResult("User's favorite color is cobalt blue", 0.05),
+  ];
+  const ok = passesRelevanceGate('what is the', reranked, COSINE_THRESHOLD);
+  assert(ok === false, 'all-stop-word query falls back to cosine path (suppress when low)');
+}
+
+{
+  // Empty reranked list: must reject regardless of query.
+  const ok = passesRelevanceGate('favorite color', [], COSINE_THRESHOLD);
+  assert(ok === false, 'empty reranked list always returns false');
+}
+
+{
+  // Cosine path still works in isolation — if the top result has high
+  // cosine, lexical match is unnecessary.
+  const reranked = [
+    makeResult("Some unrelated text about chess.", 0.42),
+  ];
+  const ok = passesRelevanceGate('favorite color', reranked, COSINE_THRESHOLD);
+  assert(ok === true, 'high cosine alone is sufficient (cosine path)');
+}
+
+// ---------------------------------------------------------------------------
+// Edge: top result without text (defensive)
+// ---------------------------------------------------------------------------
+
+console.log('# Edge cases');
+
+{
+  const reranked: RerankerResult[] = [
+    { id: 'x', text: '', rrfScore: 0.5, cosineSimilarity: 0.1 },
+  ];
+  const ok = passesRelevanceGate('favorite color', reranked, COSINE_THRESHOLD);
+  assert(ok === false, 'empty top-result text cannot satisfy lexical override');
+}
+
+{
+  // cosineSimilarity undefined (e.g. candidate had no embedding) — treated as
+  // 0 by the gate. Lexical override should still rescue when applicable.
+  const reranked: RerankerResult[] = [
+    { id: 'x', text: "User's favorite color is cobalt blue", rrfScore: 0.5 },
+  ];
+  const ok = passesRelevanceGate('favorite color', reranked, COSINE_THRESHOLD);
+  assert(ok === true, 'missing cosineSimilarity does not block lexical override');
+}
+
+console.log(`\n1..${testNum}`);
+console.log(`# pass: ${passed}`);
+console.log(`# fail: ${failed}`);
+
+if (failed === 0) {
+  console.log('\nALL TESTS PASSED');
+  process.exit(0);
+} else {
+  console.log('\nFAILURES');
+  process.exit(1);
+}

--- a/skill/plugin/reranker.ts
+++ b/skill/plugin/reranker.ts
@@ -507,3 +507,76 @@ export function rerank(
   // Preserve rrfScore and cosineSimilarity through MMR
   return mmrResults as RerankerResult[];
 }
+
+// ---------------------------------------------------------------------------
+// Relevance gate (issue #116)
+// ---------------------------------------------------------------------------
+
+/**
+ * Decide whether reranked results clear the relevance gate for surfacing to
+ * the user (recall tool) or auto-injecting into agent context (hooks).
+ *
+ * Two-signal acceptance rule, addressing issue #116 (rc.18 finding F1):
+ *
+ *   1. **Cosine path** — at least one reranked result has cosine similarity
+ *      with the query embedding >= `cosineThreshold`. This is the existing
+ *      semantic-relevance gate and remains the primary signal.
+ *
+ *   2. **Lexical override** — when cosine is below threshold (e.g. short
+ *      queries against the local Harrier-OSS-270m model produce embeddings
+ *      with low cosine sim regardless of topical match), the gate ALSO
+ *      passes when every meaningful query token (post stop-word removal)
+ *      appears as a stem-prefix substring in the top reranked result's
+ *      text. This is strong lexical evidence that the user is asking
+ *      about a fact already stored, even when embedding sim is weak.
+ *
+ * Without (2), short queries like `"favorite color"` against the stored
+ * fact `"User's favorite color is cobalt blue"` were silently filtered
+ * even though every query token was present in the candidate. Hermes
+ * (Python client) does not apply any cosine gate, which is why it
+ * recalled the same fact for the same Smart Account in rc.18 QA.
+ *
+ * The lexical override is intentionally conservative:
+ *   - Requires ALL non-stop-word query tokens to be present (any-of would
+ *     over-trigger).
+ *   - Uses 4-char-prefix substring match to be stem-tolerant ("favorite"
+ *     stems to "favorit" in the stored fact's blind index, but the raw
+ *     fact text contains the unstemmed word; the prefix check absorbs
+ *     light morphology).
+ *   - Token count must be >= 1 — empty/all-stop-word queries fall back
+ *     to cosine path.
+ *
+ * @param query - the user's search query (raw string)
+ * @param reranked - reranked results (top first)
+ * @param cosineThreshold - the configured cosine cutoff (typically 0.15)
+ * @returns true if results should be surfaced; false to suppress
+ */
+export function passesRelevanceGate(
+  query: string,
+  reranked: RerankerResult[],
+  cosineThreshold: number,
+): boolean {
+  if (reranked.length === 0) return false;
+
+  // Path 1: cosine clears threshold.
+  const maxCosine = Math.max(...reranked.map((r) => r.cosineSimilarity ?? 0));
+  if (maxCosine >= cosineThreshold) return true;
+
+  // Path 2: lexical override — every meaningful query token appears in
+  // the top reranked result's text.
+  const queryTokens = tokenize(query, /* removeStopWords */ true);
+  if (queryTokens.length === 0) return false;
+
+  const topText = (reranked[0]?.text ?? '').toLowerCase();
+  if (topText.length === 0) return false;
+
+  // 4-char prefix substring match: tolerates light stemming ("favorite"
+  // matches a fact text containing "favorite", "favorites", "favoring",
+  // etc., without re-running the WASM Porter stemmer client-side).
+  const PREFIX_LEN = 4;
+  for (const token of queryTokens) {
+    const probe = token.length >= PREFIX_LEN ? token.slice(0, PREFIX_LEN) : token;
+    if (!topText.includes(probe)) return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary

- Cosine threshold gate (`< 0.15`) was too tight for short queries — Harrier-OSS-270m embeddings produce low cosine on short text even when every token is present in result
- Added lexical-substring override: if all post-stop-word query tokens appear as 4-char prefix substrings in top result text, pass the gate regardless of cosine
- Confirmed Hermes (no gate) recalled the same fact for the same SA — pinpointed bug to plugin gate

## Test plan

- [ ] 12 regression tests in `recall-relevance-gate.test.ts` green
- [ ] Full plugin test suite green
- [ ] Manual QA on rc.20: store "favorite color = blue", recall "what's my favorite color?" returns it

🤖 Generated with [Claude Code](https://claude.com/claude-code)