### PR TITLE
chore(rc): bump 2.3.1rc24 -> 2.3.1rc25 (republish retype/set_scope per #159)

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "totalreclaw"
-version = "2.3.1rc24"
+version = "2.3.1rc25"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"

--- a/python/src/totalreclaw/__init__.py
+++ b/python/src/totalreclaw/__init__.py
@@ -9,7 +9,7 @@ except Exception:
     # installed-package metadata is absent. Must match pyproject.toml —
     # test_version.py enforces a semver-shape string; the live value in
     # a pip-installed wheel comes from importlib.metadata above.
-    __version__ = "2.3.1rc24"
+    __version__ = "2.3.1rc25"
 
 from .client import TotalReclaw
 

--- a/python/src/totalreclaw/hermes/plugin.yaml
+++ b/python/src/totalreclaw/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: totalreclaw
-version: 2.3.1rc24
+version: 2.3.1rc25
 description: End-to-end encrypted memory vault for AI agents (Memory Taxonomy v1)
 author: TotalReclaw Team
 provides_tools:


### PR DESCRIPTION
## What broke
Hermes 2.3.1rc24 published from sibling fix/issue-148 branch BEFORE PR #135 (retype + set_scope tool surface) merged into main, so the published wheel is missing `totalreclaw_retype` and `totalreclaw_set_scope`. Issue #159 captured this gap.

## What's fixed
Bump pyproject.toml + __init__.py + plugin.yaml from rc.24 to rc.25 so PyPI publish from main HEAD ships an artifact that contains the retype/set_scope tool registration.

## Impact after fix
After publish, `pip install totalreclaw==2.3.1rc25` exposes `totalreclaw_retype` and `totalreclaw_set_scope` to Hermes agents. In-place type / scope changes stop creating duplicate facts (the rc.23/rc.24 fallback was `recall + remember`).

## Verification
QA scenario S4 from `qa-totalreclaw` skill — "the zsh+starship thing should be filed as a preference, not a fact. Can you retype it?" + "Move the TanStack Query thing under a scope called frontend." — to be run on rc.25 by `tr-triage-and-fix` Stage 4 once published.

Closes #159