### PR TITLE
ci(clawhub): pin CLI to 0.8.0 (avoid 0.9.x slug-family collision)

### DIFF
--- a/.github/workflows/promote-rc.yml
+++ b/.github/workflows/promote-rc.yml
@@ -340,8 +340,12 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Install ClawHub CLI
-        run: npm install -g clawhub
+      - name: Install ClawHub CLI (pinned to 0.8.0)
+        # Pinned because 0.9.x's `clawhub package publish --family code-plugin`
+        # collides with the existing `totalreclaw` slug already registered
+        # Family=Skill (rc.22 era). Until upstream slug migration lands.
+        # See publish-clawhub.yml comment for full context.
+        run: npm install -g clawhub@0.8.0
 
       - name: Publish stable tags over the promoted version
         env:
@@ -351,12 +355,9 @@ jobs:
           STABLE="${{ needs.derive-versions.outputs.stable-version }}"
           echo "Publishing stable $STABLE to ClawHub with full tag set."
           clawhub login --token "$CLAWHUB_TOKEN" --no-browser
-          # ClawHub CLI 0.9.x: plugin publish moved to `clawhub package publish`
-          # with --name (not --slug) + --family code-plugin. Surfaced 2026-04-28
-          # on 3.3.2-rc.1 publish — see publish-clawhub.yml comment for context.
-          clawhub package publish ./skill/plugin \
-            --name totalreclaw \
-            --family code-plugin \
+          # Using legacy `clawhub publish --slug` (CLI 0.8.0). See install step.
+          clawhub publish ./skill/plugin \
+            --slug totalreclaw \
             --version "$STABLE" \
             --tags "latest,memory,encryption,e2ee,privacy,agent-memory,e2e-encryption,persistent-context" \
             --changelog "Release $STABLE (promoted from RC) -- see https://github.com/p-diogo/totalreclaw/releases/tag/v$STABLE"

--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -86,8 +86,14 @@ jobs:
       - name: Verify tarball ships built `.js` artifacts (issue #110)
         run: cd skill/plugin && npm run verify-tarball
 
-      - name: Install ClawHub CLI
-        run: npm install -g clawhub
+      - name: Install ClawHub CLI (pinned to 0.8.0)
+        # Pin to 0.8.0 because 0.9.x renamed plugin-publish to
+        # `clawhub package publish` AND the new code-plugin family collides
+        # with the existing `totalreclaw` slug already registered as Family=Skill
+        # (rc.22 era). Until the slug is migrated upstream OR we accept a
+        # rename-with-redirect, 0.8.x's legacy `clawhub publish --slug` is the
+        # only working path. See https://github.com/p-diogo/totalreclaw-internal/issues/189
+        run: npm install -g clawhub@0.8.0
 
       # ROOT CAUSE of rc.21 finding #3 (on-disk version drift): this
       # workflow used to call `clawhub publish ./skill/plugin` WITHOUT
@@ -164,14 +170,12 @@ jobs:
           echo "Publishing to slug: $SLUG"
 
           clawhub login --token "$CLAWHUB_TOKEN" --no-browser
-          # ClawHub CLI 0.9.x renamed plugin publish: `clawhub publish` rejects
-          # plugin-shaped sources with "Use clawhub package publish instead".
-          # Plugin-publish is now `clawhub package publish` with --name (not --slug)
-          # + --family code-plugin. See https://github.com/p-diogo/totalreclaw-internal/issues/189
-          # context — this surfaced 2026-04-28 during 3.3.2-rc.1 publish.
-          clawhub package publish ./skill/plugin \
-            --name "$SLUG" \
-            --family code-plugin \
+          # Using legacy `clawhub publish --slug` (CLI 0.8.0). 0.9.x's
+          # `clawhub package publish --family code-plugin` would collide with
+          # the existing `totalreclaw` slug already registered Family=Skill.
+          # See install step above for full context.
+          clawhub publish ./skill/plugin \
+            --slug "$SLUG" \
             --version "$VERSION" \
             --tags "$TAGS" \
             --changelog "$CHANGELOG"


### PR DESCRIPTION
## Why

3.3.2-rc.1 ClawHub publish has failed repeatedly:

1. **CLI 0.9.x rename** (patched in #156 with `clawhub package publish --name X --family code-plugin`)
2. **After #156 fix**: ClawHub returned
   ```
   ConvexError: Package name collides with existing skill slug "totalreclaw"
   ```
   The slug `totalreclaw` is registered Family=Skill (rc.22 era). `--family code-plugin` cannot reuse it.

## Fix

Pin to CLI 0.8.0 in both workflows. Legacy `clawhub publish --slug totalreclaw` was the path that worked through rc.22.

Until upstream slug-family migration lands (or we accept rename-with-redirect that disrupts `openclaw skills install totalreclaw`), this is the working publish path.

## Test plan

- [x] YAML syntax validated
- [ ] Re-dispatch `publish-clawhub.yml` for 3.3.2-rc.1 after merge
- [ ] `clawhub install totalreclaw --version 3.3.2-rc.1` works post-publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)