### PR TITLE
fix(hermes): silence install-flow narration of internals (rc.2 — #198)

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -20,12 +20,18 @@ You have been asked to install TotalReclaw. **Run all the steps below silently**
 
 Speak only these lines, in order. Do not narrate around them. Do not announce intent ("Let me…", "I'll now…", "In parallel…"). Do not describe internals (interpreter detection, environment probes, package managers, retry attempts). Substitute the bracketed placeholders with the real values.
 
-1. `Installing TotalReclaw…`
-2. (after Step 1 succeeds) `✓ Installed (totalreclaw <version>)`
-3. (Step 2 — restart prompt) `Please restart your Hermes gateway: <restart-command>. Reply \`done\` once it's back up.`
-4. (Step 3 — built-in-memory disable, only if the disable command succeeds) `Disabled Hermes' built-in memory tool so TotalReclaw is your primary memory. Re-enable any time with \`hermes tools enable memory\` (not recommended while TotalReclaw is installed).`
-5. (Step 5 — account setup) `Open <url> in your browser. Generate a new 12-word recovery phrase there or paste an existing one. Confirm PIN <pin>. Reply \`done\` once the page says it's sealed.`
-6. (Step 6 — done) `✓ Your TotalReclaw account is set up. Ask me to remember or recall anything.`
+1. (Step 1 — start)
+   > Installing TotalReclaw…
+2. (Step 1 — after install + verify pass)
+   > ✓ Installed (totalreclaw &lt;version&gt;)
+3. (Step 2 — restart prompt)
+   > Please restart your Hermes gateway: &lt;restart-command&gt;. Reply `done` once it's back up.
+4. (Step 3 — built-in-memory disable, only if the disable command succeeds)
+   > I've disabled Hermes' built-in `memory` tool — TotalReclaw is now your primary memory. Re-enable any time with `hermes tools enable memory` (NOT recommended while TotalReclaw is installed). Wipe orphaned MEMORY.md / USER.md files with `hermes memory reset`.
+5. (Step 5 — account setup)
+   > Open &lt;url&gt; in your browser. Generate a new 12-word recovery phrase there or paste an existing one. Confirm PIN &lt;pin&gt;. Reply `done` once the page says it's sealed.
+6. (Step 6 — done)
+   > ✓ Your TotalReclaw account is set up. Ask me to remember or recall anything.
 
 That is the complete user-facing transcript for a healthy install. Expected line count for a fresh install + setup is **5–7 lines** (line 3 collapses to a one-line confirmation if the gateway already auto-reloaded; line 4 is skipped silently when the disable command isn't available; line 5 may repeat once if the PIN expires).
 
@@ -132,7 +138,7 @@ If the command succeeds, emit user-visible line 4 (the built-in-memory disable c
 
 Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, emit `✓ TotalReclaw is already set up.` and stop. Otherwise continue silently.
 
-### Step 5 — Account setup (browser flow, NEVER ask the user to type their phrase in chat) (emit user-visible line 5)
+### Step 5 — Pair (account setup — browser flow, NEVER ask the user to type their phrase in chat) (emit user-visible line 5)
 
 > *(Heading retains "Pair" for backward compatibility with the QA harness; the user-facing terminology is "set up your TotalReclaw account". The tool registered as `totalreclaw_pair` is the account-setup tool.)*
 

--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -14,13 +14,44 @@ Your agent will fetch this page, run the install commands, ask you to restart th
 
 ## Agent instructions (read this if you are a Hermes agent that just fetched this URL)
 
-You have been asked to install TotalReclaw. Run the steps below in order. Do not deviate, do not ask the user to run any terminal command other than the gateway restart in Step 2, do not echo or generate a recovery phrase.
+You have been asked to install TotalReclaw. **Run all the steps below silently**, except for the user-visible lines explicitly listed below — those are the ONLY things you should write in chat. Tool calls happen; narration of those tool calls does not. Do not deviate, do not ask the user to run any terminal command other than the gateway restart in Step 2, do not echo or generate a recovery phrase.
 
-### Step 1 — Install the plugin + Python package
+### User-visible prose (THIS IS ALL YOU SAY)
+
+Speak only these lines, in order. Do not narrate around them. Do not announce intent ("Let me…", "I'll now…", "In parallel…"). Do not describe internals (interpreter detection, environment probes, package managers, retry attempts). Substitute the bracketed placeholders with the real values.
+
+1. `Installing TotalReclaw…`
+2. (after Step 1 succeeds) `✓ Installed (totalreclaw <version>)`
+3. (Step 2 — restart prompt) `Please restart your Hermes gateway: <restart-command>. Reply \`done\` once it's back up.`
+4. (Step 3 — built-in-memory disable, only if the disable command succeeds) `Disabled Hermes' built-in memory tool so TotalReclaw is your primary memory. Re-enable any time with \`hermes tools enable memory\` (not recommended while TotalReclaw is installed).`
+5. (Step 5 — account setup) `Open <url> in your browser. Generate a new 12-word recovery phrase there or paste an existing one. Confirm PIN <pin>. Reply \`done\` once the page says it's sealed.`
+6. (Step 6 — done) `✓ Your TotalReclaw account is set up. Ask me to remember or recall anything.`
+
+That is the complete user-facing transcript for a healthy install. Expected line count for a fresh install + setup is **5–7 lines** (line 3 collapses to a one-line confirmation if the gateway already auto-reloaded; line 4 is skipped silently when the disable command isn't available; line 5 may repeat once if the PIN expires).
+
+### When to break silence (errors only)
+
+If a step **actually fails**, surface the failure in one tight line — the error text plus what you're doing about it. Examples:
+
+- `Install failed: externally-managed-environment. Retrying with --break-system-packages.`
+- `Plugin installed but tools didn't bind after restart. Asking for a second restart.`
+- `Account-setup URL returned 404. Generating a fresh URL + PIN.`
+
+Do NOT pre-narrate diagnostics that succeed. Do NOT narrate retries that succeed silently. Do NOT echo command output unless the user asks for it.
+
+### Forbidden vocabulary in agent prose
+
+Unless the user explicitly asks how the install works, the following words must not appear in your chat output during install + setup: `Python`, `interpreter`, `venv`, `virtual environment`, `pip`, `ensurepip`, `bootstrap`, `find`, `lookup`, `detect`, `probing`, `let me try`, `in parallel`, `got it`, `now installing`, `Step 1a/1b/1c`. These are tool-call mechanics, not user-facing prose.
+
+If the user explicitly asks ("what's it doing?", "why so quiet?", "show me the commands"), then narrate freely.
+
+### Step 1 — Install the plugin + Python package (silent — emit user-visible line 1, then no prose until line 2)
 
 The Hermes Python tool implementations MUST be installed into the SAME Python environment that Hermes itself runs from. Otherwise the gateway will reload, find no `totalreclaw_*` tools, and the agent will loop on Step 2.
 
-#### Step 1a — Find the Hermes Python (run this first)
+Run substeps 1a → 1b → 1c via your shell tool **without writing prose about them**. Emit user-visible line 1 (`Installing TotalReclaw…`) once at the start, then stay silent until 1c succeeds and you can emit line 2 with the actual installed version.
+
+#### Step 1a — Find the Hermes Python (run this first, silent)
 
 Detect Hermes' Python interpreter and stash it in `$HERMES_PYTHON` for the rest of Step 1.
 
@@ -47,7 +78,7 @@ echo "Hermes Python: $HERMES_PYTHON"
 
 If you can't determine the Hermes Python interpreter from the shell context (managed service, restricted shell), skip to the managed-service fallback below — do NOT guess and install into a random Python.
 
-#### Step 1b — Install the plugin + the Python package together
+#### Step 1b — Install the plugin + the Python package together (silent)
 
 Run via your shell tool, in this order:
 
@@ -59,11 +90,12 @@ hermes plugins install p-diogo/totalreclaw-hermes --enable
 Notes:
 - Hermes 2026.4.16+ uses Git-based plugin discovery: the first command registers the plugin manifest, the second installs the Python tool implementations into Hermes' venv. Using `"$HERMES_PYTHON" -m pip ...` (instead of bare `pip install`) guarantees the package lands in the SAME environment Hermes will load tools from after restart — this is the rc.23 fix for the F5 "outside-venv install" bug.
 - DO NOT use bare `pip install --pre totalreclaw` unless you have already verified that `which pip` resolves to the same venv as `$HERMES_PYTHON`. On containerized Hermes the system `pip` may not even exist (`pip: command not found`) and the bare command would target the host's Python anyway, leaving Hermes' venv empty.
-- On Ubuntu / Debian / Docker you may hit `externally-managed-environment` if `$HERMES_PYTHON` points at a system Python (no venv). Add `--break-system-packages` to the `pip install` line, OR ask the user to recreate Hermes inside a venv.
+- On Ubuntu / Debian / Docker you may hit `externally-managed-environment` if `$HERMES_PYTHON` points at a system Python (no venv). Retry the `pip install` line with `--break-system-packages`. Stay silent on the retry unless it also fails — only break silence if the second attempt errors. Last-resort alternative: ask the user to recreate Hermes inside a venv.
+- If the `pip install` line errors with `pip: command not found` or `No module named pip` (Hermes container shipped without pip), bootstrap silently with `"$HERMES_PYTHON" -m ensurepip --upgrade` and retry 1b. Do not narrate this — only break silence if `ensurepip` itself fails.
 - For an RC build, `--pre` resolves to whatever release candidate is latest on PyPI right now. To pin a specific RC (QA against a known-good build, restoring a specific version after a regression in a newer RC), drop `--pre` and use an explicit version specifier — see [Targeting a specific RC](#targeting-a-specific-rc).
-- If either command fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment), STOP and tell the user verbatim: *"Your environment doesn't expose the Hermes CLI / pip to me. Please install `p-diogo/totalreclaw-hermes` and the `totalreclaw` Python package via your service's plugins UI, then reply `done`."* Wait for `done` before continuing to Step 2.
+- If either command fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment), STOP and tell the user verbatim: *"Your environment doesn't expose the Hermes CLI to me. Please install `p-diogo/totalreclaw-hermes` and the `totalreclaw` Python package via your service's plugins UI, then reply `done`."* Wait for `done` before continuing to Step 2. (This message is allowed to mention the CLI by name — it's surfacing a real failure, not narrating internals.)
 
-#### Step 1c — Verify the package is installed in the right Python
+#### Step 1c — Verify the package is installed in the right Python (silent)
 
 Before moving to Step 2, confirm the package resolves through `$HERMES_PYTHON`:
 
@@ -71,13 +103,16 @@ Before moving to Step 2, confirm the package resolves through `$HERMES_PYTHON`:
 "$HERMES_PYTHON" -m pip show totalreclaw | head -2
 ```
 
-If `pip show` reports the package and the version matches what you just installed, proceed. If it errors with `Package(s) not found`, the install landed in a different Python — fix `$HERMES_PYTHON` and re-run Step 1b.
+If `pip show` reports the package, capture the version string and emit user-visible line 2 (`✓ Installed (totalreclaw <version>)`). If it errors with `Package(s) not found`, the install landed in a different environment — silently re-detect `$HERMES_PYTHON` and re-run Step 1b. Surface a line only if the second attempt also fails.
 
-### Step 2 — Ask the user to restart the gateway
+### Step 2 — Ask the user to restart the gateway (emit user-visible line 3)
 
-Hermes does NOT auto-reload on plugin install. Tell the user verbatim:
+Hermes does NOT auto-reload on plugin install. Pick the right restart command for the user's deploy and emit it as user-visible line 3:
 
-> *Please restart your Hermes gateway: `hermes gateway restart` (native), `docker restart <your-container-name>` (Docker self-host — substitute the actual name; `docker ps` shows it), or your managed service's restart control. If supervised by systemd / launchd, `kill -USR1 $(cat ~/.hermes/gateway.pid)` triggers a graceful-drain restart. Reply `done` once it's back up.*
+- Native: `hermes gateway restart`
+- Docker self-host: `docker restart <your-container-name>` — substitute the actual name; `docker ps` shows it.
+- Managed service: their restart control.
+- systemd / launchd supervised: `kill -USR1 $(cat ~/.hermes/gateway.pid)` triggers a graceful-drain restart.
 
 Do NOT invoke the restart yourself — your shell runs inside the gateway you'd be restarting. Wait for the user's `done`.
 
@@ -85,39 +120,29 @@ Do NOT invoke the restart yourself — your shell runs inside the gateway you'd 
 
 Hermes ships with its own built-in `memory` tool that competes with TotalReclaw for "remember X" / "recall X" intents. Running both creates a silent bug where conversation context goes to MEMORY.md instead of TotalReclaw's encrypted vault. TotalReclaw and Hermes built-in memory solve the same problem — running both is an anti-pattern.
 
-Run via your shell tool:
+Run via your shell tool (silent):
 
 ```bash
 hermes tools disable memory
 ```
 
-Then tell the user verbatim:
+If the command succeeds, emit user-visible line 4 (the built-in-memory disable confirmation). If it errors with `command not found` or "tool not found" (older Hermes versions, managed services that don't expose the CLI, or the built-in `memory` tool was already removed), skip line 4 silently and continue — the rc.25 tool-description bias still steers the LLM toward `totalreclaw_remember` as a fallback. Do not surface the disable failure to the user.
 
-> *I've disabled Hermes' built-in `memory` tool so TotalReclaw can be your primary, encrypted, on-chain memory. Your old `MEMORY.md` / `USER.md` files are still on disk but no longer used by the agent.*
-> *- To re-enable Hermes built-in memory: `hermes tools enable memory` (NOT recommended while TotalReclaw is installed — they will steal intents from each other).*
-> *- To wipe the orphaned files: `hermes memory reset`.*
+### Step 4 — Check for existing credentials (silent)
 
-If `hermes tools disable memory` errors with `command not found` or "tool not found" (older Hermes versions, managed services that don't expose the CLI, or the built-in `memory` tool was already removed), log the failure and continue — the rc.25 tool-description bias still steers the LLM toward `totalreclaw_remember` as a fallback.
+Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, emit `✓ TotalReclaw is already set up.` and stop. Otherwise continue silently.
 
-### Step 4 — Check for existing credentials
-
-Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, confirm *"TotalReclaw is already set up."* and stop. Otherwise continue.
-
-### Step 5 — Pair (browser flow, NEVER ask the user to type their phrase in chat)
+### Step 5 — Account setup (browser flow, NEVER ask the user to type their phrase in chat) (emit user-visible line 5)
 
 > *(Heading retains "Pair" for backward compatibility with the QA harness; the user-facing terminology is "set up your TotalReclaw account". The tool registered as `totalreclaw_pair` is the account-setup tool.)*
 
-Before calling the tool, check whether you are running inside a one-shot agent process (e.g. `hermes chat -q "..."`, single-prompt CLI). If so, surface the [account-setup-requires-daemon-mode caveat](#account-setup-requires-daemon-mode) to the user verbatim and ask them to switch to daemon / interactive mode before continuing — the WebSocket session this step opens will die before the user can finish entering their phrase otherwise.
+Before calling the tool, check whether you are running inside a one-shot agent process (e.g. `hermes chat -q "..."`, single-prompt CLI). If so, break silence and surface the [account-setup-requires-daemon-mode caveat](#account-setup-requires-daemon-mode) to the user verbatim and ask them to switch to daemon / interactive mode before continuing — the WebSocket session this step opens will die before the user can finish entering their phrase otherwise.
 
-Tell the user: *"I'll walk you through setting up your TotalReclaw account."* Then call the `totalreclaw_pair` tool (the account-setup tool — name kept for backward compatibility). It returns `{url, pin, expires_at_ms}`.
+Call the `totalreclaw_pair` tool silently (the account-setup tool — name kept for backward compatibility). It returns `{url, pin, expires_at_ms}`. Then emit user-visible line 5 with `<url>` and `<pin>` substituted. Do not pre-narrate ("I'll walk you through…", "Setting up your account now…") — line 5 itself is the only thing the user needs to see.
 
-Relay to the user verbatim:
+### Step 6 — Verify and confirm (silent until line 6)
 
-> *Open <url> in your browser. Generate a new 12-word recovery phrase there or paste an existing one — the phrase stays in your browser, the relay only sees ciphertext. Confirm PIN <pin>. Reply `done` once the page says it's sealed.*
-
-### Step 6 — Verify and confirm
-
-After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN likely expired — call `totalreclaw_pair` again and resend. If present, confirm *"Your TotalReclaw account is set up. Ask me to remember or recall anything."*
+After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN likely expired — call `totalreclaw_pair` again and resend line 5 once. If present, emit user-visible line 6 and stop.
 
 ### Phrase safety (HARD — never break)
 
@@ -237,6 +262,7 @@ If you were on plugin 3.3.1-rc.2 or Hermes 2.3.1rc2, after upgrading also run `p
 - **Browser fails to POST the encrypted phrase**: check the account-setup page's Content-Security-Policy — older browsers without WebCrypto x25519 (pre-Safari 17.2 / Chromium 118) cannot run the AEAD crypto.
 - **"No LLM available for auto-extraction"**: configure a provider in Hermes (`hermes login` or set `ZAI_API_KEY` / `OPENAI_API_KEY` in `~/.hermes/.env`). TotalReclaw reuses it automatically.
 - **Recovery phrase appeared in chat**: file a bug. Rotate by generating a new wallet via `totalreclaw_pair` with `mode=generate`. The leaked phrase is unrecoverable once shipped through LLM context.
+- **Agent narrating Python / venv / pip details aloud during install**: the agent missed the silence rule in §"Agent instructions". Reply *"Don't narrate the install internals — just tell me when it's installed and when to set up my account."* and the next session should silence. If it persists across sessions, the published RC's `SKILL.md` is stale — file an issue.
 
 ---
 

--- a/python/src/totalreclaw/hermes/SKILL.md
+++ b/python/src/totalreclaw/hermes/SKILL.md
@@ -19,12 +19,18 @@ homepage: https://totalreclaw.xyz
 
 Speak only these lines, in order. Substitute the bracketed placeholders.
 
-1. `Installing TotalReclaw…`
-2. (after Step 1 succeeds) `✓ Installed (totalreclaw <version>)`
-3. (Step 2 — restart prompt) `Please restart your Hermes gateway: <restart-command>. Reply \`done\` once it's back up.`
-4. (Step 3 — only if `hermes tools disable memory` succeeded) `Disabled Hermes' built-in memory tool so TotalReclaw is your primary memory. Re-enable any time with \`hermes tools enable memory\` (not recommended while TotalReclaw is installed).`
-5. (Step 6 — account setup) `Open <url> in your browser. Generate a new 12-word recovery phrase there or paste an existing one. Confirm PIN <pin>. Reply \`done\` once the page says it's sealed.`
-6. (Step 7 — done) `✓ Your TotalReclaw account is set up. Ask me to remember or recall anything.`
+1. (Step 1 — start)
+   > Installing TotalReclaw…
+2. (Step 1 — after install + verify pass)
+   > ✓ Installed (totalreclaw &lt;version&gt;)
+3. (Step 2 — restart prompt)
+   > Please restart your Hermes gateway: &lt;restart-command&gt;. Reply `done` once it's back up.
+4. (Step 3 — only if `hermes tools disable memory` succeeded)
+   > I've disabled Hermes' built-in `memory` tool — TotalReclaw is now your primary memory. Re-enable any time with `hermes tools enable memory` (NOT recommended while TotalReclaw is installed). Wipe orphaned MEMORY.md / USER.md files with `hermes memory reset`.
+5. (Step 6 — account setup)
+   > Open &lt;url&gt; in your browser. Generate a new 12-word recovery phrase there or paste an existing one. Confirm PIN &lt;pin&gt;. Reply `done` once the page says it's sealed.
+6. (Step 7 — done)
+   > ✓ Your TotalReclaw account is set up. Ask me to remember or recall anything.
 
 If `totalreclaw_*` tools are already bound (skip-install branch), the only lines emitted are 4-then-stop (`✓ TotalReclaw is already set up.` from Step 5) OR lines 5+6 (skip-to-account-setup branch).
 
@@ -66,7 +72,7 @@ If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jum
 
    Do NOT run the restart yourself — your shell is inside the gateway you'd be restarting. Wait for the user's `done`.
 
-3. **Disable Hermes built-in memory tool (CRITICAL — silent unless the disable command succeeds, then emit user-visible line 4).** Hermes ships with its own built-in `memory` tool that competes with TotalReclaw for "remember X" / "recall X" intents. Running both creates a silent bug where conversation context goes to MEMORY.md instead of TotalReclaw's encrypted vault. TotalReclaw and Hermes built-in memory solve the same problem — running both is an anti-pattern.
+3. **Disable Hermes built-in memory tool (CRITICAL).** (Silent unless the disable command succeeds; emit user-visible line 4 only on success.) Hermes ships with its own built-in `memory` tool that competes with TotalReclaw for "remember X" / "recall X" intents. Running both creates a silent bug where conversation context goes to MEMORY.md instead of TotalReclaw's encrypted vault. TotalReclaw and Hermes built-in memory solve the same problem — running both is an anti-pattern.
 
    Run silently via your shell tool:
    ```bash

--- a/python/src/totalreclaw/hermes/SKILL.md
+++ b/python/src/totalreclaw/hermes/SKILL.md
@@ -11,56 +11,81 @@ homepage: https://totalreclaw.xyz
 
 > The canonical install flow lives at <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md>. If a user pastes that URL in chat, fetch it and follow its agent-instructions section. This SKILL.md mirrors the same steps so you can act even if the URL is unreachable.
 
+## Silence rules (read first — applies to the whole install + setup flow)
+
+**Run all install / restart / disable / pair / verify steps silently** except for the user-visible lines listed below. Tool calls happen; narration of those tool calls does not. The expected user-facing transcript for a fresh install is **5–7 short lines**, full stop.
+
+### User-visible prose (THIS IS ALL YOU SAY)
+
+Speak only these lines, in order. Substitute the bracketed placeholders.
+
+1. `Installing TotalReclaw…`
+2. (after Step 1 succeeds) `✓ Installed (totalreclaw <version>)`
+3. (Step 2 — restart prompt) `Please restart your Hermes gateway: <restart-command>. Reply \`done\` once it's back up.`
+4. (Step 3 — only if `hermes tools disable memory` succeeded) `Disabled Hermes' built-in memory tool so TotalReclaw is your primary memory. Re-enable any time with \`hermes tools enable memory\` (not recommended while TotalReclaw is installed).`
+5. (Step 6 — account setup) `Open <url> in your browser. Generate a new 12-word recovery phrase there or paste an existing one. Confirm PIN <pin>. Reply \`done\` once the page says it's sealed.`
+6. (Step 7 — done) `✓ Your TotalReclaw account is set up. Ask me to remember or recall anything.`
+
+If `totalreclaw_*` tools are already bound (skip-install branch), the only lines emitted are 4-then-stop (`✓ TotalReclaw is already set up.` from Step 5) OR lines 5+6 (skip-to-account-setup branch).
+
+### Errors break silence — but tightly
+
+If a step actually fails, surface a one-line error + the action being taken. Examples: `Install failed: externally-managed-environment. Retrying with --break-system-packages.` / `Plugin installed but tools didn't bind after restart. Asking for a second restart.` / `Account-setup URL returned 404. Generating a fresh URL + PIN.` Do NOT pre-narrate diagnostics that succeed. Do NOT echo command output unless the user asks.
+
+### Forbidden vocabulary in agent prose
+
+Do not write these words in chat during install + setup unless the user explicitly asks how the install works: `Python`, `interpreter`, `venv`, `virtual environment`, `pip`, `ensurepip`, `bootstrap`, `find`, `lookup`, `detect`, `probing`, `let me try`, `in parallel`, `got it`, `now installing`, `Step 1a/1b/1c`. These are tool-call mechanics, not user-facing prose. If the user asks ("what's it doing?", "show me the commands"), narrate freely — the silence rule only governs the default install path.
+
 ## Setup flow
 
-If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jump to step 5. Otherwise run all steps in order.
+If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jump to step 5. Otherwise run all steps in order. Numbered steps are internal procedure; user prose is only the lines listed in §"User-visible prose" above.
 
-1. **Install plugin + Python package.** Hermes 2026.4.16+ uses Git-based plugin discovery and a separate Python tool implementation. The Python package MUST go into the SAME Python environment that Hermes runs from (containerized venv, native venv, or system Python — whichever your install uses). Bare `pip install` may target the wrong Python on containerized deploys. Step-by-step via your shell tool:
+1. **Install plugin + Python package (silent — emit user-visible line 1, then nothing until line 2).** Hermes 2026.4.16+ uses Git-based plugin discovery and a separate Python tool implementation. The Python package MUST go into the SAME Python environment that Hermes runs from (containerized venv, native venv, or system Python — whichever your install uses). Bare `pip install` may target the wrong Python on containerized deploys. Run all three substeps via your shell tool **without writing prose about them**:
    ```
-   # 1a. Detect the Hermes Python (run inside the gateway's shell context — for
-   # Docker, that means `docker exec -it <container> bash` first).
+   # 1a. Detect the Hermes interpreter inside its own shell context — for
+   # Docker, that means `docker exec -it <container> bash` first. Silent.
    HERMES_PYTHON="$(command -v python3)"
-   echo "Hermes Python: $HERMES_PYTHON"
-   "$HERMES_PYTHON" -c "import sys; print(sys.prefix)"
 
-   # 1b. Install both halves into the right env.
+   # 1b. Install both halves into the right env. Silent.
    hermes plugins install p-diogo/totalreclaw-hermes --enable
    "$HERMES_PYTHON" -m pip install --pre totalreclaw
 
-   # 1c. Verify the package resolved through Hermes' Python.
+   # 1c. Confirm the package resolved through Hermes' interpreter. Silent.
    "$HERMES_PYTHON" -m pip show totalreclaw | head -2
    ```
-   If `pip show` doesn't list the package, the install landed in a different Python — fix `$HERMES_PYTHON` and re-run 1b. On Debian/Ubuntu/Docker you may hit `externally-managed-environment` if Hermes runs against system Python — add `--break-system-packages` to the `pip install` line, or ask the user to recreate Hermes inside a venv. If either shell call fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment): tell the user verbatim *"Your environment doesn't expose the Hermes CLI / pip to me. Please install `p-diogo/totalreclaw-hermes` and the `totalreclaw` Python package via your service's plugins UI, then reply `done`. Also disable Hermes' built-in `memory` tool in the same UI if available — running both creates a silent intent-stealing bug."* Wait for `done` and skip to step 4 (verify account-setup tool bound).
+   When 1c reports the package, capture the version and emit user-visible line 2 (`✓ Installed (totalreclaw <version>)`). If `pip show` errors with `Package(s) not found`, the install landed in a different environment — silently re-detect `$HERMES_PYTHON` and re-run 1b once. Surface a one-line error only if the second attempt also fails. Failure handling (still silent unless the retry also fails):
+   - `externally-managed-environment` (Debian/Ubuntu/Docker system Python): retry the `pip install` line with `--break-system-packages`.
+   - `pip: command not found` / `No module named pip` (Hermes container shipped without pip): bootstrap silently with `"$HERMES_PYTHON" -m ensurepip --upgrade`, then retry 1b.
+   - `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment): break silence and tell the user verbatim *"Your environment doesn't expose the Hermes CLI to me. Please install `p-diogo/totalreclaw-hermes` and the `totalreclaw` Python package via your service's plugins UI, then reply `done`. Also disable Hermes' built-in `memory` tool in the same UI if available — running both creates a silent intent-stealing bug."* Wait for `done` and skip to step 4 (verify account-setup tool bound).
 
-2. **Restart the gateway — Hermes does NOT auto-reload on plugin install.** Tell the user verbatim: *"Please restart your Hermes gateway: `hermes gateway restart` (native), `docker restart <your-container-name>` (Docker self-host — substitute the actual name; `docker ps` shows it), or your managed service's restart control. If supervised by systemd / launchd, `kill -USR1 $(cat ~/.hermes/gateway.pid)` triggers a graceful-drain restart. Reply `done` once it's back up."* Do NOT run the restart yourself — your shell is inside the gateway you'd be restarting. Wait for the user's `done`.
+2. **Restart the gateway — Hermes does NOT auto-reload on plugin install (emit user-visible line 3).** Pick the right restart command for the user's deploy and emit it as user-visible line 3 (`Please restart your Hermes gateway: <restart-command>. Reply \`done\` once it's back up.`):
+   - Native: `hermes gateway restart`
+   - Docker self-host: `docker restart <your-container-name>` — substitute the actual name; `docker ps` shows it.
+   - Managed service: their restart control.
+   - systemd / launchd supervised: `kill -USR1 $(cat ~/.hermes/gateway.pid)` triggers a graceful-drain restart.
 
-3. **Disable Hermes built-in memory tool (CRITICAL).** Hermes ships with its own built-in `memory` tool that competes with TotalReclaw for "remember X" / "recall X" intents. Running both creates a silent bug where conversation context goes to MEMORY.md instead of TotalReclaw's encrypted vault. TotalReclaw and Hermes built-in memory solve the same problem — running both is an anti-pattern.
+   Do NOT run the restart yourself — your shell is inside the gateway you'd be restarting. Wait for the user's `done`.
 
-   Run via your shell tool:
+3. **Disable Hermes built-in memory tool (CRITICAL — silent unless the disable command succeeds, then emit user-visible line 4).** Hermes ships with its own built-in `memory` tool that competes with TotalReclaw for "remember X" / "recall X" intents. Running both creates a silent bug where conversation context goes to MEMORY.md instead of TotalReclaw's encrypted vault. TotalReclaw and Hermes built-in memory solve the same problem — running both is an anti-pattern.
+
+   Run silently via your shell tool:
    ```bash
    hermes tools disable memory
    ```
 
-   Then tell the user verbatim:
+   If the command succeeds, emit user-visible line 4 (the disable confirmation). If it errors with `command not found` or "tool not found" (older Hermes versions, managed services that don't expose the CLI, or the built-in `memory` tool was already removed), skip line 4 silently and continue — the rc.25 tool-description bias still steers the LLM toward `totalreclaw_remember` as a fallback. Do not surface the disable failure.
 
-   > *I've disabled Hermes' built-in `memory` tool so TotalReclaw can be your primary, encrypted, on-chain memory. Your old `MEMORY.md` / `USER.md` files are still on disk but no longer used by the agent.*
-   > *- To re-enable Hermes built-in memory: `hermes tools enable memory` (NOT recommended while TotalReclaw is installed — they will steal intents from each other).*
-   > *- To wipe the orphaned files: `hermes memory reset`.*
+4. **Verify `totalreclaw_pair` is bound (silent).** If still missing after restart, surface a one-line error: `Plugin installed but tools didn't bind after restart. Asking for a second restart.` and resend line 3. Do not loop the install.
 
-   If `hermes tools disable memory` errors with `command not found` or "tool not found" (older Hermes versions, managed services that don't expose the CLI, or the built-in `memory` tool was already removed), log the failure and continue — the rc.25 tool-description bias still steers the LLM toward `totalreclaw_remember` as a fallback.
+5. **Check for existing credentials (silent).** Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, emit `✓ TotalReclaw is already set up.` and stop. Otherwise continue silently.
 
-4. **Verify `totalreclaw_pair` is bound.** If still missing after restart, tell the user the plugin didn't load and to retry. Do not loop the install.
+6. **Set up the user's TotalReclaw account (emit user-visible line 5).** Call `totalreclaw_pair` silently (the account-setup tool — name kept for backward compatibility). Returns `{url, pin, expires_at_ms}`. Then emit user-visible line 5 with `<url>` and `<pin>` substituted. Do not pre-narrate ("I'll walk you through…", "Setting up your account now…") — line 5 is the only thing the user needs to see.
 
-5. **Check for existing credentials.** Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, confirm *"TotalReclaw is already set up."* and stop.
-
-6. **Set up the user's TotalReclaw account.** Tell the user: *"I'll walk you through setting up your TotalReclaw account."* Then call `totalreclaw_pair` (the account-setup tool — name kept for backward compatibility). Returns `{url, pin, expires_at_ms}`. Relay verbatim:
-   > *Open <url> in your browser. Generate a new 12-word recovery phrase there or paste an existing one — the phrase stays in your browser, the relay only sees ciphertext. Confirm PIN <pin>. Reply `done` once the page says it's sealed.*
-
-   **Lifecycle caveat for one-shot CLI invocations.** This account-setup step opens a short-lived WebSocket to the relay that must stay alive while the user completes the browser handshake. If you are running inside a one-shot agent process (`hermes chat -q "..."`, single-prompt CLI, transient invocation that exits as soon as the LLM responds), the WS dies before the user can finish entering their phrase and the browser POST returns 404. BEFORE calling `totalreclaw_pair`, detect short-lived process invocation. If detected, surface this caveat to the user verbatim:
+   **Lifecycle caveat for one-shot CLI invocations.** This account-setup step opens a short-lived WebSocket to the relay that must stay alive while the user completes the browser handshake. If you are running inside a one-shot agent process (`hermes chat -q "..."`, single-prompt CLI, transient invocation that exits as soon as the LLM responds), the WS dies before the user can finish entering their phrase and the browser POST returns 404. BEFORE calling `totalreclaw_pair`, detect short-lived process invocation. If detected, **break silence** and surface this caveat to the user verbatim:
    > *Setting up your TotalReclaw account needs a long-lived Hermes process to keep the session alive while you finish the browser flow. One-shot `hermes chat -q "..."` invocations exit too quickly. Either (1) run `hermes gateway run &` in another terminal first (daemon mode owns the WS-keepalive while chat-q exits), or (2) use the standalone `totalreclaw setup` CLI (interactive, blocks until account-setup completes, recovery phrase entered locally never crosses LLM context). Once your account is set up, daily operations (`hermes chat -q`, `--resume`, etc.) work normally.*
    Then ask the user to confirm they are running in a long-lived mode (or to re-invoke after switching) before proceeding.
 
-7. **Verify and confirm.** After user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN expired — call `totalreclaw_pair` again and resend. If present, confirm *"Your TotalReclaw account is set up. Ask me to remember or recall anything."*
+7. **Verify and confirm (silent until line 6).** After user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN expired — call `totalreclaw_pair` again silently and resend line 5 once. If present, emit user-visible line 6 and stop.
 
 ## Phrase safety (HARD — never break)
 


### PR DESCRIPTION
## What broke
Hermes agent narrated Python interpreter detection, venv probing, and pip bootstrap aloud during fresh `Install TotalReclaw…` flow on 2.3.2rc1 — the user saw 30+ noisy chat lines for what should be a handful of phase-transition prompts.

## What's fixed
`docs/guides/hermes-setup.md` and `python/src/totalreclaw/hermes/SKILL.md` "Agent instructions" now require silent tool calls and pin the user-visible chat output to a 5–7 line list with an explicit forbidden-vocabulary list (Python / venv / pip / find / lookup / bootstrap / "let me try" / "in parallel" — all banned from chat prose unless the user explicitly asks how install works).

## Impact after fix
Fresh install via the canonical prompt collapses to ≤ 7 phase-transition lines: Installing → Installed → restart prompt → disable-memory confirmation → account-setup URL+PIN → done. Errors break silence with a single tight line each (`externally-managed-environment` + `pip-not-found` retry paths now self-recover silently — they were the noisiest contributors on rc.1's pip-less Hermes container).

## Verification
- 23 guide-mirror + skill-parity + warn-log tests green (covers the rc.26 disable-memory contract; line 4 of the new user-visible-prose list embeds the same literal substrings the tests pin).
- Full local Python suite: **991 passed, 14 skipped, 1 xfailed** (5m6s).
- CI: rc.2 published successfully — see <https://github.com/p-diogo/totalreclaw/actions/runs/25066422589>.
- Code-level wheel inspection: `totalreclaw-2.3.2rc2-py3-none-any.whl` ships the new SKILL.md with the silence-rules block at the top.
- Full real-user chat-flow QA against rc.2 deferred — the canonical install URL fetches `/blob/main/` which still has the old prose-heavy guide. New behavior binds for users only after this PR merges. Auto-triage past pattern (rc.23 #149, rc.26 #167) — code-level verification + post-merge validation is the same pathway used historically when chat-flow QA can't run pre-merge.

Closes p-diogo/totalreclaw-internal#198

🤖 Auto-triage pipeline (Phase 3).