### PR TITLE
fix(hermes): rc.23 three findings — confirm_indexed graceful + pair AttributeError + venv install

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -16,18 +16,59 @@ You have been asked to install TotalReclaw. Run the steps below in order. Do not
 
 ### Step 1 — Install the plugin + Python package
 
+The Hermes Python tool implementations MUST be installed into the SAME Python environment that Hermes itself runs from. Otherwise the gateway will reload, find no `totalreclaw_*` tools, and the agent will loop on Step 2.
+
+#### Step 1a — Find the Hermes Python (run this first)
+
+Detect Hermes' Python interpreter and stash it in `$HERMES_PYTHON` for the rest of Step 1.
+
+```bash
+# Containerized Hermes (Docker / docker-compose / supervised container).
+# The container's PATH already points at the venv — `which python3`
+# resolves to the venv's interpreter, not the host's. Run this INSIDE
+# the same shell context the gateway runs in (e.g. `docker exec -it
+# <container> bash`, then this loop). Example output:
+#   /opt/hermes/venv/bin/python3
+HERMES_PYTHON="$(command -v python3)"
+
+# Native install with a known venv (Hermes was set up with `python3 -m
+# venv ~/.hermes/venv` or similar). Override the autodetect:
+# HERMES_PYTHON=~/.hermes/venv/bin/python3
+
+# Bare-metal install with a system Python (no venv). The default
+# `python3`/`pip` should resolve fine; the autodetect above still works.
+
+# Sanity check — if this prints nothing, set HERMES_PYTHON manually:
+echo "Hermes Python: $HERMES_PYTHON"
+"$HERMES_PYTHON" -c "import sys; print(sys.prefix)"
+```
+
+If you can't determine the Hermes Python interpreter from the shell context (managed service, restricted shell), skip to the managed-service fallback below — do NOT guess and install into a random Python.
+
+#### Step 1b — Install the plugin + the Python package together
+
 Run via your shell tool, in this order:
 
 ```bash
 hermes plugins install p-diogo/totalreclaw-hermes --enable
-pip install --pre totalreclaw
+"$HERMES_PYTHON" -m pip install --pre totalreclaw
 ```
 
 Notes:
-- Hermes 2026.4.16+ uses Git-based plugin discovery: the first command registers the plugin manifest, the second installs the Python tool implementations into the Hermes venv.
-- If Hermes runs in its own venv that your default `pip` doesn't resolve to, use the venv's pip directly: `/path/to/hermes/venv/bin/python3 -m pip install --pre totalreclaw`.
-- On Ubuntu / Debian / Docker you may hit `externally-managed-environment` — add `--break-system-packages` or use a venv.
+- Hermes 2026.4.16+ uses Git-based plugin discovery: the first command registers the plugin manifest, the second installs the Python tool implementations into Hermes' venv. Using `"$HERMES_PYTHON" -m pip ...` (instead of bare `pip install`) guarantees the package lands in the SAME environment Hermes will load tools from after restart — this is the rc.23 fix for the F5 "outside-venv install" bug.
+- DO NOT use bare `pip install --pre totalreclaw` unless you have already verified that `which pip` resolves to the same venv as `$HERMES_PYTHON`. On containerized Hermes the system `pip` may not even exist (`pip: command not found`) and the bare command would target the host's Python anyway, leaving Hermes' venv empty.
+- On Ubuntu / Debian / Docker you may hit `externally-managed-environment` if `$HERMES_PYTHON` points at a system Python (no venv). Add `--break-system-packages` to the `pip install` line, OR ask the user to recreate Hermes inside a venv.
 - If either command fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment), STOP and tell the user verbatim: *"Your environment doesn't expose the Hermes CLI / pip to me. Please install `p-diogo/totalreclaw-hermes` and the `totalreclaw` Python package via your service's plugins UI, then reply `done`."* Wait for `done` before continuing to Step 2.
+
+#### Step 1c — Verify the package is installed in the right Python
+
+Before moving to Step 2, confirm the package resolves through `$HERMES_PYTHON`:
+
+```bash
+"$HERMES_PYTHON" -m pip show totalreclaw | head -2
+```
+
+If `pip show` reports the package and the version matches what you just installed, proceed. If it errors with `Package(s) not found`, the install landed in a different Python — fix `$HERMES_PYTHON` and re-run Step 1b.
 
 ### Step 2 — Ask the user to restart the gateway
 
@@ -104,7 +145,15 @@ If you can't or won't use the chat flow (self-hosted only — managed services d
 
 ```bash
 hermes plugins install p-diogo/totalreclaw-hermes --enable
-pip install --pre totalreclaw       # or your hermes venv's pip
+
+# Use the SAME Python that Hermes runs from — never bare `pip install` unless
+# you already know `which pip` and Hermes' interpreter agree.
+#   Native venv install:
+~/.hermes/venv/bin/python3 -m pip install --pre totalreclaw
+#   Containerized Hermes (run from inside the container shell):
+python3 -m pip install --pre totalreclaw
+#   System-Python install (no venv, may need --break-system-packages):
+python3 -m pip install --pre totalreclaw
 
 # Restart the gateway. Pick the line that matches your setup:
 hermes gateway restart                       # native install

--- a/python/src/totalreclaw/confirm_indexed.py
+++ b/python/src/totalreclaw/confirm_indexed.py
@@ -11,12 +11,27 @@ Gnosis production; without this wait, mutation helpers (``pin_fact``,
 Mnemonic isolation: this helper never touches the mnemonic, encryption
 key, or any decrypted blob. It only reads the public ``{id, isActive,
 blockNumber}`` of a fact.
+
+Graceful binding-fallback (rc.23 fix, mirrors ``skill/plugin/confirm-
+indexed.ts`` commit ``d9c5352``): the ``confirm_indexed_*`` PyO3 bindings
+were added to ``totalreclaw-core`` only in the Rust source slated for
+2.3.x. Hermes Python's PyPI floor (``totalreclaw-core>=2.2.0``) means
+existing user installs may pull a wheel that DOESN'T export them —
+``getattr(_core, 'confirm_indexed_query', None)`` returns ``None`` and a
+naive call would raise ``AttributeError``. The chain write itself has
+already succeeded before this helper runs, so a missing-bindings case
+must surface as ``indexed=False`` (caller flips ``partial=True``), NOT
+as an error that fails the whole tool invocation. This module wraps the
+binding lookup + first-use in a try/except so callers see a uniform
+``ConfirmIndexedResult.indexed=False`` whether the cause is timeout,
+indexer transient, or wheel-missing-bindings.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import dataclass
 from typing import Optional, Literal
 
 import totalreclaw_core as _core
@@ -26,6 +41,22 @@ from .relay import RelayClient
 logger = logging.getLogger(__name__)
 
 ExpectDirection = Literal["active", "inactive"]
+
+
+@dataclass
+class ConfirmIndexedResult:
+    """Detailed outcome of a confirm-indexed poll loop.
+
+    Mirrors the TS ``ConfirmIndexedResult`` shape (see
+    ``skill/plugin/confirm-indexed.ts``). Returned by
+    :func:`confirm_indexed_detailed`. The legacy boolean :func:`confirm_indexed`
+    is preserved as a thin wrapper that returns ``result.indexed``.
+    """
+
+    indexed: bool
+    attempts: int
+    elapsed_ms: int
+    last_error: Optional[str] = None
 
 
 def _default_poll_ms() -> int:
@@ -38,51 +69,55 @@ def _default_timeout_ms() -> int:
     return int(fn()) if callable(fn) else 30_000
 
 
-async def confirm_indexed(
+async def confirm_indexed_detailed(
     fact_id: str,
     relay: RelayClient,
     *,
     expect: ExpectDirection = "active",
     poll_interval_ms: Optional[int] = None,
     timeout_ms: Optional[int] = None,
-) -> bool:
-    """Poll the subgraph until the fact id reaches the expected state.
+) -> ConfirmIndexedResult:
+    """Poll the subgraph until the fact reaches the expected state.
 
-    Parameters
-    ----------
-    fact_id
-        The UUID of the fact to confirm. After ``pin_fact`` / retype / etc.
-        this is the **new** fact id (the supersession target). For
-        ``forget_fact`` this is the **original** fact id whose ``isActive``
-        bit is being flipped.
-    relay
-        Configured RelayClient — already knows the subgraph endpoint via
-        ``relay.query_subgraph``.
-    expect
-        ``"active"`` (default) — resolve when ``fact.isActive == True``.
-        ``"inactive"`` — resolve when fact is missing OR
-        ``fact.isActive == False``. Use ``"inactive"`` for forget.
-    poll_interval_ms / timeout_ms
-        Override the defaults from the Rust core (1s / 30s).
+    Returns a :class:`ConfirmIndexedResult` describing the outcome — never
+    raises on transient errors or missing PyO3 bindings. The chain write
+    has already succeeded before this helper runs, so on
+    ``indexed=False`` the caller should surface ``partial=True`` rather
+    than failing the whole tool.
 
-    Returns
-    -------
-    bool
-        ``True`` when the resolution condition was met inside the timeout
-        budget, ``False`` on timeout. The on-chain write is **already
-        acknowledged** before this function is called — a ``False`` return
-        only means the subgraph is still propagating, not that the chain
-        write failed. Callers should surface this to users as ``partial=
-        True`` rather than as an error.
+    Specifically guards against ``totalreclaw-core`` wheels published
+    before the ``confirm_indexed_*`` PyO3 bindings were added (any wheel
+    pinned to ``2.2.x`` on PyPI as of rc.22). Without this guard, a naive
+    ``_core.confirm_indexed_query()`` call raises::
+
+        AttributeError: module 'totalreclaw_core' has no attribute 'confirm_indexed_query'
+
+    which would bubble to the calling tool (``pin_fact`` / ``forget_fact``
+    / ``retype`` / ``set_scope``) and surface to the user as a hard crash
+    even though the on-chain write succeeded.
     """
-    poll_ms = poll_interval_ms if poll_interval_ms is not None else _default_poll_ms()
-    total_ms = timeout_ms if timeout_ms is not None else _default_timeout_ms()
-    query = _core.confirm_indexed_query()
+    # Graceful fallback: if the PyO3 bindings aren't on this wheel,
+    # short-circuit with indexed=False + a descriptive lastError. The
+    # chain write succeeded — confirm step is observational.
+    try:
+        query = _core.confirm_indexed_query()
+        poll_ms = (
+            poll_interval_ms if poll_interval_ms is not None else _default_poll_ms()
+        )
+        total_ms = timeout_ms if timeout_ms is not None else _default_timeout_ms()
+    except Exception as exc:
+        return ConfirmIndexedResult(
+            indexed=False,
+            attempts=0,
+            elapsed_ms=0,
+            last_error=f"confirm-indexed bindings unavailable: {exc}",
+        )
 
     start = asyncio.get_event_loop().time()
     deadline = start + (total_ms / 1000.0)
 
     attempts = 0
+    last_error: Optional[str] = None
     while asyncio.get_event_loop().time() < deadline:
         attempts += 1
         try:
@@ -101,8 +136,14 @@ async def confirm_indexed(
                     expect,
                     attempts,
                 )
-                return True
+                elapsed_ms = int(
+                    (asyncio.get_event_loop().time() - start) * 1000
+                )
+                return ConfirmIndexedResult(
+                    indexed=True, attempts=attempts, elapsed_ms=elapsed_ms
+                )
         except Exception as exc:  # pragma: no cover — best-effort polling
+            last_error = str(exc)
             logger.debug("confirm_indexed: poll attempt failed: %s", exc)
 
         # Sleep before the next attempt — but only if there's still budget.
@@ -111,6 +152,7 @@ async def confirm_indexed(
             break
         await asyncio.sleep(min(poll_ms / 1000.0, remaining))
 
+    elapsed_ms = int((asyncio.get_event_loop().time() - start) * 1000)
     logger.info(
         "confirm_indexed: fact_id=%s expect=%s NOT resolved within %dms (%d attempts)",
         fact_id,
@@ -118,4 +160,39 @@ async def confirm_indexed(
         total_ms,
         attempts,
     )
-    return False
+    return ConfirmIndexedResult(
+        indexed=False,
+        attempts=attempts,
+        elapsed_ms=elapsed_ms,
+        last_error=last_error,
+    )
+
+
+async def confirm_indexed(
+    fact_id: str,
+    relay: RelayClient,
+    *,
+    expect: ExpectDirection = "active",
+    poll_interval_ms: Optional[int] = None,
+    timeout_ms: Optional[int] = None,
+) -> bool:
+    """Boolean wrapper over :func:`confirm_indexed_detailed`.
+
+    Returns ``True`` when the subgraph confirmed the fact reached the
+    expected state inside the timeout budget. Returns ``False`` on
+    timeout, transient indexer errors, OR missing PyO3 bindings (the
+    rc.23 graceful-fallback case). The chain write is **already
+    acknowledged** before this function is called — a ``False`` return
+    only means the subgraph is still propagating (or the wheel doesn't
+    export the bindings yet), not that the chain write failed. Callers
+    should surface this to users as ``partial=True`` rather than as an
+    error.
+    """
+    result = await confirm_indexed_detailed(
+        fact_id,
+        relay,
+        expect=expect,
+        poll_interval_ms=poll_interval_ms,
+        timeout_ms=timeout_ms,
+    )
+    return result.indexed

--- a/python/src/totalreclaw/hermes/SKILL.md
+++ b/python/src/totalreclaw/hermes/SKILL.md
@@ -15,12 +15,22 @@ homepage: https://totalreclaw.xyz
 
 If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jump to step 4. Otherwise run all steps in order.
 
-1. **Install plugin + Python package.** Hermes 2026.4.16+ uses Git-based plugin discovery and a separate Python tool implementation. Run via your shell tool:
+1. **Install plugin + Python package.** Hermes 2026.4.16+ uses Git-based plugin discovery and a separate Python tool implementation. The Python package MUST go into the SAME Python environment that Hermes runs from (containerized venv, native venv, or system Python — whichever your install uses). Bare `pip install` may target the wrong Python on containerized deploys. Step-by-step via your shell tool:
    ```
+   # 1a. Detect the Hermes Python (run inside the gateway's shell context — for
+   # Docker, that means `docker exec -it <container> bash` first).
+   HERMES_PYTHON="$(command -v python3)"
+   echo "Hermes Python: $HERMES_PYTHON"
+   "$HERMES_PYTHON" -c "import sys; print(sys.prefix)"
+
+   # 1b. Install both halves into the right env.
    hermes plugins install p-diogo/totalreclaw-hermes --enable
-   pip install --pre totalreclaw
+   "$HERMES_PYTHON" -m pip install --pre totalreclaw
+
+   # 1c. Verify the package resolved through Hermes' Python.
+   "$HERMES_PYTHON" -m pip show totalreclaw | head -2
    ```
-   (If Hermes runs in its own venv, use that venv's pip — e.g. `/path/to/hermes/venv/bin/python3 -m pip install --pre totalreclaw`.) If either shell call fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment): tell the user verbatim *"Your environment doesn't expose the Hermes CLI / pip to me. Please install `p-diogo/totalreclaw-hermes` and the `totalreclaw` Python package via your service's plugins UI, then reply `done`."* Wait for `done` and skip to step 3.
+   If `pip show` doesn't list the package, the install landed in a different Python — fix `$HERMES_PYTHON` and re-run 1b. On Debian/Ubuntu/Docker you may hit `externally-managed-environment` if Hermes runs against system Python — add `--break-system-packages` to the `pip install` line, or ask the user to recreate Hermes inside a venv. If either shell call fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment): tell the user verbatim *"Your environment doesn't expose the Hermes CLI / pip to me. Please install `p-diogo/totalreclaw-hermes` and the `totalreclaw` Python package via your service's plugins UI, then reply `done`."* Wait for `done` and skip to step 3.
 
 2. **Restart the gateway — Hermes does NOT auto-reload on plugin install.** Tell the user verbatim: *"Please restart your Hermes gateway: `hermes gateway restart` (native), `docker restart <your-container-name>` (Docker self-host — substitute the actual name; `docker ps` shows it), or your managed service's restart control. If supervised by systemd / launchd, `kill -USR1 $(cat ~/.hermes/gateway.pid)` triggers a graceful-drain restart. Reply `done` once it's back up."* Do NOT run the restart yourself — your shell is inside the gateway you'd be restarting. Wait for the user's `done`.
 

--- a/python/src/totalreclaw/hermes/pair_tool_completion.py
+++ b/python/src/totalreclaw/hermes/pair_tool_completion.py
@@ -16,33 +16,66 @@ Phrase-safety invariants enforced here:
 - Best-effort zeroization of local variables holding the phrase after
   state configure.
 - No logging of phrase content. Only the EOA address (already public)
-  and sid prefix are logged.
+  and a session-id-fragment prefix are logged.
+
+Session-id attribute compatibility (rc.23 fix for QA finding F4):
+this handler gets called from BOTH the local-mode HTTP path
+(``..pair.session_store.PairSession`` — has ``.sid``) and the
+relay-mode shared completion path (``..pair.remote_client
+.RemotePairSession`` — has ``.token``). Pre-rc.23 the helper hard-coded
+``session.sid``, which raised ``AttributeError`` on the relay shape.
+The fix below uses :func:`_session_id_fragment` to read either
+attribute defensively so a single completion handler can serve both
+paths.
 """
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .state import PluginState
-    from ..pair.session_store import PairSession
+    from ..pair.session_store import PairSession  # noqa: F401 — type-only
 
 from ..pair.http_server import CompletePairingResult
 
 logger = logging.getLogger(__name__)
 
 
+def _session_id_fragment(session: Any) -> str:
+    """Best-effort short identifier for log lines.
+
+    Reads either ``.token`` (``RemotePairSession``) or ``.sid``
+    (``PairSession``) — the local handler shape has ``.sid``, the relay
+    handshake exposes ``.token``. Returns an 8-char prefix or ``"?"``
+    if neither attribute is present / both are empty.
+
+    NEVER raises — log lines must not torpedo a successful pairing.
+    """
+    candidate = getattr(session, "token", None) or getattr(session, "sid", None)
+    if not isinstance(candidate, str) or not candidate:
+        return "?"
+    return candidate[:8]
+
+
 def complete_pairing(
     phrase: str,
-    session: "PairSession",
+    session: Any,
     state: "PluginState",
 ) -> CompletePairingResult:
     """Apply a browser-decrypted phrase to the Hermes plugin state.
 
-    Called FROM the HTTP handler thread. ``state.configure`` is synchronous
-    (writes credentials.json, derives the EOA address). The async Smart-
-    Account derivation happens lazily on the first remember/recall call.
+    Called from BOTH the local HTTP handler thread and the relay-mode
+    completion path. ``state.configure`` is synchronous (writes
+    credentials.json, derives the EOA address). The async Smart-Account
+    derivation happens lazily on the first remember/recall call.
+
+    ``session`` accepts either a ``PairSession`` (local mode, has
+    ``.sid``) or a ``RemotePairSession`` (relay mode, has ``.token``).
+    The id is used only for log-line correlation — callers don't need
+    the same shape on both paths.
     """
+    sid_frag = _session_id_fragment(session)
     try:
         state.configure(phrase)
         client = state.get_client()
@@ -50,13 +83,13 @@ def complete_pairing(
         logger.info(
             "pair-tool: credentials configured for EOA %s (session %s…)",
             eoa or "unknown",
-            session.sid[:8],
+            sid_frag,
         )
         return CompletePairingResult(state="active", account_id=eoa)
     except Exception as err:  # pragma: no cover — defensive
         logger.error(
             "pair-tool: complete_pairing failed for session %s…: %r",
-            session.sid[:8],
+            sid_frag,
             err,
         )
         return CompletePairingResult(state="error", error=str(err))

--- a/python/src/totalreclaw/hermes/tools.py
+++ b/python/src/totalreclaw/hermes/tools.py
@@ -170,6 +170,16 @@ async def pin(args: dict, state: "PluginState", **kwargs) -> str:
         if result.get("idempotent"):
             response["idempotent"] = True
             response["message"] = "Claim was already pinned; no on-chain write."
+        # rc.23 graceful confirm-indexed: when the underlying
+        # ``totalreclaw-core`` wheel doesn't yet expose the PyO3
+        # ``confirm_indexed_*`` bindings (any wheel published pre-2.3.x),
+        # ``operations._change_claim_status`` returns ``partial=True`` on
+        # the result dict — the on-chain write succeeded but the
+        # observational read-after-write step couldn't run. Surface the
+        # flag so callers know follow-up reads may briefly show stale
+        # state.
+        if result.get("partial"):
+            response["partial"] = True
         return json.dumps(response)
     except ValueError as e:
         return json.dumps({"error": str(e)})
@@ -208,6 +218,12 @@ async def unpin(args: dict, state: "PluginState", **kwargs) -> str:
         if result.get("idempotent"):
             response["idempotent"] = True
             response["message"] = "Claim was already active; no on-chain write."
+        # rc.23 graceful confirm-indexed: see :func:`pin` — same partial
+        # propagation when the read-after-write helper short-circuits
+        # because the installed ``totalreclaw-core`` wheel lacks the
+        # ``confirm_indexed_*`` PyO3 bindings.
+        if result.get("partial"):
+            response["partial"] = True
         return json.dumps(response)
     except ValueError as e:
         return json.dumps({"error": str(e)})

--- a/python/src/totalreclaw/operations.py
+++ b/python/src/totalreclaw/operations.py
@@ -1256,9 +1256,20 @@ async def _change_claim_status(
     # — the chain write IS acknowledged — but flag ``partial=True`` so a
     # follow-up ``client.export()`` / ``client.recall()`` doesn't surprise
     # the caller with stale state.
+    #
+    # rc.23 graceful-fallback: ``confirm_indexed`` itself returns ``False``
+    # if the PyO3 bindings aren't on the installed ``totalreclaw-core``
+    # wheel (any wheel published before 2.3.x). We additionally wrap the
+    # call here so any unexpected post-binding error path also surfaces
+    # as ``partial=True`` rather than torpedoing the on-chain write that
+    # already succeeded. Mirrors the TS retype-setscope.ts pattern (commit
+    # ``d9c5352``).
     from .confirm_indexed import confirm_indexed as _confirm_indexed
 
-    indexed = await _confirm_indexed(new_fact_id, relay, expect="active")
+    try:
+        indexed = await _confirm_indexed(new_fact_id, relay, expect="active")
+    except Exception:
+        indexed = False
 
     result = {
         "success": True,

--- a/python/tests/test_rc23_three_findings.py
+++ b/python/tests/test_rc23_three_findings.py
@@ -1,0 +1,354 @@
+"""Regression shield for Hermes rc.23 brutal-QA findings (umbrella #147).
+
+Covers the three Hermes-side findings landed in branch
+``fix/hermes-rc23-three-findings``:
+
+* **F1 (umbrella #148, BLOCKER)** — ``totalreclaw_pin`` (and
+  ``_unpin`` / ``_forget`` / future ``retype`` / ``set_scope``) crash
+  on every invocation against PyPI ``totalreclaw-core@2.2.0`` with::
+
+      AttributeError: module 'totalreclaw_core' has no attribute 'confirm_indexed_query'
+
+  Root cause: the ``confirm_indexed_*`` PyO3 bindings were added in the
+  Rust source via PR #124 but never published to PyPI. Hermes Python's
+  confirm-indexed wrapper called into bindings that only exist in our
+  local source tree. The fix mirrors the TS plugin's
+  ``skill/plugin/confirm-indexed.ts`` graceful pattern (commit
+  ``d9c5352``): wrap binding lookups in try/except, return
+  ``ConfirmIndexedResult(indexed=False, last_error=...)`` instead of
+  raising. Calling tools surface ``partial=True`` rather than crashing.
+
+* **F4 (umbrella #151, MEDIUM)** —
+  ``hermes.pair_tool_completion.complete_pairing`` referenced
+  ``session.sid`` but ``RemotePairSession`` only has ``.token``,
+  raising ``AttributeError`` on the relay-mode shared completion path.
+  Fix: read either attribute defensively (``token`` first because that's
+  the canonical relay shape, falling back to ``sid`` for local mode).
+
+Out of scope here: F5 (chat install Step 1 lands ``totalreclaw``
+outside Hermes venv on containerized deploys) — that's a docs / SKILL.md
+fix verified by reading the rendered guide, not by automated test.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# F1 — confirm_indexed graceful binding-missing fallback
+# ---------------------------------------------------------------------------
+
+
+class TestConfirmIndexedGracefulBindings:
+    """When ``totalreclaw_core`` doesn't expose the ``confirm_indexed_*``
+    PyO3 bindings (any wheel published before they were added),
+    :func:`confirm_indexed` MUST NOT raise. Instead it returns ``False``
+    so callers can surface ``partial=True``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_missing_query_binding_returns_false_not_raises(self):
+        """Pre-rc.23 this raised ``AttributeError`` and crashed pin/unpin/forget.
+
+        The fix wraps the ``_core.confirm_indexed_query()`` call in
+        try/except inside :func:`confirm_indexed_detailed`. The boolean
+        wrapper :func:`confirm_indexed` propagates the False result.
+        """
+        from totalreclaw import confirm_indexed as ci_mod
+
+        relay = AsyncMock()
+
+        # Simulate a wheel that doesn't export ``confirm_indexed_query``.
+        # ``getattr`` would return None — the production helper invokes
+        # the attribute directly, which raises AttributeError.
+        broken_core = SimpleNamespace()  # No confirm_indexed_* attrs at all
+
+        with patch.object(ci_mod, "_core", broken_core):
+            indexed = await ci_mod.confirm_indexed("any-fact-id", relay)
+            assert indexed is False, (
+                "missing PyO3 bindings must return False, not raise"
+            )
+
+    @pytest.mark.asyncio
+    async def test_missing_query_binding_detailed_carries_last_error(self):
+        """The detailed helper must annotate ``last_error`` so observability /
+        Hermes logs can surface WHY the read-after-write was skipped.
+        """
+        from totalreclaw import confirm_indexed as ci_mod
+
+        relay = AsyncMock()
+        broken_core = SimpleNamespace()
+
+        with patch.object(ci_mod, "_core", broken_core):
+            result = await ci_mod.confirm_indexed_detailed(
+                "any-fact-id", relay
+            )
+
+        assert result.indexed is False
+        assert result.attempts == 0, (
+            "no poll attempts when bindings unavailable"
+        )
+        assert result.elapsed_ms == 0
+        assert result.last_error is not None
+        assert "bindings unavailable" in result.last_error
+
+    @pytest.mark.asyncio
+    async def test_query_binding_present_but_raises_returns_false(self):
+        """Even if ``confirm_indexed_query`` exists but raises (e.g. a
+        future protocol-version mismatch), the helper must still
+        gracefully return False — never bubble to the calling tool.
+        """
+        from totalreclaw import confirm_indexed as ci_mod
+
+        relay = AsyncMock()
+
+        def boom():
+            raise RuntimeError("simulated core protocol mismatch")
+
+        broken_core = SimpleNamespace(
+            confirm_indexed_query=boom,
+            confirm_indexed_default_poll_ms=lambda: 100,
+            confirm_indexed_default_timeout_ms=lambda: 1000,
+        )
+
+        with patch.object(ci_mod, "_core", broken_core):
+            indexed = await ci_mod.confirm_indexed("fact", relay)
+            assert indexed is False
+
+    @pytest.mark.asyncio
+    async def test_pin_tool_returns_partial_when_bindings_missing(self):
+        """End-to-end shield: a successful chain write that hit the
+        binding-missing path should yield ``pinned=True`` plus
+        ``partial=True`` from ``hermes.tools.pin``. Pre-rc.23 the call
+        crashed with ``AttributeError``.
+        """
+        from totalreclaw.hermes.state import PluginState
+        from totalreclaw.hermes.tools import pin as pin_tool
+        import json as _json
+
+        state = PluginState()
+        fake_client = AsyncMock()
+        fake_client.pin_fact = AsyncMock(
+            return_value={
+                "success": True,
+                "fact_id": "old-id",
+                "new_fact_id": "new-id",
+                "previous_status": "active",
+                "new_status": "pinned",
+                # operations._change_claim_status sets this when
+                # confirm_indexed returned False — the rc.23 graceful
+                # path that fires on missing PyO3 bindings.
+                "partial": True,
+            }
+        )
+        state._client = fake_client
+
+        result = _json.loads(await pin_tool({"fact_id": "old-id"}, state))
+        assert result.get("pinned") is True
+        assert result.get("partial") is True, (
+            "pin tool must propagate partial=True when confirm_indexed "
+            "short-circuits on missing PyO3 bindings"
+        )
+        # Crucially, no `error` key — pre-rc.23 the call raised
+        # AttributeError and surfaced as {'error': "module 'totalreclaw_core' "
+        # "has no attribute 'confirm_indexed_query'"}.
+        assert "error" not in result
+
+    @pytest.mark.asyncio
+    async def test_unpin_tool_returns_partial_when_bindings_missing(self):
+        """Mirror of the pin shield for unpin — the same
+        ``operations._change_claim_status`` path serves both tools, so
+        the partial flag must traverse the unpin wrapper too.
+        """
+        from totalreclaw.hermes.state import PluginState
+        from totalreclaw.hermes.tools import unpin as unpin_tool
+        import json as _json
+
+        state = PluginState()
+        fake_client = AsyncMock()
+        fake_client.unpin_fact = AsyncMock(
+            return_value={
+                "success": True,
+                "fact_id": "old-id",
+                "new_fact_id": "new-id",
+                "previous_status": "pinned",
+                "new_status": "active",
+                "partial": True,
+            }
+        )
+        state._client = fake_client
+
+        result = _json.loads(await unpin_tool({"fact_id": "old-id"}, state))
+        assert result.get("unpinned") is True
+        assert result.get("partial") is True
+        assert "error" not in result
+
+
+# ---------------------------------------------------------------------------
+# F4 — pair_tool_completion handles both PairSession (.sid) and
+# RemotePairSession (.token)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeRemoteSession:
+    """Minimal stand-in for ``..pair.remote_client.RemotePairSession``.
+
+    The real class has more fields (url, pin, expires_at, keypair, _ws)
+    but ``complete_pairing`` only reads the session-id attribute, so we
+    keep this fixture minimal.
+    """
+
+    token: str
+
+
+@dataclass
+class _FakeLocalSession:
+    """Minimal stand-in for ``..pair.session_store.PairSession``."""
+
+    sid: str
+
+
+class TestCompletePairingSessionAttribute:
+    """:func:`hermes.pair_tool_completion.complete_pairing` must read
+    either ``session.token`` (relay path, ``RemotePairSession``) or
+    ``session.sid`` (local path, ``PairSession``) without raising.
+
+    Pre-rc.23 the helper hard-coded ``session.sid``, raising
+    ``AttributeError: 'RemotePairSession' object has no attribute 'sid'``
+    on the relay-mode shared completion path (QA finding F4).
+    """
+
+    def _build_state_mock(self, eoa: str = "0xEOA") -> MagicMock:
+        """Build a fake ``PluginState`` whose ``configure`` is a no-op
+        and whose ``get_client`` exposes ``_eoa_address``.
+        """
+        state = MagicMock()
+        state.configure = MagicMock()  # synchronous + no-op
+        client = MagicMock()
+        client._eoa_address = eoa
+        state.get_client = MagicMock(return_value=client)
+        return state
+
+    def test_remote_session_with_token_does_not_raise(self):
+        """RemotePairSession-shaped object — pre-rc.23 this raised
+        AttributeError because the helper read ``session.sid``.
+        """
+        from totalreclaw.hermes.pair_tool_completion import complete_pairing
+
+        state = self._build_state_mock()
+        session = _FakeRemoteSession(token="tok_1234567890abcdef")
+
+        # Must NOT raise — the rc.23 fix uses defensive attribute
+        # lookup so this shape works on the shared completion path.
+        result = complete_pairing("abandon " * 11 + "about", session, state)
+        assert result.state == "active"
+        assert result.account_id == "0xEOA"
+        # configure was called once with the phrase argument.
+        state.configure.assert_called_once()
+
+    def test_local_session_with_sid_still_works(self):
+        """Backwards-compat: the local HTTP server passes a
+        ``PairSession`` (with ``.sid``). The rc.23 fix must not break
+        that path.
+        """
+        from totalreclaw.hermes.pair_tool_completion import complete_pairing
+
+        state = self._build_state_mock()
+        session = _FakeLocalSession(sid="sid_abcdef0123456789")
+
+        result = complete_pairing("abandon " * 11 + "about", session, state)
+        assert result.state == "active"
+        assert result.account_id == "0xEOA"
+
+    def test_session_without_either_attribute_does_not_crash_logging(self):
+        """Defensive: even a totally empty session object shouldn't
+        torpedo a successful pairing with a logging-line crash.
+        """
+        from totalreclaw.hermes.pair_tool_completion import complete_pairing
+
+        state = self._build_state_mock()
+        empty_session = SimpleNamespace()  # no .sid, no .token
+
+        # Should not raise; should still return active.
+        result = complete_pairing("abandon " * 11 + "about", empty_session, state)
+        assert result.state == "active"
+
+    def test_remote_session_logged_with_token_prefix(self, caplog):
+        """Verify the log line uses an 8-char prefix from ``.token``
+        (not ``.sid``) when the session is remote-shaped. Useful for
+        operators correlating gateway logs with relay logs.
+        """
+        import logging
+
+        from totalreclaw.hermes.pair_tool_completion import complete_pairing
+
+        state = self._build_state_mock(eoa="0xCAFE")
+        session = _FakeRemoteSession(token="tok_remoteABC123")
+
+        with caplog.at_level(logging.INFO, logger="totalreclaw.hermes.pair_tool_completion"):
+            complete_pairing("abandon " * 11 + "about", session, state)
+
+        # The first 8 chars of the token should appear in at least one
+        # log record (info-level success line).
+        joined = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert "tok_remo" in joined, (
+            "expected 8-char token prefix in info log; got: " + joined
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phrase-safety regression assertion (sanity — must continue to pass)
+# ---------------------------------------------------------------------------
+
+
+class TestPhraseSafetyUnaffected:
+    """The rc.23 fixes touch confirm_indexed + pair_tool_completion +
+    Hermes setup docs. None of these should reintroduce a phrase-
+    leaking surface. This redundant smoke check confirms the canonical
+    forbidden tool list is still empty after :func:`totalreclaw.hermes.register`
+    runs against the rc.23 changes.
+    """
+
+    def test_no_phrase_generating_tool_re_added(self):
+        """Mirror of ``test_agent_tools_phrase_safety.py``'s contract —
+        keep the rc.23 branch from accidentally regressing the
+        phrase-safety gate. If the canonical test starts failing this
+        redundant check flags it locally too.
+        """
+        from unittest.mock import MagicMock, patch
+        import os
+        from pathlib import Path
+
+        from totalreclaw.hermes import register
+
+        forbidden = (
+            "totalreclaw_setup",
+            "totalreclaw_onboard",
+            "totalreclaw_onboard_generate",
+            "totalreclaw_restore",
+            "totalreclaw_generate_phrase",
+            "totalreclaw_mnemonic",
+        )
+
+        ctx = MagicMock()
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(Path, "exists", return_value=False):
+                register(ctx)
+
+        registered_names = {
+            call.kwargs["name"]
+            for call in ctx.register_tool.call_args_list
+            if "name" in call.kwargs
+        }
+
+        for name in forbidden:
+            assert name not in registered_names, (
+                f"Phrase-safety regression: {name!r} appears in the "
+                f"registered tool set after the rc.23 fix branch."
+            )


### PR DESCRIPTION
Hermes rc.22 NO-GO findings #148 + #151 + #152.

## #148 (BLOCKER) — pin crashes with AttributeError on core@2.2.0

`totalreclaw_pin` (and unpin/forget) crashed with `'totalreclaw_core' has no attribute 'confirm_indexed_query'` on every invocation. PyPI core@2.2.0 (production stable) doesn't yet have the rc.22 confirm_indexed bindings — those are in our Rust source but not on PyPI yet.

**Fix**: graceful binding lookup mirroring TS PR #130 fixup pattern. confirm_indexed wrapped in try/except — returns `indexed=False` + `partial=True` on the calling tool when bindings missing. Chain write succeeded; confirm step is observational only.

## #151 (MEDIUM) — pair AttributeError on shared handler

`pair_tool_completion.complete_pairing` referenced `session.sid` but `RemotePairSession` only has `.token`. Added `_session_id_fragment` helper that reads either attribute.

## #152 (MEDIUM) — chat install lands outside Hermes venv on containers

Setup guide Step 1 split into 1a (detect `$HERMES_PYTHON`), 1b (use venv pip), 1c (verify install). Mirrored in Hermes SKILL.md.

## Test plan

- 10 new regression tests in `python/tests/test_rc23_three_findings.py` PASS
- Broader suite: 867 passed, 1 skipped, 1 xfailed
- Phrase-safety regression assertions clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)