### PR TITLE
fix(hermes): 2.3.2-rc.1 — auto-extraction in daemon mode + eager relay account creation

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -12,7 +12,7 @@ name = "totalreclaw"
 # which would have caused stable builds to mis-publish AND broke the
 # regex-based mutation logic on subsequent RCs. Keep this at the next
 # stable target with NO rc suffix. F3 fix in rc.24.
-version = "2.3.1"
+version = "2.3.2"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"

--- a/python/src/totalreclaw/agent/state.py
+++ b/python/src/totalreclaw/agent/state.py
@@ -236,6 +236,18 @@ class AgentState:
             creds_path.write_text(json.dumps({"mnemonic": mnemonic}))
             creds_path.chmod(0o600)
 
+        # 2.3.2-rc.1 (#192): clear any stale eager-account-register
+        # latch attached by ``totalreclaw.hermes.hooks._eager_account_
+        # register``. If the user re-pairs (different mnemonic) mid-
+        # session, the new SA needs its own first-contact request to
+        # the relay; without resetting the latch we'd silently skip
+        # account creation for the new SA.
+        if hasattr(self, "_eager_account_registered"):
+            try:
+                delattr(self, "_eager_account_registered")
+            except AttributeError:
+                pass
+
         # Do NOT read `self._client.wallet_address` here — it raises until
         # `resolve_address()` has run, and `configure()` is synchronous. The
         # EOA is what we have at this point; the Smart Account address is

--- a/python/src/totalreclaw/hermes/hooks.py
+++ b/python/src/totalreclaw/hermes/hooks.py
@@ -20,6 +20,7 @@ from totalreclaw.agent.lifecycle import (
     _owner_addresses,
     STORE_DEDUP_THRESHOLD,
 )
+from totalreclaw.agent.loop_runner import run_sync
 from totalreclaw.agent.pending_drain import drain_pending, has_pending
 from totalreclaw.agent.recall import auto_recall
 from totalreclaw.agent.extraction import extract_facts_llm, extract_facts_heuristic
@@ -93,6 +94,126 @@ def _get_hermes_llm_config():
         return None
 
 
+def _maybe_reconfigure_from_disk(state: "PluginState") -> bool:
+    """Re-read ``~/.totalreclaw/credentials.json`` and reconfigure ``state``
+    if creds appeared after the plugin was loaded (issue #191 root cause).
+
+    DAEMON-MODE flow that this fixes
+    ---------------------------------
+    The Hermes gateway is a single long-lived process. The TotalReclaw
+    plugin is loaded ONCE at gateway startup, which constructs a single
+    ``PluginState`` instance via ``register()``. That ctor calls
+    ``_try_auto_configure()`` which reads ``credentials.json`` if it
+    already exists. If the user pairs AFTER the gateway has booted, the
+    pair flow's completion path (sidecar subprocess in rc.24+) writes
+    the creds file but the gateway's in-memory ``state`` is never
+    notified. ``state.is_configured()`` stays False, so every
+    ``post_llm_call`` returns at the early check on line ~273 and NO
+    auto-extraction ever fires for the rest of the gateway's lifetime
+    — the user has to restart the gateway to pick up creds, which is
+    what ``totalreclaw_pair``'s instructions tell them to do.
+
+    Stable 2.3.1 user QA on 2026-04-27 hit exactly this: paired via
+    the chat-driven setup flow, did not restart the gateway, then had
+    a multi-turn natural conversation with NO extractions firing —
+    matching the symptom in QA-bug #191.
+
+    The lazy reconfigure here removes that restart requirement. Called
+    on every ``on_session_start`` (cheap — file-stat) and as a safety
+    net at the head of ``pre_llm_call`` / ``post_llm_call`` if the
+    state is still unconfigured. Idempotent: short-circuits when
+    ``state.is_configured()`` is already True.
+
+    Returns ``True`` if a reconfigure happened (state was unconfigured
+    and is now configured), ``False`` otherwise.
+    """
+    if state.is_configured():
+        return False
+    try:
+        # ``_try_auto_configure`` re-reads env + creds.json and calls
+        # ``state.configure()`` if it finds a usable mnemonic. Idempotent
+        # on the disk side — same canonical creds file shape stays put.
+        state._try_auto_configure()
+    except Exception as exc:  # pragma: no cover — best-effort
+        logger.debug("TotalReclaw: lazy reconfigure failed: %s", exc)
+        return False
+    if state.is_configured():
+        logger.info(
+            "TotalReclaw: lazy reconfigure picked up credentials.json "
+            "written after plugin load (daemon-mode pair flow). "
+            "Auto-extraction is now active."
+        )
+        return True
+    return False
+
+
+def _eager_account_register(state: "PluginState") -> None:
+    """Issue a one-shot ``client.status()`` so the relay creates the
+    account record eagerly — fix for QA-bug #192.
+
+    Why
+    ---
+    Pair-completion writes credentials.json + builds a TotalReclaw
+    client object, but the relay only LEARNS about the smart-account
+    address when it sees an authenticated request keyed on it. Before
+    this hook ran, the first such request was whichever tool the LLM
+    happened to call next (often ``totalreclaw_status`` AFTER the user
+    explicitly asked "what's my quota?", per the QA report). On a
+    fresh setup that means the staging relay had no account record
+    until the user manually probed.
+
+    Auto-extraction (fix for #191 above) is also a relay-write path,
+    so without this eager probe the FIRST extraction batch would race
+    the implicit account creation; the relay handles that race fine
+    today (account is created on first wallet-keyed request) but the
+    user sees no observable account until they probe — and any
+    relay-side billing logic that gates on account-existing would
+    silently no-op the first batch.
+
+    What this does
+    --------------
+    Calls ``state.get_client().status()`` once per state-configure
+    event via ``run_sync``. ``client.status()`` resolves the SA
+    address (``_ensure_address``), registers the auth key
+    (``_ensure_registered``), and hits ``GET /v1/billing/status?
+    wallet_address=<sa>`` — all of which together are what the relay
+    treats as "first contact" for an account. Best-effort: any
+    exception is logged at DEBUG and swallowed so the gateway never
+    crashes on a relay outage.
+
+    Idempotent across the gateway lifetime: the per-state ``_eager_
+    account_registered`` attribute (ad-hoc, mirrors the existing
+    ``_totalreclaw_*`` attribute pattern in this module) suppresses
+    repeat calls. Cleared whenever ``state.configure()`` re-runs,
+    via the explicit reset in :func:`_maybe_reconfigure_from_disk`.
+    """
+    if not state.is_configured():
+        return
+    if getattr(state, "_eager_account_registered", False):
+        return
+    client = state.get_client()
+    if client is None:
+        return
+    try:
+        # ``client.status`` runs the full first-contact handshake:
+        # SA derivation → auth-key register → /v1/billing/status. A
+        # 200 from the billing endpoint with the SA on it is exactly
+        # what triggers the relay-side account record.
+        run_sync(client.status())
+        state._eager_account_registered = True
+        logger.info(
+            "TotalReclaw: eager account register completed (relay "
+            "now has account record for SA before any extraction)."
+        )
+    except Exception as exc:
+        # Don't latch the flag — let the next session_start retry.
+        logger.debug(
+            "TotalReclaw: eager account register failed (will retry "
+            "next session_start): %s",
+            exc,
+        )
+
+
 def on_session_start(state: "PluginState", **kwargs) -> None:
     """Initialize client, drain any pending extraction queue, and check billing.
 
@@ -100,14 +221,32 @@ def on_session_start(state: "PluginState", **kwargs) -> None:
     previous CLI one-shot turn — see issue #148 + ``pending_drain``. The
     interpreter is healthy at session start, so the persistent sync-loop
     runner can drive httpx normally.
+
+    DAEMON-MODE FIXES (2.3.2-rc.1):
+      * Lazy reconfigure (#191): if creds.json appeared on disk after
+        the gateway loaded the plugin (the user paired mid-conversation
+        and the sidecar wrote creds without restart), pick them up here
+        instead of forcing a gateway restart.
+      * Eager account register (#192): once configured, call
+        ``client.status()`` once so the relay creates the account
+        record before the user explicitly queries it.
     """
     session_id = kwargs.get("session_id", "")
     logger.debug("TotalReclaw on_session_start: %s", session_id)
 
     state.reset_turn_counter()
 
+    # Fix #191 — pick up creds written after plugin load. Cheap (one
+    # file-stat) when the state is already configured.
+    _maybe_reconfigure_from_disk(state)
+
     if not state.is_configured():
         return
+
+    # Fix #192 — register account with relay eagerly so the first
+    # extraction (or any future write) doesn't race silent account-
+    # creation server-side.
+    _eager_account_register(state)
 
     # Drain any messages that a prior interpreter-shutdown race deferred.
     # This must run before billing-cache logic so a drain-induced
@@ -213,6 +352,16 @@ def pre_llm_call(state: "PluginState", **kwargs) -> Optional[dict]:
     user_message = kwargs.get("user_message", "")
     is_first_turn = kwargs.get("is_first_turn", False)
 
+    # Fix #191 safety net — if the user paired AFTER on_session_start
+    # already ran (e.g. they paired mid-session inside the same daemon
+    # session id), pick up creds.json before we decide whether to inject
+    # the unconfigured-user nudge or the configured-user tool-priority
+    # nudge. Cheap when the state is already configured (early return).
+    if _maybe_reconfigure_from_disk(state):
+        # Reconfigure just landed — also kick off the eager account
+        # register so #192 stays fixed for the mid-session pair path.
+        _eager_account_register(state)
+
     # Bug #6 — unconfigured: one-time setup nudge, fires only when the
     # user message looks like a memory intent. We never return None here
     # so the Hermes agent sees the nudge as soon as memory semantics hit.
@@ -269,6 +418,12 @@ def post_llm_call(state: "PluginState", **kwargs) -> None:
     state.increment_turn()
     state.add_message("user", kwargs.get("user_message", ""))
     state.add_message("assistant", kwargs.get("assistant_response", ""))
+
+    # Fix #191 safety net — same rationale as in pre_llm_call. If the
+    # user paired between on_session_start and now, this picks up the
+    # creds without a gateway restart. Idempotent + cheap.
+    if _maybe_reconfigure_from_disk(state):
+        _eager_account_register(state)
 
     if not state.is_configured():
         return

--- a/python/tests/test_issue_191_192_daemon_pair_lazy_reconfigure.py
+++ b/python/tests/test_issue_191_192_daemon_pair_lazy_reconfigure.py
@@ -1,0 +1,315 @@
+"""Regression tests for issues #191 (auto-extraction not firing in
+daemon mode) and #192 (lazy relay account creation).
+
+Both bugs surfaced during user manual QA on stable 2.3.1 (2026-04-27)
+running Hermes in DAEMON mode (gateway-served chat via Telegram). The
+common root cause: the gateway's plugin singleton is constructed ONCE
+at boot, and in rc.24+ the pair-completion sidecar runs in a SEPARATE
+PROCESS that writes ``~/.totalreclaw/credentials.json`` without any
+in-process notification to the gateway-side ``PluginState``.
+
+Pre-2.3.2 effect:
+
+* ``state.is_configured()`` stays ``False`` for the gateway's full
+  lifetime (or until the user manually restarted the gateway, per the
+  ``totalreclaw_pair`` instructions). Every ``post_llm_call`` hook
+  early-returns at the ``if not state.is_configured(): return``
+  guard, so no auto-extraction ever runs. → bug #191.
+* The relay only learns the account exists when an authenticated,
+  wallet-keyed request hits it (e.g. ``totalreclaw_status``). Until
+  the user explicitly probed (`"what's my quota?"`), the staging
+  relay had no account record. → bug #192.
+
+The 2.3.2-rc.1 fix adds two helpers in ``totalreclaw.hermes.hooks``:
+
+* ``_maybe_reconfigure_from_disk(state)`` re-reads creds.json on every
+  ``on_session_start`` / ``pre_llm_call`` / ``post_llm_call`` entry.
+  Cheap on the configured-state hot path (early return on
+  ``is_configured()``), and idempotent on disk.
+* ``_eager_account_register(state)`` issues a one-shot
+  ``client.status()`` once per state-configure event so the relay
+  side gets an authenticated wallet-keyed request before any
+  extraction batch fires.
+
+These tests pin the contract:
+
+1. ``_maybe_reconfigure_from_disk`` reconfigures when creds appeared
+   after PluginState construction; otherwise it's a no-op.
+2. ``post_llm_call`` in daemon mode picks up creds written mid-flight
+   and starts firing extraction on the next per-N-turns boundary.
+3. ``on_session_start`` calls ``client.status()`` once per state-
+   configure event for eager relay-side account creation.
+4. ``state.configure()`` clears the eager-register latch so re-pairing
+   with a different mnemonic re-registers the new SA.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _tmp_home(monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ``Path.home()`` to a fresh temp dir for the test."""
+    tmpdir = tempfile.mkdtemp()
+    monkeypatch.setenv("HOME", tmpdir)
+    monkeypatch.setattr(Path, "home", lambda: Path(tmpdir))
+    return Path(tmpdir)
+
+
+def _write_creds(home: Path, mnemonic: str) -> None:
+    """Materialize a canonical credentials.json under ``home``."""
+    creds_dir = home / ".totalreclaw"
+    creds_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    (creds_dir / "credentials.json").write_text(
+        json.dumps({"mnemonic": mnemonic})
+    )
+
+
+def _stub_client(*_, **__):
+    """Drop-in stub for ``totalreclaw.client.TotalReclaw``."""
+    c = MagicMock()
+    c._eoa_address = "0xeoatest"
+    c._sa_address = None
+    c.smart_account_address = None
+    c.wallet_address = "0xeoatest"
+    return c
+
+
+_VALID_MNEMONIC = (
+    "abandon abandon abandon abandon abandon abandon "
+    "abandon abandon abandon abandon abandon about"
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. _maybe_reconfigure_from_disk contract
+# ---------------------------------------------------------------------------
+
+
+def test_maybe_reconfigure_picks_up_creds_written_after_init(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The whole point of the fix: when creds.json appears AFTER the
+    plugin constructed its state (rc.24+ sidecar pair flow), the next
+    hook call must reconfigure without a gateway restart.
+    """
+    home = _tmp_home(monkeypatch)
+    monkeypatch.delenv("TOTALRECLAW_RECOVERY_PHRASE", raising=False)
+
+    from totalreclaw.hermes.state import PluginState
+    from totalreclaw.hermes.hooks import _maybe_reconfigure_from_disk
+
+    with patch("totalreclaw.client.TotalReclaw", side_effect=_stub_client):
+        state = PluginState()
+        assert not state.is_configured(), "no creds yet on init"
+
+        # Sidecar writes creds mid-session.
+        _write_creds(home, _VALID_MNEMONIC)
+
+        # The reconfigure helper must pick them up.
+        did = _maybe_reconfigure_from_disk(state)
+        assert did is True
+        assert state.is_configured()
+
+
+def test_maybe_reconfigure_is_no_op_when_already_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = _tmp_home(monkeypatch)
+    monkeypatch.delenv("TOTALRECLAW_RECOVERY_PHRASE", raising=False)
+    _write_creds(home, _VALID_MNEMONIC)
+
+    from totalreclaw.hermes.state import PluginState
+    from totalreclaw.hermes.hooks import _maybe_reconfigure_from_disk
+
+    with patch("totalreclaw.client.TotalReclaw", side_effect=_stub_client):
+        state = PluginState()
+        assert state.is_configured()
+        # Second call must not re-trigger; returns False.
+        assert _maybe_reconfigure_from_disk(state) is False
+
+
+def test_maybe_reconfigure_no_op_when_creds_still_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _tmp_home(monkeypatch)
+    monkeypatch.delenv("TOTALRECLAW_RECOVERY_PHRASE", raising=False)
+
+    from totalreclaw.hermes.state import PluginState
+    from totalreclaw.hermes.hooks import _maybe_reconfigure_from_disk
+
+    with patch("totalreclaw.client.TotalReclaw", side_effect=_stub_client):
+        state = PluginState()
+        assert not state.is_configured()
+        assert _maybe_reconfigure_from_disk(state) is False
+        assert not state.is_configured()
+
+
+# ---------------------------------------------------------------------------
+# 2. Daemon-mode hook flow — post_llm_call must trigger extraction once
+#    creds appear mid-conversation. This is the headline #191 regression.
+# ---------------------------------------------------------------------------
+
+
+def test_post_llm_call_fires_extraction_after_mid_session_pair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end daemon-mode simulation:
+
+    1. Gateway boots, plugin loads — no creds yet.
+    2. ``on_session_start`` fires for the user's first session.
+    3. User runs ``totalreclaw_pair`` from chat. The sidecar
+       subprocess writes creds.json (we simulate by writing the file).
+    4. Subsequent ``post_llm_call`` invocations must reconfigure the
+       in-memory state AND start firing ``_auto_extract`` every N
+       turns.
+
+    Pre-2.3.2 this test would fail at ``mock_extract.call_count >= 1``
+    because the unconfigured state suppressed every extraction.
+    """
+    home = _tmp_home(monkeypatch)
+    monkeypatch.delenv("TOTALRECLAW_RECOVERY_PHRASE", raising=False)
+
+    from totalreclaw.hermes.state import PluginState
+    from totalreclaw.hermes import hooks
+
+    with patch("totalreclaw.client.TotalReclaw", side_effect=_stub_client):
+        # Step 1: plugin loads, no creds yet.
+        state = PluginState()
+        assert not state.is_configured()
+
+        # Step 2: first session_start.
+        hooks.on_session_start(state, session_id="s1")
+        assert not state.is_configured()
+
+        # Step 3: simulate sidecar writing creds.json mid-session.
+        _write_creds(home, _VALID_MNEMONIC)
+
+        # Step 4: 4 more post_llm_call invocations. With the default
+        # extraction interval of 3 turns, we expect ≥1 extraction call.
+        with patch.object(hooks, "_auto_extract") as mock_extract, patch.object(
+            hooks, "_get_hermes_llm_config", return_value=MagicMock()
+        ), patch.object(hooks, "_eager_account_register"):
+            for i in range(1, 5):
+                hooks.post_llm_call(
+                    state,
+                    user_message=f"user turn {i}",
+                    assistant_response=f"assistant turn {i}",
+                )
+
+        # Lazy reconfigure should have fired on turn 1 and the
+        # extraction interval should have tripped on turn 3.
+        assert state.is_configured(), (
+            "post_llm_call must lazy-reconfigure when creds appear "
+            "after plugin load (issue #191)"
+        )
+        assert mock_extract.call_count >= 1, (
+            f"expected ≥1 extraction in 4 turns at interval=3, "
+            f"got {mock_extract.call_count}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. Eager account register (#192)
+# ---------------------------------------------------------------------------
+
+
+def test_eager_account_register_calls_status_once_per_configure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_eager_account_register`` must call ``client.status()`` once
+    when the state is configured, latch a flag so subsequent calls
+    are no-ops, and clear that latch when ``state.configure()`` runs
+    again (re-pair flow).
+    """
+    home = _tmp_home(monkeypatch)
+    monkeypatch.delenv("TOTALRECLAW_RECOVERY_PHRASE", raising=False)
+    _write_creds(home, _VALID_MNEMONIC)
+
+    # Track status() calls on the stubbed client.
+    status_calls: list[int] = []
+
+    def stub_with_status(*_, **__):
+        c = _stub_client()
+
+        async def _status():
+            status_calls.append(1)
+            return MagicMock()
+
+        c.status = _status
+        return c
+
+    from totalreclaw.hermes.state import PluginState
+    from totalreclaw.hermes.hooks import _eager_account_register
+
+    with patch("totalreclaw.client.TotalReclaw", side_effect=stub_with_status):
+        state = PluginState()
+        assert state.is_configured()
+
+        # First call: should invoke status().
+        _eager_account_register(state)
+        assert len(status_calls) == 1, "status() must be called once"
+
+        # Second call: latched, no-op.
+        _eager_account_register(state)
+        assert len(status_calls) == 1, "second call must short-circuit"
+
+        # Re-pair flow: configure() should clear the latch.
+        state.configure(_VALID_MNEMONIC)
+        _eager_account_register(state)
+        assert len(status_calls) == 2, (
+            "state.configure() must clear the eager-register latch so "
+            "the new SA gets its own first-contact request to the relay"
+        )
+
+
+def test_on_session_start_triggers_eager_account_register(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``on_session_start`` is the canonical fire point for the eager
+    register — must invoke ``_eager_account_register`` when the state
+    is configured (creds existed at boot OR were just lazy-reconfigured).
+    """
+    home = _tmp_home(monkeypatch)
+    monkeypatch.delenv("TOTALRECLAW_RECOVERY_PHRASE", raising=False)
+    _write_creds(home, _VALID_MNEMONIC)
+
+    from totalreclaw.hermes.state import PluginState
+    from totalreclaw.hermes import hooks
+
+    with patch("totalreclaw.client.TotalReclaw", side_effect=_stub_client):
+        state = PluginState()
+        with patch.object(hooks, "_eager_account_register") as mock_eager:
+            hooks.on_session_start(state, session_id="s1")
+            mock_eager.assert_called_once_with(state)
+
+
+def test_on_session_start_skips_eager_register_when_unconfigured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If creds still missing after the lazy reconfigure attempt,
+    don't try to register — the client doesn't exist yet.
+    """
+    _tmp_home(monkeypatch)
+    monkeypatch.delenv("TOTALRECLAW_RECOVERY_PHRASE", raising=False)
+
+    from totalreclaw.hermes.state import PluginState
+    from totalreclaw.hermes import hooks
+
+    with patch("totalreclaw.client.TotalReclaw", side_effect=_stub_client):
+        state = PluginState()
+        assert not state.is_configured()
+        with patch.object(hooks, "_eager_account_register") as mock_eager:
+            hooks.on_session_start(state, session_id="s1")
+            mock_eager.assert_not_called()

--- a/python/tests/test_v2_02_hermes_fixes.py
+++ b/python/tests/test_v2_02_hermes_fixes.py
@@ -356,18 +356,23 @@ class TestBug6FirstRunNudge:
         from totalreclaw.hermes.hooks import pre_llm_call
         from totalreclaw.hermes.state import PluginState
 
+        # 2.3.2-rc.1 (#191): the lazy-reconfigure safety net in
+        # ``pre_llm_call`` re-reads creds.json on every entry. To keep
+        # this nudge test deterministic on hosts that DO have a real
+        # ~/.totalreclaw/credentials.json (e.g. dev machines), mock
+        # the file lookup across both ctor and the pre_llm_call body.
         with patch.dict(os.environ, {}, clear=True):
             with patch.object(Path, "exists", return_value=False):
                 state = PluginState()
 
-        assert not state.is_configured()
+                assert not state.is_configured()
 
-        # First turn — user asks a natural memory-related question.
-        result = pre_llm_call(
-            state,
-            is_first_turn=True,
-            user_message="Can you remember that I prefer dark mode?",
-        )
+                # First turn — user asks a natural memory-related question.
+                result = pre_llm_call(
+                    state,
+                    is_first_turn=True,
+                    user_message="Can you remember that I prefer dark mode?",
+                )
 
         # Should return a context nudge mentioning setup.
         assert result is not None, "expected setup nudge on first turn"
@@ -379,18 +384,20 @@ class TestBug6FirstRunNudge:
         from totalreclaw.hermes.hooks import pre_llm_call
         from totalreclaw.hermes.state import PluginState
 
+        # See test above for why ``Path.exists`` is mocked through the
+        # full pre_llm_call invocation rather than just the ctor.
         with patch.dict(os.environ, {}, clear=True):
             with patch.object(Path, "exists", return_value=False):
                 state = PluginState()
 
-        first = pre_llm_call(
-            state, is_first_turn=True,
-            user_message="Remember I like dark mode",
-        )
-        second = pre_llm_call(
-            state, is_first_turn=True,
-            user_message="Can you remember another thing for me?",
-        )
+                first = pre_llm_call(
+                    state, is_first_turn=True,
+                    user_message="Remember I like dark mode",
+                )
+                second = pre_llm_call(
+                    state, is_first_turn=True,
+                    user_message="Can you remember another thing for me?",
+                )
         assert first is not None
         # Second call: nudge should not re-fire (no "totalreclaw_setup" in ctx).
         if second is not None:


### PR DESCRIPTION
## Summary

Two QA-bug fixes from user manual QA on stable 2.3.1 (2026-04-27)
running Hermes in DAEMON mode (gateway-served chat via Telegram).
Refs #183 #191 #192 in the internal repo.

- **#191 — auto-extraction silent in daemon mode.** Root cause: the
  gateway loads the plugin once at boot via `register()`, which
  constructs a single `PluginState` and reads `~/.totalreclaw/credentials.json`
  at that moment. In rc.24+, pair-completion runs in a separate
  sidecar **subprocess** that writes the creds file but cannot
  reach the gateway's in-memory state. Result: `state.is_configured()`
  stays `False` forever, every `post_llm_call` returns at the
  early-out guard, no extraction ever fires. The gateway-restart
  requirement was documented in `totalreclaw_pair`'s instructions
  but real users on a long-lived daemon don't restart for every
  pair.
- **#192 — lazy relay account creation.** Pair-completion only
  builds the client object client-side; the relay only learns the
  account exists when an authenticated wallet-keyed request hits
  it. Pre-fix the account record didn't appear until the user
  explicitly asked "what's my quota?".

## Patches

- `_maybe_reconfigure_from_disk(state)` (`python/src/totalreclaw/hermes/hooks.py`)
  — re-reads creds.json on every `on_session_start` / `pre_llm_call`
  / `post_llm_call` entry. Cheap on the configured-state hot path
  (early-return on `is_configured()`), idempotent on disk. Removes
  the gateway-restart requirement.
- `_eager_account_register(state)` (`python/src/totalreclaw/hermes/hooks.py`)
  — issues a one-shot `client.status()` once per state-configure
  event so the relay gets the SA-keyed first-contact request
  before any extraction batch fires. Latched via
  `_eager_account_registered` attr; cleared by `state.configure()`
  so re-pair flows with a different mnemonic re-register the new
  SA.
- `python/pyproject.toml`: bumped base version `2.3.1` → `2.3.2`
  (workflow appends `rcN` on dispatch — see comment in pyproject).

## Tests

- New file `tests/test_issue_191_192_daemon_pair_lazy_reconfigure.py`
  (7 cases):
  1. `_maybe_reconfigure_from_disk` reconfigures when creds appeared
     after init; no-op when already configured; no-op when creds
     still missing.
  2. End-to-end daemon-mode simulation: gateway boots unconfigured
     → on_session_start fires → sidecar writes creds → next
     `post_llm_call` lazy-reconfigures → extraction fires on the
     turn-3 boundary.
  3. `_eager_account_register` calls `client.status()` once per
     configure event; latch clears on `state.configure()`.
  4. `on_session_start` triggers the eager register when configured;
     skips when unconfigured.
- Existing `test_v2_02_hermes_fixes` nudge tests updated to mock
  `Path.exists` through the `pre_llm_call` body (the lazy
  reconfigure now re-reads creds on every entry, so the mock has
  to cover that surface too).
- Full suite: **1018 passed, 14 skipped, 1 xfailed**.

## Test plan

- [ ] Auto-QA dispatch on 2.3.2-rc.1 (canonical Hermes daemon flow
      on staging VPS).
- [ ] Verify staging relay shows account record within ~30s of pair
      completion **without** a gateway restart and **without** any
      explicit user query (#192 acceptance).
- [ ] 5+ turn natural conversation (no "remember X" prompts) on
      staging → ≥1 extraction batch lands on the subgraph (#191
      acceptance).
- [ ] No regression on the existing chat -q one-shot drain path
      (issue #148) — covered by `test_issue_148_*` in the existing
      suite.

## Phrase-safety invariant

This patch does NOT touch phrase / mnemonic / credentials code
paths. The only credential-side change is in `state.configure()`'s
already-existing body: a `delattr(self, "_eager_account_registered")`
that clears an in-memory bool flag. Reviewed against
`project_phrase_safety_rule.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)