### PR TITLE
[SECURITY] mcp-server@3.2.1 — remove totalreclaw_setup phrase leak

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,38 @@ jobs:
     # isn't paired with a safety qualifier ("NEVER display", "do not
     # show", etc) on the same line.
     #
-    # See: scripts/check-phrase-safety.sh + tests/phrase-safety/.
+    # The dist scan (added 2026-04-26 with the @totalreclaw/mcp-server@3.2.1
+    # SECURITY hotfix) is the source-code companion: it scans the COMPILED
+    # JavaScript shipped to npm for any tool-response payload that emits
+    # `recovery_phrase` or `mnemonic` as an object key. The deleted
+    # `totalreclaw_setup` MCP tool used to do exactly that.
+    #
+    # See: scripts/check-phrase-safety.sh + scripts/check-phrase-safety-dist.sh
+    # + tests/phrase-safety/.
     name: Phrase Safety
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run phrase-safety guard
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: 'v0.14.0'
+      - name: Build @totalreclaw/core (WASM) [transitional]
+        run: |
+          cd rust/totalreclaw-core
+          wasm-pack build --target nodejs --out-dir pkg --features wasm
+          node -e "const p=require('./pkg/package.json'); p.name='@totalreclaw/core'; require('fs').writeFileSync('./pkg/package.json', JSON.stringify(p,null,2)+'\n')"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Run phrase-safety guard (markdown / SKILL.md)
         run: bash scripts/check-phrase-safety.sh
       - name: Run phrase-safety regression suite
         run: bash tests/phrase-safety/run-regression.sh
+      - name: Build mcp/dist (required for dist scan)
+        run: cd mcp && rm -f package-lock.json && npm install --legacy-peer-deps && npm run build
+      - name: Run phrase-safety dist scan (compiled JS payloads)
+        run: bash scripts/check-phrase-safety-dist.sh
 
   client-tests:
     name: Client Tests (TypeScript)

--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [3.2.1] - 2026-04-26
+
+### Security
+- **[SECURITY] Removed `totalreclaw_setup` tool**; users should follow the URL-driven install flow per [`docs/guides/claude-code-setup.md`](../docs/guides/claude-code-setup.md). Onboarding now sources the recovery phrase out-of-band (OpenClaw / Hermes browser pair flow, an offline BIP-39 generator, or a prior `~/.totalreclaw/credentials.json` cache) and the user pastes it directly into `TOTALRECLAW_RECOVERY_PHRASE` in the MCP host config. The agent never sees the phrase.
+- Stale tool catalogs that still call the old name receive a structured `tool_removed` error pointing at the canonical install guide.
+- Server `SERVER_INSTRUCTIONS` rewritten to the new phrase-safety stance (no in-chat setup, never echo / print / summarize the phrase, never invoke phrase-touching CLIs via a shell tool).
+- Added `tests/phrase-safety-dist.test.ts` — a regression scan over compiled `dist/` JS that fails if any source code emits a phrase string in a response-payload-shaped JSON object.
+- Added repo-level companion to the existing markdown-only phrase-safety guard at `scripts/check-phrase-safety.sh`: new `scripts/check-phrase-safety-dist.sh` scans compiled MCP `dist/` JS for source-emitted phrase keys in tool responses.
+
+### Notes / Compatibility
+- Patch-version bump (3.2.0 -> 3.2.1). No breaking change for end-users — the MCP onboarding path was already documented as URL-driven in `docs/guides/claude-code-setup.md` (which explicitly forbids the deleted tool). Hosts that retained a stale `totalreclaw_setup` reference get a structured error with a link to the install guide.
+
 ## [3.2.0] - 2026-04-19
 
 ### Added

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -141,7 +141,8 @@ All 19 tools are invoked by the host agent from natural language context. Tool s
 | `totalreclaw_migrate` | Migrate testnet memories to mainnet after Pro upgrade |
 | `totalreclaw_account` | View account details (wallet, tier, quota, phrase hint) |
 | `totalreclaw_support` | Troubleshooting help + contact links |
-| `totalreclaw_setup` | Generate or import a recovery phrase (first-run flow) |
+
+> **Onboarding (recovery phrase):** the `totalreclaw_setup` tool was removed in 3.2.1 for phrase-safety. Onboarding follows the URL-driven flow at [`docs/guides/claude-code-setup.md`](../docs/guides/claude-code-setup.md): the user sources their phrase out-of-band (OpenClaw / Hermes browser pair flow, offline BIP-39 generator, or a prior `~/.totalreclaw/credentials.json` cache) and pastes it into `TOTALRECLAW_RECOVERY_PHRASE` in the MCP host config. The agent never sees the phrase.
 
 Users invoke the new v1 tools naturally: *"pin that"*, *"that was actually a rule, not a preference"*, *"file that under work"*. Tool descriptions teach the host LLM to match utterances to tools.
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/mcp-server",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. MCP server with XChaCha20-Poly1305 E2EE, semantic search, import/export, and on-chain storage",
   "homepage": "https://totalreclaw.xyz",
   "main": "dist/index.js",

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1814,147 +1814,16 @@ function quotaExceededResponse(): { content: Array<{ type: string; text: string 
   };
 }
 
-// ── Setup tool (unconfigured mode) ──────────────────────────────────────────
-
-const setupToolDefinition = {
-  name: 'totalreclaw_setup',
-  description: 'Set up TotalReclaw for first-time use. Generate a new recovery phrase or import an existing one.',
-  inputSchema: {
-    type: 'object' as const,
-    properties: {
-      action: {
-        type: 'string',
-        enum: ['generate', 'import'],
-        description: 'Whether to generate a new recovery phrase or import an existing one',
-      },
-      recovery_phrase: {
-        type: 'string',
-        description: 'Your existing 12-word BIP-39 recovery phrase (only for action="import")',
-      },
-    },
-    required: ['action'],
-  },
-};
-
-async function handleSetup(
-  args: unknown,
-): Promise<{ content: Array<{ type: string; text: string }> }> {
-  const input = args as Record<string, unknown>;
-  const action = input?.action as string;
-
-  if (action !== 'generate' && action !== 'import') {
-    return {
-      content: [{ type: 'text', text: JSON.stringify({
-        success: false,
-        error: 'Invalid action. Use "generate" for a new identity or "import" to restore an existing one.',
-      })}],
-    };
-  }
-
-  let mnemonic: string;
-
-  if (action === 'import') {
-    const phrase = (input?.recovery_phrase as string || '').trim();
-    const words = phrase.split(/\s+/);
-    const allWordsValid = words.length === 12 && words.every(w => wordlist.includes(w));
-    if (!phrase || (!validateMnemonic(phrase, wordlist) && !allWordsValid)) {
-      return {
-        content: [{ type: 'text', text: JSON.stringify({
-          success: false,
-          error: 'Invalid recovery phrase. Must be 12 words from the BIP-39 English wordlist.',
-        })}],
-      };
-    }
-    if (!validateMnemonic(phrase, wordlist)) {
-      console.error('Warning: recovery phrase has valid words but invalid BIP-39 checksum. Accepting anyway.');
-    }
-    mnemonic = phrase;
-  } else {
-    mnemonic = generateMnemonic(wordlist, 128);
-  }
-
-  // Derive keys
-  const { authKeyHex, saltHex } = deriveAuthKey(mnemonic);
-  const authKeyHash = computeSetupAuthKeyHash(authKeyHex);
-
-  // Register with relay
-  const serverUrl = SERVER_URL;
-  let userId: string;
-  try {
-    userId = await registerWithServer(serverUrl, authKeyHash, saltHex);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    return {
-      content: [{ type: 'text', text: JSON.stringify({
-        success: false,
-        error: `Registration failed: ${message}. Check your internet connection.`,
-      })}],
-    };
-  }
-
-  // Save credentials (including mnemonic)
-  const credDir = path.dirname(CREDENTIALS_PATH);
-  fs.mkdirSync(credDir, { recursive: true });
-  const credentials: SavedCredentials = {
-    userId,
-    salt: saltHex,
-    serverUrl,
-    mnemonic,
-  };
-  fs.writeFileSync(CREDENTIALS_PATH, JSON.stringify(credentials, null, 2), {
-    encoding: 'utf-8',
-    mode: 0o600,
-  });
-
-  // Pre-download embedding model
-  console.error('Downloading embedding model (one-time, ~600MB)...');
-  try {
-    await generateEmbedding('warmup');
-    console.error('Embedding model ready.');
-  } catch (err) {
-    console.error(`Warning: Could not pre-download embedding model: ${err instanceof Error ? err.message : String(err)}`);
-  }
-
-  // Hot-reload server state
-  try {
-    subgraphState = await initSubgraphState(mnemonic);
-    currentMode = 'subgraph';
-    console.error(`TotalReclaw configured (managed service, owner: ${subgraphState.smartAccountAddress})`);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    return {
-      content: [{ type: 'text', text: JSON.stringify({
-        success: true,
-        warning: `Setup saved but initialization failed: ${message}. Restart the MCP server.`,
-        recovery_phrase: action === 'generate' ? mnemonic : undefined,
-        user_id: userId,
-      })}],
-    };
-  }
-
-  const result: Record<string, unknown> = {
-    success: true,
-    user_id: userId,
-    mode: 'managed_service',
-    smart_account: subgraphState.smartAccountAddress,
-    tier: 'free',
-    tier_info: 'Free tier: unlimited memories and reads (test network — memories may be reset). Upgrade to Pro for permanent on-chain storage. Pricing: https://totalreclaw.xyz/pricing — upgrade anytime via totalreclaw_upgrade.',
-  };
-
-  if (action === 'generate') {
-    result.recovery_phrase = mnemonic;
-    result.recovery_phrase_warning =
-      'CRITICAL: Write down this recovery phrase and store it securely. ' +
-      'It is your ONLY identity in TotalReclaw. If you lose it, ALL your memories are lost forever. ' +
-      'There is NO password reset, NO recovery, NO support that can help.';
-  } else {
-    result.message = 'Identity restored. Your existing memories are now accessible.';
-  }
-
-  return {
-    content: [{ type: 'text', text: JSON.stringify(result) }],
-  };
-}
+// ── Setup tool — REMOVED in 3.2.1 (security: phrase-safety) ─────────────────
+// The `totalreclaw_setup` MCP tool was removed because its response payload
+// returned the BIP-39 mnemonic via the `recovery_phrase` field, which crossed
+// the LLM's context window every time an agent invoked the tool. That violated
+// the phrase-safety invariant ("the recovery phrase MUST NEVER cross the LLM
+// context"). MCP onboarding now follows the URL-driven flow documented at
+// `docs/guides/claude-code-setup.md` — agents direct users to source their
+// phrase from the OpenClaw / Hermes browser pair flow (or an offline BIP-39
+// generator) and paste it into the MCP host config themselves. No tool path
+// exists for the agent to ever see the phrase.
 
 // ── Layer 1: Server with instructions ────────────────────────────────────────
 
@@ -1998,7 +1867,6 @@ function getClientIdentifier(): string {
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [
-    setupToolDefinition,
     rememberToolDefinition,
     recallToolDefinition,
     forgetToolDefinition,
@@ -2023,9 +1891,28 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
 
-  // Handle setup tool (available in all modes)
+  // `totalreclaw_setup` was removed in 3.2.1 (security: phrase-safety).
+  // Onboarding now follows the URL-driven flow at
+  // `docs/guides/claude-code-setup.md`. If a stale agent / host catalog
+  // still calls the old tool name, return a structured error pointing at
+  // the canonical install guide — without surfacing any phrase in payload.
   if (name === 'totalreclaw_setup') {
-    return await handleSetup(args);
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          error: 'tool_removed',
+          message:
+            'The totalreclaw_setup tool was removed in @totalreclaw/mcp-server@3.2.1 ' +
+            'for phrase-safety. Follow the URL-driven install flow at ' +
+            'https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/claude-code-setup.md. ' +
+            'The user sources their recovery phrase out-of-band (OpenClaw or Hermes ' +
+            'browser pair flow, or an offline BIP-39 generator) and pastes it directly ' +
+            'into TOTALRECLAW_RECOVERY_PHRASE in the MCP host config — never into chat.',
+        }),
+      }],
+      isError: true,
+    };
   }
 
   // Handle support tool (available in all modes, including unconfigured)
@@ -2034,14 +1921,19 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     return handleSupport(walletAddress);
   }
 
-  // In unconfigured mode, all other tools return setup guidance
+  // In unconfigured mode, all other tools return setup guidance pointing at
+  // the URL-driven install flow (NOT the deleted totalreclaw_setup tool).
   if (currentMode === 'unconfigured') {
     return {
       content: [{
         type: 'text',
         text: JSON.stringify({
           error: 'not_configured',
-          message: 'TotalReclaw is not configured yet. Ask the user if they have an existing recovery phrase or want to generate a new one, then use the totalreclaw_setup tool.',
+          message:
+            'TotalReclaw is not configured yet. Follow the URL-driven install flow ' +
+            'at https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/claude-code-setup.md — ' +
+            'the user pastes their recovery phrase directly into the MCP host config (TOTALRECLAW_RECOVERY_PHRASE), ' +
+            'never into chat.',
         }),
       }],
       isError: true,
@@ -2490,7 +2382,7 @@ async function main(): Promise<void> {
   } else if (currentMode === 'http') {
     console.error('TotalReclaw MCP server started (self-hosted mode)');
   } else {
-    console.error('TotalReclaw MCP server started (unconfigured — use totalreclaw_setup tool)');
+    console.error('TotalReclaw MCP server started (unconfigured — set TOTALRECLAW_RECOVERY_PHRASE in the MCP host config; see docs/guides/claude-code-setup.md)');
   }
 
   const transport = new StdioServerTransport();

--- a/mcp/src/prompts.ts
+++ b/mcp/src/prompts.ts
@@ -6,14 +6,10 @@ export const SERVER_INSTRUCTIONS = `
 You have access to TotalReclaw, a persistent encrypted memory system. You SHOULD use these tools PROACTIVELY -- do not wait for the user to say "remember this" or "recall that."
 
 ## CRITICAL SAFETY: Recovery Phrase
-TotalReclaw uses a 12-word BIP-39 recovery phrase as the user's identity. If a user tries to import a phrase they already use for a CRYPTO WALLET, you MUST warn them: "Do NOT use a recovery phrase from an existing crypto wallet. TotalReclaw should have its own dedicated phrase to keep your funds safe." Always generate a fresh phrase for new users.
+TotalReclaw uses a 12-word BIP-39 recovery phrase as the user's identity. The recovery phrase MUST NEVER cross your context window. NEVER ask the user to paste their phrase into chat. NEVER echo, print, or summarize a phrase. NEVER invoke a phrase-touching CLI (e.g. "npx @totalreclaw/mcp-server setup", "npx @totalreclaw/mcp-server show-phrase") via a shell tool — its stdout enters your context. If the user pastes a phrase in chat anyway, tell them it is compromised and they need to generate a fresh wallet via the OpenClaw or Hermes browser pair flow.
 
 ## Setup Flow
-If any TotalReclaw tool returns a "not_configured" error, the user needs to set up TotalReclaw first. Use the totalreclaw_setup tool:
-1. Ask the user: "Do you have an existing TotalReclaw recovery phrase you'd like to restore, or should I generate a new one?"
-2. If new: call totalreclaw_setup with action="generate". Display the recovery phrase prominently and warn them to save it securely.
-3. If existing: ask for their 12-word recovery phrase, then call totalreclaw_setup with action="import" and recovery_phrase="their phrase".
-After setup completes, all TotalReclaw tools work immediately — no restart needed.
+If any TotalReclaw tool returns a "not_configured" or "tool_removed" error, the user has not yet wired their recovery phrase into the MCP host config. Direct them to the URL-driven install guide at https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/claude-code-setup.md. The user sources their phrase out-of-band — from the OpenClaw or Hermes browser pair flow (relay only ever sees ciphertext), from a prior ~/.totalreclaw/credentials.json cache, or from an offline BIP-39 generator — and pastes it directly into TOTALRECLAW_RECOVERY_PHRASE in the MCP host config (Claude Desktop / Cursor / Windsurf / Claude Code). After they save the config and restart the host, the MCP server picks up the phrase and all TotalReclaw tools become available. There is no in-chat setup tool: the totalreclaw_setup MCP tool was removed in 3.2.1 because returning the phrase through tool output crossed your context, violating phrase-safety.
 
 ## CRITICAL: Automatic Memory Behaviors
 

--- a/mcp/tests/phrase-safety-dist.test.ts
+++ b/mcp/tests/phrase-safety-dist.test.ts
@@ -1,0 +1,213 @@
+/**
+ * @jest-environment node
+ *
+ * phrase-safety-dist.test.ts
+ *
+ * Regression guard for the 3.2.1 SECURITY hotfix that removed the
+ * `totalreclaw_setup` MCP tool. The deleted tool used to return the
+ * 12-word BIP-39 recovery phrase via a `recovery_phrase` field in its
+ * tool response — which crossed the LLM context every time an agent
+ * invoked it. That violated the phrase-safety invariant
+ * ("the recovery phrase MUST NEVER cross the LLM context").
+ *
+ * This test scans the COMPILED `dist/` JavaScript (not the TypeScript
+ * source) for any string literal that looks like an MCP-tool response
+ * emitting `recovery_phrase` or `mnemonic` as an OBJECT KEY. Source
+ * lines that merely reference the literal (e.g. "Set
+ * TOTALRECLAW_RECOVERY_PHRASE in your config" instructional copy) are
+ * ignored — we only care about response-payload-shaped emissions
+ * (`recovery_phrase:` / `"recovery_phrase":` / `result.recovery_phrase = ...`
+ * / `mnemonic:` as a key inside a tool-handler return).
+ *
+ * The test FAILS if any such emission is found in `mcp/dist/`. Run via
+ * `npm test` after `npm run build`. The build step is what the
+ * `mcp-tests` CI job in `.github/workflows/ci.yml` already executes
+ * (`npm run build && npm test`), so this catches regressions at PR
+ * time.
+ *
+ * Important: this test does NOT scan reads of the file at
+ * `~/.totalreclaw/credentials.json` (where the `mnemonic` key is the
+ * persisted credential format and reading it on disk is not a phrase-
+ * safety violation). It only flags lines that emit `mnemonic` /
+ * `recovery_phrase` as a property of an object built into a tool
+ * response or other LLM-visible payload.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Patterns: an emission is a line that builds a JSON-shaped tool response
+// with `recovery_phrase` or `mnemonic` as a key. The dist/ output of TS is
+// JavaScript, so we look for both object-literal shape (`key: value`,
+// `"key": value`) and assignment shape (`obj.key = ...`) that target
+// fields likely to be returned in a tool result payload.
+// ---------------------------------------------------------------------------
+
+interface PhrasePattern {
+  name: string;
+  // Match the pattern in compiled JS. Must be JS-shape, not TS-shape.
+  regex: RegExp;
+  // A regex of ALLOWED contexts on the same line — if the matched line
+  // contains an allow pattern, the match is skipped. Used to whitelist
+  // legitimate persistence reads / writes (e.g. credentials.json) and
+  // non-payload utility code paths.
+  allowedContext?: RegExp;
+}
+
+const FORBIDDEN_PATTERNS: PhrasePattern[] = [
+  // Plain JS object key: `recovery_phrase: <expr>` (used in JSON.stringify
+  // of a tool response). The deleted handler had two such emissions.
+  {
+    name: 'recovery_phrase as JS object key (unquoted)',
+    regex: /\brecovery_phrase\s*:/,
+    // The setup-CLI's saved-credentials migration helper persists to
+    // disk only — it never returns the phrase to a tool caller. Allow
+    // lines that ALSO mention writeFileSync / credentials.json / disk-
+    // facing context AND don't build a tool-response object.
+    allowedContext:
+      /credentials\.json|writeFileSync|readFileSync|CREDENTIALS_PATH|description|inputSchema|process\.env|TOTALRECLAW_RECOVERY_PHRASE/i,
+  },
+  // Quoted JS object key: `"recovery_phrase": <expr>`.
+  {
+    name: 'recovery_phrase as JS object key (quoted)',
+    regex: /"recovery_phrase"\s*:/,
+    allowedContext:
+      /credentials\.json|writeFileSync|readFileSync|CREDENTIALS_PATH|description|inputSchema|process\.env|TOTALRECLAW_RECOVERY_PHRASE/i,
+  },
+  // Property assignment: `<obj>.recovery_phrase = ...`. The deleted
+  // handler had `result.recovery_phrase = mnemonic;` exactly here.
+  {
+    name: 'recovery_phrase property assignment',
+    regex: /\.recovery_phrase\s*=/,
+    allowedContext: /\.recovery_phrase\s*=\s*undefined/, // explicit nulling allowed
+  },
+  // mnemonic as a JS object key. The persisted SavedCredentials shape
+  // legitimately uses this key, so we allow lines that ALSO mention
+  // `credentials.json` / `CREDENTIALS_PATH` / disk persistence on the
+  // same line. We're catching mnemonic keys built into tool responses.
+  {
+    name: 'mnemonic as JS object key (unquoted)',
+    regex: /\bmnemonic\s*:/,
+    allowedContext:
+      /credentials\.json|writeFileSync|readFileSync|CREDENTIALS_PATH|SavedCredentials|generateMnemonic|validateMnemonic|mnemonicToAccount|mnemonicToSeedSync|description|inputSchema|process\.env|state\.mnemonic|subgraphState\.mnemonic|trimmed\.mnemonic|parsed\.mnemonic|input\?\.\s*mnemonic|input\.mnemonic|cli\/setup|TOTALRECLAW_RECOVERY_PHRASE/i,
+  },
+  // Quoted JS object key: `"mnemonic": <expr>`.
+  {
+    name: 'mnemonic as JS object key (quoted)',
+    regex: /"mnemonic"\s*:/,
+    allowedContext:
+      /credentials\.json|writeFileSync|readFileSync|CREDENTIALS_PATH|SavedCredentials|generateMnemonic|validateMnemonic|description|inputSchema|process\.env|cli\/setup|TOTALRECLAW_RECOVERY_PHRASE/i,
+  },
+  // Property assignment: `<obj>.mnemonic = ...`. Persisted-credentials
+  // shape legitimately writes this; tool-response shape must not.
+  {
+    name: 'mnemonic property assignment',
+    regex: /\.mnemonic\s*=(?!=)/,
+    allowedContext:
+      /credentials\.mnemonic|SavedCredentials|cli\/setup|writeFileSync|readFileSync|state\.mnemonic|subgraphState\.mnemonic|\.mnemonic\s*=\s*undefined/i,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// File walk: every .js file under mcp/dist/ in scope. We deliberately do not
+// scan source-map (.map) files or .d.ts type declarations.
+// ---------------------------------------------------------------------------
+
+const DIST_DIR = path.resolve(__dirname, '..', 'dist');
+
+function walkJs(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const out: string[] = [];
+  const stack: string[] = [dir];
+  while (stack.length) {
+    const cur = stack.pop()!;
+    const entries = fs.readdirSync(cur, { withFileTypes: true });
+    for (const e of entries) {
+      const full = path.join(cur, e.name);
+      if (e.isDirectory()) {
+        stack.push(full);
+      } else if (e.isFile() && full.endsWith('.js')) {
+        out.push(full);
+      }
+    }
+  }
+  return out.sort();
+}
+
+interface Violation {
+  file: string;
+  line: number;
+  pattern: string;
+  text: string;
+}
+
+function scanFile(file: string): Violation[] {
+  const content = fs.readFileSync(file, 'utf-8');
+  const lines = content.split('\n');
+  const violations: Violation[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Skip pure comment lines — they're not emitted in payloads.
+    const trimmed = line.trim();
+    if (
+      trimmed.startsWith('//') ||
+      trimmed.startsWith('*') ||
+      trimmed.startsWith('/*')
+    ) {
+      continue;
+    }
+    for (const pat of FORBIDDEN_PATTERNS) {
+      if (pat.regex.test(line)) {
+        if (pat.allowedContext && pat.allowedContext.test(line)) {
+          continue;
+        }
+        violations.push({
+          file,
+          line: i + 1,
+          pattern: pat.name,
+          text: line.trim().slice(0, 160),
+        });
+      }
+    }
+  }
+  return violations;
+}
+
+// ---------------------------------------------------------------------------
+// Test
+// ---------------------------------------------------------------------------
+
+describe('phrase-safety: compiled dist/ does not emit phrase strings in response payloads', () => {
+  it('mcp/dist/ exists (build must run before this test)', () => {
+    expect(fs.existsSync(DIST_DIR)).toBe(true);
+  });
+
+  it('no recovery_phrase / mnemonic emission in any compiled JS file', () => {
+    const files = walkJs(DIST_DIR);
+    expect(files.length).toBeGreaterThan(0);
+
+    const allViolations: Violation[] = [];
+    for (const f of files) {
+      allViolations.push(...scanFile(f));
+    }
+
+    if (allViolations.length > 0) {
+      const msg = allViolations
+        .map(
+          (v) =>
+            `  ${path.relative(DIST_DIR, v.file)}:${v.line} [${v.pattern}]\n    ${v.text}`,
+        )
+        .join('\n');
+      throw new Error(
+        `\nPHRASE-SAFETY VIOLATION: ${allViolations.length} occurrence(s) in compiled dist/.\n\n` +
+          `These shapes emit the user's recovery phrase or mnemonic into a JSON-shaped\n` +
+          `tool response — every agent calling such a tool gets the phrase in LLM context.\n` +
+          `Phrase-safety rule: the recovery phrase MUST NEVER cross the LLM context.\n` +
+          `Setup must follow the URL-driven flow at docs/guides/claude-code-setup.md.\n\n` +
+          msg +
+          '\n',
+      );
+    }
+  });
+});

--- a/scripts/check-phrase-safety-dist.sh
+++ b/scripts/check-phrase-safety-dist.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+#
+# check-phrase-safety-dist.sh — companion to check-phrase-safety.sh that
+# scans COMPILED JavaScript / TypeScript dist artifacts for source-emitted
+# recovery-phrase strings inside tool-response payloads.
+#
+# WHY THIS EXISTS
+# ---------------
+# `check-phrase-safety.sh` (the markdown-only guard) catches "display the
+# phrase" copy in human-facing docs / SKILL.md. That's necessary but not
+# sufficient: a separate vector is source code that BUILDS a JSON tool
+# response with `recovery_phrase` (or `mnemonic`) as a key. The MCP server
+# `totalreclaw_setup` tool used to do exactly that — every agent invoking
+# the tool received the user's BIP-39 mnemonic in its LLM context. The
+# 3.2.1 hotfix removed the tool, and this script is the regression guard.
+#
+# WHAT IT SCANS
+# -------------
+# Every `.js` file under each compiled dist/ tree we ship to a registry:
+#   - mcp/dist/                  (npm: @totalreclaw/mcp-server)
+#   - skill/plugin/dist/         (npm: @totalreclaw/totalreclaw)
+#   - skill-nanoclaw/dist/       (npm: @totalreclaw/skill-nanoclaw)
+#   - client/dist/               (npm: @totalreclaw/client)
+#
+# Build outputs are scanned only if they exist (the script does not invoke
+# `npm run build` itself; CI is responsible for ordering).
+#
+# WHAT IT FLAGS
+# -------------
+# Any line that emits `recovery_phrase` or `mnemonic` AS AN OBJECT KEY in
+# the JS — i.e. the shape that JSON.stringify() writes into a tool result
+# payload. Allowed-context filters whitelist legitimate disk persistence
+# (`credentials.json` reads / writes, the `SavedCredentials` shape) and
+# top-level utility code (`generateMnemonic`, `validateMnemonic`,
+# `mnemonicToAccount`, env-var handlers).
+#
+# Comment-only lines and source-map files are skipped.
+#
+# Usage:
+#   scripts/check-phrase-safety-dist.sh                # scan, exits 0/1
+#   PHRASE_SAFETY_DIST_DEBUG=1 scripts/check-phrase-safety-dist.sh
+#                                                      # print every match
+#
+# Exit codes:
+#   0 — clean (no violations)
+#   1 — at least one phrase-emission shape outside the safety whitelist
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Compiled dist trees to scan. We don't scan node_modules (untrusted vendor
+# code) or test fixtures — only OUR shipping artifacts.
+DIST_PATHS=(
+    "mcp/dist"
+    "skill/plugin/dist"
+    "skill-nanoclaw/dist"
+    "client/dist"
+)
+
+# Forbidden emission patterns. Each pattern is an extended-regex matched
+# against ONE line of compiled JS. We look for the JSON-shape "key:" /
+# "key" : / .key = forms — i.e. response-payload shapes.
+#
+# Comment lines and source-map files are stripped before matching (see
+# the awk filter below).
+EMISSION_PATTERNS=(
+    # `recovery_phrase: <expr>` (JS unquoted key in object literal)
+    '\brecovery_phrase[[:space:]]*:'
+    # `"recovery_phrase": <expr>` (JS quoted key)
+    '"recovery_phrase"[[:space:]]*:'
+    # `<obj>.recovery_phrase = <expr>` (assignment to a result object)
+    '\.recovery_phrase[[:space:]]*='
+    # `mnemonic: <expr>` (unquoted key — needs allow-context filter
+    # because legitimate persistence uses this key too)
+    '\bmnemonic[[:space:]]*:'
+    # `"mnemonic": <expr>`
+    '"mnemonic"[[:space:]]*:'
+    # `<obj>.mnemonic = <expr>` (assignment)
+    '\.mnemonic[[:space:]]*=[^=]'
+)
+
+# Allow-context regex: when one of these tokens is present on the SAME
+# line, the line is NOT a tool-response emission and is skipped. This
+# whitelists:
+#   - SavedCredentials shape (disk-persistence object)
+#   - readFileSync / writeFileSync (disk I/O for credentials.json)
+#   - generateMnemonic / validateMnemonic / mnemonicToAccount /
+#     mnemonicToSeedSync (BIP-39 utility entrypoints; not a payload)
+#   - process.env / TOTALRECLAW_RECOVERY_PHRASE (env-var handling, not a
+#     payload — this is how the user injects the phrase)
+#   - subgraphState.mnemonic / state.mnemonic / parsed.mnemonic (in-memory
+#     references that are READING from a stored object, not WRITING the
+#     key into a tool response)
+#   - description / inputSchema (tool schema metadata; the deleted tool's
+#     schema describing `recovery_phrase` as an input is gone, but if any
+#     OTHER tool legitimately documents the key in its description it's
+#     not a payload emission)
+#   - cli/setup (the standalone setup CLI runs in the user's terminal,
+#     not in LLM context — see CLAUDE.md phrase-safety rule)
+#   - explicit `= undefined` (defensive nulling)
+ALLOW_CONTEXT_RE='credentials\.json|writeFileSync|readFileSync|CREDENTIALS_PATH|SavedCredentials|generateMnemonic|validateMnemonic|mnemonicToAccount|mnemonicToSeedSync|process\.env|TOTALRECLAW_RECOVERY_PHRASE|subgraphState\.mnemonic|state\.mnemonic|parsed\.mnemonic|trimmed\.mnemonic|input\?\.\s*mnemonic|input\.mnemonic|description[[:space:]]*:|inputSchema|cli/setup|=[[:space:]]*undefined'
+
+violations=0
+debug="${PHRASE_SAFETY_DIST_DEBUG:-0}"
+
+for dist_dir in "${DIST_PATHS[@]}"; do
+    if [[ ! -d "$dist_dir" ]]; then
+        if [[ "$debug" == "1" ]]; then
+            echo "Skipping $dist_dir (not built)"
+        fi
+        continue
+    fi
+
+    while IFS= read -r jsfile; do
+        for pat in "${EMISSION_PATTERNS[@]}"; do
+            # `grep -nE -H` prints `path:line:matched`. We then strip
+            # comment-only lines and allow-context lines.
+            while IFS= read -r hit; do
+                [[ -n "$hit" ]] || continue
+                # `hit` is `path:line:content`. Extract content for
+                # context check (everything after the SECOND colon).
+                rest_after_path="${hit#*:}"      # strip "path:"
+                content="${rest_after_path#*:}"  # strip "line:"
+
+                # Skip comment-only lines (compiled JS may include
+                # // ... comments preserved from TS).
+                stripped="$(echo "$content" | sed -e 's/^[[:space:]]*//' )"
+                case "$stripped" in
+                    "//"*|"/*"*|"*"*)
+                        if [[ "$debug" == "1" ]]; then
+                            echo "  SKIP-COMMENT: $hit"
+                        fi
+                        continue
+                        ;;
+                esac
+
+                # Whitelist check.
+                if echo "$content" | grep -iqE "$ALLOW_CONTEXT_RE"; then
+                    if [[ "$debug" == "1" ]]; then
+                        echo "  ALLOW: $hit"
+                    fi
+                    continue
+                fi
+
+                echo "PHRASE-SAFETY-DIST VIOLATION [$pat]: $hit"
+                violations=$((violations + 1))
+            done < <(grep -nHE "$pat" "$jsfile" 2>/dev/null || true)
+        done
+    done < <(find "$dist_dir" -type f -name '*.js' 2>/dev/null | sort)
+done
+
+if [[ "$violations" -gt 0 ]]; then
+    cat <<EOF
+
+Found $violations phrase-emission shape(s) in compiled dist/.
+
+A line of compiled JS is treated as a phrase-safety violation when it builds
+\`recovery_phrase\` or \`mnemonic\` AS AN OBJECT KEY into JS source. Such a
+shape, returned by an MCP / plugin tool handler, lands the user's BIP-39
+recovery phrase inside the LLM's context window — that is forbidden.
+
+Phrase-safety rule (CLAUDE.md): the recovery phrase MUST NEVER cross the
+LLM context. Setup must follow the URL-driven install flow documented at
+docs/guides/claude-code-setup.md (parity with OpenClaw + Hermes).
+
+If a hit is a legitimate edge case (e.g. a NEW persisted-credential shape),
+extend ALLOW_CONTEXT_RE in scripts/check-phrase-safety-dist.sh — do NOT
+delete the rule.
+
+EOF
+    exit 1
+fi
+
+count=0
+for dist_dir in "${DIST_PATHS[@]}"; do
+    if [[ -d "$dist_dir" ]]; then
+        count=$((count + $(find "$dist_dir" -type f -name '*.js' 2>/dev/null | wc -l | tr -d ' ')))
+    fi
+done
+echo "Phrase-safety dist scan: $count compiled .js file(s) clean across ${#DIST_PATHS[@]} dist tree(s)."
+exit 0


### PR DESCRIPTION
## Severity: HIGH (shipping security patch)

The `totalreclaw_setup` MCP tool returned `recovery_phrase` field in its JSON response payload (`mcp/src/index.ts:1929` + `:1945`). Any agent calling this MCP tool received the user's mnemonic in LLM context. Direct violation of phrase-safety invariant.

## Fix

- **Removed `totalreclaw_setup` tool entirely** (per Pedro 2026-04-26 direction): MCP onboarding now follows URL-driven flow parity with OpenClaw + Hermes
- Replaced with structured `tool_removed` error pointing users at `docs/guides/claude-code-setup.md`
- Rewrote SERVER_INSTRUCTIONS in `mcp/src/prompts.ts` to URL-driven phrase-safety stance
- Bumped `mcp/package.json` 3.2.0 → 3.2.1 (security patch)

## CI guard extension

Existing repo-root `scripts/check-phrase-safety.sh` only scanned docs. This PR adds:
- `mcp/tests/phrase-safety-dist.test.ts` — Jest dist scanner (catches runtime-emitted phrase strings in compiled JS)
- `scripts/check-phrase-safety-dist.sh` — bash sibling
- Wired into ci.yml Phrase Safety job (builds mcp/dist + scans)

Probe test confirms both fire on intentional planted violation.

## Tests

- 580/580 npm test pass
- tsc --noEmit clean
- phrase-safety markdown 74/74 clean
- regression suite 5/5
- dist scan 39 .js files clean

## Ship plan

After merge: dispatch `npm-publish.yml` with `package=mcp-server release-type=stable` to publish 3.2.1 ASAP. This is a security patch, not an RC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)