### PR TITLE
release: stable 3.3.1 + 2.3.1 prep — account-setup terminology + chat-q daemon caveat + CHANGELOG

### DIFF
--- a/CHANGELOG-public.md
+++ b/CHANGELOG-public.md
@@ -1,6 +1,50 @@
 # TotalReclaw Changelog
 
-> **Note:** This file lists releases promoted to the public registries' stable tags. Active release-candidate work (`@rc` dist-tag on npm, `rcN` on PyPI, etc.) is tracked in the internal release-pipeline tracker, not here. The "rc.19 — Setup-agnostic instructions" entry below describes a fix list that shipped in the rc.19→rc.22 RC line; once that line promotes to stable as `3.3.1`, expect a consolidated stable entry covering 3.2.0 → 3.3.1.
+> **Note:** This file lists releases promoted to the public registries' stable tags. Active release-candidate work (`@rc` dist-tag on npm, `rcN` on PyPI, etc.) is tracked in the internal release-pipeline tracker, not here.
+
+## 3.3.1 / 2.3.1 / mcp-server 3.2.1 — Stable promote (2026-04-27)
+
+Consolidated stable line covering plugin 3.2.0 → 3.3.1, Python client 2.2.1 → 2.3.1, MCP server 3.2.0 → 3.2.1. Highlights from the rc.1 → rc.27 line:
+
+### `@totalreclaw/totalreclaw` (OpenClaw plugin) → 3.3.1
+
+- **URL-driven install flow.** The canonical install path is now a single chat message with the setup-guide URL — the agent fetches it, runs the install commands, and walks the user through browser-based account setup. No terminal commands required for the user. (rc.1, rc.18)
+- **Lazy CDN embedder.** The MiniLM ONNX model now loads from CDN on first use rather than being bundled in the plugin tarball — install footprint shrinks from ~210 MB to under 5 MB, and the model is fetched + cached locally on the first real conversation. Closes the rc.21 OOM ship-stoppers. (rc.22)
+- **Reranker hoist to `@totalreclaw/core::reranker`.** Tier 1 source-weighted reranker logic moved out of the plugin and into the Rust core (with WASM bindings). All clients now share a single byte-identical implementation. (rc.22)
+- **`confirm_indexed` read-after-write primitive.** New core primitive lets clients confirm an on-chain write is indexed by the subgraph before continuing. Closes a class of race conditions where recall ran before the write was visible. (rc.22)
+- **Phrase-safety CI guard.** New CI check forbids any code path that emits recovery-phrase material on stdout/stderr from agent-callable contexts. (rc.22)
+- **rc.18 dist-tag promote bug fix.** Earlier RCs published under wrong dist-tags; rc.18 + rc.19 fixes ensure stable promote actually moves the `latest` pointer. (rc.18, rc.19)
+- **Topology-agnostic restart instructions.** Setup guides now use `<your-container-name>` placeholders instead of hardcoded `tr-openclaw` references; works for any Docker / managed-service topology. (rc.19)
+- **Recall miss fix for short queries.** Short queries (1-2 tokens) were under-recalling due to over-aggressive cosine threshold. Threshold now adapts to query length. (rc.18 follow-up)
+- **`pin_status` preservation across retype / set_scope.** Pin state now correctly survives type or scope changes. (rc.18 follow-up)
+
+### `totalreclaw` (Python client + Hermes plugin) → 2.3.1
+
+- **`hermes plugins install p-diogo/totalreclaw-hermes`** is now the canonical Hermes plugin install path, alongside `pip install totalreclaw` for the Python tool implementations into Hermes' venv. (rc.16+)
+- **Auto-disable Hermes built-in memory.** The TotalReclaw setup flow now calls `hermes tools disable memory` on install — running both Hermes' built-in `memory` tool AND TotalReclaw simultaneously creates a silent intent-stealing bug where memories land in `MEMORY.md` instead of TotalReclaw's encrypted vault. Documented as unsupported. Companion path B: tool-description bias steers the LLM toward `totalreclaw_remember` even when the built-in tool can't be disabled. (rc.25, rc.26)
+- **Retype + set_scope on-chain operations.** Hermes now supports natural-language retype ("that's actually a directive, not a preference") and set_scope ("file that under work") via on-chain UserOps. Tool parity with the OpenClaw plugin. (rc.23)
+- **F2 same-provider cheap-model selection.** Auto-extraction now resolves a cheap model from the SAME provider as the user's main agent (previously could spin up an unrelated provider's model and fail on missing key). (rc.24)
+- **Pair AttributeError + venv install path fixes.** Closes #151 + #152 — the install/setup path now resolves correctly under Hermes-supervised venvs. (rc.10)
+- **Pending-queue drain accepts EOA OR SA owner-key.** Auto-extract drains correctly across mixed key states. (rc.26)
+- **Persist + drain auto-extract on interpreter-shutdown race.** Pending facts now survive a shutdown mid-extract. (rc.20)
+- **Graceful fallback when core wheel lacks `confirm_indexed` bindings.** Hermes degrades to write-and-hope rather than crashing on older wheels. (rc.20)
+
+### `@totalreclaw/mcp-server` (Claude Desktop / Cursor / Windsurf / IronClaw) → 3.2.1
+
+- **[SECURITY] Removed `totalreclaw_setup` tool.** This tool generated a recovery phrase and returned it via MCP tool-output JSON, which crossed the LLM context. Phrase-safety violation. The MCP server now has no phrase-touching tool surface; users source phrases from another client's `~/.totalreclaw/credentials.json`, the OpenClaw / Hermes browser account-setup flow, or an offline BIP-39 generator. (3.2.1)
+
+### Cross-cutting
+
+- **Terminology normalization.** User-facing prose, agent-verbatim messages, and tool descriptions now consistently say "set up your TotalReclaw account" / "account setup" instead of mixing "pair", "pairing", "QR-pair", and "setup". The technical tool name `totalreclaw_pair` is unchanged for backward compatibility — it remains the canonical agent-facilitated account-setup tool. API endpoints (`/pair/p/...`, `/pair/session/open`) and code identifiers are unchanged.
+- **Hermes `hermes chat -q` setup caveat documented.** One-shot `hermes chat -q "..."` invocations cannot complete account setup because the process exits before the browser handshake — the WebSocket dies and the browser POST returns 404. The Hermes setup guide now documents this explicitly with daemon-mode + standalone-CLI workarounds. Daily operations (chat-q, --resume) work normally once the account is set up. Tracked at #170.
+
+### Known carry-overs
+
+- The `~/.totalreclaw/credentials.json` schema is unchanged across this stable line. Existing vaults decrypt transparently.
+- Plugin 3.3.1 + Hermes 2.3.1 require core 2.1.1+ (bundled as a dependency).
+- ZeroClaw (Rust crate) is unchanged at 2.0.0; v2.1+ retry is on the roadmap once `confirm_indexed` bindings stabilize.
+
+---
 
 ## rc.19 — Setup-agnostic instructions (2026-04-25)
 

--- a/docs/guides/beta-tester-guide-detailed.md
+++ b/docs/guides/beta-tester-guide-detailed.md
@@ -7,9 +7,9 @@
 
 This guide is a companion to the 95-percent-of-users setup guides. **For installation, follow your runtime's setup guide first** — every flow is URL-driven and takes a single chat message:
 
-- **OpenClaw** → [openclaw-setup.md](./openclaw-setup.md) (browser pair flow, auto-reload)
-- **Hermes (Python)** → [hermes-setup.md](./hermes-setup.md) (browser pair flow, manual restart)
-- **Claude Code / Claude Desktop / Cursor / Windsurf / IronClaw (MCP)** → [claude-code-setup.md](./claude-code-setup.md) (no pair flow — phrase from another client's credentials or offline)
+- **OpenClaw** → [openclaw-setup.md](./openclaw-setup.md) (browser account-setup flow, auto-reload)
+- **Hermes (Python)** → [hermes-setup.md](./hermes-setup.md) (browser account-setup flow, manual restart)
+- **Claude Code / Claude Desktop / Cursor / Windsurf / IronClaw (MCP)** → [claude-code-setup.md](./claude-code-setup.md) (no account-setup flow — phrase from another client's credentials or offline)
 
 Once setup is done and tools are bound, come back here for the knobs.
 
@@ -39,7 +39,7 @@ Once setup is done and tools are bound, come back here for the knobs.
 | Pre-compaction flush | yes | yes | yes | no |
 | Session debrief | yes | yes | yes | no (use `totalreclaw_debrief` tool) |
 | First-run welcome | yes | yes | yes | no (MCP is stateless JSON-RPC) |
-| Browser pair flow | yes | yes | reuse OpenClaw / Hermes phrase | no — phrase from another client |
+| Browser account-setup flow | yes | yes | reuse OpenClaw / Hermes phrase | no — phrase from another client |
 | Auto-reload on plugin install | yes (`gateway.reload.mode = hybrid`) | no — manual restart | container respawn | host-restart only |
 
 If you're on MCP, all the auto behavior is replaced by tool calls the host LLM makes from context. The same memories land in the same vault.
@@ -92,7 +92,7 @@ The relay never sees plaintext, never sees query terms, and never holds an encry
 
 - **Server-blind search.** The relay sees blind index tokens (HMAC outputs) and never the plaintext keywords. Even with a full database compromise, an attacker can't reverse a query without the per-user secret.
 - **End-to-end encryption.** All fact bytes are XChaCha20-Poly1305 ciphertext when they leave your device.
-- **No phrase ever leaves your device** as long as you follow the canonical setup. Browser pair flow encrypts the phrase locally with a fresh x25519/AES-GCM key derived against the gateway's ephemeral pubkey before posting; the relay only ever sees ciphertext.
+- **No phrase ever leaves your device** as long as you follow the canonical setup. Browser setup flow encrypts the phrase locally with a fresh x25519/AES-GCM key derived against the gateway's ephemeral pubkey before posting; the relay only ever sees ciphertext.
 - **Decay is local.** Importance decay and eviction run client-side from the decrypted set. The relay can't infer which memories matter to you.
 
 ---
@@ -181,7 +181,7 @@ Canonical reference: [`docs/guides/env-vars-reference.md`](./env-vars-reference.
 
 | Variable | Description | Default |
 |---|---|---|
-| `TOTALRECLAW_RECOVERY_PHRASE` | 12-word BIP-39 phrase. Required for MCP / NanoClaw. OpenClaw + Hermes prefer the browser pair flow (writes `~/.totalreclaw/credentials.json`). | — |
+| `TOTALRECLAW_RECOVERY_PHRASE` | 12-word BIP-39 phrase. Required for MCP / NanoClaw. OpenClaw + Hermes prefer the browser account-setup flow (writes `~/.totalreclaw/credentials.json`). | — |
 | `TOTALRECLAW_SERVER_URL` | Relay URL. Only set for self-hosted. | `https://api.totalreclaw.xyz` |
 | `TOTALRECLAW_SELF_HOSTED` | `true` to disable on-chain pipeline (PostgreSQL self-host). | `false` |
 | `TOTALRECLAW_CREDENTIALS_PATH` | Override credentials file location. | `~/.totalreclaw/credentials.json` |
@@ -228,9 +228,9 @@ To migrate from one client to another:
 cat ~/.totalreclaw/credentials.json
 ```
 
-On the target machine, the agent's URL-driven setup will detect an existing credentials file and skip phrase entry. If you can't move files (e.g., switching to a phone), use the **Import existing** tab in OpenClaw / Hermes browser pair flow on the target — same phrase, same vault.
+On the target machine, the agent's URL-driven setup will detect an existing credentials file and skip phrase entry. If you can't move files (e.g., switching to a phone), use the **Import existing** tab in OpenClaw / Hermes browser account-setup flow on the target — same phrase, same vault.
 
-If you're moving from MCP (which doesn't have a pair flow) to OpenClaw / Hermes, just install the new client and reuse `~/.totalreclaw/credentials.json` — both runtimes read it on startup before falling back to the env-var path.
+If you're moving from MCP (which doesn't have an account-setup flow) to OpenClaw / Hermes, just install the new client and reuse `~/.totalreclaw/credentials.json` — both runtimes read it on startup before falling back to the env-var path.
 
 ---
 
@@ -315,7 +315,7 @@ Internal: see `~/.claude/skills/qa-totalreclaw.md` (TotalReclaw team only). Runs
 
 **Cause:** the env var is missing or empty in the runtime that needs it (typically MCP / NanoClaw).
 
-**Fix:** OpenClaw + Hermes prefer credentials at `~/.totalreclaw/credentials.json` from the browser pair flow — re-run setup. MCP / NanoClaw need the env var in your host config.
+**Fix:** OpenClaw + Hermes prefer credentials at `~/.totalreclaw/credentials.json` from the browser account-setup flow — re-run setup. MCP / NanoClaw need the env var in your host config.
 
 ### Memories aren't appearing in new conversations
 

--- a/docs/guides/claude-code-setup.md
+++ b/docs/guides/claude-code-setup.md
@@ -6,7 +6,7 @@ If you already have Claude Code (or Claude Desktop / Cursor / Windsurf) running,
 
 > **Install TotalReclaw, see <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/claude-code-setup.md>**
 
-Your agent will fetch this page, run the MCP install command, and walk you through getting a recovery phrase into the config without ever printing it in chat. The phrase comes from your browser (via the OpenClaw or Hermes pair flow) or from a phrase you already have on file.
+Your agent will fetch this page, run the MCP install command, and walk you through getting a recovery phrase into the config without ever printing it in chat. The phrase comes from your browser (via the OpenClaw or Hermes account-setup flow) or from a phrase you already have on file.
 
 ---
 
@@ -69,7 +69,7 @@ Check `test -s ~/.totalreclaw/credentials.json`. If it exists, the user already 
 
 If `~/.totalreclaw/credentials.json` does NOT exist, tell them verbatim:
 
-> *To generate or import a recovery phrase, the safest path is the browser-side pair flow that OpenClaw or Hermes uses (the relay only ever sees ciphertext). If you have OpenClaw or Hermes available, run their setup once (see [openclaw-setup.md](./openclaw-setup.md) or [hermes-setup.md](./hermes-setup.md)) — it writes `~/.totalreclaw/credentials.json`, and we'll reuse it here. If you don't, generate a 12-word BIP-39 phrase using a trusted offline tool (a hardware wallet, an air-gapped BIP-39 generator, or a password manager's seed-phrase generator), paste the 12 words into `TOTALRECLAW_RECOVERY_PHRASE` in your config (NOT into this chat), and reply `done`.*
+> *To generate or import a recovery phrase, the safest path is the browser-side account-setup flow that OpenClaw or Hermes uses (the relay only ever sees ciphertext). If you have OpenClaw or Hermes available, run their account setup once (see [openclaw-setup.md](./openclaw-setup.md) or [hermes-setup.md](./hermes-setup.md)) — it writes `~/.totalreclaw/credentials.json`, and we'll reuse it here. If you don't, generate a 12-word BIP-39 phrase using a trusted offline tool (a hardware wallet, an air-gapped BIP-39 generator, or a password manager's seed-phrase generator), paste the 12 words into `TOTALRECLAW_RECOVERY_PHRASE` in your config (NOT into this chat), and reply `done`.*
 
 Wait for `done`. Do not at any point ask the user to type the phrase into chat. Do not run `npx @totalreclaw/mcp-server setup` via your shell tool — its stdout contains the phrase.
 
@@ -87,7 +87,7 @@ Once the user replies `done`, ask the agent's own internal toolset (yourself): *
 
 ### Phrase safety (HARD — never break)
 
-NEVER echo, generate, or ask the user to paste a recovery phrase in chat. NEVER invoke `npx @totalreclaw/mcp-server setup`, `totalreclaw_setup`, `npx @totalreclaw/totalreclaw generate-mnemonic`, or any phrase-touching CLI via your shell tool — stdout enters LLM context. The MCP server has NO browser pair flow (it's stateless JSON-RPC); the user MUST source their phrase from another TotalReclaw client's pair flow (OpenClaw / Hermes browser flow), reuse `~/.totalreclaw/credentials.json` from a prior install, or paste a phrase they generated offline directly into the config file. If the user pastes a phrase in chat anyway: tell them it is compromised and they need to generate a fresh wallet via the OpenClaw or Hermes browser pair flow.
+NEVER echo, generate, or ask the user to paste a recovery phrase in chat. NEVER invoke `npx @totalreclaw/mcp-server setup`, `totalreclaw_setup`, `npx @totalreclaw/totalreclaw generate-mnemonic`, or any phrase-touching CLI via your shell tool — stdout enters LLM context. The MCP server has NO browser account-setup flow (it's stateless JSON-RPC); the user MUST source their phrase from another TotalReclaw client's account-setup flow (OpenClaw / Hermes browser flow), reuse `~/.totalreclaw/credentials.json` from a prior install, or paste a phrase they generated offline directly into the config file. If the user pastes a phrase in chat anyway: tell them it is compromised and they need to generate a fresh wallet via the OpenClaw or Hermes browser account-setup flow.
 
 ---
 
@@ -107,7 +107,7 @@ First real interaction downloads a ~600 MB embedding model (cached locally, one-
 
 - **Node.js 18+** (22 recommended)
 - **An MCP-compatible host:** Claude Code, Claude Desktop, Cursor, Windsurf, IronClaw, or similar
-- **A recovery phrase** — generated via OpenClaw / Hermes browser pair flow, an offline BIP-39 generator, or already on file at `~/.totalreclaw/credentials.json`
+- **A recovery phrase** — generated via OpenClaw / Hermes browser account-setup flow, an offline BIP-39 generator, or already on file at `~/.totalreclaw/credentials.json`
 
 ---
 
@@ -159,7 +159,7 @@ Restart the host. Verify by asking *"Do you have access to TotalReclaw memory to
 | Auto-extract every N turns | yes (lifecycle hook) | no — host invokes `totalreclaw_remember` when its prompt tells it to |
 | Pre-compaction flush | yes | no |
 | Session debrief | yes | no (use `totalreclaw_debrief` explicitly) |
-| Browser pair flow | yes (`totalreclaw_pair` tool) | **no** — MCP is stateless JSON-RPC; phrase must come from another client or offline tool |
+| Browser account-setup flow | yes (`totalreclaw_pair` account-setup tool) | **no** — MCP is stateless JSON-RPC; phrase must come from another client or offline tool |
 | First-run welcome | yes (host prepends context on session start) | no — MCP doesn't expose session lifecycle to the server |
 
 MCP is the lowest-overhead integration but the most explicit. You'll talk naturally and the host will still recall / store via tool calls when its context gates fire — you just won't get the every-turn automatic behavior that OpenClaw and Hermes provide.
@@ -230,14 +230,14 @@ Both tiers have unlimited reads. Upgrade: *"Upgrade my TotalReclaw subscription.
 - **"Not authenticated" / 401**: check your phrase — exact words, exact order, lowercase, single spaces.
 - **First-run is slow / model download**: the embedding model is ~600 MB, downloaded once and cached. Be patient on first call.
 - **Quota exceeded (403)**: free tier has a monthly write cap. Upgrade with *"Upgrade my TotalReclaw subscription"*.
-- **Recovery phrase appeared in chat**: file a bug. Rotate by generating a new wallet via the OpenClaw or Hermes browser pair flow. The leaked phrase is unrecoverable once shipped through LLM context.
+- **Recovery phrase appeared in chat**: file a bug. Rotate by generating a new wallet via the OpenClaw or Hermes browser account-setup flow. The leaked phrase is unrecoverable once shipped through LLM context.
 
 ---
 
 ## MCP-specific notes
 
 - **MCP is stateless.** There's no first-run welcome, no lifecycle hooks, and no auto-restart on config change. You restart the host explicitly to pick up new config.
-- **No browser pair flow.** The MCP server has no HTTP routes — phrase entry is the user's responsibility (config file, env var, or copying from another client's `credentials.json`). This is by design: keeping crypto secrets out of LLM context is more important than convenience parity with OpenClaw / Hermes.
+- **No browser account-setup flow.** The MCP server has no HTTP routes — phrase entry is the user's responsibility (config file, env var, or copying from another client's `credentials.json`). This is by design: keeping crypto secrets out of LLM context is more important than convenience parity with OpenClaw / Hermes.
 - **`totalreclaw_setup` exists but should not be used.** The tool exists for legacy compatibility. It generates a phrase and returns it through MCP tool-output JSON, which means the phrase enters the host LLM's context. The phrase-safety rule forbids this. New installs should always use the workflow in this guide.
 
 ---
@@ -250,8 +250,8 @@ Both tiers have unlimited reads. Upgrade: *"Upgrade my TotalReclaw subscription.
 
 ## Further reading
 
-- [OpenClaw setup guide](./openclaw-setup.md) — same vault, different runtime, with browser pair flow
-- [Hermes setup guide](./hermes-setup.md) — Python client with browser pair flow
+- [OpenClaw setup guide](./openclaw-setup.md) — same vault, different runtime, with browser account-setup flow
+- [Hermes setup guide](./hermes-setup.md) — Python client with browser account-setup flow
 - [Beta tester deep-dive](./beta-tester-guide-detailed.md) — env vars, extraction tuning, architecture
 - [Memory types guide](./memory-types-guide.md) — v1 taxonomy
 - [Importing memories](./importing-memories.md)

--- a/docs/guides/client-setup-v1.md
+++ b/docs/guides/client-setup-v1.md
@@ -123,7 +123,7 @@ If you need to generate a recovery phrase first, run `npx @totalreclaw/mcp-serve
 ## Python client
 
 **Package:** `totalreclaw>=2.3.0` (PyPI).
-**Features:** Hermes Agent plugin with pre_llm_call auto-recall + post_llm_call auto-extract + on_session_finalize debrief. Full tool parity with the OpenClaw plugin: remember / recall / forget / export / status / pair / pin / unpin / retype / set_scope / import_from / upgrade.
+**Features:** Hermes Agent plugin with pre_llm_call auto-recall + post_llm_call auto-extract + on_session_finalize debrief. Full tool parity with the OpenClaw plugin: remember / recall / forget / export / status / account-setup (`totalreclaw_pair`) / pin / unpin / retype / set_scope / import_from / upgrade.
 
 ### Install
 

--- a/docs/guides/feature-comparison.md
+++ b/docs/guides/feature-comparison.md
@@ -51,7 +51,7 @@ All clients ship v1 by default. Stable production versions: core 2.2.0, plugin 3
 
 **NanoClaw** -- Automatic, like OpenClaw. The NanoClaw agent-runner spawns the MCP server as a background process. Memory is shared within the NanoClaw group. No user setup required -- the admin configures the recovery phrase.
 
-**Hermes (Python)** -- Automatic via pre/post LLM call hooks. LLM extraction with heuristic fallback. Full tool parity with OpenClaw plugin since 2.3.x: remember / recall / forget / export / status / pair / pin / unpin / retype / set_scope / import_from / upgrade. Migrate + consolidate are managed-service-only and exposed via the plugin / MCP server.
+**Hermes (Python)** -- Automatic via pre/post LLM call hooks. LLM extraction with heuristic fallback. Full tool parity with OpenClaw plugin since 2.3.x: remember / recall / forget / export / status / account-setup (`totalreclaw_pair`) / pin / unpin / retype / set_scope / import_from / upgrade. Migrate + consolidate are managed-service-only and exposed via the plugin / MCP server.
 
 **IronClaw (NEAR AI)** -- Uses the MCP server for tools. No lifecycle hooks -- auto-extraction requires setting up routines (cron). The TEE protects the runtime; TotalReclaw protects the data.
 

--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -1,12 +1,14 @@
 # TotalReclaw for Hermes
 
-TotalReclaw gives your Hermes agent encrypted, persistent memory. The fastest setup is a single chat message — the agent fetches this guide, runs the install for you, and walks you through pairing. **You do nothing in the terminal.**
+TotalReclaw gives your Hermes agent encrypted, persistent memory. The fastest path is a single chat message — the agent fetches this guide, installs the package for you, and walks you through setting up your TotalReclaw account. **You do nothing in the terminal.**
 
 If you already have Hermes running, paste this into your Hermes chat:
 
 > **Install TotalReclaw, see <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md>**
 
-Your agent will fetch this page, run the install commands, ask you to restart the gateway once (Hermes doesn't auto-reload), and then hand you a pair URL + 6-digit PIN. You open the URL in your browser, generate or restore a 12-word recovery phrase there, confirm the PIN, and you're done.
+Your agent will fetch this page, run the install commands, ask you to restart the gateway once (Hermes doesn't auto-reload), and then hand you an account-setup URL + 6-digit PIN. You open the URL in your browser, generate or restore a 12-word recovery phrase there, confirm the PIN, and your account is ready.
+
+> **Important — Hermes account setup needs daemon mode.** See [Account setup requires daemon mode](#account-setup-requires-daemon-mode) below before invoking the account-setup flow if you are using `hermes chat -q "..."` one-shot CLI invocations.
 
 ---
 
@@ -103,7 +105,11 @@ Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, co
 
 ### Step 5 — Pair (browser flow, NEVER ask the user to type their phrase in chat)
 
-Call the `totalreclaw_pair` tool. It returns `{url, pin, expires_at_ms}`.
+> *(Heading retains "Pair" for backward compatibility with the QA harness; the user-facing terminology is "set up your TotalReclaw account". The tool registered as `totalreclaw_pair` is the account-setup tool.)*
+
+Before calling the tool, check whether you are running inside a one-shot agent process (e.g. `hermes chat -q "..."`, single-prompt CLI). If so, surface the [account-setup-requires-daemon-mode caveat](#account-setup-requires-daemon-mode) to the user verbatim and ask them to switch to daemon / interactive mode before continuing — the WebSocket session this step opens will die before the user can finish entering their phrase otherwise.
+
+Tell the user: *"I'll walk you through setting up your TotalReclaw account."* Then call the `totalreclaw_pair` tool (the account-setup tool — name kept for backward compatibility). It returns `{url, pin, expires_at_ms}`.
 
 Relay to the user verbatim:
 
@@ -111,11 +117,11 @@ Relay to the user verbatim:
 
 ### Step 6 — Verify and confirm
 
-After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN likely expired — call `totalreclaw_pair` again and resend. If present, confirm *"TotalReclaw is set up. Ask me to remember or recall anything."*
+After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN likely expired — call `totalreclaw_pair` again and resend. If present, confirm *"Your TotalReclaw account is set up. Ask me to remember or recall anything."*
 
 ### Phrase safety (HARD — never break)
 
-NEVER echo, generate, or ask the user to paste a recovery phrase in chat. NEVER invoke `totalreclaw setup`, `hermes setup`, or any phrase-touching CLI via your shell tool — stdout enters LLM context. The ONLY agent-facilitated setup path is the `totalreclaw_pair` tool. If the user pastes a phrase anyway: tell them it is compromised and call `totalreclaw_pair` with `mode=generate` for a fresh wallet.
+NEVER echo, generate, or ask the user to paste a recovery phrase in chat. NEVER invoke `totalreclaw setup`, `hermes setup`, or any phrase-touching CLI via your shell tool — stdout enters LLM context. The ONLY agent-facilitated account-setup path is the `totalreclaw_pair` tool (the account-setup tool — name kept for backward compatibility). If the user pastes a phrase anyway: tell them it is compromised and call `totalreclaw_pair` with `mode=generate` for a fresh wallet.
 
 ---
 
@@ -125,7 +131,7 @@ NEVER echo, generate, or ask the user to paste a recovery phrase in chat. NEVER 
 2. `pip install --pre totalreclaw` — installs the Python tool implementations into the Hermes venv. `--pre` resolves to the latest release candidate; drop it once a stable is promoted.
 3. The agent asks you to restart the Hermes gateway. (Hermes does not yet auto-reload on plugin install — tracked upstream.) After restart, the new tools bind.
 4. The agent calls `totalreclaw_pair`, which generates an ephemeral x25519 keypair on the gateway and a 6-digit PIN. You get a URL + PIN.
-5. You open the URL. The pair page has two tabs: **Generate new** (the browser creates a fresh BIP-39 12-word phrase locally using `crypto.getRandomValues`) and **Import existing** (paste a phrase you already have). Pick one, confirm the 6-digit PIN, click seal.
+5. You open the URL. The account-setup page has two tabs: **Generate new** (the browser creates a fresh BIP-39 12-word phrase locally using `crypto.getRandomValues`) and **Import existing** (paste a phrase you already have). Pick one, confirm the 6-digit PIN, click seal.
 6. The browser performs x25519 ECDH against the gateway's ephemeral pubkey, derives an AES-256-GCM key via HKDF-SHA256, encrypts the phrase locally, and POSTs ciphertext + nonce + its pubkey back. The gateway decrypts server-side and writes `~/.totalreclaw/credentials.json` (mode `0600`).
 7. The recovery phrase never crosses the LLM context — not the chat transcript, not the agent's shell stdout, not any tool-call payload. Browser-side crypto keeps it isolated by construction.
 
@@ -140,6 +146,23 @@ NEVER echo, generate, or ask the user to paste a recovery phrase in chat. NEVER 
 
 ---
 
+## Account setup requires daemon mode
+
+Setting up your TotalReclaw account uses a brief WebSocket session that needs to stay alive while you complete the browser-side phrase generation / import. This requires Hermes running in a long-lived process — typically `hermes gateway run` (daemon mode, recommended for any production memory use) OR a fully interactive `hermes chat` session that stays open while you finish the browser flow.
+
+**Not supported** (for account setup specifically): `hermes chat -q "..."` one-shot CLI invocations. The Hermes process exits as soon as the LLM responds; the WebSocket dies with it; the browser POST that delivers your encrypted recovery phrase to the gateway then sees a closed session and returns 404.
+
+Workarounds for one-shot CLI users:
+
+1. **Use daemon mode**: `hermes gateway run &` then `hermes chat -q "Set up TotalReclaw for me, see <URL>"` — the daemon owns the WS-keepalive while chat-q exits.
+2. **Use the standalone setup CLI**: `totalreclaw setup` (interactive, blocks until your account is set up — recovery phrase entered locally, never crosses LLM context).
+
+Once your account is set up, all daily operations (`hermes chat -q`, `--resume`, etc.) work fine — the lifecycle constraint is account-setup-flow-specific.
+
+This is tracked in [#170 — sidecar / IPC handoff to long-lived daemon for account setup](https://github.com/p-diogo/totalreclaw/issues/170) for a future improvement.
+
+---
+
 ## Managed Hermes service (no terminal, no agent shell)
 
 If you're on a managed / hosted Hermes service that doesn't expose host shell to the agent, install via the service's web UI instead:
@@ -150,9 +173,9 @@ If you're on a managed / hosted Hermes service that doesn't expose host shell to
 
    > **Install TotalReclaw, see <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md>**
 
-   The agent will detect the plugin is already loaded, skip Steps 1-2, and jump straight to pairing.
+   The agent will detect the plugin is already loaded, skip Steps 1-2, and jump straight to account setup.
 
-The browser-side crypto and pairing flow are identical to self-hosted setups.
+The browser-side crypto and account-setup flow are identical to self-hosted setups.
 
 > Managed-Hermes coverage is still emerging — if your service doesn't expose `totalreclaw` in its plugins UI yet, ask their support to surface the `p-diogo/totalreclaw-hermes` Hermes plugin + `totalreclaw` Python package, or run a self-hosted Hermes instance for now.
 
@@ -210,8 +233,8 @@ If you were on plugin 3.3.1-rc.2 or Hermes 2.3.1rc2, after upgrading also run `p
 
 - **Agent says "I'm not familiar with TotalReclaw"**: paste the canonical message above with the URL — the agent fetches the guide and follows the install steps.
 - **Agent can't see TotalReclaw tools after install**: confirm both install steps completed — on a self-host, `hermes plugins list` should show `p-diogo/totalreclaw-hermes` enabled and `pip show totalreclaw` in the Hermes venv should resolve; on a managed service, confirm `totalreclaw` is listed in your service's plugins UI. Then restart: `hermes gateway restart` (native), `docker restart <your-hermes-container>` (Docker self-host), or your managed service's restart control. If supervised by systemd / launchd, `kill -USR1 $(cat ~/.hermes/gateway.pid)` is faster than `systemctl restart`. (Hermes does not yet auto-reload on plugin install — tracked upstream.)
-- **Pair URL returns 404**: check that `~/.totalreclaw/credentials.json` isn't locked by a previous process and that the gateway is running.
-- **Browser fails to POST the encrypted phrase**: check the pair page's Content-Security-Policy — older browsers without WebCrypto x25519 (pre-Safari 17.2 / Chromium 118) cannot run the AEAD crypto.
+- **Account-setup URL returns 404**: check that `~/.totalreclaw/credentials.json` isn't locked by a previous process and that the gateway is running. If you invoked `hermes chat -q "..."` (one-shot) for account setup, the WebSocket the relay needs may have died before the browser POST landed — see [Account setup requires daemon mode](#account-setup-requires-daemon-mode).
+- **Browser fails to POST the encrypted phrase**: check the account-setup page's Content-Security-Policy — older browsers without WebCrypto x25519 (pre-Safari 17.2 / Chromium 118) cannot run the AEAD crypto.
 - **"No LLM available for auto-extraction"**: configure a provider in Hermes (`hermes login` or set `ZAI_API_KEY` / `OPENAI_API_KEY` in `~/.hermes/.env`). TotalReclaw reuses it automatically.
 - **Recovery phrase appeared in chat**: file a bug. Rotate by generating a new wallet via `totalreclaw_pair` with `mode=generate`. The leaked phrase is unrecoverable once shipped through LLM context.
 
@@ -219,7 +242,7 @@ If you were on plugin 3.3.1-rc.2 or Hermes 2.3.1rc2, after upgrading also run `p
 
 ## Returning user (new machine)
 
-Paste the same canonical message. When the pair page loads, switch to the **Import existing** tab and enter your existing 12/24-word phrase. The browser encrypts it against the gateway's ephemeral key before uploading — the relay never sees plaintext.
+Paste the same canonical message. When the account-setup page loads, switch to the **Import existing** tab and enter your existing 12/24-word phrase. The browser encrypts it against the gateway's ephemeral key before uploading — the relay never sees plaintext.
 
 ## First-time user (no phrase yet)
 
@@ -237,7 +260,7 @@ Paste the same canonical message. The **Generate new** tab is selected by defaul
 
 TotalReclaw and Hermes' built-in `memory` tool BOTH respond to "remember X" / "recall X" intents. Running both simultaneously creates a silent bug: depending on the LLM's tool-selection, your conversation context may be split between Hermes' MEMORY.md and TotalReclaw's encrypted vault — neither sees the full picture.
 
-The TotalReclaw setup flow auto-disables Hermes built-in memory on install. We DO NOT recommend re-enabling it while TotalReclaw is installed.
+The TotalReclaw account-setup flow auto-disables Hermes built-in memory on install. We DO NOT recommend re-enabling it while TotalReclaw is installed.
 
 If you want to use Hermes built-in memory instead of TotalReclaw:
 

--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -1,12 +1,12 @@
 # TotalReclaw for OpenClaw
 
-TotalReclaw gives your OpenClaw agent encrypted, persistent memory. The fastest setup is a single chat message — the agent fetches this guide, runs the install for you, and walks you through pairing. **You do nothing in the terminal.**
+TotalReclaw gives your OpenClaw agent encrypted, persistent memory. The fastest path is a single chat message — the agent fetches this guide, installs the plugin for you, and walks you through setting up your TotalReclaw account. **You do nothing in the terminal.**
 
 If you already have OpenClaw running, paste this into your OpenClaw chat:
 
 > **Install TotalReclaw, see <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md>**
 
-Your agent will fetch this page, run the two install commands, and hand you a pair URL + 6-digit PIN. You open the URL in your browser, generate or restore a 12-word recovery phrase there, confirm the PIN, and you're done.
+Your agent will fetch this page, run the two install commands, and hand you an account-setup URL + 6-digit PIN. You open the URL in your browser, generate or restore a 12-word recovery phrase there, confirm the PIN, and your account is ready.
 
 ---
 
@@ -37,9 +37,9 @@ If `totalreclaw_pair` is not bound within 10 seconds, the user has `gateway.relo
 
 Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, confirm *"TotalReclaw is already set up."* and stop. Otherwise continue.
 
-### Step 4 — Pair (browser flow, NEVER ask the user to type their phrase in chat)
+### Step 4 — Set up the user's TotalReclaw account (browser flow, NEVER ask the user to type their phrase in chat)
 
-Call the `totalreclaw_pair` tool. It returns `{url, pin, qr_ascii, qr_png_b64, qr_unicode, expires_at_ms}`.
+Tell the user: *"I'll walk you through setting up your TotalReclaw account."* Then call the `totalreclaw_pair` tool (the account-setup tool — name kept for backward compatibility). It returns `{url, pin, qr_ascii, qr_png_b64, qr_unicode, expires_at_ms}`.
 
 Relay to the user verbatim:
 
@@ -49,11 +49,11 @@ Render the QR if your transport supports it: image-capable transports (Telegram,
 
 ### Step 5 — Verify and confirm
 
-After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN likely expired — call `totalreclaw_pair` again and resend. If present, confirm *"TotalReclaw is set up. Ask me to remember or recall anything."*
+After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN likely expired — call `totalreclaw_pair` again and resend. If present, confirm *"Your TotalReclaw account is set up. Ask me to remember or recall anything."*
 
 ### Phrase safety (HARD — never break)
 
-NEVER echo, generate, or ask the user to paste a recovery phrase in chat. NEVER invoke `openclaw totalreclaw onboard` (bare interactive form), `totalreclaw setup`, or any phrase-touching CLI via your shell tool — stdout enters LLM context. The ONLY agent-facilitated setup path is the `totalreclaw_pair` tool. If the user pastes a phrase anyway: tell them it is compromised and call `totalreclaw_pair` with `mode=generate` for a fresh wallet.
+NEVER echo, generate, or ask the user to paste a recovery phrase in chat. NEVER invoke `openclaw totalreclaw onboard` (bare interactive form), `totalreclaw setup`, or any phrase-touching CLI via your shell tool — stdout enters LLM context. The ONLY agent-facilitated account-setup path is the `totalreclaw_pair` tool (the account-setup tool — name kept for backward compatibility). If the user pastes a phrase anyway: tell them it is compromised and call `totalreclaw_pair` with `mode=generate` for a fresh wallet.
 
 ---
 
@@ -63,7 +63,7 @@ NEVER echo, generate, or ask the user to paste a recovery phrase in chat. NEVER 
 2. `openclaw plugins install @totalreclaw/totalreclaw` — installs the plugin from npm (the `latest` dist-tag is always current stable; use `@rc` for the latest release candidate).
 3. OpenClaw's config-watcher detects the `plugins.*` change in `~/.openclaw/config.yaml` and (under default `gateway.reload.mode = "hybrid"`) triggers a graceful SIGUSR1 restart within 1-3s. The new tools bind automatically.
 4. The agent calls `totalreclaw_pair`, which generates an ephemeral x25519 keypair on the gateway and a 6-digit PIN. You get a URL + PIN.
-5. You open the URL. The pair page has two tabs: **Generate new** (the browser creates a fresh BIP-39 12-word phrase locally using `crypto.getRandomValues`) and **Import existing** (paste a phrase you already have). Pick one, confirm the 6-digit PIN, click seal.
+5. You open the URL. The account-setup page has two tabs: **Generate new** (the browser creates a fresh BIP-39 12-word phrase locally using `crypto.getRandomValues`) and **Import existing** (paste a phrase you already have). Pick one, confirm the 6-digit PIN, click seal.
 6. The browser performs x25519 ECDH against the gateway's ephemeral pubkey, derives an AES-256-GCM key via HKDF-SHA256, encrypts the phrase locally, and POSTs ciphertext + nonce + its pubkey back. The gateway decrypts server-side and writes `~/.totalreclaw/credentials.json` (mode `0600`).
 7. The recovery phrase never crosses the LLM context — not the chat transcript, not the agent's shell stdout, not any tool-call payload. Browser-side crypto keeps it isolated by construction.
 
@@ -88,9 +88,9 @@ If you're on a managed / hosted OpenClaw service that doesn't expose host shell 
 
    > **Install TotalReclaw, see <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md>**
 
-   The agent will detect that the plugin is already loaded, skip Steps 1-2, and jump straight to pairing.
+   The agent will detect that the plugin is already loaded, skip Steps 1-2, and jump straight to account setup.
 
-The browser-side crypto and pairing flow are identical to self-hosted setups; only the install step differs.
+The browser-side crypto and account-setup flow are identical to self-hosted setups; only the install step differs.
 
 ---
 
@@ -160,7 +160,7 @@ Ask the agent naturally; the plugin picks the right tool.
 | **Export** | "Export all my TotalReclaw memories as plain text" |
 | **Status** | "What's my TotalReclaw status?" |
 | **Import from** | "Import my Gemini history from ~/Downloads/..." |
-| **Pair** | "Set up TotalReclaw for me" — returns URL + PIN |
+| **Account setup** | "Set up TotalReclaw for me" — returns URL + PIN |
 
 Your recovery phrase is the only key to your memories. Store it safely. Retrieve later with `cat ~/.totalreclaw/credentials.json | jq -r .mnemonic`. On a new machine, paste the canonical prompt above and switch to the **Import existing** tab in the browser. First-time users can stay on the default **Generate new** tab to create a fresh BIP-39 phrase.
 
@@ -193,8 +193,8 @@ Both tiers have unlimited memories and reads. Upgrade: *"Upgrade my TotalReclaw 
 
 - **Agent says "I'm not familiar with TotalReclaw"**: paste the canonical message above with the URL — the agent fetches the guide and follows the install steps.
 - **Agent can't see TotalReclaw tools after install**: under the default config OpenClaw auto-restarts the gateway within 1-3s of `openclaw plugins install` — wait 5-10s and check `openclaw plugins list`. If the plugin is listed but the agent still can't see the tools, your config likely has `gateway.reload.mode = off` — fall back to a manual restart. Native: `openclaw gateway restart`. Docker self-host: `docker restart <your-openclaw-container>`. Managed service: use the service's restart control.
-- **Pair URL returns 404**: check that `~/.totalreclaw/credentials.json` isn't locked by a previous process and that the gateway is running.
-- **Browser fails to POST the encrypted phrase**: check the pair page's Content-Security-Policy — older browsers without WebCrypto x25519 (pre-Safari 17.2 / Chromium 118) cannot run the AEAD crypto.
+- **Account-setup URL returns 404**: check that `~/.totalreclaw/credentials.json` isn't locked by a previous process and that the gateway is running.
+- **Browser fails to POST the encrypted phrase**: check the account-setup page's Content-Security-Policy — older browsers without WebCrypto x25519 (pre-Safari 17.2 / Chromium 118) cannot run the AEAD crypto.
 - **Tool calls return "onboarding required"**: paste the canonical message again so the agent re-runs `totalreclaw_pair`.
 - **"Not authenticated" / 401**: check your phrase — exact words, exact order, lowercase, single spaces.
 

--- a/python/src/totalreclaw/hermes/SKILL.md
+++ b/python/src/totalreclaw/hermes/SKILL.md
@@ -30,7 +30,7 @@ If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jum
    # 1c. Verify the package resolved through Hermes' Python.
    "$HERMES_PYTHON" -m pip show totalreclaw | head -2
    ```
-   If `pip show` doesn't list the package, the install landed in a different Python — fix `$HERMES_PYTHON` and re-run 1b. On Debian/Ubuntu/Docker you may hit `externally-managed-environment` if Hermes runs against system Python — add `--break-system-packages` to the `pip install` line, or ask the user to recreate Hermes inside a venv. If either shell call fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment): tell the user verbatim *"Your environment doesn't expose the Hermes CLI / pip to me. Please install `p-diogo/totalreclaw-hermes` and the `totalreclaw` Python package via your service's plugins UI, then reply `done`. Also disable Hermes' built-in `memory` tool in the same UI if available — running both creates a silent intent-stealing bug."* Wait for `done` and skip to step 4 (verify pair tool bound).
+   If `pip show` doesn't list the package, the install landed in a different Python — fix `$HERMES_PYTHON` and re-run 1b. On Debian/Ubuntu/Docker you may hit `externally-managed-environment` if Hermes runs against system Python — add `--break-system-packages` to the `pip install` line, or ask the user to recreate Hermes inside a venv. If either shell call fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment): tell the user verbatim *"Your environment doesn't expose the Hermes CLI / pip to me. Please install `p-diogo/totalreclaw-hermes` and the `totalreclaw` Python package via your service's plugins UI, then reply `done`. Also disable Hermes' built-in `memory` tool in the same UI if available — running both creates a silent intent-stealing bug."* Wait for `done` and skip to step 4 (verify account-setup tool bound).
 
 2. **Restart the gateway — Hermes does NOT auto-reload on plugin install.** Tell the user verbatim: *"Please restart your Hermes gateway: `hermes gateway restart` (native), `docker restart <your-container-name>` (Docker self-host — substitute the actual name; `docker ps` shows it), or your managed service's restart control. If supervised by systemd / launchd, `kill -USR1 $(cat ~/.hermes/gateway.pid)` triggers a graceful-drain restart. Reply `done` once it's back up."* Do NOT run the restart yourself — your shell is inside the gateway you'd be restarting. Wait for the user's `done`.
 
@@ -53,14 +53,18 @@ If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jum
 
 5. **Check for existing credentials.** Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, confirm *"TotalReclaw is already set up."* and stop.
 
-6. **Pair.** Call `totalreclaw_pair`. Returns `{url, pin, expires_at_ms}`. Relay verbatim:
+6. **Set up the user's TotalReclaw account.** Tell the user: *"I'll walk you through setting up your TotalReclaw account."* Then call `totalreclaw_pair` (the account-setup tool — name kept for backward compatibility). Returns `{url, pin, expires_at_ms}`. Relay verbatim:
    > *Open <url> in your browser. Generate a new 12-word recovery phrase there or paste an existing one — the phrase stays in your browser, the relay only sees ciphertext. Confirm PIN <pin>. Reply `done` once the page says it's sealed.*
 
-7. **Verify and confirm.** After user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN expired — call `totalreclaw_pair` again and resend. If present, confirm *"TotalReclaw is set up. Ask me to remember or recall anything."*
+   **Lifecycle caveat for one-shot CLI invocations.** This account-setup step opens a short-lived WebSocket to the relay that must stay alive while the user completes the browser handshake. If you are running inside a one-shot agent process (`hermes chat -q "..."`, single-prompt CLI, transient invocation that exits as soon as the LLM responds), the WS dies before the user can finish entering their phrase and the browser POST returns 404. BEFORE calling `totalreclaw_pair`, detect short-lived process invocation. If detected, surface this caveat to the user verbatim:
+   > *Setting up your TotalReclaw account needs a long-lived Hermes process to keep the session alive while you finish the browser flow. One-shot `hermes chat -q "..."` invocations exit too quickly. Either (1) run `hermes gateway run &` in another terminal first (daemon mode owns the WS-keepalive while chat-q exits), or (2) use the standalone `totalreclaw setup` CLI (interactive, blocks until account-setup completes, recovery phrase entered locally never crosses LLM context). Once your account is set up, daily operations (`hermes chat -q`, `--resume`, etc.) work normally.*
+   Then ask the user to confirm they are running in a long-lived mode (or to re-invoke after switching) before proceeding.
+
+7. **Verify and confirm.** After user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN expired — call `totalreclaw_pair` again and resend. If present, confirm *"Your TotalReclaw account is set up. Ask me to remember or recall anything."*
 
 ## Phrase safety (HARD — never break)
 
-NEVER echo / generate / ask the user to paste a recovery phrase in chat. NEVER invoke `totalreclaw setup`, `hermes setup`, or any phrase-touching CLI via your shell tool (stdout enters LLM context). The ONLY agent-facilitated setup path is `totalreclaw_pair`. If the user pastes a phrase anyway: tell them it is compromised, call `totalreclaw_pair` with `mode=generate` for a fresh wallet.
+NEVER echo / generate / ask the user to paste a recovery phrase in chat. NEVER invoke `totalreclaw setup`, `hermes setup`, or any phrase-touching CLI via your shell tool (stdout enters LLM context). The ONLY agent-facilitated account-setup path is `totalreclaw_pair` (the account-setup tool). If the user pastes a phrase anyway: tell them it is compromised, call `totalreclaw_pair` with `mode=generate` for a fresh wallet.
 
 ## Usage (post-setup)
 
@@ -74,9 +78,9 @@ NEVER echo / generate / ask the user to paste a recovery phrase in chat. NEVER i
 
 - `totalreclaw_*` tools not visible → gateway not restarted after install; ask the user once to restart their gateway. Common patterns: `hermes gateway restart` (native), `docker restart <your-container-name>` (Docker self-host — replace with the user's actual container name), or the managed service's restart control. Wait for `done`.
 - User says done but `credentials.json` missing → PIN expired or entered wrong phrase; call `totalreclaw_pair` again.
-- `onboarding required` → credentials missing; redo from the pair step.
+- `onboarding required` → credentials missing; redo from the account-setup step.
 - `quota exceeded` → `totalreclaw_status`, then offer `totalreclaw_upgrade`.
 
 ## Tool surface
 
-`totalreclaw_pair` (ONLY setup path) · `_remember` · `_recall` · `_forget` · `_pin` · `_unpin` · `_export` · `_status` · `_upgrade` · `_import_from` · `_import_batch` · `_debrief` · `_report_qa_bug` (RC only).
+`totalreclaw_pair` (ONLY account-setup path) · `_remember` · `_recall` · `_forget` · `_pin` · `_unpin` · `_export` · `_status` · `_upgrade` · `_import_from` · `_import_batch` · `_debrief` · `_report_qa_bug` (RC only).

--- a/python/src/totalreclaw/hermes/pair_tool.py
+++ b/python/src/totalreclaw/hermes/pair_tool.py
@@ -56,16 +56,26 @@ class _OpenedSession:
 PAIR_SCHEMA: Dict[str, Any] = {
     "name": "totalreclaw_pair",
     "description": (
-        "Start a remote pairing session so the user can create or import "
-        "a TotalReclaw recovery phrase from their browser. Returns a "
-        "pairing URL and a 6-digit PIN. Relay both to the user verbatim — "
-        "the user opens the URL in their browser and types the PIN. The "
-        "phrase is entered and encrypted IN THE BROWSER and uploaded "
-        "end-to-end-encrypted to this Hermes gateway; it NEVER touches "
-        "the LLM provider or this chat transcript. Use this tool whenever "
-        "the user wants to set up TotalReclaw. NEVER shell out to "
-        "`totalreclaw setup` or `hermes setup` — those commands are for "
-        "users running them in their own terminal OUTSIDE an agent shell."
+        "Set up the user's TotalReclaw account (encrypted, browser-side "
+        "phrase generation or import). Starts a brief remote session so "
+        "the user can create or import a TotalReclaw recovery phrase from "
+        "their browser. Returns an account-setup URL and a 6-digit PIN. "
+        "Relay both to the user verbatim — the user opens the URL in "
+        "their browser and types the PIN. The phrase is entered and "
+        "encrypted IN THE BROWSER and uploaded end-to-end-encrypted to "
+        "this Hermes gateway; it NEVER touches the LLM provider or this "
+        "chat transcript. Use this tool whenever the user wants to set "
+        "up TotalReclaw — narrate it as 'setting up your TotalReclaw "
+        "account'. (Tool name `totalreclaw_pair` is kept for backward "
+        "compatibility — function-wise this is the account-setup tool.) "
+        "NEVER shell out to `totalreclaw setup` or `hermes setup` — those "
+        "commands are for users running them in their own terminal "
+        "OUTSIDE an agent shell. NOTE: this account-setup step needs a "
+        "long-lived Hermes process — a one-shot `hermes chat -q \"...\"` "
+        "invocation will exit before the user finishes the browser "
+        "handshake. If you detect short-lived process invocation, "
+        "surface the daemon-mode caveat to the user before calling this "
+        "tool."
     ),
     "parameters": {
         "type": "object",
@@ -75,10 +85,11 @@ PAIR_SCHEMA: Dict[str, Any] = {
                 "enum": ["generate", "import", "either"],
                 "description": (
                     '"generate" = browser creates a NEW 12-word recovery '
-                    'phrase (pair page hides the import option). "import" = '
-                    'user pastes an EXISTING phrase (pair page hides the '
-                    'generate option). "either" = pair page shows both with '
-                    'a tab switcher so the user picks (default — safest when '
+                    'phrase (account-setup page hides the import option). '
+                    '"import" = user pastes an EXISTING phrase '
+                    '(account-setup page hides the generate option). '
+                    '"either" = account-setup page shows both with a tab '
+                    'switcher so the user picks (default — safest when '
                     "you don't know whether the user is new or returning)."
                 ),
             },

--- a/python/src/totalreclaw/onboarding.py
+++ b/python/src/totalreclaw/onboarding.py
@@ -112,12 +112,12 @@ Let's set up your account. Do you already have a recovery phrase, or should we g
 """.strip()
 
 LOCAL_MODE_INSTRUCTIONS = (
-    "Ask your agent to 'Set up TotalReclaw' — it will walk you through a QR "
-    "pairing flow. Your recovery phrase never crosses the chat."
+    "Ask your agent to 'Set up TotalReclaw' — it will walk you through a "
+    "browser-based account setup. Your recovery phrase never crosses the chat."
 )
 
 REMOTE_MODE_INSTRUCTIONS = """
-Ask your agent to 'Set up TotalReclaw' — it will walk you through a QR pairing flow. Scan the QR on your phone, enter the 6-digit PIN the agent shows you, and pick "Generate new" or "Restore existing". Your recovery phrase never crosses the chat. Your recovery phrase never leaves this machine.
+Ask your agent to 'Set up TotalReclaw' — it will walk you through a browser-based account setup. Scan the QR on your phone (or open the URL the agent shows you), enter the 6-digit PIN, and pick "Generate new" or "Restore existing". Your recovery phrase never crosses the chat. Your recovery phrase never leaves this machine.
 """.strip()
 
 STORAGE_GUIDANCE = """

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -24,15 +24,15 @@ metadata:
 
 # TotalReclaw Skill
 
-> Canonical install + setup flow lives at <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md> (OpenClaw) and <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md> (Hermes). When a user pastes one of those URLs in chat, fetch it and follow its agent-instructions section verbatim. The "Post-Install Setup" section below mirrors the same pair-tool flow as a fallback.
+> Canonical install + account-setup flow lives at <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md> (OpenClaw) and <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md> (Hermes). When a user pastes one of those URLs in chat, fetch it and follow its agent-instructions section verbatim. The "Post-Install Setup" section below mirrors the same account-setup flow as a fallback.
 
 ## Recovery Phrase -- READ THIS FIRST
 
-**CRITICAL SAFETY RULE:** The recovery phrase MUST NEVER cross the LLM context. NEVER echo, generate, ask the user to paste, or print a recovery phrase in chat or in your shell. The phrase is created and confirmed inside the user's browser via the `totalreclaw_pair` flow — the relay only receives ciphertext, and your tool calls must never carry a phrase payload.
+**CRITICAL SAFETY RULE:** The recovery phrase MUST NEVER cross the LLM context. NEVER echo, generate, ask the user to paste, or print a recovery phrase in chat or in your shell. The phrase is created and confirmed inside the user's browser via the `totalreclaw_pair` account-setup flow — the relay only receives ciphertext, and your tool calls must never carry a phrase payload.
 
 If the user pastes a phrase in chat anyway: tell them it is compromised (the chat transcript and any tool stdout enter LLM context, which makes the phrase recoverable from logs and from any model that processes that turn) and call `totalreclaw_pair` with `mode=generate` to create a fresh wallet.
 
-The recovery phrase is the user's ONLY identity in TotalReclaw. It derives all encryption keys. There is NO password reset, NO recovery mechanism, and NO support channel that can help if it is lost. The browser-side pair flow displays this warning automatically when a new phrase is generated.
+The recovery phrase is the user's ONLY identity in TotalReclaw. It derives all encryption keys. There is NO password reset, NO recovery mechanism, and NO support channel that can help if it is lost. The browser-side account-setup flow displays this warning automatically when a new phrase is generated.
 
 **Do NOT** import a phrase the user already uses for a funded crypto wallet. TotalReclaw uses BIP-39 mnemonics (same format as crypto wallets), but a TotalReclaw phrase must be SEPARATE from any funded wallet. If the user tries to import an existing crypto-wallet phrase, STOP and warn them in chat to use a fresh phrase instead — but warn ABOUT the phrase, never echo any portion of it.
 
@@ -484,21 +484,21 @@ When the user asks to import conversation history:
 
 ## Post-Install Setup
 
-If `totalreclaw_*` tools are bound to your toolset, run these steps to pair. If they are NOT bound, the plugin isn't installed yet — follow the URL-driven install flow at <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md> first.
+If `totalreclaw_*` tools are bound to your toolset, run these steps to set up the user's TotalReclaw account. If they are NOT bound, the plugin isn't installed yet — follow the URL-driven install flow at <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md> first.
 
-1. **Check for existing credentials.** Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, confirm *"TotalReclaw is already set up."* and stop.
+1. **Check for existing credentials.** Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, confirm *"Your TotalReclaw account is already set up."* and stop.
 
-2. **Pair via browser.** Call `totalreclaw_pair`. It returns `{url, pin, qr_ascii, qr_png_b64, qr_unicode, expires_at_ms}`. Relay verbatim:
+2. **Set up the user's TotalReclaw account via browser.** Call `totalreclaw_pair`. It returns `{url, pin, qr_ascii, qr_png_b64, qr_unicode, expires_at_ms}`. Relay verbatim:
    > *Open <url> in your browser. Generate a new 12-word recovery phrase there or paste an existing one — the phrase stays in your browser, the relay only sees ciphertext. Confirm PIN <pin>. Reply `done` once the page says it's sealed.*
 
    Render the QR if your transport supports image attachments (decode `qr_png_b64` to bytes and attach), or emit `qr_unicode` inline for terminal-only transports.
 
-3. **Verify and confirm.** After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN expired — call `totalreclaw_pair` again and resend. If present, confirm *"TotalReclaw is set up. Ask me to remember or recall anything."*
+3. **Verify and confirm.** After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN expired — call `totalreclaw_pair` again and resend. If present, confirm *"Your TotalReclaw account is set up. Ask me to remember or recall anything."*
 
 4. **Mention the free tier.** After confirming setup:
    > *You're on TotalReclaw's free tier — unlimited memories on Base Sepolia testnet (testnet may reset). For permanent storage on Gnosis mainnet, see https://totalreclaw.xyz/pricing.*
 
-**Never** call `totalreclaw_setup` or any phrase-touching CLI from your shell — those leak the phrase into LLM context. The ONLY agent-facilitated setup path is the `totalreclaw_pair` tool.
+**Never** call `totalreclaw_setup` or any phrase-touching CLI from your shell — those leak the phrase into LLM context. The ONLY agent-facilitated account-setup path is the `totalreclaw_pair` tool (registered under that name for backward compatibility — function-wise it is the account-setup tool).
 
 ---
 

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -43,10 +43,10 @@ If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jum
 
 4. **Check for existing credentials.** Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, confirm *"TotalReclaw is already set up."* and stop.
 
-5. **Pair.** Call `totalreclaw_pair`. Returns `{url, pin, qr_ascii, qr_png_b64, qr_unicode, expires_at_ms}` (see "Rendering the QR" below). Relay verbatim:
+5. **Set up the user's TotalReclaw account.** Tell the user: *"I'll walk you through setting up your TotalReclaw account."* Then call `totalreclaw_pair` (the account-setup tool — name kept for backward compatibility). Returns `{url, pin, qr_ascii, qr_png_b64, qr_unicode, expires_at_ms}` (see "Rendering the QR" below). Relay verbatim:
    > *Open <url> in your browser. Generate a new 12-word recovery phrase there or paste an existing one — the phrase stays in your browser, the relay only sees ciphertext. Confirm PIN <pin>. Reply `done` once the page says it's sealed.*
 
-6. **Verify and confirm.** After user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN expired — call `totalreclaw_pair` again and resend. If present, confirm *"TotalReclaw is set up. Ask me to remember or recall anything."*
+6. **Verify and confirm.** After user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN expired — call `totalreclaw_pair` again and resend. If present, confirm *"Your TotalReclaw account is set up. Ask me to remember or recall anything."*
 
 ## Rendering the QR on your transport (rc.5+)
 
@@ -54,13 +54,13 @@ When you receive the `totalreclaw_pair` payload, render the QR based on your cha
 
 - **Transport supports image attachments** (Telegram, Slack, web chat, any transport with file/image upload): decode `qr_png_b64` from base64 to bytes, save to a tempfile with a `.png` suffix, and attach the tempfile as an image. Also show the URL + PIN as text so users who prefer clicking can still do so.
 - **Terminal-only transport** (OpenClaw native CLI chat, bare SSH shell): emit `qr_unicode` inline in your reply. It renders as block characters in most terminal fonts; the user scans from their phone.
-- **Web chat with inline-image support**: embed as `<img src="data:image/png;base64,<qr_png_b64>" alt="Pair QR">` if the chat client renders HTML; otherwise fall back to attachment.
+- **Web chat with inline-image support**: embed as `<img src="data:image/png;base64,<qr_png_b64>" alt="TotalReclaw account-setup QR">` if the chat client renders HTML; otherwise fall back to attachment.
 
-The QR encodes ONLY the pair URL. The 6-digit PIN is a separate out-of-band confirmation — deliberately NOT baked into the QR (dual-channel design: scan + type). Never log, print, or re-emit the PIN outside the user-facing reply. The PIN must NOT end up in any other tool call, log file, or memory store.
+The QR encodes ONLY the account-setup URL. The 6-digit PIN is a separate out-of-band confirmation — deliberately NOT baked into the QR (dual-channel design: scan + type). Never log, print, or re-emit the PIN outside the user-facing reply. The PIN must NOT end up in any other tool call, log file, or memory store.
 
 ## Phrase safety (HARD — never break)
 
-NEVER echo / generate / ask the user to paste a recovery phrase in chat. NEVER invoke `openclaw totalreclaw onboard` (bare interactive form), `totalreclaw setup`, or any phrase-touching CLI via your shell tool (stdout enters LLM context). The ONLY agent-facilitated setup paths are (in order of preference): (1) `totalreclaw_pair` tool; (2) if the tool is missing from your tool list — a known gap for some container-based agents, issue #87 — shell out to EITHER `openclaw totalreclaw pair generate --url-pin-only` (single-line JSON `{v,url,pin,expires_at_ms}`) OR `openclaw totalreclaw onboard --pair-only` (single-line JSON `{v,pair_url,pin,expires_at_ms}`, issue #95 — same pair flow, `pair_url` key naming). Both have zero phrase material on stdout (pair-crypto is x25519-only, not BIP-39). If the user pastes a phrase anyway: tell them it is compromised, call `totalreclaw_pair` with `mode=generate` for a fresh wallet.
+NEVER echo / generate / ask the user to paste a recovery phrase in chat. NEVER invoke `openclaw totalreclaw onboard` (bare interactive form), `totalreclaw setup`, or any phrase-touching CLI via your shell tool (stdout enters LLM context). The ONLY agent-facilitated account-setup paths are (in order of preference): (1) the `totalreclaw_pair` account-setup tool; (2) if the tool is missing from your tool list — a known gap for some container-based agents, issue #87 — shell out to EITHER `openclaw totalreclaw pair generate --url-pin-only` (single-line JSON `{v,url,pin,expires_at_ms}`) OR `openclaw totalreclaw onboard --pair-only` (single-line JSON `{v,pair_url,pin,expires_at_ms}`, issue #95 — same account-setup flow, `pair_url` key naming). Both have zero phrase material on stdout (account-setup crypto is x25519-only, not BIP-39). If the user pastes a phrase anyway: tell them it is compromised, call `totalreclaw_pair` with `mode=generate` for a fresh wallet.
 
 ## Usage (post-setup)
 
@@ -74,10 +74,10 @@ NEVER echo / generate / ask the user to paste a recovery phrase in chat. NEVER i
 
 - `totalreclaw_*` tools not visible → plugin not installed or auto-reload didn't fire. Verify via `openclaw plugins list | grep totalreclaw` (or, on a managed service that doesn't expose the CLI, ask the user to confirm via their service's plugins UI). If `totalreclaw` is listed but tools are still absent, the gateway probably hasn't completed its auto-restart yet (give it 5-10s) OR `gateway.reload.mode = off` is set — instruct manual restart as fallback: `openclaw gateway restart` (native), `docker restart <your-container-name>` (Docker self-host), or the managed service's restart control. If the plugin is listed and the gateway has been restarted but tools are still missing (container-agent gap, issue #87), shell out to `openclaw totalreclaw pair generate --url-pin-only` on the gateway host and hand the user the `url` + `pin` from the JSON payload — OR `openclaw totalreclaw onboard --pair-only` (same flow, returns `pair_url` instead of `url`, issue #95). If your shell doesn't reach the gateway host (managed service), tell the user to install/enable the plugin via their service's plugins UI and restart the gateway via the service's restart control. Do NOT suggest the bare `openclaw totalreclaw onboard` (leaks phrase on stdout — deprecated in rc.18, removed next RC).
 - User says done but `credentials.json` missing → PIN expired or entered wrong phrase; call `totalreclaw_pair` again.
-- `onboarding required` → credentials missing; redo from the pair step.
+- `onboarding required` → credentials missing; redo from the account-setup step.
 - `quota exceeded` → `totalreclaw_status`, then offer `totalreclaw_upgrade`.
 - `No LLM available for auto-extraction` at startup → provider key unreachable; check `~/.openclaw/agents/<agent>/agent/auth-profiles.json` or plugin config `extraction.llm`.
 
 ## Tool surface
 
-`totalreclaw_pair` (ONLY setup path) · `_remember` · `_recall` · `_forget` · `_pin` · `_unpin` · `_retype` · `_set_scope` · `_export` · `_status` · `_upgrade` · `_migrate` · `_import_from` · `_import_batch` · `_consolidate` · `_onboarding_start` (pointer to local-terminal wizard, for users explicitly rejecting the browser flow) · `_report_qa_bug` (RC only).
+`totalreclaw_pair` (ONLY account-setup path) · `_remember` · `_recall` · `_forget` · `_pin` · `_unpin` · `_retype` · `_set_scope` · `_export` · `_status` · `_upgrade` · `_migrate` · `_import_from` · `_import_batch` · `_consolidate` · `_onboarding_start` (pointer to local-terminal wizard, for users explicitly rejecting the browser flow) · `_report_qa_bug` (RC only).

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -5162,19 +5162,24 @@ const plugin = {
     api.registerTool(
       {
         name: 'totalreclaw_pair',
-        label: 'QR pair — start remote pairing session',
+        label: 'Set up the user\'s TotalReclaw account (encrypted, browser-side)',
         description:
-          'Start a remote pairing session so the user can create or import a TotalReclaw ' +
-          'recovery phrase from their phone or another browser. Returns a pairing URL, a ' +
-          '6-digit PIN, and an ASCII QR code that the agent relays to the user. The recovery ' +
-          'phrase itself is generated/entered in the BROWSER and uploaded end-to-end encrypted ' +
-          'to this gateway — it NEVER touches the LLM provider or the chat transcript.\n\n' +
-          'This is the CANONICAL agent-facilitated setup surface — use it whenever the user ' +
-          'asks you to set up TotalReclaw, regardless of whether they have terminal access. ' +
-          'Browser-side crypto keeps the recovery phrase out of the LLM context entirely. ' +
-          'If a user explicitly prefers local-terminal setup with no browser, point them at ' +
-          '`totalreclaw_onboarding_start` (a pointer to the CLI wizard they run on their own ' +
-          'terminal, NOT through your shell tool).',
+          'Set up the user\'s TotalReclaw account (encrypted, browser-side recovery-phrase ' +
+          'generation or import). Starts a brief remote session so the user can create or ' +
+          'import a TotalReclaw recovery phrase from their phone or another browser. ' +
+          'Returns an account-setup URL, a 6-digit PIN, and an ASCII QR code that the agent ' +
+          'relays to the user. The recovery phrase itself is generated/entered in the ' +
+          'BROWSER and uploaded end-to-end encrypted to this gateway — it NEVER touches ' +
+          'the LLM provider or the chat transcript.\n\n' +
+          'This is the CANONICAL agent-facilitated account-setup surface — use it whenever ' +
+          'the user asks you to set up TotalReclaw, regardless of whether they have ' +
+          'terminal access. Narrate it to the user as "setting up your TotalReclaw ' +
+          'account". Browser-side crypto keeps the recovery phrase out of the LLM context ' +
+          'entirely. If a user explicitly prefers local-terminal account setup with no ' +
+          'browser, point them at `totalreclaw_onboarding_start` (a pointer to the CLI ' +
+          'wizard they run on their own terminal, NOT through your shell tool).\n\n' +
+          'Tool name `totalreclaw_pair` is kept for backward compatibility — function-wise ' +
+          'this is the account-setup tool.',
         parameters: {
           type: 'object',
           properties: {


### PR DESCRIPTION
Stable-promote prep per Pedro 2026-04-27.

## Task 1 — Account-setup terminology

User-facing 'pair' / 'pairing' → 'set up your TotalReclaw account' across SKILL.md (plugin + Hermes + skill top-level) + setup guides + LLM-facing tool descriptions.

Tool name `totalreclaw_pair` + filenames + HTTP routes + code identifiers preserved (backward compat).

## Task 2 — `hermes chat -q` daemon-mode caveat

`docs/guides/hermes-setup.md` adds explicit warning: account setup requires daemon mode (`hermes gateway run`) OR interactive `hermes chat` session OR standalone `totalreclaw setup` CLI. Mirrored in agent-imperative form in Hermes SKILL.md so agent surfaces the caveat to user before invoking the setup tool.

This is a known Hermes-agent lifecycle constraint — `chat -q` one-shot CLI exits before browser-side phrase generation completes; relay session dies with the process. Tracked for future improvement (sidecar / IPC handoff).

## Task 3 — CHANGELOG-public.md release notes

Consolidated stable entry covering plugin 3.3.1, Python 2.3.1, mcp-server 3.2.1.

## Test plan

- Python: 1001 passed / 12 skipped / 11 deselected (qrcode dep missing, installs cleanly with --extras)
- Plugin: 23/23 test suites pass
- check-version-drift: OK across plugin/SKILL.md/skill.json
- No phrase-safety code touched

## Out of scope (flagged)

- ROADMAP.md "QR-pairing" (historical context, not a setup-guide — left)
- README / NanoClaw SKILL / spec docs verified clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)