### PR TITLE
feat(core): confirm_indexed primitive + phrase-safety CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,24 @@ on:
       - main
 
 jobs:
+  phrase-safety:
+    # Static guard against accidental "display the recovery phrase" copy
+    # leaking into a SKILL.md / README / docs page. Caught regressing
+    # twice (rc.20 doc rewrite + an earlier slip); fast-fails the PR if
+    # any human-facing artifact contains a phrase-display pattern that
+    # isn't paired with a safety qualifier ("NEVER display", "do not
+    # show", etc) on the same line.
+    #
+    # See: scripts/check-phrase-safety.sh + tests/phrase-safety/.
+    name: Phrase Safety
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run phrase-safety guard
+        run: bash scripts/check-phrase-safety.sh
+      - name: Run phrase-safety regression suite
+        run: bash tests/phrase-safety/run-regression.sh
+
   client-tests:
     name: Client Tests (TypeScript)
     runs-on: ubuntu-latest

--- a/docs/guides/nanoclaw-getting-started.md
+++ b/docs/guides/nanoclaw-getting-started.md
@@ -40,7 +40,7 @@ The wizard will:
 1. Ask if you have an existing recovery phrase (say **no** if this is your first time)
 2. Generate a cryptographically secure 12-word recovery phrase
 3. Register the phrase with the TotalReclaw managed service
-4. Display the recovery phrase for you to save
+4. Write the phrase to YOUR terminal so you can save it — never to the agent transcript (do not paste the phrase into chat: it would compromise the wallet)
 
 **Write down the 12 words in exact order and store them securely.** Treat this like a password -- anyone with the phrase can decrypt your memories.
 

--- a/docs/specs/totalreclaw/flows/01-identity-setup.md
+++ b/docs/specs/totalreclaw/flows/01-identity-setup.md
@@ -47,7 +47,7 @@ sequenceDiagram
     Agent->>Client: totalreclaw_setup (no phrase)
     Client->>Client: run generator CLI<br/>(scure/bip39)
     Client-->>Agent: 12-word phrase
-    Agent-->>User: display phrase +<br/>"write this down!"
+    Note over Agent,User: SUPERSEDED in rc.20 — agent must NEVER display phrase<br/>(see phrase-safety rule); use QR-pair flow instead.
     User->>Agent: "ok, proceed"
     Agent->>Client: totalreclaw_setup(phrase)
 

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -96,6 +96,7 @@ import {
   type SubgraphStoreConfig,
 } from './subgraph/store.js';
 import { searchSubgraph, searchSubgraphBroadened, getOwnerFactCount, fetchFactById } from './subgraph/search.js';
+import { confirmIndexed } from './subgraph/confirm-indexed.js';
 import {
   detectAndResolveContradictions,
   type ResolutionDecision,
@@ -1358,6 +1359,25 @@ async function handleForgetSubgraph(
 
     const { txHash, success } = await submitFactOnChain(protobuf, config);
 
+    // Read-after-write: poll the subgraph until the fact is no longer
+    // active (forget flips isActive=false). On timeout we still report
+    // deleted_count: 1 — the chain write IS acknowledged — but flag
+    // `partial: true` so callers know the indexer is still propagating.
+    let indexed = true;
+    if (success) {
+      const subgraphUrl = process.env.TOTALRECLAW_SUBGRAPH_URL || `${state.serverUrl}/v1/subgraph`;
+      try {
+        const r = await confirmIndexed(factId, {
+          subgraphUrl,
+          authKeyHex: Buffer.from(state.authKey).toString('hex'),
+          expect: 'inactive',
+        });
+        indexed = r.indexed;
+      } catch {
+        indexed = false;
+      }
+    }
+
     return {
       content: [{
         type: 'text',
@@ -1366,6 +1386,7 @@ async function handleForgetSubgraph(
           fact_ids: success ? [factId] : [],
           tx_hash: txHash,
           mode: 'subgraph',
+          ...(success && !indexed ? { partial: true } : {}),
         }),
       }],
     };
@@ -1432,6 +1453,15 @@ function buildPinDepsFromState(state: SubgraphState): PinOpDeps {
         encryptedEmbedding,
       };
     },
+    confirmIndexed: async (factId: string, expect?: 'active' | 'inactive') => {
+      const subgraphUrl = process.env.TOTALRECLAW_SUBGRAPH_URL || `${state.serverUrl}/v1/subgraph`;
+      const result = await confirmIndexed(factId, {
+        subgraphUrl,
+        authKeyHex: Buffer.from(state.authKey).toString('hex'),
+        expect,
+      });
+      return result.indexed;
+    },
   };
 }
 
@@ -1449,6 +1479,7 @@ function buildMetadataOpDepsFromState(state: SubgraphState): MetadataOpDeps {
     encryptBlob: pinDeps.encryptBlob,
     submitBatch: pinDeps.submitBatch,
     generateIndices: pinDeps.generateIndices,
+    confirmIndexed: pinDeps.confirmIndexed,
   };
 }
 

--- a/mcp/src/subgraph/confirm-indexed.ts
+++ b/mcp/src/subgraph/confirm-indexed.ts
@@ -31,7 +31,7 @@ type ConfirmIndexedCore = typeof import('@totalreclaw/core') & {
 let _wasm: ConfirmIndexedCore | null = null;
 async function getWasm(): Promise<ConfirmIndexedCore> {
   if (!_wasm) {
-    _wasm = (await import('@totalreclaw/core')) as ConfirmIndexedCore;
+    _wasm = (await import('@totalreclaw/core')) as unknown as ConfirmIndexedCore;
   }
   return _wasm!;
 }
@@ -63,12 +63,28 @@ export async function confirmIndexed(
   factId: string,
   options: ConfirmIndexedOptions,
 ): Promise<ConfirmIndexedResult> {
-  const wasm = await getWasm();
-  const pollIntervalMs =
-    options.pollIntervalMs ?? Number(wasm.wasmConfirmIndexedDefaultPollMs?.() ?? 1000);
-  const timeoutMs =
-    options.timeoutMs ?? Number(wasm.wasmConfirmIndexedDefaultTimeoutMs?.() ?? 30000);
-  const query = wasm.wasmConfirmIndexedQuery();
+  // WASM bindings may be unavailable (core@<2.3.0 not yet published).
+  // Confirm step is observational; chain write has already succeeded.
+  // Return `indexed: false` so callers surface partial=true rather than fail.
+  let wasm: ConfirmIndexedCore;
+  let query: string;
+  let pollIntervalMs: number;
+  let timeoutMs: number;
+  try {
+    wasm = await getWasm();
+    pollIntervalMs =
+      options.pollIntervalMs ?? Number(wasm.wasmConfirmIndexedDefaultPollMs?.() ?? 1000);
+    timeoutMs =
+      options.timeoutMs ?? Number(wasm.wasmConfirmIndexedDefaultTimeoutMs?.() ?? 30000);
+    query = wasm.wasmConfirmIndexedQuery();
+  } catch (err) {
+    return {
+      indexed: false,
+      attempts: 0,
+      elapsedMs: 0,
+      lastError: `confirm-indexed wasm bindings unavailable: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',

--- a/mcp/src/subgraph/confirm-indexed.ts
+++ b/mcp/src/subgraph/confirm-indexed.ts
@@ -1,0 +1,120 @@
+/**
+ * Read-after-write primitive for the MCP server — confirm a fact id has been
+ * indexed by the subgraph after an on-chain mutation.
+ *
+ * Wraps the pure-compute halves exported by `@totalreclaw/core`
+ * (`wasmConfirmIndexedQuery`, `wasmConfirmIndexedParse`) in a host-side
+ * polling loop. The subgraph indexer typically lags 5-30s behind L1 inclusion
+ * on Gnosis production; without this wait, mutation tools (set_scope,
+ * retype, pin, unpin, forget) can return success before a follow-up
+ * recall/export sees the new state.
+ *
+ * Mnemonic isolation: this helper never touches the mnemonic, encryption
+ * key, or any decrypted blob.
+ */
+
+import { getClientId } from '../client-id.js';
+
+/**
+ * `wasmConfirmIndexed*` exports ship in `@totalreclaw/core@2.3.x`. Cast to
+ * unblock the build until the published `.d.ts` is regenerated.
+ */
+type ConfirmIndexedCore = typeof import('@totalreclaw/core') & {
+  wasmConfirmIndexedQuery(): string;
+  wasmConfirmIndexedParse(responseJson: string): boolean;
+  wasmConfirmIndexedDefaultPollMs(): number;
+  wasmConfirmIndexedDefaultTimeoutMs(): number;
+};
+
+// Loaded lazily so the server doesn't bind to the WASM module unless an
+// on-chain mutation is actually exercised.
+let _wasm: ConfirmIndexedCore | null = null;
+async function getWasm(): Promise<ConfirmIndexedCore> {
+  if (!_wasm) {
+    _wasm = (await import('@totalreclaw/core')) as ConfirmIndexedCore;
+  }
+  return _wasm!;
+}
+
+export interface ConfirmIndexedResult {
+  indexed: boolean;
+  attempts: number;
+  elapsedMs: number;
+  lastError?: string;
+}
+
+export interface ConfirmIndexedOptions {
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+  /** Direction: `"active"` (default, for pin/retype/set_scope) or `"inactive"` (for forget). */
+  expect?: 'active' | 'inactive';
+  /** Required: subgraph URL. Caller passes either `${relayUrl}/v1/subgraph` or `TOTALRECLAW_SUBGRAPH_URL`. */
+  subgraphUrl: string;
+  authKeyHex?: string;
+  /** Test injection. */
+  poster?: (
+    url: string,
+    body: string,
+    headers: Record<string, string>,
+  ) => Promise<{ ok: boolean; status: number; text: () => Promise<string> }>;
+}
+
+export async function confirmIndexed(
+  factId: string,
+  options: ConfirmIndexedOptions,
+): Promise<ConfirmIndexedResult> {
+  const wasm = await getWasm();
+  const pollIntervalMs =
+    options.pollIntervalMs ?? Number(wasm.wasmConfirmIndexedDefaultPollMs?.() ?? 1000);
+  const timeoutMs =
+    options.timeoutMs ?? Number(wasm.wasmConfirmIndexedDefaultTimeoutMs?.() ?? 30000);
+  const query = wasm.wasmConfirmIndexedQuery();
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'X-TotalReclaw-Client': getClientId(),
+  };
+  if (options.authKeyHex) headers['Authorization'] = `Bearer ${options.authKeyHex}`;
+
+  const body = JSON.stringify({ query, variables: { id: factId } });
+
+  const poster =
+    options.poster ??
+    (async (url, b, h) => {
+      const r = await fetch(url, { method: 'POST', headers: h, body: b });
+      return { ok: r.ok, status: r.status, text: () => r.text() };
+    });
+
+  const expect = options.expect ?? 'active';
+  const start = Date.now();
+  let attempts = 0;
+  let lastError: string | undefined;
+
+  while (Date.now() - start < timeoutMs) {
+    attempts++;
+    try {
+      const r = await poster(options.subgraphUrl, body, headers);
+      if (r.ok) {
+        const txt = await r.text();
+        try {
+          const isActive = wasm.wasmConfirmIndexedParse(txt);
+          const resolved = expect === 'active' ? isActive : !isActive;
+          if (resolved) {
+            return { indexed: true, attempts, elapsedMs: Date.now() - start };
+          }
+        } catch (parseErr) {
+          lastError = parseErr instanceof Error ? parseErr.message : String(parseErr);
+        }
+      } else {
+        lastError = `HTTP ${r.status}`;
+      }
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+    }
+    const remaining = timeoutMs - (Date.now() - start);
+    if (remaining <= 0) break;
+    await new Promise((res) => setTimeout(res, Math.min(pollIntervalMs, remaining)));
+  }
+
+  return { indexed: false, attempts, elapsedMs: Date.now() - start, lastError };
+}

--- a/mcp/src/tools/pin.ts
+++ b/mcp/src/tools/pin.ts
@@ -548,6 +548,15 @@ export interface PinOpDeps {
     blindIndices: string[];
     encryptedEmbedding?: string;
   }>;
+  /**
+   * Optional read-after-write hook. Called after submitBatch returns success;
+   * polls the subgraph for the new fact id. Returning `false` causes the
+   * result to surface `partial: true`. When undefined, the op skips the wait.
+   */
+  confirmIndexed?: (
+    factId: string,
+    expect?: 'active' | 'inactive',
+  ) => Promise<boolean>;
 }
 
 export interface PinOpResult {
@@ -560,6 +569,12 @@ export interface PinOpResult {
   tx_hash?: string;
   reason?: string;
   error?: string;
+  /**
+   * On-chain pin/unpin succeeded but the subgraph indexer hasn't confirmed
+   * the new fact id within the timeout window. `tx_hash` is observable on
+   * the explorer; a follow-up recall/export may briefly show stale state.
+   */
+  partial?: boolean;
 }
 
 /**
@@ -777,6 +792,18 @@ export async function executePinOperation(
         tx_hash: txHash,
       };
     }
+    // 8. Read-after-write — wait for the subgraph to index the new fact id
+    //    before returning success. On timeout we still claim success (chain
+    //    write IS acknowledged) but flag `partial: true` so callers can
+    //    explain that recall/export may briefly surface stale state.
+    let indexed = true;
+    if (deps.confirmIndexed) {
+      try {
+        indexed = await deps.confirmIndexed(newFactId, 'active');
+      } catch {
+        indexed = false;
+      }
+    }
     return {
       success: true,
       fact_id: factId,
@@ -785,6 +812,7 @@ export async function executePinOperation(
       new_status: targetStatus,
       tx_hash: txHash,
       reason,
+      ...(indexed ? {} : { partial: true }),
     };
   } catch (err) {
     return {

--- a/mcp/src/tools/retype.ts
+++ b/mcp/src/tools/retype.ts
@@ -124,6 +124,16 @@ export interface MetadataOpDeps {
     blindIndices: string[];
     encryptedEmbedding?: string;
   }>;
+  /**
+   * Optional read-after-write hook. Called after submitBatch returns success;
+   * polls the subgraph for the new fact id. Returning `false` causes the op
+   * result to surface `partial: true`. When this dep is undefined the op
+   * skips the wait entirely.
+   */
+  confirmIndexed?: (
+    factId: string,
+    expect?: 'active' | 'inactive',
+  ) => Promise<boolean>;
 }
 
 export interface MetadataOpResult {
@@ -135,6 +145,14 @@ export interface MetadataOpResult {
   idempotent?: boolean;
   tx_hash?: string;
   error?: string;
+  /**
+   * Set when the chain write succeeded but the subgraph indexer didn't
+   * confirm the new fact id within the timeout window. The mutation IS
+   * on-chain — `tx_hash` is observable on the explorer — but a follow-up
+   * recall/export may briefly surface stale state until the indexer catches
+   * up. See `subgraph/confirm-indexed.ts`.
+   */
+  partial?: boolean;
 }
 
 /**
@@ -379,6 +397,21 @@ export async function executeMetadataOp<T>(
         tx_hash: txHash,
       };
     }
+    // 9. Read-after-write — wait until the new fact id is indexed and
+    //    active, OR the host's timeout elapses. On timeout, return success
+    //    with `partial: true` so the agent surfaces "chain write submitted,
+    //    indexer still propagating" instead of claiming the operation is
+    //    fully visible.
+    let indexed = true;
+    if (deps.confirmIndexed) {
+      try {
+        indexed = await deps.confirmIndexed(newFactId, 'active');
+      } catch {
+        // Defensive: a confirm helper that throws does not invalidate the
+        // chain write — fall through with `partial: true`.
+        indexed = false;
+      }
+    }
     return {
       success: true,
       memory_id: memoryId,
@@ -386,6 +419,7 @@ export async function executeMetadataOp<T>(
       previous_value: String(current),
       new_value: String(nextValue),
       tx_hash: txHash,
+      ...(indexed ? {} : { partial: true }),
     };
   } catch (err) {
     return {

--- a/python/src/totalreclaw/confirm_indexed.py
+++ b/python/src/totalreclaw/confirm_indexed.py
@@ -1,0 +1,121 @@
+"""Read-after-write primitive for Hermes — confirm a fact id has been indexed
+by the subgraph after an on-chain mutation.
+
+Wraps the pure-compute halves exported by ``totalreclaw_core``
+(``confirm_indexed_query``, ``confirm_indexed_parse``) in an async polling
+loop. The subgraph indexer typically lags 5-30s behind L1 inclusion on
+Gnosis production; without this wait, mutation helpers (``pin_fact``,
+``unpin_fact``, ``forget_fact``) can return before a follow-up
+``client.export()`` / ``client.recall()`` sees the new state.
+
+Mnemonic isolation: this helper never touches the mnemonic, encryption
+key, or any decrypted blob. It only reads the public ``{id, isActive,
+blockNumber}`` of a fact.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional, Literal
+
+import totalreclaw_core as _core
+
+from .relay import RelayClient
+
+logger = logging.getLogger(__name__)
+
+ExpectDirection = Literal["active", "inactive"]
+
+
+def _default_poll_ms() -> int:
+    fn = getattr(_core, "confirm_indexed_default_poll_ms", None)
+    return int(fn()) if callable(fn) else 1_000
+
+
+def _default_timeout_ms() -> int:
+    fn = getattr(_core, "confirm_indexed_default_timeout_ms", None)
+    return int(fn()) if callable(fn) else 30_000
+
+
+async def confirm_indexed(
+    fact_id: str,
+    relay: RelayClient,
+    *,
+    expect: ExpectDirection = "active",
+    poll_interval_ms: Optional[int] = None,
+    timeout_ms: Optional[int] = None,
+) -> bool:
+    """Poll the subgraph until the fact id reaches the expected state.
+
+    Parameters
+    ----------
+    fact_id
+        The UUID of the fact to confirm. After ``pin_fact`` / retype / etc.
+        this is the **new** fact id (the supersession target). For
+        ``forget_fact`` this is the **original** fact id whose ``isActive``
+        bit is being flipped.
+    relay
+        Configured RelayClient — already knows the subgraph endpoint via
+        ``relay.query_subgraph``.
+    expect
+        ``"active"`` (default) — resolve when ``fact.isActive == True``.
+        ``"inactive"`` — resolve when fact is missing OR
+        ``fact.isActive == False``. Use ``"inactive"`` for forget.
+    poll_interval_ms / timeout_ms
+        Override the defaults from the Rust core (1s / 30s).
+
+    Returns
+    -------
+    bool
+        ``True`` when the resolution condition was met inside the timeout
+        budget, ``False`` on timeout. The on-chain write is **already
+        acknowledged** before this function is called — a ``False`` return
+        only means the subgraph is still propagating, not that the chain
+        write failed. Callers should surface this to users as ``partial=
+        True`` rather than as an error.
+    """
+    poll_ms = poll_interval_ms if poll_interval_ms is not None else _default_poll_ms()
+    total_ms = timeout_ms if timeout_ms is not None else _default_timeout_ms()
+    query = _core.confirm_indexed_query()
+
+    start = asyncio.get_event_loop().time()
+    deadline = start + (total_ms / 1000.0)
+
+    attempts = 0
+    while asyncio.get_event_loop().time() < deadline:
+        attempts += 1
+        try:
+            data = await relay.query_subgraph(query, {"id": fact_id})
+            # `relay.query_subgraph` returns the parsed JSON envelope.
+            # `confirm_indexed_parse` accepts either {data:{fact}} or {fact}.
+            import json as _json
+
+            payload = _json.dumps(data)
+            is_active = _core.confirm_indexed_parse(payload)
+            resolved = is_active if expect == "active" else not is_active
+            if resolved:
+                logger.debug(
+                    "confirm_indexed: fact_id=%s expect=%s resolved after %d attempts",
+                    fact_id,
+                    expect,
+                    attempts,
+                )
+                return True
+        except Exception as exc:  # pragma: no cover — best-effort polling
+            logger.debug("confirm_indexed: poll attempt failed: %s", exc)
+
+        # Sleep before the next attempt — but only if there's still budget.
+        remaining = deadline - asyncio.get_event_loop().time()
+        if remaining <= 0:
+            break
+        await asyncio.sleep(min(poll_ms / 1000.0, remaining))
+
+    logger.info(
+        "confirm_indexed: fact_id=%s expect=%s NOT resolved within %dms (%d attempts)",
+        fact_id,
+        expect,
+        total_ms,
+        attempts,
+    )
+    return False

--- a/python/src/totalreclaw/operations.py
+++ b/python/src/totalreclaw/operations.py
@@ -706,6 +706,25 @@ async def forget_fact(
             client_id=relay._client_id,
             session_id=getattr(relay, "_session_id", None),
         )
+        # Read-after-write: wait until the subgraph has flipped the fact's
+        # isActive bit. Forget keeps its bool return contract — a False here
+        # would mean the chain write itself failed, which is NOT what a
+        # confirm-indexed timeout signals. We log the timeout for
+        # observability but still return True (chain write succeeded).
+        from .confirm_indexed import confirm_indexed as _confirm_indexed
+        try:
+            indexed = await _confirm_indexed(fact_id, relay, expect="inactive")
+            if not indexed:
+                import logging as _logging
+                _logging.getLogger(__name__).info(
+                    "forget_fact: chain write succeeded for %s but subgraph "
+                    "indexer did not confirm tombstone within timeout; "
+                    "follow-up recall/export may briefly show stale state",
+                    fact_id,
+                )
+        except Exception:
+            # Confirm helper failures must NEVER mask a successful chain write.
+            pass
         return True
     except Exception:
         return False
@@ -1232,13 +1251,25 @@ async def _change_claim_status(
         session_id=getattr(relay, "_session_id", None),
     )
 
-    return {
+    # Read-after-write: poll the subgraph until the new (pinned/unpinned)
+    # fact id is indexed and active. On timeout we still report success
+    # — the chain write IS acknowledged — but flag ``partial=True`` so a
+    # follow-up ``client.export()`` / ``client.recall()`` doesn't surprise
+    # the caller with stale state.
+    from .confirm_indexed import confirm_indexed as _confirm_indexed
+
+    indexed = await _confirm_indexed(new_fact_id, relay, expect="active")
+
+    result = {
         "success": True,
         "fact_id": fact_id,
         "new_fact_id": new_fact_id,
         "previous_status": current_long,
         "new_status": target_long,
     }
+    if not indexed:
+        result["partial"] = True
+    return result
 
 
 async def pin_fact(

--- a/rust/totalreclaw-core/src/confirm.rs
+++ b/rust/totalreclaw-core/src/confirm.rs
@@ -1,0 +1,170 @@
+//! Read-after-write primitive — confirm a fact id has been indexed by the subgraph.
+//!
+//! Ships in 2.2.x to fix a class of bugs where on-chain mutation tools
+//! (`set_scope`, `retype`, `pin`, `unpin`, `forget`) returned success based on
+//! the bundler ack alone — but a follow-up `export` / `recall` then surfaced
+//! stale state because the subgraph indexer hadn't yet observed the L1 inclusion
+//! (typical lag 5-30s on production Gnosis). User-visible symptom: agent says
+//! "scope set to health", user runs export, sees `unspecified`.
+//!
+//! This module provides the pure-compute halves of the read-after-write
+//! sequence: a GraphQL query string and a response-parser that returns whether
+//! the new fact id is now visible AND active. Host languages (TypeScript,
+//! Python) wrap a polling loop around these helpers — they own HTTP I/O,
+//! sleep / timeout primitives, and the caller's tx hash bookkeeping.
+//!
+//! # Mnemonic isolation
+//!
+//! By design this module never touches the mnemonic, the encryption key, or
+//! any decrypted blob. It only reads the *existence + active flag* of a fact
+//! by its UUID — information that is already public in the subgraph. The
+//! phrase-safety CI guard (`scripts/check-phrase-safety.sh`) enforces this
+//! at the repository level.
+
+/// GraphQL query that resolves a fact by its UUID. The host wraps this in
+/// a polling loop after submitting an on-chain mutation: poll until the fact
+/// is found AND `isActive == true`, OR the host's timeout elapses.
+///
+/// The query intentionally also fetches `blockNumber` so callers that DO have
+/// access to a block-number lower bound (e.g. from `eth_getTransactionReceipt`)
+/// can additionally enforce `block_number >= tx.block`. The default
+/// `parse_indexed_response()` parser ignores the block number — confirming
+/// presence + active is sufficient for the user-visible read-after-write
+/// guarantee.
+pub const FACT_BY_ID_INDEXED_QUERY: &str = r#"
+  query ConfirmIndexed($id: ID!) {
+    fact(id: $id) {
+      id
+      isActive
+      blockNumber
+    }
+  }
+"#;
+
+/// Default polling interval (ms) — 1s per attempt.
+pub const DEFAULT_POLL_INTERVAL_MS: u64 = 1_000;
+
+/// Default total timeout (ms) — 30s. Indexer lag on Gnosis production runs
+/// 5-30s under normal load; the timeout sits at the high end.
+pub const DEFAULT_TIMEOUT_MS: u64 = 30_000;
+
+/// Get the GraphQL query string used by `confirm_indexed`. Provided as a
+/// function so host bindings can re-export it through their normal calling
+/// convention rather than as a raw constant.
+pub fn confirm_indexed_query() -> &'static str {
+    FACT_BY_ID_INDEXED_QUERY
+}
+
+/// Parse a subgraph GraphQL response and return whether the fact is indexed
+/// AND active.
+///
+/// Accepts either the wrapped `{"data": {"fact": ...}}` shape or the inner
+/// `{"fact": ...}` shape — different host adapters strip the `data`
+/// envelope at different layers, so we accept both for robustness.
+///
+/// Returns:
+/// - `Ok(true)` — fact present, `isActive == true`. Mutation is fully indexed.
+/// - `Ok(false)` — fact not present, OR present but `isActive == false`
+///   (still propagating). Caller should poll again.
+/// - `Err(...)` — response was not valid JSON or did not match either shape.
+pub fn parse_indexed_response(response_json: &str) -> Result<bool, String> {
+    // Both shapes deserialize through serde_json::Value first so we don't
+    // double-decode and so `serde(rename_all = "camelCase")` propagates
+    // consistently regardless of which wrapper landed at the top.
+    let value: serde_json::Value = serde_json::from_str(response_json).map_err(|e| {
+        format!(
+            "confirm_indexed: response is not valid JSON ({}). Body: {}",
+            e,
+            response_json.chars().take(200).collect::<String>()
+        )
+    })?;
+
+    // Wrapped: `{"data":{"fact":...}}`
+    if let Some(data) = value.get("data") {
+        if data.is_null() {
+            return Ok(false);
+        }
+        if let Some(fact_field) = data.get("fact") {
+            return Ok(parse_fact_value(fact_field));
+        }
+        return Err(
+            "confirm_indexed: wrapped response missing `fact` field under `data`".to_string(),
+        );
+    }
+
+    // Unwrapped: `{"fact":...}`
+    if let Some(fact_field) = value.get("fact") {
+        return Ok(parse_fact_value(fact_field));
+    }
+
+    Err(format!(
+        "confirm_indexed: response did not match either {{data:{{fact}}}} or {{fact}} shape: {}",
+        response_json.chars().take(200).collect::<String>()
+    ))
+}
+
+/// Helper: read a JSON value at the `fact` slot and return whether it
+/// corresponds to an indexed-and-active fact.
+fn parse_fact_value(fact: &serde_json::Value) -> bool {
+    if fact.is_null() {
+        return false;
+    }
+    fact.get("isActive")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_wrapped_active_true() {
+        let r = r#"{"data":{"fact":{"id":"abc","isActive":true,"blockNumber":"123"}}}"#;
+        assert_eq!(parse_indexed_response(r).unwrap(), true);
+    }
+
+    #[test]
+    fn parses_wrapped_active_false() {
+        let r = r#"{"data":{"fact":{"id":"abc","isActive":false,"blockNumber":"123"}}}"#;
+        assert_eq!(parse_indexed_response(r).unwrap(), false);
+    }
+
+    #[test]
+    fn parses_wrapped_null_fact() {
+        let r = r#"{"data":{"fact":null}}"#;
+        assert_eq!(parse_indexed_response(r).unwrap(), false);
+    }
+
+    #[test]
+    fn parses_wrapped_null_data() {
+        let r = r#"{"data":null}"#;
+        assert_eq!(parse_indexed_response(r).unwrap(), false);
+    }
+
+    #[test]
+    fn parses_unwrapped_shape() {
+        let r = r#"{"fact":{"id":"abc","isActive":true,"blockNumber":"123"}}"#;
+        assert_eq!(parse_indexed_response(r).unwrap(), true);
+    }
+
+    #[test]
+    fn parses_missing_block_number() {
+        // `blockNumber` is optional in our parser — a subgraph that omits it
+        // (older schemas, partial response) must still resolve to true.
+        let r = r#"{"data":{"fact":{"id":"abc","isActive":true}}}"#;
+        assert_eq!(parse_indexed_response(r).unwrap(), true);
+    }
+
+    #[test]
+    fn rejects_garbage_input() {
+        assert!(parse_indexed_response("{not json").is_err());
+    }
+
+    #[test]
+    fn query_string_contains_fact_isactive() {
+        let q = confirm_indexed_query();
+        assert!(q.contains("fact(id: $id)"));
+        assert!(q.contains("isActive"));
+    }
+}

--- a/rust/totalreclaw-core/src/lib.rs
+++ b/rust/totalreclaw-core/src/lib.rs
@@ -23,9 +23,11 @@
 //! - [`smart_import`] — Smart import profiling (prompt construction + response parsing)
 //! - [`memory_types`] — Memory Taxonomy v1 string-level constants + runtime guard
 //! - [`prompts`] — Canonical extraction + compaction system prompts (2.2.0)
+//! - [`confirm`] — Read-after-write primitive for on-chain mutation tools (2.2.x)
 
 pub mod blind;
 pub mod claims;
+pub mod confirm;
 pub mod consolidation;
 pub mod contradiction;
 pub mod decision_log;

--- a/rust/totalreclaw-core/src/python.rs
+++ b/rust/totalreclaw-core/src/python.rs
@@ -15,7 +15,7 @@ use crate::search;
 #[cfg(feature = "managed")]
 use crate::userop;
 use crate::{
-    blind, claims, contradiction, crypto, debrief, digest, feedback_log, fingerprint, lsh,
+    blind, claims, confirm, contradiction, crypto, debrief, digest, feedback_log, fingerprint, lsh,
     protobuf, reranker, store,
 };
 
@@ -1503,6 +1503,38 @@ fn py_filter_shadow_mode(actions_json: &str, mode: &str) -> PyResult<String> {
 // Module registration
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Read-after-write (confirm_indexed)
+// ---------------------------------------------------------------------------
+
+/// GraphQL query string for confirm_indexed (`fact(id: $id) { id, isActive,
+/// blockNumber }`). Pair with `confirm_indexed_parse` in a host-side polling
+/// loop.
+#[pyfunction]
+fn confirm_indexed_query() -> &'static str {
+    confirm::confirm_indexed_query()
+}
+
+/// Parse a subgraph response JSON for confirm_indexed and return whether the
+/// fact is indexed AND active.
+#[pyfunction]
+fn confirm_indexed_parse(response_json: &str) -> PyResult<bool> {
+    confirm::parse_indexed_response(response_json).map_err(PyValueError::new_err)
+}
+
+/// Default polling interval (ms) — exposed so Python adapters share the
+/// same default without re-declaring the constant.
+#[pyfunction]
+fn confirm_indexed_default_poll_ms() -> u64 {
+    confirm::DEFAULT_POLL_INTERVAL_MS
+}
+
+/// Default total timeout (ms) — exposed so Python adapters share the same default.
+#[pyfunction]
+fn confirm_indexed_default_timeout_ms() -> u64 {
+    confirm::DEFAULT_TIMEOUT_MS
+}
+
 /// TotalReclaw core crypto primitives (Rust implementation).
 ///
 /// This module provides byte-for-byte compatible implementations of all
@@ -1634,6 +1666,12 @@ fn totalreclaw_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // Memory Taxonomy v1 constants + guard
     crate::memory_types::register_python_functions(m)?;
+
+    // Read-after-write (confirm_indexed)
+    m.add_function(wrap_pyfunction!(confirm_indexed_query, m)?)?;
+    m.add_function(wrap_pyfunction!(confirm_indexed_parse, m)?)?;
+    m.add_function(wrap_pyfunction!(confirm_indexed_default_poll_ms, m)?)?;
+    m.add_function(wrap_pyfunction!(confirm_indexed_default_timeout_ms, m)?)?;
 
     Ok(())
 }

--- a/rust/totalreclaw-core/src/wasm.rs
+++ b/rust/totalreclaw-core/src/wasm.rs
@@ -9,6 +9,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::blind;
 use crate::claims;
+use crate::confirm;
 use crate::contradiction;
 use crate::crypto;
 use crate::debrief;
@@ -1538,6 +1539,37 @@ pub fn wasm_filter_shadow_mode(actions_json: &str, mode: &str) -> Result<String,
         .map_err(|e| JsError::new(&format!("invalid actions JSON: {}", e)))?;
     let filtered = contradiction::filter_shadow_mode(actions, mode);
     serde_json::to_string(&filtered).map_err(|e| JsError::new(&e.to_string()))
+}
+
+// ---------------------------------------------------------------------------
+// Read-after-write (confirm_indexed)
+// ---------------------------------------------------------------------------
+
+/// GraphQL query string used to confirm a fact id has been indexed.
+/// Pair with `wasmConfirmIndexedParse` in a host-side polling loop.
+#[wasm_bindgen(js_name = wasmConfirmIndexedQuery)]
+pub fn wasm_confirm_indexed_query() -> String {
+    confirm::confirm_indexed_query().to_string()
+}
+
+/// Parse a subgraph response JSON and return whether the fact is indexed +
+/// active. Returns `true` when the read-after-write loop can stop.
+#[wasm_bindgen(js_name = wasmConfirmIndexedParse)]
+pub fn wasm_confirm_indexed_parse(response_json: &str) -> Result<bool, JsError> {
+    confirm::parse_indexed_response(response_json).map_err(|e| JsError::new(&e))
+}
+
+/// Default polling interval (ms) — exposed so host adapters share the same
+/// default without re-declaring the constant.
+#[wasm_bindgen(js_name = wasmConfirmIndexedDefaultPollMs)]
+pub fn wasm_confirm_indexed_default_poll_ms() -> u32 {
+    confirm::DEFAULT_POLL_INTERVAL_MS as u32
+}
+
+/// Default total timeout (ms) — exposed so host adapters share the same default.
+#[wasm_bindgen(js_name = wasmConfirmIndexedDefaultTimeoutMs)]
+pub fn wasm_confirm_indexed_default_timeout_ms() -> u32 {
+    confirm::DEFAULT_TIMEOUT_MS as u32
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/check-phrase-safety.sh
+++ b/scripts/check-phrase-safety.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+#
+# check-phrase-safety.sh — repository-level guard against accidental
+# recovery-phrase-display copy in human-facing artifacts.
+#
+# WHY THIS EXISTS
+# ---------------
+# The TotalReclaw recovery phrase is the user's only identity — it derives
+# every key in the system. The hard rule (CLAUDE.md, internal repo) is:
+#
+#     The recovery phrase MUST NEVER cross the LLM context. The QR-pair
+#     flow is the ONLY agent-facilitated setup path. Forbidden: agent-
+#     shell-invoked phrase-generating CLIs, --emit-phrase via tool,
+#     phrase in agent responses.
+#
+# We've been bitten twice by this rule slipping into a SKILL.md or guide
+# during a doc rewrite — each time the safety language was REPLACED with
+# instruction copy that told the agent to display the phrase. This script
+# is a static grep that fails CI when any human-facing artifact contains
+# a phrase-DISPLAY pattern that isn't covered by an explicit safety
+# whitelist (e.g. "NEVER display", "do not display", security warnings).
+#
+# Scope: every SKILL.md (plugin, hermes, nanoclaw), every README and root
+# markdown, all of `docs/`. Excluded: `node_modules/`, `dist/`, `.git/`,
+# `archive/`, the script + tests themselves, and `target/` build artifacts.
+#
+# Usage:
+#   scripts/check-phrase-safety.sh                # scans repo, exits 0/1
+#   PHRASE_SAFETY_DEBUG=1 scripts/check-phrase-safety.sh
+#                                                 # prints every match
+#
+# Exit codes:
+#   0 — clean (no violations)
+#   1 — at least one phrase-display pattern outside the safety whitelist
+#
+# This is intentionally a bash + grep script (zero deps). It runs in CI in
+# under 200ms on a clean checkout.
+
+set -euo pipefail
+
+# Resolve the repo root regardless of where this script is invoked from.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Files in scope. We keep this as an explicit list so CI cost stays bounded
+# even as the repo grows. Each entry is a path or a `find` pattern.
+SCOPE_PATHS=(
+    "README.md"
+    "CHANGELOG-public.md"
+    "CONTRIBUTING.md"
+    "skill/SKILL.md"
+    "skill/plugin/SKILL.md"
+    "skill/plugin/CLAWHUB.md"
+    "skill/plugin/README.md"
+    "skill/plugin/CHANGELOG.md"
+    "skill-nanoclaw/SKILL.md"
+    "skill-nanoclaw/mcp/SKILL.md"
+    "skill-nanoclaw/CHANGELOG.md"
+    "skill-nanoclaw/README.md"
+    "python/src/totalreclaw/hermes/SKILL.md"
+)
+
+# Add every markdown file under docs/ (excluding archive subfolders).
+while IFS= read -r f; do
+    SCOPE_PATHS+=("$f")
+done < <(find docs -type f \( -name '*.md' -o -name '*.mdx' \) ! -path 'docs/archive/*' 2>/dev/null | sort)
+
+# Phrase-DISPLAY patterns. Case-insensitive. Each pattern matches an
+# instruction-shape that would render a phrase to the user / agent. The
+# whitelist below subtracts safety language ("NEVER display", "do not
+# show", etc) from the same line.
+#
+# Patterns are kept TIGHT — we don't fish for "phrase" alone (too noisy);
+# we look for verbs that imply displaying / printing / showing / revealing.
+DISPLAY_PATTERNS=(
+    'display[[:space:]]+(the[[:space:]]+)?(recovery[[:space:]]+)?phrase'
+    'show[[:space:]]+(the[[:space:]]+)?(recovery[[:space:]]+)?phrase'
+    'show[[:space:]]+(the[[:space:]]+)?mnemonic'
+    'print[[:space:]]+(the[[:space:]]+)?(recovery[[:space:]]+)?phrase'
+    'print[[:space:]]+(the[[:space:]]+)?mnemonic'
+    'echo[[:space:]]+(the[[:space:]]+)?(recovery[[:space:]]+)?phrase'
+    'reveal[[:space:]]+(the[[:space:]]+)?(recovery[[:space:]]+)?phrase'
+    'output[[:space:]]+(the[[:space:]]+)?(recovery[[:space:]]+)?phrase'
+    'paste[[:space:]]+(the[[:space:]]+)?phrase[[:space:]]+(in|into)[[:space:]]+chat'
+    'paste[[:space:]]+(your[[:space:]]+)?(recovery[[:space:]]+)?phrase[[:space:]]+here'
+    '--emit-phrase'
+    '--print-phrase'
+    'emit[_-]phrase'
+)
+
+# Whitelist regex: when one of these tokens is present on the SAME line
+# (case-insensitive), the line is treated as legitimate safety copy and
+# does not count as a violation.
+#
+# Examples of legitimate lines this whitelists:
+#   - "NEVER display the recovery phrase in chat"
+#   - "Do not show the mnemonic"
+#   - "MUST NEVER print the phrase to stdout"
+#   - "Never paste your recovery phrase here"
+#   - "WARNING: showing the phrase here would compromise it"
+#   - "tells the user it is compromised" (post-violation guidance)
+WHITELIST_TOKENS=(
+    'never'
+    'forbidden'
+    'do[[:space:]]+not'
+    "don't"
+    'must[[:space:]]+not'
+    'must[[:space:]]+never'
+    'cannot'
+    'compromised'
+    'warn(ing)?'
+    'leak'
+    'forbid(den)?'
+    'avoid'
+    'security[[:space:]]+(rule|notice|warning)'
+    'phrase[[:space:]]+safety'
+    'hard[[:space:]]+rule'
+    'critical[[:space:]]+safety'
+    'no[[:space:]]+(part|portion)[[:space:]]+of'
+    'never[[:space:]]+echo'
+)
+
+# Build whitelist alternation once.
+WHITELIST_RE="$(IFS='|'; echo "${WHITELIST_TOKENS[*]}")"
+
+violations=0
+debug="${PHRASE_SAFETY_DEBUG:-0}"
+
+for f in "${SCOPE_PATHS[@]}"; do
+    [[ -f "$f" ]] || continue
+    for pat in "${DISPLAY_PATTERNS[@]}"; do
+        # `grep -inE -H` prints `path:line:matched-content` for every hit.
+        # We then strip whitelisted lines.
+        while IFS= read -r line; do
+            [[ -n "$line" ]] || continue
+            # Whitelist check: does the matched line contain a safety token?
+            content="${line#*:*:}"
+            if echo "$content" | grep -iqE "$WHITELIST_RE"; then
+                if [[ "$debug" == "1" ]]; then
+                    echo "WHITELISTED: $line"
+                fi
+                continue
+            fi
+            echo "PHRASE-SAFETY VIOLATION: $line"
+            violations=$((violations + 1))
+        done < <(grep -inHE "$pat" "$f" 2>/dev/null || true)
+    done
+done
+
+if [[ "$violations" -gt 0 ]]; then
+    echo ""
+    echo "Found $violations phrase-display pattern(s) without safety qualifier."
+    echo "Phrase-safety rule (CLAUDE.md): the recovery phrase must never cross"
+    echo "the LLM context. Replace any 'display/show/print/echo/reveal phrase'"
+    echo "instruction with the QR-pair flow (\`totalreclaw_pair\` tool) OR add"
+    echo "an explicit safety qualifier on the same line (\"NEVER display ...\")."
+    echo ""
+    echo "If a hit is a legitimate edge case, expand WHITELIST_TOKENS in"
+    echo "scripts/check-phrase-safety.sh — do not delete the rule."
+    exit 1
+fi
+
+echo "Phrase-safety check: $((${#SCOPE_PATHS[@]})) artifact(s) clean."
+exit 0

--- a/skill-nanoclaw/README.md
+++ b/skill-nanoclaw/README.md
@@ -42,7 +42,7 @@ npx @totalreclaw/mcp-server setup
 The wizard will:
 1. Generate a 12-word recovery phrase
 2. Register the phrase with the managed service
-3. Print the phrase for you to save
+3. Output the phrase to YOUR terminal only — never to the agent transcript (do not paste it into chat)
 
 > **Save your recovery phrase somewhere safe.** It is the only way to recover your encrypted memories. If you lose it, your memories are gone permanently.
 

--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -493,7 +493,8 @@ See: `plans/2026-04-22-plugin-3.3.1-provider-agnostic-llm.md` (internal).
     - `--json` — emits a structured payload (requires `--non-interactive`).
     - `--mode <generate|restore>` — skip the menu prompt.
     - `--phrase <12-or-24>` — required for `--mode restore`; `-` reads stdin.
-    - `--emit-phrase` — opt-in path that includes the plaintext phrase in the
+    - `--emit-phrase` — historic opt-in flag (do not invoke via agent shell:
+      forbidden by the phrase-safety rule); included plaintext phrase in the
       JSON payload. Default omits the phrase; the agent should direct the
       user to read `~/.totalreclaw/credentials.json` in their terminal.
 

--- a/skill/plugin/confirm-indexed.ts
+++ b/skill/plugin/confirm-indexed.ts
@@ -1,0 +1,176 @@
+/**
+ * Read-after-write primitive — confirm a fact id has been indexed by the
+ * subgraph after an on-chain mutation (retype / set_scope / pin / unpin /
+ * forget).
+ *
+ * Wraps the pure-compute halves exported by `@totalreclaw/core`
+ * (`wasmConfirmIndexedQuery`, `wasmConfirmIndexedParse`) in a host-side
+ * polling loop. Subgraph indexer lag on Gnosis production runs 5-30s; this
+ * helper polls every `pollIntervalMs` (default 1000ms) up to `timeoutMs`
+ * (default 30000ms).
+ *
+ * Why this exists
+ * ---------------
+ * Pre-fix, mutation tools returned `{success: true}` based on the bundler
+ * ack alone. A user who immediately ran `totalreclaw_export` would see the
+ * pre-mutation state, because the subgraph indexer hadn't yet observed the
+ * L1 inclusion. Confusing UX, root cause of rc.18 finding #117.
+ *
+ * Post-fix, mutation tools call `confirmIndexed(newFactId)` after submitting
+ * the batched UserOp; on success they return normally, on timeout they
+ * return `{success: true, partial: true, ...}` with the chain write
+ * acknowledged but the indexer-level confirmation withheld.
+ *
+ * Mnemonic isolation: this helper never touches the mnemonic, encryption
+ * key, or any decrypted blob. Only reads the public {id, isActive,
+ * blockNumber} of a fact.
+ */
+
+import { createRequire } from 'node:module';
+import { getSubgraphConfig } from './subgraph-store.js';
+import { buildRelayHeaders } from './relay-headers.js';
+
+/**
+ * The four `wasmConfirmIndexed*` exports below ship in `@totalreclaw/core@2.3.x`
+ * (the `confirm` module added in 2.2.x). Older type declarations don't list
+ * them — we use a structural cast so the plugin's `--noCheck` build is
+ * unblocked and runtime resolution is via dynamic require.
+ */
+type ConfirmIndexedCore = typeof import('@totalreclaw/core') & {
+  wasmConfirmIndexedQuery(): string;
+  wasmConfirmIndexedParse(responseJson: string): boolean;
+  wasmConfirmIndexedDefaultPollMs(): number;
+  wasmConfirmIndexedDefaultTimeoutMs(): number;
+};
+
+const requireWasm = createRequire(import.meta.url);
+let _wasm: ConfirmIndexedCore | null = null;
+function getWasm(): ConfirmIndexedCore {
+  if (!_wasm) _wasm = requireWasm('@totalreclaw/core') as ConfirmIndexedCore;
+  return _wasm!;
+}
+
+/** Result of a confirm-indexed poll loop. */
+export interface ConfirmIndexedResult {
+  /** True if the fact was found and `isActive == true` before the timeout. */
+  indexed: boolean;
+  /** Number of poll attempts before resolution (or timeout). */
+  attempts: number;
+  /** Total wall-clock ms spent polling. */
+  elapsedMs: number;
+  /** Last error message from the GraphQL adapter, if any. */
+  lastError?: string;
+}
+
+export interface ConfirmIndexedOptions {
+  /** Override the default 1s poll interval. */
+  pollIntervalMs?: number;
+  /** Override the default 30s total timeout. */
+  timeoutMs?: number;
+  /** Override `${relayUrl}/v1/subgraph` (test injection point). */
+  subgraphUrl?: string;
+  /** Override the auth-key-hex header (defaults to none). */
+  authKeyHex?: string;
+  /**
+   * Direction of the read-after-write check.
+   *   - `"active"` (default) — wait until fact is found AND `isActive == true`.
+   *     Use after pin/unpin/retype/set_scope (we're confirming the *new* fact
+   *     id has appeared).
+   *   - `"inactive"` — wait until fact either disappears OR `isActive ==
+   *     false`. Use after `forget`, where the *original* fact id is being
+   *     tombstoned and a confirm-indexed wait should resolve once the
+   *     subgraph has flipped it.
+   */
+  expect?: 'active' | 'inactive';
+  /**
+   * Test injection — caller-provided `fetch`-compatible POST. Defaults to
+   * the global `fetch`. Letting tests stub this out avoids a network mock
+   * dependency.
+   */
+  poster?: (url: string, body: string, headers: Record<string, string>) => Promise<{
+    ok: boolean;
+    status: number;
+    text: () => Promise<string>;
+  }>;
+}
+
+/**
+ * Poll the subgraph until the new fact id is indexed-and-active, or the
+ * timeout elapses. Returns a result object describing the outcome — never
+ * throws on indexer-level transient errors; the caller decides whether to
+ * surface a `partial: true` flag based on `result.indexed`.
+ *
+ * The host's submitBatch already returned a tx hash before this is called,
+ * so on `indexed: false` the on-chain write is still acknowledged — just not
+ * yet visible in the read API.
+ */
+export async function confirmIndexed(
+  factId: string,
+  options: ConfirmIndexedOptions = {},
+): Promise<ConfirmIndexedResult> {
+  const wasm = getWasm();
+  // Fall back to the WASM-exposed defaults so the Rust core remains the
+  // single source of truth for the polling cadence.
+  const pollIntervalMs = options.pollIntervalMs ?? Number(wasm.wasmConfirmIndexedDefaultPollMs?.() ?? 1000);
+  const timeoutMs = options.timeoutMs ?? Number(wasm.wasmConfirmIndexedDefaultTimeoutMs?.() ?? 30000);
+  const subgraphUrl =
+    options.subgraphUrl ?? `${getSubgraphConfig().relayUrl}/v1/subgraph`;
+  const query = wasm.wasmConfirmIndexedQuery();
+
+  const overrides: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (options.authKeyHex) overrides['Authorization'] = `Bearer ${options.authKeyHex}`;
+  const headers = buildRelayHeaders(overrides);
+
+  const body = JSON.stringify({ query, variables: { id: factId } });
+
+  const poster =
+    options.poster ??
+    (async (url, b, h) => {
+      const r = await fetch(url, { method: 'POST', headers: h, body: b });
+      return { ok: r.ok, status: r.status, text: () => r.text() };
+    });
+
+  const expect = options.expect ?? 'active';
+  const start = Date.now();
+  let attempts = 0;
+  let lastError: string | undefined;
+
+  while (Date.now() - start < timeoutMs) {
+    attempts++;
+    try {
+      const r = await poster(subgraphUrl, body, headers);
+      if (r.ok) {
+        const txt = await r.text();
+        try {
+          // wasmConfirmIndexedParse returns `true` when fact is present AND
+          // isActive==true. For `expect: 'inactive'` we invert: a `false`
+          // (fact missing OR present-but-inactive) is the resolution signal.
+          const isActive = wasm.wasmConfirmIndexedParse(txt);
+          const resolved = expect === 'active' ? isActive : !isActive;
+          if (resolved) {
+            return { indexed: true, attempts, elapsedMs: Date.now() - start };
+          }
+        } catch (parseErr) {
+          lastError = parseErr instanceof Error ? parseErr.message : String(parseErr);
+        }
+      } else {
+        lastError = `HTTP ${r.status}`;
+      }
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+    }
+    // Sleep before the next attempt — but only if there's still budget.
+    const remaining = timeoutMs - (Date.now() - start);
+    if (remaining <= 0) break;
+    await new Promise((res) => setTimeout(res, Math.min(pollIntervalMs, remaining)));
+  }
+
+  return {
+    indexed: false,
+    attempts,
+    elapsedMs: Date.now() - start,
+    lastError,
+  };
+}

--- a/skill/plugin/confirm-indexed.ts
+++ b/skill/plugin/confirm-indexed.ts
@@ -46,7 +46,7 @@ type ConfirmIndexedCore = typeof import('@totalreclaw/core') & {
 const requireWasm = createRequire(import.meta.url);
 let _wasm: ConfirmIndexedCore | null = null;
 function getWasm(): ConfirmIndexedCore {
-  if (!_wasm) _wasm = requireWasm('@totalreclaw/core') as ConfirmIndexedCore;
+  if (!_wasm) _wasm = requireWasm('@totalreclaw/core') as unknown as ConfirmIndexedCore;
   return _wasm!;
 }
 
@@ -108,14 +108,29 @@ export async function confirmIndexed(
   factId: string,
   options: ConfirmIndexedOptions = {},
 ): Promise<ConfirmIndexedResult> {
-  const wasm = getWasm();
-  // Fall back to the WASM-exposed defaults so the Rust core remains the
-  // single source of truth for the polling cadence.
-  const pollIntervalMs = options.pollIntervalMs ?? Number(wasm.wasmConfirmIndexedDefaultPollMs?.() ?? 1000);
-  const timeoutMs = options.timeoutMs ?? Number(wasm.wasmConfirmIndexedDefaultTimeoutMs?.() ?? 30000);
+  // WASM bindings may be unavailable (e.g. core@<2.3.0 not yet published).
+  // In that case the chain write has still succeeded — confirm step is
+  // observational only. Return `indexed: false` so callers surface
+  // `partial: true` rather than fail the whole tool invocation.
+  let wasm: ConfirmIndexedCore;
+  let query: string;
+  let pollIntervalMs: number;
+  let timeoutMs: number;
+  try {
+    wasm = getWasm();
+    pollIntervalMs = options.pollIntervalMs ?? Number(wasm.wasmConfirmIndexedDefaultPollMs?.() ?? 1000);
+    timeoutMs = options.timeoutMs ?? Number(wasm.wasmConfirmIndexedDefaultTimeoutMs?.() ?? 30000);
+    query = wasm.wasmConfirmIndexedQuery();
+  } catch (err) {
+    return {
+      indexed: false,
+      attempts: 0,
+      elapsedMs: 0,
+      lastError: `confirm-indexed wasm bindings unavailable: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
   const subgraphUrl =
     options.subgraphUrl ?? `${getSubgraphConfig().relayUrl}/v1/subgraph`;
-  const query = wasm.wasmConfirmIndexedQuery();
 
   const overrides: Record<string, string> = {
     'Content-Type': 'application/json',

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -92,6 +92,7 @@ import {
   type DecryptedCandidate,
 } from './consolidation.js';
 import { isSubgraphMode, getSubgraphConfig, encodeFactProtobuf, submitFactOnChain, submitFactBatchOnChain, deriveSmartAccountAddress, PROTOBUF_VERSION_V4, type FactPayload } from './subgraph-store.js';
+import { confirmIndexed } from './confirm-indexed.js';
 import {
   DIGEST_TRAPDOOR,
   buildCanonicalClaim,
@@ -3779,14 +3780,29 @@ const plugin = {
                 throw new Error(`On-chain tombstone failed (tx=${result.txHash?.slice(0, 10) || 'none'}…)`);
               }
               api.logger.info(`Tombstone written for ${factId}: tx=${result.txHash}`);
+              // Read-after-write: poll the subgraph until the original fact id
+              // is no longer active (forget flips isActive=false). On timeout
+              // surface `partial: true` so the agent can explain the chain
+              // write succeeded but the subgraph is still propagating.
+              const confirm = await confirmIndexed(factId, {
+                expect: 'inactive',
+                authKeyHex: authKeyHex!,
+              });
               return {
                 content: [{
                   type: 'text',
-                  text:
-                    `Memory ${factId} deleted on-chain (tx: ${result.txHash}). ` +
-                    'The subgraph will reflect isActive=false within ~30 seconds.',
+                  text: confirm.indexed
+                    ? `Memory ${factId} deleted on-chain and confirmed by the subgraph (tx: ${result.txHash}).`
+                    : `Memory ${factId} deleted on-chain (tx: ${result.txHash}). ` +
+                      'The subgraph indexer is still propagating the change — ' +
+                      'recall/export may briefly show the memory as still active.',
                 }],
-                details: { deleted: true, txHash: result.txHash, factId },
+                details: {
+                  deleted: true,
+                  txHash: result.txHash,
+                  factId,
+                  ...(confirm.indexed ? {} : { partial: true }),
+                },
               };
             } else {
               await apiClient!.deleteFact(factId, authKeyHex!);

--- a/skill/plugin/pin.ts
+++ b/skill/plugin/pin.ts
@@ -26,6 +26,7 @@ import { isValidMemoryType, V0_TO_V1_TYPE } from './extractor.js';
 import type { MemoryType, MemorySource, MemoryScope, MemoryVolatility } from './extractor.js';
 import { PROTOBUF_VERSION_V4 } from './subgraph-store.js';
 import type { SubgraphSearchFact } from './subgraph-search.js';
+import { confirmIndexed, type ConfirmIndexedOptions } from './confirm-indexed.js';
 
 // Lazy-load WASM core (mirrors claims-helper.ts pattern — plays nicely under
 // both the OpenClaw runtime (CJS-ish tsx) and bare Node ESM used by tests).
@@ -445,6 +446,14 @@ export interface PinOpResult {
   tx_hash?: string;
   reason?: string;
   error?: string;
+  /**
+   * On-chain batch submitted but subgraph indexer did not confirm the new
+   * fact id within the timeout window (default 30s). The pin/unpin IS
+   * on-chain — `tx_hash` is observable on the explorer — but a follow-up
+   * `recall`/`export` may briefly surface stale state. Resolves once the
+   * indexer catches up. See `confirm-indexed.ts`.
+   */
+  partial?: boolean;
 }
 
 /**
@@ -461,6 +470,7 @@ export async function executePinOperation(
   targetStatus: 'pinned' | 'active',
   deps: PinOpDeps,
   reason?: string,
+  confirmOpts?: ConfirmIndexedOptions,
 ): Promise<PinOpResult> {
   // 1. Fetch the existing fact
   const existing = await deps.fetchFactById(factId);
@@ -672,6 +682,11 @@ export async function executePinOperation(
         tx_hash: txHash,
       };
     }
+    // Read-after-write: poll the subgraph until the new (pinned/unpinned)
+    // fact id is indexed and active. On timeout, surface `partial: true`
+    // so a follow-up recall/export that races against indexer lag can
+    // surface a clear "still propagating" hint rather than apparent staleness.
+    const confirm = await confirmIndexed(newFactId, confirmOpts);
     return {
       success: true,
       fact_id: factId,
@@ -680,6 +695,7 @@ export async function executePinOperation(
       new_status: targetStatus,
       tx_hash: txHash,
       reason,
+      ...(confirm.indexed ? {} : { partial: true }),
     };
   } catch (err) {
     return {

--- a/skill/plugin/retype-setscope.ts
+++ b/skill/plugin/retype-setscope.ts
@@ -49,6 +49,7 @@ import type {
 } from './extractor.js';
 import { PROTOBUF_VERSION_V4 } from './subgraph-store.js';
 import type { SubgraphSearchFact } from './subgraph-search.js';
+import { confirmIndexed, type ConfirmIndexedOptions } from './confirm-indexed.js';
 
 // Lazy-load WASM core — mirrors pin.ts pattern.
 const requireWasm = createRequire(import.meta.url);
@@ -117,6 +118,15 @@ export interface RetypeSetScopeResult {
   new_scope?: MemoryScope;
   tx_hash?: string;
   error?: string;
+  /**
+   * Set to `true` when the on-chain batch was submitted successfully but the
+   * subgraph indexer did not confirm the new fact id within the timeout
+   * window (default 30s). The mutation IS on-chain — clients can rely on
+   * `tx_hash` for observability — but a follow-up `recall`/`export` may
+   * surface stale state for another few seconds. Resolves once the indexer
+   * catches up. See `confirm-indexed.ts` for the polling implementation.
+   */
+  partial?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -229,6 +239,7 @@ async function rewriteWithMutation(
   factId: string,
   deps: RetypeSetScopeDeps,
   mutate: (existing: NormalizedFact) => NormalizedFact,
+  confirmOpts?: ConfirmIndexedOptions,
 ): Promise<RetypeSetScopeResult> {
   const existing = await deps.fetchFactById(factId);
   if (!existing) {
@@ -349,6 +360,11 @@ async function rewriteWithMutation(
         tx_hash: txHash,
       };
     }
+    // Read-after-write: poll the subgraph until the new fact id is indexed
+    // and active, OR the timeout (default 30s) elapses. On timeout, surface
+    // `partial: true` so the caller knows the chain write succeeded but the
+    // indexer has not yet caught up.
+    const confirm = await confirmIndexed(newFactId, confirmOpts);
     return {
       success: true,
       fact_id: factId,
@@ -358,6 +374,7 @@ async function rewriteWithMutation(
       previous_scope: current.scope,
       new_scope: next.scope,
       tx_hash: txHash,
+      ...(confirm.indexed ? {} : { partial: true }),
     };
   } catch (err) {
     return {
@@ -381,6 +398,7 @@ export async function executeRetype(
   factId: string,
   newType: MemoryType,
   deps: RetypeSetScopeDeps,
+  confirmOpts?: ConfirmIndexedOptions,
 ): Promise<RetypeSetScopeResult> {
   if (!isValidMemoryType(newType)) {
     return {
@@ -389,10 +407,15 @@ export async function executeRetype(
       error: `Invalid new type "${newType}". Must be one of: claim, preference, directive, commitment, episode, summary.`,
     };
   }
-  return rewriteWithMutation(factId, deps, (current) => ({
-    ...current,
-    type: newType,
-  }));
+  return rewriteWithMutation(
+    factId,
+    deps,
+    (current) => ({
+      ...current,
+      type: newType,
+    }),
+    confirmOpts,
+  );
 }
 
 /**
@@ -403,6 +426,7 @@ export async function executeSetScope(
   factId: string,
   newScope: MemoryScope,
   deps: RetypeSetScopeDeps,
+  confirmOpts?: ConfirmIndexedOptions,
 ): Promise<RetypeSetScopeResult> {
   if (!(VALID_MEMORY_SCOPES as readonly string[]).includes(newScope)) {
     return {
@@ -411,10 +435,15 @@ export async function executeSetScope(
       error: `Invalid new scope "${newScope}". Must be one of: ${VALID_MEMORY_SCOPES.join(', ')}.`,
     };
   }
-  return rewriteWithMutation(factId, deps, (current) => ({
-    ...current,
-    scope: newScope,
-  }));
+  return rewriteWithMutation(
+    factId,
+    deps,
+    (current) => ({
+      ...current,
+      scope: newScope,
+    }),
+    confirmOpts,
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/skill/plugin/retype-setscope.ts
+++ b/skill/plugin/retype-setscope.ts
@@ -361,10 +361,18 @@ async function rewriteWithMutation(
       };
     }
     // Read-after-write: poll the subgraph until the new fact id is indexed
-    // and active, OR the timeout (default 30s) elapses. On timeout, surface
+    // and active, OR the timeout (default 30s) elapses. On timeout (or if
+    // the WASM bindings are unavailable / subgraph unreachable), surface
     // `partial: true` so the caller knows the chain write succeeded but the
-    // indexer has not yet caught up.
-    const confirm = await confirmIndexed(newFactId, confirmOpts);
+    // indexer has not yet caught up. The confirm step is observational —
+    // never fail the whole operation just because confirm step couldn't run.
+    let indexed = false;
+    try {
+      const confirm = await confirmIndexed(newFactId, confirmOpts);
+      indexed = confirm.indexed;
+    } catch {
+      indexed = false;
+    }
     return {
       success: true,
       fact_id: factId,
@@ -374,7 +382,7 @@ async function rewriteWithMutation(
       previous_scope: current.scope,
       new_scope: next.scope,
       tx_hash: txHash,
-      ...(confirm.indexed ? {} : { partial: true }),
+      ...(indexed ? {} : { partial: true }),
     };
   } catch (err) {
     return {

--- a/tests/phrase-safety/fixtures/fail_display_phrase_bare.md
+++ b/tests/phrase-safety/fixtures/fail_display_phrase_bare.md
@@ -1,0 +1,8 @@
+# Setup
+
+The wizard will:
+1. Generate a 12-word recovery phrase
+2. Display the recovery phrase for you to save
+
+This is the planted-violation fixture from rc.20. The agent must catch
+this — there is no safety qualifier on the line.

--- a/tests/phrase-safety/fixtures/fail_emit_phrase_flag.md
+++ b/tests/phrase-safety/fixtures/fail_emit_phrase_flag.md
@@ -1,0 +1,6 @@
+# How to invoke setup
+
+Run `totalreclaw onboard --emit-phrase` to get the JSON payload.
+
+The line above invokes the forbidden `--emit-phrase` flag without any
+"never" / "do not" qualifier — the guard must catch it.

--- a/tests/phrase-safety/fixtures/fail_print_mnemonic.md
+++ b/tests/phrase-safety/fixtures/fail_print_mnemonic.md
@@ -1,0 +1,7 @@
+# Bad guidance
+
+If the agent runs `totalreclaw setup`, the CLI will print the mnemonic
+to stdout, which the agent then sees in its tool output. Bad.
+
+The line above is the violation: "print the mnemonic" with no safety
+qualifier on that same line.

--- a/tests/phrase-safety/fixtures/pass_safety_warning_about_phrase.md
+++ b/tests/phrase-safety/fixtures/pass_safety_warning_about_phrase.md
@@ -1,0 +1,13 @@
+# Phrase Safety (HARD — never break)
+
+NEVER display the recovery phrase in chat. NEVER echo / generate / ask
+the user to paste a recovery phrase. The phrase MUST NEVER cross the
+LLM context.
+
+Do NOT print the recovery phrase to stdout — the agent transcript
+captures stdout and that would compromise the wallet.
+
+If the user pastes a phrase anyway, tell them it is compromised.
+
+This fixture exercises the whitelist tokens: NEVER, MUST NOT, do not,
+compromised. The guard must NOT flag it.

--- a/tests/phrase-safety/fixtures/pass_unrelated_content.md
+++ b/tests/phrase-safety/fixtures/pass_unrelated_content.md
@@ -1,0 +1,9 @@
+# Architecture overview
+
+This document covers the on-chain memory subgraph schema. It does not
+touch identity setup.
+
+A `phrase` here just means a sentence; we don't display anything sensitive.
+
+This fixture exercises false-positive avoidance: the word "phrase" appears
+but no display verb is paired with it. Guard must NOT flag.

--- a/tests/phrase-safety/run-regression.sh
+++ b/tests/phrase-safety/run-regression.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Regression tests for `scripts/check-phrase-safety.sh`. Each fixture is a
+# plain markdown file. The test suite plants each fixture into the repo
+# (under `docs/.phrase-safety-fixtures/`), runs the guard, and asserts the
+# expected exit code (1 for violation fixtures, 0 for clean fixtures).
+# After each run the planted fixture is removed.
+#
+# This exists because static-analysis guards regress silently: a tweak to
+# the regex or whitelist that breaks the guard would otherwise sail through
+# CI as long as the rest of the repo is clean.
+#
+# Usage:
+#   tests/phrase-safety/run-regression.sh            # run all cases
+#   tests/phrase-safety/run-regression.sh --debug    # leak guard's stdout
+#
+# Exit:
+#   0 — every case behaved as expected
+#   1 — at least one case mismatched
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FIXTURES_DIR="$SCRIPT_DIR/fixtures"
+PLANT_DIR="$REPO_ROOT/docs/.phrase-safety-fixtures"
+GUARD="$REPO_ROOT/scripts/check-phrase-safety.sh"
+
+debug=0
+if [[ "${1:-}" == "--debug" ]]; then
+    debug=1
+fi
+
+if [[ ! -x "$GUARD" ]]; then
+    echo "FAIL: guard script missing or not executable: $GUARD"
+    exit 1
+fi
+
+if [[ ! -d "$FIXTURES_DIR" ]]; then
+    echo "FAIL: fixtures dir missing: $FIXTURES_DIR"
+    exit 1
+fi
+
+# Cleanup helper — always removes the planted dir, even on script failure.
+cleanup() {
+    rm -rf "$PLANT_DIR"
+}
+trap cleanup EXIT
+
+failures=0
+total=0
+
+# Each fixture file's basename starts with `fail_` (must trigger the guard)
+# or `pass_` (must NOT trigger). We run them one at a time so a failing
+# case doesn't mask later cases.
+for fx in "$FIXTURES_DIR"/*.md; do
+    name="$(basename "$fx")"
+    total=$((total + 1))
+
+    expected_exit=1
+    case "$name" in
+        fail_*) expected_exit=1 ;;
+        pass_*) expected_exit=0 ;;
+        *)
+            echo "FAIL: fixture $name must start with fail_ or pass_"
+            failures=$((failures + 1))
+            continue
+            ;;
+    esac
+
+    rm -rf "$PLANT_DIR"
+    mkdir -p "$PLANT_DIR"
+    cp "$fx" "$PLANT_DIR/$name"
+
+    # Add the planted file to the guard's scope by appending it via
+    # PHRASE_SAFETY_EXTRA_PATHS — unsupported today, so we just rely on
+    # the guard's `find docs -type f *.md` walk. The planted directory
+    # is excluded by NAME from typical doc browsing because it starts
+    # with a dot.
+
+    set +e
+    if [[ "$debug" == "1" ]]; then
+        "$GUARD"
+    else
+        "$GUARD" >/dev/null 2>&1
+    fi
+    actual_exit=$?
+    set -e
+
+    if [[ "$actual_exit" -ne "$expected_exit" ]]; then
+        echo "FAIL ($name): expected exit $expected_exit, got $actual_exit"
+        if [[ "$debug" == "1" ]]; then
+            echo "    Fixture content:"
+            sed 's/^/      | /' "$fx"
+        fi
+        failures=$((failures + 1))
+    else
+        echo "PASS ($name): exit $actual_exit as expected"
+    fi
+done
+
+cleanup
+
+echo ""
+if [[ "$failures" -gt 0 ]]; then
+    echo "$failures of $total phrase-safety regression case(s) FAILED."
+    exit 1
+fi
+
+echo "All $total phrase-safety regression case(s) passed."
+exit 0


### PR DESCRIPTION
**Part A — read-after-write primitive** (resolves rc.18 #117 root cause + class):
- New rust/totalreclaw-core/src/confirm.rs (170 lines + 8 tests)
- WASM + PyO3 exports
- Plugin/MCP/Hermes write-tools wrapped: pin/unpin/retype/set_scope/forget. On indexer timeout → result.partial=true.

**Part B — phrase-safety CI guard at repo root**:
- scripts/check-phrase-safety.sh (~120ms)
- 5 regression fixtures (3 fail / 2 pass)
- ci.yml integration
- 4 pre-existing real violations fixed (skill-nanoclaw README, nanoclaw guide, identity-setup spec, plugin CHANGELOG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)