### PR TITLE
fix(hermes): rc.26 auto-disable Hermes built-in memory tool + warn dual-mode

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -78,11 +78,29 @@ Hermes does NOT auto-reload on plugin install. Tell the user verbatim:
 
 Do NOT invoke the restart yourself — your shell runs inside the gateway you'd be restarting. Wait for the user's `done`.
 
-### Step 3 — Check for existing credentials
+### Step 3 — Disable Hermes built-in memory tool (CRITICAL)
+
+Hermes ships with its own built-in `memory` tool that competes with TotalReclaw for "remember X" / "recall X" intents. Running both creates a silent bug where conversation context goes to MEMORY.md instead of TotalReclaw's encrypted vault. TotalReclaw and Hermes built-in memory solve the same problem — running both is an anti-pattern.
+
+Run via your shell tool:
+
+```bash
+hermes tools disable memory
+```
+
+Then tell the user verbatim:
+
+> *I've disabled Hermes' built-in `memory` tool so TotalReclaw can be your primary, encrypted, on-chain memory. Your old `MEMORY.md` / `USER.md` files are still on disk but no longer used by the agent.*
+> *- To re-enable Hermes built-in memory: `hermes tools enable memory` (NOT recommended while TotalReclaw is installed — they will steal intents from each other).*
+> *- To wipe the orphaned files: `hermes memory reset`.*
+
+If `hermes tools disable memory` errors with `command not found` or "tool not found" (older Hermes versions, managed services that don't expose the CLI, or the built-in `memory` tool was already removed), log the failure and continue — the rc.25 tool-description bias still steers the LLM toward `totalreclaw_remember` as a fallback.
+
+### Step 4 — Check for existing credentials
 
 Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, confirm *"TotalReclaw is already set up."* and stop. Otherwise continue.
 
-### Step 4 — Pair (browser flow, NEVER ask the user to type their phrase in chat)
+### Step 5 — Pair (browser flow, NEVER ask the user to type their phrase in chat)
 
 Call the `totalreclaw_pair` tool. It returns `{url, pin, expires_at_ms}`.
 
@@ -90,7 +108,7 @@ Relay to the user verbatim:
 
 > *Open <url> in your browser. Generate a new 12-word recovery phrase there or paste an existing one — the phrase stays in your browser, the relay only sees ciphertext. Confirm PIN <pin>. Reply `done` once the page says it's sealed.*
 
-### Step 5 — Verify and confirm
+### Step 6 — Verify and confirm
 
 After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN likely expired — call `totalreclaw_pair` again and resend. If present, confirm *"TotalReclaw is set up. Ask me to remember or recall anything."*
 
@@ -195,6 +213,24 @@ Paste the same canonical message. The **Generate new** tab is selected by defaul
 ## Canonical prompt (matches the QA harness scenario contracts)
 
 > **Install TotalReclaw, see <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md>**
+
+---
+
+## Compatibility with Hermes built-in memory
+
+TotalReclaw and Hermes' built-in `memory` tool BOTH respond to "remember X" / "recall X" intents. Running both simultaneously creates a silent bug: depending on the LLM's tool-selection, your conversation context may be split between Hermes' MEMORY.md and TotalReclaw's encrypted vault — neither sees the full picture.
+
+The TotalReclaw setup flow auto-disables Hermes built-in memory on install. We DO NOT recommend re-enabling it while TotalReclaw is installed.
+
+If you want to use Hermes built-in memory instead of TotalReclaw:
+
+```bash
+hermes tools enable memory
+totalreclaw forget --all     # optional: clear TotalReclaw's vault
+pip uninstall totalreclaw    # optional: remove the package
+```
+
+If you want to use both (NOT supported, results may be unreliable): file an issue at <https://github.com/p-diogo/totalreclaw/issues> describing your use case so we can scope dual-mode support.
 
 ---
 

--- a/python/src/totalreclaw/hermes/SKILL.md
+++ b/python/src/totalreclaw/hermes/SKILL.md
@@ -13,7 +13,7 @@ homepage: https://totalreclaw.xyz
 
 ## Setup flow
 
-If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jump to step 4. Otherwise run all steps in order.
+If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jump to step 5. Otherwise run all steps in order.
 
 1. **Install plugin + Python package.** Hermes 2026.4.16+ uses Git-based plugin discovery and a separate Python tool implementation. The Python package MUST go into the SAME Python environment that Hermes runs from (containerized venv, native venv, or system Python — whichever your install uses). Bare `pip install` may target the wrong Python on containerized deploys. Step-by-step via your shell tool:
    ```
@@ -30,18 +30,33 @@ If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jum
    # 1c. Verify the package resolved through Hermes' Python.
    "$HERMES_PYTHON" -m pip show totalreclaw | head -2
    ```
-   If `pip show` doesn't list the package, the install landed in a different Python — fix `$HERMES_PYTHON` and re-run 1b. On Debian/Ubuntu/Docker you may hit `externally-managed-environment` if Hermes runs against system Python — add `--break-system-packages` to the `pip install` line, or ask the user to recreate Hermes inside a venv. If either shell call fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment): tell the user verbatim *"Your environment doesn't expose the Hermes CLI / pip to me. Please install `p-diogo/totalreclaw-hermes` and the `totalreclaw` Python package via your service's plugins UI, then reply `done`."* Wait for `done` and skip to step 3.
+   If `pip show` doesn't list the package, the install landed in a different Python — fix `$HERMES_PYTHON` and re-run 1b. On Debian/Ubuntu/Docker you may hit `externally-managed-environment` if Hermes runs against system Python — add `--break-system-packages` to the `pip install` line, or ask the user to recreate Hermes inside a venv. If either shell call fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment): tell the user verbatim *"Your environment doesn't expose the Hermes CLI / pip to me. Please install `p-diogo/totalreclaw-hermes` and the `totalreclaw` Python package via your service's plugins UI, then reply `done`. Also disable Hermes' built-in `memory` tool in the same UI if available — running both creates a silent intent-stealing bug."* Wait for `done` and skip to step 4 (verify pair tool bound).
 
 2. **Restart the gateway — Hermes does NOT auto-reload on plugin install.** Tell the user verbatim: *"Please restart your Hermes gateway: `hermes gateway restart` (native), `docker restart <your-container-name>` (Docker self-host — substitute the actual name; `docker ps` shows it), or your managed service's restart control. If supervised by systemd / launchd, `kill -USR1 $(cat ~/.hermes/gateway.pid)` triggers a graceful-drain restart. Reply `done` once it's back up."* Do NOT run the restart yourself — your shell is inside the gateway you'd be restarting. Wait for the user's `done`.
 
-3. **Verify `totalreclaw_pair` is bound.** If still missing after restart, tell the user the plugin didn't load and to retry. Do not loop the install.
+3. **Disable Hermes built-in memory tool (CRITICAL).** Hermes ships with its own built-in `memory` tool that competes with TotalReclaw for "remember X" / "recall X" intents. Running both creates a silent bug where conversation context goes to MEMORY.md instead of TotalReclaw's encrypted vault. TotalReclaw and Hermes built-in memory solve the same problem — running both is an anti-pattern.
 
-4. **Check for existing credentials.** Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, confirm *"TotalReclaw is already set up."* and stop.
+   Run via your shell tool:
+   ```bash
+   hermes tools disable memory
+   ```
 
-5. **Pair.** Call `totalreclaw_pair`. Returns `{url, pin, expires_at_ms}`. Relay verbatim:
+   Then tell the user verbatim:
+
+   > *I've disabled Hermes' built-in `memory` tool so TotalReclaw can be your primary, encrypted, on-chain memory. Your old `MEMORY.md` / `USER.md` files are still on disk but no longer used by the agent.*
+   > *- To re-enable Hermes built-in memory: `hermes tools enable memory` (NOT recommended while TotalReclaw is installed — they will steal intents from each other).*
+   > *- To wipe the orphaned files: `hermes memory reset`.*
+
+   If `hermes tools disable memory` errors with `command not found` or "tool not found" (older Hermes versions, managed services that don't expose the CLI, or the built-in `memory` tool was already removed), log the failure and continue — the rc.25 tool-description bias still steers the LLM toward `totalreclaw_remember` as a fallback.
+
+4. **Verify `totalreclaw_pair` is bound.** If still missing after restart, tell the user the plugin didn't load and to retry. Do not loop the install.
+
+5. **Check for existing credentials.** Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, confirm *"TotalReclaw is already set up."* and stop.
+
+6. **Pair.** Call `totalreclaw_pair`. Returns `{url, pin, expires_at_ms}`. Relay verbatim:
    > *Open <url> in your browser. Generate a new 12-word recovery phrase there or paste an existing one — the phrase stays in your browser, the relay only sees ciphertext. Confirm PIN <pin>. Reply `done` once the page says it's sealed.*
 
-6. **Verify and confirm.** After user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN expired — call `totalreclaw_pair` again and resend. If present, confirm *"TotalReclaw is set up. Ask me to remember or recall anything."*
+7. **Verify and confirm.** After user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN expired — call `totalreclaw_pair` again and resend. If present, confirm *"TotalReclaw is set up. Ask me to remember or recall anything."*
 
 ## Phrase safety (HARD — never break)
 

--- a/python/src/totalreclaw/hermes/__init__.py
+++ b/python/src/totalreclaw/hermes/__init__.py
@@ -238,4 +238,76 @@ def register(ctx):
     except Exception:  # pragma: no cover — validation must not crash plugin load
         logger.debug("LLM-config load-time validation skipped", exc_info=True)
 
+    # rc.26 (issue #167 path A): defensive WARN if the user re-enabled
+    # Hermes' built-in `memory` tool after install. The SKILL.md install
+    # flow auto-disables it (`hermes tools disable memory`), but this
+    # belt-and-suspenders check runs on every plugin load to surface the
+    # anti-pattern in logs if someone manually re-enabled the built-in.
+    # Best-effort — never crashes plugin load. Shells out to the `hermes`
+    # CLI; absence of the CLI is silently tolerated.
+    try:
+        _warn_if_built_in_memory_enabled()
+    except Exception:  # pragma: no cover — defensive check must not crash
+        logger.debug("built-in memory enablement check skipped", exc_info=True)
+
     logger.info("TotalReclaw plugin registered (14+ tools, 6 hooks)")
+
+
+def _warn_if_built_in_memory_enabled() -> None:
+    """Check whether Hermes' built-in `memory` tool is currently enabled.
+
+    Emits a single WARN line if it is. No-op (DEBUG only) if the
+    `hermes` CLI is not on PATH or if `hermes tools list` doesn't
+    expose a parseable enabled-set — we don't want this defensive
+    check to spam logs in environments where it can't be answered
+    cleanly.
+
+    rc.26 fix for the rc.24 NO-GO finding (issue #167): TotalReclaw
+    and Hermes built-in `memory` solve the same problem and compete
+    for "remember X" / "recall X" intents during natural conversation.
+    The install flow disables the built-in via SKILL.md step 3, but
+    this WARN catches users who re-enabled it manually.
+    """
+    import shutil
+    import subprocess
+
+    if shutil.which("hermes") is None:
+        logger.debug("hermes CLI not found on PATH; skipping built-in memory check")
+        return
+
+    try:
+        proc = subprocess.run(
+            ["hermes", "tools", "list"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, PermissionError):
+        logger.debug("hermes tools list failed; skipping built-in memory check", exc_info=True)
+        return
+
+    if proc.returncode != 0:
+        logger.debug(
+            "hermes tools list exited with code %d; skipping built-in memory check",
+            proc.returncode,
+        )
+        return
+
+    output = proc.stdout or ""
+    # Parse heuristically — match `memory` token followed by an
+    # enabled marker. Tolerant of whitespace + alternative formats
+    # (`memory: enabled`, `memory  enabled`, table-style, JSON-style).
+    lower = output.lower()
+    if "memory" in lower and "enabled" in lower:
+        # Tighten the match: only WARN if `memory` and `enabled` co-occur
+        # on the same line.
+        for line in output.splitlines():
+            ll = line.lower()
+            if "memory" in ll and "enabled" in ll and "disabled" not in ll:
+                logger.warning(
+                    "Hermes built-in 'memory' tool is enabled. TotalReclaw "
+                    "recommends disabling it to avoid intent-stealing. "
+                    "Run: hermes tools disable memory"
+                )
+                return

--- a/python/tests/test_setup_guide_includes_compatibility_section.py
+++ b/python/tests/test_setup_guide_includes_compatibility_section.py
@@ -1,0 +1,141 @@
+"""rc.26: ``docs/guides/hermes-setup.md`` must include the disable-memory
+agent-imperative step + a Compatibility section.
+
+Context — rc.24 NO-GO finding (issue #167)
+-------------------------------------------
+
+The public guide at ``docs/guides/hermes-setup.md`` is the canonical
+URL the user pastes into Hermes chat. The agent fetches it and follows
+its agent-instructions block. rc.26 ships path A (auto-disable
+built-in memory) and the doc MUST mirror SKILL.md so the agent does
+the same thing whether it loaded the local skill or fetched the URL.
+
+What this test enforces
+-----------------------
+
+The shipped ``hermes-setup.md`` MUST contain:
+
+1. The ``hermes tools disable memory`` invocation in the agent-imperative
+   block (Step 3 in rc.26).
+2. The user-verbatim warning text mirroring SKILL.md.
+3. A ``## Compatibility with Hermes built-in memory`` section near the
+   bottom that documents dual-mode as unsupported.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+GUIDE_MD = (
+    Path(__file__).resolve().parents[2]
+    / "docs"
+    / "guides"
+    / "hermes-setup.md"
+)
+
+
+def _read_guide() -> str:
+    assert GUIDE_MD.exists(), f"hermes-setup.md not found at {GUIDE_MD}"
+    return GUIDE_MD.read_text(encoding="utf-8")
+
+
+def test_guide_includes_disable_memory_agent_step():
+    """The agent-instructions block must include the disable-memory step."""
+    body = _read_guide()
+    # Step heading + invocation (CRITICAL marker per the rc.26 plan).
+    assert "Disable Hermes built-in memory" in body, (
+        "hermes-setup.md must include a step heading 'Disable Hermes "
+        "built-in memory' in the agent-instructions block."
+    )
+    assert "(CRITICAL)" in body, (
+        "Disable-memory step must be marked '(CRITICAL)' so the agent "
+        "treats it as non-optional during install."
+    )
+    assert "hermes tools disable memory" in body, (
+        "Agent-instructions block must invoke `hermes tools disable memory`."
+    )
+
+
+def test_guide_includes_user_verbatim_warning():
+    """Mirrors SKILL.md user-verbatim text."""
+    body = _read_guide()
+    assert "disabled Hermes' built-in `memory` tool" in body, (
+        "hermes-setup.md must mirror the SKILL.md user-verbatim warning."
+    )
+    assert "hermes tools enable memory" in body, (
+        "User-verbatim warning must include the re-enable command + "
+        "the NOT-recommended caveat."
+    )
+    assert "NOT recommended" in body, (
+        "Re-enable instruction must be explicitly NOT recommended while "
+        "TotalReclaw is installed."
+    )
+    assert "hermes memory reset" in body, (
+        "User-verbatim warning must include the optional `hermes memory "
+        "reset` pointer for wiping orphaned MEMORY.md / USER.md files."
+    )
+
+
+def test_guide_has_compatibility_section():
+    """The bottom-of-doc Compatibility section explains dual-mode."""
+    body = _read_guide()
+    assert "## Compatibility with Hermes built-in memory" in body, (
+        "hermes-setup.md must include a `## Compatibility with Hermes "
+        "built-in memory` section near the bottom — this is the durable "
+        "human-reader documentation of why dual-mode is unsupported."
+    )
+    # Compatibility content must explain the auto-disable + recommend
+    # against re-enabling.
+    assert "auto-disables" in body, (
+        "Compatibility section must state that the install flow "
+        "auto-disables Hermes built-in memory."
+    )
+    assert "DO NOT recommend re-enabling" in body, (
+        "Compatibility section must explicitly say DO NOT recommend "
+        "re-enabling while TotalReclaw is installed."
+    )
+
+
+def test_guide_compatibility_section_documents_switch_back_path():
+    """If the user wants to switch back to Hermes built-in memory,
+    the doc must show the canonical commands (enable + clear + uninstall)."""
+    body = _read_guide()
+    # Switch-back recipe — the canonical 3-step flow.
+    assert "totalreclaw forget --all" in body, (
+        "Compatibility section must document the optional "
+        "`totalreclaw forget --all` command for users switching back "
+        "to Hermes built-in memory."
+    )
+    assert "pip uninstall totalreclaw" in body, (
+        "Compatibility section must document the optional "
+        "`pip uninstall totalreclaw` command for users switching back."
+    )
+
+
+def test_guide_compatibility_section_points_users_to_issue_tracker():
+    """Users who want dual-mode must be pointed at GitHub issues so we
+    can scope demand without committing to support upfront."""
+    body = _read_guide()
+    # rc.26 plan asked for a link to the GitHub discussion / issue
+    # tracker; we use the issues page.
+    assert "github.com/p-diogo/totalreclaw/issues" in body, (
+        "Compatibility section must link to the GitHub issue tracker so "
+        "users wanting dual-mode can flag demand."
+    )
+
+
+def test_guide_post_install_steps_renumbered():
+    """Inserting the disable-memory step at position 3 shifts the rest
+    of the agent-instructions block. Verify the renumbering landed
+    consistently — Step 4 is credentials, Step 5 is pair, Step 6 is
+    verify-and-confirm."""
+    body = _read_guide()
+    assert "### Step 4 — Check for existing credentials" in body, (
+        "Step 4 must be the credentials check (was Step 3 in rc.25)."
+    )
+    assert "### Step 5 — Pair" in body, (
+        "Step 5 must be the pair flow (was Step 4 in rc.25)."
+    )
+    assert "### Step 6 — Verify and confirm" in body, (
+        "Step 6 must be the verify-and-confirm flow (was Step 5 in rc.25)."
+    )

--- a/python/tests/test_skill_md_includes_disable_memory_step.py
+++ b/python/tests/test_skill_md_includes_disable_memory_step.py
@@ -1,0 +1,128 @@
+"""rc.26: SKILL.md must include the ``hermes tools disable memory`` step.
+
+Context — rc.24 NO-GO finding (issue #167)
+-------------------------------------------
+
+rc.24 chat-flow QA showed that Hermes' built-in ``memory`` tool steals
+"remember X" / "recall X" intents from ``totalreclaw_remember`` during
+natural conversation, causing memories to land in MEMORY.md instead of
+TotalReclaw's encrypted vault. rc.25 shipped path B (tool-description
+bias). rc.26 ships path A (hard-coded exclusivity): the install flow
+auto-disables the built-in memory tool, and the dual-mode setup is
+documented as unsupported.
+
+What this test enforces
+-----------------------
+
+The shipped ``SKILL.md`` MUST contain:
+
+1. The ``hermes tools disable memory`` invocation.
+2. The user-verbatim warning text exactly as decided in the rc.26 plan
+   (re-enable instructions + ``hermes memory reset`` pointer).
+
+Test source: SKILL.md is the canonical spec for what the agent does at
+install time. If a future refactor breaks this block, the rc.26 fix
+silently regresses and we re-introduce the rc.24 bug.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+SKILL_MD = (
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "totalreclaw"
+    / "hermes"
+    / "SKILL.md"
+)
+
+
+def _read_skill_md() -> str:
+    assert SKILL_MD.exists(), f"SKILL.md not found at {SKILL_MD}"
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+def test_skill_md_invokes_hermes_tools_disable_memory():
+    """SKILL.md must instruct the agent to run ``hermes tools disable memory``."""
+    body = _read_skill_md()
+    assert "hermes tools disable memory" in body, (
+        "SKILL.md must include the literal `hermes tools disable memory` "
+        "command — the rc.26 fix for issue #167 (Hermes built-in memory "
+        "steals memory intents from TotalReclaw)."
+    )
+
+
+def test_skill_md_marks_disable_step_critical():
+    """The disable-memory step must be marked CRITICAL so install
+    flows that skim the doc don't treat it as optional polish."""
+    body = _read_skill_md()
+    assert "Disable Hermes built-in memory" in body, (
+        "SKILL.md must contain a step heading mentioning 'Disable Hermes "
+        "built-in memory' so the agent doesn't skip past it."
+    )
+    # The plan asked for a CRITICAL marker on the step heading.
+    assert "(CRITICAL)" in body, (
+        "Disable-memory step must be marked '(CRITICAL)' in the heading so "
+        "the agent treats it as non-optional during install."
+    )
+
+
+def test_skill_md_includes_user_verbatim_warning_text():
+    """The user-verbatim block must include the re-enable + reset
+    pointers exactly as the rc.26 plan dictates."""
+    body = _read_skill_md()
+    # Mention that built-in memory is disabled.
+    assert "disabled Hermes' built-in `memory` tool" in body, (
+        "SKILL.md must include the user-verbatim warning that TotalReclaw "
+        "disabled the built-in memory tool."
+    )
+    # Re-enable instruction.
+    assert "hermes tools enable memory" in body, (
+        "SKILL.md must instruct the user how to re-enable Hermes built-in "
+        "memory (and warn it's NOT recommended while TotalReclaw is "
+        "installed)."
+    )
+    assert "NOT recommended" in body, (
+        "User-verbatim warning must explicitly say re-enabling is NOT "
+        "recommended while TotalReclaw is installed."
+    )
+    # Wipe-files pointer.
+    assert "hermes memory reset" in body, (
+        "SKILL.md must reference `hermes memory reset` as the optional "
+        "wipe step for orphaned MEMORY.md / USER.md files."
+    )
+
+
+def test_skill_md_explains_why_dual_mode_is_anti_pattern():
+    """The step must explain WHY built-in memory must be disabled —
+    so a future refactor doesn't accidentally drop the reasoning + the
+    instruction together."""
+    body = _read_skill_md()
+    # Match the explanatory clause about intent-stealing / silent bug.
+    assert "competes" in body.lower() or "steal" in body.lower(), (
+        "Disable-memory step must explain that the built-in memory tool "
+        "competes / steals intents from TotalReclaw — preserves the why "
+        "if the doc gets refactored."
+    )
+    # The "MEMORY.md instead of vault" failure mode must be called out
+    # by name so a future contributor reading only the install flow
+    # understands the data-loss surface.
+    assert "MEMORY.md" in body, (
+        "Disable-memory step must reference MEMORY.md by name so the "
+        "failure mode (data lands in the wrong file) is explicit."
+    )
+
+
+def test_skill_md_keeps_post_install_steps_renumbered():
+    """The disable-memory step inserted itself between restart-gateway
+    and verify-tool-bound, so subsequent steps re-number. SKIP-install
+    fast-path pointer must point at the credential-check step (now
+    step 5), not step 4 as in rc.25."""
+    body = _read_skill_md()
+    assert "SKIP install and jump to step 5" in body, (
+        "After inserting the disable-memory step, the fast-path pointer "
+        "for already-installed plugins MUST jump to step 5 (credential "
+        "check), not step 4 — otherwise the agent mis-routes for "
+        "returning users."
+    )

--- a/python/tests/test_warn_log_on_built_in_memory_enabled.py
+++ b/python/tests/test_warn_log_on_built_in_memory_enabled.py
@@ -1,0 +1,143 @@
+"""rc.26: defensive WARN log when Hermes built-in `memory` is enabled.
+
+Context — rc.24 NO-GO finding (issue #167)
+-------------------------------------------
+
+The SKILL.md / hermes-setup.md install flow auto-disables Hermes
+built-in memory at install time. But if the user later runs
+``hermes tools enable memory`` manually, both tools compete for
+"remember X" / "recall X" intents and TotalReclaw silently regresses
+into the rc.24 bug (memories landing in MEMORY.md instead of vault).
+
+What this test enforces
+-----------------------
+
+The plugin's ``register()`` function MUST run a defensive check at
+plugin load: shell out to ``hermes tools list``, parse for an
+enabled ``memory`` tool, and emit a WARN log line if found. The WARN
+must be best-effort — must NOT crash plugin load if the CLI is
+absent or returns garbage.
+
+Implementation lives in ``totalreclaw.hermes.__init__:_warn_if_built_in_memory_enabled``.
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from totalreclaw.hermes import _warn_if_built_in_memory_enabled
+
+
+def _make_proc(stdout: str = "", returncode: int = 0) -> MagicMock:
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.returncode = returncode
+    return proc
+
+
+class TestWarnIfBuiltInMemoryEnabled:
+    def test_warns_when_memory_listed_as_enabled(self, caplog):
+        """If `hermes tools list` includes `memory  enabled`, WARN."""
+        with patch("shutil.which", return_value="/usr/bin/hermes"), patch(
+            "subprocess.run", return_value=_make_proc("memory  enabled\nfoo  disabled\n")
+        ):
+            with caplog.at_level(logging.WARNING, logger="totalreclaw.hermes"):
+                _warn_if_built_in_memory_enabled()
+        assert any(
+            "Hermes built-in 'memory' tool is enabled" in rec.message
+            for rec in caplog.records
+        ), "Expected a WARN line when built-in memory is enabled"
+        # Must include the recommended remediation command.
+        assert any(
+            "hermes tools disable memory" in rec.message for rec in caplog.records
+        ), "WARN line must include the `hermes tools disable memory` remediation"
+
+    def test_warns_on_colon_format(self, caplog):
+        """Tolerates `memory: enabled` (alternative output format)."""
+        with patch("shutil.which", return_value="/usr/bin/hermes"), patch(
+            "subprocess.run", return_value=_make_proc("memory: enabled\n")
+        ):
+            with caplog.at_level(logging.WARNING, logger="totalreclaw.hermes"):
+                _warn_if_built_in_memory_enabled()
+        assert any(
+            "Hermes built-in 'memory' tool is enabled" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_no_warn_when_memory_disabled(self, caplog):
+        """If `memory` is listed as disabled, do NOT WARN."""
+        with patch("shutil.which", return_value="/usr/bin/hermes"), patch(
+            "subprocess.run",
+            return_value=_make_proc("memory  disabled\nfoo  enabled\n"),
+        ):
+            with caplog.at_level(logging.WARNING, logger="totalreclaw.hermes"):
+                _warn_if_built_in_memory_enabled()
+        assert not any(
+            "Hermes built-in 'memory' tool is enabled" in rec.message
+            for rec in caplog.records
+        ), "Should NOT WARN when built-in memory is disabled"
+
+    def test_no_warn_when_memory_absent_from_listing(self, caplog):
+        """If the CLI doesn't list a `memory` tool at all, no WARN
+        (older Hermes versions, custom builds, etc.)."""
+        with patch("shutil.which", return_value="/usr/bin/hermes"), patch(
+            "subprocess.run",
+            return_value=_make_proc("foo  enabled\nbar  disabled\n"),
+        ):
+            with caplog.at_level(logging.WARNING, logger="totalreclaw.hermes"):
+                _warn_if_built_in_memory_enabled()
+        assert not any(
+            "Hermes built-in 'memory' tool is enabled" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_no_warn_when_hermes_cli_absent(self, caplog):
+        """`hermes` not on PATH → silently skip (no WARN, no crash)."""
+        with patch("shutil.which", return_value=None):
+            with caplog.at_level(logging.WARNING, logger="totalreclaw.hermes"):
+                _warn_if_built_in_memory_enabled()
+        assert not any(
+            "Hermes built-in 'memory' tool is enabled" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_no_warn_on_subprocess_timeout(self, caplog):
+        """`hermes tools list` hangs → silently skip (no WARN)."""
+        with patch("shutil.which", return_value="/usr/bin/hermes"), patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="hermes", timeout=5),
+        ):
+            with caplog.at_level(logging.WARNING, logger="totalreclaw.hermes"):
+                _warn_if_built_in_memory_enabled()
+        assert not any(
+            "Hermes built-in 'memory' tool is enabled" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_no_warn_on_nonzero_exit(self, caplog):
+        """If `hermes tools list` exits non-zero, skip (no WARN)."""
+        with patch("shutil.which", return_value="/usr/bin/hermes"), patch(
+            "subprocess.run", return_value=_make_proc("error: not authorized", returncode=1)
+        ):
+            with caplog.at_level(logging.WARNING, logger="totalreclaw.hermes"):
+                _warn_if_built_in_memory_enabled()
+        assert not any(
+            "Hermes built-in 'memory' tool is enabled" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_does_not_raise_on_unexpected_error(self):
+        """Defensive: even unhandled exceptions inside the shell call
+        must not propagate — the function is wrapped in a broad
+        try/except inside register(), but the unit MUST also tolerate
+        whatever subprocess decides to raise."""
+        with patch("shutil.which", return_value="/usr/bin/hermes"), patch(
+            "subprocess.run", side_effect=PermissionError("denied")
+        ):
+            try:
+                _warn_if_built_in_memory_enabled()
+            except Exception as exc:  # pragma: no cover
+                pytest.fail(f"_warn_if_built_in_memory_enabled raised: {exc!r}")


### PR DESCRIPTION
Layered on top of rc.25 path B (commit d2878a3 — tool-description bias). Path A (auto-disable) is the canonical exclusivity contract per Pedro 2026-04-26.

## What lands

- **SKILL.md Step 3 (NEW)**: agent runs `hermes tools disable memory` via shell, relays verbatim user message about disable + revert path + `hermes memory reset` pointer.
- **hermes-setup.md Compatibility section**: explicit "DO NOT recommend running both" + 3-step switch-back recipe.
- **Runtime WARN log**: `_warn_if_built_in_memory_enabled()` shells out to `hermes tools list` at plugin load, warns if user manually re-enabled built-in memory after install. Belt-and-suspenders.

## Why both A + B together

- Path A (auto-disable) = exclusivity by default. User has to explicitly re-enable to break the contract.
- Path B (tool-description bias) = backstop if user re-enables. Better tool-selection if both ever run simultaneously.
- Together: silent intent-stealing bug class is closed.

## Tests

- 19 new tests in 3 files, all pass
- 53 existing hermes_plugin tests still pass (path B untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)