### PR TITLE
fix(hermes): pair AttributeError + venv install path (closes #151, #152)

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -16,18 +16,59 @@ You have been asked to install TotalReclaw. Run the steps below in order. Do not
 
 ### Step 1 — Install the plugin + Python package
 
+The Hermes Python tool implementations MUST be installed into the SAME Python environment that Hermes itself runs from. Otherwise the gateway will reload, find no `totalreclaw_*` tools, and the agent will loop on Step 2.
+
+#### Step 1a — Find the Hermes Python (run this first)
+
+Detect Hermes' Python interpreter and stash it in `$HERMES_PYTHON` for the rest of Step 1.
+
+```bash
+# Containerized Hermes (Docker / docker-compose / supervised container).
+# The container's PATH already points at the venv — `which python3`
+# resolves to the venv's interpreter, not the host's. Run this INSIDE
+# the same shell context the gateway runs in (e.g. `docker exec -it
+# <container> bash`, then this loop). Example output:
+#   /opt/hermes/venv/bin/python3
+HERMES_PYTHON="$(command -v python3)"
+
+# Native install with a known venv (Hermes was set up with `python3 -m
+# venv ~/.hermes/venv` or similar). Override the autodetect:
+# HERMES_PYTHON=~/.hermes/venv/bin/python3
+
+# Bare-metal install with a system Python (no venv). The default
+# `python3`/`pip` should resolve fine; the autodetect above still works.
+
+# Sanity check — if this prints nothing, set HERMES_PYTHON manually:
+echo "Hermes Python: $HERMES_PYTHON"
+"$HERMES_PYTHON" -c "import sys; print(sys.prefix)"
+```
+
+If you can't determine the Hermes Python interpreter from the shell context (managed service, restricted shell), skip to the managed-service fallback below — do NOT guess and install into a random Python.
+
+#### Step 1b — Install the plugin + the Python package together
+
 Run via your shell tool, in this order:
 
 ```bash
 hermes plugins install p-diogo/totalreclaw-hermes --enable
-pip install --pre totalreclaw
+"$HERMES_PYTHON" -m pip install --pre totalreclaw
 ```
 
 Notes:
-- Hermes 2026.4.16+ uses Git-based plugin discovery: the first command registers the plugin manifest, the second installs the Python tool implementations into the Hermes venv.
-- If Hermes runs in its own venv that your default `pip` doesn't resolve to, use the venv's pip directly: `/path/to/hermes/venv/bin/python3 -m pip install --pre totalreclaw`.
-- On Ubuntu / Debian / Docker you may hit `externally-managed-environment` — add `--break-system-packages` or use a venv.
+- Hermes 2026.4.16+ uses Git-based plugin discovery: the first command registers the plugin manifest, the second installs the Python tool implementations into Hermes' venv. Using `"$HERMES_PYTHON" -m pip ...` (instead of bare `pip install`) guarantees the package lands in the SAME environment Hermes will load tools from after restart — this is the rc.23 fix for the F5 "outside-venv install" bug.
+- DO NOT use bare `pip install --pre totalreclaw` unless you have already verified that `which pip` resolves to the same venv as `$HERMES_PYTHON`. On containerized Hermes the system `pip` may not even exist (`pip: command not found`) and the bare command would target the host's Python anyway, leaving Hermes' venv empty.
+- On Ubuntu / Debian / Docker you may hit `externally-managed-environment` if `$HERMES_PYTHON` points at a system Python (no venv). Add `--break-system-packages` to the `pip install` line, OR ask the user to recreate Hermes inside a venv.
 - If either command fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment), STOP and tell the user verbatim: *"Your environment doesn't expose the Hermes CLI / pip to me. Please install `p-diogo/totalreclaw-hermes` and the `totalreclaw` Python package via your service's plugins UI, then reply `done`."* Wait for `done` before continuing to Step 2.
+
+#### Step 1c — Verify the package is installed in the right Python
+
+Before moving to Step 2, confirm the package resolves through `$HERMES_PYTHON`:
+
+```bash
+"$HERMES_PYTHON" -m pip show totalreclaw | head -2
+```
+
+If `pip show` reports the package and the version matches what you just installed, proceed. If it errors with `Package(s) not found`, the install landed in a different Python — fix `$HERMES_PYTHON` and re-run Step 1b.
 
 ### Step 2 — Ask the user to restart the gateway
 
@@ -104,7 +145,15 @@ If you can't or won't use the chat flow (self-hosted only — managed services d
 
 ```bash
 hermes plugins install p-diogo/totalreclaw-hermes --enable
-pip install --pre totalreclaw       # or your hermes venv's pip
+
+# Use the SAME Python that Hermes runs from — never bare `pip install` unless
+# you already know `which pip` and Hermes' interpreter agree.
+#   Native venv install:
+~/.hermes/venv/bin/python3 -m pip install --pre totalreclaw
+#   Containerized Hermes (run from inside the container shell):
+python3 -m pip install --pre totalreclaw
+#   System-Python install (no venv, may need --break-system-packages):
+python3 -m pip install --pre totalreclaw
 
 # Restart the gateway. Pick the line that matches your setup:
 hermes gateway restart                       # native install

--- a/python/src/totalreclaw/hermes/SKILL.md
+++ b/python/src/totalreclaw/hermes/SKILL.md
@@ -15,12 +15,22 @@ homepage: https://totalreclaw.xyz
 
 If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jump to step 4. Otherwise run all steps in order.
 
-1. **Install plugin + Python package.** Hermes 2026.4.16+ uses Git-based plugin discovery and a separate Python tool implementation. Run via your shell tool:
+1. **Install plugin + Python package.** Hermes 2026.4.16+ uses Git-based plugin discovery and a separate Python tool implementation. The Python package MUST go into the SAME Python environment that Hermes runs from (containerized venv, native venv, or system Python — whichever your install uses). Bare `pip install` may target the wrong Python on containerized deploys. Step-by-step via your shell tool:
    ```
+   # 1a. Detect the Hermes Python (run inside the gateway's shell context — for
+   # Docker, that means `docker exec -it <container> bash` first).
+   HERMES_PYTHON="$(command -v python3)"
+   echo "Hermes Python: $HERMES_PYTHON"
+   "$HERMES_PYTHON" -c "import sys; print(sys.prefix)"
+
+   # 1b. Install both halves into the right env.
    hermes plugins install p-diogo/totalreclaw-hermes --enable
-   pip install --pre totalreclaw
+   "$HERMES_PYTHON" -m pip install --pre totalreclaw
+
+   # 1c. Verify the package resolved through Hermes' Python.
+   "$HERMES_PYTHON" -m pip show totalreclaw | head -2
    ```
-   (If Hermes runs in its own venv, use that venv's pip — e.g. `/path/to/hermes/venv/bin/python3 -m pip install --pre totalreclaw`.) If either shell call fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment): tell the user verbatim *"Your environment doesn't expose the Hermes CLI / pip to me. Please install `p-diogo/totalreclaw-hermes` and the `totalreclaw` Python package via your service's plugins UI, then reply `done`."* Wait for `done` and skip to step 3.
+   If `pip show` doesn't list the package, the install landed in a different Python — fix `$HERMES_PYTHON` and re-run 1b. On Debian/Ubuntu/Docker you may hit `externally-managed-environment` if Hermes runs against system Python — add `--break-system-packages` to the `pip install` line, or ask the user to recreate Hermes inside a venv. If either shell call fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment): tell the user verbatim *"Your environment doesn't expose the Hermes CLI / pip to me. Please install `p-diogo/totalreclaw-hermes` and the `totalreclaw` Python package via your service's plugins UI, then reply `done`."* Wait for `done` and skip to step 3.
 
 2. **Restart the gateway — Hermes does NOT auto-reload on plugin install.** Tell the user verbatim: *"Please restart your Hermes gateway: `hermes gateway restart` (native), `docker restart <your-container-name>` (Docker self-host — substitute the actual name; `docker ps` shows it), or your managed service's restart control. If supervised by systemd / launchd, `kill -USR1 $(cat ~/.hermes/gateway.pid)` triggers a graceful-drain restart. Reply `done` once it's back up."* Do NOT run the restart yourself — your shell is inside the gateway you'd be restarting. Wait for the user's `done`.
 

--- a/python/src/totalreclaw/hermes/pair_tool_completion.py
+++ b/python/src/totalreclaw/hermes/pair_tool_completion.py
@@ -16,33 +16,66 @@ Phrase-safety invariants enforced here:
 - Best-effort zeroization of local variables holding the phrase after
   state configure.
 - No logging of phrase content. Only the EOA address (already public)
-  and sid prefix are logged.
+  and a session-id-fragment prefix are logged.
+
+Session-id attribute compatibility (rc.23 fix for QA finding F4):
+this handler gets called from BOTH the local-mode HTTP path
+(``..pair.session_store.PairSession`` — has ``.sid``) and the
+relay-mode shared completion path (``..pair.remote_client
+.RemotePairSession`` — has ``.token``). Pre-rc.23 the helper hard-coded
+``session.sid``, which raised ``AttributeError`` on the relay shape.
+The fix below uses :func:`_session_id_fragment` to read either
+attribute defensively so a single completion handler can serve both
+paths.
 """
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .state import PluginState
-    from ..pair.session_store import PairSession
+    from ..pair.session_store import PairSession  # noqa: F401 — type-only
 
 from ..pair.http_server import CompletePairingResult
 
 logger = logging.getLogger(__name__)
 
 
+def _session_id_fragment(session: Any) -> str:
+    """Best-effort short identifier for log lines.
+
+    Reads either ``.token`` (``RemotePairSession``) or ``.sid``
+    (``PairSession``) — the local handler shape has ``.sid``, the relay
+    handshake exposes ``.token``. Returns an 8-char prefix or ``"?"``
+    if neither attribute is present / both are empty.
+
+    NEVER raises — log lines must not torpedo a successful pairing.
+    """
+    candidate = getattr(session, "token", None) or getattr(session, "sid", None)
+    if not isinstance(candidate, str) or not candidate:
+        return "?"
+    return candidate[:8]
+
+
 def complete_pairing(
     phrase: str,
-    session: "PairSession",
+    session: Any,
     state: "PluginState",
 ) -> CompletePairingResult:
     """Apply a browser-decrypted phrase to the Hermes plugin state.
 
-    Called FROM the HTTP handler thread. ``state.configure`` is synchronous
-    (writes credentials.json, derives the EOA address). The async Smart-
-    Account derivation happens lazily on the first remember/recall call.
+    Called from BOTH the local HTTP handler thread and the relay-mode
+    completion path. ``state.configure`` is synchronous (writes
+    credentials.json, derives the EOA address). The async Smart-Account
+    derivation happens lazily on the first remember/recall call.
+
+    ``session`` accepts either a ``PairSession`` (local mode, has
+    ``.sid``) or a ``RemotePairSession`` (relay mode, has ``.token``).
+    The id is used only for log-line correlation — callers don't need
+    the same shape on both paths.
     """
+    sid_frag = _session_id_fragment(session)
     try:
         state.configure(phrase)
         client = state.get_client()
@@ -50,13 +83,13 @@ def complete_pairing(
         logger.info(
             "pair-tool: credentials configured for EOA %s (session %s…)",
             eoa or "unknown",
-            session.sid[:8],
+            sid_frag,
         )
         return CompletePairingResult(state="active", account_id=eoa)
     except Exception as err:  # pragma: no cover — defensive
         logger.error(
             "pair-tool: complete_pairing failed for session %s…: %r",
-            session.sid[:8],
+            sid_frag,
             err,
         )
         return CompletePairingResult(state="error", error=str(err))


### PR DESCRIPTION
Extracted from closed #134 after auto-triage shipped #132 (#148 portion) on main. These 2 findings remained un-fixed:

## #151 (MEDIUM) — pair AttributeError
`pair_tool_completion.complete_pairing` referenced `session.sid` but `RemotePairSession` only has `.token`. Added `_session_id_fragment` helper reading `.token` then `.sid`. Signature accepts `Any` so both PairSession + RemotePairSession flow through.

## #152 (MEDIUM) — venv install path on containerized Hermes
Chat install Step 1 lands `totalreclaw` outside Hermes venv when running in containers (Hermes venv has no pip → agent can't recover). Step 1 split into:
- 1a: detect `$HERMES_PYTHON`
- 1b: `"$HERMES_PYTHON" -m pip install` (venv-correct pip)
- 1c: `pip show` verify

Mirrored in Hermes SKILL.md so the agent reading the markdown follows the same probe-decide pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)