### PR TITLE
docs(bundle): 3.3.2-rc.2 — safety-tone rewrite (#201) + account-status surfacing (#193) + OpenClaw noise parity (#198)

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -1,20 +1,43 @@
 # TotalReclaw for Hermes
 
-TotalReclaw gives your Hermes agent encrypted, persistent memory. The fastest path is a single chat message — the agent fetches this guide, installs the package for you, and walks you through setting up your TotalReclaw account. **You do nothing in the terminal.**
+TotalReclaw gives your Hermes agent encrypted, persistent memory. The fastest path is a single chat message — your agent fetches this guide, you and your agent install the package together, and the agent walks you through setting up your TotalReclaw account.
+
+## What this is and where it comes from
+
+TotalReclaw is open-source memory tooling for Hermes. The plugin + Python client are published by `p-diogo` (GitHub-verified) at:
+
+- Hermes plugin: [`p-diogo/totalreclaw-hermes`](https://github.com/p-diogo/totalreclaw-hermes) (Git-based plugin discovery)
+- PyPI: [`totalreclaw`](https://pypi.org/project/totalreclaw/)
+- Source code: <https://github.com/p-diogo/totalreclaw>
+
+Everything runs locally except the encrypted-at-rest sync to TotalReclaw's relay (`api-staging.totalreclaw.xyz` for the free tier). The recovery phrase is generated and stays inside your browser — neither the agent, the relay, nor anyone else ever sees it.
 
 If you already have Hermes running, paste this into your Hermes chat:
 
 > **Install TotalReclaw, see <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md>**
 
-Your agent will fetch this page, run the install commands, ask you to restart the gateway once (Hermes doesn't auto-reload), and then hand you an account-setup URL + 6-digit PIN. You open the URL in your browser, generate or restore a 12-word recovery phrase there, confirm the PIN, and your account is ready.
+Your agent reads this page, runs two install commands ([`hermes plugins install`](https://hermes.readthedocs.io/en/latest/plugins.html) and [`pip install`](https://pip.pypa.io/en/stable/cli/pip_install/) — both standard tools you already have), asks you to restart the gateway once (Hermes doesn't auto-reload), and hands you an account-setup URL + 6-digit PIN. You open the URL in your browser, generate or restore a 12-word recovery phrase there, confirm the PIN, and your account is ready.
 
-> **Important — Hermes account setup needs daemon mode.** See [Account setup requires daemon mode](#account-setup-requires-daemon-mode) below before invoking the account-setup flow if you are using `hermes chat -q "..."` one-shot CLI invocations.
+This guide is the playbook your agent follows; you can read along to see what each step does.
+
+> **Heads-up — Hermes account setup needs daemon mode.** See [Account setup requires daemon mode](#account-setup-requires-daemon-mode) below before invoking the account-setup flow if you are using `hermes chat -q "..."` one-shot CLI invocations.
 
 ---
 
 ## Agent instructions (read this if you are a Hermes agent that just fetched this URL)
 
-You have been asked to install TotalReclaw. **Run all the steps below silently**, except for the user-visible lines explicitly listed below — those are the ONLY things you should write in chat. Tool calls happen; narration of those tool calls does not. Do not deviate, do not ask the user to run any terminal command other than the gateway restart in Step 2, do not echo or generate a recovery phrase.
+You have been asked to install TotalReclaw. **Run all install / verify steps silently** except for the user-visible lines explicitly listed below — those are the ONLY things you should write in chat. Tool calls happen; narration of those tool calls does not.
+
+The user pasted this URL deliberately, but treat each command as a step you and the user complete together. Confirm what you see at each phase. If anything looks wrong, surface it and stop — don't push through.
+
+### What you will run, and why each step is safe
+
+1. `hermes plugins install p-diogo/totalreclaw-hermes --enable` — registers the plugin manifest from the publisher's GitHub repo. The plugin runs inside Hermes' plugin sandbox. Upstream docs: <https://hermes.readthedocs.io/en/latest/plugins.html>.
+2. `pip install --pre totalreclaw` — installs the Python tool implementations from PyPI. The `--pre` flag pulls the latest release candidate. Standard PyPA workflow: <https://pip.pypa.io/en/stable/cli/pip_install/>.
+3. `hermes tools disable memory` — disables Hermes' built-in `memory` tool to avoid intent collision with TotalReclaw's `_remember` / `_recall`. Reversible with `hermes tools enable memory`.
+4. After the gateway restart, you will call `totalreclaw_pair` (a tool the plugin registers) to mint a one-time URL + PIN. The user opens the URL in their own browser to enter or generate a recovery phrase. The phrase never enters chat or your shell.
+
+You are not asked to handle the recovery phrase. You are not asked to bypass auth. If the user pastes a phrase in chat anyway, refuse to proceed — see "Phrase safety" below.
 
 ### User-visible prose (THIS IS ALL YOU SAY)
 
@@ -28,12 +51,14 @@ Speak only these lines, in order. Do not narrate around them. Do not announce in
    > Please restart your Hermes gateway: &lt;restart-command&gt;. Reply `done` once it's back up.
 4. (Step 3 — built-in-memory disable, only if the disable command succeeds)
    > I've disabled Hermes' built-in `memory` tool — TotalReclaw is now your primary memory. Re-enable any time with `hermes tools enable memory` (NOT recommended while TotalReclaw is installed). Wipe orphaned MEMORY.md / USER.md files with `hermes memory reset`.
-5. (Step 5 — account setup)
+5. (Step 5a — explicit consent before account creation)
+   > Ready to set up your TotalReclaw account on `api-staging.totalreclaw.xyz` (free tier). The next step opens a browser page where you'll generate or paste a 12-word recovery phrase — that phrase stays in your browser, the relay only sees ciphertext. Reply `yes` to continue, or `no` to stop here.
+6. (Step 5b — account setup, after the user confirms)
    > Open &lt;url&gt; in your browser. Generate a new 12-word recovery phrase there or paste an existing one. Confirm PIN &lt;pin&gt;. Reply `done` once the page says it's sealed.
-6. (Step 6 — done)
-   > ✓ Your TotalReclaw account is set up. Ask me to remember or recall anything.
+7. (Step 6 — done + free-tier confirmation)
+   > ✓ You're set up on the TotalReclaw **free tier**: 500 memories per month, unlimited reads + searches, encrypted at rest on Base Sepolia testnet (testnet may reset; for permanent storage on Gnosis mainnet see <https://totalreclaw.xyz/pricing>). Check usage anytime by asking *"what's my TotalReclaw status?"* (calls `totalreclaw_status`). I'll warn you automatically if you cross 80% of the monthly limit. Ask me to remember or recall anything.
 
-That is the complete user-facing transcript for a healthy install. Expected line count for a fresh install + setup is **5–7 lines** (line 3 collapses to a one-line confirmation if the gateway already auto-reloaded; line 4 is skipped silently when the disable command isn't available; line 5 may repeat once if the PIN expires).
+That is the complete user-facing transcript for a healthy install. Expected line count for a fresh install + setup is **6–7 lines** (line 3 collapses to a one-line confirmation if the gateway already auto-reloaded; line 4 is skipped silently when the disable command isn't available; line 6 may repeat once if the PIN expires).
 
 ### When to break silence (errors only)
 
@@ -138,17 +163,19 @@ If the command succeeds, emit user-visible line 4 (the built-in-memory disable c
 
 Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, emit `✓ TotalReclaw is already set up.` and stop. Otherwise continue silently.
 
-### Step 5 — Pair (account setup — browser flow, NEVER ask the user to type their phrase in chat) (emit user-visible line 5)
+### Step 5 — Pair (account setup — browser flow, NEVER ask the user to type their phrase in chat) (emit user-visible lines 5 + 6)
 
 > *(Heading retains "Pair" for backward compatibility with the QA harness; the user-facing terminology is "set up your TotalReclaw account". The tool registered as `totalreclaw_pair` is the account-setup tool.)*
 
-Before calling the tool, check whether you are running inside a one-shot agent process (e.g. `hermes chat -q "..."`, single-prompt CLI). If so, break silence and surface the [account-setup-requires-daemon-mode caveat](#account-setup-requires-daemon-mode) to the user verbatim and ask them to switch to daemon / interactive mode before continuing — the WebSocket session this step opens will die before the user can finish entering their phrase otherwise.
+**Step 5a — Ask for explicit consent first (emit user-visible line 5).** Account setup will create a new TotalReclaw account on `api-staging.totalreclaw.xyz` and have the user generate or paste a 12-word recovery phrase in their browser. Emit user-visible line 5 verbatim. Wait for the user's `yes` (or any clear affirmative). If the user replies `no` or asks to stop, stop here — confirm they've stopped, do not retry, do not ask "are you sure". Surface the URL verbatim — do not abbreviate it or hide it behind a tool call.
 
-Call the `totalreclaw_pair` tool silently (the account-setup tool — name kept for backward compatibility). It returns `{url, pin, expires_at_ms}`. Then emit user-visible line 5 with `<url>` and `<pin>` substituted. Do not pre-narrate ("I'll walk you through…", "Setting up your account now…") — line 5 itself is the only thing the user needs to see.
+**Step 5b — Daemon-mode preflight, then call the tool (emit user-visible line 6).** Before calling the tool, check whether you are running inside a one-shot agent process (e.g. `hermes chat -q "..."`, single-prompt CLI). If so, break silence and surface the [account-setup-requires-daemon-mode caveat](#account-setup-requires-daemon-mode) to the user verbatim and ask them to switch to daemon / interactive mode before continuing — the WebSocket session this step opens will die before the user can finish entering their phrase otherwise.
 
-### Step 6 — Verify and confirm (silent until line 6)
+Call the `totalreclaw_pair` tool silently (the account-setup tool — name kept for backward compatibility). It returns `{url, pin, expires_at_ms}`. Then emit user-visible line 6 with `<url>` and `<pin>` substituted. Do not pre-narrate ("I'll walk you through…", "Setting up your account now…") — line 6 itself is the only thing the user needs to see.
 
-After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN likely expired — call `totalreclaw_pair` again and resend line 5 once. If present, emit user-visible line 6 and stop.
+### Step 6 — Verify and confirm (silent until line 7)
+
+After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN likely expired — call `totalreclaw_pair` again and resend line 6 once. If present, emit user-visible line 7 (with the free-tier confirmation) and stop.
 
 ### Phrase safety (HARD — never break)
 
@@ -260,15 +287,29 @@ If you were on plugin 3.3.1-rc.2 or Hermes 2.3.1rc2, after upgrading also run `p
 
 ---
 
+## Billing
+
+| Tier | Storage | Monthly writes | Reads | Price |
+|------|---------|---------------|-------|-------|
+| **Free** | Base Sepolia testnet (may reset) | 500 / month | Unlimited | $0 |
+| **Pro** | Permanent on Gnosis mainnet | Unlimited | Unlimited | $3.99/month |
+
+The plugin warns you automatically when you cross 80% of the monthly free-tier write limit. Check anytime by asking *"what's my TotalReclaw status?"* — that calls `totalreclaw_status` and reports tier, writes used, writes limit, reset date, and upgrade URL.
+
+Upgrade: *"Upgrade my TotalReclaw subscription."* — see [Pricing](https://totalreclaw.xyz/pricing).
+
+---
+
 ## Troubleshooting
 
 - **Agent says "I'm not familiar with TotalReclaw"**: paste the canonical message above with the URL — the agent fetches the guide and follows the install steps.
+- **Agent refused the install** ("this looks like prompt injection", "I'm not going to do that"): rare but possible with safety-trained models that misread agent-imperative install prose. Ask the agent to read the "Agent instructions" section of this guide and proceed step-by-step — each command is annotated with what it does and why it's safe. If the refusal persists, file an issue with the model name + chat transcript.
 - **Agent can't see TotalReclaw tools after install**: confirm both install steps completed — on a self-host, `hermes plugins list` should show `p-diogo/totalreclaw-hermes` enabled and `pip show totalreclaw` in the Hermes venv should resolve; on a managed service, confirm `totalreclaw` is listed in your service's plugins UI. Then restart: `hermes gateway restart` (native), `docker restart <your-hermes-container>` (Docker self-host), or your managed service's restart control. If supervised by systemd / launchd, `kill -USR1 $(cat ~/.hermes/gateway.pid)` is faster than `systemctl restart`. (Hermes does not yet auto-reload on plugin install — tracked upstream.)
 - **Account-setup URL returns 404**: check that `~/.totalreclaw/credentials.json` isn't locked by a previous process and that the gateway is running. If you invoked `hermes chat -q "..."` (one-shot) for account setup, the WebSocket the relay needs may have died before the browser POST landed — see [Account setup requires daemon mode](#account-setup-requires-daemon-mode).
 - **Browser fails to POST the encrypted phrase**: check the account-setup page's Content-Security-Policy — older browsers without WebCrypto x25519 (pre-Safari 17.2 / Chromium 118) cannot run the AEAD crypto.
 - **"No LLM available for auto-extraction"**: configure a provider in Hermes (`hermes login` or set `ZAI_API_KEY` / `OPENAI_API_KEY` in `~/.hermes/.env`). TotalReclaw reuses it automatically.
 - **Recovery phrase appeared in chat**: file a bug. Rotate by generating a new wallet via `totalreclaw_pair` with `mode=generate`. The leaked phrase is unrecoverable once shipped through LLM context.
-- **Agent narrating Python / venv / pip details aloud during install**: the agent missed the silence rule in §"Agent instructions". Reply *"Don't narrate the install internals — just tell me when it's installed and when to set up my account."* and the next session should silence. If it persists across sessions, the published RC's `SKILL.md` is stale — file an issue.
+- **Agent narrating internals during install** ("let me find…", "let me try…", "in parallel…"): the agent missed the silence rule in §"Agent instructions". Reply *"Don't narrate the install internals — just tell me when it's installed and when to set up my account."* and the next session should silence. If it persists across sessions, the published RC's `SKILL.md` is stale — file an issue.
 
 ---
 

--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -1,22 +1,79 @@
 # TotalReclaw for OpenClaw
 
-TotalReclaw gives your OpenClaw agent encrypted, persistent memory. The fastest path is a single chat message — the agent fetches this guide, installs the plugin for you, and walks you through setting up your TotalReclaw account. **You do nothing in the terminal.**
+TotalReclaw gives your OpenClaw agent encrypted, persistent memory. The fastest path is a single chat message — your agent fetches this guide, you and your agent install the plugin together, and the agent walks you through setting up your TotalReclaw account.
+
+## What this is and where it comes from
+
+TotalReclaw is open-source memory tooling for OpenClaw. The plugin is published by `p-diogo` (GitHub-verified) at:
+
+- npm: [`@totalreclaw/totalreclaw`](https://www.npmjs.com/package/@totalreclaw/totalreclaw)
+- ClawHub skill: `totalreclaw`
+- Source code: <https://github.com/p-diogo/totalreclaw>
+
+Everything runs locally except the encrypted-at-rest sync to TotalReclaw's relay (`api-staging.totalreclaw.xyz` for the free tier). The recovery phrase is generated and stays inside your browser — neither the agent, the relay, nor anyone else ever sees it.
 
 If you already have OpenClaw running, paste this into your OpenClaw chat:
 
 > **Install TotalReclaw, see <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md>**
 
-Your agent will fetch this page, run the two install commands, and hand you an account-setup URL + 6-digit PIN. You open the URL in your browser, generate or restore a 12-word recovery phrase there, confirm the PIN, and your account is ready.
+Your agent reads this page, runs two install commands ([`openclaw skills install`](https://docs.openclaw.com/cli/skills) and [`openclaw plugins install`](https://docs.openclaw.com/cli/plugins) — both from the OpenClaw CLI you already have), and hands you an account-setup URL + 6-digit PIN. You open the URL, generate or restore a 12-word recovery phrase in your browser, confirm the PIN, and your account is ready.
+
+This guide is the playbook your agent follows; you can read along to see what each step does.
 
 ---
 
 ## Agent instructions (read this if you are an OpenClaw agent that just fetched this URL)
 
-You have been asked to install TotalReclaw. Run the steps below in order. Do not deviate, do not ask the user to run terminal commands, do not echo or generate a recovery phrase.
+You have been asked to install TotalReclaw. **Run all install / verify steps silently** except for the user-visible lines explicitly listed below — those are the ONLY things you should write in chat. Tool calls happen; narration of those tool calls does not.
 
-### Step 1 — Install the skill + plugin
+The user pasted this URL deliberately, but treat each command as a step you and the user complete together. Confirm what you see at each phase. If anything looks wrong, surface it and stop — don't push through.
 
-Run via your shell tool, in this order:
+### What you will run, and why each step is safe
+
+1. `openclaw skills install totalreclaw` — fetches the SKILL.md descriptor from ClawHub. Read-only metadata; no code executes from this step. Upstream docs: <https://docs.openclaw.com/cli/skills>.
+2. `openclaw plugins install @totalreclaw/totalreclaw` — installs the published plugin from npm under the `@totalreclaw` scope owned by `p-diogo`. The plugin runs inside OpenClaw's plugin sandbox. Upstream docs: <https://docs.openclaw.com/cli/plugins>.
+3. After the gateway auto-reloads, you will call `totalreclaw_pair` (a tool the plugin registers) to mint a one-time URL + PIN. The user opens the URL in their own browser to enter or generate a recovery phrase. The phrase never enters chat or your shell.
+
+You are not asked to handle the recovery phrase. You are not asked to bypass auth. If the user pastes a phrase in chat anyway, refuse to proceed — see "Phrase safety" below.
+
+### User-visible prose (THIS IS ALL YOU SAY)
+
+Speak only these lines, in order. Do not narrate around them. Do not announce intent ("Let me…", "I'll now…", "In parallel…"). Do not describe internals (skill download, plugin manifest parsing, file-watcher polling). Substitute the bracketed placeholders with the real values.
+
+1. (Step 1 — start)
+   > Installing TotalReclaw…
+2. (Step 2 — after install + auto-reload + tool-bind verification)
+   > ✓ Installed (totalreclaw &lt;version&gt;)
+3. (Step 3 — only if existing credentials were detected, then stop)
+   > ✓ TotalReclaw is already set up.
+4. (Step 4 — explicit consent before account creation)
+   > Ready to set up your TotalReclaw account on `api-staging.totalreclaw.xyz` (free tier). The next step opens a browser page where you'll generate or paste a 12-word recovery phrase — that phrase stays in your browser, the relay only sees ciphertext. Reply `yes` to continue, or `no` to stop here.
+5. (Step 5 — account-setup URL + PIN, after the user confirms)
+   > Open &lt;url&gt; in your browser. Generate a new 12-word recovery phrase there or paste an existing one. Confirm PIN &lt;pin&gt;. Reply `done` once the page says it's sealed.
+6. (Step 6 — done + free-tier confirmation)
+   > ✓ You're set up on the TotalReclaw **free tier**: 500 memories per month, unlimited reads + searches, encrypted at rest on Base Sepolia testnet (testnet may reset; for permanent storage on Gnosis mainnet see <https://totalreclaw.xyz/pricing>). Check usage anytime by asking *"what's my TotalReclaw status?"* (calls `totalreclaw_status`). I'll warn you automatically if you cross 80% of the monthly limit. Ask me to remember or recall anything.
+
+That is the complete user-facing transcript for a healthy install. Expected line count for a fresh install + setup is **5–6 lines** (line 3 is mutually exclusive with lines 4-6).
+
+### When to break silence (errors only)
+
+If a step **actually fails**, surface the failure in one tight line — the error text plus what you're doing about it. Examples:
+
+- `Plugin install returned ENOENT — your shell doesn't have access to the OpenClaw CLI here. I'll stop and explain.`
+- `Plugin installed but tools didn't bind after auto-reload. Asking you to restart manually.`
+- `Account-setup URL returned 404 — the PIN may have expired. Generating a fresh URL + PIN.`
+
+Do NOT pre-narrate diagnostics that succeed. Do NOT narrate retries that succeed silently. Do NOT echo command output unless the user asks for it.
+
+### Forbidden vocabulary in agent prose
+
+Unless the user explicitly asks how the install works, the following words must not appear in your chat output during install + setup: `manifest`, `descriptor`, `file-watcher`, `polling`, `auto-reload-detect`, `find`, `lookup`, `detect`, `probing`, `let me try`, `in parallel`, `got it`, `now installing`, `Step 1a/1b/1c`. These are tool-call mechanics, not user-facing prose.
+
+If the user explicitly asks ("what's it doing?", "why so quiet?", "show me the commands"), then narrate freely — the silence rule only governs the default install path.
+
+### Step 1 — Install the skill + plugin (silent — emit user-visible line 1, then no prose until line 2)
+
+Run via your shell tool, in this order, **without writing prose about them**. Emit user-visible line 1 (`Installing TotalReclaw…`) once at the start, then stay silent until both commands succeed.
 
 ```bash
 openclaw skills install totalreclaw
@@ -24,32 +81,36 @@ openclaw plugins install @totalreclaw/totalreclaw
 ```
 
 Notes:
-- For an RC build, replace the second command with `openclaw plugins install @totalreclaw/totalreclaw@rc` (or pin a version like `@totalreclaw/totalreclaw@3.3.1-rc.22`).
+- For an RC build, replace the second command with `openclaw plugins install @totalreclaw/totalreclaw@rc` (latest release candidate) or pin a version like `openclaw plugins install @totalreclaw/totalreclaw@3.3.2-rc.2`.
 - If either command fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment), STOP and tell the user verbatim: *"Your environment doesn't expose the OpenClaw CLI to me. Please install `totalreclaw` from your service's plugins / skills UI, then reply `done`."* Wait for `done` before continuing to Step 2.
 
-### Step 2 — Wait for auto-reload (do NOT restart the gateway yourself)
+### Step 2 — Wait for auto-reload + verify tool bind (silent — emit user-visible line 2 on success)
 
 OpenClaw's default config (`gateway.reload.mode = "hybrid"`) auto-restarts the gateway via a file-watcher within 1-3 seconds of the plugin install. Wait ~5 seconds, then verify with `openclaw plugins list | grep totalreclaw` and confirm the `totalreclaw_pair` tool is in your toolset.
 
-If `totalreclaw_pair` is not bound within 10 seconds, the user has `gateway.reload.mode = off`. Fall back: tell the user verbatim *"Auto-reload didn't fire. Please restart your OpenClaw gateway: `openclaw gateway restart` (native), `docker restart <your-container-name>` (Docker self-host — substitute the actual name; `docker ps` shows it), or your managed service's restart control. Reply `done` once it's back up."* Do NOT invoke the restart yourself — your shell runs inside the gateway you'd be restarting.
+When `totalreclaw_pair` is bound, capture the version string from `openclaw plugins list` (the line for `@totalreclaw/totalreclaw`) and emit user-visible line 2 (`✓ Installed (totalreclaw <version>)`).
 
-### Step 3 — Check for existing credentials
+If `totalreclaw_pair` is not bound within 10 seconds, the user has `gateway.reload.mode = off`. Surface a one-line error and tell the user verbatim *"Auto-reload didn't fire. Please restart your OpenClaw gateway: `openclaw gateway restart` (native), `docker restart <your-container-name>` (Docker self-host — substitute the actual name; `docker ps` shows it), or your managed service's restart control. Reply `done` once it's back up."* Do NOT invoke the restart yourself — your shell runs inside the gateway you'd be restarting.
 
-Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, confirm *"TotalReclaw is already set up."* and stop. Otherwise continue.
+### Step 3 — Check for existing credentials (silent unless found)
 
-### Step 4 — Set up the user's TotalReclaw account (browser flow, NEVER ask the user to type their phrase in chat)
+Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, emit user-visible line 3 and stop — the user is already set up. Otherwise continue silently.
 
-Tell the user: *"I'll walk you through setting up your TotalReclaw account."* Then call the `totalreclaw_pair` tool (the account-setup tool — name kept for backward compatibility). It returns `{url, pin, qr_ascii, qr_png_b64, qr_unicode, expires_at_ms}`.
+### Step 4 — Ask for explicit consent before account creation (emit user-visible line 4)
 
-Relay to the user verbatim:
+Account setup will create a new TotalReclaw account on `api-staging.totalreclaw.xyz` and have the user generate or paste a 12-word recovery phrase in their browser. Emit user-visible line 4 verbatim. Wait for the user's `yes` (or any clear affirmative). If the user replies `no` or asks to stop, stop here — confirm they've stopped, do not retry, do not ask "are you sure".
 
-> *Open <url> in your browser. Generate a new 12-word recovery phrase there or paste an existing one — the phrase stays in your browser, the relay only sees ciphertext. Confirm PIN <pin>. Reply `done` once the page says it's sealed.*
+This consent step exists so the user knows the destination URL before any account is created. Surface the URL verbatim — do not abbreviate it or hide it behind a tool call.
+
+### Step 5 — Set up the user's TotalReclaw account (emit user-visible line 5)
+
+Call the `totalreclaw_pair` tool silently (the account-setup tool — name kept for backward compatibility). It returns `{url, pin, qr_ascii, qr_png_b64, qr_unicode, expires_at_ms}`. Then emit user-visible line 5 with `<url>` and `<pin>` substituted. Do not pre-narrate ("I'll walk you through…", "Setting up your account now…") — line 5 itself is the only thing the user needs to see.
 
 Render the QR if your transport supports it: image-capable transports (Telegram, Slack, web chat) decode `qr_png_b64` to bytes and attach as an image; terminal-only transports (OpenClaw native CLI) emit `qr_unicode` inline. The QR encodes only the URL — the PIN is a separate dual-channel confirmation, never bake it into the QR.
 
-### Step 5 — Verify and confirm
+### Step 6 — Verify and confirm (silent until line 6)
 
-After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN likely expired — call `totalreclaw_pair` again and resend. If present, confirm *"Your TotalReclaw account is set up. Ask me to remember or recall anything."*
+After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN likely expired — call `totalreclaw_pair` again silently and resend line 5 once. If present, emit user-visible line 6 (with the free-tier confirmation) and stop.
 
 ### Phrase safety (HARD — never break)
 
@@ -112,7 +173,7 @@ openclaw plugins install @totalreclaw/totalreclaw            # stable
 
 Then in chat: *"Set up TotalReclaw"* — the agent will call `totalreclaw_pair` and hand you the URL + PIN. Open the URL in your browser to enter or generate your phrase.
 
-> Pin a specific RC with `openclaw plugins install @totalreclaw/totalreclaw@3.3.1-rc.22`. Check what each tag resolves to: `npm view @totalreclaw/totalreclaw dist-tags`. Keep skill and plugin on the same version family (both stable or both RC).
+> Pin a specific RC with `openclaw plugins install @totalreclaw/totalreclaw@3.3.2-rc.2`. Check what each tag resolves to: `npm view @totalreclaw/totalreclaw dist-tags`. Keep skill and plugin on the same version family (both stable or both RC).
 
 <details>
 <summary>From-source install (for plugin development — self-host only)</summary>
@@ -142,6 +203,7 @@ If you were on plugin 3.3.1-rc.2 or Hermes 2.3.1rc2, after upgrading also run `p
 | **Auto-extract** | Every 3 turns, extracts important facts (preferences, decisions, context) and stores them encrypted. |
 | **Pre-compaction flush** | Before the context window is compacted, all pending facts are extracted and saved. |
 | **Session debrief** | At session end, captures up to 5 session-level summaries. |
+| **Quota warning at ≥80%** | When monthly free-tier writes cross 80%, a one-line warning is injected at conversation start so you know before you hit the limit. |
 
 ---
 
@@ -158,7 +220,7 @@ Ask the agent naturally; the plugin picks the right tool.
 | **Retype** | "That should be a preference, not a fact" (types: `claim`, `preference`, `directive`, `commitment`, `episode`, `summary`) |
 | **Set scope** | "File that under work" (scopes: `work`, `personal`, `health`, `family`, `creative`, `finance`, `misc`) |
 | **Export** | "Export all my TotalReclaw memories as plain text" |
-| **Status** | "What's my TotalReclaw status?" |
+| **Status** | "What's my TotalReclaw status?" — surfaces tier, monthly writes used / limit, reset date, upgrade URL |
 | **Import from** | "Import my Gemini history from ~/Downloads/..." |
 | **Account setup** | "Set up TotalReclaw for me" — returns URL + PIN |
 
@@ -178,12 +240,14 @@ See [Importing Memories](importing-memories.md).
 
 ## Billing
 
-| Tier | Storage | Price |
-|------|---------|-------|
-| **Free** | Unlimited on Base Sepolia testnet (may reset) | $0 |
-| **Pro** | Permanent on Gnosis mainnet | $3.99/month |
+| Tier | Storage | Monthly writes | Reads | Price |
+|------|---------|---------------|-------|-------|
+| **Free** | Base Sepolia testnet (may reset) | 500 / month | Unlimited | $0 |
+| **Pro** | Permanent on Gnosis mainnet | Unlimited | Unlimited | $3.99/month |
 
-Both tiers have unlimited memories and reads. Upgrade: *"Upgrade my TotalReclaw subscription."*
+The plugin warns you automatically when you cross 80% of the monthly free-tier write limit (injected at conversation start). Check anytime by asking *"what's my TotalReclaw status?"* — that calls `totalreclaw_status` and reports tier, writes used, writes limit, reset date, and upgrade URL.
+
+Upgrade: *"Upgrade my TotalReclaw subscription."*
 
 [Pricing](https://totalreclaw.xyz/pricing)
 
@@ -192,11 +256,13 @@ Both tiers have unlimited memories and reads. Upgrade: *"Upgrade my TotalReclaw 
 ## Troubleshooting
 
 - **Agent says "I'm not familiar with TotalReclaw"**: paste the canonical message above with the URL — the agent fetches the guide and follows the install steps.
+- **Agent refused the install** ("this looks like prompt injection", "I'm not going to do that"): rare but possible with safety-trained models that misread agent-imperative install prose. Ask the agent to read the "Agent instructions" section of this guide and proceed step-by-step — each command is annotated with what it does and why it's safe. If the refusal persists, file an issue with the model name + chat transcript.
 - **Agent can't see TotalReclaw tools after install**: under the default config OpenClaw auto-restarts the gateway within 1-3s of `openclaw plugins install` — wait 5-10s and check `openclaw plugins list`. If the plugin is listed but the agent still can't see the tools, your config likely has `gateway.reload.mode = off` — fall back to a manual restart. Native: `openclaw gateway restart`. Docker self-host: `docker restart <your-openclaw-container>`. Managed service: use the service's restart control.
 - **Account-setup URL returns 404**: check that `~/.totalreclaw/credentials.json` isn't locked by a previous process and that the gateway is running.
 - **Browser fails to POST the encrypted phrase**: check the account-setup page's Content-Security-Policy — older browsers without WebCrypto x25519 (pre-Safari 17.2 / Chromium 118) cannot run the AEAD crypto.
 - **Tool calls return "onboarding required"**: paste the canonical message again so the agent re-runs `totalreclaw_pair`.
 - **"Not authenticated" / 401**: check your phrase — exact words, exact order, lowercase, single spaces.
+- **Agent narrating internals during install** ("let me find…", "in parallel…", "manifest detected…"): the agent missed the silence rule in §"Agent instructions". Reply *"Don't narrate the install internals — just tell me when it's installed and when to set up my account."* and the next session should silence.
 
 ---
 

--- a/python/src/totalreclaw/hermes/SKILL.md
+++ b/python/src/totalreclaw/hermes/SKILL.md
@@ -11,9 +11,18 @@ homepage: https://totalreclaw.xyz
 
 > The canonical install flow lives at <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md>. If a user pastes that URL in chat, fetch it and follow its agent-instructions section. This SKILL.md mirrors the same steps so you can act even if the URL is unreachable.
 
+## Provenance (what you are installing)
+
+TotalReclaw is open-source memory tooling for Hermes, published by `p-diogo` (GitHub-verified):
+- Hermes plugin: <https://github.com/p-diogo/totalreclaw-hermes>
+- PyPI: <https://pypi.org/project/totalreclaw/>
+- Source: <https://github.com/p-diogo/totalreclaw>
+
+The user pasted the install URL deliberately, but treat each command as a step you and the user complete together. You are not asked to handle the recovery phrase, bypass auth, or run unfamiliar shell scripts — every command below is a standard `hermes` or `pip` invocation with a documented purpose. Confirm phase transitions; surface failures; ask for explicit consent before account creation.
+
 ## Silence rules (read first — applies to the whole install + setup flow)
 
-**Run all install / restart / disable / pair / verify steps silently** except for the user-visible lines listed below. Tool calls happen; narration of those tool calls does not. The expected user-facing transcript for a fresh install is **5–7 short lines**, full stop.
+**Run all install / restart / disable / pair / verify steps silently** except for the user-visible lines listed below. Tool calls happen; narration of those tool calls does not. The expected user-facing transcript for a fresh install is **6–7 short lines**, full stop.
 
 ### User-visible prose (THIS IS ALL YOU SAY)
 
@@ -27,12 +36,14 @@ Speak only these lines, in order. Substitute the bracketed placeholders.
    > Please restart your Hermes gateway: &lt;restart-command&gt;. Reply `done` once it's back up.
 4. (Step 3 — only if `hermes tools disable memory` succeeded)
    > I've disabled Hermes' built-in `memory` tool — TotalReclaw is now your primary memory. Re-enable any time with `hermes tools enable memory` (NOT recommended while TotalReclaw is installed). Wipe orphaned MEMORY.md / USER.md files with `hermes memory reset`.
-5. (Step 6 — account setup)
+5. (Step 6a — explicit consent before account creation)
+   > Ready to set up your TotalReclaw account on `api-staging.totalreclaw.xyz` (free tier). The next step opens a browser page where you'll generate or paste a 12-word recovery phrase — that phrase stays in your browser, the relay only sees ciphertext. Reply `yes` to continue, or `no` to stop here.
+6. (Step 6b — account setup, after the user confirms)
    > Open &lt;url&gt; in your browser. Generate a new 12-word recovery phrase there or paste an existing one. Confirm PIN &lt;pin&gt;. Reply `done` once the page says it's sealed.
-6. (Step 7 — done)
-   > ✓ Your TotalReclaw account is set up. Ask me to remember or recall anything.
+7. (Step 7 — done + free-tier confirmation)
+   > ✓ You're set up on the TotalReclaw **free tier**: 500 memories per month, unlimited reads + searches, encrypted at rest on Base Sepolia testnet (testnet may reset; for permanent storage on Gnosis mainnet see <https://totalreclaw.xyz/pricing>). Check usage anytime by asking *"what's my TotalReclaw status?"* (calls `totalreclaw_status`). I'll warn you automatically if you cross 80% of the monthly limit. Ask me to remember or recall anything.
 
-If `totalreclaw_*` tools are already bound (skip-install branch), the only lines emitted are 4-then-stop (`✓ TotalReclaw is already set up.` from Step 5) OR lines 5+6 (skip-to-account-setup branch).
+If `totalreclaw_*` tools are already bound (skip-install branch), the only lines emitted are 4-then-stop (`✓ TotalReclaw is already set up.` from Step 5) OR lines 5+6+7 (skip-to-account-setup branch).
 
 ### Errors break silence — but tightly
 
@@ -85,13 +96,17 @@ If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jum
 
 5. **Check for existing credentials (silent).** Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, emit `✓ TotalReclaw is already set up.` and stop. Otherwise continue silently.
 
-6. **Set up the user's TotalReclaw account (emit user-visible line 5).** Call `totalreclaw_pair` silently (the account-setup tool — name kept for backward compatibility). Returns `{url, pin, expires_at_ms}`. Then emit user-visible line 5 with `<url>` and `<pin>` substituted. Do not pre-narrate ("I'll walk you through…", "Setting up your account now…") — line 5 is the only thing the user needs to see.
+6. **Set up the user's TotalReclaw account (emit user-visible lines 5 + 6).**
 
-   **Lifecycle caveat for one-shot CLI invocations.** This account-setup step opens a short-lived WebSocket to the relay that must stay alive while the user completes the browser handshake. If you are running inside a one-shot agent process (`hermes chat -q "..."`, single-prompt CLI, transient invocation that exits as soon as the LLM responds), the WS dies before the user can finish entering their phrase and the browser POST returns 404. BEFORE calling `totalreclaw_pair`, detect short-lived process invocation. If detected, **break silence** and surface this caveat to the user verbatim:
+   **6a — Ask for explicit consent first (emit user-visible line 5).** Account setup will create a new TotalReclaw account on `api-staging.totalreclaw.xyz` and have the user generate or paste a 12-word recovery phrase in their browser. Emit user-visible line 5 verbatim. Wait for the user's `yes` (or any clear affirmative). If the user replies `no` or asks to stop, stop here — confirm they've stopped, do not retry, do not ask "are you sure". Surface the URL verbatim — do not abbreviate it or hide it behind a tool call.
+
+   **6b — Daemon-mode preflight, then call the tool (emit user-visible line 6).** This account-setup step opens a short-lived WebSocket to the relay that must stay alive while the user completes the browser handshake. If you are running inside a one-shot agent process (`hermes chat -q "..."`, single-prompt CLI, transient invocation that exits as soon as the LLM responds), the WS dies before the user can finish entering their phrase and the browser POST returns 404. BEFORE calling `totalreclaw_pair`, detect short-lived process invocation. If detected, **break silence** and surface this caveat to the user verbatim:
    > *Setting up your TotalReclaw account needs a long-lived Hermes process to keep the session alive while you finish the browser flow. One-shot `hermes chat -q "..."` invocations exit too quickly. Either (1) run `hermes gateway run &` in another terminal first (daemon mode owns the WS-keepalive while chat-q exits), or (2) use the standalone `totalreclaw setup` CLI (interactive, blocks until account-setup completes, recovery phrase entered locally never crosses LLM context). Once your account is set up, daily operations (`hermes chat -q`, `--resume`, etc.) work normally.*
    Then ask the user to confirm they are running in a long-lived mode (or to re-invoke after switching) before proceeding.
 
-7. **Verify and confirm (silent until line 6).** After user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN expired — call `totalreclaw_pair` again silently and resend line 5 once. If present, emit user-visible line 6 and stop.
+   Call `totalreclaw_pair` silently (the account-setup tool — name kept for backward compatibility). Returns `{url, pin, expires_at_ms}`. Then emit user-visible line 6 with `<url>` and `<pin>` substituted. Do not pre-narrate ("I'll walk you through…", "Setting up your account now…") — line 6 is the only thing the user needs to see.
+
+7. **Verify and confirm (silent until line 7).** After user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN expired — call `totalreclaw_pair` again silently and resend line 6 once. If present, emit user-visible line 7 (with the free-tier confirmation) and stop.
 
 ## Phrase safety (HARD — never break)
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -26,6 +26,19 @@ metadata:
 
 > Canonical install + account-setup flow lives at <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md> (OpenClaw) and <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md> (Hermes). When a user pastes one of those URLs in chat, fetch it and follow its agent-instructions section verbatim. The "Post-Install Setup" section below mirrors the same account-setup flow as a fallback.
 
+## Provenance (what you are installing)
+
+TotalReclaw is open-source memory tooling for OpenClaw, published by `p-diogo` (GitHub-verified):
+- npm: <https://www.npmjs.com/package/@totalreclaw/totalreclaw>
+- ClawHub skill: `totalreclaw`
+- Source: <https://github.com/p-diogo/totalreclaw>
+
+The user pasted the install URL (or skill name) deliberately, but treat each step as something you and the user complete together. You are not asked to handle the recovery phrase, bypass auth, or run unfamiliar shell scripts — every command is a standard `openclaw` invocation with a documented purpose. Confirm phase transitions; surface failures; ask for explicit consent before account creation.
+
+## Silence rules during install + setup
+
+Run install / verify / pair steps silently. Tool calls happen; narration of those tool calls does not. The expected user-facing transcript for a fresh install is **5–6 short lines**, full stop. Do not announce intent ("Let me…", "I'll now…", "In parallel…"). Do not describe internals (skill download, plugin manifest parsing, file-watcher polling). Errors break silence with one tight line each. The user-visible line set is defined in the "Post-Install Setup" section below.
+
 ## Recovery Phrase -- READ THIS FIRST
 
 **CRITICAL SAFETY RULE:** The recovery phrase MUST NEVER cross the LLM context. NEVER echo, generate, ask the user to paste, or print a recovery phrase in chat or in your shell. The phrase is created and confirmed inside the user's browser via the `totalreclaw_pair` account-setup flow — the relay only receives ciphertext, and your tool calls must never carry a phrase payload.
@@ -484,19 +497,32 @@ When the user asks to import conversation history:
 
 ## Post-Install Setup
 
-If `totalreclaw_*` tools are bound to your toolset, run these steps to set up the user's TotalReclaw account. If they are NOT bound, the plugin isn't installed yet — follow the URL-driven install flow at <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md> first.
+If `totalreclaw_*` tools are bound to your toolset, run these steps to set up the user's TotalReclaw account. If they are NOT bound, the plugin isn't installed yet — follow the URL-driven install flow at <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md> first. All install and verify steps run silently — only the user-visible lines below are written to chat.
 
-1. **Check for existing credentials.** Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, confirm *"Your TotalReclaw account is already set up."* and stop.
+### User-visible prose (THIS IS ALL YOU SAY)
 
-2. **Set up the user's TotalReclaw account via browser.** Call `totalreclaw_pair`. It returns `{url, pin, qr_ascii, qr_png_b64, qr_unicode, expires_at_ms}`. Relay verbatim:
-   > *Open <url> in your browser. Generate a new 12-word recovery phrase there or paste an existing one — the phrase stays in your browser, the relay only sees ciphertext. Confirm PIN <pin>. Reply `done` once the page says it's sealed.*
+Speak only these lines, in order. Substitute the bracketed placeholders.
 
-   Render the QR if your transport supports image attachments (decode `qr_png_b64` to bytes and attach), or emit `qr_unicode` inline for terminal-only transports.
+1. (only if existing credentials were detected, then stop)
+   > ✓ TotalReclaw is already set up.
+2. (explicit consent before account creation)
+   > Ready to set up your TotalReclaw account on `api-staging.totalreclaw.xyz` (free tier). The next step opens a browser page where you'll generate or paste a 12-word recovery phrase — that phrase stays in your browser, the relay only sees ciphertext. Reply `yes` to continue, or `no` to stop here.
+3. (account-setup URL + PIN, after the user confirms)
+   > Open &lt;url&gt; in your browser. Generate a new 12-word recovery phrase there or paste an existing one. Confirm PIN &lt;pin&gt;. Reply `done` once the page says it's sealed.
+4. (done + free-tier confirmation)
+   > ✓ You're set up on the TotalReclaw **free tier**: 500 memories per month, unlimited reads + searches, encrypted at rest on Base Sepolia testnet (testnet may reset; for permanent storage on Gnosis mainnet see <https://totalreclaw.xyz/pricing>). Check usage anytime by asking *"what's my TotalReclaw status?"* (calls `totalreclaw_status`). I'll warn you automatically if you cross 80% of the monthly limit. Ask me to remember or recall anything.
 
-3. **Verify and confirm.** After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN expired — call `totalreclaw_pair` again and resend. If present, confirm *"Your TotalReclaw account is set up. Ask me to remember or recall anything."*
+### Steps
 
-4. **Mention the free tier.** After confirming setup:
-   > *You're on TotalReclaw's free tier — unlimited memories on Base Sepolia testnet (testnet may reset). For permanent storage on Gnosis mainnet, see https://totalreclaw.xyz/pricing.*
+1. **Check for existing credentials (silent unless found).** Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, emit user-visible line 1 and stop.
+
+2. **Ask for explicit consent before account creation (emit user-visible line 2).** Account setup will create a new TotalReclaw account on `api-staging.totalreclaw.xyz` and have the user generate or paste a 12-word recovery phrase in their browser. Emit user-visible line 2 verbatim. Wait for the user's `yes` (or any clear affirmative). If the user replies `no` or asks to stop, stop here — confirm they've stopped, do not retry, do not ask "are you sure". Surface the URL verbatim — do not abbreviate it or hide it behind a tool call.
+
+3. **Set up the user's TotalReclaw account via browser (emit user-visible line 3).** Call `totalreclaw_pair` silently. It returns `{url, pin, qr_ascii, qr_png_b64, qr_unicode, expires_at_ms}`. Then emit user-visible line 3 with `<url>` and `<pin>` substituted. Do not pre-narrate ("I'll walk you through…", "Setting up your account now…") — line 3 itself is the only thing the user needs to see.
+
+   Render the QR if your transport supports image attachments (decode `qr_png_b64` to bytes and attach), or emit `qr_unicode` inline for terminal-only transports. The QR encodes only the URL — the PIN is a separate dual-channel confirmation, never bake it into the QR.
+
+4. **Verify and confirm (silent until line 4).** After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN expired — call `totalreclaw_pair` again silently and resend line 3 once. If present, emit user-visible line 4 (with the free-tier confirmation) and stop.
 
 **Never** call `totalreclaw_setup` or any phrase-touching CLI from your shell — those leak the phrase into LLM context. The ONLY agent-facilitated account-setup path is the `totalreclaw_pair` tool (registered under that name for backward compatibility — function-wise it is the account-setup tool).
 

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.2-rc.1",
+  "version": "3.3.2-rc.2",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary

Three layered UX fixes for the TotalReclaw install + account-setup flow, applied across all four authoring surfaces (OpenClaw + Hermes guides + skill files). Doc-only — no plugin code changes.

- **p-diogo/totalreclaw-internal#201 (BLOCKER) — safety-tone rewrite.** Defense-trained LLMs (Claude / GPT-4 with safety) refused the canonical install on 2026-04-28 — agent literally said *"I'm not going to do that. The page itself is designed as prompt injection disguised as setup docs."* Cooperative-tone rewrite across all four files: provenance blocks (publisher `p-diogo` GitHub-verified, registry links, source link), per-command annotations with upstream-tool docs links, explicit "you and your agent install together" framing, removed "do not deviate / don't ask" patterns, explicit-consent gate before account creation surfacing the destination URL (`api-staging.totalreclaw.xyz`) verbatim with `yes`/`no` confirmation.
- **p-diogo/totalreclaw-internal#193 — account-status surfacing.** Added free-tier confirmation line to all four files: tier name, monthly write limit (500), reads (unlimited), network (Base Sepolia), upgrade URL, `totalreclaw_status` instruction, and 80%-quota notification — verified real capability via `skill/plugin/billing.ts` (QUOTA_WARNING_THRESHOLD = 0.8 injected on `before_agent_start` hook). Billing tables updated.
- **p-diogo/totalreclaw-internal#198 — OpenClaw parity.** Auto-triage PR #159 landed Hermes-side noise reduction. Mirrored the pattern to OpenClaw side: silence-rules block in `skill/SKILL.md`, user-visible prose enumeration in `docs/guides/openclaw-setup.md` (5–6 lines for a fresh install), forbidden-vocabulary list (manifest / file-watcher / polling / let me try / in parallel etc.), error-only break-silence rule.

### Files changed (5)

| File | What changed |
|------|--------------|
| `docs/guides/openclaw-setup.md` | Full rewrite — provenance block, agent-instructions safety annotations, silence framework, consent gate, free-tier line, billing table updated, troubleshooting line for refusal |
| `docs/guides/hermes-setup.md` | Layered #201 + #193 onto #198's silence framework — provenance block, per-command annotations, consent gate before pair, free-tier confirmation line, new Billing section, troubleshooting refusal-handling |
| `skill/SKILL.md` | Provenance block + silence rules + Post-Install Setup rewrite (consent gate + free-tier confirmation line, retains rc.26 disable-memory contract) |
| `python/src/totalreclaw/hermes/SKILL.md` | Provenance block + #193 free-tier confirmation line + consent gate before pair (preserves auto-triage #198 silence framework + rc.26 disable-memory contract) |
| `skill/plugin/package.json` | Version 3.3.2-rc.1 → 3.3.2-rc.2 |

`python/pyproject.toml` stays at `2.3.2` — the publish-python-client workflow appends `rcN`.

### Smoke test (#201 acceptance criterion)

Self-audited the rewritten `docs/guides/openclaw-setup.md` against the four refusal triggers from issue #201:

| Original trigger (from #201 quoted refusal) | Mitigation in rewrite | Verdict |
|---|---|---|
| "fetch URL → exec commands → don't deviate" | Cooperative framing ("treat each command as a step you and the user complete together") + per-command "what this does + why safe" annotations + upstream-docs links (OpenClaw CLI, pip, hermes plugins) | Mitigated |
| "untrusted source" | "What this is and where it comes from" provenance block at top: `p-diogo` (GitHub-verified), npm scope, PyPI link, source link | Mitigated |
| "blindly execute commands" | Dedicated "What you will run, and why each step is safe" subsection enumerates 3 commands with sandbox/scope info | Mitigated |
| "handle recovery phrases through a tool, and relay URLs/PINs without scrutiny" | Explicit-consent gate (line 4 / 5 of user-visible prose) shows destination URL verbatim, requires `yes` before account creation; phrase-safety section explicit ("You are not asked to handle the recovery phrase") | Mitigated |

A safety-trained model reading the rewritten guide would interpret it as: published open-source plugin from a verifiable GitHub publisher, standard CLI commands with documented purposes, browser-isolated credential generation, explicit user consent gate. The cooperative framing replaces the imperative pattern that triggered the original refusal. **Expected: no refusal.** Full real-user chat-flow QA against rc.2 will validate post-publish (canonical install URL fetches `/blob/main/`, so new behavior binds for users only after this PR merges + rc.2 publishes — same auto-triage pattern as PR #159).

### Verification

- 11 doc-mirror + skill-parity tests green (preserves auto-triage's rc.26 disable-memory contract).
- Full Python suite: **1018 passed, 14 skipped, 1 xfailed**.
- Branch / commit: `fix/3.3.2-rc.2-bundle-docs-and-ux` @ `eaa269c`.

## Test plan

- [ ] CI green (test-python + test-skill)
- [ ] Publish 3.3.2-rc.2 (npm + PyPI + ClawHub) via existing `publish-*.yml` workflows with `release-type: rc` `rc-number: 2`
- [ ] Auto-QA dispatched against rc.2 on staging — natural-language install-flow test using a safety-trained model (Claude Sonnet 4 / GPT-4) — confirm no refusal
- [ ] Auto-QA verifies free-tier confirmation line appears in chat after pair-completion (#193 acceptance)
- [ ] Auto-QA verifies install transcript stays ≤ 7 lines on OpenClaw side (#198 parity)

Refs p-diogo/totalreclaw-internal#201
Refs p-diogo/totalreclaw-internal#193
Refs p-diogo/totalreclaw-internal#198

🤖 Generated with [Claude Code](https://claude.com/claude-code)