### PR TITLE
cleanup(rc.18): dynamic state.json version + stale SESSION_ID doc (closes #119, #120)

### DIFF
--- a/skill-nanoclaw/SKILL.md
+++ b/skill-nanoclaw/SKILL.md
@@ -323,7 +323,7 @@ This provides memory isolation between different contexts.
 
 The v1 env cleanup removed the following user-facing vars: `TOTALRECLAW_CHAIN_ID`
 (chain is auto-detected from billing tier), `TOTALRECLAW_EMBEDDING_MODEL`,
-`TOTALRECLAW_STORE_DEDUP`, `TOTALRECLAW_LLM_MODEL`, `TOTALRECLAW_SESSION_ID`,
+`TOTALRECLAW_STORE_DEDUP`, `TOTALRECLAW_LLM_MODEL`,
 `TOTALRECLAW_TAXONOMY_VERSION`, `TOTALRECLAW_CLAIM_FORMAT`,
 `TOTALRECLAW_DIGEST_MODE`. Tuning knobs like `TOTALRECLAW_EXTRACT_INTERVAL`
 and `TOTALRECLAW_MIN_IMPORTANCE` are now delivered via the relay billing

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -2832,6 +2832,13 @@ const plugin = {
     // function — stable builds never see it. The version is resolved via
     // `readPluginVersion` from fs-helpers.ts (scanner-safe, pure-fs).
     let rcMode = false;
+    // Plugin version resolved from package.json once at register time. Reused
+    // by writeOnboardingState callsites below so the `version` field in
+    // state.json tracks the actual shipped plugin version (avoids drift —
+    // e.g. rc.18 finding F4 where a hardcoded `'3.3.1-rc.11'` stayed put
+    // through 7 RC bumps). Fallback `'3.3.0'` matches the prior literal at
+    // the loopback callsite if package.json read fails.
+    let pluginVersion: string | null = null;
     try {
       // `import.meta.url` is ESM-only; fallback to `__dirname` for the CJS
       // build path. `require` comes from Node core and is available in both
@@ -2839,10 +2846,10 @@ const plugin = {
       const url = require('node:url') as typeof import('node:url');
       const nodePath = require('node:path') as typeof import('node:path');
       const pluginDir = nodePath.dirname(url.fileURLToPath(import.meta.url));
-      const version = readPluginVersion(pluginDir);
-      rcMode = isRcBuild(version);
+      pluginVersion = readPluginVersion(pluginDir);
+      rcMode = isRcBuild(pluginVersion);
       if (rcMode) {
-        api.logger.info(`TotalReclaw: RC build detected (version=${version}). RC-gated tools will be registered.`);
+        api.logger.info(`TotalReclaw: RC build detected (version=${pluginVersion}). RC-gated tools will be registered.`);
       }
     } catch {
       rcMode = false;
@@ -3021,7 +3028,7 @@ const plugin = {
             onboardingState: 'active',
             createdBy: 'generate',
             credentialsCreatedAt: new Date().toISOString(),
-            version: '3.3.0',
+            version: pluginVersion ?? '3.3.0',
           });
           return { state: 'active' };
         },
@@ -5079,7 +5086,7 @@ const plugin = {
                           onboardingState: 'active',
                           createdBy: mode === 'generate' ? 'generate' : 'import',
                           credentialsCreatedAt: new Date().toISOString(),
-                          version: '3.3.1-rc.11',
+                          version: pluginVersion ?? '3.3.0',
                         });
                         api.logger.info(
                           `totalreclaw_pair(relay): session ${remoteSession.token.slice(0, 8)}… completed; credentials written`,


### PR DESCRIPTION
## Summary

- **#119**: hoisted readPluginVersion() call to register-scope, replaced two hardcoded version literals (\`'3.3.0'\` loopback, \`'3.3.1-rc.11'\` relay) with dynamic value. Future RC bumps flow into ~/.totalreclaw/state.json automatically.
- **#120**: removed misleading TOTALRECLAW_SESSION_ID reference from skill-nanoclaw/SKILL.md "v1 cleanup removed" list — Hermes restored support in v2.0.2.

## Test plan

- [ ] Build clean
- [ ] 39/39 onboarding-state tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)