### PR TITLE
fix(hermes): bias LLM toward totalreclaw_remember over built-in 'memory' (F4 / #167)

### DIFF
--- a/python/src/totalreclaw/hermes/hooks.py
+++ b/python/src/totalreclaw/hermes/hooks.py
@@ -40,6 +40,25 @@ _SETUP_NUDGE = (
     "built-in 'memory' tool for durability + encryption."
 )
 
+#: F4 (issue #167): for configured users, schema-level "prefer this tool"
+#: language in the REMEMBER/RECALL descriptions is not strong enough — the
+#: rc.24 chat-flow QA showed every memory-intent turn routing to Hermes's
+#: built-in ``memory`` tool. We inject this nudge on every memory-intent
+#: turn (not just first) so context-window summarization can't drop it on
+#: the turn it matters. Cost is small (~80 tokens) and only paid when
+#: ``_looks_like_memory_intent`` matches.
+_TOOL_PRIORITY_NUDGE = (
+    "## TotalReclaw tool priority\n"
+    "For any user fact, preference, decision-with-reasoning, directive "
+    "('always X' / 'never Y'), commitment, or notable episode the user "
+    "shares — ALWAYS call `totalreclaw_remember` instead of any built-in "
+    "`memory` tool. TotalReclaw stores memories end-to-end encrypted, "
+    "on-chain (Base/Gnosis), and portable across every AI tool the user "
+    "runs; the built-in `memory` tool is plain-text, session-scoped, and "
+    "not cross-agent. For lookups, prefer `totalreclaw_recall` over any "
+    "built-in equivalent for the same reason."
+)
+
 #: Keywords that trigger the setup nudge when the user isn't configured.
 #: Kept intentionally broad — a missed nudge on an unrelated question is
 #: a no-op, but a missed nudge on a memory-relevant question means the
@@ -168,14 +187,21 @@ def _drain_into_state(state: "PluginState", batches: list[list[dict]]) -> int:
 
 
 def pre_llm_call(state: "PluginState", **kwargs) -> Optional[dict]:
-    """Auto-recall on first turn, inject memories, quota warnings, and the
-    unconfigured-user setup nudge (Bug #6) into context.
+    """Auto-recall on first turn, inject memories, quota warnings, the
+    unconfigured-user setup nudge (Bug #6), and the configured-user
+    tool-priority nudge (F4 / issue #167) into context.
 
     When the plugin is installed but the user hasn't run
     ``totalreclaw_setup`` yet, a one-time nudge is injected on the first
     turn that references any memory intent. The nudge tells the Hermes
     agent to offer setup — preventing silent routing to Hermes's
     built-in ``memory`` tool.
+
+    For configured users, a parallel tool-priority nudge fires on every
+    memory-intent turn (cheap and reliably present in active LLM context)
+    so the LLM picks ``totalreclaw_remember`` instead of Hermes's
+    built-in ``memory`` for fact/preference/directive/commitment/episode
+    intents.
     """
     user_message = kwargs.get("user_message", "")
     is_first_turn = kwargs.get("is_first_turn", False)
@@ -194,6 +220,13 @@ def pre_llm_call(state: "PluginState", **kwargs) -> Optional[dict]:
         return None
 
     context_parts: list[str] = []
+
+    # F4 (issue #167) — configured: bias LLM toward totalreclaw_remember
+    # over Hermes's built-in ``memory`` for memory-intent turns. Fires
+    # every matching turn (not gated to first) so sliding context windows
+    # can't drop it on the turn the user actually expresses an intent.
+    if user_message and _looks_like_memory_intent(user_message):
+        context_parts.append(_TOOL_PRIORITY_NUDGE)
 
     # Inject quota warning (once per session)
     quota_warning = state.get_quota_warning()

--- a/python/src/totalreclaw/hermes/plugin.yaml
+++ b/python/src/totalreclaw/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: totalreclaw
-version: 2.3.1rc24
+version: 2.3.1rc25
 description: End-to-end encrypted memory vault for AI agents (Memory Taxonomy v1)
 author: TotalReclaw Team
 provides_tools:

--- a/python/src/totalreclaw/hermes/plugin.yaml
+++ b/python/src/totalreclaw/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: totalreclaw
-version: 2.3.1rc25
+version: 2.3.1rc26
 description: End-to-end encrypted memory vault for AI agents (Memory Taxonomy v1)
 author: TotalReclaw Team
 provides_tools:

--- a/python/tests/test_v2_02_hermes_fixes.py
+++ b/python/tests/test_v2_02_hermes_fixes.py
@@ -417,3 +417,108 @@ class TestBug6FirstRunNudge:
         if result is not None:
             ctx = result.get("context", "").lower()
             assert "totalreclaw_setup" not in ctx
+
+
+class TestIssue167ToolPriorityNudge:
+    """F4 / issue #167 — configured users must receive a tool-priority
+    nudge so the LLM picks ``totalreclaw_remember`` over Hermes's built-in
+    ``memory`` for memory-intent turns. The rc.24 chat-flow QA proved that
+    schema-level "prefer this tool" descriptions are not strong enough on
+    their own; the hook needs to inject a system-context nudge.
+    """
+
+    def _make_configured_state(self):
+        from totalreclaw.hermes.state import PluginState
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(Path, "exists", return_value=False):
+                state = PluginState()
+        state._client = MagicMock()  # forge configured
+        return state
+
+    def test_issue_167_priority_nudge_fires_on_memory_intent(self):
+        """Configured user + 'remember X' message → priority nudge injected."""
+        from totalreclaw.hermes.hooks import pre_llm_call
+
+        state = self._make_configured_state()
+        with patch("totalreclaw.hermes.hooks.auto_recall", return_value=None):
+            result = pre_llm_call(
+                state,
+                is_first_turn=True,
+                user_message="Please remember that I prefer dark mode.",
+            )
+        assert result is not None, "expected priority nudge"
+        ctx = result.get("context", "").lower()
+        assert "totalreclaw_remember" in ctx
+        assert "built-in" in ctx
+        # Setup nudge must NOT fire for configured users.
+        assert "totalreclaw_setup" not in ctx
+
+    def test_issue_167_priority_nudge_no_op_on_non_memory_message(self):
+        """Configured user + non-memory message → no priority nudge."""
+        from totalreclaw.hermes.hooks import pre_llm_call
+
+        state = self._make_configured_state()
+        with patch("totalreclaw.hermes.hooks.auto_recall", return_value=None):
+            result = pre_llm_call(
+                state,
+                is_first_turn=True,
+                user_message="What's the weather like today?",
+            )
+        if result is not None:
+            ctx = result.get("context", "").lower()
+            assert "totalreclaw tool priority" not in ctx
+
+    def test_issue_167_priority_nudge_fires_on_later_turns(self):
+        """Nudge isn't gated to first turn — sliding-window context could
+        drop a once-only injection on the turn the user actually expresses
+        memory intent. Must fire on every memory-intent turn.
+        """
+        from totalreclaw.hermes.hooks import pre_llm_call
+
+        state = self._make_configured_state()
+        with patch("totalreclaw.hermes.hooks.auto_recall", return_value=None):
+            # Simulate a non-first turn (is_first_turn=False) that still
+            # has clear memory intent.
+            result = pre_llm_call(
+                state,
+                is_first_turn=False,
+                user_message="Save this preference: I like Postgres over MySQL.",
+            )
+        assert result is not None
+        ctx = result.get("context", "").lower()
+        assert "totalreclaw_remember" in ctx
+
+    def test_issue_167_priority_nudge_repeats_across_turns(self):
+        """Each memory-intent turn re-injects the nudge (not gated to once-per-session)."""
+        from totalreclaw.hermes.hooks import pre_llm_call
+
+        state = self._make_configured_state()
+        with patch("totalreclaw.hermes.hooks.auto_recall", return_value=None):
+            r1 = pre_llm_call(state, is_first_turn=True,
+                              user_message="Remember I like Python.")
+            r2 = pre_llm_call(state, is_first_turn=False,
+                              user_message="Note that I prefer Postgres.")
+        assert r1 is not None and "totalreclaw_remember" in r1["context"].lower()
+        assert r2 is not None and "totalreclaw_remember" in r2["context"].lower()
+
+    def test_issue_167_priority_nudge_combines_with_recall_context(self):
+        """Priority nudge + auto-recalled memories should both appear in the
+        combined context (priority nudge is additive, not replacement).
+        """
+        from totalreclaw.hermes.hooks import pre_llm_call
+
+        state = self._make_configured_state()
+
+        def fake_auto_recall(msg, st, top_k=8):
+            return "## Memories\n- User prefers dark mode."
+
+        with patch("totalreclaw.hermes.hooks.auto_recall", side_effect=fake_auto_recall):
+            result = pre_llm_call(
+                state,
+                is_first_turn=True,
+                user_message="Recall what you know about my editor preferences.",
+            )
+        assert result is not None
+        ctx = result["context"]
+        assert "totalreclaw_remember" in ctx.lower()
+        assert "dark mode" in ctx.lower()


### PR DESCRIPTION
## What broke
Hermes built-in `memory` tool was winning over `totalreclaw_remember` for natural-language "remember X" prompts in rc.24 — user data landed in Hermes's plain-text profile cache instead of the encrypted TotalReclaw vault.

## What's fixed
`pre_llm_call` now injects a `_TOOL_PRIORITY_NUDGE` system-context block on every memory-intent turn for configured users, biasing the LLM toward `totalreclaw_remember`. The Bug-#6 setup-nudge logic was unconfigured-only; this is the configured-user counterpart.

## Impact after fix
F4 LLM-routing test on glm-5.1 with realistic 9-tool surface and the verbatim rc.24 S3 prompts: T3 ("I prefer Postgres over MySQL...") migrates from Hermes built-in `memory` (baseline) to `totalreclaw_remember` (with nudge); no regressions on other turns. User-fact intents now land in the encrypted vault, not the plain-text profile cache.

## Verification
- 5/5 unit tests pass post-patch; 4/5 fail on the pre-patch tree (proves they exercise the bug). Full hermes test suite (73 tests) green.
- F4 LLM-routing test against z.ai glm-5.1 (same chat model as rc.24 QA) — see `docs/notes/QA-hermes-RC-2.3.1-rc.26-issue-167.md` in the internal repo.
- Full chat-flow re-QA blocked by sibling #164 (escalated) — F1 pair onboarding broken.

Closes #167

QA report: https://github.com/p-diogo/totalreclaw-internal/blob/main/docs/notes/QA-hermes-RC-2.3.1-rc.26-issue-167.md
Umbrella: p-diogo/totalreclaw-internal#163 (other findings remain open)