### PR TITLE
docs: URL-driven parity rewrite — beta-tester-guide + claude-code-setup

### DIFF
--- a/docs/guides/beta-tester-guide-detailed.md
+++ b/docs/guides/beta-tester-guide-detailed.md
@@ -1,886 +1,385 @@
-# TotalReclaw Beta Tester Guide
+# TotalReclaw — Beta Tester Deep-Dive
 
-**Version:** 1.1
-**Date:** March 2026
-**Audience:** Internal beta testers (OpenClaw, Claude Desktop, Cursor, or any MCP-compatible agent)
-**Time to read:** ~15 minutes
-**Time to complete setup:** ~10 minutes (MCP) / ~30 minutes (OpenClaw plugin)
+**Version:** 3.3.1 (RC line; promotes to 3.3.1 stable)
+**Date:** April 2026
+**Audience:** Power users and beta testers who want to tune extraction, understand the encryption pipeline, run E2E validation, or self-host.
+**Time to read:** ~15 minutes.
 
----
+This guide is a companion to the 95-percent-of-users setup guides. **For installation, follow your runtime's setup guide first** — every flow is URL-driven and takes a single chat message:
 
-## Table of Contents
+- **OpenClaw** → [openclaw-setup.md](./openclaw-setup.md) (browser pair flow, auto-reload)
+- **Hermes (Python)** → [hermes-setup.md](./hermes-setup.md) (browser pair flow, manual restart)
+- **Claude Code / Claude Desktop / Cursor / Windsurf / IronClaw (MCP)** → [claude-code-setup.md](./claude-code-setup.md) (no pair flow — phrase from another client's credentials or offline)
 
-1. [What Is TotalReclaw?](#1-what-is-totalreclaw)
-2. [Installation](#2-installation)
-3. [First-Time Setup -- Key Generation](#3-first-time-setup----key-generation)
-4. [Understanding the Wallet Address](#4-understanding-the-wallet-address)
-5. [Free Tier -- How It Works](#5-free-tier----how-it-works)
-6. [Automatic Memory (No Action Required)](#6-automatic-memory-no-action-required)
-7. [Explicit Memory Tools](#7-explicit-memory-tools)
-8. [Testing Your Setup (Manual Validation)](#8-testing-your-setup-manual-validation)
-9. [Upgrading to Pro Tier](#9-upgrading-to-pro-tier)
-10. [Recovery on a New Device](#10-recovery-on-a-new-device)
-11. [MCP Server Setup (Claude Desktop / Cursor)](#11-mcp-server-setup-claude-desktop--cursor)
-12. [Running E2E Validation (Optional, for Technical Testers)](#12-running-e2e-validation-optional-for-technical-testers)
-13. [Configuration Reference](#13-configuration-reference)
-14. [Troubleshooting](#14-troubleshooting)
-15. [Known Limitations (Beta)](#15-known-limitations-beta)
+Once setup is done and tools are bound, come back here for the knobs.
 
 ---
 
-## 1. What Is TotalReclaw?
+## Table of contents
 
-TotalReclaw is a private, encrypted memory layer for your AI agent. It remembers things you tell it across sessions -- your preferences, decisions, facts about your projects -- and only you can decrypt those memories. Not even the TotalReclaw server can read them. Think of it as a password manager, but for your AI's memory: fully encrypted, fully portable, and under your control.
-
----
-
-## 2. Installation
-
-TotalReclaw works with two types of AI agents: **OpenClaw** (via the plugin) and **any MCP-compatible agent** such as Claude Desktop or Cursor (via the MCP server). Choose the path that matches your setup.
-
-### Prerequisites
-
-Before you begin, make sure you have:
-
-1. **Node.js 18 or later** installed on your machine. You can check by running:
-   ```
-   node --version
-   ```
-   If you see `v18.x.x` or higher, you are all set. If not, download Node.js from [nodejs.org](https://nodejs.org).
-2. **Internet access** -- TotalReclaw communicates with the relay server at `api.totalreclaw.xyz`.
-3. **A safe place to write down 12 words** -- you will generate a recovery phrase during setup. This is your only way to recover your memories if you switch devices. More on this in the next section.
-
-**For OpenClaw users only:**
-
-4. **An OpenClaw account** with an active workspace.
-5. **An LLM provider configured in OpenClaw.** TotalReclaw auto-detects your agent's LLM provider and API key -- no extra LLM configuration is needed. Embeddings are generated locally (no API key required). Fact extraction uses a cheap model from your existing provider (e.g., Anthropic -> `claude-haiku-4-5`, OpenAI -> `gpt-4.1-mini`).
-
-**For MCP users (Claude Desktop / Cursor):** Skip to [Section 11](#11-mcp-server-setup-claude-desktop--cursor) for the fastest setup path.
-
-### Install the OpenClaw Plugin
-
-One command, installed from npm:
-
-```
-openclaw plugins install @totalreclaw/totalreclaw
-```
-
-This registers the plugin with your gateway under the ID `totalreclaw` and sets it up automatically on first run. Verify it appears in your OpenClaw skill/plugin list -- you should see **TotalReclaw** described as "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime."
-
-**Scanner status (plugin 3.1.0):** `openclaw security audit --deep` reports **0 `code_safety` warnings** for totalreclaw. The install completes without any `--dangerously-force-unsafe-install` flag. Earlier 3.0.x releases could trip a false-positive `potential-exfiltration` warning -- that was resolved in 3.0.8 / 3.1.0 by consolidating filesystem helpers.
-
-> **TotalReclaw is distributed via npm.** Future CLI resolvers may surface it via additional registries.
-
-> **Beta tester note — installing an RC.** The bare spec above resolves to npm's `latest` dist-tag, which is always the current **stable** build. If you installed the skill via `openclaw skills install totalreclaw`, ClawHub may have handed you a release-candidate skill — in that case install the matching RC plugin explicitly with the `@rc` tag (or pin a specific candidate):
->
-> ```
-> openclaw plugins install @totalreclaw/totalreclaw@rc          # latest RC
-> openclaw plugins install @totalreclaw/totalreclaw@3.3.1-rc.13 # pinned RC
-> ```
->
-> Run `npm view @totalreclaw/totalreclaw dist-tags` to see what `latest` and `rc` currently resolve to. Keeping the skill and plugin on the same version family (both stable or both RC) avoids skill-instruction / plugin-behavior drift.
-
-<details>
-<summary>Developer / from-source install (plugin contributors only)</summary>
-
-If you are working from a fork or want to pin a specific local source tree, clone the repo and point `openclaw plugins install` at the local path:
-
-```
-git clone https://github.com/p-diogo/totalreclaw.git
-openclaw plugins install ./totalreclaw/skill/plugin
-```
-
-This is for plugin development only. Users following this guide should stick with the one-line npm install above.
-
-</details>
-
-### What you get in plugin 3.1.0 (release notes)
-
-Plugin 3.1.0 is the first v1-taxonomy-complete stable release after the 3.0.x stabilization wave. Relative to 3.0.4, it fixes the following user-visible issues:
-
-| Fix | Description |
-|-----|-------------|
-| Scanner-clean install | No `potential-exfiltration` warnings; one-line install works without any force flags. |
-| Auto-bootstrap credentials | Plugin generates a recovery phrase automatically on first load when `credentials.json` is missing -- no explicit `totalreclaw_setup` call needed. |
-| Digest stubs populated | Session digests flushed to storage carry the fields downstream consumers expect (schema fix). |
-| `pin_status` round-trips on-chain | Pinning / unpinning through the natural-language tools emits v1 protobuf blobs with `pin_status` set; cross-client verified against core 2.1.1. |
-
-Paired with `@totalreclaw/core@2.1.1`, these close out the post-v1.0.0 stabilization items tracked in the project's Wave 1 verdict.
+1. [What's auto-running and on which client](#1-whats-auto-running-and-on-which-client)
+2. [Architecture](#2-architecture)
+3. [Memory types (v1 taxonomy)](#3-memory-types-v1-taxonomy)
+4. [Tuning extraction and recall](#4-tuning-extraction-and-recall)
+5. [Environment variables — full reference](#5-environment-variables--full-reference)
+6. [Cross-client portability](#6-cross-client-portability)
+7. [Self-hosted mode](#7-self-hosted-mode)
+8. [Manual validation checklist](#8-manual-validation-checklist)
+9. [E2E test suites](#9-e2e-test-suites)
+10. [Troubleshooting](#10-troubleshooting)
 
 ---
 
-## 3. First-Time Setup -- Key Generation
+## 1. What's auto-running and on which client
 
-TotalReclaw uses a 12-word recovery phrase (called a BIP-39 mnemonic) as your master key. This phrase is used to derive your encryption key and your identity. You must generate it before using TotalReclaw for the first time.
+| Behavior | OpenClaw | Hermes | NanoClaw | MCP (Claude Code, etc.) |
+|---|---|---|---|---|
+| Auto-recall on every message | yes (`before_agent_start`) | yes | yes (`additionalContext`) | no — explicit `totalreclaw_recall` |
+| Auto-extract every N turns | yes (`agent_end`) | yes | yes | no — explicit `totalreclaw_remember` |
+| Pre-compaction flush | yes | yes | yes | no |
+| Session debrief | yes | yes | yes | no (use `totalreclaw_debrief` tool) |
+| First-run welcome | yes | yes | yes | no (MCP is stateless JSON-RPC) |
+| Browser pair flow | yes | yes | reuse OpenClaw / Hermes phrase | no — phrase from another client |
+| Auto-reload on plugin install | yes (`gateway.reload.mode = hybrid`) | no — manual restart | container respawn | host-restart only |
 
-> **WARNING: Your recovery phrase is the ONLY way to access your memories.**
-> If you lose it, your memories are permanently unrecoverable.
-> There is no reset, no recovery email, no support ticket.
-> Write it down on paper and store it somewhere safe.
+If you're on MCP, all the auto behavior is replaced by tool calls the host LLM makes from context. The same memories land in the same vault.
 
-### Step 1: Generate your recovery phrase
+---
 
-**MCP users (recommended path):** Run the setup wizard, which generates a phrase, registers you, and prints the MCP config snippet all in one step:
+## 2. Architecture
 
-```
-npx @totalreclaw/mcp-server setup
-```
+### Identity and key derivation
 
-The wizard will ask if you already have a recovery phrase. If you are a new user, it generates one, displays it, and asks you to confirm you have saved it before proceeding. It then registers you with the relay server and saves your credentials to `~/.totalreclaw/credentials.json`. See [Section 11](#11-mcp-server-setup-claude-desktop--cursor) for the full MCP setup flow.
+Your 12-word recovery phrase is the single root of every key in the system.
 
-**OpenClaw plugin users (v3.1.0+):** Auto-bootstrap handles this for you. On the first conversation turn after install, if `~/.openclaw/extensions/totalreclaw/credentials.json` does not exist, the plugin generates a 12-word phrase, writes it to that file, and continues. You do not need to run any `generate-mnemonic` command or explicitly ask the agent to set TotalReclaw up.
+1. **BIP-39 seed** — 12 words → 512-bit master seed.
+2. **Private key** — BIP-32 path `m/44'/60'/0'/0/0` → 256-bit secp256k1 private key.
+3. **EOA address** — standard Ethereum address derived from the private key.
+4. **Smart Account** — deterministic ERC-4337 address via CREATE2 from the EOA (canonical SimpleAccountFactory v0.7).
+5. **Encryption key** — HKDF-SHA256(seed, info=`totalreclaw-encryption-key-v1`) → 256-bit XChaCha20-Poly1305 key.
+6. **Auth key** — HKDF-SHA256(seed, info=`totalreclaw-auth-key-v1`) → 256-bit auth secret. Its SHA-256 hash is your relay-side identity.
 
-The phrase **may** also appear in the agent's first chat reply via a one-time banner -- but this surfacing is LLM-dependent. To retrieve your phrase reliably:
+The same phrase always produces the same Smart Account, encryption key, and auth identity — that's how cross-device and cross-client portability works.
+
+> **Core library.** All five derivation paths plus XChaCha20-Poly1305, blind-index hashing, content fingerprinting, and protobuf packing live in `@totalreclaw/core` (Rust core, compiled to native + WASM + PyO3 wheel). Every client links the same crate, so byte-for-byte parity is enforced by cross-runtime parity tests in CI.
+
+### Storage pipeline (write path)
+
+When a fact is stored:
+
+1. Plain text + metadata are encrypted with XChaCha20-Poly1305 (24-byte nonce).
+2. A SHA-256 content fingerprint over the canonical text dedupes duplicates client-side.
+3. Blind search trapdoors are generated for keyword tokens (HMAC-SHA256 with a per-user index secret).
+4. A 384-dim embedding (`Xenova/all-MiniLM-L6-v2`, INT8 quantized) is computed locally for semantic search.
+5. The encrypted blob, blind indices, content fingerprint, and (for v1) the protobuf-packed taxonomy fields are wrapped in a v=4 outer envelope and submitted via ERC-4337 UserOp to the EventfulDataEdge contract.
+6. The Pimlico paymaster sponsors gas. Free-tier writes hit Base Sepolia testnet; Pro-tier writes hit Gnosis mainnet. Chain auto-detection comes from your billing tier.
+7. The Graph indexes the on-chain event so it's queryable seconds later.
+
+### Retrieval pipeline (read path)
+
+When you query:
+
+1. Your query is embedded locally (same MiniLM model).
+2. Blind trapdoors for query tokens are generated.
+3. The relay returns up to several thousand encrypted candidates matching the trapdoors.
+4. The plugin / MCP server / Hermes client decrypts every candidate locally.
+5. Tier 1 source-weighted reranker scores: BM25 (lexical) + cosine (semantic) + RRF fusion + source weights (user > assistant) + scope bonus + pin override.
+6. The top-N (default 8) are returned to the host LLM as context.
+
+The relay never sees plaintext, never sees query terms, and never holds an encryption key.
+
+### Privacy guarantees
+
+- **Server-blind search.** The relay sees blind index tokens (HMAC outputs) and never the plaintext keywords. Even with a full database compromise, an attacker can't reverse a query without the per-user secret.
+- **End-to-end encryption.** All fact bytes are XChaCha20-Poly1305 ciphertext when they leave your device.
+- **No phrase ever leaves your device** as long as you follow the canonical setup. Browser pair flow encrypts the phrase locally with a fresh x25519/AES-GCM key derived against the gateway's ephemeral pubkey before posting; the relay only ever sees ciphertext.
+- **Decay is local.** Importance decay and eviction run client-side from the decrypted set. The relay can't infer which memories matter to you.
+
+---
+
+## 3. Memory types (v1 taxonomy)
+
+Plugin 3.0+ writes the v1 taxonomy. Six speech-act types map to Searle's classes:
+
+| Type | What it covers | Example |
+|---|---|---|
+| **claim** | assertive — facts about the world, decisions made | "I live in Lisbon", "Chose PostgreSQL for the prod DB" |
+| **preference** | expressive — likes / dislikes | "Likes dark mode", "Hates trailing commas" |
+| **directive** | imperative — rules to follow | "Always check `d.get(errors)` before `d.errors`" |
+| **commitment** | commissive — promises / goals | "Will ship v2 by Friday" |
+| **episode** | narrative — events that happened | "Deployed v1.0 on March 15" |
+| **summary** | derived — compressed synthesis from debrief | (auto-generated only) |
+
+Three orthogonal axes attach to every memory:
+
+- **source** — `user` (you said it), `assistant` (LLM inferred it), `extracted` (auto-extraction). Source-weighted reranking ranks user > extracted > assistant.
+- **scope** — `work`, `personal`, `health`, `family`, `creative`, `finance`, `misc`. Scope bonus boosts in-scope hits.
+- **volatility** — `stable`, `slow`, `fast`. Used by importance decay.
+
+You can override the type / scope of any memory via natural language: *"that's actually a directive, not a preference"* → calls `totalreclaw_retype`. *"file that under work"* → calls `totalreclaw_set_scope`. See [memory-types-guide.md](./memory-types-guide.md).
+
+---
+
+## 4. Tuning extraction and recall
+
+The defaults work for most users. These are the knobs that matter when something feels off.
+
+### Extraction is too noisy (storing low-value facts)
+
+Raise the importance floor:
 
 ```bash
-cat ~/.openclaw/extensions/totalreclaw/credentials.json
+TOTALRECLAW_MIN_IMPORTANCE=5     # default 3 (1-10 scale)
 ```
 
-Copy the `mnemonic` field and store it somewhere safe.
+Or extract less often:
 
-> **Known UX limitation (v3.1.0):** the first-turn phrase banner goes through the LLM channel, so (a) it is visible to your LLM provider, and (b) the LLM may choose not to surface it to you. v3.2.0 ships an onboarding flow that keeps the phrase off the LLM channel. Until then, `cat ~/.openclaw/extensions/totalreclaw/credentials.json` is the source of truth.
-
-> **Do not reuse a blockchain wallet mnemonic.** TotalReclaw keys are memory-only. Using a recovery phrase that has funds or on-chain history attached increases your blast radius with no benefit.
-
-If you prefer to generate a phrase outside the plugin (e.g., to pre-provision it before first run), you can still run:
-
-```
-npx @totalreclaw/totalreclaw generate-mnemonic
+```bash
+TOTALRECLAW_EXTRACT_EVERY_TURNS=5    # default 3
 ```
 
-You will see output like this:
+### Extraction is missing facts you wanted stored
 
-```
-  Your TotalReclaw master mnemonic (12 words):
+Lower the importance floor (`TOTALRECLAW_MIN_IMPORTANCE=2`) or extract more often (`TOTALRECLAW_EXTRACT_EVERY_TURNS=2`). Or just say *"remember that…"* explicitly — that bypasses scoring.
 
-  apple banana cherry dolphin eagle falcon grape honey iris jungle kite lemon
+### Recall is returning irrelevant memories
 
-  WRITE THIS DOWN. If you lose it, your memories are unrecoverable.
-  Set it as TOTALRECLAW_RECOVERY_PHRASE in your environment.
-```
+Raise the cosine threshold:
 
-The 12 words shown above are an example. Your actual phrase will be different and unique to you.
-
-### Step 2: Write it down
-
-Write all 12 words on paper, in the exact order shown. Double-check every word. Store the paper somewhere safe -- a locked drawer, a safe, or wherever you keep important documents.
-
-> **Do not store your recovery phrase in a text file on your computer, in a screenshot,
-> or in a cloud notes app.** If someone gains access to these 12 words, they can
-> decrypt all your memories.
-
-### Step 3: Set your environment variables (OpenClaw plugin)
-
-> **MCP users:** If you used `npx @totalreclaw/mcp-server setup`, your credentials are already saved and the setup wizard printed the config snippet you need. Skip to [Section 11](#11-mcp-server-setup-claude-desktop--cursor).
-
-Set the following environment variables in your OpenClaw configuration (e.g., workspace settings or shell environment):
-
-```
-# --- Required ---
-TOTALRECLAW_RECOVERY_PHRASE="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
-
-# --- Managed service is the default (no env var needed) ---
-# Set TOTALRECLAW_SELF_HOSTED="true" only if using your own server.
-# Chain (Base Sepolia vs Gnosis) is auto-detected from your billing tier.
+```bash
+TOTALRECLAW_COSINE_THRESHOLD=0.25    # default 0.15 — strict
 ```
 
-Replace `word1 word2 ...` with your actual 12-word phrase. Keep the quotes around it. These can be set in your OpenClaw workspace environment settings, your shell profile, or any method your OpenClaw instance supports for environment variables.
+Or raise the auto-injection threshold (so fewer memories get pre-pended to context automatically):
 
-The recovery phrase is all you need. The server URL defaults to the managed service at `api.totalreclaw.xyz`, which handles on-chain storage (Gnosis mainnet), gas sponsorship, billing, and query routing -- without ever seeing your data.
+```bash
+TOTALRECLAW_RELEVANCE_THRESHOLD=0.4    # default 0.3
+```
 
-Your agent's LLM API key (e.g., `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`) should already be configured in your OpenClaw environment. TotalReclaw auto-detects it -- no extra LLM setup is needed.
+### Recall is missing relevant memories
 
-### Step 4: Understand what happens behind the scenes
+Lower the same thresholds (`TOTALRECLAW_COSINE_THRESHOLD=0.10`, `TOTALRECLAW_RELEVANCE_THRESHOLD=0.2`).
 
-Your 12-word phrase is the single root of all your keys and identity. The derivation chain works as follows:
+### Auto-extraction silently produces zero facts
 
-1. **BIP-39 seed** -- Your 12-word mnemonic produces a 512-bit master seed.
-2. **Private key** -- BIP-32 hierarchical derivation at path `m/44'/60'/0'/0/0` (the standard Ethereum path) produces a 256-bit private key.
-3. **EOA address** -- The standard Ethereum address derived from the private key. This is the "owner" of your Smart Account.
-4. **Encryption key** -- HKDF-SHA256 with info string `totalreclaw-encryption-key-v1` derives your XChaCha20-Poly1305 encryption key.
-5. **Auth key** -- HKDF-SHA256 with info string `totalreclaw-auth-key-v1` derives an authentication key. Its SHA-256 hash is registered with the server as your identity.
-6. **Smart Account address** -- A deterministic ERC-4337 Smart Account address computed via CREATE2 from your EOA address. This is your on-chain identity.
+This usually means there's no LLM available. The plugin auto-detects your agent's provider key (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `ZAI_API_KEY`, etc.). If none is set or all are rate-limited, extraction silently no-ops. Plugin 3.3.1+ logs a single INFO at startup when no LLM resolves; Hermes 2.3.1+ raises on first extraction attempt. Configure at least one provider key.
 
-You never need to manage crypto or interact with any blockchain directly -- it all happens automatically. The same mnemonic always produces the same keys and the same wallet address, on any device. This is how cross-device recovery works (validated by the E2E integration test suite in Journey 3).
+### Stored memories aren't surviving across sessions
+
+Two common causes:
+
+1. **Wrong phrase.** Even one wrong word produces a different Smart Account and you'll be treated as a new user. BIP-39 is all-lowercase, single-spaced, exact order.
+2. **Pre-compaction flush didn't fire.** OpenClaw flushes pending facts before context compaction; Hermes flushes on session end; MCP has no flush. If you're on MCP and the host compacted before any explicit `totalreclaw_remember` call, the unstored facts are lost. Workaround: call `totalreclaw_debrief` periodically, or migrate to OpenClaw / Hermes for that workload.
 
 ---
 
-## 4. Understanding the Wallet Address
+## 5. Environment variables — full reference
 
-Your 12-word recovery phrase derives an Ethereum-compatible wallet address in two steps:
+Canonical reference: [`docs/guides/env-vars-reference.md`](./env-vars-reference.md). Summary:
 
-1. **EOA (Externally Owned Account)** -- Derived from the BIP-44 path `m/44'/60'/0'/0/0`. This is the same method used by popular wallets like MetaMask.
-2. **Smart Account** -- A deterministic ERC-4337 Smart Account address computed from the EOA via CREATE2 (using the canonical SimpleAccountFactory v0.7). This is your actual on-chain identity.
-
-Here is what you need to know:
-
-- **Your Smart Account address is your identity** on Gnosis Chain, the blockchain where TotalReclaw stores encrypted data. It is also the key used for billing and subscription tracking.
-- **You never need to fund it.** The TotalReclaw paymaster (Pimlico) sponsors all transaction fees (gas) on your behalf during the beta.
-- **You never need to send transactions or interact with the blockchain.** The plugin and MCP server handle everything automatically.
-- **The same phrase always produces the same wallet address and the same encryption key.** This is how recovery works -- enter your phrase on any device, and you get the same identity and can decrypt all your memories. This property is validated by the E2E integration tests (Journey 3: same mnemonic on "Device B" derives identical auth and encryption keys).
-
-If you want to view your derived wallet address, check the plugin logs after the first run. The plugin logs a message like `Registered new user: <user-id>` during initialization. Your credentials (user ID and salt -- not the mnemonic itself) are stored in the credentials file (see [Configuration Reference](#13-configuration-reference) for its location).
-
----
-
-## 5. Free Tier -- How It Works
-
-TotalReclaw includes a free tier so you can start using it immediately:
-
-- **Free tier memories are unlimited.** Your memories are stored on Base Sepolia testnet at no cost.
-- **Reading and searching your memories is always free and never metered.** You can always access your own data.
-- All transaction fees (gas) are covered by the TotalReclaw paymaster (Pimlico). You pay nothing.
-- No credit card, no crypto, and no signup beyond your recovery phrase are required.
-
-The free tier uses Base Sepolia testnet, which is a test network. This means your data is stored on a network that may be reset. For permanent, production-grade storage on Gnosis mainnet, upgrade to Pro (see [Upgrading to Pro Tier](#9-upgrading-to-pro-tier)).
-
----
-
-## 6. Automatic Memory (No Action Required)
-
-Once TotalReclaw is installed and configured, it works in the background without any action from you. Two automatic behaviors are always running via OpenClaw lifecycle hooks.
-
-> **Note:** Automatic behaviors (auto-search and auto-store) are OpenClaw plugin features. The MCP server does not have lifecycle hooks -- it responds to explicit tool calls only. See [Section 11](#11-mcp-server-setup-claude-desktop--cursor) for MCP-specific behavior.
-
-### Auto-Search (every message)
-
-Before every agent turn (via the `before_agent_start` hook), if your message is at least 5 characters long, the plugin automatically searches your stored memories for anything relevant. If it finds matching memories, it silently injects them into the agent's context so the agent can reference them naturally.
-
-You do not need to ask the agent to recall anything -- it happens automatically. The agent will simply "know" relevant things from past conversations.
-
-### Auto-Store (every N turns)
-
-On the `agent_end` hook (which fires after each conversation turn), the plugin checks whether enough turns have elapsed since the last extraction. By default, it extracts every 3 turns. During extraction, it scores each fact by importance (1-10 scale), and facts that meet the minimum importance threshold (default: 3) are encrypted and stored.
-
-This means you do not need to explicitly tell the agent to remember things. Preferences, decisions, and notable facts are captured automatically as you chat.
-
-The number of turns between automatic extractions is configurable via the `TOTALRECLAW_EXTRACT_EVERY_TURNS` environment variable (default: `3`).
-
-### Pre-Compaction Flush
-
-When OpenClaw triggers a context compaction (because your conversation is getting long), TotalReclaw performs a full memory flush beforehand. This ensures no important information is lost when older messages are compressed or removed from context. This happens automatically with no action from you.
-
-### Pre-Reset Flush
-
-Similarly, if a session is reset or cleared, the plugin extracts and stores any important facts from the conversation before the reset occurs.
-
----
-
-## 7. Explicit Memory Tools
-
-In addition to automatic behaviors, TotalReclaw provides seven tools you can use by asking the agent directly. The OpenClaw plugin exposes the first four (remember, recall, forget, export). The MCP server exposes all seven, adding import, status, and upgrade.
-
-### 7.1 Remember -- `totalreclaw_remember`
-
-Use this when you want to explicitly store something.
-
-**Example prompts:**
-- "Remember that I prefer dark mode in all my apps."
-- "Store this: my database password rotation schedule is every 90 days."
-- "Remember that the project deadline is March 15th."
-
-**What happens behind the scenes:**
-1. The plugin extracts the fact from your message.
-2. It encrypts the fact with your key (XChaCha20-Poly1305).
-3. It generates blind search indices (hashed keywords) so the server can find it later without seeing the plaintext.
-4. It generates a content fingerprint to prevent duplicates.
-5. It stores the encrypted blob on the server.
-
-**Expected agent response:**
-> "Memory stored (ID: a1b2c3d4-e5f6-7890-abcd-ef1234567890)"
-
-### 7.2 Recall -- `totalreclaw_recall`
-
-Use this when you want to search your stored memories.
-
-**Example prompts:**
-- "What do you remember about my coding preferences?"
-- "Recall anything related to the TotalReclaw project."
-- "What databases have I mentioned preferring?"
-
-**What happens behind the scenes:**
-1. The plugin encrypts your query into blind search trapdoors.
-2. The server returns matching encrypted candidates (up to several thousand).
-3. The plugin decrypts all candidates on your device.
-4. It re-ranks them using BM25 (text matching) + cosine similarity (semantic matching) + RRF fusion (combining scores).
-5. The top results (default: 8) are returned.
-
-**Expected agent response:**
-> 1. User prefers PostgreSQL for databases (importance: 8/10) -- 2h ago [ID: ...]
-> 2. User prefers TypeScript over JavaScript (importance: 7/10) -- 1d ago [ID: ...]
-
-### 7.3 Forget -- `totalreclaw_forget`
-
-Use this when you want to delete a specific memory.
-
-**Example prompts:**
-- "Forget that I said I like Java."
-- "Delete the memory about my old email address."
-
-**What happens behind the scenes:**
-The agent first searches for matching memories using `totalreclaw_recall`, identifies the relevant one by ID, and then calls `totalreclaw_forget` with that ID. The memory is soft-deleted (marked as a tombstone with importance set to 0).
-
-**Expected agent response:**
-> "Memory a1b2c3d4-e5f6-7890-abcd-ef1234567890 deleted"
-
-### 7.4 Export -- `totalreclaw_export`
-
-Use this to get a copy of all your stored memories.
-
-**Example prompts:**
-- "Export all my memories as JSON."
-- "Export my memories in markdown format."
-
-**What happens behind the scenes:**
-1. The plugin downloads all your encrypted memory blobs from the server.
-2. It decrypts every memory on your device.
-3. It formats them as JSON or Markdown (your choice).
-
-**Expected agent response (JSON format):**
-```json
-[
-  {
-    "id": "a1b2c3d4-...",
-    "text": "User prefers PostgreSQL for databases",
-    "metadata": {
-      "type": "preference",
-      "importance": 0.8,
-      "source": "explicit",
-      "created_at": "2026-03-04T10:30:00.000Z"
-    },
-    "created_at": "2026-03-04T10:30:00.000Z"
-  }
-]
-```
-
-**Expected agent response (Markdown format):**
-```
-# Exported Memories (3)
-
-1. **[preference]** User prefers PostgreSQL for databases (importance: 8/10)
-   _ID: a1b2c3d4-... | Created: 2026-03-04T10:30:00.000Z_
-2. **[fact]** User prefers TypeScript over JavaScript (importance: 7/10)
-   _ID: b2c3d4e5-... | Created: 2026-03-04T10:25:00.000Z_
-```
-
-### 7.5 Import from External Systems -- `totalreclaw_import_from`
-
-Import memories from Mem0, MCP Memory Server, or other supported sources. Available in both OpenClaw plugin and MCP server.
-
-**Example prompts:**
-- "Import my memories from Mem0 using API key m0-abc123..."
-- "Import memories from MCP Memory Server at ~/.mcp-memory/memory.jsonl"
-
-All processing happens client-side — source data is fetched/parsed locally, encrypted with your key, then stored. The import is idempotent (duplicates are skipped via content fingerprinting).
-
-For full details, supported sources, parameters, and troubleshooting, see the [Importing Memories guide](./importing-memories.md).
-
-### 7.6 Status -- `totalreclaw_status` (MCP only)
-
-Use this to check your subscription status and usage.
-
-**Example prompts:**
-- "What's my TotalReclaw subscription status?"
-- "How many free memories do I have left?"
-
-**Expected agent response:**
-> "You're on the free tier (Base Sepolia testnet). You've stored 42 memories."
-
-### 7.7 Upgrade -- `totalreclaw_upgrade` (MCP only)
-
-Use this to get a payment link for upgrading to Pro.
-
-**Example prompts:**
-- "I'd like to upgrade TotalReclaw."
-- "Get me a payment link for TotalReclaw Pro."
-
-**What happens behind the scenes:**
-1. The MCP server requests a checkout session from the relay server (Stripe).
-2. It returns a payment URL that you open in your browser.
-3. After payment, the webhook activates your subscription within 60 seconds.
-
-**Expected agent response:**
-> "Here's your upgrade link: https://checkout.stripe.com/... Open it in your browser to complete payment."
-
----
-
-## 8. Testing Your Setup (Manual Validation)
-
-Follow this checklist step by step to verify that TotalReclaw is working correctly. Each step has a clear expected outcome. If any step fails, see [Troubleshooting](#13-troubleshooting).
-
-### Checklist
-
-**Step 1: Store a fact via auto-extraction.**
-
-1. Start a new conversation with your agent.
-2. Say: "I always use PostgreSQL for databases and prefer TypeScript over JavaScript."
-3. Continue chatting for at least 5 more turns about unrelated topics (this triggers auto-extraction).
-4. **Expected:** The plugin silently extracts and stores your database and language preferences. You will not see a confirmation, but the facts are stored in the background.
-
-**Step 2: Verify cross-session memory.**
-
-5. Start a **new conversation** (to confirm memories persist across sessions).
-6. Ask: "What databases do I prefer?"
-7. **Expected:** The agent mentions PostgreSQL. It may phrase this naturally (e.g., "Based on what I know about you, you prefer PostgreSQL for databases.") or reference the memory explicitly.
-
-**Step 3: Explicitly store a memory.**
-
-8. Say: "Remember that my favorite color is blue."
-9. **Expected:** The agent responds with a confirmation, such as: "Memory stored (ID: ...)"
-
-**Step 4: Explicitly recall a memory.**
-
-10. In another message, ask: "What is my favorite color?"
-11. **Expected:** The agent responds with "blue."
-
-**Step 5: Forget a memory.**
-
-12. Say: "Forget that my favorite color is blue."
-13. **Expected:** The agent searches for the memory, finds it, and confirms deletion: "Memory ... deleted."
-
-**Step 6: Verify the memory is gone.**
-
-14. Ask: "What is my favorite color?"
-15. **Expected:** The agent does not mention blue, or says it does not know.
-
-**Step 7: Export your memories.**
-
-16. Say: "Export all my memories as JSON."
-17. **Expected:** The agent returns a JSON array containing your stored facts (your database preference and any other facts extracted during the conversation). The favorite-color memory should not appear (it was deleted in Step 5).
-
-### Validation Summary
-
-| Step | Action | Expected Result | Pass? |
-|------|--------|----------------|-------|
-| 1-4 | Auto-store + auto-recall | Agent remembers PostgreSQL preference in new session | |
-| 8-9 | Explicit remember | Confirmation with memory ID | |
-| 10-11 | Explicit recall | Agent knows favorite color is blue | |
-| 12-13 | Explicit forget | Confirmation of deletion | |
-| 14-15 | Verify forget | Agent no longer knows favorite color | |
-| 16-17 | Export | JSON with stored facts, no deleted memory | |
-
----
-
-## 9. Upgrading to Pro Tier
-
-The free tier stores memories on Base Sepolia testnet (unlimited, but may be reset). Upgrading to Pro moves your storage to Gnosis mainnet for permanent, production-grade on-chain storage.
-
-### Payment:
-
-**Credit card (Stripe)**
-
-1. Tell the agent: "I'd like to upgrade with a credit card."
-2. The agent generates a Stripe Checkout URL and shares it with you.
-3. Click the URL. It opens in your browser.
-4. Complete the payment (card, Apple Pay, or Google Pay are all accepted).
-5. After payment, Stripe sends a webhook to the relay server, which activates your subscription.
-6. The agent confirms: "You're all set on the Pro tier."
-
-After upgrading, your memories are stored on Gnosis mainnet (permanent on-chain storage). Your subscription is tied to your wallet address, so it follows you across devices (as long as you use the same recovery phrase).
-
-> **Note:** Your client caches billing status for up to 2 hours. After upgrading, the new tier may take up to 2 hours to fully activate. If Pro features are not reflected immediately, restart your agent to force a billing cache refresh.
-
----
-
-## 10. Recovery on a New Device
-
-If you switch to a new computer or install TotalReclaw on a second agent, you can restore all your memories using your 12-word recovery phrase. This works because the same mnemonic always derives the same encryption key and the same wallet address -- your data is not tied to a specific device.
-
-### OpenClaw Plugin Recovery
-
-1. Install the TotalReclaw plugin on the new device (follow [Section 2](#2-installation)).
-2. Set the same environment variables as in [Step 3](#step-3-set-your-environment-variables-openclaw-plugin) -- use the same 12-word phrase and the same server URL.
-3. Start a conversation with your agent.
-4. The plugin derives the same Smart Account address and encryption key from your phrase.
-5. All your memories are automatically retrieved and decrypted on your device.
-6. If you have an active Pro subscription, it is recognized automatically (same wallet address).
-
-### MCP Server Recovery
-
-1. Run the setup wizard with your existing phrase:
-   ```
-   npx @totalreclaw/mcp-server setup
-   ```
-2. When asked "Do you have an existing recovery phrase?", answer **yes** and enter your 12 words.
-3. The wizard re-derives the same wallet address, saves credentials, and prints the MCP config snippet.
-4. Add the config snippet to your MCP client. All your existing memories are accessible immediately.
-
-### Recovery Troubleshooting
-
-> **If recovery does not work,** double-check every word in your recovery phrase and its
-> exact order. BIP-39 phrases are all lowercase. Even one wrong word
-> derives a completely different encryption key and wallet address, meaning the server
-> will treat you as a different user with no memories. The E2E integration tests
-> (Journey 3) validate this property: a wrong mnemonic produces different keys, and
-> the server rejects authentication with a 401 or 403 error.
-
----
-
-## 11. MCP Server Setup (Claude Desktop / Cursor)
-
-If you use Claude Desktop, Cursor, VS Code, or any other MCP-compatible AI agent, TotalReclaw is available as a standalone MCP server. This is the fastest way to get started -- no OpenClaw required.
-
-### Step 1: Run the setup wizard
-
-Open a terminal and run:
-
-```
-npx @totalreclaw/mcp-server setup
-```
-
-The wizard walks you through:
-
-1. **Recovery phrase** -- Generate a new 12-word phrase or import an existing one.
-2. **Key derivation** -- Derives your auth key, encryption key, and wallet address.
-3. **Server registration** -- Registers you with the relay server at `https://api.totalreclaw.xyz` (free tier, no payment required).
-4. **Credential storage** -- Saves your user ID and salt to `~/.totalreclaw/credentials.json` (the mnemonic itself is NOT stored on disk).
-5. **Config snippet** -- Prints the JSON snippet you need to add to your MCP client config.
-
-### Step 2: Configure your MCP client
-
-Copy the config snippet printed by the setup wizard into your MCP client configuration file.
-
-**Claude Desktop:** Edit `claude_desktop_config.json` (usually at `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
-
-```json
-{
-  "mcpServers": {
-    "totalreclaw": {
-      "command": "npx",
-      "args": ["@totalreclaw/mcp-server"],
-      "env": {
-        "TOTALRECLAW_RECOVERY_PHRASE": "your twelve words here"
-      }
-    }
-  }
-}
-```
-
-> **Note:** The server URL defaults to `https://api.totalreclaw.xyz` (the managed service). You only need to set `TOTALRECLAW_SERVER_URL` if you are running a self-hosted server.
-
-**Cursor:** Add the same config block to your Cursor MCP settings.
-
-> **Security note:** The mnemonic is stored in your MCP client config file. Ensure the file has restricted permissions (mode 600, owner read/write only). Do not use TotalReclaw on shared machines without full disk encryption.
-
-### Step 3: Start using it
-
-Restart your MCP client (Claude Desktop, Cursor, etc.). The MCP server starts automatically, loads your credentials, and derives your keys. You can immediately use the seven tools:
-
-- **totalreclaw_remember** -- Store a memory
-- **totalreclaw_recall** -- Search your memories
-- **totalreclaw_forget** -- Delete a memory
-- **totalreclaw_export** -- Export all memories (JSON or Markdown)
-- **totalreclaw_import** -- Import memories from a previous export
-- **totalreclaw_status** -- Check subscription status and usage
-- **totalreclaw_upgrade** -- Get a payment link to upgrade
-
-### MCP vs OpenClaw: Key Differences
-
-| Feature | OpenClaw Plugin | MCP Server |
-|---------|----------------|------------|
-| Auto-search (every message) | Yes (via `before_agent_start` hook) | No -- use `totalreclaw_recall` explicitly |
-| Auto-store (every N turns) | Yes (via `agent_end` hook) | No -- use `totalreclaw_remember` explicitly |
-| Pre-compaction flush | Yes | No |
-| Near-duplicate prevention | Yes (store-time cosine dedup) | Yes (store-time cosine dedup) |
-| Memory consolidation | Yes (`totalreclaw_consolidate`) | Yes (`totalreclaw_consolidate`) |
-| Billing tools (status, upgrade) | Via agent orchestration | Via `totalreclaw_status` and `totalreclaw_upgrade` tools |
-| Import from Mem0/MCP Memory | Yes (`totalreclaw_import_from`) | Yes (`totalreclaw_import_from`) |
-| Import from JSON/Markdown export | No | Yes (`totalreclaw_import`) |
-| Setup method | Environment variables in OpenClaw config | `npx @totalreclaw/mcp-server setup` wizard |
-| LLM for fact extraction | Auto-detected from agent's provider | Handled by host agent (Claude, etc.) |
-
-### Alternative: Environment Variable Only (No Setup Wizard)
-
-If you prefer not to run the setup command, you can set the mnemonic directly as an environment variable in your MCP client config. The MCP server will auto-register on first run if no `~/.totalreclaw/credentials.json` exists:
-
-```json
-{
-  "mcpServers": {
-    "totalreclaw": {
-      "command": "npx",
-      "args": ["@totalreclaw/mcp-server"],
-      "env": {
-        "TOTALRECLAW_RECOVERY_PHRASE": "your twelve words here"
-      }
-    }
-  }
-}
-```
-
----
-
-## 12. Running E2E Validation (Optional, for Technical Testers)
-
-TotalReclaw has two test suites: **functional tests** (plugin-level, mock infrastructure) and **integration tests** (server-level, real PostgreSQL). This section requires familiarity with the command line and Node.js.
-
-### Functional Test Suite (Plugin)
-
-If you want to run the automated end-to-end test suite to verify the plugin against a mock server:
-
-1. Clone the test repository and install dependencies:
-   ```
-   git clone https://github.com/p-diogo/totalreclaw-plugin.git
-   cd totalreclaw-plugin/tests/e2e-functional
-   npm install
-   ```
-
-2. Run the full test suite:
-   ```
-   npx tsx run-all.ts --scenarios=A,B,C,D,E,F,G,H --instances=server-improved
-   ```
-
-3. To run a subset of scenarios:
-   ```
-   npx tsx run-all.ts --scenarios=A,B --instances=server-improved
-   ```
-
-#### What each scenario tests
-
-| Scenario | Name | What it validates |
-|----------|------|-------------------|
-| A | Preferences | Storing and recalling user preferences (e.g., "I prefer dark mode") |
-| B | Technical Facts | Technical knowledge recall (e.g., "I use PostgreSQL") |
-| C | Noise Filtering | Low-importance facts are filtered out and not stored |
-| D | Topic Switching | Correct recall after switching between multiple conversation topics |
-| E | Long Conversations | Memory extraction and recall in extended conversations (many turns) |
-| F | On-Chain Storage | End-to-end flow using the on-chain storage path (mock) |
-| G | Pagination | Correct behavior when the memory vault has many entries (pagination) |
-| H | Freeform | Open-ended conversational memory with diverse fact types |
-
-#### Expected result
-
-All scenarios should show **PASS**. The test runner outputs a summary table and writes a detailed JSON report to `tests/e2e-functional/e2e-results/`.
-
-#### Available test instances
-
-You can test against multiple configurations by specifying different instances:
-
-| Instance | Description |
-|----------|-------------|
-| `server-improved` | Self-hosted with all retrieval improvements enabled |
-| `server-baseline` | Self-hosted with baseline configuration |
-| `server-recency` | Self-hosted with recency-weighted ranking |
-| `subgraph-improved` | Managed service (on-chain) with all improvements enabled |
-| `subgraph-baseline` | Managed service (on-chain) with baseline configuration |
-
-Example running all instances:
-```
-npx tsx run-all.ts --scenarios=A,B,C,D,E,F,G,H --instances=server-improved,server-baseline,server-recency,subgraph-improved,subgraph-baseline
-```
-
-### Integration Test Suite (Server API)
-
-The integration tests run against a real server with PostgreSQL and validate the full API surface including billing, authentication, relay proxy, and cross-device recovery.
-
-1. Start the test infrastructure (requires Docker):
-   ```
-   cd totalreclaw-plugin/tests/e2e-integration
-   npm install
-   docker compose up -d  # Starts PostgreSQL and mock services
-   ```
-
-2. Run all journeys:
-   ```
-   npx tsx run-integration-tests.ts
-   ```
-
-#### What each journey tests
-
-| Journey | Name | Assertions | What it validates |
-|---------|------|:---:|-------------------|
-| 1 | Core Memory Operations | 12 | Register, store, search, decrypt, export, delete round-trip |
-| 2 | Deduplication | -- | Content fingerprint prevents duplicate storage |
-| 3 | Wallet & Seed Derivation | 10 | BIP-39 mnemonic generation, HKDF key derivation, cross-device recovery (same mnemonic = same keys), wrong mnemonic rejection |
-| 4 | Free Tier Quota | 10 | Write quota enforcement (N writes then 403), read operations bypass quota, billing status reporting |
-| 5 | Stripe Upgrade | 10 | Free -> exhaust -> Stripe webhook -> pro activation -> cancel -> revert to free, write counter persistence |
-| 6 | Billing Edge Cases | 10 | Webhook idempotency, failed payment handling, monthly counter reset |
-| 7 | Security | 10 | Auth enforcement (no token, bad token, unregistered token), webhook signature validation, cross-user isolation, SQL injection handling |
-| 8 | Full Relay Pipeline | 7 | Bundler proxy, subgraph proxy, mock request forwarding, error propagation |
-
----
-
-## 13. Configuration Reference
-
-All configuration is done through environment variables, set in your OpenClaw workspace environment settings or in the MCP client config.
-
-### Required Variables
+### Core (all clients)
 
 | Variable | Description | Default |
-|----------|-------------|---------|
-| `TOTALRECLAW_RECOVERY_PHRASE` | Your 12-word BIP-39 recovery phrase. **Required.** | -- (none) |
-| `TOTALRECLAW_SERVER_URL` | URL of the TotalReclaw relay server. Only needed for self-hosted mode. | `https://api.totalreclaw.xyz` |
+|---|---|---|
+| `TOTALRECLAW_RECOVERY_PHRASE` | 12-word BIP-39 phrase. Required for MCP / NanoClaw. OpenClaw + Hermes prefer the browser pair flow (writes `~/.totalreclaw/credentials.json`). | — |
+| `TOTALRECLAW_SERVER_URL` | Relay URL. Only set for self-hosted. | `https://api.totalreclaw.xyz` |
+| `TOTALRECLAW_SELF_HOSTED` | `true` to disable on-chain pipeline (PostgreSQL self-host). | `false` |
+| `TOTALRECLAW_CREDENTIALS_PATH` | Override credentials file location. | `~/.totalreclaw/credentials.json` |
+| `TOTALRECLAW_CACHE_PATH` | Override encrypted cache file location. | `~/.totalreclaw/cache.enc` |
 
-### LLM Provider Keys (OpenClaw plugin only, auto-detected from your agent)
-
-The OpenClaw plugin auto-detects your agent's LLM provider and API key for fact extraction. No extra configuration is needed -- the key your agent already uses for its own LLM calls is reused. The MCP server does not need an LLM key because the host agent (Claude, etc.) handles fact extraction directly. The table below shows which providers are supported by the OpenClaw plugin.
-
-| Variable | Provider |
-|----------|----------|
-| `OPENAI_API_KEY` | OpenAI (GPT-4.1-mini for extraction) |
-| `ANTHROPIC_API_KEY` | Anthropic (Claude Haiku for extraction) |
-| `ZAI_API_KEY` | Z.AI (GLM-4.5-flash for extraction) |
-| `GEMINI_API_KEY` | Google Gemini (Gemini 2.0 Flash for extraction) |
-| `MISTRAL_API_KEY` | Mistral (Mistral Small for extraction) |
-| `GROQ_API_KEY` | Groq (LLaMA 3.3 70B for extraction) |
-| `DEEPSEEK_API_KEY` | DeepSeek (DeepSeek Chat for extraction) |
-| `OPENROUTER_API_KEY` | OpenRouter (routes to Claude Haiku for extraction) |
-| `XAI_API_KEY` | xAI (Grok-2 for extraction) |
-| `TOGETHER_API_KEY` | Together AI |
-| `CEREBRAS_API_KEY` | Cerebras |
-
-### Optional Variables (Tuning)
+### Extraction tuning (OpenClaw plugin + Hermes + NanoClaw — MCP has no extraction hooks)
 
 | Variable | Description | Default |
-|----------|-------------|---------|
-| `TOTALRECLAW_CREDENTIALS_PATH` | Path to the credentials file (stores user ID and salt). The MCP setup wizard saves to `~/.totalreclaw/credentials.json` by default. | `~/.totalreclaw/credentials.json` |
-| `TOTALRECLAW_COSINE_THRESHOLD` | Minimum cosine similarity of the top result required to return memories. Lower = more permissive. | `0.15` |
-| `TOTALRECLAW_MIN_IMPORTANCE` | Minimum importance score (1-10) for auto-extracted facts. Facts below this are silently dropped. | `3` |
-| `TOTALRECLAW_EXTRACT_EVERY_TURNS` | Number of conversation turns between automatic extractions. | `3` |
-| `TOTALRECLAW_RELEVANCE_THRESHOLD` | Minimum cosine relevance score for auto-injecting memories into context. | `0.3` |
-| `TOTALRECLAW_SEMANTIC_SKIP_THRESHOLD` | Cosine similarity threshold for deduplication. Facts too similar to existing ones are skipped. | `0.85` |
-| `TOTALRECLAW_CACHE_TTL_MS` | Hot cache time-to-live in milliseconds. Cached results within this window are reused for similar queries. | `300000` (5 minutes) |
-(`TOTALRECLAW_LLM_MODEL` was removed in the v1 env cleanup — the extraction
-model is auto-derived from your provider, with `OPENAI_MODEL` /
-`ANTHROPIC_MODEL` as generic fallbacks. See
-[`docs/guides/env-vars-reference.md`](./env-vars-reference.md).)
+|---|---|---|
+| `TOTALRECLAW_EXTRACT_EVERY_TURNS` | Turns between auto-extractions. | `3` |
+| `TOTALRECLAW_MIN_IMPORTANCE` | Floor for storing extracted facts (1–10). | `3` |
+| `TOTALRECLAW_SEMANTIC_SKIP_THRESHOLD` | Cosine similarity above which a fact is treated as a near-duplicate. | `0.85` |
 
-### On-Chain Storage Variables (Advanced / self-hosted only)
-
-These variables are for operators running against their own chain / self-hosted
-relay. The default (managed service on Base Sepolia / Gnosis) requires none
-of them — chain ID is auto-detected from your billing tier.
+### Recall tuning
 
 | Variable | Description | Default |
-|----------|-------------|---------|
-| `TOTALRECLAW_SELF_HOSTED` | Set to `true` to use your own self-hosted server with PostgreSQL instead of the managed service. When not set (or `false`), TotalReclaw uses the managed service with on-chain storage via The Graph. | `false` (managed service) |
-| `TOTALRECLAW_DATA_EDGE_ADDRESS` | Address of the EventfulDataEdge smart contract. | Built-in |
-| `TOTALRECLAW_ENTRYPOINT_ADDRESS` | ERC-4337 EntryPoint v0.7 address. Same on all chains. | `0x0000000071727De22E5E9d8BAf0edAc6f37da032` |
-| `TOTALRECLAW_SUBGRAPH_PAGE_SIZE` | Maximum results per subgraph query page (Graph Studio limit: 1000). | `1000` |
-| `TOTALRECLAW_TRAPDOOR_BATCH_SIZE` | Number of trapdoors per batch in subgraph queries. | `5` |
+|---|---|---|
+| `TOTALRECLAW_COSINE_THRESHOLD` | Minimum cosine of top result to return memories at all. | `0.15` |
+| `TOTALRECLAW_RELEVANCE_THRESHOLD` | Minimum relevance for auto-injecting into context. | `0.3` |
+| `TOTALRECLAW_CACHE_TTL_MS` | Hot-cache TTL for repeated queries. | `300000` (5 min) |
+
+### LLM keys (auto-detected by OpenClaw + Hermes; not used by MCP)
+
+OpenClaw + Hermes auto-detect whichever provider key is set in your environment and use a cheap model from that provider for fact extraction. Supported: `OPENAI_API_KEY` (gpt-4.1-mini), `ANTHROPIC_API_KEY` (claude-haiku-4-5), `ZAI_API_KEY` (glm-4.5-flash), `GEMINI_API_KEY` (gemini-2.0-flash), `MISTRAL_API_KEY`, `GROQ_API_KEY`, `DEEPSEEK_API_KEY`, `OPENROUTER_API_KEY`, `XAI_API_KEY`, `TOGETHER_API_KEY`, `CEREBRAS_API_KEY`. MCP doesn't extract — the host LLM (Claude, etc.) is responsible.
+
+### Removed in v1
+
+These vars were removed in the v1 env cleanup and are silently ignored:
+
+`TOTALRECLAW_CHAIN_ID`, `TOTALRECLAW_EMBEDDING_MODEL`, `TOTALRECLAW_STORE_DEDUP`, `TOTALRECLAW_LLM_MODEL`, `TOTALRECLAW_SESSION_ID`, `TOTALRECLAW_TAXONOMY_VERSION`, `TOTALRECLAW_CLAIM_FORMAT`, `TOTALRECLAW_DIGEST_MODE`.
+
+Chain ID is auto-detected from billing tier. Embedding model is fixed (`Xenova/all-MiniLM-L6-v2`). Extraction model is auto-derived from the provider key. v1 taxonomy is always on.
 
 ---
 
-## 14. Troubleshooting
+## 6. Cross-client portability
 
-### "TOTALRECLAW_RECOVERY_PHRASE not set"
+Same recovery phrase = same Smart Account = same memories. Verified by Journey 3 in the integration test suite (a wrong mnemonic produces different keys; the relay rejects auth with a 401).
 
-**Cause:** The `TOTALRECLAW_RECOVERY_PHRASE` environment variable is missing or empty.
+To migrate from one client to another:
 
-**Fix (OpenClaw plugin):** Make sure the `TOTALRECLAW_RECOVERY_PHRASE` environment variable is set in your OpenClaw workspace environment settings:
+```bash
+# On the source machine, copy the credentials file:
+cat ~/.totalreclaw/credentials.json
 ```
-TOTALRECLAW_RECOVERY_PHRASE="your twelve words here"
+
+On the target machine, the agent's URL-driven setup will detect an existing credentials file and skip phrase entry. If you can't move files (e.g., switching to a phone), use the **Import existing** tab in OpenClaw / Hermes browser pair flow on the target — same phrase, same vault.
+
+If you're moving from MCP (which doesn't have a pair flow) to OpenClaw / Hermes, just install the new client and reuse `~/.totalreclaw/credentials.json` — both runtimes read it on startup before falling back to the env-var path.
+
+---
+
+## 7. Self-hosted mode
+
+For full control of your encrypted blobs (PostgreSQL instead of on-chain):
+
+```bash
+TOTALRECLAW_SELF_HOSTED=true
+TOTALRECLAW_SERVER_URL=https://your-relay.example.com
 ```
-Restart the plugin after updating the variable.
 
-**Fix (MCP server):** Make sure the `TOTALRECLAW_RECOVERY_PHRASE` env var is set in your MCP client config (e.g., `claude_desktop_config.json`). The MCP server automatically registers with the relay on startup when using the env var -- no manual setup step is needed. Alternatively, run `npx @totalreclaw/mcp-server setup` to generate credentials interactively.
+The relay code is open-source (`totalreclaw-relay` package). It exposes the same auth + storage API but writes to a local PostgreSQL instead of submitting UserOps. Encryption guarantees are identical — the server never sees plaintext or query terms.
 
-### "TotalReclaw is not set up" (MCP only)
+This trades:
+- on-chain permanence (Gnosis mainnet) for whatever durability your DB has
+- Pimlico-sponsored gas (free) for your own infra cost
+- Pro tier billing (Stripe) for whatever auth you wire on your relay
 
-**Cause:** The MCP server started without a recovery phrase and without a `credentials.json` file.
+Worthwhile if you have specific data-residency or compliance requirements.
 
-**Fix:** Run `npx @totalreclaw/mcp-server setup` in your terminal. This generates or imports your recovery phrase, registers with the server, and saves your credentials.
+---
 
-### Memories not appearing in new conversations
+## 8. Manual validation checklist
 
-**Cause:** The plugin may not be connecting to the correct server, or the auto-search hook may not be triggering.
+After setup, run this sequence to confirm everything is wired. Step numbers correspond to the auto-QA harness's manual scenario.
 
-**Fix:**
-1. Verify your internet connection -- the managed service is at `api.totalreclaw.xyz`. If you are using a self-hosted server, verify that `TOTALRECLAW_SERVER_URL` points to the correct address.
-2. Try an explicit recall: "What do you remember about me?" If this returns results, auto-search is working but may have filtered your query as irrelevant (messages shorter than 5 characters are skipped).
-3. Check the plugin logs for error messages (look for lines starting with `TotalReclaw:`).
+| # | Action | Expected |
+|---|---|---|
+| 1 | Open a fresh chat. Say *"I always use PostgreSQL and prefer TypeScript."* Continue chatting for 5+ turns on unrelated topics. | (silent) — auto-extract fires after N turns |
+| 2 | Open a NEW chat. Ask *"What databases do I prefer?"* | Agent mentions PostgreSQL without you re-stating it |
+| 3 | Say *"Remember that my favorite color is blue."* | Agent confirms `Memory stored (ID: …)` |
+| 4 | Ask *"What's my favorite color?"* | Agent responds blue |
+| 5 | Say *"Forget that my favorite color is blue."* | Agent confirms deletion |
+| 6 | Ask *"What's my favorite color?"* again | Agent doesn't know |
+| 7 | Say *"Export all my memories as markdown."* | Markdown list, no deleted color memory |
+| 8 | Verify on-chain: `https://thegraph.com/explorer/subgraph/p-diogo/totalreclaw` (free tier on Base Sepolia → check the testnet subgraph) — query for your Smart Account address | Encrypted blobs visible with `version: 4` outer envelope and v1 taxonomy fields in the inner protobuf |
 
-### "Free tier quota exceeded"
+Any step failing → check [Troubleshooting](#10-troubleshooting) and `~/.openclaw/extensions/totalreclaw/` (or equivalent) logs.
 
-**Cause:** You have exceeded the abuse-prevention write cap for the month. (Note: reads are never metered.)
+---
 
-**Fix:** Upgrade to Pro (see [Section 9](#9-upgrading-to-pro-tier)). You can still search and recall your existing memories while on the free tier -- only new writes are blocked.
+## 9. E2E test suites
+
+For technical testers running the validation harness:
+
+### Functional suite (plugin-level, mock infrastructure)
+
+```bash
+git clone https://github.com/p-diogo/totalreclaw.git
+cd totalreclaw/skill/plugin
+npm install
+npm test
+```
+
+Eight scenarios (A–H): preferences, technical facts, noise filtering, topic switching, long conversations, on-chain mock, pagination, freeform. All should PASS.
+
+### Integration suite (real PostgreSQL, full API surface)
+
+```bash
+cd totalreclaw/relay
+npm install
+docker compose up -d    # PostgreSQL + mock services
+npx tsx tests/run-integration-tests.ts
+```
+
+Eight journeys: core memory ops, dedup, wallet derivation, free-tier quota, Stripe upgrade, billing edge cases, security (auth + cross-user isolation + SQLi), full relay pipeline.
+
+### Cross-client parity
+
+The cross-runtime parity tests in `mcp/tests/reranker-cross-runtime-parity.test.ts`, `python/tests/test_reranker_cross_runtime_parity.py`, and `skill/plugin/reranker-cross-runtime-parity.test.ts` verify that the WASM, PyO3, and native paths in `@totalreclaw/core` produce byte-identical reranker output for the same input vector.
+
+### Real-user QA harness
+
+Internal: see `~/.claude/skills/qa-totalreclaw.md` (TotalReclaw team only). Runs natural-language conversations against the staging relay using published RC artifacts before any stable promote.
+
+---
+
+## 10. Troubleshooting
+
+### `TOTALRECLAW_RECOVERY_PHRASE not set`
+
+**Cause:** the env var is missing or empty in the runtime that needs it (typically MCP / NanoClaw).
+
+**Fix:** OpenClaw + Hermes prefer credentials at `~/.totalreclaw/credentials.json` from the browser pair flow — re-run setup. MCP / NanoClaw need the env var in your host config.
+
+### Memories aren't appearing in new conversations
+
+1. Verify network reachability to `api.totalreclaw.xyz` (or your self-host).
+2. Try an explicit recall: *"What do you remember about me?"* If that returns results, auto-search is working but your normal queries aren't hitting the threshold — lower `TOTALRECLAW_RELEVANCE_THRESHOLD`.
+3. Check the runtime's logs (look for lines starting with `TotalReclaw:` in OpenClaw, `tr.` in Hermes, stderr in MCP).
+
+### Free-tier quota exceeded (403)
+
+Reads are never metered. The cap is monthly write volume on the free tier. Upgrade to Pro: *"Upgrade my TotalReclaw subscription."* Counter resets monthly.
 
 ### Slow retrieval
 
-**Cause:** Network latency to the relay server, or a large number of stored memories.
+- Hot cache (5-min TTL) accelerates repeated queries.
+- First query each session has to download + decrypt candidates client-side; with thousands of memories this is a few seconds.
+- If consistently slow, check `TOTALRECLAW_TRAPDOOR_BATCH_SIZE` (default 5) and your network RTT to the relay.
 
-**Fix:**
-1. Check your internet connection.
-2. The hot cache (5-minute TTL) speeds up repeated queries. If you query the same topic twice within 5 minutes, the second query is near-instant.
-3. If you have thousands of memories, retrieval may take a few seconds for the initial query each session. This is normal -- the plugin downloads and decrypts candidates client-side.
+### Wrong memories returned
 
-### Wrong memories returned or low relevance
+Try adjusting `TOTALRECLAW_COSINE_THRESHOLD` (raise for stricter), `TOTALRECLAW_RELEVANCE_THRESHOLD`, or `TOTALRECLAW_MIN_IMPORTANCE` (raise to store fewer noisy facts in the first place).
 
-**Cause:** The search and reranking thresholds may not match your use case.
+### LLM call failed during extraction
 
-**Fix:** Try adjusting these environment variables:
-- `TOTALRECLAW_COSINE_THRESHOLD` -- lower the value (e.g., `0.10`) to be more permissive, or raise it (e.g., `0.25`) to be stricter.
-- `TOTALRECLAW_RELEVANCE_THRESHOLD` -- lower the value (e.g., `0.15`) to inject memories more often, or raise it to reduce noise.
-- `TOTALRECLAW_MIN_IMPORTANCE` -- raise the value (e.g., `5`) to only store more important facts.
+Provider key invalid, expired, rate-limited, or the model isn't accessible. Test the key independently (`curl` the provider's API). Plugin retries on the next extraction cycle.
 
-### No LLM available for extraction
+### Recovery on a new device doesn't surface memories
 
-**Cause:** The plugin could not find an API key for any supported LLM provider.
+Same phrase MUST produce the same Smart Account. Check:
+1. Every word matches what you wrote down, in order, lowercase, single-spaced.
+2. No leading / trailing spaces.
+3. Same managed-vs-self-hosted mode (chain auto-detection only works against the relay your subscription is on).
 
-**Fix:** Add at least one LLM provider API key to your environment. The simplest option:
-```
-OPENAI_API_KEY="sk-your-key-here"
-```
-
-### Recovery phrase does not restore memories
-
-**Cause:** One or more words in the recovery phrase are wrong or in the wrong order.
-
-**Fix:**
-1. Double-check every word against what you wrote down.
-2. BIP-39 phrases are **all lowercase**. Make sure you did not capitalize any words.
-3. Verify the word order is exactly right. Even one wrong word derives a completely different key and wallet address, meaning the server will treat you as a new user.
-4. Make sure there is exactly one space between each word, no leading or trailing spaces.
+If still failing, check the integration test suite's Journey 3 — that's the canonical wallet-derivation reference.
 
 ### Permission denied on model download (Docker)
-
-If you see EACCES errors when the embedding model downloads, set the `HF_HOME` environment variable to a writable directory:
 
 ```bash
 export HF_HOME=/tmp/hf-cache
 ```
 
-This is common in Docker containers where the global npm cache directory isn't writable.
+Common when the npm cache directory isn't writable inside a container.
 
-### Plugin logs show "LLM call failed" errors
+### Subscription not reflected after upgrade
 
-**Cause:** Your LLM API key may be invalid, expired, or rate-limited.
-
-**Fix:**
-1. Test your API key independently (e.g., make a simple curl request to the provider's API).
-2. Check that your API key has not expired or run out of credits.
-3. If rate-limited, the plugin will retry on the next extraction cycle (every 3 turns by default).
+Billing status is cached for up to 2 hours client-side. After Stripe webhook fires (~60s post-payment), restart the runtime to force a refresh.
 
 ---
 
-## 15. Known Limitations (Beta)
+## Further reading
 
-This is a beta release. The following items are known limitations that will be addressed in future updates:
+- [Memory types guide](./memory-types-guide.md) — v1 taxonomy with override examples
+- [Importing memories](./importing-memories.md) — Mem0, MCP Memory Server, ChatGPT, Claude, Gemini
+- [Environment variables reference](./env-vars-reference.md) — full canonical list
+- [Feature comparison](./feature-comparison.md) — what works on each client
+- [v1 migration guide](./v1-migration.md) — upgrading from v0 taxonomy
+- [Memory dedup](./memory-dedup.md) — how content fingerprinting + cosine dedup work
 
-- **Free tier storage:** Base Sepolia testnet (unlimited writes, but testnet data may be reset). An abuse-prevention cap exists server-side but is high enough for normal usage.
-- **Subscription pricing:** Pro tier is $3.99/month (unlimited memories, permanent on-chain storage on Gnosis mainnet).
-- **Billing tools:** The upgrade flow (`totalreclaw_status`, `totalreclaw_upgrade`) may not be fully wired in all environments. If the agent cannot generate a checkout URL, contact the TotalReclaw team directly.
-- **Auto-extraction timing (OpenClaw only):** The `TOTALRECLAW_EXTRACT_EVERY_TURNS` environment variable controls extraction frequency. The plugin fires extraction on the `agent_end` hook every N turns (default: 3). The skill config also accepts `autoExtractEveryTurns` via the `TOTALRECLAW_EXTRACT_EVERY_TURNS` env var.
-- **MCP server has no auto-memory:** The MCP server does not have lifecycle hooks. It only responds to explicit tool calls. The host agent (Claude Desktop, Cursor) must call `totalreclaw_remember` and `totalreclaw_recall` explicitly.
-- **Batch writes:** On-chain writes support batching multiple facts per UserOp via ERC-4337 executeBatch.
-- **Decay and eviction engine:** The importance decay formula runs, but tuning is ongoing. Low-importance facts decay over time and may be evicted.
-- **Downgrade after cancellation:** If you cancel a Pro subscription, your storage reverts to Base Sepolia testnet. Existing mainnet memories remain accessible but new writes go to testnet.
-- **Self-hosted mode:** If you prefer full control, you can self-host the open-source server and store encrypted memories in your own PostgreSQL database instead. Set `TOTALRECLAW_SELF_HOSTED=true` and provide your own `TOTALRECLAW_SERVER_URL`.
+For implementation depth:
 
----
-
-## Further Reading
-
-- **Importing Memories:** [importing-memories.md](./importing-memories.md) -- how to migrate from Mem0, MCP Memory Server, and other AI memory tools.
-
-For those who want to understand the technical architecture:
-
-- **E2EE Architecture:** `docs/specs/totalreclaw/architecture.md` -- how encryption, LSH blind indices, and server-blind search work.
-- **Skill Specification:** `docs/specs/totalreclaw/skill-openclaw.md` -- full plugin spec with data models, triggers, and processing pipelines.
-- **MCP Onboarding:** `docs/specs/totalreclaw/mcp-onboarding.md` -- MCP-specific onboarding design, seed management, and billing tool specifications.
-- **Billing and Onboarding:** `docs/specs/subgraph/billing-and-onboarding.md` -- tier structure, payment infrastructure, and Gnosis Chain rationale.
-- **Seed-to-Subgraph:** `docs/specs/subgraph/seed-to-subgraph.md` -- how BIP-39 derivation connects to on-chain identity.
+- `docs/specs/totalreclaw/architecture.md` — encryption, blind indices, server-blind search
+- `docs/specs/totalreclaw/memory-taxonomy-v1.md` — the v1 taxonomy spec
+- `docs/specs/subgraph/seed-to-subgraph.md` — BIP-39 → on-chain identity
+- `docs/specs/subgraph/billing-and-onboarding.md` — tier structure and Gnosis Chain rationale
 
 ---
 
-*This guide was written for TotalReclaw beta v1.0-beta (updated v1.1). If you encounter issues not covered here, contact the TotalReclaw team.*
+*This guide tracks plugin 3.3.1 / Hermes 2.3.1 / mcp-server 3.2.x / nanoclaw 3.1.x. Stable line: plugin 3.2.3, mcp-server 3.2.0, nanoclaw 3.0.0, Hermes 2.3.0.*

--- a/docs/guides/claude-code-setup.md
+++ b/docs/guides/claude-code-setup.md
@@ -1,203 +1,260 @@
-# TotalReclaw Setup for Claude Code, Claude Desktop, Cursor, and Windsurf
+# TotalReclaw for Claude Code, Claude Desktop, Cursor, and Windsurf
 
-Encrypted, cross-session memory for MCP-compatible AI agents. Set up in under 2 minutes.
+TotalReclaw gives any MCP-compatible agent (Claude Code, Claude Desktop, Cursor, Windsurf, IronClaw) encrypted, persistent memory. The fastest setup is a single chat message — the agent fetches this guide, runs the MCP install for you, and walks you through wiring your recovery phrase. **You do nothing in the terminal.**
+
+If you already have Claude Code (or Claude Desktop / Cursor / Windsurf) running, paste this into your chat:
+
+> **Install TotalReclaw, see <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/claude-code-setup.md>**
+
+Your agent will fetch this page, run the MCP install command, and walk you through getting a recovery phrase into the config without ever printing it in chat. The phrase comes from your browser (via the OpenClaw or Hermes pair flow) or from a phrase you already have on file.
+
+---
+
+## Agent instructions (read this if you are a Claude Code / Claude Desktop / Cursor / Windsurf agent that just fetched this URL)
+
+You have been asked to install TotalReclaw. Run the steps below in order. Do not deviate. **Do not invoke `npx @totalreclaw/mcp-server setup`, `totalreclaw_setup`, or any other phrase-touching CLI / tool — those return the recovery phrase through your context, which violates the phrase-safety rule.** Phrase entry is the user's responsibility.
+
+### Step 1 — Detect the host runtime
+
+Decide which of these the user is running:
+
+- **Claude Code** — has the `claude` CLI on PATH (run `command -v claude`).
+- **Claude Desktop** — macOS / Windows native app; config at `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows).
+- **Cursor / Windsurf** — config via Settings UI or `.cursor/mcp.json` / `~/.codeium/windsurf/mcp_config.json`.
+- **IronClaw (NEAR AI)** — config at `~/.ironclaw/mcp.json` or via the IronClaw dashboard. See [ironclaw-setup.md](./ironclaw-setup.md) for the IronClaw-specific walkthrough.
+
+If you have a shell tool and `claude` is on PATH, prefer Step 2A (CLI). Otherwise, walk the user through the JSON snippet (Step 2B).
+
+### Step 2A — Register the MCP server via the Claude Code CLI (preferred)
+
+If `claude` is on PATH, run via your shell tool:
+
+```bash
+claude mcp add -s user totalreclaw -- npx -y @totalreclaw/mcp-server
+```
+
+This registers `totalreclaw` at user scope (available across all Claude Code sessions). Do NOT pass `-e TOTALRECLAW_RECOVERY_PHRASE=...` here — the user will add the phrase themselves in Step 3 so it never enters your context.
+
+To pin a release candidate: `claude mcp add -s user totalreclaw -- npx -y @totalreclaw/mcp-server@rc` (latest RC) or `@totalreclaw/mcp-server@3.2.3` (pin specific stable / RC version).
+
+If the CLI exits cleanly, continue to Step 3. If it fails with `command not found` / ENOENT, fall back to Step 2B.
+
+### Step 2B — Register the MCP server via JSON config (fallback)
+
+Tell the user verbatim:
+
+> *Open your MCP config file ([Claude Desktop on macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`](file:///Users/$USER/Library/Application%20Support/Claude/claude_desktop_config.json), Windows: `%APPDATA%\Claude\claude_desktop_config.json`; Cursor: `.cursor/mcp.json` or Settings → MCP Servers; Windsurf: `~/.codeium/windsurf/mcp_config.json`) and paste the block below into `mcpServers`. Leave the recovery phrase placeholder for now — we'll fill it in next. Reply `done` once the file is saved.*
+
+```json
+{
+  "mcpServers": {
+    "totalreclaw": {
+      "command": "npx",
+      "args": ["-y", "@totalreclaw/mcp-server"],
+      "env": {
+        "TOTALRECLAW_RECOVERY_PHRASE": "REPLACE_ME_IN_STEP_3"
+      }
+    }
+  }
+}
+```
+
+Wait for `done` before continuing.
+
+### Step 3 — Get a recovery phrase to the user (NEVER through chat)
+
+Check `test -s ~/.totalreclaw/credentials.json`. If it exists, the user already has a phrase from a previous TotalReclaw client (OpenClaw, Hermes, NanoClaw). Tell them verbatim:
+
+> *You already have a recovery phrase from another TotalReclaw client. Run `cat ~/.totalreclaw/credentials.json | jq -r .mnemonic` in your own terminal (NOT through me — your terminal output should not enter my context), copy the 12 words, and paste them as the value of `TOTALRECLAW_RECOVERY_PHRASE` in the config you just opened. Reply `done` once it's set.*
+
+If `~/.totalreclaw/credentials.json` does NOT exist, tell them verbatim:
+
+> *To generate or import a recovery phrase, the safest path is the browser-side pair flow that OpenClaw or Hermes uses (the relay only ever sees ciphertext). If you have OpenClaw or Hermes available, run their setup once (see [openclaw-setup.md](./openclaw-setup.md) or [hermes-setup.md](./hermes-setup.md)) — it writes `~/.totalreclaw/credentials.json`, and we'll reuse it here. If you don't, generate a 12-word BIP-39 phrase using a trusted offline tool (a hardware wallet, an air-gapped BIP-39 generator, or a password manager's seed-phrase generator), paste the 12 words into `TOTALRECLAW_RECOVERY_PHRASE` in your config (NOT into this chat), and reply `done`.*
+
+Wait for `done`. Do not at any point ask the user to type the phrase into chat. Do not run `npx @totalreclaw/mcp-server setup` via your shell tool — its stdout contains the phrase.
+
+### Step 4 — Restart the host
+
+Tell the user verbatim:
+
+> *Restart your host: in Claude Code, run `claude mcp restart totalreclaw` (or quit and reopen `claude`); in Claude Desktop, quit (Cmd-Q on macOS) and relaunch; in Cursor / Windsurf, restart the app from Settings → MCP Servers (toggle off / on) or quit and relaunch. Reply `done` once it's back up.*
+
+MCP is stateless JSON-RPC — there is no auto-reload, the host has to spawn a fresh `mcp-server` process to pick up the new config.
+
+### Step 5 — Verify
+
+Once the user replies `done`, ask the agent's own internal toolset (yourself): *"Are TotalReclaw tools bound?"* List the `totalreclaw_*` tools you can see. If `totalreclaw_remember`, `totalreclaw_recall`, `totalreclaw_pin`, etc. are present and don't return `"TotalReclaw is not configured"`, confirm: *"TotalReclaw is set up. Ask me to remember or recall anything."* If they're missing, the host didn't pick up the config — re-prompt the restart in Step 4.
+
+### Phrase safety (HARD — never break)
+
+NEVER echo, generate, or ask the user to paste a recovery phrase in chat. NEVER invoke `npx @totalreclaw/mcp-server setup`, `totalreclaw_setup`, `npx @totalreclaw/totalreclaw generate-mnemonic`, or any phrase-touching CLI via your shell tool — stdout enters LLM context. The MCP server has NO browser pair flow (it's stateless JSON-RPC); the user MUST source their phrase from another TotalReclaw client's pair flow (OpenClaw / Hermes browser flow), reuse `~/.totalreclaw/credentials.json` from a prior install, or paste a phrase they generated offline directly into the config file. If the user pastes a phrase in chat anyway: tell them it is compromised and they need to generate a fresh wallet via the OpenClaw or Hermes browser pair flow.
+
+---
+
+## What's happening (for the human reader)
+
+1. `claude mcp add -s user totalreclaw -- npx -y @totalreclaw/mcp-server` registers the TotalReclaw MCP server in your Claude Code user-scope config (`~/.claude.json`). Other MCP-compatible hosts use a JSON config block with the same shape.
+2. When the host launches, it spawns `npx @totalreclaw/mcp-server` as a stdio child process and discovers the available tools via the MCP handshake.
+3. The MCP server reads `TOTALRECLAW_RECOVERY_PHRASE` from its environment, derives your auth + encryption keys via BIP-39 + HKDF, registers with the relay (`api.totalreclaw.xyz` by default), and writes a credentials cache to `~/.totalreclaw/credentials.json`.
+4. All encryption — XChaCha20-Poly1305 for memories, blind indices for search trapdoors, content fingerprinting — happens inside the MCP server process on your machine. The relay only ever sees ciphertext.
+5. Unlike OpenClaw and Hermes, the MCP server has **no lifecycle hooks** — there's no auto-recall on every message and no auto-extract every N turns. The host agent (Claude Code, etc.) calls `totalreclaw_remember` and `totalreclaw_recall` explicitly when its prompt context tells it to.
+
+First real interaction downloads a ~600 MB embedding model (cached locally, one-time).
 
 ---
 
 ## Prerequisites
 
 - **Node.js 18+** (22 recommended)
-- **An MCP-compatible host app:** Claude Code, Claude Desktop, Cursor, Windsurf, or similar
-- ~344 MB disk space for the embedding model (one-time download, cached locally)
+- **An MCP-compatible host:** Claude Code, Claude Desktop, Cursor, Windsurf, IronClaw, or similar
+- **A recovery phrase** — generated via OpenClaw / Hermes browser pair flow, an offline BIP-39 generator, or already on file at `~/.totalreclaw/credentials.json`
 
 ---
 
-## 1. Get your recovery phrase
+## Manual install (if the chat flow doesn't apply)
 
-You have two options:
-
-### Option A: Run the setup wizard (recommended for new users)
+If you can't or won't use the chat flow:
 
 ```bash
-npx @totalreclaw/mcp-server setup
+# Register the MCP server (Claude Code; user scope so it's available across sessions)
+claude mcp add -s user totalreclaw -- npx -y @totalreclaw/mcp-server
+
+# Other hosts: paste the JSON block below into the appropriate config file.
 ```
 
-The wizard will:
+```json
+{
+  "mcpServers": {
+    "totalreclaw": {
+      "command": "npx",
+      "args": ["-y", "@totalreclaw/mcp-server"],
+      "env": {
+        "TOTALRECLAW_RECOVERY_PHRASE": "your twelve word recovery phrase here"
+      }
+    }
+  }
+}
+```
 
-1. Ask if you have an existing recovery phrase or need a new one
-2. Generate a 12-word recovery phrase (BIP-39) if needed
-3. Register with the TotalReclaw relay
-4. Print a config snippet to paste into your host app
+| Host | Config file |
+|---|---|
+| Claude Code | `~/.claude.json` (or `claude mcp add -s user`) |
+| Claude Desktop (macOS) | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Claude Desktop (Windows) | `%APPDATA%\Claude\claude_desktop_config.json` |
+| Cursor | `.cursor/mcp.json` (project) or Settings → MCP Servers (global) |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` |
+| IronClaw | `~/.ironclaw/mcp.json` or IronClaw dashboard — see [ironclaw-setup.md](./ironclaw-setup.md) |
 
-### Option B: Use an existing recovery phrase directly
+Restart the host. Verify by asking *"Do you have access to TotalReclaw memory tools?"*.
 
-If you already have a recovery phrase from another TotalReclaw client (OpenClaw, NanoClaw, Hermes, ZeroClaw), you can skip the wizard entirely. Just set `TOTALRECLAW_RECOVERY_PHRASE` in your host app config (step 2 below). The MCP server automatically registers with the relay on startup -- no manual registration step is needed.
-
-> **Save your recovery phrase somewhere safe.** It is the only key to your encrypted memories. There is no password reset, no recovery email, no support ticket that can help. If you lose it, your memories are permanently unrecoverable. This is by design.
+> **Pin a specific RC** with `args: ["-y", "@totalreclaw/mcp-server@rc"]` (latest RC) or `@totalreclaw/mcp-server@3.3.1-rc.22` (pinned). Stable is `3.2.3` on the `latest` dist-tag. Check what each tag resolves to: `npm view @totalreclaw/mcp-server dist-tags`.
 
 ---
 
-## 2. Add to your host app
+## How MCP differs from OpenClaw and Hermes
 
-Copy the config snippet from the wizard into your app's MCP configuration file.
+| Behavior | OpenClaw plugin / Hermes | MCP server (this guide) |
+|---|---|---|
+| Auto-recall on every message | yes (lifecycle hook) | no — host invokes `totalreclaw_recall` when its prompt tells it to |
+| Auto-extract every N turns | yes (lifecycle hook) | no — host invokes `totalreclaw_remember` when its prompt tells it to |
+| Pre-compaction flush | yes | no |
+| Session debrief | yes | no (use `totalreclaw_debrief` explicitly) |
+| Browser pair flow | yes (`totalreclaw_pair` tool) | **no** — MCP is stateless JSON-RPC; phrase must come from another client or offline tool |
+| First-run welcome | yes (host prepends context on session start) | no — MCP doesn't expose session lifecycle to the server |
 
-### Claude Code
-
-Add to `~/.claude.json` (or use `claude mcp add`):
-
-```json
-{
-  "mcpServers": {
-    "totalreclaw": {
-      "command": "npx",
-      "args": ["-y", "@totalreclaw/mcp-server"],
-      "env": {
-        "TOTALRECLAW_RECOVERY_PHRASE": "your twelve word recovery phrase goes here"
-      }
-    }
-  }
-}
-```
-
-### Claude Desktop
-
-Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
-
-```json
-{
-  "mcpServers": {
-    "totalreclaw": {
-      "command": "npx",
-      "args": ["-y", "@totalreclaw/mcp-server"],
-      "env": {
-        "TOTALRECLAW_RECOVERY_PHRASE": "your twelve word recovery phrase goes here"
-      }
-    }
-  }
-}
-```
-
-### Cursor
-
-Add to `.cursor/mcp.json` in your project root (or global settings via Settings > MCP Servers):
-
-```json
-{
-  "mcpServers": {
-    "totalreclaw": {
-      "command": "npx",
-      "args": ["-y", "@totalreclaw/mcp-server"],
-      "env": {
-        "TOTALRECLAW_RECOVERY_PHRASE": "your twelve word recovery phrase goes here"
-      }
-    }
-  }
-}
-```
-
-### Windsurf
-
-Add to `~/.codeium/windsurf/mcp_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "totalreclaw": {
-      "command": "npx",
-      "args": ["-y", "@totalreclaw/mcp-server"],
-      "env": {
-        "TOTALRECLAW_RECOVERY_PHRASE": "your twelve word recovery phrase goes here"
-      }
-    }
-  }
-}
-```
+MCP is the lowest-overhead integration but the most explicit. You'll talk naturally and the host will still recall / store via tool calls when its context gates fire — you just won't get the every-turn automatic behavior that OpenClaw and Hermes provide.
 
 ---
-
-## 3. Verify
-
-Restart your host app and ask:
-
-> "Do you have access to TotalReclaw memory tools?"
-
-The agent should confirm it can see the tools. If not, check the troubleshooting section below.
 
 ## Available tools
 
-| Tool | Description |
-|------|-------------|
-| `totalreclaw_remember` | Store a fact in encrypted memory |
-| `totalreclaw_recall` | Search memories by natural language query |
-| `totalreclaw_forget` | Delete a specific memory by ID |
-| `totalreclaw_export` | Export all memories as Markdown or JSON (self-hosted only) |
-| `totalreclaw_status` | Check billing status, tier, and usage |
-| `totalreclaw_setup` | First-time setup (if not done via the CLI wizard) |
-| `totalreclaw_upgrade` | Get a Stripe checkout link to upgrade to Pro |
-| `totalreclaw_migrate` | Migrate testnet memories to mainnet after Pro upgrade |
-| `totalreclaw_import_from` | Import from Mem0, ChatGPT, Claude, or MCP Memory Server |
-| `totalreclaw_import` | Re-import previously exported JSON or Markdown (self-hosted only) |
-| `totalreclaw_consolidate` | Merge duplicate memories (self-hosted only) |
-| `totalreclaw_debrief` | Extract and store key takeaways from the current session |
-| `totalreclaw_support` | Get help with common issues |
-| `totalreclaw_account` | View account details |
+| Tool | Example prompt |
+|------|---------------|
+| **Remember** | "Remember that I prefer PostgreSQL over MySQL" |
+| **Recall** | "What do you remember about my database choices?" |
+| **Forget** | "Forget what you know about my old email address" |
+| **Pin / Unpin** | "Pin that — it's important" / "Unpin the note about my old editor" |
+| **Retype** | "That should be a preference, not a fact" (types: `claim`, `preference`, `directive`, `commitment`, `episode`, `summary`) |
+| **Set scope** | "File that under work" (scopes: `work`, `personal`, `health`, `family`, `creative`, `finance`, `misc`) |
+| **Export** | "Export all my TotalReclaw memories as markdown" |
+| **Status** | "What's my TotalReclaw status?" |
+| **Import from** | "Import my Gemini history from ~/Downloads/..." |
+| **Debrief** | "Debrief this session" — captures session-level summaries |
+| **Upgrade / Migrate / Account** | billing flow tools (Stripe checkout, testnet → mainnet migration) |
+
+Talk naturally — the host LLM picks the right tool from context. See [memory types guide](./memory-types-guide.md) for the v1 taxonomy.
 
 ---
 
-## Usage examples
+## Importing from other tools
 
-You do not need special syntax. Just talk naturally:
+TotalReclaw can import from Mem0, MCP Memory Server, ChatGPT, Claude, and Gemini:
 
-- "Remember that I prefer TypeScript for backend services"
-- "What do you know about my project preferences?"
-- "Forget the memory about my old address"
-- "Show my TotalReclaw status"
-- "Export all my memories as Markdown"
-- "Import my memories from Mem0 using API key m0-xxx"
+> "Import my memories from Mem0 using API key m0-your-key-here"
 
-The MCP server also instructs the agent to recall relevant memories at the start of each conversation and to proactively store important facts you share (preferences, decisions, context). You can always be explicit, but much of it happens automatically.
-
-## How it works
-
-1. **All encryption happens on your machine.** Memories are encrypted with XChaCha20-Poly1305 before leaving your device. The server only ever sees ciphertext.
-2. **Your recovery phrase is your identity.** It derives all encryption keys via Argon2id + HKDF. Same phrase on any device or agent = same memories.
-3. **Search is privacy-preserving.** Queries use blind indices (SHA-256 hashes) and locality-sensitive hashing -- the server never sees your search terms.
-4. **Free tier** stores unlimited memories on Base Sepolia testnet ($0, testnet data may be reset). **Pro** stores permanently on Gnosis mainnet ($3.99/month via Stripe). Check current pricing with `totalreclaw_status` or at [totalreclaw.xyz/pricing](https://totalreclaw.xyz/pricing/).
-
-## Troubleshooting
-
-| Problem | Fix |
-|---------|-----|
-| Embedding model download is slow | Normal on first run (~344 MB). Check disk space and retry if it fails. Subsequent runs use the cached model. |
-| "Not configured" error | Run `npx @totalreclaw/mcp-server setup` or ask the agent to use the `totalreclaw_setup` tool. |
-| Agent does not see TotalReclaw tools | Restart the host app after adding the config. Verify with "Do you have access to TotalReclaw memory tools?" |
-| "Not authenticated" / 401 | Check your recovery phrase -- exact words, exact order, no extra spaces. The MCP server auto-registers with the relay on startup, so no manual registration step is needed. If the error persists, verify your internet connection and restart the host app. |
-| Recovery phrase lost | Memories are permanently unrecoverable. This is by design for end-to-end encryption security. |
-| Quota exceeded (403) | Free tier has a monthly write cap. Use `totalreclaw_upgrade` to move to Pro. |
+See [Importing Memories](importing-memories.md).
 
 ---
 
 ## Multi-device and portability
 
-Your recovery phrase works across every TotalReclaw-compatible agent:
+Your recovery phrase works across every TotalReclaw client. Same phrase = same memories.
 
-- **Claude Code / Claude Desktop / Cursor / Windsurf** (this guide)
-- **OpenClaw** (`openclaw skills install totalreclaw`)
-- **NanoClaw** (set `TOTALRECLAW_RECOVERY_PHRASE` in deployment config)
-- **IronClaw** (see [IronClaw setup guide](./ironclaw-setup.md))
-- **Hermes Agent** (Python client)
-- **ZeroClaw** (Rust crate)
+- **OpenClaw** — see [openclaw-setup.md](./openclaw-setup.md)
+- **Hermes (Python)** — see [hermes-setup.md](./hermes-setup.md)
+- **NanoClaw** — see [nanoclaw-getting-started.md](./nanoclaw-getting-started.md)
+- **IronClaw (NEAR AI)** — see [ironclaw-setup.md](./ironclaw-setup.md)
+- **ZeroClaw (Rust)** — see the ZeroClaw README in the main repo
 
-Same phrase, same memories. Switch agents without losing anything.
-
-## Learn more
-
-- [Getting Started Guide](./beta-tester-guide.md) -- full reference with architecture and configuration details
-- [Importing Memories](./importing-memories.md) -- migrate from Mem0, MCP Memory Server, ChatGPT, and Claude
-- [IronClaw Setup](./ironclaw-setup.md) -- setup guide for IronClaw (NEAR AI) agents
-- [MCP Server README](../../mcp/README.md) -- environment variables and development info
-- [totalreclaw.xyz](https://totalreclaw.xyz) -- project homepage
+Same phrase, same memories. Switch agents without losing anything. To migrate, copy `~/.totalreclaw/credentials.json` (or just the `mnemonic` field) to the new machine.
 
 ---
 
-*TotalReclaw v1.0-beta -- [totalreclaw.xyz](https://totalreclaw.xyz)*
+## Billing
+
+| Tier | Storage | Price |
+|------|---------|-------|
+| **Free** | Unlimited on Base Sepolia testnet (may reset) | $0 |
+| **Pro** | Permanent on Gnosis mainnet | $3.99/month |
+
+Both tiers have unlimited reads. Upgrade: *"Upgrade my TotalReclaw subscription."*
+
+[Pricing](https://totalreclaw.xyz/pricing)
+
+---
+
+## Troubleshooting
+
+- **Agent says "I'm not familiar with TotalReclaw"**: paste the canonical message above with the URL — the agent fetches the guide and follows the install steps.
+- **Agent can't see TotalReclaw tools after restart**: confirm `claude mcp list` (Claude Code) or your host's MCP UI lists `totalreclaw`. Verify `TOTALRECLAW_RECOVERY_PHRASE` is set in the config (host won't strip stderr from the spawned `mcp-server` process — check your host's MCP server logs for the `TotalReclaw configured` line). If the env var is missing, the server starts in unconfigured mode and tool calls return `{"error": "TotalReclaw is not configured"}`.
+- **"Not authenticated" / 401**: check your phrase — exact words, exact order, lowercase, single spaces.
+- **First-run is slow / model download**: the embedding model is ~600 MB, downloaded once and cached. Be patient on first call.
+- **Quota exceeded (403)**: free tier has a monthly write cap. Upgrade with *"Upgrade my TotalReclaw subscription"*.
+- **Recovery phrase appeared in chat**: file a bug. Rotate by generating a new wallet via the OpenClaw or Hermes browser pair flow. The leaked phrase is unrecoverable once shipped through LLM context.
+
+---
+
+## MCP-specific notes
+
+- **MCP is stateless.** There's no first-run welcome, no lifecycle hooks, and no auto-restart on config change. You restart the host explicitly to pick up new config.
+- **No browser pair flow.** The MCP server has no HTTP routes — phrase entry is the user's responsibility (config file, env var, or copying from another client's `credentials.json`). This is by design: keeping crypto secrets out of LLM context is more important than convenience parity with OpenClaw / Hermes.
+- **`totalreclaw_setup` exists but should not be used.** The tool exists for legacy compatibility. It generates a phrase and returns it through MCP tool-output JSON, which means the phrase enters the host LLM's context. The phrase-safety rule forbids this. New installs should always use the workflow in this guide.
+
+---
+
+## Canonical prompt (matches the QA harness scenario contracts)
+
+> **Install TotalReclaw, see <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/claude-code-setup.md>**
+
+---
+
+## Further reading
+
+- [OpenClaw setup guide](./openclaw-setup.md) — same vault, different runtime, with browser pair flow
+- [Hermes setup guide](./hermes-setup.md) — Python client with browser pair flow
+- [Beta tester deep-dive](./beta-tester-guide-detailed.md) — env vars, extraction tuning, architecture
+- [Memory types guide](./memory-types-guide.md) — v1 taxonomy
+- [Importing memories](./importing-memories.md)
+- [IronClaw setup](./ironclaw-setup.md) — full walkthrough for IronClaw (NEAR AI)
+- [Feature comparison](./feature-comparison.md)
+- [totalreclaw.xyz](https://totalreclaw.xyz)


### PR DESCRIPTION
- beta-tester-guide-detailed.md: 886→385 lines, repurposed as power-user companion to openclaw-setup.md
- claude-code-setup.md: parity rewrite to URL-driven canonical-prompt pattern (matches openclaw + hermes guides)

🤖 Generated with [Claude Code](https://claude.com/claude-code)