### PR TITLE
fix(plugin): add openclaw.compat.pluginApi + build.openclawVersion (ClawHub req)

### DIFF
--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -77,6 +77,12 @@
   "openclaw": {
     "extensions": [
       "./dist/index.js"
-    ]
+    ],
+    "compat": {
+      "pluginApi": ">=2026.3.22"
+    },
+    "build": {
+      "openclawVersion": "2026.4.24"
+    }
   }
 }


### PR DESCRIPTION
## Why

ClawHub `clawhub package publish` rejects code-plugins missing required `openclaw.compat.pluginApi` + `openclaw.build.openclawVersion`. Surfaced 2026-04-28 on 3.3.2-rc.1 ClawHub publish:

```
Error: openclaw.compat.pluginApi is required for external code plugins
       published to ClawHub. openclaw.build.openclawVersion is required
       for external code plugins published to ClawHub.
```

## Values

- `pluginApi`: `">=2026.3.22"` — matches `@openclaw/twitch` (official OpenClaw plugin) floor
- `openclawVersion`: `"2026.4.24"` — current pinned image in pop-os QA stack + latest stable upstream

Plugin source unchanged; manifest field additions only.

## Test plan

- [x] `package.json` is valid JSON
- [ ] Re-dispatch `publish-clawhub.yml` for 3.3.2-rc.2 (rc.1 already on npm; ClawHub bumps to rc.2 to clear rejected-publish state)
- [ ] `clawhub package inspect totalreclaw` shows updated compat fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)