### PR TITLE
chore(docs): post-stable cleanup — drop @rc from default install paths (3.3.1 + 2.3.1)

### DIFF
--- a/docs/guides/beta-tester-guide-detailed.md
+++ b/docs/guides/beta-tester-guide-detailed.md
@@ -382,4 +382,4 @@ For implementation depth:
 
 ---
 
-*This guide tracks plugin 3.3.1 / Hermes 2.3.1 / mcp-server 3.2.x / nanoclaw 3.1.x. Stable line: plugin 3.2.3, mcp-server 3.2.0, nanoclaw 3.0.0, Hermes 2.3.0.*
+*This guide tracks plugin 3.3.1 / Hermes 2.3.1 / mcp-server 3.2.1 / nanoclaw 3.0.0. Stable line: plugin 3.3.1, mcp-server 3.2.1, nanoclaw 3.0.0, Hermes 2.3.1.*

--- a/docs/guides/claude-code-setup.md
+++ b/docs/guides/claude-code-setup.md
@@ -35,8 +35,6 @@ claude mcp add -s user totalreclaw -- npx -y @totalreclaw/mcp-server
 
 This registers `totalreclaw` at user scope (available across all Claude Code sessions). Do NOT pass `-e TOTALRECLAW_RECOVERY_PHRASE=...` here — the user will add the phrase themselves in Step 3 so it never enters your context.
 
-To pin a release candidate: `claude mcp add -s user totalreclaw -- npx -y @totalreclaw/mcp-server@rc` (latest RC) or `@totalreclaw/mcp-server@3.2.3` (pin specific stable / RC version).
-
 If the CLI exits cleanly, continue to Step 3. If it fails with `command not found` / ENOENT, fall back to Step 2B.
 
 ### Step 2B — Register the MCP server via JSON config (fallback)
@@ -147,7 +145,7 @@ claude mcp add -s user totalreclaw -- npx -y @totalreclaw/mcp-server
 
 Restart the host. Verify by asking *"Do you have access to TotalReclaw memory tools?"*.
 
-> **Pin a specific RC** with `args: ["-y", "@totalreclaw/mcp-server@rc"]` (latest RC) or `@totalreclaw/mcp-server@3.3.1-rc.22` (pinned). Stable is `3.2.3` on the `latest` dist-tag. Check what each tag resolves to: `npm view @totalreclaw/mcp-server dist-tags`.
+> **Testing a release candidate?** Pin via `args: ["-y", "@totalreclaw/mcp-server@rc"]` (latest RC on the `@rc` dist-tag) or `@totalreclaw/mcp-server@3.2.1` (pin a specific version). Check what each tag resolves to: `npm view @totalreclaw/mcp-server dist-tags`. Most users should leave the args at `["-y", "@totalreclaw/mcp-server"]`, which resolves to the current stable.
 
 ---
 

--- a/docs/guides/client-setup-v1.md
+++ b/docs/guides/client-setup-v1.md
@@ -1,6 +1,6 @@
 # Client Setup — v1
 
-**Applies to:** TotalReclaw v1, all clients. Current stable versions: core 2.2.0, plugin 3.2.3, mcp-server 3.2.0, nanoclaw 3.0.0, python 2.3.0.
+**Applies to:** TotalReclaw v1, all clients. Current stable versions: core 2.2.0, plugin 3.3.1, mcp-server 3.2.1, nanoclaw 3.0.0, python 2.3.1.
 
 One setup page per client. v1 is the default on every client — no env toggles, no feature flags to flip. Pick your platform.
 

--- a/docs/guides/feature-comparison.md
+++ b/docs/guides/feature-comparison.md
@@ -2,7 +2,7 @@
 
 TotalReclaw works across multiple AI agent platforms. The core encryption, storage, search pipeline, and v1 taxonomy are identical everywhere -- the differences are in automation (lifecycle hooks) and available tools. This table shows what each platform supports.
 
-All clients ship v1 by default. Stable production versions: core 2.2.0, plugin 3.2.3, mcp-server 3.2.0, nanoclaw 3.0.0, python 2.3.0.
+All clients ship v1 by default. Stable production versions: core 2.2.0, plugin 3.3.1, mcp-server 3.2.1, nanoclaw 3.0.0, python 2.3.1.
 
 ---
 

--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -53,14 +53,14 @@ Run via your shell tool, in this order:
 
 ```bash
 hermes plugins install p-diogo/totalreclaw-hermes --enable
-"$HERMES_PYTHON" -m pip install --pre totalreclaw
+"$HERMES_PYTHON" -m pip install totalreclaw
 ```
 
 Notes:
 - Hermes 2026.4.16+ uses Git-based plugin discovery: the first command registers the plugin manifest, the second installs the Python tool implementations into Hermes' venv. Using `"$HERMES_PYTHON" -m pip ...` (instead of bare `pip install`) guarantees the package lands in the SAME environment Hermes will load tools from after restart — this is the rc.23 fix for the F5 "outside-venv install" bug.
-- DO NOT use bare `pip install --pre totalreclaw` unless you have already verified that `which pip` resolves to the same venv as `$HERMES_PYTHON`. On containerized Hermes the system `pip` may not even exist (`pip: command not found`) and the bare command would target the host's Python anyway, leaving Hermes' venv empty.
+- DO NOT use bare `pip install totalreclaw` unless you have already verified that `which pip` resolves to the same venv as `$HERMES_PYTHON`. On containerized Hermes the system `pip` may not even exist (`pip: command not found`) and the bare command would target the host's Python anyway, leaving Hermes' venv empty.
 - On Ubuntu / Debian / Docker you may hit `externally-managed-environment` if `$HERMES_PYTHON` points at a system Python (no venv). Add `--break-system-packages` to the `pip install` line, OR ask the user to recreate Hermes inside a venv.
-- For an RC build, `--pre` resolves to whatever release candidate is latest on PyPI right now. To pin a specific RC (QA against a known-good build, restoring a specific version after a regression in a newer RC), drop `--pre` and use an explicit version specifier — see [Targeting a specific RC](#targeting-a-specific-rc).
+- Testing a release candidate? See [Installing release candidates (advanced)](#installing-release-candidates-advanced) at the bottom of this guide.
 - If either command fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment), STOP and tell the user verbatim: *"Your environment doesn't expose the Hermes CLI / pip to me. Please install `p-diogo/totalreclaw-hermes` and the `totalreclaw` Python package via your service's plugins UI, then reply `done`."* Wait for `done` before continuing to Step 2.
 
 #### Step 1c — Verify the package is installed in the right Python
@@ -128,7 +128,7 @@ NEVER echo, generate, or ask the user to paste a recovery phrase in chat. NEVER 
 ## What's happening (for the human reader)
 
 1. `hermes plugins install p-diogo/totalreclaw-hermes --enable` — registers TotalReclaw's plugin manifest from its Git repo.
-2. `pip install --pre totalreclaw` — installs the Python tool implementations into the Hermes venv. `--pre` resolves to the latest release candidate; drop it once a stable is promoted.
+2. `pip install totalreclaw` — installs the Python tool implementations into the Hermes venv. The default resolves to the current stable on PyPI.
 3. The agent asks you to restart the Hermes gateway. (Hermes does not yet auto-reload on plugin install — tracked upstream.) After restart, the new tools bind.
 4. The agent calls `totalreclaw_pair`, which generates an ephemeral x25519 keypair on the gateway and a 6-digit PIN. You get a URL + PIN.
 5. You open the URL. The account-setup page has two tabs: **Generate new** (the browser creates a fresh BIP-39 12-word phrase locally using `crypto.getRandomValues`) and **Import existing** (paste a phrase you already have). Pick one, confirm the 6-digit PIN, click seal.
@@ -191,11 +191,11 @@ hermes plugins install p-diogo/totalreclaw-hermes --enable
 # Use the SAME Python that Hermes runs from — never bare `pip install` unless
 # you already know `which pip` and Hermes' interpreter agree.
 #   Native venv install:
-~/.hermes/venv/bin/python3 -m pip install --pre totalreclaw
+~/.hermes/venv/bin/python3 -m pip install totalreclaw
 #   Containerized Hermes (run from inside the container shell):
-python3 -m pip install --pre totalreclaw
+python3 -m pip install totalreclaw
 #   System-Python install (no venv, may need --break-system-packages):
-python3 -m pip install --pre totalreclaw
+python3 -m pip install totalreclaw
 
 # Restart the gateway. Pick the line that matches your setup:
 hermes gateway restart                       # native install
@@ -213,15 +213,20 @@ If you were on plugin 3.3.1-rc.2 or Hermes 2.3.1rc2, after upgrading also run `p
 
 ---
 
-## Targeting a specific RC
+## Installing release candidates (advanced)
 
-`pip install --pre totalreclaw` always resolves to the latest published release candidate on PyPI. For QA harnesses pinned to a known build, or for re-installing a specific RC after a regression in a newer one, pin the version explicitly:
+Most users should install stable (the default — `pip install totalreclaw` resolves to the current stable on PyPI). Skip this section unless you are testing a pre-release build.
+
+For pre-release builds:
 
 ```bash
-# Fresh install of a specific RC (no --pre needed when the version is explicit):
+# Latest release candidate (whatever's currently on PyPI as the most recent rcN):
+"$HERMES_PYTHON" -m pip install --pre totalreclaw
+
+# Pin a specific RC (e.g. for QA harnesses or restoring a known-good build after a regression):
 "$HERMES_PYTHON" -m pip install 'totalreclaw==2.3.1rc24'
 
-# Re-pin (downgrade) over a newer RC that's already installed:
+# Re-pin (downgrade) over a newer RC or stable that's already installed:
 "$HERMES_PYTHON" -m pip install --force-reinstall 'totalreclaw==2.3.1rc24'
 ```
 

--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -24,8 +24,8 @@ openclaw plugins install @totalreclaw/totalreclaw
 ```
 
 Notes:
-- For an RC build, replace the second command with `openclaw plugins install @totalreclaw/totalreclaw@rc` (or pin a version like `@totalreclaw/totalreclaw@3.3.1-rc.22`).
 - If either command fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment), STOP and tell the user verbatim: *"Your environment doesn't expose the OpenClaw CLI to me. Please install `totalreclaw` from your service's plugins / skills UI, then reply `done`."* Wait for `done` before continuing to Step 2.
+- Testing a release candidate? See [Installing release candidates (advanced)](#installing-release-candidates-advanced) at the bottom of this guide.
 
 ### Step 2 — Wait for auto-reload (do NOT restart the gateway yourself)
 
@@ -60,7 +60,7 @@ NEVER echo, generate, or ask the user to paste a recovery phrase in chat. NEVER 
 ## What's happening (for the human reader)
 
 1. `openclaw skills install totalreclaw` — fetches TotalReclaw's SKILL.md from ClawHub and registers it under `~/.openclaw/workspace/skills/totalreclaw/`. The agent picks it up on next config reload.
-2. `openclaw plugins install @totalreclaw/totalreclaw` — installs the plugin from npm (the `latest` dist-tag is always current stable; use `@rc` for the latest release candidate).
+2. `openclaw plugins install @totalreclaw/totalreclaw` — installs the plugin from npm (the `latest` dist-tag is always current stable).
 3. OpenClaw's config-watcher detects the `plugins.*` change in `~/.openclaw/config.yaml` and (under default `gateway.reload.mode = "hybrid"`) triggers a graceful SIGUSR1 restart within 1-3s. The new tools bind automatically.
 4. The agent calls `totalreclaw_pair`, which generates an ephemeral x25519 keypair on the gateway and a 6-digit PIN. You get a URL + PIN.
 5. You open the URL. The account-setup page has two tabs: **Generate new** (the browser creates a fresh BIP-39 12-word phrase locally using `crypto.getRandomValues`) and **Import existing** (paste a phrase you already have). Pick one, confirm the 6-digit PIN, click seal.
@@ -99,8 +99,7 @@ The browser-side crypto and account-setup flow are identical to self-hosted setu
 If you can't or won't use the chat flow (self-hosted only — managed services don't expose the host shell):
 
 ```bash
-openclaw plugins install @totalreclaw/totalreclaw            # stable
-# Or for an RC: @totalreclaw/totalreclaw@rc
+openclaw plugins install @totalreclaw/totalreclaw
 # Under the default config (`gateway.reload.mode = "hybrid"`), OpenClaw's file-watcher
 # auto-restarts the gateway within 1-3s of the install — no manual restart needed.
 # Verify with: `openclaw plugins list | grep totalreclaw`.
@@ -111,8 +110,6 @@ openclaw plugins install @totalreclaw/totalreclaw            # stable
 ```
 
 Then in chat: *"Set up TotalReclaw"* — the agent will call `totalreclaw_pair` and hand you the URL + PIN. Open the URL in your browser to enter or generate your phrase.
-
-> Pin a specific RC with `openclaw plugins install @totalreclaw/totalreclaw@3.3.1-rc.22`. Check what each tag resolves to: `npm view @totalreclaw/totalreclaw dist-tags`. Keep skill and plugin on the same version family (both stable or both RC).
 
 <details>
 <summary>From-source install (for plugin development — self-host only)</summary>
@@ -203,6 +200,24 @@ Both tiers have unlimited memories and reads. Upgrade: *"Upgrade my TotalReclaw 
 ## Canonical prompt (matches the QA harness scenario contracts)
 
 > **Install TotalReclaw, see <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md>**
+
+---
+
+## Installing release candidates (advanced)
+
+Most users should install stable (the default — `openclaw plugins install @totalreclaw/totalreclaw` resolves to the current stable on the `latest` dist-tag). Skip this section unless you are testing a pre-release build.
+
+For pre-release builds:
+
+```bash
+# Latest release candidate (whatever's currently on the @rc dist-tag):
+openclaw plugins install @totalreclaw/totalreclaw@rc
+
+# Pin a specific RC (e.g. for QA harnesses or restoring a known-good build after a regression):
+openclaw plugins install @totalreclaw/totalreclaw@3.3.1-rc.22
+```
+
+Check what each tag resolves to with `npm view @totalreclaw/totalreclaw dist-tags`. Keep skill and plugin on the same version family (both stable or both RC).
 
 ---
 


### PR DESCRIPTION
Stable 3.3.1 + 2.3.1 just shipped. Default install commands no longer need @rc / --pre. RC-testing guidance preserved at bottom of each guide for advanced users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)