### PR TITLE
ci(promote-rc): add --ignore-scripts to npm publish (fix retag prepublishOnly path)

### DIFF
--- a/.github/workflows/promote-rc.yml
+++ b/.github/workflows/promote-rc.yml
@@ -251,7 +251,7 @@ jobs:
               fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
               console.log('Repackaging', pkg.name, 'as', pkg.version);
             "
-            npm publish --access public --tag latest
+            npm publish --access public --tag latest --ignore-scripts
             cd /tmp/promote
             rm -rf unpacked "$TARBALL"
           done


### PR DESCRIPTION
Promote workflow fails to retag rc → stable because unpacked tarball's prepublishOnly references ../scripts/* outside the package. Skip lifecycle scripts on retag (byte-identical promotion).

Surfaced today during 3.3.1 stable promote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)