### PR TITLE
fix(hermes): drain pending queue from pre_llm_call so --resume turns recover (#165)

### DIFF
--- a/python/src/totalreclaw/hermes/hooks.py
+++ b/python/src/totalreclaw/hermes/hooks.py
@@ -73,6 +73,35 @@ def _get_hermes_llm_config():
         return None
 
 
+def _maybe_drain_pending(state: "PluginState") -> None:
+    """Drain any deferred-extraction queue for the configured owner.
+
+    Issue #165 (umbrella #163, F2): Hermes does not fire ``on_session_start``
+    for ``hermes chat -q --resume <sid>`` turns, so a drain wired only to
+    that hook never recovers queue entries when users continue a
+    conversation. Calling this from both ``on_session_start`` AND the head
+    of ``pre_llm_call`` makes drain fire on every turn including resumes.
+    The path is idempotent — ``has_pending`` is a cheap read, so the
+    no-op cost on quiet turns is one filesystem stat.
+    """
+    try:
+        owner = _owner_address(state)
+        if owner and has_pending(owner):
+            batches = drain_pending(owner)
+            recovered_count = _drain_into_state(state, batches)
+            if recovered_count > 0:
+                logger.info(
+                    "TotalReclaw: drained %d message(s) from prior interpreter-shutdown race.",
+                    recovered_count,
+                )
+                state.set_quota_warning(
+                    f"TotalReclaw: caught up on auto-extraction for {recovered_count} "
+                    f"message(s) deferred from a prior CLI session."
+                )
+    except Exception as exc:
+        logger.warning("TotalReclaw: pending-drain failed: %s", exc)
+
+
 def on_session_start(state: "PluginState", **kwargs) -> None:
     """Initialize client, drain any pending extraction queue, and check billing.
 
@@ -90,24 +119,9 @@ def on_session_start(state: "PluginState", **kwargs) -> None:
         return
 
     # Drain any messages that a prior interpreter-shutdown race deferred.
-    # This must run before billing-cache logic so a drain-induced
-    # quota_warning isn't overwritten.
-    try:
-        owner = _owner_address(state)
-        if owner and has_pending(owner):
-            batches = drain_pending(owner)
-            recovered_count = _drain_into_state(state, batches)
-            if recovered_count > 0:
-                logger.info(
-                    "TotalReclaw: drained %d message(s) from prior interpreter-shutdown race.",
-                    recovered_count,
-                )
-                state.set_quota_warning(
-                    f"TotalReclaw: caught up on auto-extraction for {recovered_count} "
-                    f"message(s) deferred from a prior CLI session."
-                )
-    except Exception as exc:
-        logger.warning("TotalReclaw: pending-drain failed at session start: %s", exc)
+    # Must run before billing-cache logic so a drain-induced quota_warning
+    # isn't overwritten.
+    _maybe_drain_pending(state)
 
     # Check billing cache and update server-driven config
     try:
@@ -192,6 +206,12 @@ def pre_llm_call(state: "PluginState", **kwargs) -> Optional[dict]:
             state._totalreclaw_setup_nudge_shown = True
             return {"context": _SETUP_NUDGE}
         return None
+
+    # Issue #165: Hermes doesn't fire on_session_start for ``--resume`` turns,
+    # so the drain-on-session-start path (issue #148) never recovers the queue
+    # for users running multi-turn ``hermes chat -q --resume <sid>``. Drain
+    # here too — idempotent and cheap when the queue is empty.
+    _maybe_drain_pending(state)
 
     context_parts: list[str] = []
 

--- a/python/tests/test_issue_148_interpreter_shutdown_drain.py
+++ b/python/tests/test_issue_148_interpreter_shutdown_drain.py
@@ -294,3 +294,97 @@ def test_on_session_start_drains_pending_into_state(pending_path, monkeypatch):
     assert not pending_path.exists()
     # Quota warning announces the catch-up.
     assert state.quota_warning and "caught up" in state.quota_warning
+
+
+# ---------------------------------------------------------------------------
+# 5. Issue #165 (umbrella #163, F2): pre_llm_call must also drain so the
+#    --resume case (where Hermes does NOT fire on_session_start) recovers
+#    the queue. Without this, drain is gated to fresh-session boundaries
+#    only and ``hermes chat -q --resume <sid>`` users accumulate pending
+#    entries forever.
+# ---------------------------------------------------------------------------
+
+
+def test_issue_165_pre_llm_call_drains_pending_for_resume_case(
+    pending_path, monkeypatch
+):
+    from totalreclaw.hermes import hooks
+
+    drained_calls: list = []
+
+    def fake_auto_extract(state, mode="turn", llm_config=None):
+        drained_calls.append({"mode": mode, "msg_count": len(state._messages)})
+        return []
+
+    def fake_auto_recall(*_a, **_kw):
+        return ""
+
+    monkeypatch.setattr(hooks, "_auto_extract", fake_auto_extract)
+    monkeypatch.setattr(hooks, "_get_hermes_llm_config", lambda: None)
+    monkeypatch.setattr(hooks, "auto_recall", fake_auto_recall)
+
+    owner = "0xdeadbeef00000000000000000000000000000001"
+    enqueue_messages(
+        owner,
+        [
+            {"role": "user", "content": "queued during --resume turn N-1"},
+            {"role": "assistant", "content": "queued reply"},
+        ],
+    )
+
+    state = _FakeState(_FakeClient(raise_on="never"), [])
+    state.add_message = lambda role, content: state._messages.append(
+        {"role": role, "content": content}
+    )
+    # PluginState surface used by pre_llm_call.
+    state.get_quota_warning = lambda: None
+    state.clear_quota_warning = lambda: None
+
+    # Simulate ``hermes chat -q --resume <sid> --query "..."`` — Hermes
+    # treats this as a continuing session and skips on_session_start, but
+    # pre_llm_call still fires.
+    hooks.pre_llm_call(state, user_message="continue", is_first_turn=False)
+
+    assert len(drained_calls) == 1, (
+        "drain should have run from pre_llm_call even though "
+        "on_session_start was never called for the --resume turn"
+    )
+    assert drained_calls[0]["mode"] == "full"
+    assert drained_calls[0]["msg_count"] == 2
+    assert not pending_path.exists(), "queue should be consumed after drain"
+    assert state.quota_warning and "caught up" in state.quota_warning
+
+
+def test_issue_165_pre_llm_call_drain_is_noop_when_queue_empty(
+    pending_path, monkeypatch
+):
+    """The drain hook must be cheap on the hot path. With no queue entry,
+    no extraction should fire and no quota warning should be set."""
+    from totalreclaw.hermes import hooks
+
+    drained_calls: list = []
+
+    def fake_auto_extract(state, mode="turn", llm_config=None):
+        drained_calls.append({"mode": mode})
+        return []
+
+    def fake_auto_recall(*_a, **_kw):
+        return ""
+
+    monkeypatch.setattr(hooks, "_auto_extract", fake_auto_extract)
+    monkeypatch.setattr(hooks, "_get_hermes_llm_config", lambda: None)
+    monkeypatch.setattr(hooks, "auto_recall", fake_auto_recall)
+
+    state = _FakeState(_FakeClient(raise_on="never"), [])
+    state.add_message = lambda role, content: state._messages.append(
+        {"role": role, "content": content}
+    )
+    state.get_quota_warning = lambda: None
+    state.clear_quota_warning = lambda: None
+
+    hooks.pre_llm_call(state, user_message="hi", is_first_turn=False)
+
+    # Queue empty → no auto_extract, no quota warning, no on-disk file.
+    assert drained_calls == []
+    assert not pending_path.exists()
+    assert state.quota_warning is None


### PR DESCRIPTION
## What broke
On `hermes chat -q --resume <sid>`, the deferred-extraction queue grew on every turn but never drained — multi-turn `--resume` users on rc.24/rc.25/rc.26 lost data indefinitely.

## What's fixed
The drain trigger now also fires from `pre_llm_call` (in addition to `on_session_start`), so it runs on every turn including `--resume` turns where Hermes does not dispatch `on_session_start`. Existing drain logic extracted into a private `_maybe_drain_pending(state)` helper for the second call site.

## Impact after fix
Continuous-conversation users running `hermes chat -q --resume <sid>` now have queued messages drained on the very next turn, with a one-time quota-channel notice announcing the catch-up. No behavior change on fresh sessions — `_maybe_drain_pending` is idempotent and `has_pending` is a cheap filesystem stat.

## Verification
F2 scenario from umbrella #163 — multi-turn `--resume` chain pre-populated with a queue entry; `hooks.pre_llm_call` consumes the queue on the next turn (was: queue grew monotonically). New regression tests `test_issue_165_pre_llm_call_drains_pending_for_resume_case` + `test_issue_165_pre_llm_call_drain_is_noop_when_queue_empty` pass on the post-patch tree; the first FAILS on the pre-patch tree (asserted via `git stash`). Full hermes test suite (112 unrelated tests across `test_hermes_plugin`, `test_v1_hooks_integration`, `test_v2_02_hermes_fixes`, `test_wave2a_hermes_fixes`, `test_event_loop_lifecycle`) passes. Pinned-RC verification on VPS (`docker exec tr-hermes` with rc.27 installed) drained a pre-populated queue from `pre_llm_call` and was a no-op on the next call — verdict GO.

Closes p-diogo/totalreclaw-internal#165

🤖 Generated with [Claude Code](https://claude.com/claude-code) — auto-triage pipeline (Phase 3)
