### PR TITLE
fix(plugin): rc.20 ESM require + dist-esm-smoke CI gate (closes #124)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,17 @@ jobs:
       - name: Verify tarball ships built `.js` artifacts (issue #110)
         run: cd skill/plugin && npm run verify-tarball
 
+      # Issue #124 (rc.20 ship-stopper): the published `dist/index.js` is
+      # ESM-only (`"type":"module"`) but had three runtime `require()` calls
+      # left over from an unfinished migration — every plugin entry point
+      # died with `require is not defined`. The pre-publish gate above only
+      # runs `node --check` (syntax-only) and missed it. This step actually
+      # imports the built dist in a clean Node ESM process AND grep-guards
+      # the dist files for any bare `require(` outside comments. Catches
+      # the regression at PR time, never publish-time.
+      - name: ESM-shape smoke (issue #124 — bare require regression)
+        run: cd skill/plugin && npm run smoke:dist
+
   mcp-tests:
     name: MCP Server Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -372,6 +372,16 @@ jobs:
       - name: Verify tarball ships built `.js` artifacts (issue #110)
         run: cd skill/plugin && npm run verify-tarball
 
+      # Issue #124 (rc.20 ship-stopper): the published `dist/index.js` had
+      # three runtime `require()` calls under `"type":"module"`. The
+      # tarball-smoke step below imports the entry, but `require()`s on
+      # lazy paths (extractor, hot-cache, plugin-version reader) don't
+      # fire on import alone. This grep+exec gate scans every dist/*.js
+      # for bare `require(` outside comments AND executes the dist in a
+      # clean ESM process. Fail-fast at publish, never reach the registry.
+      - name: ESM-shape smoke (issue #124 — bare require regression)
+        run: cd skill/plugin && npm run smoke:dist
+
       - name: Smoke-import the plugin module from a clean Node env
         run: |
           cd skill/plugin

--- a/skill/plugin/crypto.ts
+++ b/skill/plugin/crypto.ts
@@ -15,10 +15,18 @@
  *     -> HKDF-SHA256(seed, salt, "openmemory-dedup-v1",           32) -> dedupKey
  */
 
-// Lazy-load WASM to avoid crash when npm install hasn't finished yet.
+// Lazy-load WASM. Uses createRequire so this module loads cleanly under bare
+// Node ESM — the shipped `dist/index.js` declares `"type":"module"`, where
+// the CJS `require` global is undefined at runtime. Prior to the rc.21 fix
+// this file called bare `require('@totalreclaw/core')` and every consumer
+// died with `require is not defined`. Matches the pattern already used by
+// claims-helper / consolidation / contradiction-sync / digest-sync / pin /
+// retype-setscope. See issue #124.
+import { createRequire } from 'node:module';
+const requireWasm = createRequire(import.meta.url);
 let _wasm: typeof import('@totalreclaw/core') | null = null;
 function getWasm() {
-  if (!_wasm) _wasm = require('@totalreclaw/core');
+  if (!_wasm) _wasm = requireWasm('@totalreclaw/core');
   return _wasm;
 }
 

--- a/skill/plugin/dist-esm-smoke.test.ts
+++ b/skill/plugin/dist-esm-smoke.test.ts
@@ -1,0 +1,200 @@
+/**
+ * dist-esm-smoke.test.ts — regression guard for issue #124.
+ *
+ * Background (rc.20 ship-stopper)
+ *   The shipped `dist/index.js` declared `"type":"module"` but contained
+ *   three runtime `require()` calls left over from an unfinished migration:
+ *
+ *     - `require('@totalreclaw/core')` — lazy WASM loader (smart-import path)
+ *     - `require('node:url')`          — plugin-version reader fallback
+ *     - `require('node:path')`         — plugin-version reader fallback
+ *
+ *   Bare `require` is undefined under pure-ESM Node. Every code path that
+ *   touched these helpers died with `require is not defined` — including
+ *   the `before_agent_start` hook (universal), the `agent_end` extraction
+ *   pipeline, every `totalreclaw_*` tool, and credentials hot-reload. The
+ *   plugin appeared to register cleanly but stored zero memories.
+ *
+ *   The pre-publish gate that should have caught this — `verify-tarball.mjs`
+ *   — only ran `node --check`, which is a syntax-only inspection and does
+ *   NOT execute the file. This test fills the gap by actually importing
+ *   `dist/index.js` in a bare Node ESM process.
+ *
+ * What this test asserts
+ *   1. `dist/index.js` exists (i.e. `npm run build` was run before tests).
+ *   2. `node --input-type=module --eval "await import('./dist/index.js')"`
+ *      completes without throwing. This proves the bundle is syntactically
+ *      valid AND every top-level statement runs (including any future
+ *      module-init code that may add new createRequire shapes).
+ *   3. The default export resolves to a plugin object with `id === 'totalreclaw'`,
+ *      matching what the OpenClaw loader expects.
+ *   4. Grep guard: no bare `require(` call appears outside comments in the
+ *      built dist files. This is the ESM-shape contract — every CJS-style
+ *      load MUST go through createRequire (or be replaced with a static
+ *      `import`). Catches the regression at the source level even before
+ *      the runtime smoke fires.
+ *
+ * What this test does NOT do
+ *   It does not invoke the OpenClaw plugin lifecycle (api.registerTool,
+ *   api.registerHttpRoute, api.registerHook). Doing so would require a
+ *   stub of the full OpenClaw plugin API + a faked workspace tree. The
+ *   import-side smoke covers the failure mode that bit rc.20 — a `require`
+ *   call evaluated at module init or during the lazy-loader path that the
+ *   `before_agent_start` hook trips on every turn.
+ *
+ * Runtime
+ *   `npx tsx dist-esm-smoke.test.ts` — wired into the npm test script.
+ *   Requires `npm run build` to have been run first; the `prepack` hook
+ *   builds dist/, but the test script does not auto-build, so the CI
+ *   step order is:
+ *     1. npm install
+ *     2. npm test         (this includes import-time-smoke against ./index.ts source)
+ *     3. npm run build    (emits dist/)
+ *     4. npm run verify-tarball  (runs node --check on dist + tarball ship list)
+ *
+ *   This test belongs AFTER step 3 because it inspects dist/. We add it as
+ *   a separate `npm run smoke:dist` script invoked from the publish workflow
+ *   immediately after build.
+ *
+ * Why both this AND verify-tarball?
+ *   verify-tarball is a syntax check — fast, catches mis-paths and broken
+ *   parses. dist-esm-smoke is an execution check — catches runtime
+ *   ReferenceErrors like the rc.20 `require is not defined`. Both are
+ *   cheap (sub-second) and target different failure surfaces.
+ */
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import * as nodePath from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = nodePath.dirname(fileURLToPath(import.meta.url));
+const DIST_DIR = nodePath.join(HERE, 'dist');
+const DIST_INDEX = nodePath.join(DIST_DIR, 'index.js');
+
+// ---- assertion 1 ----------------------------------------------------------
+assert.ok(
+  existsSync(DIST_INDEX),
+  `dist-esm-smoke: ${DIST_INDEX} is missing — run \`npm run build\` from skill/plugin/ first`,
+);
+console.log(`ok 1 - dist/index.js exists at ${DIST_INDEX}`);
+
+// ---- assertion 2 ----------------------------------------------------------
+//
+// We run this in a child process (a) to get a clean Node ESM context with
+// no test-runner residue, (b) to mirror exactly how OpenClaw loads the
+// plugin in production. `--input-type=module` forces ESM evaluation; the
+// stdin path lets us pass the load script without writing a temp file.
+//
+// We import a file:// URL because Node's ESM loader on Windows does not
+// accept bare relative paths from --eval/stdin scripts.
+const distFileUrl = new URL(`file://${DIST_INDEX}`).href;
+const child = execFileSync(
+  process.execPath,
+  ['--input-type=module', '-e', `await import(${JSON.stringify(distFileUrl)})`],
+  { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8', timeout: 60_000 },
+);
+// `child` is the captured stdout. We don't expect any output on success;
+// we just need the process to exit 0. execFileSync throws on non-zero
+// exit, so reaching this line means the import succeeded.
+console.log(`ok 2 - dist/index.js imported in clean Node ESM (${child.length} bytes stdout, no throw)`);
+
+// ---- assertion 3 ----------------------------------------------------------
+//
+// Re-import in this same process to actually inspect the default export.
+// We can't introspect the child's exports, so this is a second load path.
+// On a healthy build both loads are equivalent.
+const mod = (await import(distFileUrl)) as { default?: { id?: string } };
+assert.ok(
+  mod.default && typeof mod.default === 'object',
+  'dist-esm-smoke: dist/index.js default export must be an object',
+);
+assert.equal(
+  mod.default.id,
+  'totalreclaw',
+  `dist-esm-smoke: plugin id must be "totalreclaw" (got ${JSON.stringify(mod.default.id)})`,
+);
+console.log(`ok 3 - dist default export has id="totalreclaw"`);
+
+// ---- assertion 4 ----------------------------------------------------------
+//
+// Static-shape guard: scan every .js file in dist/ for bare `require(` calls
+// outside of comments. The only acceptable shape post-rc.21 is via
+// createRequire — call sites use a local binding (`requireWasm`,
+// `__cjsRequire`, etc.) and NOT the bare global. Comments mentioning
+// require are fine.
+//
+// Implementation: read each line, strip `//`-line comments, strip block
+// comments crudely (nesting is rare in transpiled TS), then regex for
+// the bare `require(` pattern. False-positive rate is acceptable — this
+// is a pre-publish gate, not a production check.
+function stripCommentsRough(src: string): string {
+  // Remove block comments first (greedy, handles multi-line).
+  let out = src.replace(/\/\*[\s\S]*?\*\//g, '');
+  // Remove single-line comments.
+  out = out
+    .split('\n')
+    .map((line) => {
+      // Keep //-inside-string-literal alone — heuristic: only strip if //
+      // is preceded by whitespace or start-of-line. Covers TS-emitted JS,
+      // which never embeds // inside strings of meaningful spots.
+      const idx = line.search(/(?:^|\s)\/\//);
+      if (idx === -1) return line;
+      return line.slice(0, idx);
+    })
+    .join('\n');
+  return out;
+}
+
+function* walkJsFiles(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = nodePath.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkJsFiles(full);
+    } else if (entry.isFile() && entry.name.endsWith('.js')) {
+      yield full;
+    }
+  }
+}
+
+const violations: { file: string; line: number; text: string }[] = [];
+for (const file of walkJsFiles(DIST_DIR)) {
+  const src = readFileSync(file, 'utf-8');
+  const stripped = stripCommentsRough(src);
+  const lines = stripped.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    // Bare `require(` not preceded by `.` (so `requireWasm(` and
+    // `createRequire(` are excluded), not preceded by a word char (so
+    // `myrequire(` is excluded), and not followed by a `.` (cheap dedup).
+    if (/(?:^|[^\w.])require\s*\(/.test(lines[i])) {
+      violations.push({
+        file: nodePath.relative(DIST_DIR, file),
+        line: i + 1,
+        text: lines[i].trim().slice(0, 160),
+      });
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error('dist-esm-smoke: bare require() calls found in built dist:');
+  for (const v of violations.slice(0, 10)) {
+    console.error(`  ${v.file}:${v.line}  ${v.text}`);
+  }
+  if (violations.length > 10) {
+    console.error(`  ... and ${violations.length - 10} more`);
+  }
+  console.error(
+    '\nESM build (`"type":"module"`) — the bare `require` global is undefined ' +
+      'at runtime. Use `createRequire(import.meta.url)` from `node:module` ' +
+      'and call through that local binding (see crypto.ts / lsh.ts for the pattern). ' +
+      'Issue #124 was rc.20 shipping with three of these.',
+  );
+  process.exit(1);
+}
+console.log(`ok 4 - no bare require() in dist/*.js (${violations.length} violations)`);
+
+console.log('# fail: 0');
+console.log('# 4/4 passed');
+console.log('ALL TESTS PASSED');

--- a/skill/plugin/dist-esm-smoke.test.ts
+++ b/skill/plugin/dist-esm-smoke.test.ts
@@ -1,3 +1,4 @@
+// scanner-sim: allow — CI-only smoke test, child_process used to spawn clean Node and verify dist ESM-loads. Not part of plugin runtime.
 /**
  * dist-esm-smoke.test.ts — regression guard for issue #124.
  *

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -161,6 +161,19 @@ import { detectGatewayHost } from './gateway-url.js';
 import { validateMnemonic } from '@scure/bip39';
 import { wordlist } from '@scure/bip39/wordlists/english.js';
 import crypto from 'node:crypto';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import * as nodePath from 'node:path';
+
+// CJS-style require for the @totalreclaw/core WASM module. We keep this
+// load path lazy (only inside getSmartImportWasm() below) so a partial
+// install of the dependency tree doesn't crash module init. Bare
+// `require()` is a CommonJS global and is undefined under bare Node ESM —
+// the shipped `dist/index.js` declares `"type":"module"`, so calling the
+// global directly emits "require is not defined" at runtime (issue #124).
+// createRequire bridges the gap. Same shape as crypto.ts / lsh.ts /
+// subgraph-store.ts / claims-helper.ts.
+const __cjsRequire = createRequire(import.meta.url);
 
 // ---------------------------------------------------------------------------
 // OpenClaw Plugin API type (defined locally to avoid SDK dependency)
@@ -2298,10 +2311,13 @@ async function handlePluginImportFrom(
 // Smart Import — Two-Pass Pipeline (Profile + Triage)
 // ---------------------------------------------------------------------------
 
-// Lazy-load WASM for smart import functions (same pattern as crypto.ts / subgraph-store.ts).
+// Lazy-load WASM for smart import functions (same pattern as crypto.ts /
+// subgraph-store.ts). Goes through __cjsRequire (createRequire(import.meta.url))
+// declared at the top of the file — bare `require()` is undefined under
+// pure-ESM Node, see issue #124.
 let _smartImportWasm: typeof import('@totalreclaw/core') | null = null;
 function getSmartImportWasm() {
-  if (!_smartImportWasm) _smartImportWasm = require('@totalreclaw/core');
+  if (!_smartImportWasm) _smartImportWasm = __cjsRequire('@totalreclaw/core');
   return _smartImportWasm;
 }
 
@@ -2840,12 +2856,13 @@ const plugin = {
     // the loopback callsite if package.json read fails.
     let pluginVersion: string | null = null;
     try {
-      // `import.meta.url` is ESM-only; fallback to `__dirname` for the CJS
-      // build path. `require` comes from Node core and is available in both
-      // module formats. `fileURLToPath` / `path.dirname` are pure-sync.
-      const url = require('node:url') as typeof import('node:url');
-      const nodePath = require('node:path') as typeof import('node:path');
-      const pluginDir = nodePath.dirname(url.fileURLToPath(import.meta.url));
+      // Resolve our own dist/ directory so `readPluginVersion` can locate
+      // package.json. We use `import.meta.url` + ESM-static stdlib imports
+      // (`fileURLToPath` from `node:url`, `nodePath.dirname` from `node:path`,
+      // both imported at the top of this file). Earlier shape used inline
+      // `require('node:url')` — undefined under bare-ESM Node, broke the
+      // before_agent_start hook in the published rc.20 bundle (issue #124).
+      const pluginDir = nodePath.dirname(fileURLToPath(import.meta.url));
       pluginVersion = readPluginVersion(pluginDir);
       rcMode = isRcBuild(pluginVersion);
       if (rcMode) {

--- a/skill/plugin/lsh.ts
+++ b/skill/plugin/lsh.ts
@@ -7,10 +7,15 @@
  * Default parameters: 32 bits per table, 20 tables.
  */
 
-// Lazy-load WASM to avoid crash when npm install hasn't finished yet.
+// Lazy-load WASM via createRequire. The shipped `dist/index.js` is ESM-only
+// (`"type":"module"`) so the bare `require` global is undefined at runtime.
+// See issue #124 for the bug this avoids; matches the pattern in
+// claims-helper / consolidation / digest-sync / pin / retype-setscope.
+import { createRequire } from 'node:module';
+const requireWasm = createRequire(import.meta.url);
 let _WasmLshHasher: typeof import('@totalreclaw/core')['WasmLshHasher'] | null = null;
 function getWasmLshHasher() {
-  if (!_WasmLshHasher) _WasmLshHasher = require('@totalreclaw/core').WasmLshHasher;
+  if (!_WasmLshHasher) _WasmLshHasher = requireWasm('@totalreclaw/core').WasmLshHasher;
   return _WasmLshHasher!;
 }
 

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -63,6 +63,7 @@
     "build": "rm -rf dist && tsc -p tsconfig.json --noCheck",
     "verify-tarball": "node ../scripts/verify-tarball.mjs",
     "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx llm-client-retry.test.ts && npx tsx gateway-url.test.ts && npx tsx retype-setscope.test.ts && npx tsx tool-gating.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts && npx tsx pair-qr.test.ts && npx tsx pair-remote-client.test.ts && npx tsx qa-bug-report.test.ts && npx tsx nonce-serialization.test.ts && npx tsx phrase-safety-registry.test.ts && npx tsx test_issue_92_onnx_download_ux.test.ts && npx tsx onboard-pair-only.test.ts && npx tsx import-time-smoke.test.ts && npx tsx recall-relevance-gate.test.ts",
+    "smoke:dist": "npx tsx dist-esm-smoke.test.ts",
     "check-scanner": "node ../scripts/check-scanner.mjs",
     "prepack": "npm run build",
     "prepublishOnly": "node ../scripts/check-scanner.mjs"

--- a/skill/plugin/subgraph-store.ts
+++ b/skill/plugin/subgraph-store.ts
@@ -10,10 +10,14 @@
  * and chain RPCs. No viem, no permissionless.
  */
 
-// Lazy-load WASM to avoid crash when npm install hasn't finished yet.
+// Lazy-load WASM via createRequire — the shipped bundle is ESM-only and
+// the bare `require` global is undefined there (issue #124). Same pattern
+// as crypto / lsh / claims-helper / consolidation / digest-sync.
+import { createRequire } from 'node:module';
+const requireWasm = createRequire(import.meta.url);
 let _wasm: typeof import('@totalreclaw/core') | null = null;
 function getWasm() {
-  if (!_wasm) _wasm = require('@totalreclaw/core');
+  if (!_wasm) _wasm = requireWasm('@totalreclaw/core');
   return _wasm;
 }
 import { CONFIG } from './config.js';


### PR DESCRIPTION
## Summary

**rc.20 yanked**: published `dist/index.js` is ESM (`"type": "module"`) but contains 3 runtime `require()` calls — every plugin entry point dies with `require is not defined`. Zero on-chain writes. Silent fallback to plaintext `~/.openclaw/workspace/USER.md`.

## Root cause

Half-done ESM migration. Some files (`claims-helper`, `consolidation`, `contradiction-sync`, `digest-sync`, `pin`, `retype-setscope`) already used `createRequire(import.meta.url)`. Others (`crypto.ts`, `lsh.ts`, `subgraph-store.ts`, `index.ts`) still called bare `require()`. Built dist was syntactically valid (TS `types:["node"]` declares `var require` globally) so `node --check` passed. Bug surfaced only at runtime on lazy paths — exactly the paths plugin entry points exercise.

## Changes

- `crypto.ts`, `lsh.ts`, `subgraph-store.ts`, `index.ts`: replace bare `require()` with `createRequire(import.meta.url)`
- `dist-esm-smoke.test.ts` (NEW, 200 lines): grep-asserts no bare `require()` in dist + loads dist in clean ESM Node context
- `.github/workflows/ci.yml` + `.github/workflows/npm-publish.yml`: wire smoke into pre-publish gate

## Why CI didn't catch this

`verify-tarball.mjs` is syntax-only (`node --check`). New `dist-esm-smoke.test.ts` fills the runtime gap. Companion fix #129 (totalreclaw-internal) restores the QA harness pair simulator that should have caught this end-to-end but had been silently broken since rc.12 (cipher + endpoint divergence — three issues stacked).

## Test plan

- [ ] `dist-esm-smoke.test.ts` PASSes on this branch (verified locally)
- [ ] `dist-esm-smoke.test.ts` FAILs on rc.20 baseline (verified locally — tagged checkout)
- [ ] CI gates green
- [ ] rc.21 brutal QA confirms zero `require is not defined` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)