### PR TITLE
fix(plugin): write .loaded.json + .error.json from register() (umbrella #182 F3 / #186)

### DIFF
--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "Install + set up TotalReclaw encrypted memory for OpenClaw, then use totalreclaw_remember / totalreclaw_recall. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', or any remember / recall request."
-version: 3.3.1
+version: 3.3.2-rc.1
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz

--- a/skill/plugin/fs-helpers.ts
+++ b/skill/plugin/fs-helpers.ts
@@ -870,3 +870,109 @@ export function resolveOnboardingState(
   writeOnboardingState(statePath, next);
   return next;
 }
+
+// ---------------------------------------------------------------------------
+// Plugin-load manifests (umbrella #182 finding F3 — issue #186)
+// ---------------------------------------------------------------------------
+
+/**
+ * Filename written into `<pluginRootDir>` when `register()` completes
+ * successfully. Agents running inside the gateway use this as a filesystem
+ * verification path when `openclaw plugins list` is unavailable (e.g. the
+ * `openclaw` CLI hangs inside the gateway — umbrella #182 finding F1).
+ */
+export const PLUGIN_LOADED_MANIFEST = '.loaded.json';
+
+/**
+ * Filename written into `<pluginRootDir>` when `register()` throws. Captures
+ * the error message + stack so an agent can diagnose load failures without
+ * shell access to the gateway logs.
+ */
+export const PLUGIN_ERROR_MANIFEST = '.error.json';
+
+/**
+ * Payload of `<pluginRootDir>/.loaded.json`. Schema is intentionally minimal
+ * so it's stable across RC bumps and easy to grep / `cat | jq` from an agent.
+ */
+export interface PluginLoadedManifest {
+  /** UNIX milliseconds when register() started. */
+  loadedAt: number;
+  /** Plugin version from package.json (`null` if unreadable). */
+  version: string | null;
+  /** Names of every tool registered via `api.registerTool` during this load. */
+  tools: string[];
+}
+
+/**
+ * Payload of `<pluginRootDir>/.error.json`. Written when register() throws.
+ */
+export interface PluginErrorManifest {
+  /** UNIX milliseconds when register() started. */
+  loadedAt: number;
+  /** Captured `err.message`, or `String(err)` for non-Error throws. */
+  error: string;
+  /** Captured `err.stack`, or empty string when unavailable. */
+  stack: string;
+}
+
+/**
+ * Write the success manifest at `<pluginRootDir>/.loaded.json`. Best-effort:
+ * returns `true` on success, `false` on any I/O / serialization failure.
+ * Caller treats `false` as "agent will lose the verification artifact this
+ * load cycle" — never block plugin init on this.
+ */
+export function writePluginLoadedManifest(
+  pluginRootDir: string,
+  payload: PluginLoadedManifest,
+): boolean {
+  try {
+    if (!fs.existsSync(pluginRootDir)) return false;
+    const target = path.join(pluginRootDir, PLUGIN_LOADED_MANIFEST);
+    fs.writeFileSync(target, JSON.stringify(payload, null, 2));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Write the failure manifest at `<pluginRootDir>/.error.json`. Best-effort.
+ */
+export function writePluginErrorManifest(
+  pluginRootDir: string,
+  payload: PluginErrorManifest,
+): boolean {
+  try {
+    if (!fs.existsSync(pluginRootDir)) return false;
+    const target = path.join(pluginRootDir, PLUGIN_ERROR_MANIFEST);
+    fs.writeFileSync(target, JSON.stringify(payload, null, 2));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Delete both manifest files at the start of `register()`. Stale state from
+ * a prior load cycle would otherwise mask a current load failure (a fresh
+ * `.error.json` with the new failure is the signal — but only if no stale
+ * `.loaded.json` from yesterday is also sitting next to it).
+ *
+ * Best-effort: missing files are not errors. Returns the count of files
+ * actually removed (useful for diagnostics, but most callers ignore it).
+ */
+export function clearPluginManifests(pluginRootDir: string): number {
+  let removed = 0;
+  for (const name of [PLUGIN_LOADED_MANIFEST, PLUGIN_ERROR_MANIFEST]) {
+    try {
+      const target = path.join(pluginRootDir, name);
+      if (fs.existsSync(target)) {
+        fs.unlinkSync(target);
+        removed++;
+      }
+    } catch {
+      // Best-effort.
+    }
+  }
+  return removed;
+}

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -164,6 +164,9 @@ import {
   cleanupInstallStagingDirs,
   detectPartialInstall,
   clearPartialInstallMarker,
+  writePluginLoadedManifest,
+  writePluginErrorManifest,
+  clearPluginManifests,
   type OnboardingState,
 } from './fs-helpers.js';
 import { isRcBuild } from './qa-bug-report.js';
@@ -2856,6 +2859,53 @@ const plugin = {
   },
 
   register(api: OpenClawPluginApi) {
+    // ---------------------------------------------------------------
+    // Load manifests (umbrella #182 finding F3 — issue #186)
+    // ---------------------------------------------------------------
+    //
+    // Two filesystem artifacts an agent can `cat` to verify load state when
+    // the `openclaw plugins list` CLI is unavailable (umbrella #182 F1 —
+    // CLI hangs inside the gateway):
+    //
+    //   <pluginRoot>/.loaded.json — written on successful register()
+    //   <pluginRoot>/.error.json  — written when register() throws
+    //
+    // Resolve plugin root from `import.meta.url` (the dist/ dir → one up to
+    // package root). Stale manifests are cleared on entry so a current load
+    // failure isn't masked by yesterday's success file.
+    const __manifestStartedAt = Date.now();
+    let __manifestPluginRoot: string | null = null;
+    try {
+      const __pluginDistDir = nodePath.dirname(fileURLToPath(import.meta.url));
+      __manifestPluginRoot = nodePath.resolve(__pluginDistDir, '..');
+      clearPluginManifests(__manifestPluginRoot);
+    } catch {
+      // import.meta.url unresolvable — manifests will silently no-op.
+      __manifestPluginRoot = null;
+    }
+    // Capture every name passed to api.registerTool by shadowing the method
+    // for the lifetime of register(). Names are read from opts.name /
+    // opts.names if present, else from the tool object's own `name` field
+    // (the shape used by every existing api.registerTool callsite below).
+    const __registeredToolNames: string[] = [];
+    const __originalRegisterTool = api.registerTool.bind(api);
+    api.registerTool = ((tool: unknown, opts?: { name?: string; names?: string[] }) => {
+      try {
+        if (opts?.name) {
+          __registeredToolNames.push(opts.name);
+        } else if (opts?.names) {
+          for (const n of opts.names) __registeredToolNames.push(n);
+        } else if (tool && typeof tool === 'object') {
+          const t = tool as Record<string, unknown>;
+          if (typeof t.name === 'string') __registeredToolNames.push(t.name);
+        }
+      } catch {
+        // Capture is best-effort; never block tool registration.
+      }
+      return __originalRegisterTool(tool, opts);
+    }) as typeof api.registerTool;
+
+    try {
     // ---------------------------------------------------------------
     // RC-build detection (3.3.1-rc.3)
     // ---------------------------------------------------------------
@@ -6296,6 +6346,53 @@ const plugin = {
       },
       { priority: 5 },
     );
+
+    // ---------------------------------------------------------------
+    // Load manifest write — success path (umbrella #182 finding F3 / #186)
+    // ---------------------------------------------------------------
+    //
+    // Reached only if every preceding registration step completed without
+    // throwing. The manifest captures the version + the tool list so an
+    // agent inside the gateway can verify both that we loaded AND that
+    // every expected tool is bound (covers umbrella #182 F2 verification —
+    // sibling issue #185).
+    if (__manifestPluginRoot) {
+      const __manifestVersion = (() => {
+        try {
+          const __pluginDistDir = nodePath.dirname(fileURLToPath(import.meta.url));
+          return readPluginVersion(__pluginDistDir);
+        } catch {
+          return null;
+        }
+      })();
+      writePluginLoadedManifest(__manifestPluginRoot, {
+        loadedAt: __manifestStartedAt,
+        version: __manifestVersion,
+        tools: [...__registeredToolNames],
+      });
+    }
+    } catch (__registerErr: unknown) {
+      // ---------------------------------------------------------------
+      // Load manifest write — failure path (umbrella #182 F3 / #186)
+      // ---------------------------------------------------------------
+      //
+      // Capture diagnostics for the agent before re-throwing. Re-throw is
+      // mandatory: the SDK's plugin loader must still see the failure so
+      // it can flag this plugin as unloaded — silent swallow would mask
+      // the symptom.
+      if (__manifestPluginRoot) {
+        const __errMessage =
+          __registerErr instanceof Error ? __registerErr.message : String(__registerErr);
+        const __errStack =
+          __registerErr instanceof Error ? __registerErr.stack ?? '' : '';
+        writePluginErrorManifest(__manifestPluginRoot, {
+          loadedAt: __manifestStartedAt,
+          error: __errMessage,
+          stack: __errStack,
+        });
+      }
+      throw __registerErr;
+    }
   },
 };
 

--- a/skill/plugin/package-lock.json
+++ b/skill/plugin/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.1-rc.15",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/totalreclaw",
-      "version": "3.3.1-rc.15",
+      "version": "3.3.1",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@totalreclaw/client": "^1.2.0",
@@ -2367,7 +2368,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.1",
+  "version": "3.3.2-rc.1",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [
@@ -63,7 +63,7 @@
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.json --noCheck",
     "verify-tarball": "node ../scripts/verify-tarball.mjs",
-    "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx config.test.ts && npx tsx relay-headers.test.ts && npx tsx scope-address-visible.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx llm-client-retry.test.ts && npx tsx gateway-url.test.ts && npx tsx retype-setscope.test.ts && npx tsx tool-gating.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts && npx tsx pair-qr.test.ts && npx tsx pair-remote-client.test.ts && npx tsx qa-bug-report.test.ts && npx tsx nonce-serialization.test.ts && npx tsx phrase-safety-registry.test.ts && npx tsx test_issue_92_onnx_download_ux.test.ts && npx tsx onboard-pair-only.test.ts && npx tsx import-time-smoke.test.ts && npx tsx install-staging-cleanup.test.ts && npx tsx partial-install-detection.test.ts && npx tsx install-reload-idempotency.test.ts && npx tsx json-stdout-cleanliness.test.ts",
+    "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx config.test.ts && npx tsx relay-headers.test.ts && npx tsx scope-address-visible.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx llm-client-retry.test.ts && npx tsx gateway-url.test.ts && npx tsx retype-setscope.test.ts && npx tsx tool-gating.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts && npx tsx pair-qr.test.ts && npx tsx pair-remote-client.test.ts && npx tsx qa-bug-report.test.ts && npx tsx nonce-serialization.test.ts && npx tsx phrase-safety-registry.test.ts && npx tsx test_issue_92_onnx_download_ux.test.ts && npx tsx onboard-pair-only.test.ts && npx tsx import-time-smoke.test.ts && npx tsx install-staging-cleanup.test.ts && npx tsx partial-install-detection.test.ts && npx tsx install-reload-idempotency.test.ts && npx tsx json-stdout-cleanliness.test.ts && npx tsx test_issue_186_load_manifests.test.ts",
     "smoke:dist": "npx tsx dist-esm-smoke.test.ts",
     "check-scanner": "node ../scripts/check-scanner.mjs",
     "check-version-drift": "node ../scripts/check-version-drift.mjs",

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "3.3.1",
+  "version": "3.3.2-rc.1",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",

--- a/skill/plugin/test_issue_186_load_manifests.test.ts
+++ b/skill/plugin/test_issue_186_load_manifests.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Regression test for umbrella #182 finding F3 (issue #186) — plugin-load
+ * manifests at `<pluginRoot>/.loaded.json` and `.error.json`.
+ *
+ * The agent inside the gateway uses these manifests to verify TR loaded
+ * (and which tools bound) when `openclaw plugins list` is unavailable —
+ * sibling F1 #184 (CLI hangs inside gateway).
+ *
+ * What this asserts
+ * -----------------
+ *   1. `writePluginLoadedManifest` writes valid JSON with `loadedAt`,
+ *      `version`, and `tools` fields at `<pluginRoot>/.loaded.json`.
+ *   2. `writePluginErrorManifest` writes valid JSON with `loadedAt`,
+ *      `error`, and `stack` fields at `<pluginRoot>/.error.json`.
+ *   3. `clearPluginManifests` removes both files when present, returns the
+ *      removed-count, and is a no-op (returns 0) when neither is present.
+ *   4. Both writers are best-effort: missing pluginRootDir → false return,
+ *      no throw.
+ *   5. The on-disk JSON for the loaded manifest is human-readable
+ *      (pretty-printed with 2-space indent) so an agent can `cat | head`
+ *      without piping through `jq`.
+ *
+ * Run with: `npx tsx test_issue_186_load_manifests.test.ts`
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  writePluginLoadedManifest,
+  writePluginErrorManifest,
+  clearPluginManifests,
+  PLUGIN_LOADED_MANIFEST,
+  PLUGIN_ERROR_MANIFEST,
+} from './fs-helpers.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond: boolean, name: string): void {
+  const n = passed + failed + 1;
+  if (cond) {
+    console.log(`ok ${n} - ${name}`);
+    passed++;
+  } else {
+    console.log(`not ok ${n} - ${name}`);
+    failed++;
+  }
+}
+
+function mkTmpRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'tr-issue-186-'));
+}
+
+function rmrf(dir: string): void {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 — writePluginLoadedManifest happy path.
+// ---------------------------------------------------------------------------
+{
+  const root = mkTmpRoot();
+  const ok = writePluginLoadedManifest(root, {
+    loadedAt: 1700000000000,
+    version: '3.3.2-rc.1',
+    tools: ['totalreclaw_pair', 'totalreclaw_remember', 'totalreclaw_recall'],
+  });
+  assert(ok === true, 'writePluginLoadedManifest returns true on success');
+
+  const file = path.join(root, PLUGIN_LOADED_MANIFEST);
+  assert(fs.existsSync(file), `.loaded.json written at ${file}`);
+
+  const raw = fs.readFileSync(file, 'utf-8');
+  const parsed = JSON.parse(raw) as { loadedAt: number; version: string; tools: string[] };
+  assert(parsed.loadedAt === 1700000000000, 'loadedAt round-trips');
+  assert(parsed.version === '3.3.2-rc.1', 'version round-trips');
+  assert(parsed.tools.length === 3, 'tools array preserved');
+  assert(parsed.tools[0] === 'totalreclaw_pair', 'first tool name preserved');
+
+  // Human-readable: pretty-printed JSON has at least one newline.
+  assert(raw.includes('\n'), 'JSON is pretty-printed (has newlines)');
+
+  rmrf(root);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2 — writePluginErrorManifest happy path.
+// ---------------------------------------------------------------------------
+{
+  const root = mkTmpRoot();
+  const ok = writePluginErrorManifest(root, {
+    loadedAt: 1700000001000,
+    error: 'register failed: bad config',
+    stack: 'Error: register failed\n    at register (index.ts:42)',
+  });
+  assert(ok === true, 'writePluginErrorManifest returns true on success');
+
+  const file = path.join(root, PLUGIN_ERROR_MANIFEST);
+  assert(fs.existsSync(file), `.error.json written at ${file}`);
+
+  const parsed = JSON.parse(fs.readFileSync(file, 'utf-8')) as {
+    loadedAt: number;
+    error: string;
+    stack: string;
+  };
+  assert(parsed.loadedAt === 1700000001000, 'loadedAt round-trips');
+  assert(parsed.error === 'register failed: bad config', 'error message round-trips');
+  assert(parsed.stack.startsWith('Error:'), 'stack round-trips');
+
+  rmrf(root);
+}
+
+// ---------------------------------------------------------------------------
+// Test 3 — clearPluginManifests removes both files when present.
+// ---------------------------------------------------------------------------
+{
+  const root = mkTmpRoot();
+  fs.writeFileSync(path.join(root, PLUGIN_LOADED_MANIFEST), '{}');
+  fs.writeFileSync(path.join(root, PLUGIN_ERROR_MANIFEST), '{}');
+
+  const removed = clearPluginManifests(root);
+  assert(removed === 2, 'clearPluginManifests reports 2 removed');
+  assert(!fs.existsSync(path.join(root, PLUGIN_LOADED_MANIFEST)), '.loaded.json deleted');
+  assert(!fs.existsSync(path.join(root, PLUGIN_ERROR_MANIFEST)), '.error.json deleted');
+
+  rmrf(root);
+}
+
+// ---------------------------------------------------------------------------
+// Test 4 — clearPluginManifests no-op on a clean dir.
+// ---------------------------------------------------------------------------
+{
+  const root = mkTmpRoot();
+  const removed = clearPluginManifests(root);
+  assert(removed === 0, 'clearPluginManifests on clean dir reports 0 removed');
+  rmrf(root);
+}
+
+// ---------------------------------------------------------------------------
+// Test 5 — writers return false when pluginRootDir does not exist (no throw).
+// ---------------------------------------------------------------------------
+{
+  const missing = path.join(os.tmpdir(), 'tr-issue-186-does-not-exist-' + Date.now());
+  const okLoaded = writePluginLoadedManifest(missing, {
+    loadedAt: 0,
+    version: null,
+    tools: [],
+  });
+  assert(okLoaded === false, 'writePluginLoadedManifest on missing dir returns false (no throw)');
+
+  const okError = writePluginErrorManifest(missing, {
+    loadedAt: 0,
+    error: 'x',
+    stack: '',
+  });
+  assert(okError === false, 'writePluginErrorManifest on missing dir returns false (no throw)');
+}
+
+// ---------------------------------------------------------------------------
+// Test 6 — version=null is preserved (package.json read can fail).
+// ---------------------------------------------------------------------------
+{
+  const root = mkTmpRoot();
+  writePluginLoadedManifest(root, {
+    loadedAt: 1700000002000,
+    version: null,
+    tools: ['totalreclaw_remember'],
+  });
+  const parsed = JSON.parse(
+    fs.readFileSync(path.join(root, PLUGIN_LOADED_MANIFEST), 'utf-8'),
+  ) as { version: string | null };
+  assert(parsed.version === null, 'version=null is preserved as JSON null');
+  rmrf(root);
+}
+
+// ---------------------------------------------------------------------------
+// Test 7 — empty tools array round-trips.
+// ---------------------------------------------------------------------------
+{
+  const root = mkTmpRoot();
+  writePluginLoadedManifest(root, {
+    loadedAt: 1700000003000,
+    version: '3.3.2-rc.1',
+    tools: [],
+  });
+  const parsed = JSON.parse(
+    fs.readFileSync(path.join(root, PLUGIN_LOADED_MANIFEST), 'utf-8'),
+  ) as { tools: string[] };
+  assert(Array.isArray(parsed.tools) && parsed.tools.length === 0, 'empty tools array preserved');
+  rmrf(root);
+}
+
+// ---------------------------------------------------------------------------
+console.log(`\n${passed}/${passed + failed} passed`);
+if (failed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
## What broke
Agent inside the gateway has no filesystem-based way to verify TR loaded — and `openclaw plugins list` hangs (sibling F1 #184), so the documented verification step is unusable.

## What's fixed
`register()` now writes `<pluginRoot>/.loaded.json` (`{ loadedAt, version, tools[] }`) on success and `<pluginRoot>/.error.json` (`{ loadedAt, error, stack }`) on failure. Stale manifests cleared on entry. Tool names captured by shadowing `api.registerTool` for the lifetime of `register()` — no edits to the ~16 existing call sites.

## Impact after fix
Agent can verify install with two `cat` commands:

```
cat ~/.openclaw/extensions/totalreclaw/.loaded.json
test -f ~/.openclaw/extensions/totalreclaw/.error.json && cat ~/.openclaw/extensions/totalreclaw/.error.json || echo "No error"
```

The `tools[]` field also lets the agent verify whether sibling F2 #185 (`totalreclaw_pair` not bound) is actually fixed once that lands.

## Verification
- Local plugin test suite GO: 59/59 + 30/30 + 49/49 + 99/99 + 22/22 + 37/37 + 14/14 + 34/34 + 73/73 + 9/9 + 14/14 + 16/16 + 51/51 + 2/2 + 16/16 + 27/27 + 14/14 + 11/11 + **20/20** (new test_issue_186_load_manifests.test.ts)
- check-scanner OK (114 files, 0 flags)
- check-version-drift OK (3.3.2-rc.1 across package.json + SKILL.md + skill.json)
- smoke:dist OK (4/4)
- New regression test asserts: write happy paths, JSON shape round-trip, clear-on-entry idempotency, missing-dir best-effort no-throw, null-version + empty-tools edge cases.
- Real chat-flow QA on staging deferred — staging install path is gated behind the same blockers (F1 #184 CLI hang, F2 #185 pair tool not bound) this fix is meant to help diagnose. Best verified once F1 + F2 land or via a clean inside-gateway QA run on rc.1.

## Coordination call (escalated)
Umbrella #182 explicitly recommends bundling F3 + F2 + direct-node fallback docs into one **3.3.2** hotfix release. F2 (#185) is currently `triage:escalated`; F1 (#184) is also `triage:escalated`. This PR is ready to merge but I'm holding off on auto-merge + RC publish until you decide:

- **Merge + publish 3.3.2-rc.1 alone now** — agent gets the manifest verification path immediately; subsequent RCs (rc.2…) fold in F2 fix when ready.
- **Hold this PR until F2 lands** — bundle F2 + F3 into a single 3.3.2-rc.1 publish per umbrella's plan.
- **Hold for a different bundle shape** — e.g. F1 must land first, or F3 should be deferred entirely.

Closes #186 (on merge — not yet merged).

🤖 Auto-triage pipeline (held for user review).