### PR TITLE
chore(docs): rc.22 audit pass — version pins + roadmap + broken-link fixes

### DIFF
--- a/CHANGELOG-public.md
+++ b/CHANGELOG-public.md
@@ -1,5 +1,7 @@
 # TotalReclaw Changelog
 
+> **Note:** This file lists releases promoted to the public registries' stable tags. Active release-candidate work (`@rc` dist-tag on npm, `rcN` on PyPI, etc.) is tracked in the internal release-pipeline tracker, not here. The "rc.19 — Setup-agnostic instructions" entry below describes a fix list that shipped in the rc.19→rc.22 RC line; once that line promotes to stable as `3.3.1`, expect a consolidated stable entry covering 3.2.0 → 3.3.1.
+
 ## rc.19 — Setup-agnostic instructions (2026-04-25)
 
 - **Fix:** setup instructions agnostic to container names. Both shipped SKILL.md files (`skill/plugin/SKILL.md`, `python/src/totalreclaw/hermes/SKILL.md`) and both user-facing guides (`docs/guides/openclaw-setup.md`, `docs/guides/hermes-setup.md`) replaced 12 hardcoded `docker restart tr-openclaw` / `docker restart tr-hermes` literals with topology-agnostic `docker restart <your-container-name>` placeholders + a three-pattern fork (native / Docker self-host / managed service) so users whose container is not named `tr-*` get correct instructions.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,28 +13,29 @@ TotalReclaw is an end-to-end encrypted memory vault for AI agents. The project p
 
 ---
 
-## Now / Next (Wave status, 2026-04-19)
+## Now / Next (Wave status, 2026-04-25)
 
 The phase breakdown below is the canonical long-term plan. This section surfaces what's live right now and what the next publish wave looks like, for users tracking against the CHANGELOG.
 
-### Shipped in Wave 1 -- v1 Stabilization (2026-04-19) — COMPLETE
+### Shipped — current stable (2026-04-25)
 
-- `@totalreclaw/core@2.1.0` + `2.1.1` (npm + PyPI + crates.io) -- Tier 2 hoist of `VALID_MEMORY_TYPES` / `TYPE_TO_CATEGORY` + additive `pin_status` field on `MemoryClaimV1`. Spec v1.1 addendum.
-- `@totalreclaw/mcp-server@3.1.0` + `3.2.0` (npm) -- Phase 2 contradiction detection wired via core WASM; pin-on-tombstone recovery; `pin` / `unpin` emit v1 blobs with `pin_status`.
-- `@totalreclaw/totalreclaw@3.0.5` through `3.1.0` (ClawHub + npm) -- scanner false-positive fixes, consolidation delegated to Rust core, 4-bug stabilization wave in 3.1.0 (schema dedup, digest stub filter, auto-bootstrap credentials).
-- `totalreclaw@2.0.2` / `2.1.0` / `2.2.0` / `2.2.1` (PyPI) -- Python client + Hermes stabilization, Phase A parity (upgrade + debrief + Mem0 import), Gap 3 UserOp batching (`remember_batch`), lifecycle `auto_extract` wired through batching.
-- Infra: `publish-*.yml` workflows gained `release-type: stable | rc` + `rc-number`; new `promote-rc.yml`; public [`docs/guides/release-process.md`](guides/release-process.md).
+- `@totalreclaw/totalreclaw@3.2.3` (npm `latest`) — OpenClaw plugin. Auto-recall, auto-extract every 3 turns, pre-compaction flush, session debrief, full v1 tool surface (remember / recall / forget / export / status / pair / pin / unpin / retype / set_scope / import_from / migrate / consolidate / upgrade).
+- `@totalreclaw/mcp-server@3.2.0` (npm) — MCP server for Claude Desktop / Cursor / Windsurf. Pin/unpin/retype/set_scope wired; v1 contradiction detection via core WASM.
+- `@totalreclaw/core@2.2.0` (npm WASM) + `totalreclaw-core@2.2.0` (PyPI PyO3) + `totalreclaw-core@2.2.0` (crates.io) — shared Rust core: claim proto, crypto, pin state machine, source-weighted reranker.
+- `totalreclaw@2.3.0` (PyPI) — Python client + Hermes Agent plugin. Full Hermes parity with the plugin tool surface.
+- `@totalreclaw/skill-nanoclaw@3.0.0` (npm) — NanoClaw skill (auto-recall + auto-extract via `additionalContext`).
+- Wave 1 (2026-04-19) shipped post-v1 stabilization (core 2.1.x, mcp 3.1/3.2, plugin 3.0.x, python 2.0.2-2.2.1). Subsequent waves landed: 3.2.x (plugin secure onboarding CLI wizard), 3.3.x RC line (QR-pairing + relay-brokered pair flow + URL-driven install via canonical chat prompt + ESM/createRequire fix). Public `docs/guides/release-process.md` documents the RC-then-promote flow.
 
-Known issues carried over: plugin 3.1.0 auto-bootstrap recovery-phrase LLM-leak risk (fix in 3.2.0), bundled-core version mismatch on older plugin tarballs (mitigation: 3.1.1 patch if needed), `totalreclaw-memory@2.0.1` crates.io publish blocked at dry-run (deferred).
+### In flight — RC wave (2026-04-25)
 
-### Next
+- `@totalreclaw/totalreclaw@3.3.1-rc.22` (npm `rc` dist-tag) + `totalreclaw==2.3.1rc22` (PyPI) — under QA. Bundle adds: install scanner robustness, ESM `createRequire` / await-import fix, pair simulator v2 cipher alignment, post-install sweeper for orphan staging dirs, plus prior rc.20 work (URL-driven install via canonical chat prompt + relay-brokered pair flow). Promote target is `3.3.1` once full chat-flow QA returns GO.
+- See [`totalreclaw-internal/docs/release-pipeline.md`](https://github.com/p-diogo/totalreclaw-internal) for live RC + QA state.
 
-- **Plugin 3.2.0 (secure onboarding CLI wizard)** -- replaces the 3.1.0 `prependContext` recovery-phrase banner with a CLI wizard. Design-in-progress. Closes the LLM-leak UX gap.
-- **Plugin 3.3.0 (QR-pairing for remote-gateway users)** -- QR-based handoff for users running the OpenClaw gateway remotely. Follow-on to the 3.2.0 wizard.
-- **`totalreclaw-memory@2.0.1` (crates.io) publish retry** -- deferred from Wave 1 after the cargo dry-run sanity check flagged a metadata mismatch. ZeroClaw continues on 2.0.0 until the retry lands.
-- **Python client Hermes parity Phase B/C** -- remaining tools (`retype`, `set_scope`, MCP adapter, `migrate`, `consolidate`, JSON re-import) to reach full Hermes feature parity with OpenClaw.
-- **PR #45 (prompt hoist + NanoClaw align)** -- rebase, merge, and publish the hoisted extraction prompt + NanoClaw alignment work.
-- **ClawHub reclassification path** -- either via a reclassification request to ClawHub, or by validating the `totalreclaw-canary@3.1.0-canary.0` slug against the scanner and then re-registering under a clean classification.
+### Next (post-rc.22 promote)
+
+- **`totalreclaw-memory@2.0.1` (crates.io) publish retry** — deferred from Wave 1 after the cargo dry-run sanity check flagged a metadata mismatch. ZeroClaw continues on 2.0.0 until the retry lands.
+- **ClawHub reclassification path** — via a reclassification request to ClawHub, or by validating a clean canary slug against the scanner and re-registering.
+- **Phase 3 autonomous QA / triage pipeline (in production)** — see `docs/operations/autonomous-qa-pipeline.md` in the internal repo. Phase 1 manual dispatch and Phase 2 webhook-triggered ephemeral QA are live; Phase 3 auto-triage of QA findings into umbrella issues + scoped fix branches is shipping incrementally.
 
 ---
 

--- a/docs/guides/client-setup-v1.md
+++ b/docs/guides/client-setup-v1.md
@@ -1,6 +1,6 @@
 # Client Setup — v1
 
-**Applies to:** TotalReclaw v1 (core 2.0.0, plugin 3.0.0, mcp-server 3.0.0, nanoclaw 3.0.0, python 2.0.0, ZeroClaw 2.0.0).
+**Applies to:** TotalReclaw v1, all clients. Current stable versions: core 2.2.0, plugin 3.2.3, mcp-server 3.2.0, nanoclaw 3.0.0, python 2.3.0.
 
 One setup page per client. v1 is the default on every client — no env toggles, no feature flags to flip. Pick your platform.
 
@@ -122,8 +122,8 @@ If you need to generate a recovery phrase first, run `npx @totalreclaw/mcp-serve
 
 ## Python client
 
-**Package:** `totalreclaw==2.0.0` (PyPI).
-**Features:** Hermes Agent plugin with pre_llm_call auto-recall + post_llm_call auto-extract + on_session_end debrief. Core remember/recall/forget/export/status tools.
+**Package:** `totalreclaw>=2.3.0` (PyPI).
+**Features:** Hermes Agent plugin with pre_llm_call auto-recall + post_llm_call auto-extract + on_session_finalize debrief. Full tool parity with the OpenClaw plugin: remember / recall / forget / export / status / pair / pin / unpin / retype / set_scope / import_from / upgrade.
 
 ### Install
 
@@ -180,7 +180,7 @@ The plugin registers automatically with Hermes Agent v0.5.0+.
 
 ## ZeroClaw (Rust crate)
 
-**Crate:** `totalreclaw-memory = "2.0.0"` (crates.io).
+**Crate:** `totalreclaw-memory = "2.0.0"` (crates.io). The `totalreclaw-core` Rust crate (canonical claim proto + crypto + pin state machine) is at 2.2.0.
 **Features:** native Rust Memory trait with v1 write path (`store_v1`), cosine + fingerprint dedup, v4 outer protobuf. Designed for ZeroClaw (NEAR AI agent framework) but usable in any Rust app.
 
 ### Add dependency

--- a/docs/guides/env-vars-reference.md
+++ b/docs/guides/env-vars-reference.md
@@ -1,7 +1,7 @@
 # Environment Variables Reference
 
 **Applies to:** TotalReclaw v1 (all clients).
-**Last updated:** 2026-04-18.
+**Last updated:** 2026-04-25.
 
 v1 deliberately removes every env var that was an internal knob pretending to be user configuration. The list below is the **complete** set of env vars that end users or deployment operators should ever need to set.
 
@@ -81,7 +81,7 @@ export TOTALRECLAW_CACHE_PATH="$HOME/.config/totalreclaw/cache.enc"
 **Optional.** QA / observability session tag. When set, every outbound relay call adds the `X-TotalReclaw-Session` header so Axiom log filters and the `qa-totalreclaw` skill can scope log searches per QA run.
 
 ```bash
-export TOTALRECLAW_SESSION_ID="qa-rc.20-run-7"
+export TOTALRECLAW_SESSION_ID="qa-rc.22-run-7"
 ```
 
 **Default:** unset — header omitted, requests are untagged.

--- a/docs/guides/feature-comparison.md
+++ b/docs/guides/feature-comparison.md
@@ -2,7 +2,7 @@
 
 TotalReclaw works across multiple AI agent platforms. The core encryption, storage, search pipeline, and v1 taxonomy are identical everywhere -- the differences are in automation (lifecycle hooks) and available tools. This table shows what each platform supports.
 
-All clients below ship v1 (core 2.0.0, plugin 3.0.0, mcp-server 3.0.0, nanoclaw 3.0.0, python 2.0.0, ZeroClaw 2.0.0).
+All clients ship v1 by default. Stable production versions: core 2.2.0, plugin 3.2.3, mcp-server 3.2.0, nanoclaw 3.0.0, python 2.3.0.
 
 ---
 
@@ -24,10 +24,10 @@ All clients below ship v1 (core 2.0.0, plugin 3.0.0, mcp-server 3.0.0, nanoclaw 
 | **Explicit Tools** | | | | | | |
 | Remember / Recall / Forget / Export | Yes | Yes | Yes | Yes | Yes | Yes |
 | Status (billing & usage) | Yes | Yes | Yes | Yes | Yes | Yes |
-| Pin / Unpin (v1) | -- | Yes | Yes (via MCP) | -- | Yes (via MCP) | -- |
-| Retype (v1) | -- | Yes | Yes (via MCP) | -- | Yes (via MCP) | -- |
-| Set scope (v1) | -- | Yes | Yes (via MCP) | -- | Yes (via MCP) | -- |
-| Import from Mem0 / ChatGPT / Claude | Yes | Yes | Yes | -- | Yes | -- |
+| Pin / Unpin (v1) | Yes | Yes | Yes (via MCP) | Yes | Yes (via MCP) | -- |
+| Retype (v1) | Yes | Yes | Yes (via MCP) | Yes | Yes (via MCP) | -- |
+| Set scope (v1) | Yes | Yes | Yes (via MCP) | Yes | Yes (via MCP) | -- |
+| Import from Mem0 / ChatGPT / Claude / Gemini | Yes | Yes | Yes | Yes | Yes | -- |
 | Upgrade to Pro | Yes | Yes | Yes | -- | Yes | -- |
 | Migrate (testnet to mainnet) | Yes | Yes | Yes | -- | Yes | -- |
 | Consolidate (bulk dedup) | Yes | Yes | Yes | -- | Yes | -- |
@@ -51,7 +51,7 @@ All clients below ship v1 (core 2.0.0, plugin 3.0.0, mcp-server 3.0.0, nanoclaw 
 
 **NanoClaw** -- Automatic, like OpenClaw. The NanoClaw agent-runner spawns the MCP server as a background process. Memory is shared within the NanoClaw group. No user setup required -- the admin configures the recovery phrase.
 
-**Hermes (Python)** -- Automatic via pre/post LLM call hooks. LLM extraction with heuristic fallback. Core tools work; import/migrate/consolidate not yet implemented.
+**Hermes (Python)** -- Automatic via pre/post LLM call hooks. LLM extraction with heuristic fallback. Full tool parity with OpenClaw plugin since 2.3.x: remember / recall / forget / export / status / pair / pin / unpin / retype / set_scope / import_from / upgrade. Migrate + consolidate are managed-service-only and exposed via the plugin / MCP server.
 
 **IronClaw (NEAR AI)** -- Uses the MCP server for tools. No lifecycle hooks -- auto-extraction requires setting up routines (cron). The TEE protects the runtime; TotalReclaw protects the data.
 

--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -24,7 +24,7 @@ openclaw plugins install @totalreclaw/totalreclaw
 ```
 
 Notes:
-- For an RC build, replace the second command with `openclaw plugins install @totalreclaw/totalreclaw@rc` (or pin a version like `@totalreclaw/totalreclaw@3.3.1-rc.19`).
+- For an RC build, replace the second command with `openclaw plugins install @totalreclaw/totalreclaw@rc` (or pin a version like `@totalreclaw/totalreclaw@3.3.1-rc.22`).
 - If either command fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment), STOP and tell the user verbatim: *"Your environment doesn't expose the OpenClaw CLI to me. Please install `totalreclaw` from your service's plugins / skills UI, then reply `done`."* Wait for `done` before continuing to Step 2.
 
 ### Step 2 — Wait for auto-reload (do NOT restart the gateway yourself)
@@ -112,7 +112,7 @@ openclaw plugins install @totalreclaw/totalreclaw            # stable
 
 Then in chat: *"Set up TotalReclaw"* — the agent will call `totalreclaw_pair` and hand you the URL + PIN. Open the URL in your browser to enter or generate your phrase.
 
-> Pin a specific RC with `openclaw plugins install @totalreclaw/totalreclaw@3.3.1-rc.19`. Check what each tag resolves to: `npm view @totalreclaw/totalreclaw dist-tags`. Keep skill and plugin on the same version family (both stable or both RC).
+> Pin a specific RC with `openclaw plugins install @totalreclaw/totalreclaw@3.3.1-rc.22`. Check what each tag resolves to: `npm view @totalreclaw/totalreclaw dist-tags`. Keep skill and plugin on the same version family (both stable or both RC).
 
 <details>
 <summary>From-source install (for plugin development — self-host only)</summary>

--- a/docs/guides/v1-migration.md
+++ b/docs/guides/v1-migration.md
@@ -87,7 +87,7 @@ Full detail in [`docs/specs/totalreclaw/tiered-retrieval.md`](../specs/totalrecl
 
 The on-chain wire format bumps from v3 to v4 to signal that the encrypted blob now contains v1 JSON (not v0 binary). Subgraph schema is unchanged — no re-indexing required.
 
-Details: [`totalreclaw-internal/docs/plans/2026-04-18-protobuf-v4-design.md`](https://github.com/p-diogo/totalreclaw-internal/) (internal).
+Details: see the protobuf claim definitions in `python/src/totalreclaw/proto/` (Python) and `rust/totalreclaw-core/src/proto/` (Rust) for the canonical wire schema.
 
 ### 6. Environment variables removed
 


### PR DESCRIPTION
Auto-applied from doc audit:
- ROADMAP.md rewritten Wave 1 → current (stable 3.2.3 / core 2.2.0 / python 2.3.0; rc.22 RC line in flight)
- feature-comparison.md version pins refreshed + pin/retype/set_scope rows flipped `--` → `Yes` (plugin actually ships them)
- client-setup-v1.md Python pin `==2.0.0` → `>=2.3.0`
- openclaw-setup.md RC examples rc.19 → rc.22
- env-vars-reference.md SESSION_ID example bumped
- v1-migration.md broken cross-repo link fixed
- CHANGELOG-public.md rc.19 framed as RC line

🤖 Generated with [Claude Code](https://claude.com/claude-code)