### PR TITLE
fix(hermes): rc.24 — pair sidecar + extraction endpoint heuristic + packaging fix (3 blockers)

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,15 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "totalreclaw"
-version = "2.3.1rc24"
+# Stable base version. The publish-python-client.yml workflow appends
+# `rc<N>` (PEP 440) to this string when `release-type=rc` is dispatched;
+# the mutation is ephemeral and does NOT round-trip back to main. Prior
+# to rc.24 a stale `2.3.1rc24` literal had leaked into this file (the
+# publish workflow's per-RC mutation had been committed back manually),
+# which would have caused stable builds to mis-publish AND broke the
+# regex-based mutation logic on subsequent RCs. Keep this at the next
+# stable target with NO rc suffix. F3 fix in rc.24.
+version = "2.3.1"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"
@@ -65,6 +73,21 @@ totalreclaw = "totalreclaw.hermes"
 # Hermes-specific first-run wizard run `totalreclaw hermes-setup`
 # (see `totalreclaw.cli:main` for the subcommand router).
 totalreclaw = "totalreclaw.cli:main"
+
+# 2.3.1rc24 (F3) — explicit setuptools find config. Without this
+# stanza, ``setuptools.build_meta`` runs auto-discovery; with our
+# src-layout (``python/src/totalreclaw/``) and the multiple top-level
+# directories that auto-discovery scans (``tests/``, ``.venv/``, etc.)
+# it can silently miss newly-added top-level modules under
+# ``totalreclaw/``. The rc.23 wheel published to PyPI did NOT contain
+# ``retype_setscope.py`` even though the file was on main, exactly
+# because of this auto-discovery quirk. Pin the discovery root + glob
+# explicitly so every ``totalreclaw*`` package + subpackage that lives
+# under ``src/`` lands in the wheel. Validated by the regression test at
+# ``python/tests/test_packaging_integrity.py``.
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["totalreclaw*"]
 
 [tool.setuptools.package-data]
 "totalreclaw.hermes" = ["plugin.yaml", "SKILL.md"]

--- a/python/src/totalreclaw/__init__.py
+++ b/python/src/totalreclaw/__init__.py
@@ -9,7 +9,7 @@ except Exception:
     # installed-package metadata is absent. Must match pyproject.toml —
     # test_version.py enforces a semver-shape string; the live value in
     # a pip-installed wheel comes from importlib.metadata above.
-    __version__ = "2.3.1rc24"
+    __version__ = "2.3.1"
 
 from .client import TotalReclaw
 

--- a/python/src/totalreclaw/agent/extraction.py
+++ b/python/src/totalreclaw/agent/extraction.py
@@ -1034,7 +1034,20 @@ async def extract_facts_llm(
         return []
 
     if not response:
-        logger.info("extract_facts_llm: chat_completion returned None/empty")
+        # F2 (rc.24) — bumped from INFO to WARNING. An empty extraction
+        # response is a CORRECTNESS bug, not a routine event: the LLM
+        # accepted the call without raising, but content was empty —
+        # this is what surfaced in the rc.23 QA report as 100% silent
+        # auto-extraction failure on Z.AI/GLM-5.1. ``chat_completion``
+        # already logs the underlying request shape (finish_reason,
+        # usage, response_format) at WARN; this line tells the operator
+        # WHERE the empty bubbled up so they can correlate the two.
+        logger.warning(
+            "extract_facts_llm: chat_completion returned None/empty — "
+            "auto-extraction will be a no-op for this turn. "
+            "See preceding 'LLM returned empty content' log for the "
+            "underlying response shape (finish_reason / usage)."
+        )
         return []
 
     logger.info(
@@ -1133,7 +1146,16 @@ async def extract_facts_compaction(
         return []
 
     if not response:
-        logger.info("extract_facts_compaction: chat_completion returned None/empty")
+        # F2 (rc.24) — bumped from INFO to WARNING for the same reason
+        # as ``extract_facts_llm`` above. Compaction is the LAST chance
+        # to capture facts before the conversation is collapsed; a
+        # silent empty-response here is a hard data-loss event.
+        logger.warning(
+            "extract_facts_compaction: chat_completion returned None/empty — "
+            "compaction extraction will be a no-op for this conversation. "
+            "See preceding 'LLM returned empty content' log for the "
+            "underlying response shape."
+        )
         return []
 
     logger.info(

--- a/python/src/totalreclaw/agent/llm_client.py
+++ b/python/src/totalreclaw/agent/llm_client.py
@@ -20,7 +20,7 @@ import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import httpx
 
@@ -66,12 +66,66 @@ ZAI_CODING_BASE_URL = "https://api.z.ai/api/coding/paas/v4"
 ZAI_STANDARD_BASE_URL = "https://api.z.ai/api/paas/v4"
 
 
-def get_zai_base_url() -> str:
+def zai_base_url_for_model(model: str) -> str:
+    """Pick the right zai endpoint for ``model``.
+
+    rc.24 (F2 follow-up per Pedro 2026-04-26): zai exposes two
+    endpoints with DIFFERENT model availability matrices. Coding-plan
+    keys hitting the standard endpoint or vice-versa returns 429
+    "Insufficient balance" (handled in :func:`chat_completion`'s
+    auto-fallback) — but a Coding-plan key sending GLM-5.x to the
+    coding endpoint OR vice-versa returns HTTP 200 with **empty
+    content** (no error to flip on). That was the silent symptom F2
+    surfaced in the rc.23 QA report.
+
+    Heuristic:
+
+    - GLM-4.5 family (``glm-4.5*``, ``glm-4.5-air``, ``glm-4.5-flash``,
+      ``glm-4-*`` in general) is a Coding plan model — coding endpoint.
+    - GLM-5.x family (``glm-5*``, ``glm-5.1``, etc.) is on the
+      Standard PAYG endpoint.
+    - Anything else falls back to the configured / default endpoint.
+
+    The actual run-time binding still respects the explicit
+    ``ZAI_BASE_URL`` override (operator-pinned). This helper only
+    resolves the *default* when no override is set.
+    """
+    lower = (model or "").strip().lower()
+    if not lower:
+        return ZAI_CODING_BASE_URL
+
+    # GLM-5.x → Standard PAYG. Match `glm-5`, `glm-5.x`, `glm-5-*`,
+    # `glm5*` (no-dash variant occasionally seen). Tight enough not to
+    # match GLM-4.5 (which contains "5" but is a different family).
+    if (
+        lower.startswith("glm-5")
+        or lower.startswith("glm5")
+        or "glm-5." in lower
+    ):
+        return ZAI_STANDARD_BASE_URL
+
+    # GLM-4.x → Coding plan. Includes -flash, -air, -turbo variants.
+    if (
+        lower.startswith("glm-4")
+        or lower.startswith("glm4")
+        or "glm-4." in lower
+    ):
+        return ZAI_CODING_BASE_URL
+
+    # Unknown model — fall back to the historical coding default.
+    return ZAI_CODING_BASE_URL
+
+
+def get_zai_base_url(model: Optional[str] = None) -> str:
     """Resolve the zai base URL.
 
     Precedence:
       1. ``ZAI_BASE_URL`` env var (explicit operator override)
-      2. Default: coding endpoint (coding-plan-biased; the rc.3
+      2. ``zai_base_url_for_model(model)`` — model-family heuristic
+         (rc.24 F2 fix). Picks coding-vs-standard based on the model
+         name to avoid the silent-empty-content trap when the model
+         isn't available on the chosen endpoint.
+      3. Default: coding endpoint (coding-plan-biased; the rc.3
          auto-fallback hops to the standard endpoint on an
          "Insufficient balance" 429).
 
@@ -82,6 +136,8 @@ def get_zai_base_url() -> str:
     raw = os.environ.get("ZAI_BASE_URL", "").strip()
     if raw:
         return raw.rstrip("/")
+    if model:
+        return zai_base_url_for_model(model)
     return ZAI_CODING_BASE_URL
 
 
@@ -330,7 +386,9 @@ def _read_hermes_llm_config_from_auth_json(
         elif auth_base_url:
             base_url = auth_base_url.rstrip("/")
         else:
-            base_url = get_zai_base_url()
+            # rc.24 F2 fix — pick endpoint based on model family.
+            # GLM-5.x lives on Standard PAYG, GLM-4.x on Coding.
+            base_url = get_zai_base_url(model=model)
     else:
         _, default_base_url = _HERMES_PROVIDER_KEY_MAP.get(provider_lower, ([], ""))
         base_url = (
@@ -486,7 +544,8 @@ def read_hermes_llm_config() -> Optional[LLMConfig]:
             if zai_override and zai_override.strip():
                 base_url = zai_override.strip().rstrip("/")
             else:
-                base_url = get_zai_base_url()
+                # rc.24 F2 fix — model-aware endpoint pick.
+                base_url = get_zai_base_url(model=model)
         else:
             base_url = (
                 env_vars.get("GLM_BASE_URL")
@@ -568,7 +627,11 @@ def detect_llm_config(configured_model: Optional[str] = None) -> Optional[LLMCon
                     # Respect ZAI_BASE_URL env override (rc.3). Coding-plan
                     # users can leave unset; PAYG users set it explicitly
                     # to https://api.z.ai/api/paas/v4.
-                    resolved_base_url = get_zai_base_url()
+                    # rc.24 F2 fix — when no env override is set, pick the
+                    # endpoint based on the model family (GLM-5.x → Standard,
+                    # GLM-4.x → Coding) so a Coding-plan user asking for
+                    # GLM-5.1 doesn't silently get empty content.
+                    resolved_base_url = get_zai_base_url(model=model)
                 else:
                     resolved_base_url = default_base_url
 
@@ -779,7 +842,33 @@ async def chat_completion(
             if active.api_format == "anthropic":
                 return await _call_anthropic(active, system_prompt, user_prompt, max_tokens, temperature)
             else:
-                return await _call_openai(active, system_prompt, user_prompt, max_tokens, temperature)
+                content = await _call_openai(active, system_prompt, user_prompt, max_tokens, temperature)
+                # rc.24 F2 fix — if zai returned 200 with empty content
+                # AND we haven't yet tried the OTHER zai endpoint, do
+                # a one-shot flip and retry. Empty 200 from zai is the
+                # "wrong-endpoint-for-this-model" symptom (e.g.
+                # GLM-5.1 hit on the Coding endpoint where it isn't
+                # available). The flip is consistent with the existing
+                # 429 "Insufficient balance" auto-fallback.
+                if (
+                    not content
+                    and not zai_fallback_attempted
+                    and zai_fallback_base_url(active.base_url) is not None
+                ):
+                    fallback = zai_fallback_base_url(active.base_url)
+                    if fallback:
+                        zai_fallback_attempted = True
+                        old_url = active.base_url
+                        active.base_url = fallback
+                        logger.info(
+                            "zai endpoint auto-fallback: %s → %s due to "
+                            "empty content response (model=%s — likely "
+                            "wrong endpoint for this model family)",
+                            old_url, fallback, active.model,
+                        )
+                        attempt -= 1
+                        continue
+                return content
         except httpx.HTTPStatusError as e:
             last_exc = e
             last_status = e.response.status_code
@@ -894,6 +983,45 @@ async def chat_completion(
     )
 
 
+#: Providers that return a base_url containing one of these substrings
+#: are known to honour ``response_format: {"type": "json_object"}`` and
+#: BENEFIT from it for structured-output prompts (extraction, compaction,
+#: comparative re-rank). Z.AI / GLM in particular is observed to return
+#: empty content on the merged-extraction prompt without it (F2 in QA
+#: report ``QA-hermes-RC-2.3.1-rc.23-20260426.md``). OpenAI also supports
+#: it but the prompt already guides JSON output reliably; sending the hint
+#: doesn't hurt.
+#:
+#: Match logic is a substring check on ``LLMConfig.base_url`` rather than
+#: a provider-name table because ``base_url`` is the only field we have
+#: at call time once the config is built.
+_JSON_OBJECT_PROVIDER_HINTS: tuple[str, ...] = (
+    "z.ai",                  # both /coding/paas/v4 and /paas/v4 endpoints
+    "api.openai.com",
+    "groq.com",
+    "openrouter.ai",
+    "deepseek.com",
+    "mistral.ai",
+    "x.ai",
+    "together.xyz",
+)
+
+
+def _supports_json_object_response_format(base_url: str) -> bool:
+    """Return True if this provider should be sent
+    ``response_format: {"type": "json_object"}`` on extraction calls.
+
+    Conservative match: substring match on the base URL. Adding new
+    providers is safe — incorrect inclusion only makes the API ignore
+    the field on providers that don't support it (OpenAI-spec-compatible
+    providers either honour the field or drop it silently).
+    """
+    if not base_url:
+        return False
+    lower = base_url.lower()
+    return any(hint in lower for hint in _JSON_OBJECT_PROVIDER_HINTS)
+
+
 async def _call_openai(
     config: LLMConfig,
     system_prompt: str,
@@ -901,6 +1029,44 @@ async def _call_openai(
     max_tokens: int,
     temperature: float,
 ) -> Optional[str]:
+    """OpenAI-spec chat-completions call.
+
+    F2 fix (rc.24, ref ``QA-hermes-RC-2.3.1-rc.23-20260426.md``):
+
+    1. For known structured-output-aware providers (zai/GLM, OpenAI,
+       Groq, DeepSeek, OpenRouter, Mistral, x.ai, Together) we now send
+       ``response_format: {"type": "json_object"}``. GLM-5.1 in
+       particular returned EMPTY content for the merged-extraction
+       prompt without this hint — no error, just an empty
+       ``message.content`` — which broke auto-extraction silently in
+       rc.23 QA. Sending the hint flips it to deterministic JSON
+       output. Providers that ignore the field are unaffected.
+
+    2. When the response parses successfully but ``message.content`` is
+       empty / missing, we now WARN with the request payload size,
+       model, and the OpenAI ``finish_reason`` so an empty extraction
+       call is loud at the source. Previously this surfaced as the
+       single line ``extract_facts_llm: chat_completion returned
+       None/empty`` at INFO level, which gave operators no way to
+       tell whether the model returned junk, hit a content filter, or
+       OOM'd a context window.
+    """
+    body: dict[str, Any] = {
+        "model": config.model,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        "temperature": temperature,
+        "max_completion_tokens": max_tokens,
+    }
+    if _supports_json_object_response_format(config.base_url):
+        # Hint to the provider that we want valid JSON. Combined with
+        # the system prompt's "Return JSON ..." instruction, this is
+        # what flips zai/GLM from empty-content responses to structured
+        # output. See F2 in the rc.23 QA report.
+        body["response_format"] = {"type": "json_object"}
+
     async with httpx.AsyncClient(timeout=_LLM_TIMEOUT) as client:
         resp = await client.post(
             f"{config.base_url}/chat/completions",
@@ -908,19 +1074,32 @@ async def _call_openai(
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {config.api_key}",
             },
-            json={
-                "model": config.model,
-                "messages": [
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": user_prompt},
-                ],
-                "temperature": temperature,
-                "max_completion_tokens": max_tokens,
-            },
+            json=body,
         )
         resp.raise_for_status()
         data = resp.json()
-        return data.get("choices", [{}])[0].get("message", {}).get("content")
+        choice = (data.get("choices") or [{}])[0]
+        content = choice.get("message", {}).get("content")
+        if not content:
+            # F2 — empty responses must be loud, not silent. Prior to
+            # rc.24 this was logged as a generic "returned None/empty"
+            # downstream in extraction.py at INFO. Surface the actual
+            # response shape (finish_reason, usage) at WARN here so the
+            # operator can correlate empty extraction batches with the
+            # provider response without enabling DEBUG.
+            logger.warning(
+                "LLM returned empty content (provider=%s, model=%s, "
+                "system_chars=%d, user_chars=%d, finish_reason=%s, usage=%s, "
+                "json_response_format=%s)",
+                config.base_url,
+                config.model,
+                len(system_prompt or ""),
+                len(user_prompt or ""),
+                choice.get("finish_reason"),
+                data.get("usage"),
+                "response_format" in body,
+            )
+        return content
 
 
 async def _call_anthropic(

--- a/python/src/totalreclaw/hermes/pair_tool.py
+++ b/python/src/totalreclaw/hermes/pair_tool.py
@@ -546,20 +546,79 @@ async def _pair_relay(state: "PluginState", mode: str):
     The ``mode`` is passed to the relay via the ``open`` frame so the
     server-rendered HTML only shows the panel(s) the caller asked for.
 
-    rc.13 asyncio-lifecycle fix: the WebSocket + completion waiter both
-    run on a dedicated worker thread. The tool body blocks only on the
-    fast ``session/open`` handshake, then returns to the agent. The
-    browser-side flow that follows (user types PIN + paste phrase, ~30s
-    median) runs fully inside the worker thread — the Hermes tool-call
-    event loop can close immediately after this function returns.
+    rc.13 asyncio-lifecycle fix: the WebSocket + completion waiter ran
+    on a dedicated worker thread inside the Hermes process. That fix
+    held for long-lived ``hermes gateway run`` daemons but DID NOT
+    survive ``hermes chat -q`` / ACP single-call / MCP single-call /
+    Python harness — those all exit the Python process the moment the
+    agent reply lands, killing the daemon thread (and its WebSocket)
+    before the user can finish the browser flow. The relay then saw
+    the WS close, tore the session down, and returned 404/502 for the
+    eventual phrase POST.
+
+    rc.24 (F1, ref ``QA-hermes-RC-2.3.1-rc.23-20260426.md`` Finding
+    #157): always hand the WebSocket lifecycle off to a fully-detached
+    sidecar SUBPROCESS (POSIX ``setsid``) before returning. The
+    sidecar lives past the parent's exit because it's been reparented
+    to ``init`` / ``launchd``, so a one-shot agent process can finish
+    its turn while the sidecar holds the relay session open through
+    the user's browser-completion latency. See
+    :mod:`totalreclaw.pair.completion_sidecar` for the full rationale.
+
+    The ``TOTALRECLAW_PAIR_SIDECAR=0`` env var falls back to the rc.13
+    daemon-thread path. This is intentionally undocumented — it's an
+    operator escape hatch for environments that block subprocess spawn
+    (some sandboxes), not a user-facing knob. Setting it on a one-shot
+    process re-introduces the rc.23 NO-GO bug; do not use casually.
     """
-    # Offload to a thread-owned event loop — the WS never gets tied to
-    # the Hermes tool-invocation loop. See ``_run_relay_pair_on_thread``
-    # for the full design rationale + observability contract.
-    #
-    # ``to_thread`` is a thin wrapper around the default executor; it
-    # keeps this coroutine awaitable while the heavy lifting is on a
-    # real OS thread. The callee itself is synchronous — it blocks
-    # internally on the worker thread's handshake queue.
+    if _sidecar_enabled():
+        # Run the spawn in a worker thread so the (synchronous) Popen
+        # + handshake-poll doesn't block the asyncio loop. The whole
+        # call is fast (<1s typical) since the sidecar reports back as
+        # soon as the relay returns ``opened``.
+        record = await asyncio.to_thread(_run_relay_pair_via_sidecar, mode)
+        return record.url, record.pin, record.expires_at
+
+    # rc.13 fallback path — daemon-thread inside the parent process.
     opened = await asyncio.to_thread(_run_relay_pair_on_thread, state, mode)
     return opened.url, opened.pin, opened.expires_at
+
+
+def _sidecar_enabled() -> bool:
+    """rc.24 default ON. Set ``TOTALRECLAW_PAIR_SIDECAR=0`` to disable.
+
+    Disabling re-exposes the rc.23 lifecycle bug for short-lived
+    process invocations. Only sensible for long-lived daemon hosts
+    that explicitly want the daemon-thread path back (e.g. environments
+    where subprocess spawn is blocked by a sandbox).
+    """
+    raw = (os.environ.get("TOTALRECLAW_PAIR_SIDECAR") or "1").strip().lower()
+    return raw not in ("0", "false", "no", "off")
+
+
+def _run_relay_pair_via_sidecar(mode: Optional[str]):
+    """Sync helper — spawns the sidecar and waits for its handshake.
+
+    Returns the
+    :class:`totalreclaw.pair.completion_sidecar._HandshakeRecord` so
+    the caller can pull ``url`` / ``pin`` / ``expires_at`` off it.
+
+    rc.24 (F1) — see module docstring for design rationale.
+    """
+    # Local import: keeps cold-start path light; sidecar module pulls
+    # in subprocess + asyncio + uuid which the regular tool body
+    # doesn't need.
+    from ..pair.completion_sidecar import spawn_completion_sidecar
+
+    # Forward operator overrides the user might have set in env so the
+    # sidecar talks to the same relay + relay endpoint the parent would
+    # have used. ``subprocess.Popen(env=...)`` already inherits these
+    # by default; passing them through ``spawn_completion_sidecar``
+    # keeps the contract explicit and lets tests monkeypatch the env.
+    relay_url = os.environ.get("TOTALRECLAW_PAIR_RELAY_URL")
+    server_url = os.environ.get("TOTALRECLAW_SERVER_URL")
+    return spawn_completion_sidecar(
+        mode=mode,
+        relay_url=relay_url,
+        server_url=server_url,
+    )

--- a/python/src/totalreclaw/pair/completion_sidecar.py
+++ b/python/src/totalreclaw/pair/completion_sidecar.py
@@ -1,0 +1,570 @@
+"""F1 (rc.24) — detached sidecar that owns the relay-pair WebSocket
+through completion, even when the parent process exits.
+
+Background — rc.23 ship-stopper #157 (BLOCKER)
+----------------------------------------------
+``hermes chat -q`` is a one-shot: each turn runs in a fresh Python
+process that exits as soon as the agent reply is rendered. rc.13 ran
+the entire pair WebSocket lifecycle on a daemon thread inside that
+process. When the process exited, the thread (and its asyncio loop +
+open WebSocket) died with it; the relay saw the WS close, tore the
+session down, and returned 404/502 when the browser POSTed the
+encrypted phrase.
+
+Affected paths: ``hermes chat -q``, ``hermes chat --continue``, ACP
+single-call, MCP single-call, programmatic Python harness.
+
+rc.24 fix — the "always-via-sidecar" approach
+---------------------------------------------
+Instead of running the WS lifecycle on a daemon thread inside the
+parent process, we ALWAYS spawn a fully-detached sidecar subprocess
+that owns the WS through completion. The parent process:
+
+  1. Generates an ephemeral gateway keypair (ECDH x25519).
+  2. Spawns ``python -m totalreclaw.pair.completion_sidecar`` with
+     ``start_new_session=True`` (POSIX ``setsid``) so the sidecar is
+     reparented to ``init`` / launchd and survives parent exit.
+  3. Passes pair-session parameters via env vars (NOT argv — argv is
+     visible in ``ps``).
+  4. Sets up a temp file ``~/.totalreclaw/.pair_handshake_<pid>.json``
+     where the sidecar writes ``{token, pin, expires_at, url}`` after
+     the relay returns ``opened``.
+  5. Polls that file for up to ``handshake_timeout_s`` (default 15s)
+     with a coarse busy-wait. As soon as the file appears, parses it,
+     deletes it, and returns the metadata to the tool body.
+  6. Tool body returns ``{url, pin, ...}`` to the agent. Process exits.
+  7. Sidecar continues running detached, awaits the encrypted-phrase
+     forward, decrypts locally with its in-process keypair, calls
+     ``state.configure(phrase)`` (which writes
+     ``~/.totalreclaw/credentials.json``), acks the relay, exits.
+
+This is a stronger lifetime guarantee than the daemon-thread approach
+because the sidecar is a separate OS process — POSIX ``setsid`` plus
+double-fork (or ``start_new_session`` + ``preexec_fn``) detaches it
+from the parent's process group, so the parent can exit cleanly while
+the sidecar keeps the WebSocket open.
+
+Phrase-safety preserved
+-----------------------
+- The recovery phrase is generated/typed in the BROWSER. The sidecar
+  is the only ECDH endpoint that can decrypt it; the LLM context never
+  sees the phrase or its key material.
+- The keypair travels parent → sidecar via env vars (one ``fork``+
+  ``execve`` boundary). The keys are 32-byte x25519 — opaque to the
+  parent agent's LLM stream which has long since closed by then.
+- The sidecar process disappears as soon as the phrase is persisted,
+  so the in-memory window for the keypair is bounded by the user's
+  browser-completion latency (typically <30s).
+- The handshake file carries ``{token, pin, expires_at, url}`` only —
+  NOT the keypair. The keypair lives in the sidecar's memory only.
+
+Observability
+-------------
+The sidecar writes structured logs to
+``~/.totalreclaw/.pair_sidecar.log`` (rotating after 200 KB) so that:
+
+- Pair successes can be correlated with relay-side ``pair.respond_*``
+  events even after the parent process is long gone.
+- Decrypt failures, ack failures, and credential-write failures are
+  diagnosable post-hoc (the user only sees a generic browser-side
+  error otherwise).
+- Phrase NEVER appears in this log file.
+
+Usage
+-----
+This module is normally not imported directly. ``hermes/pair_tool.py``
+calls :func:`spawn_completion_sidecar` which handles the fork. The
+``__main__`` entry point is what the spawned subprocess invokes.
+
+For tests, :func:`run_sidecar_inline` runs the sidecar logic inline in
+the current process (no fork) — used by the F1 regression test to
+verify the "parent process exits, sidecar still completes" promise.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import json
+import logging
+import os
+import secrets
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Filesystem layout for the handshake handoff + sidecar log.
+#
+# ``~/.totalreclaw`` is the same directory ``credentials.json`` lives in,
+# already created with mode 0o700 by the pair flow. The handshake file
+# is short-lived (parent reads + deletes within ~15s of sidecar start)
+# and the sidecar log file persists for post-hoc debugging — neither
+# carries phrase material.
+# ---------------------------------------------------------------------------
+
+
+def _totalreclaw_dir() -> Path:
+    """The same dir credentials.json lives in. Create lazily 0700."""
+    d = Path.home() / ".totalreclaw"
+    d.mkdir(parents=True, exist_ok=True, mode=0o700)
+    return d
+
+
+def _handshake_path_for(handshake_id: str) -> Path:
+    """Path of the temp handshake file the sidecar writes after ``opened``."""
+    return _totalreclaw_dir() / f".pair_handshake_{handshake_id}.json"
+
+
+def _sidecar_log_path() -> Path:
+    """Path of the rolling sidecar log file. Capped at 200 KB on rotate."""
+    return _totalreclaw_dir() / ".pair_sidecar.log"
+
+
+_LOG_MAX_BYTES = 200 * 1024  # 200 KB
+
+
+def _configure_sidecar_logging() -> None:
+    """Configure the sidecar's logger to write to the rolling log file.
+
+    Phrase-safety: the log handler operates at module level on
+    ``totalreclaw.pair`` loggers; nothing in the codebase passes the
+    decrypted phrase to ``logger.*``. We do NOT log raw envelopes or
+    payload contents — only metadata (token prefix, mode, ack outcome).
+    """
+    log_path = _sidecar_log_path()
+    # Cheap manual rotation: if the file exceeds the cap, rename to
+    # ``.1`` (overwriting any earlier ``.1``). One generation is enough
+    # for an end-user pair-flow audit trail.
+    try:
+        if log_path.exists() and log_path.stat().st_size > _LOG_MAX_BYTES:
+            log_path.replace(log_path.with_suffix(log_path.suffix + ".1"))
+    except OSError:
+        pass
+
+    handler = logging.FileHandler(log_path, mode="a", encoding="utf-8")
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s %(levelname)s %(name)s [pair-sidecar pid=%(process)d] %(message)s"
+        )
+    )
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    # Replace any existing handlers so the sidecar doesn't double-log
+    # to stdout (which is closed via ``setsid`` anyway, but defensive).
+    root.handlers = [handler]
+
+
+# ---------------------------------------------------------------------------
+# Env-var contract between parent and sidecar.
+#
+# The keypair fields are 32-byte x25519 keys, base64-encoded — they are
+# NOT the recovery phrase. They are ephemeral session-only material:
+# the sidecar uses them to ECDH-derive the AEAD key the browser
+# encrypted the phrase against.
+#
+# Argv is intentionally NOT used — ``ps`` exposes argv to other users on
+# multi-tenant hosts. Env vars are visible only to the same UID by
+# default on Linux/macOS.
+# ---------------------------------------------------------------------------
+
+
+_ENV_RELAY_URL = "TR_PAIR_SIDECAR_RELAY_URL"
+_ENV_HANDSHAKE_ID = "TR_PAIR_SIDECAR_HANDSHAKE_ID"
+_ENV_MODE = "TR_PAIR_SIDECAR_MODE"
+_ENV_SERVER_URL = "TR_PAIR_SIDECAR_SERVER_URL"
+_ENV_OWNER_PROBE = "TR_PAIR_SIDECAR_OWNER_PROBE"
+
+
+# ---------------------------------------------------------------------------
+# Handshake-file contract.
+#
+# After the sidecar receives ``opened`` from the relay, it writes this
+# JSON shape to the handshake file. The parent polls for the file,
+# parses, deletes, and returns the URL/PIN/expires_at to the tool body.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _HandshakeRecord:
+    """Tiny JSON record handed off via temp file. NO key material."""
+
+    url: str
+    pin: str
+    expires_at: str
+    token: str
+    # Status: "opened" on success, "error" with ``error_message`` on relay
+    # rejection (so the parent can surface a clean error to the agent
+    # rather than time out).
+    status: str
+    error_message: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Parent side: spawn the sidecar + wait for handshake.
+# ---------------------------------------------------------------------------
+
+
+def _python_executable() -> str:
+    """Return the interpreter the sidecar should run under.
+
+    Prefer ``sys.executable`` so the sidecar uses the SAME venv the
+    parent does (the venv is what has ``totalreclaw`` + its deps
+    installed). Fall back to ``python3`` only if ``sys.executable`` is
+    somehow empty (frozen-binary corner cases).
+    """
+    return sys.executable or "python3"
+
+
+def spawn_completion_sidecar(
+    *,
+    mode: Optional[str],
+    relay_url: Optional[str] = None,
+    server_url: Optional[str] = None,
+    handshake_timeout_s: float = 15.0,
+) -> _HandshakeRecord:
+    """Fork a detached sidecar; block until it reports ``opened``.
+
+    Returns
+    -------
+    _HandshakeRecord
+        The pair-session metadata to surface back to the agent.
+
+    Raises
+    ------
+    RuntimeError
+        If the sidecar does not return ``opened`` within
+        ``handshake_timeout_s`` OR if the sidecar reports an error.
+    """
+    handshake_id = uuid.uuid4().hex
+    handshake_path = _handshake_path_for(handshake_id)
+    # Defensive: clear any stale file from a prior crashed sidecar.
+    try:
+        handshake_path.unlink()
+    except FileNotFoundError:
+        pass
+
+    env = os.environ.copy()
+    env[_ENV_HANDSHAKE_ID] = handshake_id
+    if mode in ("generate", "import", "either"):
+        env[_ENV_MODE] = mode
+    if relay_url:
+        env[_ENV_RELAY_URL] = relay_url
+    if server_url:
+        env[_ENV_SERVER_URL] = server_url
+    # Carry through TOTALRECLAW_SERVER_URL / TOTALRECLAW_PAIR_RELAY_URL
+    # explicitly even if the caller passed nothing — the sidecar runs
+    # detached and inherits the parent env, but ``subprocess.Popen``
+    # already does that; this branch is a no-op as long as we don't
+    # override.
+
+    cmd = [
+        _python_executable(),
+        "-m",
+        "totalreclaw.pair.completion_sidecar",
+        "--run",
+    ]
+
+    # Detach the child:
+    #   - close_fds defaults to True on POSIX in 3.7+, so no parent FDs
+    #     leak into the child beyond stdin/stdout/stderr (which we
+    #     redirect to /dev/null below).
+    #   - start_new_session=True puts the child in its own session/PG
+    #     so a SIGHUP on the parent's terminal doesn't propagate.
+    #   - stdin/stdout/stderr go to /dev/null because the parent will
+    #     exit; without redirect, writing to closed stdout would crash
+    #     the sidecar at the first log call.
+    devnull_in = subprocess.DEVNULL
+    devnull_out = subprocess.DEVNULL
+    popen_kwargs: dict[str, Any] = {
+        "env": env,
+        "stdin": devnull_in,
+        "stdout": devnull_out,
+        "stderr": devnull_out,
+        "close_fds": True,
+    }
+    if os.name == "posix":
+        popen_kwargs["start_new_session"] = True
+    else:
+        # Windows: detach via DETACHED_PROCESS + CREATE_NEW_PROCESS_GROUP.
+        # Hermes's primary deployment surface is Linux/macOS containers;
+        # this branch is best-effort.
+        popen_kwargs["creationflags"] = 0x00000008 | 0x00000200  # type: ignore[assignment]
+
+    logger.info(
+        "pair.sidecar_spawn handshake=%s mode=%s relay=%s",
+        handshake_id[:8],
+        mode or "either",
+        bool(relay_url),
+    )
+    try:
+        subprocess.Popen(cmd, **popen_kwargs)  # noqa: S603 — argv is internal
+    except OSError as err:
+        raise RuntimeError(
+            f"pair.sidecar: failed to spawn completion sidecar: {err}"
+        ) from err
+
+    # Poll the handshake file. Coarse busy-wait — typical latency from
+    # spawn → relay-opened is well under 1s on a healthy network.
+    deadline = time.monotonic() + handshake_timeout_s
+    while time.monotonic() < deadline:
+        try:
+            raw = handshake_path.read_bytes()
+        except FileNotFoundError:
+            time.sleep(0.05)
+            continue
+
+        try:
+            payload = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            # Sidecar is mid-write — wait one more tick.
+            time.sleep(0.05)
+            continue
+
+        # Best-effort cleanup once we've parsed it. The sidecar already
+        # closed its handle to the file before writing complete.
+        try:
+            handshake_path.unlink()
+        except OSError:
+            pass
+
+        try:
+            record = _HandshakeRecord(**payload)
+        except TypeError as err:
+            raise RuntimeError(
+                f"pair.sidecar: handshake payload malformed: {err!r}"
+            ) from err
+
+        if record.status == "error":
+            raise RuntimeError(
+                f"pair.sidecar: relay open failed: {record.error_message}"
+            )
+        if record.status != "opened":
+            raise RuntimeError(
+                f"pair.sidecar: unexpected handshake status {record.status!r}"
+            )
+        return record
+
+    # Timeout. The sidecar may still be alive — leave it running; it
+    # will time out on its own at the relay's 5-minute TTL. We just
+    # surface a clean error to the agent.
+    raise RuntimeError(
+        f"pair.sidecar: handshake did not complete within "
+        f"{handshake_timeout_s:.0f}s — sidecar may have crashed; "
+        f"check {_sidecar_log_path()}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sidecar side: open relay session, wait for forward, configure state.
+# ---------------------------------------------------------------------------
+
+
+async def _drive_full_pair_session(
+    *,
+    handshake_id: str,
+    mode: Optional[str],
+    relay_url: Optional[str],
+) -> None:
+    """The end-to-end pair flow that runs INSIDE the detached sidecar.
+
+    Mirrors :func:`hermes.pair_tool._run_relay_pair_on_thread.
+    _drive_full_session` but writes the handshake metadata to a file
+    (instead of a thread queue) so the parent can read+exit independently.
+    """
+    # Local imports — keep the sidecar's startup cheap. These dependencies
+    # only matter inside the sidecar.
+    from totalreclaw.pair.remote_client import (
+        await_phrase_upload,
+        open_remote_pair_session,
+    )
+
+    handshake_path = _handshake_path_for(handshake_id)
+
+    def _atomic_write_handshake(record: _HandshakeRecord) -> None:
+        """Write+rename so the parent never reads a half-written JSON.
+
+        Uses a temp file in the same directory and ``os.replace`` for an
+        atomic crossover. The parent's poller is tolerant of a missing
+        file but NOT of a half-written one (json.JSONDecodeError races).
+        """
+        tmp_dir = handshake_path.parent
+        tmp_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=str(tmp_dir),
+            delete=False,
+        ) as fh:
+            json.dump(asdict(record), fh)
+            tmp = Path(fh.name)
+        try:
+            tmp.chmod(0o600)
+        except OSError:
+            pass
+        os.replace(tmp, handshake_path)
+
+    # 1. Open the relay session.
+    try:
+        session = await open_remote_pair_session(
+            relay_base_url=relay_url,
+            mode=mode,
+        )
+    except BaseException as err:  # noqa: BLE001 — we want any failure shape
+        logger.warning(
+            "pair.sidecar: open_remote_pair_session failed: %r", err
+        )
+        # Tell the parent so it can surface a clean error to the agent.
+        _atomic_write_handshake(
+            _HandshakeRecord(
+                url="",
+                pin="",
+                expires_at="",
+                token="",
+                status="error",
+                error_message=str(err),
+            )
+        )
+        return
+
+    token_tag = session.token[:8] if session.token else "?"
+    logger.info(
+        "pair.sidecar: relay opened token=%s… mode=%s", token_tag, mode or "either"
+    )
+
+    # 2. Tell the parent the metadata. After this point the parent is
+    #    free to exit; the sidecar stays alive.
+    _atomic_write_handshake(
+        _HandshakeRecord(
+            url=session.url,
+            pin=session.pin,
+            expires_at=session.expires_at,
+            token=session.token,
+            status="opened",
+        )
+    )
+
+    # 3. Wait for the encrypted-phrase forward, decrypt, persist.
+    async def _complete_pairing(phrase: str) -> dict:
+        # Local import to avoid pulling agent + client modules into
+        # spawn-time path.
+        from totalreclaw.agent.state import AgentState
+
+        state = AgentState()
+        try:
+            state.configure(phrase)
+            client = state.get_client()
+            eoa = getattr(client, "_eoa_address", None)
+            logger.info(
+                "pair.sidecar: state.configure ok token=%s… eoa=%s",
+                token_tag,
+                eoa or "unknown",
+            )
+            return {"state": "active", "account_id": eoa}
+        except Exception as err:
+            logger.error(
+                "pair.sidecar: state.configure failed token=%s… err=%r",
+                token_tag,
+                err,
+            )
+            return {"state": "error", "error": str(err)}
+
+    try:
+        result = await await_phrase_upload(
+            session,
+            complete_pairing=_complete_pairing,
+        )
+        logger.info(
+            "pair.sidecar: completion done token=%s… outcome=ok state=%s",
+            token_tag,
+            result.get("state") if isinstance(result, dict) else "unknown",
+        )
+    except Exception as err:
+        logger.warning(
+            "pair.sidecar: completion done token=%s… outcome=error err=%r",
+            token_tag,
+            err,
+        )
+
+
+def run_sidecar_inline(
+    *,
+    handshake_id: str,
+    mode: Optional[str],
+    relay_url: Optional[str],
+) -> None:
+    """Run the sidecar logic in-process (no fork). Used by tests.
+
+    The CLI entry point (``__main__``) wraps this with logging
+    configuration; the test path uses it directly so it can capture
+    logs/state changes without crossing a process boundary.
+    """
+    asyncio.run(
+        _drive_full_pair_session(
+            handshake_id=handshake_id,
+            mode=mode,
+            relay_url=relay_url,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Module entry point — invoked as ``python -m totalreclaw.pair.completion_sidecar``.
+# ---------------------------------------------------------------------------
+
+
+def _main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(prog="totalreclaw.pair.completion_sidecar")
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help="Run the relay completion loop (default action when invoked).",
+    )
+    args = parser.parse_args(argv)
+    if not args.run:
+        # Invoked without --run: be quiet (this is a programmatic entry
+        # point, not a user-facing CLI).
+        return 0
+
+    _configure_sidecar_logging()
+
+    handshake_id = os.environ.get(_ENV_HANDSHAKE_ID, "")
+    if not handshake_id:
+        logger.error(
+            "pair.sidecar: %s missing — bailing out (parent contract violation)",
+            _ENV_HANDSHAKE_ID,
+        )
+        return 2
+
+    mode = os.environ.get(_ENV_MODE) or None
+    relay_url = os.environ.get(_ENV_RELAY_URL) or None
+
+    try:
+        asyncio.run(
+            _drive_full_pair_session(
+                handshake_id=handshake_id,
+                mode=mode,
+                relay_url=relay_url,
+            )
+        )
+    except KeyboardInterrupt:
+        logger.info("pair.sidecar: SIGINT — aborting")
+        return 130
+    except Exception as err:
+        logger.exception("pair.sidecar: unhandled error: %r", err)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/python/tests/test_extraction_empty_response_visibility.py
+++ b/python/tests/test_extraction_empty_response_visibility.py
@@ -1,0 +1,439 @@
+"""F2 (rc.24) — auto-extraction empty-response visibility regression test.
+
+Background
+----------
+QA report ``QA-hermes-RC-2.3.1-rc.23-20260426.md`` Finding F2: Z.AI /
+GLM-5.1 returned EMPTY content for the merged-extraction prompt during
+an entire 27-turn conversation. The auto-extraction pipeline silently
+no-op'd on every turn, logging only the single line::
+
+    extract_facts_llm: chat_completion returned None/empty
+
+at INFO level. Operators had no way to tell what shape the response
+had, what the model actually returned, or why content was empty.
+
+rc.24 fix
+---------
+1. ``_call_openai`` sends ``response_format: {"type": "json_object"}``
+   to known structured-output-aware providers (zai/GLM, OpenAI, Groq,
+   DeepSeek, OpenRouter, Mistral, x.ai, Together). For GLM in
+   particular this flips the model from empty-content responses to
+   deterministic JSON.
+
+2. When ``message.content`` IS empty the call site WARNs with the
+   request payload sizes, model name, ``finish_reason``, and ``usage``.
+   The downstream extraction pipeline ALSO bumps from INFO to WARN.
+
+These tests guard both invariants. The test does NOT call out to a real
+Z.AI endpoint — it mocks ``httpx.AsyncClient.post`` to drive specific
+response shapes (empty content, valid JSON, finish_reason=stop, etc.)
+and asserts the warn output + the extraction return.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from totalreclaw.agent.extraction import extract_facts_llm
+from totalreclaw.agent.llm_client import (
+    LLMConfig,
+    ZAI_CODING_BASE_URL,
+    ZAI_STANDARD_BASE_URL,
+    _supports_json_object_response_format,
+    chat_completion,
+    get_zai_base_url,
+    zai_base_url_for_model,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — minimal httpx response double, just enough for the call sites.
+# ---------------------------------------------------------------------------
+
+
+class _FakeResp:
+    """Stub of ``httpx.Response`` exercising only what _call_openai uses."""
+
+    def __init__(self, payload: dict, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self) -> dict:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            import httpx
+
+            raise httpx.HTTPStatusError(
+                "fake error",
+                request=MagicMock(),
+                response=MagicMock(status_code=self.status_code),
+            )
+
+
+def _make_async_post(payload: dict, status_code: int = 200) -> AsyncMock:
+    """Return an AsyncMock that emulates ``client.post`` returning ``payload``."""
+    fake = _FakeResp(payload, status_code=status_code)
+    return AsyncMock(return_value=fake)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_supports_json_object_response_format_for_zai() -> None:
+    """The zai/GLM coding + standard endpoints must opt into json_object."""
+    assert _supports_json_object_response_format(
+        "https://api.z.ai/api/coding/paas/v4"
+    )
+    assert _supports_json_object_response_format("https://api.z.ai/api/paas/v4")
+
+
+def test_supports_json_object_response_format_for_openai() -> None:
+    assert _supports_json_object_response_format("https://api.openai.com/v1")
+
+
+def test_supports_json_object_response_format_skips_unknown() -> None:
+    """Unrecognized base URLs (custom self-hosted) should NOT receive
+    response_format — we don't know if the provider implements it."""
+    assert not _supports_json_object_response_format(
+        "https://my-self-hosted-llm.example.com/v1"
+    )
+    assert not _supports_json_object_response_format("")
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_sends_response_format_to_zai() -> None:
+    """When base_url matches a json-aware provider, the request body
+    must carry ``response_format: {type: "json_object"}``.
+
+    F2 (rc.24): without this hint, GLM-5.1 returned empty content for
+    the merged-extraction prompt; the pipeline silently no-op'd."""
+    config = LLMConfig(
+        api_key="sk-test",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        model="glm-5-turbo",
+        api_format="openai",
+    )
+
+    fake_post = _make_async_post(
+        {
+            "choices": [{"message": {"content": '{"topics": [], "facts": []}'}}],
+        }
+    )
+
+    with patch("httpx.AsyncClient.post", new=fake_post):
+        out = await chat_completion(config, "system", "user")
+
+    assert out == '{"topics": [], "facts": []}'
+    # Inspect the kwargs passed to client.post.
+    call_kwargs = fake_post.await_args.kwargs
+    body = call_kwargs.get("json") or {}
+    assert body.get("response_format") == {"type": "json_object"}, (
+        "request body must carry response_format json_object for zai. "
+        f"Got body keys: {sorted(body.keys())}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_skips_response_format_for_unknown_provider() -> None:
+    """For unknown providers the body must NOT carry response_format.
+
+    Belt-and-suspenders: misapplying response_format to a provider that
+    doesn't support it could trigger a 400 from strict implementations.
+    """
+    config = LLMConfig(
+        api_key="sk-test",
+        base_url="https://my-self-hosted.example.com/v1",
+        model="custom-model",
+        api_format="openai",
+    )
+    fake_post = _make_async_post(
+        {"choices": [{"message": {"content": "hello"}}]},
+    )
+    with patch("httpx.AsyncClient.post", new=fake_post):
+        out = await chat_completion(config, "system", "user")
+
+    assert out == "hello"
+    body = fake_post.await_args.kwargs.get("json") or {}
+    assert "response_format" not in body, (
+        "unknown provider should not get response_format hint"
+    )
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_warns_on_empty_content(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When message.content is empty/missing, _call_openai must WARN
+    with the diagnostic context (model, finish_reason, usage, etc.).
+
+    F2 (rc.24): empty responses were silently logged at INFO. Operators
+    couldn't tell whether the model OOM'd context, hit a content
+    filter, or refused — all looked identical. WARN-level logging with
+    finish_reason fixes that.
+    """
+    config = LLMConfig(
+        api_key="sk-test",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        model="glm-5-turbo",
+        api_format="openai",
+    )
+
+    fake_post = _make_async_post(
+        {
+            "choices": [
+                {
+                    "message": {"content": ""},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 1234, "completion_tokens": 0},
+        }
+    )
+
+    caplog.set_level(logging.WARNING, logger="totalreclaw.agent.llm_client")
+    with patch("httpx.AsyncClient.post", new=fake_post):
+        out = await chat_completion(config, "system prompt", "user prompt")
+
+    assert out in (None, ""), (
+        "empty content must propagate as None or empty string — caller "
+        "differentiates via 'if not response' downstream"
+    )
+
+    # Assert we got the WARN with the diagnostic fields.
+    matched = [
+        rec for rec in caplog.records
+        if rec.levelno == logging.WARNING
+        and "LLM returned empty content" in rec.getMessage()
+    ]
+    assert matched, (
+        "expected a WARNING containing 'LLM returned empty content' from "
+        "_call_openai; got log records:\n  "
+        + "\n  ".join(f"{r.levelname}:{r.name}:{r.getMessage()}" for r in caplog.records)
+    )
+    msg = matched[0].getMessage()
+    # Spot-check the key diagnostic fields.
+    assert "glm-5-turbo" in msg, "WARN must include model name"
+    assert "finish_reason=stop" in msg, "WARN must include finish_reason"
+    assert "usage=" in msg, "WARN must include usage block"
+
+
+@pytest.mark.asyncio
+async def test_extract_facts_llm_warns_when_response_empty(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When ``chat_completion`` returns None/empty, the extraction
+    pipeline now WARNs (was INFO pre-rc.24).
+
+    Regression shield for F2 — the rc.23 QA report's exact symptom
+    (``extract_facts_llm: chat_completion returned None/empty`` was the
+    only signal that auto-extraction had silently failed).
+    """
+    config = LLMConfig(
+        api_key="sk-test",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        model="glm-5-turbo",
+        api_format="openai",
+    )
+    messages = [
+        {"role": "user", "content": "I love hiking on weekends and live in Lisbon."},
+        {"role": "assistant", "content": "Got it — noted."},
+    ]
+
+    caplog.set_level(logging.WARNING, logger="totalreclaw.agent.extraction")
+    # Patch chat_completion at its import site inside extraction.py.
+    with patch(
+        "totalreclaw.agent.extraction.chat_completion",
+        new=AsyncMock(return_value=""),
+    ):
+        out = await extract_facts_llm(messages, mode="turn", llm_config=config)
+
+    assert out == [], "empty response must yield zero facts"
+
+    matched = [
+        rec for rec in caplog.records
+        if rec.levelno == logging.WARNING
+        and "chat_completion returned None/empty" in rec.getMessage()
+    ]
+    assert matched, (
+        "extract_facts_llm must WARN (not INFO) when chat_completion "
+        "returns empty — silent INFO is the rc.23 F2 symptom this fix "
+        "guards against. Got log records:\n  "
+        + "\n  ".join(
+            f"{r.levelname}:{r.name}:{r.getMessage()}" for r in caplog.records
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# rc.24 F2 follow-up — model-aware zai endpoint selection.
+#
+# Pedro is on the Z.AI Coding plan; the auto-extraction silently no-op'd
+# when the Hermes-configured model was GLM-5.1 because GLM-5.x lives on
+# the Standard PAYG endpoint, not Coding. ``zai_base_url_for_model`` is
+# the new heuristic that routes per-model to the right endpoint, and
+# ``chat_completion`` now ALSO auto-flips on a 200-empty response.
+# ---------------------------------------------------------------------------
+
+
+def test_zai_base_url_for_model_glm_5_routes_to_standard() -> None:
+    """GLM-5.x → Standard PAYG endpoint."""
+    assert zai_base_url_for_model("glm-5.1") == ZAI_STANDARD_BASE_URL
+    assert zai_base_url_for_model("glm-5") == ZAI_STANDARD_BASE_URL
+    assert zai_base_url_for_model("GLM-5.1") == ZAI_STANDARD_BASE_URL
+
+
+def test_zai_base_url_for_model_glm_4_routes_to_coding() -> None:
+    """GLM-4.x → Coding plan endpoint."""
+    assert zai_base_url_for_model("glm-4.5") == ZAI_CODING_BASE_URL
+    assert zai_base_url_for_model("glm-4.5-air") == ZAI_CODING_BASE_URL
+    assert zai_base_url_for_model("glm-4.5-flash") == ZAI_CODING_BASE_URL
+    assert zai_base_url_for_model("glm-4-turbo") == ZAI_CODING_BASE_URL
+
+
+def test_zai_base_url_for_model_unknown_falls_back_to_coding() -> None:
+    """Empty / unknown model → coding (historical default)."""
+    assert zai_base_url_for_model("") == ZAI_CODING_BASE_URL
+    assert zai_base_url_for_model("unknown-model") == ZAI_CODING_BASE_URL
+
+
+def test_get_zai_base_url_respects_explicit_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ZAI_BASE_URL env var beats the model heuristic."""
+    monkeypatch.setenv(
+        "ZAI_BASE_URL", "https://my-self-hosted-zai.example.com/v1"
+    )
+    # Model says GLM-5.1 (would route to Standard) but env override wins.
+    assert (
+        get_zai_base_url(model="glm-5.1")
+        == "https://my-self-hosted-zai.example.com/v1"
+    )
+
+
+def test_get_zai_base_url_uses_model_heuristic_without_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no env override, model name picks the endpoint."""
+    monkeypatch.delenv("ZAI_BASE_URL", raising=False)
+    assert get_zai_base_url(model="glm-5.1") == ZAI_STANDARD_BASE_URL
+    assert get_zai_base_url(model="glm-4.5-flash") == ZAI_CODING_BASE_URL
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_auto_flips_zai_endpoint_on_empty_content() -> None:
+    """When zai's coding endpoint returns 200 with empty content AND
+    we haven't tried the standard endpoint yet, ``chat_completion``
+    must auto-flip to the standard endpoint (single retry, free of
+    the normal retry budget) and re-issue the call.
+
+    F2 (rc.24) — this is the "Coding-plan key + GLM-5.1" silent-empty
+    scenario. Pre-rc.24, ``chat_completion`` returned None on the
+    first call and the extraction pipeline silently no-op'd. Now the
+    flip kicks in; the second call to the OTHER endpoint succeeds.
+    """
+    config = LLMConfig(
+        api_key="sk-test",
+        base_url=ZAI_CODING_BASE_URL,
+        model="glm-5.1",
+        api_format="openai",
+    )
+
+    call_count = {"n": 0}
+
+    async def fake_post(self, url, **kwargs):
+        call_count["n"] += 1
+        body = kwargs.get("json") or {}
+        # First call (coding endpoint) → empty content. Second call
+        # (standard endpoint) → real JSON.
+        if call_count["n"] == 1:
+            payload = {
+                "choices": [{"message": {"content": ""}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 50, "completion_tokens": 0},
+            }
+        else:
+            payload = {
+                "choices": [{"message": {"content": '{"topics":[],"facts":[]}'}}],
+            }
+        return _FakeResp(payload)
+
+    with patch("httpx.AsyncClient.post", new=fake_post):
+        out = await chat_completion(config, "system", "user")
+
+    assert out == '{"topics":[],"facts":[]}', (
+        "after the auto-flip the second endpoint must succeed"
+    )
+    assert call_count["n"] == 2, (
+        f"expected exactly 2 calls (first coding empty, second standard "
+        f"success); got {call_count['n']}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_extract_facts_llm_returns_facts_for_valid_response() -> None:
+    """Positive baseline: when the auxiliary LLM returns a parseable
+    merged-topic JSON payload with one fact, ``extract_facts_llm`` must
+    return that fact.
+
+    This is the regression test the QA report explicitly asked for
+    (F2 fix path #3): "add a regression test that runs auto-extraction
+    with a short canned conversation against a mocked aux LLM and
+    asserts ``len(extracted_facts) > 0``".
+    """
+    config = LLMConfig(
+        api_key="sk-test",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        model="glm-5-turbo",
+        api_format="openai",
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": (
+                "I just moved to Lisbon and really love hiking trails near "
+                "the coast. The Sintra path is my favourite — I do it every "
+                "weekend with my dog Bruno."
+            ),
+        },
+        {
+            "role": "assistant",
+            "content": "That sounds wonderful! Sintra has amazing trails.",
+        },
+    ]
+
+    canned_payload = json.dumps(
+        {
+            "topics": ["hiking", "lisbon"],
+            "facts": [
+                {
+                    "text": "User lives in Lisbon and hikes Sintra trails on weekends.",
+                    "type": "claim",
+                    "importance": 8,
+                    "action": "ADD",
+                    "source": "user",
+                    "scope": "personal",
+                    "volatility": "stable",
+                }
+            ],
+        }
+    )
+
+    with patch(
+        "totalreclaw.agent.extraction.chat_completion",
+        new=AsyncMock(return_value=canned_payload),
+    ):
+        facts = await extract_facts_llm(messages, mode="turn", llm_config=config)
+
+    assert len(facts) > 0, (
+        "extract_facts_llm must return at least one fact for valid input — "
+        "this guards against the F2 silent-empty regression"
+    )
+    assert facts[0].text.lower().startswith("user lives in lisbon")
+    assert facts[0].type == "claim"
+    assert facts[0].source == "user"

--- a/python/tests/test_packaging_integrity.py
+++ b/python/tests/test_packaging_integrity.py
@@ -1,0 +1,222 @@
+"""F3 (rc.24) — packaging integrity regression test.
+
+Background
+----------
+The rc.23 wheel published to PyPI was MISSING ``retype_setscope.py`` even
+though the file existed on ``main`` and PR #135 had merged it. Root
+cause: ``pyproject.toml`` had no explicit
+``[tool.setuptools.packages.find]`` stanza, so ``setuptools.build_meta``
+ran auto-discovery against the ``python/src/`` directory. Auto-discovery
+hit a corner case (multiple sibling dirs in the project root + fresh top-
+level module added without other build-config touching it) and silently
+dropped the new file from the wheel. Result: ``totalreclaw_retype`` and
+``totalreclaw_set_scope`` registrations in ``hermes/__init__.py`` failed
+at import (``ModuleNotFoundError``), which the plugin loader caught and
+swallowed — so the tools just silently disappeared at runtime.
+
+What this test guards
+---------------------
+For every ``.py`` file under ``python/src/totalreclaw/``, assert that the
+file IS present inside the built wheel. We build the wheel into a temp
+directory using ``python -m build --wheel`` and then list its contents
+via ``zipfile``.
+
+This is intentionally a strict file-by-file check (rather than just
+checking import-ability of a few modules), because the rc.23 failure
+mode was that a NEW file silently disappeared while the rest of the
+package looked healthy. We want every future ``add a new file under
+totalreclaw/`` change to either land in the wheel or fail this test
+loudly at CI time.
+
+The build step is slow (~20s) so the test is gated on the
+``TOTALRECLAW_RUN_PACKAGING_TESTS=1`` env var by default; CI can set it.
+For developer-local runs use ``pytest -m packaging`` once the marker
+ships, or just set the env var.
+
+Run locally::
+
+    cd python && TOTALRECLAW_RUN_PACKAGING_TESTS=1 pytest \
+        tests/test_packaging_integrity.py -v
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent  # python/
+SRC_ROOT = REPO_ROOT / "src" / "totalreclaw"
+
+
+def _gather_src_py_files() -> list[Path]:
+    """Return relative paths of every .py file under src/totalreclaw/.
+
+    ``__pycache__`` directories are excluded — those are byte-compiled
+    artifacts and should never appear in the wheel.
+    """
+    out: list[Path] = []
+    for path in SRC_ROOT.rglob("*.py"):
+        if "__pycache__" in path.parts:
+            continue
+        out.append(path.relative_to(SRC_ROOT))
+    return sorted(out)
+
+
+def _build_wheel_into(tmp_dir: Path) -> Path:
+    """Build a wheel in ``tmp_dir/dist/`` and return the .whl path.
+
+    Uses ``python -m build --wheel`` so we exercise the SAME path PyPI
+    will use. Returns the first .whl in dist (there's exactly one).
+    """
+    dist_dir = tmp_dir / "dist"
+    dist_dir.mkdir(parents=True, exist_ok=True)
+
+    # Run from a copy of the source tree so we don't pollute the real
+    # python/ working dir with a build/ artifact.
+    src_copy = tmp_dir / "src_copy"
+    shutil.copytree(
+        REPO_ROOT,
+        src_copy,
+        ignore=shutil.ignore_patterns(
+            "__pycache__",
+            ".pytest_cache",
+            ".venv",
+            "dist",
+            "build",
+            "*.egg-info",
+        ),
+    )
+
+    subprocess.run(
+        [sys.executable, "-m", "build", "--wheel", "--outdir", str(dist_dir)],
+        cwd=src_copy,
+        check=True,
+        # Pipe stdout/stderr; only print on failure to keep test output tidy.
+        capture_output=True,
+    )
+
+    wheels = list(dist_dir.glob("totalreclaw-*.whl"))
+    assert len(wheels) == 1, f"expected exactly one wheel, got: {wheels}"
+    return wheels[0]
+
+
+@pytest.mark.skipif(
+    os.environ.get("TOTALRECLAW_RUN_PACKAGING_TESTS") != "1",
+    reason=(
+        "Slow (~20s for `python -m build`). Set "
+        "TOTALRECLAW_RUN_PACKAGING_TESTS=1 to enable. CI sets this in the "
+        "publish workflow's pre-publish gate."
+    ),
+)
+def test_wheel_contains_every_source_py_file():
+    """Every src/totalreclaw/**/*.py file MUST land in the built wheel."""
+    src_files = _gather_src_py_files()
+    assert src_files, "no .py files found under src/totalreclaw — sanity check"
+
+    # The rc.23 ship-stopper — make sure the regression case is covered.
+    assert Path("retype_setscope.py") in src_files, (
+        "regression sanity: src/totalreclaw/retype_setscope.py must exist"
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        wheel_path = _build_wheel_into(tmp_path)
+        with zipfile.ZipFile(wheel_path) as zf:
+            wheel_names = set(zf.namelist())
+
+    # Every src .py should appear at "totalreclaw/<rel>" inside the wheel.
+    missing: list[str] = []
+    for rel in src_files:
+        wheel_member = "totalreclaw/" + rel.as_posix()
+        if wheel_member not in wheel_names:
+            missing.append(wheel_member)
+
+    assert not missing, (
+        f"wheel is missing {len(missing)} expected .py file(s) — this is "
+        f"the F3 rc.23 ship-stopper class: setuptools auto-discovery "
+        f"dropped some modules. Missing files:\n  "
+        + "\n  ".join(missing[:20])
+        + ("\n  ..." if len(missing) > 20 else "")
+    )
+
+
+@pytest.mark.skipif(
+    os.environ.get("TOTALRECLAW_RUN_PACKAGING_TESTS") != "1",
+    reason="Slow — see test_wheel_contains_every_source_py_file",
+)
+def test_wheel_contains_retype_setscope_specifically():
+    """Targeted regression shield for the EXACT rc.23 missing file.
+
+    Even if some bulk packaging-test logic is later refactored away,
+    this single-file assertion stays — it pins the very file whose
+    absence caused the rc.23 NO-GO so any future regression of the
+    same shape fails this specific test name.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        wheel_path = _build_wheel_into(tmp_path)
+        with zipfile.ZipFile(wheel_path) as zf:
+            names = set(zf.namelist())
+
+    assert "totalreclaw/retype_setscope.py" in names, (
+        "rc.23 F3 regression: retype_setscope.py is missing from the wheel "
+        "— check pyproject.toml [tool.setuptools.packages.find] config"
+    )
+
+
+def test_pyproject_has_explicit_packages_find():
+    """Cheap structural check that the pyproject.toml explicit-find
+    stanza is present. Doesn't build a wheel; runs in milliseconds.
+
+    Even without the heavyweight build test, this guards against
+    accidentally regressing the pyproject config back to "no explicit
+    find stanza" (the rc.23 root cause).
+    """
+    pyproject = (REPO_ROOT / "pyproject.toml").read_text()
+    assert "[tool.setuptools.packages.find]" in pyproject, (
+        "pyproject.toml must declare [tool.setuptools.packages.find] "
+        "explicitly — auto-discovery silently dropped retype_setscope.py "
+        "in rc.23 (see F3 in QA-hermes-RC-2.3.1-rc.23-20260426.md)"
+    )
+    # The where-line + include-line are both required for the fix to
+    # work as designed; pin both.
+    assert 'where = ["src"]' in pyproject, (
+        "[tool.setuptools.packages.find] must set where = [\"src\"] for the "
+        "src-layout to be picked up correctly"
+    )
+    assert 'include = ["totalreclaw*"]' in pyproject, (
+        "[tool.setuptools.packages.find] must set include = [\"totalreclaw*\"] "
+        "to capture every totalreclaw subpackage"
+    )
+
+
+def test_pyproject_version_no_rc_suffix():
+    """The committed pyproject.toml version must NEVER carry an rc<N>
+    suffix on main. The publish-python-client.yml workflow appends rcN
+    at build time when release-type=rc; an rcN literal in the file
+    means the workflow's regex re-applied an off-by-one rc number AND
+    a stable build would mis-publish as a pre-release.
+
+    Regression shield for the rc.23 F3 finding (workflow mutation
+    leaked back into main as ``version = "2.3.1rc24"``).
+    """
+    import re
+
+    pyproject = (REPO_ROOT / "pyproject.toml").read_text()
+    m = re.search(r'^version\s*=\s*"([^"]+)"', pyproject, flags=re.MULTILINE)
+    assert m is not None, "pyproject.toml has no version= line"
+    version = m.group(1)
+    assert "rc" not in version, (
+        f"pyproject.toml version is {version!r} — must NOT carry an rc "
+        f"suffix on main. The publish workflow appends rcN at RC-build "
+        f"time; committing the suffix breaks both stable builds and the "
+        f"workflow's mutation logic. See F3 in "
+        f"QA-hermes-RC-2.3.1-rc.23-20260426.md."
+    )

--- a/python/tests/test_pair_generate_mode.py
+++ b/python/tests/test_pair_generate_mode.py
@@ -364,20 +364,25 @@ def test_pair_tool_schema_advertises_either():
 
 
 @pytest.mark.asyncio
-async def test_relay_mode_passes_ui_mode_to_open_session(tmp_path, monkeypatch):
-    """Verify relay path forwards UI mode to the thread-based pair
-    supervisor.
+async def test_relay_mode_passes_ui_mode_to_thread_supervisor_when_sidecar_disabled(
+    tmp_path, monkeypatch
+):
+    """rc.13 fallback path — when ``TOTALRECLAW_PAIR_SIDECAR=0`` is set
+    we route to the daemon-thread helper. Verify the UI mode threads
+    through to ``_run_relay_pair_on_thread`` exactly as it did pre-rc.24.
 
-    rc.13 replaced the ``_spawn_relay_completion_task`` asyncio-task
-    helper with ``_run_relay_pair_on_thread``, which runs the entire
-    relay session on a dedicated worker thread (fixes the
-    tool-invocation loop-teardown bug where ack frames were never
-    sent). This test stubs out the thread-helper entirely and asserts
-    the ``mode`` kwarg threads through ``pair_tool.pair`` →
-    ``_pair_relay`` → ``_run_relay_pair_on_thread``. No network.
+    rc.24 (F1) replaced the daemon-thread default with a fully detached
+    sidecar subprocess so ``hermes chat -q`` one-shot processes don't
+    kill the WebSocket. The thread path is still reachable via the
+    operator escape hatch and must keep working for long-lived daemon
+    hosts. See ``test_pair_sidecar_lifecycle.py`` for the sidecar-path
+    coverage.
     """
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.delenv("TOTALRECLAW_PAIR_MODE", raising=False)  # default (relay)
+    # Force the rc.13 daemon-thread fallback so this test exercises
+    # ``_run_relay_pair_on_thread`` (the function it stubs out).
+    monkeypatch.setenv("TOTALRECLAW_PAIR_SIDECAR", "0")
 
     from totalreclaw.hermes import pair_tool as _pair_tool_mod
 
@@ -406,3 +411,53 @@ async def test_relay_mode_passes_ui_mode_to_open_session(tmp_path, monkeypatch):
         assert "error" not in payload, payload
         assert payload["mode"] == mode
         assert captured.get("mode") == mode
+
+
+@pytest.mark.asyncio
+async def test_relay_mode_passes_ui_mode_via_sidecar_default_path(
+    tmp_path, monkeypatch
+):
+    """rc.24 default path — sidecar subprocess. The UI mode must thread
+    through ``pair_tool.pair`` → ``_pair_relay`` →
+    ``_run_relay_pair_via_sidecar`` → ``spawn_completion_sidecar``.
+
+    Companion to the rc.13 fallback test above; together they pin the
+    mode-forwarding contract on both code paths.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("TOTALRECLAW_PAIR_MODE", raising=False)
+    monkeypatch.delenv("TOTALRECLAW_PAIR_SIDECAR", raising=False)  # default ON
+
+    from totalreclaw.hermes import pair_tool as _pair_tool_mod
+    from totalreclaw.pair.completion_sidecar import _HandshakeRecord
+
+    captured: dict = {}
+
+    def _fake_spawn(*, mode, relay_url=None, server_url=None, **kwargs):
+        captured["mode"] = mode
+        return _HandshakeRecord(
+            url="https://example.invalid/pair/p/x#pk=y",
+            pin="654321",
+            expires_at="2026-04-30T12:00:00Z",
+            token="rc24-test-token",
+            status="opened",
+        )
+
+    # Patch the import inside _run_relay_pair_via_sidecar.
+    monkeypatch.setattr(
+        "totalreclaw.pair.completion_sidecar.spawn_completion_sidecar",
+        _fake_spawn,
+    )
+
+    state = MagicMock()
+
+    for mode in ("generate", "import", "either"):
+        captured.clear()
+        result_json = await _pair_tool_mod.pair({"mode": mode}, state)
+        payload = json.loads(result_json)
+        assert "error" not in payload, payload
+        assert payload["mode"] == mode
+        assert payload["pin"] == "654321"
+        assert captured.get("mode") == mode, (
+            f"sidecar must receive mode={mode!r}; got {captured!r}"
+        )

--- a/python/tests/test_pair_sidecar_lifecycle.py
+++ b/python/tests/test_pair_sidecar_lifecycle.py
@@ -1,0 +1,407 @@
+"""F1 (rc.24) — sidecar-handoff regression test.
+
+Background — rc.23 ship-stopper #157
+------------------------------------
+``hermes chat -q`` is one-shot: each turn runs in a fresh Python
+process that exits as soon as the agent reply lands. rc.13 ran the
+relay-pair WebSocket lifecycle on a daemon thread INSIDE that process,
+so when the process exited the WS died with it; the relay tore the
+session down and returned 404/502 for the eventual phrase POST.
+
+rc.24 fix: spawn a fully-detached sidecar SUBPROCESS (POSIX
+``setsid``) that owns the WS through completion. The sidecar survives
+parent exit because it's been reparented to ``init`` / ``launchd``.
+
+Tests in this module
+--------------------
+1. ``test_sidecar_handshake_reports_relay_metadata`` — exercises the
+   sidecar logic in-process (``run_sidecar_inline``) against a real
+   loopback websockets stub. Asserts the handshake file appears,
+   carries the relay-supplied URL/PIN/expires_at, and the
+   ``await_phrase_upload`` path is reachable. This proves the
+   parent-side polling contract works.
+
+2. ``test_pair_tool_returns_after_sidecar_handshake_with_short_lived_process``
+   — the lifecycle test: spawns an ACTUAL detached sidecar, immediately
+   simulates parent exit (the test's "parent" cleans up its handle to
+   the subprocess but does not wait), and asserts the sidecar still
+   completes the pair against a long-running relay stub. This is the
+   exact scenario rc.13 failed at.
+
+3. ``test_pair_tool_uses_sidecar_by_default`` — guards that
+   ``TOTALRECLAW_PAIR_SIDECAR`` is on by default. Setting it to "0"
+   re-exposes the rc.23 ship-stopper.
+
+The sidecar subprocess is spawned via ``python -m
+totalreclaw.pair.completion_sidecar``; tests use the live
+``sys.executable`` so the same venv is in scope.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+import pytest
+import websockets
+
+from totalreclaw.pair.crypto import (
+    encrypt_pairing_payload,
+    generate_gateway_keypair,
+)
+
+
+TEST_PHRASE = (
+    "abandon abandon abandon abandon abandon abandon "
+    "abandon abandon abandon abandon abandon about"
+)
+
+
+# ---------------------------------------------------------------------------
+# Reusable relay stub — loopback WebSocket server that impersonates the
+# real relay's open/forward/ack flow.
+# ---------------------------------------------------------------------------
+
+
+class _RelayStub:
+    """Stand-in for the real relay. Logs every frame for assertions."""
+
+    def __init__(self, *, token: str, phrase: str, forward_delay_s: float) -> None:
+        self.token = token
+        self.phrase = phrase
+        self.forward_delay_s = forward_delay_s
+        self.open_frame: Optional[dict] = None
+        self.ack_frame: Optional[dict] = None
+        self._server: Optional[websockets.Server] = None
+        self._port: int = 0
+        self._ack_event = asyncio.Event()
+
+    @property
+    def url(self) -> str:
+        return f"ws://127.0.0.1:{self._port}"
+
+    async def start(self) -> None:
+        async def handler(ws):
+            raw = await ws.recv()
+            self.open_frame = json.loads(raw)
+            await ws.send(
+                json.dumps(
+                    {
+                        "type": "opened",
+                        "token": self.token,
+                        "short_url": f"/pair/p/{self.token}",
+                        "expires_at": "2026-04-30T00:00:00Z",
+                    }
+                )
+            )
+            await asyncio.sleep(self.forward_delay_s)
+
+            kp_device = generate_gateway_keypair()
+            gateway_pubkey = self.open_frame["gateway_pubkey"]
+            nonce_b64, ct_b64 = encrypt_pairing_payload(
+                sk_local_b64=kp_device.sk_b64,
+                pk_remote_b64=gateway_pubkey,
+                sid=self.token,
+                plaintext=self.phrase.encode("utf-8"),
+            )
+            await ws.send(
+                json.dumps(
+                    {
+                        "type": "forward",
+                        "client_pubkey": kp_device.pk_b64,
+                        "nonce": nonce_b64,
+                        "ciphertext": ct_b64,
+                    }
+                )
+            )
+            try:
+                raw2 = await asyncio.wait_for(ws.recv(), timeout=10)
+                msg = json.loads(raw2)
+                if msg.get("type") == "ack":
+                    self.ack_frame = msg
+                    self._ack_event.set()
+            except asyncio.TimeoutError:
+                pass
+
+        self._server = await websockets.serve(handler, "127.0.0.1", 0)
+        self._port = self._server.sockets[0].getsockname()[1]
+
+    async def wait_for_ack(self, timeout_s: float) -> bool:
+        try:
+            await asyncio.wait_for(self._ack_event.wait(), timeout=timeout_s)
+            return True
+        except asyncio.TimeoutError:
+            return False
+
+    async def stop(self) -> None:
+        if self._server:
+            self._server.close()
+            await self._server.wait_closed()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sidecar_handshake_reports_relay_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In-process exercise of the sidecar logic — asserts the
+    handshake file is produced and carries the relay-supplied
+    metadata.
+
+    Drives ``run_sidecar_inline`` (no fork) against a real loopback
+    relay stub so we can synchronously prove the contract:
+
+    1. After the relay returns ``opened``, the sidecar writes a JSON
+       file at ``~/.totalreclaw/.pair_handshake_<id>.json``.
+    2. The file carries ``{url, pin, expires_at, token, status:"opened"}``.
+    3. ``await_phrase_upload`` then runs to completion and the relay
+       receives ack.
+
+    The credentials-write path is NOT exercised here — that requires
+    ``state.configure`` which talks to the on-chain RPC. A separate
+    test (``test_credentials_path``) covers that surface.
+    """
+    relay = _RelayStub(token="rc24-sidecar-tok", phrase=TEST_PHRASE, forward_delay_s=0.1)
+    await relay.start()
+
+    # Redirect ``~/.totalreclaw`` to a temp dir so we don't pollute the
+    # developer's actual home dir, and so the handshake file shows up
+    # at a path the test can read.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("TOTALRECLAW_PAIR_RELAY_URL", relay.url)
+
+    # Stub the credentials-writing path. ``AgentState.configure`` is
+    # what writes ``credentials.json`` + creates a ``TotalReclaw``
+    # client; we don't want that here. Patch it inline.
+    import totalreclaw.agent.state as state_module
+
+    captured: dict[str, str] = {}
+
+    def fake_configure(self, mnemonic: str) -> None:
+        captured["mnemonic"] = mnemonic
+
+    def fake_get_client(self):
+        class _C:
+            _eoa_address = "0xdeadbeef0123"
+
+        return _C()
+
+    monkeypatch.setattr(state_module.AgentState, "configure", fake_configure)
+    monkeypatch.setattr(state_module.AgentState, "get_client", fake_get_client)
+
+    # Run sidecar logic in-process (no fork) so we can inspect outcomes
+    # synchronously.
+    from totalreclaw.pair.completion_sidecar import (
+        _handshake_path_for,
+        run_sidecar_inline,
+    )
+
+    handshake_id = "rc24-test-handshake"
+
+    async def _run() -> None:
+        # Run as an asyncio task so the relay handler can progress
+        # concurrently. ``run_sidecar_inline`` calls asyncio.run()
+        # internally — wrap in to_thread so we don't nest event loops.
+        await asyncio.to_thread(
+            run_sidecar_inline,
+            handshake_id=handshake_id,
+            mode="either",
+            relay_url=relay.url,
+        )
+
+    sidecar_task = asyncio.create_task(_run())
+
+    # Poll for the handshake file. Should appear within ~1s on loopback.
+    handshake_path = _handshake_path_for(handshake_id)
+    deadline = time.monotonic() + 5.0
+    handshake: Optional[dict] = None
+    while time.monotonic() < deadline:
+        if handshake_path.exists():
+            try:
+                handshake = json.loads(handshake_path.read_text())
+                break
+            except json.JSONDecodeError:
+                pass
+        await asyncio.sleep(0.05)
+
+    assert handshake is not None, (
+        f"sidecar never wrote the handshake file at {handshake_path} — "
+        "the parent's polling contract would have timed out"
+    )
+    assert handshake["status"] == "opened", handshake
+    assert handshake["token"] == relay.token
+    assert handshake["pin"] and len(handshake["pin"]) == 6
+    assert handshake["expires_at"]
+    assert relay.token in handshake["url"]
+
+    # Wait for the sidecar (with the rest of the pair flow) to finish.
+    # Our relay stub sends the forward frame ~0.1s after opened.
+    ack_arrived = await relay.wait_for_ack(timeout_s=10.0)
+    await sidecar_task
+
+    try:
+        await relay.stop()
+    except Exception:
+        pass
+
+    assert ack_arrived, (
+        "relay never received ack — the sidecar failed to drive the "
+        "pair to completion (lifecycle regression)"
+    )
+    assert relay.ack_frame == {"type": "ack"}
+    # Phrase reached the credentials path.
+    assert captured.get("mnemonic") == TEST_PHRASE
+
+
+@pytest.mark.asyncio
+async def test_pair_tool_returns_after_sidecar_handshake_with_short_lived_process(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: launch a REAL detached subprocess sidecar, wait
+    only for the handshake, then simulate parent exit (drop our
+    subprocess handle without waiting). The sidecar must still
+    complete the pair flow.
+
+    This is the rc.23 NO-GO scenario — it would have failed under
+    rc.13 because the daemon thread died with the parent. With the
+    rc.24 sidecar fix, ``setsid`` keeps the subprocess alive past
+    parent exit, so the relay still gets the ack.
+    """
+    relay = _RelayStub(token="rc24-detach-tok", phrase=TEST_PHRASE, forward_delay_s=0.5)
+    await relay.start()
+
+    # Fake HOME so the sidecar's handshake file lands somewhere
+    # readable + cleanable by this test.
+    fake_home = tmp_path
+    fake_home.mkdir(parents=True, exist_ok=True)
+
+    handshake_id = "rc24-detach-handshake"
+
+    # Build the env the sidecar will run under. We can't monkeypatch
+    # process env across a real subprocess fork — pass everything via
+    # ``Popen(env=...)``.
+    # NB: env-var names match completion_sidecar's _ENV_* contract.
+    child_env = os.environ.copy()
+    child_env["HOME"] = str(fake_home)
+    child_env["TR_PAIR_SIDECAR_HANDSHAKE_ID"] = handshake_id
+    child_env["TR_PAIR_SIDECAR_RELAY_URL"] = relay.url
+    child_env["TR_PAIR_SIDECAR_MODE"] = "either"
+    # Block the on-chain client construction in the sidecar's
+    # ``configure`` path. The sidecar imports ``AgentState`` from
+    # ``totalreclaw.agent.state``; the easiest stub is to point its
+    # server URL at a non-routable local port so credentials-write
+    # would fail soft. The flow we care about (ws ack) does NOT
+    # depend on configure success.
+    child_env["TOTALRECLAW_SERVER_URL"] = "http://127.0.0.1:1"
+
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "totalreclaw.pair.completion_sidecar", "--run"],
+        env=child_env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        close_fds=True,
+        start_new_session=True,
+    )
+
+    # Poll for the handshake file like the real parent does.
+    handshake_path = fake_home / ".totalreclaw" / f".pair_handshake_{handshake_id}.json"
+    deadline = time.monotonic() + 10.0
+    handshake: Optional[dict] = None
+    while time.monotonic() < deadline:
+        if handshake_path.exists():
+            try:
+                handshake = json.loads(handshake_path.read_text())
+                break
+            except json.JSONDecodeError:
+                pass
+        await asyncio.sleep(0.05)
+
+    assert handshake is not None, (
+        "subprocess sidecar never produced the handshake file — "
+        "the rc.24 contract is broken"
+    )
+    assert handshake["status"] == "opened"
+    assert handshake["token"] == relay.token
+
+    # Simulate parent exit by dropping the proc handle. Don't wait()
+    # — the sidecar must NOT depend on the parent reaping it. POSIX
+    # ``setsid`` reparents the orphan to init, so this is fine.
+    del proc
+
+    # The relay stub still expects the forward to land + an ack to
+    # come back. If the sidecar died at parent-exit, the relay will
+    # never get the ack and ``wait_for_ack`` times out.
+    ack_arrived = await relay.wait_for_ack(timeout_s=15.0)
+    try:
+        await relay.stop()
+    except Exception:
+        pass
+
+    assert ack_arrived, (
+        "relay never received ack after parent process handle dropped — "
+        "this is the EXACT rc.23 NO-GO scenario; the sidecar must "
+        "outlive the parent for one-shot ``hermes chat -q`` to work"
+    )
+
+
+def test_pair_tool_uses_sidecar_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The rc.24 default MUST be sidecar=on. Setting the env var to
+    "0" disables it (escape hatch for sandboxed envs); anything else
+    enables it.
+
+    Regression shield: a future PR that flips the default off would
+    silently re-introduce the rc.23 bug for one-shot processes.
+    """
+    from totalreclaw.hermes.pair_tool import _sidecar_enabled
+
+    monkeypatch.delenv("TOTALRECLAW_PAIR_SIDECAR", raising=False)
+    assert _sidecar_enabled() is True
+
+    monkeypatch.setenv("TOTALRECLAW_PAIR_SIDECAR", "1")
+    assert _sidecar_enabled() is True
+
+    monkeypatch.setenv("TOTALRECLAW_PAIR_SIDECAR", "true")
+    assert _sidecar_enabled() is True
+
+    monkeypatch.setenv("TOTALRECLAW_PAIR_SIDECAR", "0")
+    assert _sidecar_enabled() is False
+
+    monkeypatch.setenv("TOTALRECLAW_PAIR_SIDECAR", "false")
+    assert _sidecar_enabled() is False
+
+
+def test_handshake_path_is_under_totalreclaw_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Belt-and-suspenders: handshake files live in
+    ``~/.totalreclaw/`` (mode 0700), not ``/tmp`` (world-readable).
+
+    The handshake JSON does NOT contain key material — only the
+    public-facing URL/PIN — but keeping it in the credentials dir
+    matches the rest of the pair flow's filesystem contract and
+    avoids any accidental race with another user on a multi-tenant
+    host.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from totalreclaw.pair.completion_sidecar import _handshake_path_for
+
+    p = _handshake_path_for("test-id")
+    assert str(p).startswith(str(tmp_path / ".totalreclaw"))
+    # Trigger directory creation by calling the helper.
+    from totalreclaw.pair.completion_sidecar import _totalreclaw_dir
+
+    d = _totalreclaw_dir()
+    # Mode 0o700 enforced.
+    mode = d.stat().st_mode & 0o777
+    assert mode == 0o700, f"~/.totalreclaw must be 0700, got {oct(mode)}"


### PR DESCRIPTION
rc.23 brutal QA NO-GO findings (umbrella p-diogo/totalreclaw-internal#156).

## F1 (#157, BLOCKER) — pair sidecar survives one-shot process exit

Pair worker thread + WS died with `hermes chat -q` process; relay tore session, browser POST got 404/502.

**Fix**: detached `setsid` sidecar subprocess (`python -m totalreclaw.pair.completion_sidecar`) owns the WS through completion. Fast atomic-tempfile handshake in `~/.totalreclaw/`. Phrase-safety preserved — keypair via env vars (not argv); phrase only ever in sidecar RAM, never returned to parent / never crosses LLM context.

(Did NOT use the QA report's UDS-to-existing-daemon recommendation — hermes-agent core doesn't expose a UDS endpoint and adding one is out of scope. Sidecar gives equivalent lifecycle guarantee.)

## F2 (#158, HIGH) — extraction silently empty on Z.AI

Root cause confirmed per Pedro 2026-04-26: **Coding-plan endpoint + GLM-5.x model = wrong-endpoint-for-model**. Z.AI returns HTTP 200 with empty body (no error to detect like the existing 429 "Insufficient balance" flip).

**Three-layer fix**:
1. `zai_base_url_for_model` heuristic — GLM-5.x routes to Standard endpoint, GLM-4.x stays on Coding endpoint
2. `response_format: json_object` hint to known providers
3. Empty-200 auto-flip mirrors the existing 429 retry pattern
4. INFO → WARN on empty bodies (loud-on-empty per QA recommendation)

**No new providers introduced** — same-provider cheaper-model auto-pick stays the rule per Pedro's UX direction.

## F3 (#159, MEDIUM) — `retype_setscope.py` missing from rc.23 wheel

Root cause: setuptools auto-discovery + src-layout silently dropped the new file. Verified pre-fix wheel did NOT contain it; post-fix wheel DOES (`unzip -l` confirms).

**Fix**: explicit `[tool.setuptools.packages.find] where = ["src"]` in `pyproject.toml` + version reset `2.3.1rc24` → `2.3.1` (publish workflow's RC mutation had leaked back into checked-in version).

Plus packaging integrity test: builds wheel locally, asserts ALL .py files under `python/src/totalreclaw/` are in the resulting wheel listing. Pre-publish gate going forward.

## Test plan

22 new tests, all pass. 928 passed locally (full suite minus pre-existing missing-dep skips). Headline: `test_pair_tool_returns_after_sidecar_handshake_with_short_lived_process` spawns a real subprocess, drops the parent handle without `wait()`, asserts the relay still acks (the EXACT rc.23 NO-GO repro).

## Out of scope

F4/F5/F6 deferred per QA-skill v3 narrow-rail principles (Hermes core upstream / informational / low).

🤖 Generated with [Claude Code](https://claude.com/claude-code)