### PR TITLE
fix(#158): loud warn + reduced-prompt retry on empty extraction LLM (rc.25)

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "totalreclaw"
-version = "2.3.1rc24"
+version = "2.3.1rc25"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"

--- a/python/src/totalreclaw/agent/extraction.py
+++ b/python/src/totalreclaw/agent/extraction.py
@@ -1021,11 +1021,12 @@ async def extract_facts_llm(
             + "\n".join(mem_lines)
         )
 
-    user_prompt = (
-        f"Extract important facts from these recent conversation turns:\n\n{conversation_text}{memories_ctx}"
+    framing = (
+        "Extract important facts from these recent conversation turns:"
         if mode == "turn"
-        else f"Extract ALL valuable long-term memories from this conversation before it is lost:\n\n{conversation_text}{memories_ctx}"
+        else "Extract ALL valuable long-term memories from this conversation before it is lost:"
     )
+    user_prompt = f"{framing}\n\n{conversation_text}{memories_ctx}"
 
     try:
         response = await chat_completion(config, EXTRACTION_SYSTEM_PROMPT, user_prompt)
@@ -1033,9 +1034,35 @@ async def extract_facts_llm(
         logger.warning("extract_facts_llm: chat_completion threw: %s", e)
         return []
 
+    # Issue #158: empty 200-response on the aux LLM path used to silently
+    # zero out auto-extraction. Retry once with a reduced prompt (drop
+    # existing-memories context, trim conversation to the last 3 messages)
+    # before giving up — covers length / context-shape sensitivities.
     if not response:
-        logger.info("extract_facts_llm: chat_completion returned None/empty")
-        return []
+        retry_text = _truncate_messages(relevant[-3:]) if relevant else conversation_text
+        retry_prompt = f"{framing}\n\n{retry_text}"
+        logger.warning(
+            "extract_facts_llm: chat_completion returned None/empty on first call "
+            "(user_chars=%d, memories_ctx_chars=%d); retrying with reduced prompt "
+            "(user_chars=%d, no memories_ctx)",
+            len(user_prompt),
+            len(memories_ctx),
+            len(retry_prompt),
+        )
+        try:
+            response = await chat_completion(config, EXTRACTION_SYSTEM_PROMPT, retry_prompt)
+        except Exception as e:
+            logger.warning("extract_facts_llm: reduced-prompt retry threw: %s", e)
+            return []
+        if not response:
+            logger.warning(
+                "extract_facts_llm: chat_completion returned None/empty on reduced-"
+                "prompt retry too — no facts extracted from this turn"
+            )
+            return []
+        logger.info(
+            "extract_facts_llm: reduced-prompt retry recovered %d chars", len(response),
+        )
 
     logger.info(
         "extract_facts_llm: LLM returned %d chars; parsing merged response",

--- a/python/src/totalreclaw/agent/llm_client.py
+++ b/python/src/totalreclaw/agent/llm_client.py
@@ -920,7 +920,22 @@ async def _call_openai(
         )
         resp.raise_for_status()
         data = resp.json()
-        return data.get("choices", [{}])[0].get("message", {}).get("content")
+        choice = (data.get("choices") or [{}])[0]
+        content = (choice.get("message") or {}).get("content")
+        if not content:
+            # Issue #158: 200-with-empty-content used to be silent. Surface
+            # finish_reason + payload sizes so triage doesn't have to guess
+            # whether it was content_filter / length / refusal-empty / hiccup.
+            logger.warning(
+                "LLM returned empty content (provider=openai, base=%s, model=%s, "
+                "finish_reason=%s, system_chars=%d, user_chars=%d)",
+                config.base_url,
+                config.model,
+                choice.get("finish_reason"),
+                len(system_prompt),
+                len(user_prompt),
+            )
+        return content
 
 
 async def _call_anthropic(
@@ -950,5 +965,25 @@ async def _call_anthropic(
         data = resp.json()
         for block in data.get("content", []):
             if block.get("type") == "text":
-                return block.get("text")
+                text = block.get("text")
+                if not text:
+                    logger.warning(
+                        "LLM returned empty content (provider=anthropic, base=%s, "
+                        "model=%s, stop_reason=%s, system_chars=%d, user_chars=%d)",
+                        config.base_url,
+                        config.model,
+                        data.get("stop_reason"),
+                        len(system_prompt),
+                        len(user_prompt),
+                    )
+                return text
+        logger.warning(
+            "LLM returned no text blocks (provider=anthropic, base=%s, model=%s, "
+            "stop_reason=%s, system_chars=%d, user_chars=%d)",
+            config.base_url,
+            config.model,
+            data.get("stop_reason"),
+            len(system_prompt),
+            len(user_prompt),
+        )
         return None

--- a/python/tests/test_extractor.py
+++ b/python/tests/test_extractor.py
@@ -557,12 +557,49 @@ class TestExtractFactsLLM:
 
     @pytest.mark.asyncio
     async def test_llm_returns_none(self):
+        # Issue #158: empty 200-response triggers a reduced-prompt retry. If
+        # BOTH the first call and the retry are empty, extraction yields [].
         with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test", "OPENAI_MODEL": "gpt-4.1-mini"}, clear=True):
             with patch("totalreclaw.agent.extraction.chat_completion", new_callable=AsyncMock) as mock_chat:
                 mock_chat.return_value = None
                 messages = [{"role": "user", "content": "Some conversation content here"}]
                 facts = await extract_facts_llm(messages)
                 assert facts == []
+                assert mock_chat.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_issue_158_empty_response_retries_with_reduced_prompt(self):
+        """Issue #158: when chat_completion returns empty 200 on the first call,
+        extract_facts_llm retries once with a smaller prompt (no existing-memories
+        block, last 3 messages only) before giving up."""
+        recovery_payload = json.dumps([
+            {"text": "User lives in Lisbon", "type": "fact", "importance": 8, "action": "ADD"},
+        ])
+
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test", "OPENAI_MODEL": "gpt-4.1-mini"}, clear=True):
+            with patch("totalreclaw.agent.extraction.chat_completion", new_callable=AsyncMock) as mock_chat:
+                # First call: empty (mimics the rc.23 silent-fail symptom).
+                # Second call (reduced-prompt retry): valid extraction.
+                mock_chat.side_effect = ["", recovery_payload]
+                messages = [
+                    {"role": "user", "content": "I want to talk about my home setup"},
+                    {"role": "assistant", "content": "Sure, tell me more."},
+                    {"role": "user", "content": "I live in Lisbon and work on TotalReclaw"},
+                    {"role": "assistant", "content": "Got it."},
+                ]
+                existing = [{"id": f"mem_{i}", "text": f"old memory {i}"} for i in range(20)]
+                facts = await extract_facts_llm(messages, existing_memories=existing)
+
+                assert mock_chat.call_count == 2, "should retry exactly once on empty response"
+                # First call carries existing-memories context; retry strips it.
+                first_user_prompt = mock_chat.call_args_list[0][0][2]
+                retry_user_prompt = mock_chat.call_args_list[1][0][2]
+                assert "Existing memories" in first_user_prompt
+                assert "Existing memories" not in retry_user_prompt
+                assert len(retry_user_prompt) < len(first_user_prompt)
+                # Recovery payload survives the rest of the pipeline.
+                assert len(facts) == 1
+                assert facts[0].text == "User lives in Lisbon"
 
     @pytest.mark.asyncio
     async def test_short_conversation_skipped(self):


### PR DESCRIPTION
## What broke
On Z.AI/GLM-5.1 the auxiliary extraction LLM occasionally returns `200 OK` with empty content; the agent silently logged at `INFO` and yielded zero auto-extracted facts on every affected turn (rc.23 QA: 15 hits across S2). On tool-call-eager LLMs the `totalreclaw_remember` path masked the bug; quieter aux models would have shipped silent zero-extraction with no visible error.

## What's fixed
- `_call_openai` / `_call_anthropic` log `WARNING` with `finish_reason` / `stop_reason` + system+user prompt sizes + endpoint base on empty 200 responses.
- `extract_facts_llm` retries once with a reduced prompt (drop existing-memories context, trim to last 3 messages) on empty response; loud `WARNING` if both calls empty.
- Bumps `pyproject.toml` to `2.3.1rc25`.

## Impact after fix
Empty 200-content from the aux LLM is no longer silent — surfaced via `WARNING` with diagnostics on every occurrence, and the pipeline auto-recovers via reduced-prompt retry when the failure is length / context-shape sensitive.

## Verification
QA report: [`docs/notes/QA-hermes-RC-2.3.1-rc.25-20260426-fix158.md`](https://github.com/p-diogo/totalreclaw-internal/blob/main/docs/notes/QA-hermes-RC-2.3.1-rc.25-20260426-fix158.md) — GO.
- 943 unit tests pass on full Python suite + new `test_issue_158_empty_response_retries_with_reduced_prompt` regression.
- Probe on published rc.25 install: forced-empty case fires retry + recovers + emits both diagnostic logs; both-calls-empty case emits two WARNs and returns `[]`; happy-path live call to Z.AI yields valid extraction with no spurious empty-content WARNs.

Closes #158