### PR TITLE
docs(specs): rewrite architecture.md + server.md to v1

### DIFF
--- a/docs/specs/totalreclaw/architecture.md
+++ b/docs/specs/totalreclaw/architecture.md
@@ -1,595 +1,306 @@
 <!--
 Product: TotalReclaw
-Formerly: tech specs/v0.3 (grok)/TS v0.3: E2EE with LSH + Blind Buckets.md
-Version: 0.3 (1.0)
-Last updated: 2026-02-24
+Version: v1.0 — 2026-04-26
+Last updated: 2026-04-26
 -->
 
-# Technical Specification — Crypto-Only (LSH + Blind Buckets)
+# TotalReclaw — System Architecture (v1)
 
-**Title:** TotalReclaw v0.3 — Server-Blind Vector Search via LSH + Encrypted Embeddings
-**Version:** 1.0 (complete, copy-paste for any coding agent with zero prior context)
-**Target stack:** Python 3.12+ (server + client lib) + TypeScript client for OpenClaw
-**Assumed PRD (lousy version):** "Make TotalReclaw truly server-blind for both documents and embeddings while keeping accuracy within 3% of plaintext and latency <150ms at 1M memories."
+**Title:** TotalReclaw v1.0 — End-to-end-encrypted memory across AI clients, with permanent on-chain anchoring
+**Audience:** anyone integrating, auditing, or extending TotalReclaw (engineers, security reviewers, downstream client authors)
+**Scope:** the architectural picture — identity, crypto, storage, retrieval, multi-client model, on-chain layer, install model. Implementation-level schemas live in their own specs (linked).
 
----
+This document is intentionally architectural. Concrete schemas, retrieval pipeline weights, and individual flow diagrams live in:
 
-## 1.1 Problem Statement (recap for new developer)
+- [`memory-taxonomy-v1.md`](./memory-taxonomy-v1.md) — canonical claim schema (6 types + source / scope / volatility axes)
+- [`retrieval-v2.md`](./retrieval-v2.md) — Tier 1 source-weighted reranker + tiers
+- [`server.md`](./server.md) — relay surface (sibling spec)
+- [`flows/`](./flows/README.md) — write/read/recovery flow walkthroughs
 
-Current code stores embeddings as raw `np.ndarray` → server sees plaintext vectors.
-Query embeddings are sent in plaintext → server learns semantic content.
-
-**Goal:** Server must never see plaintext embeddings or query vectors at any time.
-
-**Constraint:** Keep exact same two-pass flow and RRF fusion; no TEEs, no homomorphic crypto.
+Update this guide when **architectural** invariants change (trust split, key model, on-chain primitives, install model). Schema-level evolution belongs in the linked specs, not here.
 
 ---
 
-## 1.2 Chosen Solution: Locality-Sensitive Hashing + Blind Bucket Indexing
+## 1. Trust split — what runs where, and what each layer can see
 
-We extend the existing blind-index system (SHA-256 token hashes) to also index LSH buckets.
-This gives ~92–96% recall@500 with 400–1,200 candidates → client reranks exactly as today.
+TotalReclaw is split across three trust layers. This split is the single load-bearing claim of the architecture; everything else is in service of preserving it.
+
+```
+   Client (device)               Relay Service                     Open Network
+ ┌──────────────────┐         ┌──────────────────┐             ┌──────────────────┐
+ │ Mnemonic-rooted   │         │ Encrypted blobs   │             │ Gnosis (Pro)     │
+ │ key derivation    │ cipher  │ + LSH trapdoors   │   anchor    │ Base Sepolia     │
+ │ Embedding model   │ + LSH   │ GIN-indexed       │  (sponsored │ (Free testnet)   │
+ │ Extraction LLM    │ ─────▸  │ candidate retrieval│ ERC-4337) ▸ │ EventfulDataEdge │
+ │ Reranker (core)   │ ◂─────  │ AA bundler shim   │  ◂────────  │ Subgraph indexer │
+ │ Smart Account sig │ results │ Pair-flow relay   │   indexed   └──────────────────┘
+ └──────────────────┘         └──────────────────┘    events
+```
+
+| Layer | Sees plaintext? | Sees embeddings? | Holds keys? | Notes |
+|---|---|---|---|---|
+| Client | yes | yes (locally) | yes (mnemonic + derived) | All extraction, embedding, encryption, reranking |
+| Relay | **no** | **no** | **no** (only `SHA256(authKey)`) | Stores ciphertext, returns candidates by trapdoor match, brokers ephemeral pair-flow handshakes, shims AA bundler calls |
+| Open network | **no** | **no** | **no** | Anchors ciphertext as event logs; permanent, permissionless |
+
+**Critical invariant:** the embedding model stays client-side. Putting it on the relay would break the trust split — the server would learn semantic content from queries, even if storage stayed encrypted. This is why the lazy-CDN embedder (§7) downloads the model to the device, not to the relay.
 
 ---
 
-## 1.3 Data Models (updated)
+## 2. Identity — one mnemonic, deterministic everything
 
-```python
-# In EncryptedMemoryStore (Python)
-@dataclass
-class MemoryItem:
-    id: str                          # UUIDv7
-    encrypted_doc: bytes             # XChaCha20-Poly1305
-    encrypted_embedding: bytes       # XChaCha20-Poly1305
-    blind_indices: list[str]         # SHA-256(token) + SHA-256(LSH_bucket)
-    metadata: dict                   # source, timestamp, importance, etc.
+A 12-word BIP-39 mnemonic is the **only** secret the user holds. Every other key, address, and stable identifier is derived from it.
+
 ```
+BIP-39 mnemonic
+   │
+   ├─► PBKDF2 (BIP-39 standard, 2048 rounds) → 512-bit seed
+   │
+   ├─► HKDF-SHA256(seed, "totalreclaw-auth-v1")        → authKey         (relay auth)
+   ├─► HKDF-SHA256(seed, "totalreclaw-enc-v1")         → encryptionKey   (XChaCha20)
+   ├─► HKDF-SHA256(seed, "totalreclaw-dedup-v1")       → dedupKey        (HMAC fingerprints)
+   ├─► HKDF-SHA256(seed, "totalreclaw-lsh-v1")         → lshSeed         (deterministic hyperplanes)
+   │
+   └─► BIP-44 derivation m/44'/60'/0'/0/0
+         → secp256k1 keypair → ERC-4337 Smart Account address (counterfactual, deterministic)
+```
+
+**Properties this gives us:**
+
+- **Cross-client portability.** Same mnemonic on OpenClaw, Hermes, NanoClaw, MCP server → identical Smart Account address, same encryption key, same LSH hyperplanes → all clients see the same memories. No server-side coordination required.
+- **Server blindness.** The relay only ever stores `SHA256(authKey)`. It cannot derive `encryptionKey`, `dedupKey`, or `lshSeed` from this.
+- **Recovery.** Lose the device, keep the mnemonic → re-derive everything, query the subgraph for the smart-account's event history, decrypt locally. Relay outage / acquisition / shutdown does not lose data.
+
+### Phrase-safety rule
+
+The recovery phrase MUST NEVER cross an LLM context. Concretely:
+
+- Agents do **not** display, store, log, or transmit the phrase.
+- Setup happens via a browser-side QR-pair flow (§6) — the phrase never leaves the user's browser tab.
+- No CLI tool exposed to an agent emits or accepts the phrase as text.
+
+This rule is structural, not advisory. All client implementations are audited against it.
 
 ---
 
-## Re-ranking Architecture (Research-Backed)
+## 3. Crypto choices — which primitive, where, why
 
-### Do NOT Use Main LLM for Re-ranking
+Two separate authenticated symmetric ciphers are used, deliberately, because the threat model differs.
 
-Based on research of Mem0, Zep, Letta:
-- **Re-ranking latency budget**: <100ms
-- **Main LLM latency**: 500-2000ms (too slow!)
-- **Zep's approach**: Hybrid scoring without LLM (fastest)
+| Use site | Primitive | Rationale |
+|---|---|---|
+| **Long-term storage** of memory ciphertext (relay + on-chain) | **XChaCha20-Poly1305** | 192-bit nonce → safe to pick at random without a counter; constant-time ChaCha is faster than AES-GCM on TotalReclaw's targets (browsers, Node, PyO3, embedded Rust); long-term storage means many writes, large nonce space matters |
+| **Pair-flow ECDH session** (browser ↔ client during onboarding, rc.12+) | **AES-256-GCM** | Short-lived session payload (the paired phrase, encrypted to the client's ephemeral pubkey); native WebCrypto support across browsers; nonce reuse risk is trivial because each pair session uses a fresh ECDH session key |
+| Authentication | HKDF-SHA256-derived `authKey`, sent as bearer token; relay stores only `SHA256(authKey)` | Stateless; no separate password; same mnemonic re-derives auth on any device |
+| Dedup | `HMAC-SHA256(dedupKey, normalize(plaintext))` → content fingerprint | Server can de-duplicate without learning plaintext; one bit of leakage per pair (same/not-same) |
+| Blind search | `SHA-256` of word tokens + LSH bucket IDs (trapdoors) | Server matches trapdoors via GIN index; cannot invert |
 
-### Recommended: Dedicated Cross-Encoder
-
-| Model | Size | Latency (10 docs) | Accuracy |
-|-------|------|-------------------|----------|
-| BGE-Reranker-base (ONNX) | 400MB | 30-50ms | High |
-| BGE-Reranker-large | 1GB | 50-100ms | Very High |
-| ms-marco-MiniLM-L-6-v2 | 100MB | 10-30ms | Good |
-
-### Recommended: Use Main LLM for Extraction
-
-| Model | Size | Latency | When to Use |
-|-------|------|---------|-------------|
-| **Main agent LLM** | - | 500ms+ | **Preferred** - already available, no extra RAM |
-| Qwen3-0.6B (local) | 400MB | 100-300ms | Only if main LLM unavailable (extraction LLM, not embedding) |
-| Phi-3-mini (local) | 2GB | 200-500ms | Higher accuracy (not recommended) |
-
-**Extraction is async** - doesn't block user queries, so latency is acceptable.
-
-**IMPORTANT**: Prefer using the main LLM for extraction to minimize RAM footprint. This enables deployment on low-resource devices (e.g., Raspberry Pi). A separate extraction model adds 400MB-2GB RAM overhead. Only consider a dedicated small LLM if:
-- Main LLM doesn't support async calls
-- Privacy requires fully local processing
-- Main LLM is cloud-based and user wants offline capability
-
-### Implementation Architecture
-
-```
-SYNCHRONOUS PATH (<100ms total):
-  Query → Embedding (5-10ms) → Server Search (10-20ms) → Cross-Encoder Rerank (30-50ms)
-
-ASYNC PATH (non-blocking):
-  New memories → Small LLM Extraction (100-300ms) → Encrypt → Upload
-```
+**One-line summary:** XChaCha20-Poly1305 for things that live a long time, AES-GCM for the brief ECDH onboarding payload, SHA-256/HMAC for everything the server needs to *match without decrypting*.
 
 ---
 
-## 1.4 LSH Configuration (VALIDATED 2026-02-22)
+## 4. Memory model — the v1 taxonomy
 
-**Library:** Custom Random Hyperplane LSH (or Faiss IndexLSH)
+The plaintext inside each ciphertext is a **v1 Memory Claim** — a structured object, not a free-text blob. Six closed types, three orthogonal axes, provenance as a first-class field.
 
-**Parameters** (validated on combined WhatsApp + Slack data, 8,727 embeddings):
+The architectural points:
 
-```python
-n_bits_per_table = 64   # 64-bit hash per table (NOT 512 as originally proposed)
-n_tables = 16           # 16 independent hash tables (increased from 12 for scale)
-candidate_pool = 3000   # number of candidates to retrieve for re-ranking
-```
+- **Six types, closed enum:** `claim`, `preference`, `directive`, `commitment`, `episode`, `summary`. Cross-client agreement requires a small, fixed vocabulary.
+- **Three orthogonal axes:** `source` (who authored — user / user-inferred / derived / external / agent), `scope` (life domain), `volatility` (how stable over time).
+- **Provenance is structural, not metadata.** The reranker reads `source` and weights it (Tier 1, §5). This is what defends against the Mem0 97.8%-junk failure mode: assistant-tagged content cannot score equal to user-authored claims.
+- **Importance is advisory.** Receivers may recompute it.
+- **Pin status is additive (v1.1).** Pinned claims are immune to auto-supersede; the field is optional and ignorable by older readers.
 
-**Validation Results (Combined WhatsApp + Slack data, 8,727 embeddings):**
-| Metric | Target | Achieved |
-|--------|--------|----------|
-| Mean Recall@3000 | ≥93% | **93.6%** |
-| P5 Recall | - | 84.4% |
-| Query Latency | <50ms | **9.71ms** |
-| Storage Overhead | ≤2.2x | **0.06x** |
-| Candidates Returned | - | ~1,848 |
-
-**Alternative Configurations:**
-| Config | n_bits | n_tables | candidate_pool | Mean Recall | P5 Recall | Latency |
-|--------|--------|----------|----------------|-------------|-----------|---------|
-| Efficient | 64 | 16 | 2800 | 93.3% | 84.0% | 13.73ms |
-| **Balanced** | 64 | 12 | 3000 | 93.6% | 84.4% | 9.71ms |
-| Higher Recall | 64 | 12 | 4000 | 96.6% | 90.8% | 10.04ms |
-
-**Scaling Note:** Parameters were adjusted from WhatsApp-only validation (99% recall with 2,000 candidates) to account for the larger, more diverse Slack dataset. The candidate pool scales roughly with dataset size.
-
-**Key Finding:** The `candidate_pool` size is the critical lever for recall:
-- 500 candidates → ~75% recall
-- 1000 candidates → ~91% recall
-- 1500 candidates → ~97% recall (small dataset)
-- **3000 candidates → ~93.6% recall (large, diverse dataset)** ✅
+Full schema, axis enums, validation rules, version-history details — see **[`memory-taxonomy-v1.md`](./memory-taxonomy-v1.md)**. Do not duplicate them here; this section is the architectural framing only.
 
 ---
 
-### Scaling Formula for Production
+## 5. Storage and retrieval
 
-**`candidate_pool` is FULLY DYNAMIC** - no index rebuild needed!
+### Write path (architectural)
 
-For production deployments with large corpora, the server auto-adjusts `candidate_pool` based on corpus size:
-
-```python
-def calculate_candidate_pool(corpus_size: int) -> int:
-    """
-    Calculate optimal candidate pool size based on corpus size.
-
-    VALIDATED DATA POINTS:
-    - 1,162 memories → 2,000 candidates = 99.0% recall (34% of corpus)
-    - 8,727 memories → 3,000 candidates = 93.6% recall (34% of corpus)
-
-    Key insight: candidate_pool scales roughly logarithmically, not linearly.
-    """
-    import math
-
-    MIN_POOL = 2000
-    MAX_POOL = 10000
-
-    if corpus_size < 2000:
-        return MIN_POOL
-    elif corpus_size < 10000:
-        # Validated: 8,727 → 3,000 (34% ratio)
-        return max(MIN_POOL, min(4000, int(corpus_size * 0.35)))
-    elif corpus_size < 100000:
-        # Estimate: logarithmic scaling for medium corpora
-        return min(MAX_POOL, 3000 + int(math.log10(corpus_size) * 500))
-    else:
-        # Large corpora: cap at 10,000 but consider hierarchical LSH
-        return MAX_POOL
+```
+plaintext claim (v1 taxonomy)
+   │
+   ├─► extract → embed → compute LSH buckets → hash buckets to trapdoors
+   ├─► compute content fingerprint = HMAC-SHA256(dedupKey, normalize(text))
+   ├─► XChaCha20-Poly1305 encrypt {claim, embedding, metadata}
+   │
+   ▼
+protobuf v=4 envelope { ciphertext, blind_indices[], content_fp, ... }
+   │
+   ├─► POST to relay (fast path) — stored under user's authKeyHash
+   └─► ERC-4337 UserOp via relay's bundler shim → on-chain log → indexed by subgraph
 ```
 
-**Validated Scaling Table:**
+### Read path (architectural)
 
-| Corpus Size | Candidate Pool | Ratio | Expected Recall | Validated? |
-|-------------|----------------|-------|-----------------|------------|
-| 1,162 | 2,000 | 172% | 99.0% | ✅ WhatsApp |
-| 8,727 | 3,000 | 34% | 93.6% | ✅ Combined |
-| 10,000 | 3,500 | 35% | ~93% | 🟡 Extrapolated |
-| 50,000 | 5,000 | 10% | ~90% | 🟡 Extrapolated |
-| 100,000 | 6,500 | 6.5% | ~88% | 🟡 Extrapolated |
-| 1,000,000 | 10,000 | 1% | ~85%* | 🟡 Extrapolated |
+```
+query text
+   │
+   ├─► embed query (client-side; instruction-prefixed)
+   ├─► generate trapdoors (token hashes + LSH bucket hashes)
+   │
+   ▼
+relay GIN index returns N encrypted candidates (auto-tuned by corpus size)
+   │
+   ▼
+client decrypts, runs core::reranker:
+   ├─► BM25 + cosine + decay + importance
+   ├─► RRF fusion
+   ├─► Tier 1 source-weighted multiplier (v1)
+   │
+   ▼
+top K (default 8)
+```
 
-*At 1M+ scale, consider increasing `n_tables` to 24 or using **hierarchical LSH** (cluster → LSH per cluster).
+### Source-weighted reranker (Tier 1)
+
+Lives in `rust/totalreclaw-core/src/reranker.rs` and is consumed by every client (WASM for JS/TS, PyO3 for Python). After RRF fusion, the final score is multiplied by a `source` weight (user > user-inferred > derived ≈ external > agent). This is the minimum retrieval change that lets v1 taxonomy actually do work — without it, provenance tagging is observability, not behavior.
+
+Full reranker spec including tiers 2–4 and validation results: **[`retrieval-v2.md`](./retrieval-v2.md)**.
+
+### Read-after-write consistency
+
+On-chain writes are visible only after the subgraph indexes them. Empirically: **~5–30s lag** in steady state. As of `totalreclaw-core` rc.22+, reads opt into a primitive that polls the subgraph until the just-written sequence is visible, so callers don't see "I just stored that — why isn't it there?" races. The primitive is in `core`, so all clients inherit it.
+
+### Storage tiers
+
+| Tier | Anchor | Cost | Persistence |
+|---|---|---|---|
+| **Free** | Base Sepolia testnet | $0 | May reset (testnet) — fine for evaluation, not for irreplaceable data |
+| **Pro** | Gnosis mainnet | $3.99 / mo | Permanent, permissionless |
+
+Both tiers use the same `EventfulDataEdge` contract pattern (single `fallback()` emitting `Log(msg.data)`), the same ERC-4337 Smart Account derivation, and the same paymaster-sponsored UserOps. Tier choice is at write time and recorded per claim.
 
 ---
 
-### Production Monitoring for LSH Scaling
+## 6. Onboarding — the QR-pair flow
 
-Track these metrics in production to know when to adjust parameters:
+The mnemonic must reach the client without ever crossing an LLM context. The flow:
 
-```python
-# Add to your /health or /metrics endpoint
-{
-    "lsh_metrics": {
-        "total_embeddings": 8727,           # Track corpus size
-        "candidate_pool_configured": 3000,  # Current setting
-        "avg_candidates_returned": 1848,    # From search responses
-        "avg_recall_estimate": 0.936,       # Based on validation curves
-        "p95_query_latency_ms": 15.2,       # Monitor latency
-        "last_param_update": "2026-02-22"   # When params were last changed
-    }
-}
+```
+┌─────────────────┐                                 ┌─────────────────┐
+│ Browser tab     │   1. Show pair QR + nonce       │ Client (e.g.    │
+│ (totalreclaw.xyz)│ ◀──────────────────────────────│  OpenClaw,      │
+│                 │                                 │  Hermes, MCP)   │
+│ User enters or  │   2. Scan QR → ECDH pubkey      │                 │
+│ generates       │      exchange via relay         │ Generates       │
+│ phrase locally  │      (ephemeral WebSocket)      │ ephemeral       │
+│                 │                                 │ ECDH keypair    │
+│ AES-GCM encrypt │   3. Encrypted paired_phrase    │                 │
+│ phrase to       │ ──────────────────────────────▶ │ Decrypts with   │
+│ client's pubkey │      via relay (transient)      │ session key,    │
+│                 │                                 │ derives all keys│
+└─────────────────┘                                 └─────────────────┘
 ```
 
-**Alert Thresholds:**
+Properties:
 
-| Metric | Warning | Critical | Action |
-|--------|---------|----------|--------|
-| `total_embeddings` > 50K | - | ⚠️ | Re-validate LSH params |
-| `avg_candidates_returned` < 500 | ⚠️ | - | Increase candidate_pool |
-| `p95_query_latency_ms` > 100ms | ⚠️ | ⚠️⚠️ | Check database indexes |
-| Estimated recall < 90% | ⚠️ | ⚠️⚠️ | Increase candidate_pool or n_tables |
+- **Phrase never enters an agent context.** The browser holds it; the client receives only the AES-GCM ciphertext.
+- **Relay is a dumb transport.** It brokers the WebSocket pubkey exchange and forwards the encrypted blob. It cannot decrypt — it doesn't have the ECDH session key.
+- **Same mnemonic, any client.** Pair OpenClaw today, pair Hermes tomorrow with the same phrase → same Smart Account, same memories.
 
-**Scaling Triggers:**
-1. **Every 10x growth** (10K → 100K → 1M): Re-run LSH validation on sample
-2. **Recall drops below 90%**: Increase `candidate_pool` by 1,000
-3. **Latency exceeds 100ms**: Consider read replicas or caching
+The pair handshake mechanism shipped in relay rc.10+; AES-GCM payload encryption shipped client-side in rc.12+.
 
 ---
 
-### Server-Side Auto-Adjustment (IMPLEMENT THIS)
+## 7. Install model — URL-driven setup, lazy-CDN embedder
 
-```python
-# In server search handler
-async def search(request: SearchRequest) -> SearchResponse:
-    # Get current corpus size for user
-    corpus_size = await db.get_active_memory_count(request.user_id)
+### URL-driven install (rc.20+)
 
-    # Auto-calculate candidate_pool using validated formula
-    candidate_pool = calculate_candidate_pool(corpus_size)
+The user does not install via copy-pasted shell commands. The flow:
 
-    # Use whichever is larger: auto-calculated or client-requested
-    max_candidates = max(candidate_pool, request.max_candidates or 3000)
+1. User pastes a setup URL (e.g. `https://totalreclaw.xyz/setup/openclaw`) into their agent.
+2. Agent fetches the markdown at that URL.
+3. The markdown contains the install commands; the agent runs them.
 
-    # Execute search with dynamic pool
-    results = await db.search_with_blind_indices(
-        user_id=request.user_id,
-        trapdoors=request.trapdoors,
-        limit=max_candidates
-    )
+This decouples install instructions from agent prompt-engineering and gives the project a single place to update setup steps without re-publishing every client.
 
-    return SearchResponse(results=results, total_candidates=len(results))
-```
+### Lazy-CDN embedder (rc.22+)
 
-**Benefits:**
-- No admin intervention needed
-- Scales automatically with corpus growth
-- Per-user optimization (user with 100 memories uses smaller pool than user with 10K)
+The plugin tarball is small (~5–10 MB) — small enough to install fast even on slow connections. The embedding model (~325 MB) is **not** in the tarball. On the first auto-extraction turn, the client downloads the embedder from GitHub Releases, caches it locally, and uses it from then on.
+
+**E2EE invariant preserved:** the embedder runs on the device. The relay never sees it, never proxies it, and could not host it without breaking the trust split.
 
 ---
 
-### Manual Scaling Workflow (Admin Guide)
+## 8. Clients — one core, many surfaces
 
-**`candidate_pool` is AUTOMATIC** - server auto-adjusts based on corpus size.
+Every client speaks to the relay and the chain through the same Rust core (`totalreclaw-core`), exposed via WASM (browsers / Node / Deno) or PyO3 (Python). This means crypto, retrieval, dedup, and protobuf framing have **one** implementation — clients are thin agent-integration shells around it.
 
-**Only `n_bits` and `n_tables` require manual intervention** (rarely needed, only at 500K+ scale).
+| Client | Package | Role |
+|---|---|---|
+| OpenClaw plugin | `@totalreclaw/totalreclaw` | Plugin for the OpenClaw agent runtime |
+| Hermes | `totalreclaw` (PyPI) | Python client for Claude Agent SDK / direct API users |
+| NanoClaw skill | bundled | Lightweight overlay skill |
+| MCP server | `@totalreclaw/mcp-server` | Model Context Protocol server — any MCP host (Claude Desktop, Cursor, etc.) |
 
-#### Step 1: Check Current Metrics
-```bash
-# Check corpus size and performance
-curl http://localhost:8080/metrics
+Stable versions are tracked in [`docs/release-pipeline.md`](../../release-pipeline.md) (in the internal repo) and in the public-facing release pages. Don't pin them in this doc — they drift.
 
-# Response:
-{
-  "total_embeddings": 52000,
-  "candidate_pool_configured": 3000,
-  "avg_candidates_returned": 1450,
-  "p95_query_latency_ms": 22
-}
-```
-
-#### Step 2: Decide If Adjustment Needed
-```python
-# Use the formula or table above
-current_corpus = 52000
-recommended_pool = 3000 + int(log10(52000) * 500)  # = ~4600
-
-# Current is 3000, should be ~4600 → NEEDS ADJUSTMENT
-```
-
-#### Step 3: Update Configuration
-```bash
-# Option A: Update server config file
-# Edit /server/config.yaml:
-lsh:
-  candidate_pool: 4600
-
-# Option B: Update via environment variable
-export LSH_CANDIDATE_POOL=4600
-
-# Option C: Update database (persistent)
-psql -c "UPDATE config SET value='4600' WHERE key='lsh_candidate_pool'"
-```
-
-#### Step 4: Restart Server (if needed)
-```bash
-# For config file changes
-docker-compose restart totalreclaw-server
-
-# For env vars (requires restart)
-docker-compose up -d --force-recreate totalreclaw-server
-```
-
-#### Step 5: Verify
-```bash
-curl http://localhost:8080/metrics
-# Confirm candidate_pool_configured = 4600
-```
+**Architectural consequence:** to add a new client (e.g. a new IDE), you bind to `totalreclaw-core` and implement the agent-glue. You don't reimplement crypto, retrieval, or dedup. This is what keeps cross-client behavior consistent as the surface area grows.
 
 ---
 
-### User Impact Analysis
+## 9. Relay — a blind intermediary
 
-**When you change `candidate_pool`, users ARE affected:**
+The relay (separate `totalreclaw-relay` repo) is **not** a memory backend in the traditional sense. It does four things:
 
-| Change | User Impact | Severity |
-|--------|-------------|----------|
-| **Increase pool** | Higher recall (better results) | ✅ Positive |
-| **Increase pool** | Slightly slower search (more candidates to decrypt) | ⚠️ Minor negative |
-| **Increase pool** | More bandwidth usage | ⚠️ Minor negative |
-| **Decrease pool** | Lower recall (might miss relevant memories) | ❌ Negative |
-| **Decrease pool** | Faster search | ✅ Positive |
+1. **Stores opaque ciphertext + trapdoors** under `SHA256(authKey)` namespaces.
+2. **Returns candidates by trapdoor match** (PostgreSQL GIN index over the blind-index array).
+3. **Brokers pair-flow handshakes** via ephemeral WebSocket sessions.
+4. **Shims ERC-4337 bundler calls** so clients can send UserOps without running their own bundler.
 
-**Recommendation: Only INCREASE, never DECREASE in production.**
+Health endpoints:
 
-#### Before/After Comparison
+- Staging: `https://api-staging.totalreclaw.xyz`
+- Production: `https://api.totalreclaw.xyz`
 
-| Metric | Before (3000) | After (4600) | Impact |
-|--------|---------------|--------------|--------|
-| Recall | ~90% | ~93% | Better results ✅ |
-| Latency | 22ms | 28ms | +6ms (negligible) |
-| Bandwidth | ~500KB/query | ~750KB/query | +250KB |
-| Client CPU | Low | Medium | More decryption |
-
-#### No User Action Required
-- **Clients auto-adapt**: The `max_candidates` is a server-side limit
-- **No client updates needed**: Client just receives more candidates to re-rank
-- **Seamless transition**: Users won't notice except better recall
-
-#### Communication (Optional)
-If you want to notify users:
-```
-System Notice: Memory search improved!
-We've increased search depth to find more relevant memories.
-You may notice slightly more comprehensive results.
-```
+Full surface (protobuf wire format, endpoints, dedup behavior, sync semantics, schema, deployment) lives in the sibling spec: **[`server.md`](./server.md)**.
 
 ---
 
-### Scaling Decision Tree
+## 10. Performance envelope (architectural targets)
 
-```
-Is total_embeddings > 50K?
-├── YES → Check avg_recall_estimate
-│   ├── < 90% → URGENT: Increase candidate_pool
-│   └── ≥ 90% → OK, but plan for 100K milestone
-│
-└── NO → Check growth rate
-    ├── Growing fast (>10K/month) → Pre-emptively increase
-    └── Growing slow → Monitor monthly
-```
+The following are the architectural targets the system is designed around. Implementation-specific measured numbers live next to each implementation in code or in the relevant spec.
 
----
+| Concern | Target |
+|---|---|
+| End-to-end search latency (client + relay roundtrip) | < 150 ms p95 |
+| Trapdoor generation + GIN lookup | < 15 ms |
+| Recall@8 on real-user corpora | ≥ 95% (validated 98.1% on benchmark) |
+| Plugin tarball size | ~5–10 MB |
+| Embedder download (first-turn lazy fetch) | ~325 MB |
+| On-chain write visibility (subgraph lag) | 5–30 s typical |
+| Smart-account derivation determinism | 100% — same mnemonic → same address, every client |
 
-### At 500K+ Scale: Hierarchical LSH (Future)
-
-When corpus exceeds 500K, single LSH becomes inefficient. Switch to:
-
-```
-Hierarchical LSH:
-1. Cluster memories into groups (~10K each)
-2. LSH index per cluster
-3. Query: Find top 3 relevant clusters → search within each
-4. Total candidates: 3 × 3000 = 9000 (same as before, better recall)
-
-Implementation: Post-PoC, requires additional development.
-```
+When these targets slip, the architecture is wrong, not the implementation. (LSH parameters, reranker tiers, embedder choice — all live in linked specs and can be tuned without touching this doc.)
 
 ---
 
-## Latency Optimizations (Future Improvements)
+## 11. What this doc does NOT cover
 
-If latency becomes an issue, implement these optimizations in order of impact:
+By design. Each topic below has a canonical home:
 
-### 1. Client-Side Caching (60%+ Hit Rate)
-```typescript
-// Cache recent searches by query hash
-const searchCache = new LRUCache<string, SearchResult[]>({ max: 100 });
+- **Claim schema, axis enums, version history** → [`memory-taxonomy-v1.md`](./memory-taxonomy-v1.md)
+- **Reranker weights, tier definitions, validation** → [`retrieval-v2.md`](./retrieval-v2.md)
+- **Relay protobuf wire format, endpoints, DB schema, dedup behavior** → [`server.md`](./server.md)
+- **Step-by-step user flows** (identity setup, write, read, recovery, storage modes) → [`flows/README.md`](./flows/README.md)
+- **Conflict resolution beyond exact-fingerprint dedup** → conflict-resolution spec (see `conflict-resolution.md`)
+- **LSH parameter tuning + scaling formula** → [`lsh-tuning.md`](./lsh-tuning.md)
+- **MCP server specifics** → [`mcp-server.md`](./mcp-server.md)
+- **Skills (OpenClaw / NanoClaw)** → [`skill-openclaw.md`](./skill-openclaw.md), [`skill-nanoclaw.md`](./skill-nanoclaw.md)
 
-async function cachedSearch(query: string): Promise<SearchResult[]> {
-  const hash = sha256(query);
-  const cached = searchCache.get(hash);
-  if (cached) return cached;  // Cache hit - instant return
-
-  const results = await server.search(query);
-  searchCache.set(hash, results);
-  return results;
-}
-```
-
-**Impact**: 60%+ of queries hit cache → 0ms latency for those queries
-
-### 2. Debounce Rapid Messages
-```typescript
-// Don't search on every keystroke - wait for user to pause
-const debouncedSearch = debounce(search, 300);  // 300ms delay
-
-onMessageReceived((msg) => {
-  if (msg.length < 10) return;  // Skip short messages
-  debouncedSearch(msg);
-});
-```
-
-**Impact**: Reduces unnecessary searches by 40%
-
-### 3. Async Pre-Fetching
-```typescript
-// Predict and pre-fetch likely queries in background
-onMessageReceived((msg) => {
-  const likelyQueries = predictQueries(msg);  // Simple keyword extraction
-  likelyQueries.forEach(q => backgroundSearch(q));
-});
-```
-
-**Impact**: 200-300ms head-start on likely queries
-
-### 4. Edge Deployment
-- Deploy TotalReclaw server to multiple regions
-- Use CDN-like routing to nearest server
-- Target: <20ms network RTT
-
-**Impact**: Reduces network latency by 50-70%
-
-### 5. Local LSH Index Cache
-```typescript
-// Cache LSH hyperplanes and blind indices locally
-// Avoids re-computing on every query
-const lshCache = await loadLSHFromDisk();
-```
-
-**Impact**: Saves 10-20ms per query
-
-### Optimization Priority
-
-| Optimization | Effort | Impact | Priority |
-|--------------|--------|--------|----------|
-| Client caching | Low | High | P1 |
-| Debounce | Low | Medium | P1 |
-| Skip short messages | Low | Medium | P1 |
-| Async pre-fetch | Medium | Medium | P2 |
-| Local LSH cache | Medium | Low | P2 |
-| Edge deployment | High | High | P3 |
+If you find yourself wanting to extend this doc with a schema field, a tuning constant, or a sequence diagram for a specific flow, you're probably in the wrong file.
 
 ---
 
-## 1.5 Ingestion Pipeline (client-side only)
+## See also
 
-```python
-# pseudocode — full implementation provided in repo skeleton
-def ingest(memory_item: dict, master_password: str):
-    # 1. Compute embedding (same as today)
-    emb = embedder.encode(memory_item["text"])
-
-    # 2. Generate LSH buckets
-    lsh_hashes = lsh_index.hash_vector(emb)          # returns list of 12 strings
-
-    # 3. Generate blind indices
-    blind = [sha256(token) for token in tokenize(text)]
-    blind += [sha256(h) for h in lsh_hashes]
-
-    # 4. Encrypt BOTH doc and embedding
-    key = derive_key(master_password)
-    enc_doc = xchacha20_encrypt(memory_item["text"], key)
-    enc_emb = xchacha20_encrypt(emb.tobytes(), key)
-
-    # 5. Upload
-    server.upload({
-        "id": uuid7(),
-        "encrypted_doc": enc_doc,
-        "encrypted_embedding": enc_emb,
-        "blind_indices": blind,
-        "metadata": {...}
-    })
-```
-
----
-
-## 1.6 Search Pipeline (unchanged outer flow)
-
-1. **Client:** embed query → compute LSH hashes → generate trapdoors (SHA-256 of each bucket).
-2. **Client:** send ONLY trapdoors + optional keyword blind indices.
-3. **Server:** inverted-index lookup → union of all matching memories (400–1,200 candidates).
-4. **Server:** return encrypted docs + encrypted embeddings for those IDs.
-5. **Client:** decrypt 400–1,200 items → exact cosine on decrypted embeddings + BM25 + RRF → top 8.
-
-**(Optional)** client caches LSH index locally for 24h to reduce server load on repeat queries.
-
----
-
-## 1.7 Migration from current plaintext-embeddings
-
-- **One-time script:** download all items (they are still decryptable by user), re-ingest with LSH + encryption.
-- **Backward compatible:** old items without LSH buckets fall back to keyword-only pre-filter (still works, just lower recall).
-
----
-
-## 1.8 Full File Structure & Deliverables Expected from Coding Agent
-
-```
-totalreclaw/core/lsh.py          — Faiss wrapper + hash generation
-totalreclaw/client.py            — updated store() and search() with LSH
-totalreclaw/server/blind_index.py — extended inverted index (already exists, just add LSH bucket column)
-tests/benchmarks/               — 10k, 100k, 1M synthetic + real WhatsApp datasets
-docs/migration.md
-```
-
-**Config file:** `totalreclaw/config.yaml` with all LSH tunables
-
----
-
-## Performance Targets (must hit)
-
-| Metric | Target |
-|--------|--------|
-| 1M memories search p95 | <140ms |
-| Download size | <2MB |
-| Recall@500 of true top-250 | ≥93% |
-| Storage overhead vs v0.2 | ≤2.2× |
-
----
-
-## LSH Parameter Immutability & Re-indexing (MVP Requirement)
-
-### Problem
-
-LSH parameters `n_bits` and `n_tables` are **index-time parameters**:
-- Old memory indexed with `n_tables=12`
-- Server scales to `n_tables=16` (at 500K+ scale)
-- New queries use 16 tables, old memory only has 12 buckets
-- **Search breaks for old memories**
-
-### Solution: Full Re-index on Param Change
-
-When LSH params must change (rare, only at 500K+ scale):
-
-```
-RE-INDEX WORKFLOW:
-
-1. ADMIN TRIGGERS: PUT /admin/lsh-reindex
-   - New params: { n_bits: 64, n_tables: 16 }
-   - System enters MAINTENANCE mode
-
-2. PAUSE OPERATIONS:
-   - Block all exports (prevent partial data)
-   - Block new memory storage
-   - Allow read-only search (with old params)
-
-3. FOR EACH USER:
-   a. Fetch all encrypted memories
-   b. Client-side: decrypt with recovery phrase
-   c. Client-side: re-compute LSH buckets with NEW params
-   d. Client-side: re-encrypt, re-upload
-   e. Server: update blind_indices atomically
-
-4. RESUME OPERATIONS:
-   - System exits MAINTENANCE mode
-   - All queries use new params
-```
-
-### Implementation Notes
-
-| Aspect | Detail |
-|--------|--------|
-| **Frequency** | Rare - only at 500K+ corpus size |
-| **Downtime** | Per-user, not global (each user re-indexes independently) |
-| **Client requirement** | Must have recovery phrase (cannot re-index server-side) |
-| **Rollback** | Keep old blind_indices until re-index complete |
-| **Export blocking** | Prevent export during re-index to avoid inconsistent data |
-
-### Config Storage
-
-```python
-# Per-user LSH config (immutable until re-index)
-class UserLSHConfig:
-    user_id: str
-    n_bits: int = 64
-    n_tables: int = 12
-    created_at: datetime
-    reindex_in_progress: bool = False
-```
-
-### API Endpoints (MVP)
-
-| Endpoint | Purpose |
-|----------|---------|
-| `GET /lsh-config` | Get current user's LSH params |
-| `POST /admin/lsh-reindex` | Trigger re-index (admin only) |
-| `GET /lsh-reindex/status` | Check re-index progress |
-
-**Note: This is OUT OF SCOPE for PoC, required for MVP launch.**
+- [`memory-taxonomy-v1.md`](./memory-taxonomy-v1.md) — claim schema (canonical)
+- [`retrieval-v2.md`](./retrieval-v2.md) — reranker (canonical)
+- [`server.md`](./server.md) — relay surface (sibling)
+- [`flows/README.md`](./flows/README.md) — flow walkthroughs
+- [`mcp-server.md`](./mcp-server.md) — MCP client specifics
+- [`tiered-retrieval.md`](./tiered-retrieval.md) — tier rationale + validation
+- [`benchmark.md`](./benchmark.md) — retrieval benchmark methodology

--- a/docs/specs/totalreclaw/server.md
+++ b/docs/specs/totalreclaw/server.md
@@ -1,700 +1,335 @@
 <!--
 Product: TotalReclaw
-Formerly: tech specs/v0.3 (grok)/TS v0.3.1: Server-side PoC (with Auth).md
-Version: 0.3.1b
-Last updated: 2026-02-24
+Version: v1.0 — 2026-04-26
+Last updated: 2026-04-26
 -->
 
-# Technical Specification: TotalReclaw Server PoC v0.3.1
+# TotalReclaw Relay — Architecture (v1)
 
-**Version:** 0.3.1b (Auth + Content Fingerprint Dedup)
-**Date:** February 24, 2026 (updated from February 21, 2026)
-**Supersedes:** TS v0.3 Server-side PoC (no Subgraph).md
-**Status:** Ready for Implementation
-**See also:** TS v0.3.2 (Multi-Agent Conflict Resolution) for advanced conflict resolution layers beyond what this spec covers.
+**Title:** TotalReclaw v1.0 — Relay (server-blind intermediary, AA bundler shim, pair-flow broker)
+**Audience:** anyone reading, auditing, or operating the relay; integrators who need to understand what the relay can and cannot do for them.
+**Scope:** the relay's architectural responsibilities, surface, and invariants. Concrete schemas (memory claim, reranker, retrieval) live in sibling specs. The relay codebase lives in a separate repo (`totalreclaw-relay`); details specific to deployment, ops runbooks, and CI live there.
 
----
-
-## Changelog from v0.3
-
-| Change | Section |
-|--------|---------|
-| Added authentication system using recovery phrase derivation | §5 |
-| Added rate limiting design (deferred to post-PoC) | §6 |
-| Clarified API error codes | §4 |
-| Added conflict resolution strategy | §8 |
-| Added security considerations | §10 |
-| Added deferred MVP items (LSH re-index, conflict enhancement) | §14 |
-| **Added content fingerprint dedup (v0.3.1b)** | **§3, §7, §8** |
-| **Added DUPLICATE_CONTENT error code (v0.3.1b)** | **§3** |
-| **Added sync endpoint for delta reconciliation (v0.3.1b)** | **§4, §7** |
-| **Referenced v0.3.2 for advanced conflict resolution (v0.3.1b)** | **§14** |
+This document is the **architectural** spec for the relay. Update it when the relay's role, surface boundaries, or invariants change. Do not duplicate claim-schema or reranker details here.
 
 ---
 
-## 1. Goals & Non-Goals
+## 1. Role of the relay
 
-### Goals
-- Simple, single-binary server for PoC testing
-- Server-blind: server never sees plaintext or recovery phrase
-- Authentication derived from user's recovery phrase (no separate API keys)
-- Protobuf API (future-proof for decentralized migration)
-- PostgreSQL backend with event-sourced storage
+The relay is **not** a memory backend in the traditional sense. It is a server-blind intermediary that makes day-to-day reads and writes fast — without ever decrypting anything, ever holding a key, or ever seeing a recovery phrase.
 
-### Non-Goals (for PoC)
-- No subgraphs, no ERC-4337, no paymaster
-- No production-scale deployment (single Postgres)
-- Rate limiting (deferred)
-- Multi-tenant isolation (single user per instance for PoC)
+It has exactly four jobs:
+
+1. **Store opaque ciphertext + trapdoors** under per-user `SHA256(authKey)` namespaces.
+2. **Return candidates by trapdoor match** for blind retrieval (PostgreSQL GIN index over the blind-index array).
+3. **Broker the pair-flow handshake** via ephemeral WebSocket sessions during onboarding.
+4. **Shim ERC-4337 bundler calls** so clients can submit UserOps without running their own bundler.
+
+Everything plaintext — extraction, embedding, dedup decisions, reranking, claim schema validation — happens on the client. The relay can be fully compromised without exposing user memories.
+
+For the trust split that justifies this design, see [`architecture.md`](./architecture.md) §1.
 
 ---
 
-## 2. Architecture Overview
+## 2. Architectural diagram
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                    CLIENT (OpenClaw Skill)                       │
+│                    CLIENT (any of: OpenClaw, Hermes,             │
+│                    MCP server, NanoClaw, browser pair tab)      │
 ├─────────────────────────────────────────────────────────────────┤
-│  master_password                                                 │
-│       │                                                          │
-│       ├──► HKDF(pw, salt, "auth") ──► auth_key ──► Auth Header  │
-│       │                                                          │
-│       └──► HKDF(pw, salt, "enc") ──► encryption_key             │
-│                   │                                              │
-│                   ▼                                              │
-│            XChaCha20-Poly1305 Encrypt                             │
-│                   │                                              │
-│                   ▼                                              │
-│            Protobuf Request                                      │
+│  mnemonic                                                       │
+│       │                                                         │
+│       ├─► HKDF(seed, "totalreclaw-auth-v1")  ─► authKey         │
+│       ├─► HKDF(seed, "totalreclaw-enc-v1")   ─► encryptionKey   │
+│       ├─► HKDF(seed, "totalreclaw-dedup-v1") ─► dedupKey        │
+│       ├─► HKDF(seed, "totalreclaw-lsh-v1")   ─► lshSeed         │
+│       └─► BIP-44 m/44'/60'/0'/0/0  ─► secp256k1 → AA address    │
+│                                                                 │
+│  XChaCha20-Poly1305 encrypt {claim, embedding, metadata}        │
+│  Compute trapdoors (token hashes + LSH bucket hashes)           │
+│  Compute content_fp = HMAC-SHA256(dedupKey, normalize(text))    │
+│  Sign UserOp (ERC-4337)                                         │
 └─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼ HTTP/Protobuf
+          │                              │
+          │ HTTPS / Protobuf v=4         │ WebSocket
+          ▼                              ▼ (pair handshake only)
 ┌─────────────────────────────────────────────────────────────────┐
-│                      SERVER (PoC)                                │
+│                          RELAY                                   │
 ├─────────────────────────────────────────────────────────────────┤
-│  ┌─────────────┐    ┌─────────────┐    ┌─────────────────────┐  │
-│  │ Auth Check  │───►│ Rate Limit  │───►│ Request Handler     │  │
-│  │ (SHA256)    │    │ (deferred)  │    │                     │  │
-│  └─────────────┘    └─────────────┘    └─────────────────────┘  │
-│                                                  │               │
-│                                                  ▼               │
-│                                          ┌─────────────┐         │
-│                                          │ PostgreSQL  │         │
-│                                          │ • raw_events│         │
-│                                          │ • facts     │         │
-│                                          │ • users     │         │
-│                                          └─────────────┘         │
+│  Auth      Rate    Request Handlers                             │
+│  ┌──────┐ ┌─────┐ ┌────────────────────────────────────────┐    │
+│  │SHA256│►│limit│►│ /store /search /update /sync /export   │    │
+│  │  fp  │ └─────┘ │ /pair-init /pair-claim (WS)            │    │
+│  └──────┘         │ /aa-bundler-shim                        │    │
+│                   └────────────────────────────────────────┘    │
+│                                       │                          │
+│                                       ▼                          │
+│                              ┌──────────────────┐                │
+│                              │   PostgreSQL     │                │
+│                              │ • users           │                │
+│                              │ • facts (GIN)    │                │
+│                              │ • raw_events     │                │
+│                              │ • tombstones     │                │
+│                              └──────────────────┘                │
 └─────────────────────────────────────────────────────────────────┘
+          │                              │
+          ▼                              ▼
+   Subgraph indexer                ERC-4337 bundler
+   (The Graph)                     (sponsored by paymaster)
+          │                              │
+          ▼                              ▼
+   Gnosis (Pro)                    Gnosis / Base Sepolia chain
+   Base Sepolia (Free)             (EventfulDataEdge contract)
 ```
 
 ---
 
-## 3. Protobuf Schema
+## 3. What the relay sees, and what it doesn't
 
-```proto
-syntax = "proto3";
-package totalreclaw;
+The architectural invariant. Everything else in this doc serves it.
 
-message TotalReclawFact {
-  string id = 1;                    // UUIDv7 (time-sortable)
-  string timestamp = 2;             // ISO 8601
-  string owner = 3;                 // user_id from auth
-  string encrypted_blob = 4;        // Base64 of XChaCha20-Poly1305 (doc + embedding + metadata)
-  repeated string blind_indices = 5; // SHA-256(token) + SHA-256(LSH bucket)
-  float decay_score = 6;
-  bool is_active = 7;
-  int32 version = 8;
-  string source = 9;                // conversation | pre_compaction | explicit | etc.
-  // --- Added in v0.3.1b ---
-  string content_fp = 10;           // HMAC-SHA256 content fingerprint (for dedup, see §8.2)
-  string agent_id = 11;             // identifier of the agent that created this fact
-}
+| The relay stores or sees | The relay never sees |
+|---|---|
+| `SHA256(authKey)` per user | the mnemonic |
+| `encryptionKey`-encrypted ciphertext blobs | `encryptionKey` |
+| `dedupKey`-derived `content_fp` | `dedupKey` |
+| `lshSeed`-derived bucket trapdoors | `lshSeed` (and therefore the LSH hyperplanes) |
+| Trapdoor sets at query time | the query text or query embedding |
+| ERC-4337 UserOp bytes (signed) | the secp256k1 private key that signed them |
+| Pair-flow ECDH pubkeys + ciphertext | the ECDH session key or paired-phrase plaintext |
 
-message StoreRequest {
-  repeated TotalReclawFact facts = 1;
-}
-
-message StoreResponse {
-  bool success = 1;
-  repeated string ids = 2;
-  ErrorCode error_code = 3;
-  string error_message = 4;
-  // --- Added in v0.3.1b ---
-  repeated string duplicate_ids = 5;  // fact IDs that were rejected as duplicates
-}
-
-message SearchRequest {
-  repeated string blind_trapdoors = 1;   // LSH + keyword trapdoors from client
-  int32 limit = 2;                       // default 500
-  float min_decay_score = 3;             // default 0.3
-}
-
-message SearchResponse {
-  repeated TotalReclawFact facts = 1;     // encrypted, client decrypts & reranks
-  int32 total_available = 2;
-  ErrorCode error_code = 3;
-  string error_message = 4;
-}
-
-// --- Added in v0.3.1b: Delta sync for agent reconnection ---
-message SyncRequest {
-  int64 since_sequence = 1;              // agent's last known sequence_id
-  int32 limit = 2;                       // max facts to return (default 1000)
-}
-
-message SyncResponse {
-  repeated TotalReclawFact facts = 1;
-  int64 latest_sequence = 2;             // current highest sequence_id for this user
-  bool has_more = 3;                     // true if more facts beyond limit
-}
-
-enum ErrorCode {
-  OK = 0;
-  INVALID_REQUEST = 1;
-  UNAUTHORIZED = 2;
-  RATE_LIMITED = 3;
-  NOT_FOUND = 4;
-  INTERNAL_ERROR = 5;
-  VERSION_CONFLICT = 6;
-  DUPLICATE_CONTENT = 7;                 // Added in v0.3.1b: content fingerprint match
-}
-```
+If the relay's database leaks in full, an attacker recovers ciphertext + trapdoors + signed-UserOp history. They do not recover any plaintext, any embedding, any key, or any recovery phrase. This is by construction.
 
 ---
 
-## 4. API Endpoints
+## 4. Wire format — protobuf v=4
 
-### Base URL
-```
-http://localhost:8080  (PoC only, never expose to internet)
-```
+The on-the-wire envelope between client and relay is protobuf, schema version 4 (locked rc.20+ as part of the v1 cutover). Architecturally, the envelope carries:
 
-### Endpoints
+- **Encrypted blob.** `XChaCha20-Poly1305(encryptionKey, plaintext)` where the plaintext is a v1 Memory Claim (see [`memory-taxonomy-v1.md`](./memory-taxonomy-v1.md)) plus its embedding and metadata. The relay never parses inside the blob.
+- **Blind indices.** SHA-256 of word tokens + SHA-256 of LSH bucket IDs.
+- **Content fingerprint.** `HMAC-SHA256(dedupKey, normalize(text))`. Server uses this for exact-duplicate dedup.
+- **Decay score, version, source channel, sequence id.** Server-readable scalars for indexing, ordering, and conflict checks. None of these reveal claim content.
 
-| Method | Path | Request | Response | Description |
-|--------|------|---------|----------|-------------|
-| POST | /register | RegisterRequest | RegisterResponse | One-time user registration |
-| POST | /store | StoreRequest | StoreResponse | Store new facts (with dedup) |
-| POST | /search | SearchRequest | SearchResponse | Blind-index search |
-| POST | /update | StoreRequest | StoreResponse | Update/decay facts |
-| DELETE | /facts/{id} | - | { success: bool } | Soft delete (tombstone) |
-| GET | /health | - | { status: "ok" } | Health check |
-| GET | /export | - | ExportResponse | Export all user data |
-| GET | /sync | SyncRequest | SyncResponse | Delta sync since sequence (v0.3.1b) |
+**Schema version semantics:** the protobuf envelope version (`v=4`) gates the wire layout. The taxonomy `schema_version` (`"1.0"`, `"1.1"`, etc.) is *inside* the encrypted blob — invisible to the relay, evolved independently, additive on read.
 
-### New: Registration
-
-```proto
-message RegisterRequest {
-  string auth_key_hash = 1;    // SHA256(HKDF(master_password, salt, "auth"))
-  bytes salt = 2;              // 32 random bytes
-}
-
-message RegisterResponse {
-  bool success = 1;
-  string user_id = 2;          // Server-generated UUID
-  ErrorCode error_code = 3;
-  string error_message = 4;
-}
-```
-
-### Authentication Header
-
-All requests except `/register` and `/health` require:
-```
-Authorization: Bearer <auth_key>
-```
-
-Where `auth_key = HKDF(master_password, salt, "auth")` (derived client-side).
-
-Server validates: `SHA256(auth_key) == stored_auth_key_hash`
+The exhaustive `.proto` field list, RPC method signatures, and codegen targets live in `totalreclaw-relay/proto/` (canonical source). Don't duplicate them in this doc — they drift.
 
 ---
 
-## 5. Authentication System
+## 5. Surface — what endpoints exist and why
 
-### Design Principles
-1. **No separate API key** - recovery phrase IS the auth credential
-2. **Server-blind** - server never sees recovery phrase
-3. **Cryptographic separation** - auth key ≠ encryption key
-4. **Stateless requests** - no sessions, no tokens to refresh
-5. **Portable** - same recovery phrase works on any device
+| Endpoint | Method | Purpose | Auth |
+|---|---|---|---|
+| `/health` | GET | Liveness probe | none |
+| `/register` | POST | One-time user registration; stores `SHA256(authKey)` + salt | derives auth |
+| `/store` | POST | Append encrypted facts; idempotent via `content_fp` | bearer `authKey` |
+| `/search` | POST | Trapdoor-matched candidate retrieval | bearer `authKey` |
+| `/update` | POST | Version-checked edits to existing facts | bearer `authKey` |
+| `/facts/{id}` | DELETE | Soft-delete (tombstone) | bearer `authKey` |
+| `/sync` | GET | Delta reconciliation since last `sequence_id` (multi-agent crash recovery) | bearer `authKey` |
+| `/export` | GET | Full encrypted dump for offline backup / migration | bearer `authKey` |
+| `/pair-init`, `/pair-claim` | WS | Pair-flow ECDH pubkey exchange + transient ciphertext relay | nonce-scoped |
+| `/aa-bundler-shim` | POST | Forward signed UserOps to an ERC-4337 bundler; return tx hash | bearer `authKey` |
 
-### Registration Flow
+Health URLs:
 
-```
-┌──────────────────────────────────────────────────────────────┐
-│ CLIENT                                                        │
-├──────────────────────────────────────────────────────────────┤
-│ 1. User enters master_password                               │
-│ 2. Generate: salt = random(32 bytes)                         │
-│ 3. Derive: auth_key = HKDF-SHA256(                           │
-│                master_password,                              │
-│                salt,                                         │
-│                "totalreclaw-auth-v1",                         │
-│                length=32                                     │
-│            )                                                 │
-│ 4. Compute: auth_key_hash = SHA256(auth_key)                 │
-│ 5. Send: POST /register { auth_key_hash, salt }              │
-└──────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌──────────────────────────────────────────────────────────────┐
-│ SERVER                                                        │
-├──────────────────────────────────────────────────────────────┤
-│ 1. Generate: user_id = UUIDv7()                              │
-│ 2. Store: INSERT INTO users (user_id, auth_key_hash, salt)   │
-│ 3. Return: { success: true, user_id }                        │
-└──────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌──────────────────────────────────────────────────────────────┐
-│ CLIENT (Post-Registration)                                    │
-├──────────────────────────────────────────────────────────────┤
-│ Store locally in OS keychain:                                 │
-│   • user_id                                                   │
-│   • salt (for future auth_key derivation)                     │
-│                                                               │
-│ User remembers: master_password                               │
-└──────────────────────────────────────────────────────────────┘
-```
-
-### Request Authentication
-
-```
-┌──────────────────────────────────────────────────────────────┐
-│ CLIENT (Every Request)                                        │
-├──────────────────────────────────────────────────────────────┤
-│ 1. User enters master_password (or from OS keychain)         │
-│ 2. Retrieve: salt from local storage                         │
-│ 3. Derive: auth_key = HKDF-SHA256(master_password, salt, ...)│
-│ 4. Send request with header:                                 │
-│      Authorization: Bearer <auth_key>                        │
-└──────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌──────────────────────────────────────────────────────────────┐
-│ SERVER                                                        │
-├──────────────────────────────────────────────────────────────┤
-│ 1. Extract: auth_key from Authorization header               │
-│ 2. Compute: auth_key_hash = SHA256(auth_key)                 │
-│ 3. Lookup: SELECT * FROM users WHERE auth_key_hash = ?       │
-│ 4. If found: use user_id for all operations                  │
-│ 5. If not found: return 401 Unauthorized                     │
-└──────────────────────────────────────────────────────────────┘
-```
-
-### Key Separation
-
-```
-master_password
-       │
-       ├──► HKDF(pw, salt, "totalreclaw-auth-v1")  ──► auth_key (for server auth)
-       │
-       └──► HKDF(pw, salt, "totalreclaw-enc-v1")   ──► encryption_key (for AES-GCM)
-```
-
-**Critical**: Server only ever sees `auth_key` (and stores `SHA256(auth_key)`). Server never has enough information to derive `encryption_key`.
+- **Staging:** `https://api-staging.totalreclaw.xyz` — auto-QA always targets this
+- **Production:** `https://api.totalreclaw.xyz`
 
 ---
 
-## 6. Rate Limiting (Deferred)
+## 6. Authentication — derived, not configured
 
-Design for future implementation:
+Architecturally, there is **no** separate API key, no password reset, no session token. The mnemonic is the credential.
 
-| Endpoint | Limit | Window |
-|----------|-------|--------|
-| /register | 5 | per hour per IP |
-| /store | 100 | per minute per user |
-| /search | 200 | per minute per user |
-| /export | 5 | per hour per user |
+```
+client:  authKey       = HKDF-SHA256(seed, "totalreclaw-auth-v1")
+client:  Authorization = Bearer <authKey>
+server:  if SHA256(authKey) == stored_auth_key_hash → ok
+```
 
-Implementation: Use Redis with sliding window or Postgres-based rate limiter.
+Cryptographic separation is structural:
+
+```
+mnemonic
+   ├─► HKDF(..., "totalreclaw-auth-v1")  ─► authKey         (server sees SHA-256 only)
+   ├─► HKDF(..., "totalreclaw-enc-v1")   ─► encryptionKey   (server NEVER derivable)
+   └─► HKDF(..., "totalreclaw-dedup-v1") ─► dedupKey        (server NEVER derivable)
+```
+
+The relay can verify the user is authentic without learning anything that lets it decrypt their data. There is no "give me my data back" recovery path through the relay; the only recovery path is the mnemonic + the subgraph (see [`architecture.md`](./architecture.md) §2 + §5).
 
 ---
 
-## 7. Database Schema
+## 7. Dedup — content fingerprint at write, sync at reconnect
 
-```sql
--- Users table (authentication)
-CREATE TABLE users (
-  user_id TEXT PRIMARY KEY,           -- UUIDv7
-  auth_key_hash BYTEA NOT NULL,       -- SHA256(auth_key)
-  salt BYTEA NOT NULL,                -- 32 bytes
-  created_at TIMESTAMPTZ DEFAULT NOW(),
-  last_seen_at TIMESTAMPTZ
-);
-
-CREATE INDEX idx_users_auth_hash ON users(auth_key_hash);
-
--- Raw events (immutable log)
-CREATE TABLE raw_events (
-  id BIGSERIAL PRIMARY KEY,
-  user_id TEXT NOT NULL REFERENCES users(user_id),
-  event_bytes BYTEA NOT NULL,         -- raw Protobuf of StoreRequest
-  created_at TIMESTAMPTZ DEFAULT NOW()
-);
-
-CREATE INDEX idx_events_user ON raw_events(user_id, created_at DESC);
-
--- Facts (mutable view)
-CREATE TABLE facts (
-  id TEXT PRIMARY KEY,                -- fact UUIDv7
-  user_id TEXT NOT NULL REFERENCES users(user_id),
-  encrypted_blob BYTEA NOT NULL,
-  blind_indices TEXT[] NOT NULL,
-  decay_score FLOAT NOT NULL,
-  is_active BOOLEAN NOT NULL DEFAULT true,
-  version INT NOT NULL DEFAULT 1,
-  source TEXT NOT NULL,
-  created_at TIMESTAMPTZ DEFAULT NOW(),
-  updated_at TIMESTAMPTZ DEFAULT NOW(),
-  -- Added in v0.3.1b: content fingerprint dedup + sync
-  sequence_id BIGSERIAL,              -- monotonic per-user, for delta sync
-  content_fp TEXT,                    -- HMAC-SHA256 fingerprint for exact dedup
-  agent_id TEXT                       -- which agent created this fact
-);
-
-CREATE INDEX idx_facts_user ON facts(user_id);
-CREATE INDEX idx_facts_blind_gin ON facts USING GIN(blind_indices);
-CREATE INDEX idx_facts_active_decay ON facts(user_id, is_active, decay_score DESC);
--- Added in v0.3.1b:
-CREATE UNIQUE INDEX idx_facts_user_fp ON facts(user_id, content_fp) WHERE is_active = true;
-CREATE INDEX idx_facts_user_seq ON facts(user_id, sequence_id);
-
--- Tombstones (for soft delete, 30-day retention)
-CREATE TABLE tombstones (
-  fact_id TEXT PRIMARY KEY,
-  user_id TEXT NOT NULL,
-  deleted_at TIMESTAMPTZ DEFAULT NOW()
-);
-
-CREATE INDEX idx_tombstones_expiry ON tombstones(deleted_at);
-```
-
----
-
-## 8. Conflict Resolution
-
-### 8.1 Version-Based Optimistic Locking (Unchanged)
-
-For updates to **existing facts** (same fact ID):
-
-```sql
--- On update, include version check
-UPDATE facts
-SET encrypted_blob = ?, version = version + 1, updated_at = NOW()
-WHERE id = ? AND user_id = ? AND version = ?;
-
--- If affected_rows == 0, return VERSION_CONFLICT error
-```
-
-**Client strategy on VERSION_CONFLICT:**
-1. Re-retrieve latest version
-2. Merge changes (LLM-assisted merge for text)
-3. Retry update with new version
-
-### 8.2 Content Fingerprint Dedup (Added v0.3.1b)
-
-For **new facts** that may duplicate existing content (e.g., after agent restart, or when
-multiple agents extract from the same source material):
-
-#### Content Fingerprint Computation (Client-Side)
+### Exact-content dedup (HMAC-SHA256)
 
 ```
-dedup_key   = HKDF-SHA256(master_password, salt, "totalreclaw-dedup-v1")
-content_fp  = HMAC-SHA256(dedup_key, normalize(plaintext))
+content_fp = HMAC-SHA256(dedupKey, normalize(text))
+
+normalize(text):
+  Unicode NFC → lowercase → collapse whitespace → trim → UTF-8 encode
 ```
 
-**`normalize(text)` function:**
-1. Unicode NFC normalization
-2. Lowercase
-3. Collapse whitespace (multiple spaces/tabs/newlines to single space)
-4. Trim leading/trailing whitespace
-5. UTF-8 encode
-
-**Key derivation note:** The dedup key is derived via a separate HKDF context string
-(`"totalreclaw-dedup-v1"`) so that it survives encryption key rotation independently.
-It follows the same pattern as auth/encryption key separation (§5).
+Server-side `/store` handler:
 
 ```
-master_password
-       │
-       ├──► HKDF(pw, salt, "totalreclaw-auth-v1")   ──► auth_key
-       ├──► HKDF(pw, salt, "totalreclaw-enc-v1")    ──► encryption_key
-       └──► HKDF(pw, salt, "totalreclaw-dedup-v1")  ──► dedup_key  (NEW)
+for each fact in request:
+  if exists where (user_id = ?, content_fp = ?, is_active = true):
+    skip → add existing id to response.duplicate_ids[]
+  else:
+    insert → add new id to response.ids[]
+return success (partial = full)
 ```
 
-**Extraction temperature requirement:** For content fingerprint dedup to be effective, the
-LLM fact extraction call MUST use `temperature=0` (or the lowest available setting). This
-maximizes output determinism: the same input text produces the same extracted fact text
-across agents and sessions. Without this, minor wording variations in extraction output
-defeat the fingerprint. Note that `temperature=0` is not guaranteed to be fully deterministic
-by all providers, but achieves >95% consistency on short structured extractions — sufficient
-for dedup where occasional misses are a minor storage cost, not a correctness failure.
+**Why HMAC, not plain hash:** plain SHA-256 of plaintext would let the relay confirm or deny known content (build a rainbow table of common facts and probe). Keying with `dedupKey` (derived from the mnemonic) means the relay cannot probe — it can only match fingerprints from the same user.
 
-**Platform-specific implementation:**
+**Why it's idempotent:** same fact pushed twice from a recovered agent or two parallel clients → second push is a no-op, returned via `duplicate_ids`. The store operation is safe to retry without coordination.
 
-- **OpenClaw:** Use the built-in `llm-task` plugin tool. The skill instructs the agent to
-  invoke `llm-task` with `temperature: 0`, the fact extraction prompt, and a JSON schema
-  for structured output. This runs a separate LLM call that does NOT affect the main
-  conversation's temperature. The `llm-task` tool is JSON-only, no tools exposed — ideal
-  for structured extraction. Must be enabled in OpenClaw config:
-  ```json
-  { "plugins": { "entries": { "llm-task": { "enabled": true } } } }
-  ```
+**Extraction determinism note:** for fingerprint dedup to be effective, the extraction LLM should run with `temperature=0` so the same input produces the same extracted text. In OpenClaw this is enforced via the `llm-task` plugin tool. NanoClaw inherits Agent SDK defaults until the SDK exposes temperature (open issue: anthropics/claude-agent-sdk-python#273); duplicates that slip through are a storage cost, not a correctness issue.
 
-- **NanoClaw:** The Claude Agent SDK does not currently expose `temperature` as a parameter
-  (open issue: anthropics/claude-agent-sdk-python#273, 20+ upvotes). Do NOT implement a
-  workaround that bypasses the Agent SDK. Revisit when the Agent SDK adds native temperature
-  support — expected to land given community demand. Until then, NanoClaw extraction uses
-  the SDK default temperature, which reduces fingerprint dedup effectiveness but does not
-  break it (duplicates that slip through are a storage cost, not a correctness issue).
+### Multi-agent sync (sequence_id watermark)
 
-**Privacy:** The server sees the fingerprint but cannot reverse it without the dedup key.
-The fingerprint reveals only one bit per fact pair: "same content or not." This is strictly
-less information than blind indices already reveal (approximate similarity). See TS v0.3.2
-§9 for full privacy analysis.
-
-#### Server-Side Dedup Check (in `/store` handler)
-
-```
-POST /store receives StoreRequest with facts[]:
-
-FOR EACH fact in request:
-  1. Check: SELECT id FROM facts
-            WHERE user_id = $uid AND content_fp = $fp AND is_active = true;
-
-  2. IF found:
-       Skip this fact. Add existing fact ID to response.duplicate_ids[].
-       Do NOT return an error — continue processing remaining facts.
-
-  3. IF not found:
-       Insert fact normally. Assign sequence_id. Add to response.ids[].
-
-Return StoreResponse with:
-  success = true (partial success is still success)
-  ids = [newly stored fact IDs]
-  duplicate_ids = [skipped fact IDs that already existed]
-```
-
-**Behavior:** Duplicates are silently skipped, not hard-rejected. The client knows which
-facts were skipped via `duplicate_ids` and can proceed without retry logic. This makes the
-store operation **idempotent** — pushing the same facts twice is safe.
-
-#### Sync Endpoint (for Agent Reconnection)
-
-```
-GET /sync?since_sequence={seq}&limit=1000
-
-Returns all facts for the authenticated user with sequence_id > since_sequence.
-Used by agents after coming online to pull changes made by other agents.
-
-Response: SyncResponse {
-  facts: [...],           // facts since the given sequence
-  latest_sequence: 4721,  // current highest sequence_id
-  has_more: false         // true if more facts beyond limit (paginate)
-}
-```
-
-The agent stores `latest_sequence` locally and uses it on the next reconnection.
-
-#### Client Reconnection Protocol
+`/sync?since_sequence={seq}` returns facts with `sequence_id > seq`. Architecturally this lets multiple agents (e.g. OpenClaw on desktop + Hermes on a VPS, both paired with the same mnemonic) reconcile after one of them was offline:
 
 ```
 1. Agent comes online.
-2. GET /sync?since_sequence={last_known_sequence}
-3. Build set of server fingerprints: { content_fp → fact_id }
-4. For each local pending fact:
-   a. IF content_fp already in server set → skip (already stored)
-   b. ELSE → POST /store (server will also check, but pre-filtering avoids round trips)
+2. GET /sync?since_sequence={last_known}.
+3. Build server fingerprint set: { content_fp → fact_id }.
+4. For each pending local fact:
+     if content_fp in server set → skip.
+     else → POST /store.
 5. Update local last_known_sequence.
 ```
 
-> **For advanced conflict resolution** (semantic near-duplicates, contradictions, LLM-assisted
-> merge), see TS v0.3.2: Multi-Agent Conflict Resolution.
+The store operation is also idempotent server-side (§7 above), so step 4's pre-filter is an optimization, not a correctness requirement.
+
+### Beyond exact dedup
+
+Semantic near-duplicates ("prefers Python" vs "likes Python over JS"), stale contradictions ("lives in Lisbon" vs "moved to Berlin"), and LLM-assisted merging are **client-side** concerns by design — the relay can't see plaintext, so it can't do semantic comparison. See `conflict-resolution.md` for the multi-layer client pipeline.
 
 ---
 
-## 9. Search Implementation
+## 8. Database schema (architectural)
 
-### Query Flow
+The relay uses PostgreSQL. Architecturally, there are four tables; their existence is part of the spec, their column-by-column shapes evolve in the codebase.
+
+| Table | Purpose | Key invariants |
+|---|---|---|
+| `users` | One row per registered identity | Stores `SHA256(authKey)` + salt only. No phrase, no encryption material. Never deleted (would break recovery). |
+| `facts` | Mutable view of active claims | GIN index on `blind_indices` powers retrieval. Unique `(user_id, content_fp) WHERE is_active` enforces exact dedup at the DB level. Monotonic `sequence_id` per user powers `/sync`. |
+| `raw_events` | Immutable append-only log of `StoreRequest` payloads | Audit + debugging. Re-derivable view if `facts` corrupts. |
+| `tombstones` | Soft-delete records | 30-day retention; lets sync resolve "this was deleted, don't re-add" across agents. |
+
+The canonical DDL (column types, indices, migrations) lives in `totalreclaw-relay/db/`. This doc only fixes the architectural shape.
+
+---
+
+## 9. Search semantics
+
 ```sql
--- Blind index lookup using GIN array contains operator
 SELECT id, encrypted_blob, decay_score
 FROM facts
 WHERE user_id = ?
   AND is_active = true
   AND decay_score >= ?
-  AND blind_indices && ARRAY[?]::text[]  -- GIN index
+  AND blind_indices && ARRAY[?]::text[]   -- GIN index
 ORDER BY decay_score DESC
 LIMIT ?;
 ```
 
-### Performance Target
-- <50ms for 100K facts with GIN index
-- Client-side reranking handles the rest
+The relay's job ends at "return matching ciphertext." Reranking — BM25, cosine, decay, importance, RRF, source-weighting (Tier 1) — is **client-side**, in `totalreclaw-core::reranker`. See [`retrieval-v2.md`](./retrieval-v2.md).
+
+**Performance envelope:** GIN-indexed lookup over 100K facts target < 50 ms. End-to-end search latency target < 150 ms p95 (client + relay + reranking). LSH parameters and candidate-pool sizing live in [`lsh-tuning.md`](./lsh-tuning.md) — they're tunable knobs, not architectural commitments.
 
 ---
 
-## 10. Security Considerations
+## 10. Pair-flow brokering
 
-### Server-Side Protections
-
-| Threat | Mitigation |
-|--------|------------|
-| Brute force auth | Rate limiting (post-PoC) |
-| DB leak | auth_key_hash + salt only, no passwords |
-| Replay attacks | Include timestamp in future versions |
-| MITM | HTTPS in production (localhost for PoC) |
-
-### Client Responsibilities
-
-| Threat | Mitigation |
-|--------|------------|
-| Weak password | Enforce minimum entropy check |
-| Password reuse | Warn user (can't detect server-side) |
-| Key exfiltration | OS keychain storage |
-
-### E2EE Guarantee
-- Server stores: `auth_key_hash`, `salt`, `encrypted_blob`, `blind_indices`
-- Server NEVER sees: `master_password`, `encryption_key`, `plaintext`
-
----
-
-## 11. Implementation Order
-
-| Day | Tasks |
-|-----|-------|
-| 1 | Protobuf schema + codegen, DB schema + migrations |
-| 2 | /register, /health endpoints, auth middleware |
-| 3 | /store, /search endpoints with GIN queries |
-| 4 | /update, /delete, version conflict handling |
-| 5 | Integration tests, Docker Compose |
-
----
-
-## 12. Deliverables
+The relay is a transport, not a participant, in the onboarding handshake.
 
 ```
-server/
-├── proto/
-│   └── totalreclaw.proto
-├── src/
-│   ├── main.py (or index.ts)
-│   ├── auth.py
-│   ├── handlers/
-│   │   ├── register.py
-│   │   ├── store.py
-│   │   └── search.py
-│   └── db/
-│       ├── schema.sql
-│       └── queries.py
-├── tests/
-│   ├── test_auth.py
-│   ├── test_store.py
-│   └── test_search.py
-├── Dockerfile
-├── docker-compose.yml
-└── README.md
+1. Browser tab opens pair-init WebSocket → relay assigns ephemeral nonce.
+2. Client (OpenClaw / Hermes / MCP) opens pair-claim WebSocket with the same nonce
+   and sends its ephemeral ECDH pubkey.
+3. Relay forwards client's pubkey to browser tab.
+4. Browser AES-256-GCM-encrypts the paired_phrase to client's pubkey,
+   sends ciphertext through relay.
+5. Relay forwards ciphertext to client.
+6. Client decrypts with its ECDH session key, derives all keys from the mnemonic,
+   never echoes the phrase back.
+7. Pair session closes; relay drops all session state.
 ```
+
+**Architectural invariants:**
+
+- The relay holds no key. The ECDH session key exists only in the two endpoints.
+- AES-GCM is the right primitive here (short-lived session, native WebCrypto, fresh key per session) — distinct from XChaCha20-Poly1305 used for long-term storage. See [`architecture.md`](./architecture.md) §3.
+- The phrase never crosses an LLM context. The browser is the only place it lives in plaintext.
+
+The pair handshake landed in relay rc.10+; AES-GCM payload encryption shipped client-side in rc.12+.
 
 ---
 
-## 13. Docker Compose (PoC)
+## 11. ERC-4337 bundler shim
 
-```yaml
-version: '3.9'
-services:
-  totalreclaw-server:
-    build: .
-    container_name: totalreclaw-poc
-    environment:
-      DATABASE_URL: postgresql://totalreclaw:dev@postgres:5432/totalreclaw
-    ports:
-      - "127.0.0.1:8080:8080"  # localhost ONLY
-    depends_on:
-      - postgres
-    restart: unless-stopped
+The relay forwards signed UserOps to an ERC-4337 bundler so clients don't have to run one. Architecturally this is a transport convenience — the signature is generated client-side from the secp256k1 key derived from the mnemonic; the relay cannot forge it.
 
-  postgres:
-    image: postgres:16
-    container_name: totalreclaw-db
-    environment:
-      POSTGRES_USER: totalreclaw
-      POSTGRES_PASSWORD: dev  # Change in production
-      POSTGRES_DB: totalreclaw
-    volumes:
-      - totalreclaw-data:/var/lib/postgresql/data
-    ports:
-      - "127.0.0.1:5432:5432"  # localhost ONLY
-    restart: unless-stopped
+The paymaster sponsors gas (free for users on both Free and Pro tiers). The chain selection — Base Sepolia for Free, Gnosis mainnet for Pro — is part of the UserOp; the relay does not choose it.
 
-volumes:
-  totalreclaw-data:
-```
-
-**Security Notes:**
-- All ports bound to 127.0.0.1 (localhost only)
-- Default password MUST be changed for any non-PoC use
-- No external network access required
+For chain choice rationale, paymaster topology, and the contract surface (`EventfulDataEdge`), see [`architecture.md`](./architecture.md) §5 ("Storage tiers") and the on-chain repo.
 
 ---
 
-## 14. Deferred to MVP Phase
+## 12. Subgraph integration
 
-These items are **out of scope for PoC** but **required before MVP launch**.
+The subgraph (The Graph, AssemblyScript indexer) sits **off** the relay's critical path. Writes go: client → relay → bundler → chain → subgraph indexer (5–30 s lag).
 
-### 14.1 LSH Runtime Re-indexing
+The relay does not query the subgraph. Clients do. As of `totalreclaw-core` rc.22+, a read-after-write primitive in `core` polls the subgraph until the just-written sequence is visible — this absorbs the indexer lag for callers without involving the relay.
 
-**Reference:** `TS v0.3: E2EE with LSH + Blind Buckets.md` §530-587
+Recovery from device loss does not touch the relay at all: mnemonic → subgraph → ciphertext → decrypt locally. This is the failure mode the architecture is designed for.
 
-When LSH parameters (`n_bits`, `n_tables`) need to change (rare, only at 500K+ corpus size):
+---
 
-| Aspect | Detail |
-|--------|--------|
-| **Trigger** | Admin `POST /admin/lsh-reindex` with new params |
-| **Downtime** | Per-user, not global |
-| **Client requirement** | Must have recovery phrase (cannot re-index server-side) |
-| **Process** | Client-side: decrypt → recompute LSH → re-encrypt → re-upload |
-| **APIs needed** | `GET /lsh-config`, `POST /admin/lsh-reindex`, `GET /lsh-reindex/status` |
+## 13. Operational expectations
 
-**Note:** `candidate_pool` is dynamic and auto-adjusts based on corpus size (no re-index needed).
+The relay is single-tenant per deployment in PoC and small-scale, multi-tenant per `user_id` in staging/production. It is **stateless** in the sense that all durable state is in PostgreSQL — restarts are safe, horizontal scaling is bounded by DB writes.
 
-### 14.2 Conflict Resolution Enhancement
+| Concern | Approach |
+|---|---|
+| Rate limiting | Per-endpoint per-user (auth-keyed) sliding windows; protects against scraping but cannot prevent legitimate-looking traffic from a stolen `authKey` |
+| Replay protection | Timestamp + sequence-id checks on signed payloads; bearer auth alone is not a replay defense |
+| MITM | HTTPS everywhere; auth happens over TLS, never plain HTTP |
+| DB leak | Recovers ciphertext + trapdoors + sequenced fingerprints; no plaintext, no keys |
+| Relay compromise | Same blast radius as DB leak — the relay does not hold keys, so compromise yields ciphertext only |
 
-**Current state (§8):** Optimistic locking + content fingerprint dedup (v0.3.1b)
+Concrete thresholds, deploy topology, monitoring dashboards, and runbooks live in the relay repo. They evolve faster than this spec.
 
-**What v0.3.1b covers:**
-- Exact duplicate prevention via content fingerprint (HMAC-SHA256)
-- Delta sync via sequence_id watermark
-- Idempotent store operations (safe to retry)
-- Agent crash recovery (re-push is safe)
+---
 
-**What remains for post-MVP (see TS v0.3.2 for full specification):**
+## 14. Out of scope for this doc
 
-| Gap | Description | Priority | TS v0.3.2 Layer |
-|-----|-------------|----------|-----------------|
-| Semantic near-duplicate detection | "prefers Python" vs "likes Python over JS" | MEDIUM | Layer 3 (blind index overlap) |
-| Stale contradiction resolution | "lives in Lisbon" vs "moved to Berlin" | MEDIUM | Layer 4 (client reconciliation) |
-| LLM-assisted merge | Prompt, model, fallback for merging conflicting facts | MEDIUM | Layer 4 |
-| Import conflicts | How to handle duplicates during bulk import | LOW | Layer 1 (fingerprint covers exact) |
-| Namespace collisions | Same namespace on different servers | LOW | Out of scope |
+- Memory claim schema → [`memory-taxonomy-v1.md`](./memory-taxonomy-v1.md)
+- Reranker behavior → [`retrieval-v2.md`](./retrieval-v2.md)
+- Trust split, key model, install model, on-chain layer → [`architecture.md`](./architecture.md)
+- Step-by-step user flows → [`flows/README.md`](./flows/README.md)
+- Conflict resolution beyond `content_fp` dedup → `conflict-resolution.md`
+- LSH parameter tuning → [`lsh-tuning.md`](./lsh-tuning.md)
+- MCP-specific client surface → [`mcp-server.md`](./mcp-server.md)
 
-**Recommended phasing:**
-1. **MVP (this spec):** Content fingerprint dedup + sync endpoint — catches ~70% of duplicates
-2. **Post-MVP:** Blind index overlap detection (TS v0.3.2 Layer 3) — catches semantic near-dupes
-3. **Post-MVP:** Client-side LLM merge (TS v0.3.2 Layer 4) — handles contradictions
+If a change to the relay would alter what the relay can see, what it stores, or how it interacts with the chain or the pair flow — update this doc. If it just adjusts a constant, an index, or a column type — update the codebase or the tunable spec.
 
-### 14.3 MVP Checklist
+---
 
-Before launching MVP:
+## See also
 
-- [ ] Implement `POST /admin/lsh-reindex` endpoint
-- [ ] Implement `GET /lsh-reindex/status` endpoint
-- [ ] Add per-user `lsh_config` table
-- [x] Content fingerprint dedup in `/store` handler (v0.3.1b §8.2)
-- [x] `GET /sync` endpoint for delta reconciliation (v0.3.1b §8.2)
-- [x] `DUPLICATE_CONTENT` error code (v0.3.1b §3)
-- [ ] Client-side sync protocol implementation
-- [ ] Test multi-agent dedup scenarios (crash recovery, shared context)
+- [`architecture.md`](./architecture.md) — system architecture (sibling)
+- [`memory-taxonomy-v1.md`](./memory-taxonomy-v1.md) — claim schema (canonical)
+- [`retrieval-v2.md`](./retrieval-v2.md) — reranker (canonical)
+- [`flows/README.md`](./flows/README.md) — flow walkthroughs
+- [`conflict-resolution.md`](./conflict-resolution.md) — semantic conflict handling
+- [`lsh-tuning.md`](./lsh-tuning.md) — LSH parameter tuning
+- [`mcp-server.md`](./mcp-server.md) — MCP-specific surface


### PR DESCRIPTION
- architecture.md: v0.3→v1 (595→306 lines)
- server.md: v0.3.1b→v1 (700→335 lines)
- Updated diagrams: trust-split, HKDF key derivation, write/read paths, pair-flow handshake
- Cross-links to memory-taxonomy-v1.md + retrieval-v2.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)