### PR TITLE
ci(clawhub): use 'clawhub package publish' for plugins (CLI 0.9.x rename)

### DIFF
--- a/.github/workflows/promote-rc.yml
+++ b/.github/workflows/promote-rc.yml
@@ -351,8 +351,12 @@ jobs:
           STABLE="${{ needs.derive-versions.outputs.stable-version }}"
           echo "Publishing stable $STABLE to ClawHub with full tag set."
           clawhub login --token "$CLAWHUB_TOKEN" --no-browser
-          clawhub publish ./skill/plugin \
-            --slug totalreclaw \
+          # ClawHub CLI 0.9.x: plugin publish moved to `clawhub package publish`
+          # with --name (not --slug) + --family code-plugin. Surfaced 2026-04-28
+          # on 3.3.2-rc.1 publish — see publish-clawhub.yml comment for context.
+          clawhub package publish ./skill/plugin \
+            --name totalreclaw \
+            --family code-plugin \
             --version "$STABLE" \
             --tags "latest,memory,encryption,e2ee,privacy,agent-memory,e2e-encryption,persistent-context" \
             --changelog "Release $STABLE (promoted from RC) -- see https://github.com/p-diogo/totalreclaw/releases/tag/v$STABLE"

--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -164,8 +164,14 @@ jobs:
           echo "Publishing to slug: $SLUG"
 
           clawhub login --token "$CLAWHUB_TOKEN" --no-browser
-          clawhub publish ./skill/plugin \
-            --slug "$SLUG" \
+          # ClawHub CLI 0.9.x renamed plugin publish: `clawhub publish` rejects
+          # plugin-shaped sources with "Use clawhub package publish instead".
+          # Plugin-publish is now `clawhub package publish` with --name (not --slug)
+          # + --family code-plugin. See https://github.com/p-diogo/totalreclaw-internal/issues/189
+          # context — this surfaced 2026-04-28 during 3.3.2-rc.1 publish.
+          clawhub package publish ./skill/plugin \
+            --name "$SLUG" \
+            --family code-plugin \
             --version "$VERSION" \
             --tags "$TAGS" \
             --changelog "$CHANGELOG"


### PR DESCRIPTION
## Why

3.3.2-rc.1 ClawHub publish failed 2026-04-28 ([run](https://github.com/p-diogo/totalreclaw/actions/runs/25055611721)):

```
Error: This looks like a plugin. Use "clawhub package publish <source>" instead.
```

ClawHub CLI 0.9.x renamed plugin publish — `clawhub publish` now refuses plugin-shaped sources.

## Fix

Both `publish-clawhub.yml` (RC + stable) and `promote-rc.yml` (stable retag) updated:

```diff
- clawhub publish ./skill/plugin --slug X
+ clawhub package publish ./skill/plugin --name X --family code-plugin
```

## Test plan

- [x] YAML syntax validated
- [ ] Re-dispatch `publish-clawhub.yml` for 3.3.2-rc.1 after merge
- [ ] Confirm `clawhub install totalreclaw --version 3.3.2-rc.1` works post-publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)