### PR TITLE
fix(plugin): 3.3.2-rc.1 hotfix bundle — load manifest + skill-side pair + atomic dep validation

### DIFF
--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,7 +4,83 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.3.2-rc.1] — 2026-04-27
+
+Hotfix bundle for the inside-gateway agent-flow ship-stoppers caught by the
+2026-04-27 user QA against stable 3.3.1 (umbrella issue #182). The four fixes
+combined unblock the agent-driven canonical install path.
+
+### Added — filesystem load manifest (issue #186)
+
+The plugin now writes `.loaded.json` and `.error.json` into its own
+extension directory at register-time. The agent has no working CLI inside
+the gateway (issue #182 finding F1 — `openclaw plugins list` hangs in
+some Docker setups), so the manifests are the canonical filesystem signal
+that register() ran to completion AND which tools the SDK saw.
+
+- `~/.openclaw/extensions/totalreclaw/.loaded.json` —
+  `{loadedAt: <ms>, tools: [<name>...], version: <semver>}`. Written
+  synchronously at the end of `register(api)`. Captures every tool name
+  passed to `api.registerTool` during the call.
+- `~/.openclaw/extensions/totalreclaw/.error.json` —
+  `{loadedAt, error, stack?, version?}`. Written from the try/catch
+  surrounding the register() body when register() throws. Successful
+  boots clear any stale `.error.json`; failed boots preserve any prior
+  `.loaded.json` so the agent can compare timestamps.
+
+Synchronous writes only (same constraint as `registerHttpRoute` — the SDK
+freezes plugin registries the moment register() returns; an async write
+would race that freeze and the manifest could miss late tool
+registrations).
+
+Regression: `load-manifest.test.ts` (22 assertions).
+
+### Added — `totalreclaw_pair` declared in skill manifest (issue #185)
+
+The `totalreclaw_pair` tool is now advertised in `skill.json` alongside
+`totalreclaw_remember`/`recall`/`forget`/`export`/`status`/`consolidate`/
+`upgrade`/`import_from`. Previously plugin-only — if the plugin runtime
+load failed silently (e.g. dep race in #188), the tool never appeared
+in the agent's toolset and the canonical setup flow was unreachable.
+
+The skill-side declaration ensures the tool name is visible in the
+skill registry advertisement even when plugin runtime issues prevent
+binding. The implementation remains in the plugin (browser-side
+e2e-encrypted recovery-phrase flow); only the declaration moves up.
+
+### Added — atomic dependency validation in postinstall (issue #188)
+
+`postinstall.mjs` is now a real lifecycle script (replacing the inline
+`node -e` shim). After `npm install`, it require()s every critical dep
+(`@scure/bip39`, `@scure/bip39/wordlists/english.js`, `@totalreclaw/core`,
+`@totalreclaw/client`, `qrcode`, `ws`). On first-attempt failure: clears
+`node_modules`, re-runs `npm install --ignore-scripts` once, re-validates.
+If retry also fails, exits non-zero so the install surfaces the failure
+instead of writing `enabled: true` over a broken half-state.
+
+The retry loop can be skipped with `TOTALRECLAW_SKIP_POSTINSTALL_RETRY=1`
+for sandboxed CI / restricted-network environments.
+
+Phrase-safety: the script does NOT touch credentials.json, mnemonics,
+or any phrase code path. Only validates module loading and cleans
+staging directories.
+
+### Added — install-stage cleanup at install-time (issue #190)
+
+`postinstall.mjs` extends the rc.21 staging-cleanup behavior (which ran
+at register-time) to ALSO sweep `<extensions>/.openclaw-install-stage-*`
+siblings during the post-install step itself. Goal: a re-install starts
+from a clean parent dir, eliminating the
+"duplicate plugin id detected; global plugin will be overridden by global
+plugin" warning during the install. Safety: skipped when the plugin's
+parent dir is not an `extensions/` directory (dev checkouts) so no random
+siblings are deleted.
+
+Regression: `postinstall-validation.test.ts` (17 assertions) covers
+happy path, marker clearing, staging sweep, idempotent re-runs,
+unrelated-dotfile preservation, and dev-checkout safety.
+
+
 
 ### Install / runtime hygiene (issues #126, #128)
 

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "Install + set up TotalReclaw encrypted memory for OpenClaw, then use totalreclaw_remember / totalreclaw_recall. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', or any remember / recall request."
-version: 3.3.1
+version: 3.3.2-rc.1
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz

--- a/skill/plugin/fs-helpers.ts
+++ b/skill/plugin/fs-helpers.ts
@@ -495,6 +495,130 @@ export function wipePartialInstall(pluginRootDir: string): boolean {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Plugin load manifest (.loaded.json / .error.json) — 3.3.2-rc.1 #186
+// ---------------------------------------------------------------------------
+
+/**
+ * Filenames written into the plugin root dir at the end of register() and
+ * (on failure) from the surrounding try/catch. The presence of `.loaded.json`
+ * is the canonical filesystem signal that the plugin's register() body ran
+ * to completion AND the SDK tool/route/hook registries received calls.
+ *
+ * Acceptance criteria (issue #186):
+ *   - `cat ~/.openclaw/extensions/totalreclaw/.loaded.json` shows
+ *     `{loadedAt, tools, version}` after every successful gateway start.
+ *   - `cat ~/.openclaw/extensions/totalreclaw/.error.json` shows
+ *     `{loadedAt, error, stack}` if register() threw.
+ *   - Both are overwritten on each register() call so the agent can rely
+ *     on the timestamp matching the most recent gateway start.
+ *
+ * Why these MUST be synchronous writes (same constraint as
+ * `registerHttpRoute` per the comment in index.ts around the route
+ * registration site): the SDK loader treats register() returning as the
+ * signal to freeze the registries. An async `fs.promises.writeFile` would
+ * settle one microtask AFTER the loader has moved on, so the manifest
+ * could miss tools that registered late OR drop entirely if the gateway
+ * exits before the microtask runs. `writeFileSync` is the only safe choice.
+ */
+export const PLUGIN_LOADED_MANIFEST = '.loaded.json';
+export const PLUGIN_ERROR_MANIFEST = '.error.json';
+
+/** Schema written to `.loaded.json` — see PLUGIN_LOADED_MANIFEST. */
+export interface PluginLoadManifest {
+  /** Unix epoch milliseconds when register() finished. */
+  loadedAt: number;
+  /** Tool names passed to api.registerTool() during register(). */
+  tools: string[];
+  /** Plugin version string from package.json (or "unknown"). */
+  version: string;
+}
+
+/** Schema written to `.error.json` when register() throws. */
+export interface PluginLoadError {
+  loadedAt: number;
+  error: string;
+  stack?: string;
+  version?: string;
+}
+
+/**
+ * Resolve the plugin root dir from the loaded module's directory. The plugin
+ * is shipped with `dist/index.js` as the entry, so `import.meta.url` resolves
+ * to `<root>/dist/`. We walk up one level to put the manifests next to
+ * `package.json`. Defensive: if the caller already passed the root (no
+ * trailing `dist`), we still return a sensible path.
+ */
+function resolvePluginRootForManifest(pluginDir: string): string {
+  const base = path.basename(pluginDir);
+  return base === 'dist' ? path.resolve(pluginDir, '..') : pluginDir;
+}
+
+/**
+ * Write the success manifest. SYNCHRONOUS — the SDK freezes the plugin
+ * registries the moment register() returns; `fs.promises.writeFile` would
+ * race that freeze and the manifest could miss late tool registrations or
+ * never land at all if the process exits before the microtask runs.
+ *
+ * Best-effort: returns `true` on success, `false` on any I/O error. Never
+ * throws — failing to write the manifest is a diagnostic loss, not a
+ * correctness loss, so we don't propagate.
+ *
+ * The manifest is written at mode 0644 (world-readable). It contains no
+ * secrets — only a timestamp, the (publicly known) tool names, and the
+ * plugin version. Cleared first so a stale `.error.json` from a previous
+ * failed boot doesn't survive a successful boot.
+ */
+export function writePluginManifest(
+  pluginDir: string,
+  manifest: PluginLoadManifest,
+): boolean {
+  try {
+    const root = resolvePluginRootForManifest(pluginDir);
+    if (!fs.existsSync(root)) return false;
+    const loadedPath = path.join(root, PLUGIN_LOADED_MANIFEST);
+    const errorPath = path.join(root, PLUGIN_ERROR_MANIFEST);
+    // Best-effort error-file cleanup — a successful boot supersedes any
+    // prior failure marker. If the unlink fails (e.g. permission), the
+    // .loaded.json timestamp still tells the agent which is current.
+    try {
+      if (fs.existsSync(errorPath)) fs.unlinkSync(errorPath);
+    } catch {
+      // Swallow — best-effort.
+    }
+    fs.writeFileSync(loadedPath, JSON.stringify(manifest, null, 2));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Write the error manifest. SYNCHRONOUS for the same reason as
+ * `writePluginManifest`. Called from the try/catch surrounding the
+ * register() body so the agent has a filesystem signal that the plugin
+ * registered AT LEAST attempted to load and failed in a specific way.
+ *
+ * Does NOT clear `.loaded.json` from a prior successful boot — keeping
+ * the older success marker around lets the agent see "last good boot was
+ * X, current boot failed at Y" without spelunking logs. The newer
+ * `.error.json` timestamp wins as "current state".
+ */
+export function writePluginError(
+  pluginDir: string,
+  error: PluginLoadError,
+): boolean {
+  try {
+    const root = resolvePluginRootForManifest(pluginDir);
+    if (!fs.existsSync(root)) return false;
+    const errorPath = path.join(root, PLUGIN_ERROR_MANIFEST);
+    fs.writeFileSync(errorPath, JSON.stringify(error, null, 2));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Drop the `.tr-partial-install` marker into `pluginRootDir`. Idempotent
  * (overwrites any existing marker) and best-effort — returns `true` on

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -164,6 +164,8 @@ import {
   cleanupInstallStagingDirs,
   detectPartialInstall,
   clearPartialInstallMarker,
+  writePluginManifest,
+  writePluginError,
   type OnboardingState,
 } from './fs-helpers.js';
 import { isRcBuild } from './qa-bug-report.js';
@@ -2857,6 +2859,50 @@ const plugin = {
 
   register(api: OpenClawPluginApi) {
     // ---------------------------------------------------------------
+    // 3.3.2-rc.1 (issue #186) — load manifest instrumentation
+    // ---------------------------------------------------------------
+    //
+    // Capture every `api.registerTool({name, ...})` call so we can write
+    // a `.loaded.json` manifest at the end of register(). Wrap the body
+    // in try/catch so a register-time throw produces `.error.json` for
+    // agent-side filesystem verification (the CLI hangs in some Docker
+    // setups — issue #182 — so the manifest is the canonical "did the
+    // plugin load?" probe).
+    //
+    // Implementation: we intercept the api.registerTool method by
+    // wrapping it on the api object passed in. The wrapper inspects the
+    // `name` field (every TR registerTool call sets it) and forwards
+    // verbatim. NO behavior change to the SDK call — the original method
+    // is invoked with original args and `this` binding.
+    //
+    // Synchronous writes ONLY (see writePluginManifest doc): the SDK
+    // freezes plugin registries the moment register() returns; an async
+    // write would race that freeze.
+    const _registeredToolNames: string[] = [];
+    const _originalRegisterTool = api.registerTool.bind(api);
+    api.registerTool = (tool: unknown, opts?: { name?: string; names?: string[] }) => {
+      try {
+        const t = tool as { name?: unknown } | null | undefined;
+        if (t && typeof t === 'object' && typeof t.name === 'string' && t.name.length > 0) {
+          _registeredToolNames.push(t.name);
+        }
+      } catch {
+        // Manifest is diagnostic; never let bookkeeping break tool registration.
+      }
+      _originalRegisterTool(tool, opts);
+    };
+
+    // Lazily resolved inside the try below — needed by both the manifest
+    // write and the error path. `dist/` after build, package root in tests.
+    let _pluginDirForManifest: string | null = null;
+
+    // NOTE: the body of register() below is intentionally NOT re-indented
+    // under this `try` block — re-indenting would touch every line in a
+    // 3,500-line function and obscure the actual hotfix diff. The closing
+    // `} catch (registerErr: unknown) { ... }` is at the very end of
+    // register() (search for "register() threw").
+    try {
+    // ---------------------------------------------------------------
     // RC-build detection (3.3.1-rc.3)
     // ---------------------------------------------------------------
     //
@@ -2880,6 +2926,7 @@ const plugin = {
       // `require('node:url')` — undefined under bare-ESM Node, broke the
       // before_agent_start hook in the published rc.20 bundle (issue #124).
       const pluginDir = nodePath.dirname(fileURLToPath(import.meta.url));
+      _pluginDirForManifest = pluginDir; // captured for #186 .loaded.json/.error.json
       pluginVersion = readPluginVersion(pluginDir);
       rcMode = isRcBuild(pluginVersion);
       if (rcMode) {
@@ -6296,6 +6343,60 @@ const plugin = {
       },
       { priority: 5 },
     );
+
+    // ---------------------------------------------------------------
+    // 3.3.2-rc.1 (issue #186) — write `.loaded.json` manifest
+    // ---------------------------------------------------------------
+    //
+    // Final step of register(): drop the success manifest so the agent
+    // can `cat ~/.openclaw/extensions/totalreclaw/.loaded.json` to
+    // verify which tools bound. Synchronous (see writePluginManifest doc).
+    // Never throws — diagnostic loss only on I/O failure.
+    if (_pluginDirForManifest) {
+      try {
+        const ok = writePluginManifest(_pluginDirForManifest, {
+          loadedAt: Date.now(),
+          tools: _registeredToolNames.slice(),
+          version: pluginVersion ?? 'unknown',
+        });
+        if (ok) {
+          api.logger.info(
+            `TotalReclaw: wrote .loaded.json manifest (${_registeredToolNames.length} tools, version=${pluginVersion ?? 'unknown'})`,
+          );
+        }
+      } catch {
+        // Best-effort; helper swallows internally too.
+      }
+    }
+    } catch (registerErr: unknown) {
+      // ---------------------------------------------------------------
+      // 3.3.2-rc.1 (issue #186) — write `.error.json` on register() throw
+      // ---------------------------------------------------------------
+      //
+      // Some surface threw out of register(). Drop a structured error
+      // marker the agent can grep. Best-effort logging then re-throw so
+      // the SDK sees the original failure.
+      const errMsg = registerErr instanceof Error ? registerErr.message : String(registerErr);
+      const errStack = registerErr instanceof Error ? registerErr.stack : undefined;
+      try {
+        api.logger.error(`TotalReclaw: register() threw: ${errMsg}`);
+      } catch {
+        // Logger may be unavailable (very early failure path).
+      }
+      if (_pluginDirForManifest) {
+        try {
+          writePluginError(_pluginDirForManifest, {
+            loadedAt: Date.now(),
+            error: errMsg,
+            stack: errStack,
+            version: 'unknown',
+          });
+        } catch {
+          // Best-effort.
+        }
+      }
+      throw registerErr;
+    }
   },
 };
 

--- a/skill/plugin/load-manifest.test.ts
+++ b/skill/plugin/load-manifest.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Regression test for issue #186 — `.loaded.json` / `.error.json` manifest writes.
+ *
+ * Asserts:
+ *   1. `writePluginManifest` writes `.loaded.json` with the expected schema
+ *      to the plugin root (parent of `dist/`).
+ *   2. The manifest captures the tools array verbatim (caller controls
+ *      collection — helper does not filter).
+ *   3. A successful `.loaded.json` write clears any pre-existing
+ *      `.error.json` from a prior failed boot.
+ *   4. `writePluginError` writes `.error.json` with `loadedAt` + `error`
+ *      + `stack`. It does NOT clear `.loaded.json` from a prior good boot
+ *      (so the agent sees both: "last successful boot was X, current
+ *      boot failed at Y").
+ *   5. Both helpers accept either the plugin root OR the `dist/` subdir
+ *      and resolve to the package root in both cases.
+ *   6. Helpers are best-effort: writing into a missing dir returns false,
+ *      never throws.
+ *
+ * Run with: `npx tsx load-manifest.test.ts`
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  writePluginManifest,
+  writePluginError,
+  PLUGIN_LOADED_MANIFEST,
+  PLUGIN_ERROR_MANIFEST,
+} from './fs-helpers.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond: boolean, name: string): void {
+  const n = passed + failed + 1;
+  if (cond) {
+    console.log(`ok ${n} - ${name}`);
+    passed++;
+  } else {
+    console.log(`not ok ${n} - ${name}`);
+    failed++;
+  }
+}
+
+function mkPluginTree(): { pluginRoot: string; pluginDist: string } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tr-load-manifest-'));
+  const pluginRoot = path.join(root, 'totalreclaw');
+  const pluginDist = path.join(pluginRoot, 'dist');
+  fs.mkdirSync(pluginDist, { recursive: true });
+  fs.writeFileSync(path.join(pluginDist, 'index.js'), '// stub');
+  fs.writeFileSync(path.join(pluginRoot, 'package.json'), JSON.stringify({ name: '@totalreclaw/totalreclaw', version: '3.3.2-rc.1' }));
+  return { pluginRoot, pluginDist };
+}
+
+function rmrf(p: string): void {
+  try { fs.rmSync(p, { recursive: true, force: true }); } catch { /* swallow */ }
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 — manifest written to plugin root with correct schema
+// ---------------------------------------------------------------------------
+{
+  const { pluginRoot, pluginDist } = mkPluginTree();
+  const ok = writePluginManifest(pluginDist, {
+    loadedAt: 1234567890,
+    tools: ['totalreclaw_remember', 'totalreclaw_recall', 'totalreclaw_pair'],
+    version: '3.3.2-rc.1',
+  });
+  assert(ok === true, 'writePluginManifest returns true on success');
+  const manifestPath = path.join(pluginRoot, PLUGIN_LOADED_MANIFEST);
+  assert(fs.existsSync(manifestPath), '.loaded.json exists at plugin root');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+  assert(manifest.loadedAt === 1234567890, 'loadedAt persisted');
+  assert(Array.isArray(manifest.tools) && manifest.tools.length === 3, 'tools array persisted');
+  assert(manifest.tools.includes('totalreclaw_pair'), 'pair tool name in manifest');
+  assert(manifest.version === '3.3.2-rc.1', 'version persisted');
+  rmrf(path.dirname(pluginRoot));
+}
+
+// ---------------------------------------------------------------------------
+// Test 2 — successful .loaded.json clears any pre-existing .error.json
+// ---------------------------------------------------------------------------
+{
+  const { pluginRoot, pluginDist } = mkPluginTree();
+  // Seed a stale error file from a prior failed boot.
+  fs.writeFileSync(path.join(pluginRoot, PLUGIN_ERROR_MANIFEST), JSON.stringify({ error: 'stale' }));
+  const ok = writePluginManifest(pluginDist, {
+    loadedAt: 999,
+    tools: [],
+    version: '3.3.2-rc.1',
+  });
+  assert(ok === true, 'manifest write succeeds');
+  assert(!fs.existsSync(path.join(pluginRoot, PLUGIN_ERROR_MANIFEST)), 'stale .error.json was cleared');
+  assert(fs.existsSync(path.join(pluginRoot, PLUGIN_LOADED_MANIFEST)), '.loaded.json present');
+  rmrf(path.dirname(pluginRoot));
+}
+
+// ---------------------------------------------------------------------------
+// Test 3 — error manifest is written with the expected schema
+// ---------------------------------------------------------------------------
+{
+  const { pluginRoot, pluginDist } = mkPluginTree();
+  const ok = writePluginError(pluginDist, {
+    loadedAt: 555,
+    error: 'register() blew up',
+    stack: 'at foo (bar.js:1:1)',
+    version: '3.3.2-rc.1',
+  });
+  assert(ok === true, 'writePluginError returns true on success');
+  const errPath = path.join(pluginRoot, PLUGIN_ERROR_MANIFEST);
+  assert(fs.existsSync(errPath), '.error.json exists');
+  const err = JSON.parse(fs.readFileSync(errPath, 'utf-8'));
+  assert(err.loadedAt === 555, 'error timestamp persisted');
+  assert(err.error === 'register() blew up', 'error message persisted');
+  assert(typeof err.stack === 'string' && err.stack.includes('foo'), 'stack persisted');
+  rmrf(path.dirname(pluginRoot));
+}
+
+// ---------------------------------------------------------------------------
+// Test 4 — error manifest does NOT clear .loaded.json from prior boot
+// ---------------------------------------------------------------------------
+{
+  const { pluginRoot, pluginDist } = mkPluginTree();
+  // Seed a successful prior-boot manifest.
+  fs.writeFileSync(
+    path.join(pluginRoot, PLUGIN_LOADED_MANIFEST),
+    JSON.stringify({ loadedAt: 100, tools: ['x'], version: '3.3.1' }),
+  );
+  // Now record a failure.
+  writePluginError(pluginDist, {
+    loadedAt: 200,
+    error: 'second boot died',
+  });
+  // Both should exist — agent can compare timestamps.
+  assert(fs.existsSync(path.join(pluginRoot, PLUGIN_LOADED_MANIFEST)), 'prior .loaded.json survives');
+  assert(fs.existsSync(path.join(pluginRoot, PLUGIN_ERROR_MANIFEST)), 'new .error.json present');
+  rmrf(path.dirname(pluginRoot));
+}
+
+// ---------------------------------------------------------------------------
+// Test 5 — both helpers work when called with the package root path
+// ---------------------------------------------------------------------------
+{
+  const { pluginRoot } = mkPluginTree();
+  const ok1 = writePluginManifest(pluginRoot, {
+    loadedAt: 1,
+    tools: ['a'],
+    version: '3.3.2-rc.1',
+  });
+  const ok2 = writePluginError(pluginRoot, { loadedAt: 2, error: 'x' });
+  // Note: in Test 5 the success-write happens first then the error-write,
+  // and writePluginError does NOT clear .loaded.json — but writePluginManifest
+  // DOES clear .error.json. So order matters. Reset between calls:
+  rmrf(pluginRoot);
+  fs.mkdirSync(path.join(pluginRoot, 'dist'), { recursive: true });
+  fs.writeFileSync(path.join(pluginRoot, 'package.json'), JSON.stringify({ name: '@totalreclaw/totalreclaw' }));
+
+  const okm = writePluginManifest(pluginRoot, { loadedAt: 1, tools: ['a'], version: 'v' });
+  assert(okm === true, 'manifest write via package-root path');
+  assert(fs.existsSync(path.join(pluginRoot, PLUGIN_LOADED_MANIFEST)), 'manifest at root');
+
+  const oke = writePluginError(pluginRoot, { loadedAt: 2, error: 'x' });
+  assert(oke === true, 'error write via package-root path');
+  assert(fs.existsSync(path.join(pluginRoot, PLUGIN_ERROR_MANIFEST)), 'error at root');
+  // Suppress unused warnings.
+  void ok1; void ok2;
+  rmrf(path.dirname(pluginRoot));
+}
+
+// ---------------------------------------------------------------------------
+// Test 6 — best-effort: writing into a non-existent dir returns false
+// ---------------------------------------------------------------------------
+{
+  const ghost = path.join(os.tmpdir(), 'tr-load-manifest-ghost-' + Date.now(), 'totalreclaw', 'dist');
+  const okm = writePluginManifest(ghost, { loadedAt: 0, tools: [], version: 'v' });
+  assert(okm === false, 'manifest write returns false (not throw) on missing dir');
+  const oke = writePluginError(ghost, { loadedAt: 0, error: 'x' });
+  assert(oke === false, 'error write returns false (not throw) on missing dir');
+}
+
+// ---------------------------------------------------------------------------
+console.log(`\n${passed}/${passed + failed} passed`);
+if (failed > 0) {
+  process.exit(1);
+}

--- a/skill/plugin/package-lock.json
+++ b/skill/plugin/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.1-rc.15",
+  "version": "3.3.2-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/totalreclaw",
-      "version": "3.3.1-rc.15",
+      "version": "3.3.2-rc.1",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@totalreclaw/client": "^1.2.0",
@@ -2367,7 +2368,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.1",
+  "version": "3.3.2-rc.1",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [
@@ -58,18 +58,19 @@
     "README.md",
     "CHANGELOG.md",
     "CLAWHUB.md",
-    "skill.json"
+    "skill.json",
+    "postinstall.mjs"
   ],
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.json --noCheck",
     "verify-tarball": "node ../scripts/verify-tarball.mjs",
-    "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx config.test.ts && npx tsx relay-headers.test.ts && npx tsx scope-address-visible.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx llm-client-retry.test.ts && npx tsx gateway-url.test.ts && npx tsx retype-setscope.test.ts && npx tsx tool-gating.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts && npx tsx pair-qr.test.ts && npx tsx pair-remote-client.test.ts && npx tsx qa-bug-report.test.ts && npx tsx nonce-serialization.test.ts && npx tsx phrase-safety-registry.test.ts && npx tsx test_issue_92_onnx_download_ux.test.ts && npx tsx onboard-pair-only.test.ts && npx tsx import-time-smoke.test.ts && npx tsx install-staging-cleanup.test.ts && npx tsx partial-install-detection.test.ts && npx tsx install-reload-idempotency.test.ts && npx tsx json-stdout-cleanliness.test.ts",
+    "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx config.test.ts && npx tsx relay-headers.test.ts && npx tsx scope-address-visible.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx llm-client-retry.test.ts && npx tsx gateway-url.test.ts && npx tsx retype-setscope.test.ts && npx tsx tool-gating.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts && npx tsx pair-qr.test.ts && npx tsx pair-remote-client.test.ts && npx tsx qa-bug-report.test.ts && npx tsx nonce-serialization.test.ts && npx tsx phrase-safety-registry.test.ts && npx tsx test_issue_92_onnx_download_ux.test.ts && npx tsx onboard-pair-only.test.ts && npx tsx import-time-smoke.test.ts && npx tsx install-staging-cleanup.test.ts && npx tsx partial-install-detection.test.ts && npx tsx install-reload-idempotency.test.ts && npx tsx json-stdout-cleanliness.test.ts && npx tsx load-manifest.test.ts && npx tsx postinstall-validation.test.ts",
     "smoke:dist": "npx tsx dist-esm-smoke.test.ts",
     "check-scanner": "node ../scripts/check-scanner.mjs",
     "check-version-drift": "node ../scripts/check-version-drift.mjs",
     "sync-version": "node ../scripts/sync-version.mjs",
     "preinstall": "node -e \"try{require('fs').writeFileSync('.tr-partial-install','');}catch{}\"",
-    "postinstall": "node -e \"try{require('fs').unlinkSync('.tr-partial-install');}catch{}\"",
+    "postinstall": "node ./postinstall.mjs",
     "prepack": "npm run build",
     "prepublishOnly": "node ../scripts/check-scanner.mjs && node ../scripts/check-version-drift.mjs"
   },

--- a/skill/plugin/postinstall-validation.test.ts
+++ b/skill/plugin/postinstall-validation.test.ts
@@ -1,0 +1,188 @@
+// scanner-sim: allow — *.test.ts files are excluded from the npm tarball (see "files" array in package.json) and never reach the OpenClaw runtime sandbox. This test spawns the postinstall.mjs CLI via execFileSync to validate its end-to-end behavior; the child_process import is only present in test infrastructure, not shipped code.
+/**
+ * Regression test for issue #188 — postinstall.mjs atomic dep validation.
+ * Regression test for issue #190 — postinstall sweeps `.openclaw-install-stage-*` siblings.
+ *
+ * Asserts (via subprocess execution since postinstall.mjs is a CLI script):
+ *   1. Running postinstall.mjs in a fresh (deps-resolvable) tree exits 0.
+ *   2. The `.tr-partial-install` marker is cleared if present.
+ *   3. The smoke check passes when all critical deps resolve.
+ *   4. (#190) Stale `.openclaw-install-stage-*` siblings in the parent
+ *      `extensions/` dir are removed when the postinstall runs from the
+ *      plugin root inside an `extensions/` parent.
+ *   5. The script's idempotent — re-running on a clean tree is a no-op.
+ *   6. The required `TOTALRECLAW_SKIP_POSTINSTALL_RETRY=1` escape hatch
+ *      works (the test sandbox cannot reach the npm registry, so the
+ *      retry path would always fail; we set the env var to skip it).
+ *
+ * Run with: `npx tsx postinstall-validation.test.ts`
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond: boolean, name: string): void {
+  const n = passed + failed + 1;
+  if (cond) {
+    console.log(`ok ${n} - ${name}`);
+    passed++;
+  } else {
+    console.log(`not ok ${n} - ${name}`);
+    failed++;
+  }
+}
+
+function rmrf(p: string): void {
+  try { fs.rmSync(p, { recursive: true, force: true }); } catch { /* swallow */ }
+}
+
+/**
+ * Stage a fake plugin-extensions tree with a symlinked node_modules so the
+ * postinstall script can resolve real critical deps. We re-use the test
+ * runner's already-installed node_modules to avoid a registry round-trip.
+ */
+function stageExtensionsTree(opts: { withStaging?: boolean; withMarker?: boolean }): {
+  extensionsDir: string;
+  pluginRoot: string;
+} {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tr-postinstall-test-'));
+  const extensionsDir = path.join(root, 'extensions');
+  const pluginRoot = path.join(extensionsDir, 'totalreclaw');
+  fs.mkdirSync(pluginRoot, { recursive: true });
+
+  // Copy postinstall.mjs into the staged plugin root (the script reads
+  // its own location to resolve siblings, so it must run in-tree).
+  fs.copyFileSync(path.join(here, 'postinstall.mjs'), path.join(pluginRoot, 'postinstall.mjs'));
+
+  // Symlink node_modules from the real plugin tree so require() works.
+  fs.symlinkSync(path.join(here, 'node_modules'), path.join(pluginRoot, 'node_modules'), 'dir');
+
+  if (opts.withMarker) {
+    fs.writeFileSync(path.join(pluginRoot, '.tr-partial-install'), '');
+  }
+  if (opts.withStaging) {
+    const stagingA = path.join(extensionsDir, '.openclaw-install-stage-aaa111');
+    const stagingB = path.join(extensionsDir, '.openclaw-install-stage-bbb222');
+    fs.mkdirSync(stagingA);
+    fs.mkdirSync(stagingB);
+  }
+  return { extensionsDir, pluginRoot };
+}
+
+function runPostinstall(pluginRoot: string): { stdout: string; stderr: string; status: number } {
+  try {
+    const out = execFileSync('node', ['./postinstall.mjs'], {
+      cwd: pluginRoot,
+      env: {
+        ...process.env,
+        TOTALRECLAW_SKIP_POSTINSTALL_RETRY: '1',
+      },
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { stdout: out, stderr: '', status: 0 };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string };
+    return {
+      stdout: typeof e.stdout === 'string' ? e.stdout : (e.stdout?.toString() ?? ''),
+      stderr: typeof e.stderr === 'string' ? e.stderr : (e.stderr?.toString() ?? ''),
+      status: e.status ?? -1,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 — happy path: marker cleared, deps validate, exit 0
+// ---------------------------------------------------------------------------
+{
+  const { extensionsDir, pluginRoot } = stageExtensionsTree({ withMarker: true });
+  const result = runPostinstall(pluginRoot);
+  assert(result.status === 0, 'postinstall exits 0 on a healthy tree');
+  assert(!fs.existsSync(path.join(pluginRoot, '.tr-partial-install')), '.tr-partial-install marker cleared');
+  assert(result.stdout.includes('smoke check OK'), 'smoke check OK message in stdout');
+  assert(result.stdout.includes('postinstall complete'), 'postinstall completion message');
+  rmrf(path.dirname(extensionsDir));
+}
+
+// ---------------------------------------------------------------------------
+// Test 2 — issue #190: stale `.openclaw-install-stage-*` siblings get swept
+// ---------------------------------------------------------------------------
+{
+  const { extensionsDir, pluginRoot } = stageExtensionsTree({ withStaging: true });
+  // Pre-check: 2 staging dirs exist before running the script.
+  assert(fs.existsSync(path.join(extensionsDir, '.openclaw-install-stage-aaa111')), 'staging dir A pre-exists');
+  assert(fs.existsSync(path.join(extensionsDir, '.openclaw-install-stage-bbb222')), 'staging dir B pre-exists');
+
+  const result = runPostinstall(pluginRoot);
+  assert(result.status === 0, 'postinstall exits 0 with staging cleanup');
+
+  // After-check: both staging dirs gone.
+  assert(!fs.existsSync(path.join(extensionsDir, '.openclaw-install-stage-aaa111')), 'staging dir A removed');
+  assert(!fs.existsSync(path.join(extensionsDir, '.openclaw-install-stage-bbb222')), 'staging dir B removed');
+  // The real plugin root must survive.
+  assert(fs.existsSync(pluginRoot), 'real plugin root survived sweep');
+  rmrf(path.dirname(extensionsDir));
+}
+
+// ---------------------------------------------------------------------------
+// Test 3 — sweep does NOT touch unrelated dotfile siblings
+// ---------------------------------------------------------------------------
+{
+  const { extensionsDir, pluginRoot } = stageExtensionsTree({ withStaging: false });
+  // Add a non-staging dotfile sibling — the sweep must not delete it.
+  const unrelated = path.join(extensionsDir, '.openclaw-cache');
+  fs.mkdirSync(unrelated);
+  // Add ONE staging dir to ensure the sweep block runs.
+  fs.mkdirSync(path.join(extensionsDir, '.openclaw-install-stage-targeted'));
+
+  const result = runPostinstall(pluginRoot);
+  assert(result.status === 0, 'postinstall exits 0 (mixed siblings)');
+  assert(fs.existsSync(unrelated), '.openclaw-cache sibling NOT touched');
+  assert(!fs.existsSync(path.join(extensionsDir, '.openclaw-install-stage-targeted')), 'staging dir removed');
+  rmrf(path.dirname(extensionsDir));
+}
+
+// ---------------------------------------------------------------------------
+// Test 4 — idempotent: a second run on a clean tree exits 0 and is a no-op
+// ---------------------------------------------------------------------------
+{
+  const { extensionsDir, pluginRoot } = stageExtensionsTree({});
+  const r1 = runPostinstall(pluginRoot);
+  assert(r1.status === 0, 'first run exits 0');
+  const r2 = runPostinstall(pluginRoot);
+  assert(r2.status === 0, 'second run exits 0 (idempotent)');
+  rmrf(path.dirname(extensionsDir));
+}
+
+// ---------------------------------------------------------------------------
+// Test 5 — when run outside an `extensions/` parent (dev checkout),
+//          the staging sweep is skipped safely.
+// ---------------------------------------------------------------------------
+{
+  // Stage a tree where the parent dir is NOT named `extensions` AND has
+  // no staging siblings (so the heuristic returns null).
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tr-postinstall-dev-'));
+  const pluginRoot = path.join(root, 'totalreclaw');
+  fs.mkdirSync(pluginRoot, { recursive: true });
+  fs.copyFileSync(path.join(here, 'postinstall.mjs'), path.join(pluginRoot, 'postinstall.mjs'));
+  fs.symlinkSync(path.join(here, 'node_modules'), path.join(pluginRoot, 'node_modules'), 'dir');
+
+  const result = runPostinstall(pluginRoot);
+  assert(result.status === 0, 'dev checkout postinstall exits 0');
+  assert(result.stdout.includes('skipping staging sweep'), 'sweep skipped for dev checkout');
+  rmrf(root);
+}
+
+// ---------------------------------------------------------------------------
+console.log(`\n${passed}/${passed + failed} passed`);
+if (failed > 0) {
+  process.exit(1);
+}

--- a/skill/plugin/postinstall.mjs
+++ b/skill/plugin/postinstall.mjs
@@ -1,0 +1,260 @@
+// scanner-sim: allow — postinstall scripts run during `npm install`, NOT inside the OpenClaw runtime sandbox. Per check-scanner.mjs guidance ("Moving the subprocess call into a separate post-install helper that OpenClaw sandboxes (NOT covered by this scanner)"), this file is the intended home for child_process usage. The plugin's runtime code (index.ts, etc.) stays scanner-clean; this file only runs once at install-time.
+/**
+ * postinstall.mjs — TotalReclaw plugin post-install lifecycle script.
+ *
+ * Runs after `npm install` finishes inside the plugin extension dir
+ * (`~/.openclaw/extensions/totalreclaw/`). Three jobs, in order:
+ *
+ *   1. Clean the partial-install marker (`.tr-partial-install`) that
+ *      `preinstall` dropped. Mirrors the inline shim that shipped in
+ *      pre-3.3.2 releases.
+ *   2. (3.3.2-rc.1 / issue #188) Smoke-check critical deps. After `npm
+ *      install` claims success we require() the modules whose absence
+ *      bricked rc.22 first-attempt installs (`@scure/bip39`,
+ *      `@scure/bip39/wordlists/english.js`, `@totalreclaw/core`,
+ *      `@totalreclaw/client`, `qrcode`, `ws`). If any throws, the
+ *      post-install fails LOUDLY — better than the rc.21 silent
+ *      half-install where `enabled: true` shipped with a missing dep.
+ *   3. (3.3.2-rc.1 / issue #190) Sweep `<extensions>/.openclaw-install-stage-*`
+ *      siblings. The runtime register() helper handles this on plugin
+ *      load too, but doing it here means a re-install starts from a
+ *      clean parent dir — no "duplicate plugin id detected; global
+ *      plugin will be overridden by global plugin" warning during the
+ *      install itself.
+ *
+ * Constraints:
+ *   - Must be idempotent: re-running on a clean tree is a no-op.
+ *   - Must not import any production module that itself runs `register()`
+ *     or makes outbound calls. We use only Node stdlib + dynamic require()
+ *     of the smoke-check deps.
+ *   - Must run in CommonJS-compatible Node ESM (the plugin's package.json
+ *     declares `"type": "module"`, so this file uses `.mjs` and
+ *     `createRequire` to call require() against the plugin's node_modules).
+ *
+ * Phrase-safety note: this file does NOT touch credentials.json, mnemonics,
+ * keys, or any phrase code path. It only validates module loading and
+ * cleans staging directories.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+import { execSync } from 'node:child_process';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+const PARTIAL_INSTALL_MARKER = '.tr-partial-install';
+
+// Order matters: light, fast modules first so a failure surfaces quickly.
+// `@scure/bip39/wordlists/english.js` is the EXACT path that bricked rc.21
+// (issue #188 — `Cannot find module '@scure/bip39/wordlists/english.js'`).
+const CRITICAL_DEPS = [
+  '@scure/bip39',
+  '@scure/bip39/wordlists/english.js',
+  '@totalreclaw/core',
+  '@totalreclaw/client',
+  'qrcode',
+  'ws',
+];
+
+function log(msg) {
+  process.stdout.write(`[totalreclaw postinstall] ${msg}\n`);
+}
+
+function warn(msg) {
+  process.stderr.write(`[totalreclaw postinstall] WARN: ${msg}\n`);
+}
+
+// ---------------------------------------------------------------------------
+// Step 1 — clear .tr-partial-install marker
+// ---------------------------------------------------------------------------
+
+function clearPartialInstallMarker() {
+  try {
+    const markerPath = path.join(here, PARTIAL_INSTALL_MARKER);
+    if (fs.existsSync(markerPath)) {
+      fs.unlinkSync(markerPath);
+      log('cleared .tr-partial-install marker');
+    }
+  } catch (err) {
+    // Best-effort. The runtime register() also clears this defensively.
+    warn(`could not clear .tr-partial-install marker: ${err.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Step 2 — atomic critical-dep validation (issue #188)
+// ---------------------------------------------------------------------------
+
+/**
+ * Try to require() each critical dep. Returns the list of names that
+ * failed; an empty array means everything resolved.
+ */
+function smokeCheckDeps() {
+  const missing = [];
+  for (const dep of CRITICAL_DEPS) {
+    try {
+      require(dep);
+    } catch (err) {
+      missing.push({ dep, message: err.message });
+    }
+  }
+  return missing;
+}
+
+/**
+ * Recovery path: if smoke-check fails, blow away the local node_modules
+ * tree the parent install populated and re-run `npm install --no-audit
+ * --no-fund --no-save --offline=false` once. This is meant to recover
+ * from race-condition partial-fetches (issue #188), NOT from a missing
+ * dep in package.json.
+ *
+ * If the second attempt also fails, exit non-zero so `openclaw plugins
+ * install` surfaces the failure to the agent rather than writing
+ * `enabled: true` over a broken install.
+ *
+ * Skipped if `TOTALRECLAW_SKIP_POSTINSTALL_RETRY=1` (CI / sandboxes that
+ * cannot reach the registry from inside the postinstall hook).
+ */
+function retryNpmInstall() {
+  if (process.env.TOTALRECLAW_SKIP_POSTINSTALL_RETRY === '1') {
+    warn('TOTALRECLAW_SKIP_POSTINSTALL_RETRY=1 — skipping retry');
+    return false;
+  }
+  try {
+    log('first-attempt smoke check failed — clearing node_modules and retrying npm install once...');
+    const nm = path.join(here, 'node_modules');
+    if (fs.existsSync(nm)) {
+      fs.rmSync(nm, { recursive: true, force: true });
+    }
+    // Note: we deliberately re-invoke npm install here. The `--ignore-scripts`
+    // flag is critical — without it we'd re-trigger this same postinstall
+    // and recurse forever.
+    execSync('npm install --no-audit --no-fund --ignore-scripts', {
+      cwd: here,
+      stdio: 'inherit',
+    });
+    log('retry npm install completed; re-validating deps');
+    return true;
+  } catch (err) {
+    warn(`retry npm install failed: ${err.message}`);
+    return false;
+  }
+}
+
+function validateDepsOrFail() {
+  const firstMiss = smokeCheckDeps();
+  if (firstMiss.length === 0) {
+    log(`smoke check OK (${CRITICAL_DEPS.length} critical deps resolved)`);
+    return;
+  }
+
+  warn(`smoke check failed on first attempt:`);
+  for (const m of firstMiss) {
+    warn(`  - ${m.dep}: ${m.message}`);
+  }
+
+  const retried = retryNpmInstall();
+  if (!retried) {
+    process.exitCode = 1;
+    throw new Error(
+      `TotalReclaw postinstall: critical deps missing after npm install — ` +
+        `[${firstMiss.map((m) => m.dep).join(', ')}]. ` +
+        `Re-run \`openclaw plugins install @totalreclaw/totalreclaw\` to retry, ` +
+        `or set TOTALRECLAW_SKIP_POSTINSTALL_RETRY=1 to bypass and surface the ` +
+        `original error.`,
+    );
+  }
+
+  const secondMiss = smokeCheckDeps();
+  if (secondMiss.length === 0) {
+    log(`smoke check OK after retry (${CRITICAL_DEPS.length} deps resolved)`);
+    return;
+  }
+
+  process.exitCode = 1;
+  throw new Error(
+    `TotalReclaw postinstall: deps still missing after retry — ` +
+      `[${secondMiss.map((m) => m.dep).join(', ')}]. ` +
+      `This is likely a permanent breakage (registry outage, package rename, ` +
+      `or corrupted node_modules). The plugin will not load. Original errors:\n` +
+      secondMiss.map((m) => `  - ${m.dep}: ${m.message}`).join('\n'),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 3 — sweep `.openclaw-install-stage-*` siblings (issue #190)
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the OpenClaw extensions dir from the plugin's own location.
+ * The plugin lives at `<extensions>/totalreclaw/` so the parent is the
+ * extensions root. Returns null if the layout is not what we expect
+ * (npm tarball linked outside an `<extensions>/` parent — e.g. dev
+ * checkout) so we never delete random siblings.
+ */
+function resolveExtensionsDir() {
+  // `here` is the plugin root (this file is at the package root, NOT in dist/).
+  // The parent should be the OpenClaw extensions directory.
+  const parent = path.resolve(here, '..');
+  // Heuristic check: only sweep if we look like we're inside an OpenClaw
+  // install dir. We accept (a) the well-known `extensions` dirname, OR
+  // (b) the presence of any sibling `.openclaw-install-stage-*` (which is
+  // proof we're inside an extensions dir).
+  if (path.basename(parent) === 'extensions') return parent;
+  try {
+    const entries = fs.readdirSync(parent);
+    if (entries.some((n) => n.startsWith('.openclaw-install-stage-'))) {
+      return parent;
+    }
+  } catch {
+    // Parent unreadable — bail safely.
+  }
+  return null;
+}
+
+function sweepStagingSiblings() {
+  const extensionsDir = resolveExtensionsDir();
+  if (!extensionsDir) {
+    log('no extensions parent detected (dev checkout?) — skipping staging sweep');
+    return;
+  }
+  let removed = 0;
+  let entries;
+  try {
+    entries = fs.readdirSync(extensionsDir);
+  } catch (err) {
+    warn(`could not list ${extensionsDir}: ${err.message}`);
+    return;
+  }
+  for (const name of entries) {
+    if (!name.startsWith('.openclaw-install-stage-')) continue;
+    const target = path.join(extensionsDir, name);
+    try {
+      const st = fs.lstatSync(target);
+      if (!st.isDirectory()) continue;
+      fs.rmSync(target, { recursive: true, force: true });
+      removed++;
+      log(`removed stale staging dir: ${name}`);
+    } catch (err) {
+      warn(`could not remove ${name}: ${err.message}`);
+    }
+  }
+  if (removed === 0) {
+    log('no stale staging dirs to sweep');
+  } else {
+    log(`swept ${removed} stale staging dir(s)`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+clearPartialInstallMarker();
+sweepStagingSiblings();
+validateDepsOrFail();
+
+log('postinstall complete');

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "3.3.1",
+  "version": "3.3.2-rc.1",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",
@@ -173,6 +173,19 @@
             "required": false,
             "default": false,
             "description": "Preview consolidation without deleting"
+          }
+        }
+      },
+      {
+        "name": "totalreclaw_pair",
+        "description": "Set up the user's TotalReclaw account (encrypted, browser-side recovery-phrase generation or import). Returns an account-setup URL, a 6-digit PIN, and an ASCII QR code that the agent relays to the user. The recovery phrase is generated/entered in the BROWSER and uploaded end-to-end encrypted to this gateway — it NEVER touches the LLM provider or the chat transcript. This is the canonical agent-facilitated account-setup surface. Tool name kept for backward compatibility — function-wise this is the account-setup tool.",
+        "parameters": {
+          "mode": {
+            "type": "string",
+            "required": false,
+            "enum": ["generate", "import"],
+            "default": "generate",
+            "description": "\"generate\" = browser will create a NEW recovery phrase. \"import\" = browser will accept an EXISTING phrase pasted by the user in their browser (never through chat)."
           }
         }
       }

--- a/skill/skill.json
+++ b/skill/skill.json
@@ -175,6 +175,19 @@
             "description": "Preview consolidation without deleting"
           }
         }
+      },
+      {
+        "name": "totalreclaw_pair",
+        "description": "Set up the user's TotalReclaw account (encrypted, browser-side recovery-phrase generation or import). Returns an account-setup URL, a 6-digit PIN, and an ASCII QR code that the agent relays to the user. The recovery phrase is generated/entered in the BROWSER and uploaded end-to-end encrypted to this gateway — it NEVER touches the LLM provider or the chat transcript. This is the canonical agent-facilitated account-setup surface. Tool name kept for backward compatibility — function-wise this is the account-setup tool.",
+        "parameters": {
+          "mode": {
+            "type": "string",
+            "required": false,
+            "enum": ["generate", "import"],
+            "default": "generate",
+            "description": "\"generate\" = browser will create a NEW recovery phrase. \"import\" = browser will accept an EXISTING phrase pasted by the user in their browser (never through chat)."
+          }
+        }
       }
     ],
     "config": {


### PR DESCRIPTION
## Summary

Hotfix bundle for OpenClaw plugin **3.3.2-rc.1** — addresses the four ship-stoppers from the 2026-04-27 user QA against stable 3.3.1 that combined to make the agent-driven inside-gateway install path completely broken.

Refs: p-diogo/totalreclaw-internal#182 (umbrella) · #185 · #186 · #188 · #190

## Fixes

### #186 — filesystem load manifest
The plugin now writes `.loaded.json` and `.error.json` into its own extension directory at register-time.

- `~/.openclaw/extensions/totalreclaw/.loaded.json` — `{loadedAt, tools: [<name>...], version}`. Written synchronously at the end of `register(api)`; the wrapper intercepts `api.registerTool` to capture the name list as registrations occur.
- `~/.openclaw/extensions/totalreclaw/.error.json` — `{loadedAt, error, stack?, version?}`. Written from a try/catch surrounding the register() body when register() throws. Successful boots clear any stale `.error.json`; failed boots preserve any prior `.loaded.json` so the agent can compare timestamps.

Why this matters: `openclaw plugins list` hangs in some Docker setups (#182 finding F1) so the manifests are the canonical filesystem-side signal that the plugin loaded.

Synchronous writes only (same constraint as `registerHttpRoute` per existing comment in the route registration code — the SDK freezes plugin registries the moment register() returns).

Implementation note: the body of `register()` is wrapped in `try { ... } catch (registerErr) { ... }` but is intentionally NOT re-indented under the new try block. Re-indenting would touch every line in a 3,500-line function and obscure the actual hotfix diff. A leading comment in `index.ts` documents this.

### #185 — `totalreclaw_pair` declared in skill manifest
Added the `totalreclaw_pair` tool declaration to both `skill/skill.json` and `skill/plugin/skill.json`. Previously plugin-only — if the plugin runtime load failed silently (e.g. dep race in #188), the tool never appeared in the agent's toolset and the canonical setup flow was unreachable.

The skill-side declaration ensures the tool name is visible in the skill registry advertisement even when plugin runtime issues prevent binding. The implementation remains in the plugin (browser-side e2e-encrypted recovery-phrase flow); only the declaration moves up.

**Note for handler resolution:** the skill manifest now advertises `totalreclaw_pair` but the actual handler lives in the plugin's `register()` and is bound via `api.registerTool(...)`. OpenClaw's tool dispatcher prefers the plugin-side handler when it exists; the skill-side declaration is a discovery hint. If a future OpenClaw version gates handler resolution on skill-side handler presence, we may need to bind a stub on the skill side that delegates to the plugin route — to be evaluated in QA.

### #188 — atomic dep validation in `postinstall.mjs`
Replaced the inline `node -e` shim with a real `postinstall.mjs` lifecycle script. After `npm install`:

1. Clear the `.tr-partial-install` marker (preserves rc.22 behavior).
2. Sweep `<extensions>/.openclaw-install-stage-*` siblings (#190 — see below).
3. `require()` every critical dep: `@scure/bip39`, `@scure/bip39/wordlists/english.js`, `@totalreclaw/core`, `@totalreclaw/client`, `qrcode`, `ws`.
4. On first-attempt smoke-check failure: clear `node_modules`, re-run `npm install --ignore-scripts` once, re-validate.
5. Exit non-zero on second-attempt failure so the install surfaces the failure instead of writing `enabled: true` over a broken half-state.

Escape hatch: `TOTALRECLAW_SKIP_POSTINSTALL_RETRY=1` skips the registry round-trip for sandboxed CI.

The script imports `child_process` (necessary for `npm install` retry), so it carries a `// scanner-sim: allow` comment on line 1. This is the explicitly-supported pattern per the comment in `check-scanner.mjs` ("Moving the subprocess call into a separate post-install helper that OpenClaw sandboxes (NOT covered by this scanner)") — postinstall scripts run during `npm install` outside the OpenClaw runtime sandbox.

Phrase-safety: this file does NOT touch `credentials.json`, mnemonics, keys, or any phrase code path.

### #190 — install-stage cleanup before re-install
`postinstall.mjs` extends the rc.21 register-time staging-cleanup behavior to ALSO sweep `<extensions>/.openclaw-install-stage-*` siblings during the post-install step itself. Goal: a re-install starts from a clean parent dir, eliminating the `duplicate plugin id detected; global plugin will be overridden by global plugin` warning during the install.

Safety: skipped when the plugin's parent dir is not an `extensions/` directory AND no `.openclaw-install-stage-*` siblings are present (dev checkouts) so no random siblings are deleted.

## Version bump

- `skill/plugin/package.json`: `3.3.1` → `3.3.2-rc.1`
- `skill/plugin/SKILL.md` frontmatter + `skill/plugin/skill.json` synced via `skill/scripts/sync-version.mjs`
- `skill/skill.json` (outer skill manifest) is independent — keeps its own `3.6.0` version (unchanged)

## Tests added

- `load-manifest.test.ts` — 22 assertions covering manifest schema, success → error transitions, error → success transitions, package-root vs `dist/` path resolution, missing-dir best-effort safety.
- `postinstall-validation.test.ts` — 17 assertions covering happy path, `.tr-partial-install` marker clearing, `.openclaw-install-stage-*` staging sweep (#190), idempotent re-runs, unrelated-dotfile preservation, dev-checkout (non-`extensions/` parent) safety.

Both tests added to the `npm test` script in `package.json`.

All existing tests still pass. `check-scanner.mjs` and `check-version-drift.mjs` prepublish gates pass.

## Test plan

- [x] `npm test` (full suite) passes — 25 test files, ~580 assertions
- [x] `npm run build` produces a clean `dist/index.js` that imports without error
- [x] `node skill/scripts/check-scanner.mjs` returns 0 (116 files, 0 flags)
- [x] `node skill/scripts/check-version-drift.mjs` returns 0 (all three sites = 3.3.2-rc.1)
- [x] `npm install --no-audit --no-fund` runs the new postinstall.mjs cleanly (smoke check passes)
- [ ] **QA on staging** — RC publish + qa-totalreclaw against `api-staging.totalreclaw.xyz` (post-merge): exercise inside-gateway install via natural-language chat, verify `.loaded.json` written with full tools list, verify `totalreclaw_pair` advertised, verify no duplicate-plugin-id warnings on re-install.
- [ ] **Cross-client portability** — same mnemonic → identical Smart Account address from rc.1 plugin and Hermes 2.3.1.

## Out of scope

- The other umbrella sub-issues (#187 ONNX catch-22, #189 ClawHub stable tag drift) are NOT addressed here. They were either already fixed in rc.21/22 or require infra-side work (#189 git-tag backfill is in PR #152 and just merged to main).
- Direct-node fallback in the user-setup guide (umbrella recommendation) is documentation-only and lives in a separate PR.

## Do NOT auto-merge

Per CLAUDE.md autonomy matrix and the user's manual QA pending — this PR is intentionally not labeled `auto-merge`. RC publish + auto-QA dispatch happens after human review of the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)