### PR TITLE
fix(publish): version-drift gate + auto git-tag (closes rc.21 #3, #8)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -336,7 +336,7 @@ jobs:
     name: Publish @totalreclaw/totalreclaw (OpenClaw plugin)
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write  # `write` so the post-publish step can `git push origin v<VERSION>` (rc.21 finding #8)
       id-token: write  # OIDC trusted publishing
     steps:
       - uses: actions/checkout@v4
@@ -420,6 +420,18 @@ jobs:
           console.log('RC version:', p.version);
           "
 
+      # Propagate the (possibly RC-mutated) package.json::version into
+      # SKILL.md frontmatter and skill.json, then GATE the publish on
+      # those three sites being aligned. Catches the rc.21 drift class
+      # (package.json says rc.21, SKILL.md says rc.11, skill.json says
+      # 1.6.2) BEFORE we publish a confused tarball. See
+      # skill/scripts/sync-version.mjs + check-version-drift.mjs.
+      - name: Sync bundled-tarball version sites + drift gate
+        run: |
+          cd skill/plugin
+          node ../scripts/sync-version.mjs
+          node ../scripts/check-version-drift.mjs
+
       - name: Publish
         if: inputs.dry-run == false
         run: |
@@ -441,5 +453,30 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Report version
+        id: report
         run: |
-          node -e "const p = require('./skill/plugin/package.json'); console.log('Published:', p.name + '@' + p.version)"
+          VERSION=$(node -e "console.log(require('./skill/plugin/package.json').version)")
+          echo "Published: @totalreclaw/totalreclaw@${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      # Tag the source SHA the workflow published from. Idempotent: if the
+      # tag already exists on the remote (re-run, manual backfill), skip.
+      # Uses the RESOLVED version (e.g. 3.3.1-rc.22), so RCs and stables
+      # both get a tag. Closes the rc.21 finding #8 gap (no `v3.3.1-rc.*`
+      # tags in the public repo, only stables up to v3.0.4).
+      - name: Tag git commit with published version
+        if: inputs.dry-run == false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.report.outputs.version }}"
+          TAG="v${VERSION}"
+          if git ls-remote --tags origin "refs/tags/${TAG}" | grep -q "${TAG}$"; then
+            echo "Tag ${TAG} already exists on origin, skipping"
+            exit 0
+          fi
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name  "github-actions[bot]"
+          git tag "${TAG}"
+          git push origin "${TAG}"
+          echo "Tagged: ${TAG}"

--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -56,6 +56,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # `write` so the post-publish step can `git push origin v<VERSION>` (rc.21 finding #8)
     steps:
       - uses: actions/checkout@v4
 
@@ -87,9 +89,21 @@ jobs:
       - name: Install ClawHub CLI
         run: npm install -g clawhub
 
-      - name: Publish to ClawHub
-        env:
-          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+      # ROOT CAUSE of rc.21 finding #3 (on-disk version drift): this
+      # workflow used to call `clawhub publish ./skill/plugin` WITHOUT
+      # ever mutating package.json / SKILL.md / skill.json in the
+      # working tree. So even when `--version` was set to the right RC
+      # string in the catalog, the tarball ClawHub built from
+      # `./skill/plugin/` shipped whatever was checked into main —
+      # which was a stale 3.3.1-rc.15 in package.json + 3.3.1-rc.11 in
+      # SKILL.md + 1.6.2 in skill.json. New users installing rc.21 got
+      # rc.15-on-disk, no matter what the catalog said.
+      #
+      # Fix: resolve the publish version, write it into all three
+      # bundled files BEFORE `clawhub publish`, then run the drift
+      # gate so a sync regression is impossible.
+      - name: Resolve version + propagate to bundled tarball files
+        id: resolve
         run: |
           set -e
           BASE_VERSION="${{ github.event.inputs.version || github.ref_name }}"
@@ -102,13 +116,43 @@ jobs:
 
           if [ "$RELEASE_TYPE" = "rc" ]; then
             VERSION="${BASE_VERSION}-rc.${RC_NUMBER}"
+          else
+            VERSION="$BASE_VERSION"
+          fi
+
+          # Mutate skill/plugin/package.json::version in-place. Same shape
+          # as the npm-publish.yml RC suffix step — keeps the canonical
+          # source of truth in one place.
+          node -e "
+          const fs = require('fs');
+          const p = require('./skill/plugin/package.json');
+          p.version = '${VERSION}';
+          fs.writeFileSync('./skill/plugin/package.json', JSON.stringify(p, null, 2) + '\n');
+          console.log('package.json::version =', p.version);
+          "
+
+          # Propagate into SKILL.md frontmatter + skill.json, then GATE.
+          node skill/scripts/sync-version.mjs
+          node skill/scripts/check-version-drift.mjs
+
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "release_type=${RELEASE_TYPE}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to ClawHub
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+        run: |
+          set -e
+          VERSION="${{ steps.resolve.outputs.version }}"
+          RELEASE_TYPE="${{ steps.resolve.outputs.release_type }}"
+
+          if [ "$RELEASE_TYPE" = "rc" ]; then
             # `rc`-only tags; do NOT set `latest` so the ClawHub front page
             # keeps pointing at the last stable version until promote-rc
             # republishes the same content as `latest`.
             TAGS="rc"
             CHANGELOG="Release candidate $VERSION -- testing build, not recommended for production. See https://github.com/p-diogo/totalreclaw/releases"
           else
-            VERSION="$BASE_VERSION"
             TAGS="latest,memory,encryption,e2ee,privacy,agent-memory,e2e-encryption,persistent-context"
             CHANGELOG="Release $VERSION -- see https://github.com/p-diogo/totalreclaw/releases/tag/v$VERSION"
           fi
@@ -129,6 +173,26 @@ jobs:
           # Surface the published version for downstream jobs / notifications.
           echo "published_version=$VERSION" >> "$GITHUB_OUTPUT"
         id: publish
+
+      # Idempotent git-tag of the source SHA the ClawHub publish came
+      # from. Same logic as npm-publish.yml so manual dispatches that
+      # only hit ClawHub still tag history. Closes rc.21 finding #8
+      # (no v3.3.1-rc.* tags in public repo).
+      - name: Tag git commit with published version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.publish.outputs.published_version }}"
+          TAG="v${VERSION}"
+          if git ls-remote --tags origin "refs/tags/${TAG}" | grep -q "${TAG}$"; then
+            echo "Tag ${TAG} already exists on origin, skipping"
+            exit 0
+          fi
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name  "github-actions[bot]"
+          git tag "${TAG}"
+          git push origin "${TAG}"
+          echo "Tagged: ${TAG}"
 
       - name: Notify on Telegram
         if: success()

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "Install + set up TotalReclaw encrypted memory for OpenClaw, then use totalreclaw_remember / totalreclaw_recall. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', or any remember / recall request."
-version: 3.3.1-rc.11
+version: 3.3.1
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.1-rc.15",
+  "version": "3.3.1",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [
@@ -65,8 +65,10 @@
     "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx config.test.ts && npx tsx relay-headers.test.ts && npx tsx scope-address-visible.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx llm-client-retry.test.ts && npx tsx gateway-url.test.ts && npx tsx retype-setscope.test.ts && npx tsx tool-gating.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts && npx tsx pair-qr.test.ts && npx tsx pair-remote-client.test.ts && npx tsx qa-bug-report.test.ts && npx tsx nonce-serialization.test.ts && npx tsx phrase-safety-registry.test.ts && npx tsx test_issue_92_onnx_download_ux.test.ts && npx tsx onboard-pair-only.test.ts && npx tsx import-time-smoke.test.ts && npx tsx recall-relevance-gate.test.ts && npx tsx install-staging-cleanup.test.ts && npx tsx json-stdout-cleanliness.test.ts",
     "smoke:dist": "npx tsx dist-esm-smoke.test.ts",
     "check-scanner": "node ../scripts/check-scanner.mjs",
+    "check-version-drift": "node ../scripts/check-version-drift.mjs",
+    "sync-version": "node ../scripts/sync-version.mjs",
     "prepack": "npm run build",
-    "prepublishOnly": "node ../scripts/check-scanner.mjs"
+    "prepublishOnly": "node ../scripts/check-scanner.mjs && node ../scripts/check-version-drift.mjs"
   },
   "openclaw": {
     "extensions": [

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "1.6.2",
+  "version": "3.3.1",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",

--- a/skill/scripts/check-version-drift.mjs
+++ b/skill/scripts/check-version-drift.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * check-version-drift.mjs — Pre-publish gate that FAILS if any of the
+ * three plugin version sites drift from `package.json::version`.
+ *
+ * Sites checked:
+ *   1. skill/plugin/package.json::version           (canonical / source of truth)
+ *   2. skill/plugin/SKILL.md frontmatter `version:`
+ *   3. skill/plugin/skill.json::version
+ *
+ * Why this exists (2026-04-25):
+ *   The rc.21 brutal QA caught three different versions on disk for what
+ *   should have been a single rc.21 bundle. See `sync-version.mjs` for
+ *   the full root-cause write-up.
+ *
+ *   This script is run:
+ *     - As `prepublishOnly` in skill/plugin/package.json (npm publish path)
+ *     - As an explicit step in npm-publish.yml + publish-clawhub.yml,
+ *       AFTER the RC suffix mutation + sync, so a sync regression also
+ *       surfaces as a workflow-level failure (not buried in a packlist).
+ *
+ * Performance:
+ *   Three small file reads, no network, no spawn. <100ms in practice.
+ *   Well under the <1min "fast gate" budget.
+ *
+ * Exit codes:
+ *   0 — all three sites match
+ *   1 — drift detected (printed to stderr in actionable form)
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pluginDir = resolve(here, '..', 'plugin');
+
+const pkgPath = resolve(pluginDir, 'package.json');
+const skillMdPath = resolve(pluginDir, 'SKILL.md');
+const skillJsonPath = resolve(pluginDir, 'skill.json');
+
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+const canonical = pkg.version;
+if (!canonical) {
+  console.error('FATAL: skill/plugin/package.json has no `version` field');
+  process.exit(1);
+}
+
+const skillMd = readFileSync(skillMdPath, 'utf8');
+const skillJson = JSON.parse(readFileSync(skillJsonPath, 'utf8'));
+
+// SKILL.md: extract the `version:` line from frontmatter only (first
+// --- ... --- block at top of file).
+const fmStart = skillMd.indexOf('---');
+const fmEnd = skillMd.indexOf('\n---', fmStart + 3);
+if (fmStart !== 0 || fmEnd === -1) {
+  console.error('FATAL: SKILL.md does not start with a YAML frontmatter block');
+  process.exit(1);
+}
+const frontmatter = skillMd.slice(fmStart, fmEnd);
+const versionMatch = frontmatter.match(/^version:\s*(\S+)\s*$/m);
+if (!versionMatch) {
+  console.error('FATAL: SKILL.md frontmatter has no `version:` line');
+  process.exit(1);
+}
+const skillMdVersion = versionMatch[1];
+const skillJsonVersion = skillJson.version;
+
+const sites = [
+  { name: 'skill/plugin/package.json::version', value: canonical },
+  { name: 'skill/plugin/SKILL.md frontmatter version', value: skillMdVersion },
+  { name: 'skill/plugin/skill.json::version', value: skillJsonVersion },
+];
+
+const drift = sites.filter((s) => s.value !== canonical);
+
+if (drift.length === 0) {
+  console.log(`check-version-drift: OK (all three sites = ${canonical})`);
+  process.exit(0);
+}
+
+console.error('check-version-drift: FAIL — version drift detected');
+console.error('');
+console.error(`  canonical (package.json::version) = ${canonical}`);
+console.error('');
+for (const s of sites) {
+  const marker = s.value === canonical ? '   ok   ' : '  DRIFT ';
+  console.error(`  [${marker}] ${s.name} = ${s.value}`);
+}
+console.error('');
+console.error('Fix: run `node skill/scripts/sync-version.mjs` to propagate package.json::version');
+console.error('to SKILL.md and skill.json, then re-run this gate.');
+process.exit(1);

--- a/skill/scripts/sync-version.mjs
+++ b/skill/scripts/sync-version.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * sync-version.mjs — Propagate `skill/plugin/package.json::version` into
+ * the other version sites bundled with the plugin tarball.
+ *
+ * Why this exists (2026-04-25):
+ *   `skill/plugin/package.json::version` is the source of truth. The
+ *   `npm-publish.yml` workflow mutates this file in-place during the
+ *   "Apply RC version suffix" step (e.g. `3.3.1` -> `3.3.1-rc.22`).
+ *   But the SKILL.md frontmatter `version:` line and `skill.json::version`
+ *   were NEVER kept in sync, which produced three drift modes seen in
+ *   the rc.21 brutal QA:
+ *     - package.json checked into main:    3.3.1-rc.15  (stale RC bump)
+ *     - SKILL.md frontmatter:               3.3.1-rc.11  (10 RCs stale)
+ *     - skill.json:                          1.6.2       (totally divorced)
+ *   And the ClawHub workflow never mutated package.json AT ALL before
+ *   `clawhub publish`, so the catalog said "rc.21" but the tarball
+ *   shipped rc.15 internals.
+ *
+ * Behavior:
+ *   - Reads canonical version from skill/plugin/package.json::version.
+ *   - Writes that exact string into:
+ *       1. skill/plugin/SKILL.md frontmatter `version:` line
+ *       2. skill/plugin/skill.json::version
+ *   - Idempotent: running twice on an aligned tree is a no-op.
+ *   - Logs each site it touched.
+ *
+ * Invocation:
+ *   - In CI, runs AFTER the "Apply RC version suffix" step that mutates
+ *     package.json (npm-publish.yml + publish-clawhub.yml).
+ *   - Locally, you can run it any time you bump package.json::version.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pluginDir = resolve(here, '..', 'plugin');
+
+const pkgPath = resolve(pluginDir, 'package.json');
+const skillMdPath = resolve(pluginDir, 'SKILL.md');
+const skillJsonPath = resolve(pluginDir, 'skill.json');
+
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+const canonical = pkg.version;
+if (!canonical) {
+  console.error('FATAL: skill/plugin/package.json has no `version` field');
+  process.exit(2);
+}
+
+console.log(`sync-version: canonical = ${canonical}`);
+
+// 1. SKILL.md frontmatter
+{
+  const before = readFileSync(skillMdPath, 'utf8');
+  // Frontmatter is the first --- ... --- block. The version line looks like:
+  //   version: 3.3.1-rc.11
+  // We update only the FIRST occurrence inside the frontmatter to avoid
+  // touching a `version:` line that might appear in the body.
+  const fmEnd = before.indexOf('\n---', before.indexOf('---') + 3);
+  if (fmEnd === -1) {
+    console.error('FATAL: SKILL.md has no closing frontmatter ---');
+    process.exit(2);
+  }
+  const fmBlock = before.slice(0, fmEnd);
+  const rest = before.slice(fmEnd);
+  const versionLineRe = /^version:\s*.*$/m;
+  if (!versionLineRe.test(fmBlock)) {
+    console.error('FATAL: SKILL.md frontmatter has no `version:` line to update');
+    process.exit(2);
+  }
+  const updatedFm = fmBlock.replace(versionLineRe, `version: ${canonical}`);
+  const after = updatedFm + rest;
+  if (after !== before) {
+    writeFileSync(skillMdPath, after);
+    console.log(`sync-version: updated SKILL.md frontmatter -> ${canonical}`);
+  } else {
+    console.log('sync-version: SKILL.md already aligned');
+  }
+}
+
+// 2. skill.json — targeted regex on the `"version": "..."` top-level line.
+//    Avoids JSON.parse/stringify round-tripping (which would reflow arrays
+//    like "os": ["macos","linux","windows"] across multiple lines and
+//    produce noisy diffs every publish).
+{
+  const before = readFileSync(skillJsonPath, 'utf8');
+  // Sanity: confirm there IS a top-level version field, and that JSON parses.
+  const parsed = JSON.parse(before);
+  if (typeof parsed.version !== 'string') {
+    console.error('FATAL: skill.json has no top-level string `version` field');
+    process.exit(2);
+  }
+  if (parsed.version === canonical) {
+    console.log('sync-version: skill.json already aligned');
+  } else {
+    // Match the FIRST `"version": "..."` line at the top of the file.
+    // Anchored to the indentation that the existing `"version"` line uses
+    // (top-level field, 2-space indent in this repo's house style).
+    const versionLineRe = /^(\s*"version"\s*:\s*")[^"]*(")/m;
+    if (!versionLineRe.test(before)) {
+      console.error('FATAL: skill.json has no `"version": "..."` line to update');
+      process.exit(2);
+    }
+    const after = before.replace(versionLineRe, `$1${canonical}$2`);
+    // Sanity: re-parse to make sure we didn't break the file.
+    JSON.parse(after);
+    writeFileSync(skillJsonPath, after);
+    console.log(`sync-version: updated skill.json -> ${canonical}`);
+  }
+}
+
+console.log('sync-version: OK');


### PR DESCRIPTION
Single source of truth: package.json::version. SKILL.md frontmatter + skill.json templated at publish-time via sync-version.mjs. Pre-publish drift gate (~50ms). Auto git-tag post-publish in npm-publish.yml + publish-clawhub.yml.

Root cause of rc.15-on-disk: publish-clawhub.yml never mutated package.json — bundled whatever was checked into main (stale rc.15 from prior cycle). Compounded by npm-publish.yml only mutating package.json for RC suffix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)