### PR TITLE
fix(hermes): use built-in /restart slash command for autonomous gateway reload (rc.4)

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -16,7 +16,7 @@ If you already have Hermes running, paste this into your Hermes chat:
 
 > **Install TotalReclaw, see <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md>**
 
-Your agent reads this page, runs two install commands ([`hermes plugins install`](https://hermes.readthedocs.io/en/latest/plugins.html) and [`pip install`](https://pip.pypa.io/en/stable/cli/pip_install/) — both standard tools you already have), asks you to restart the gateway once (Hermes doesn't auto-reload), and hands you an account-setup URL + 6-digit PIN. You open the URL in your browser, generate or restore a 12-word recovery phrase there, confirm the PIN, and your account is ready.
+Your agent reads this page, runs two install commands ([`hermes plugins install`](https://hermes.readthedocs.io/en/latest/plugins.html) and [`pip install`](https://pip.pypa.io/en/stable/cli/pip_install/) — both standard tools you already have), issues Hermes' built-in `/restart` slash command to reload the plugin (graceful drain — no manual restart needed), and hands you an account-setup URL + 6-digit PIN. You open the URL in your browser, generate or restore a 12-word recovery phrase there, confirm the PIN, and your account is ready.
 
 This guide is the playbook your agent follows; you can read along to see what each step does.
 
@@ -35,7 +35,8 @@ The user pasted this URL deliberately, but treat each command as a step you and 
 1. `hermes plugins install p-diogo/totalreclaw-hermes --enable` — registers the plugin manifest from the publisher's GitHub repo. The plugin runs inside Hermes' plugin sandbox. Upstream docs: <https://hermes.readthedocs.io/en/latest/plugins.html>.
 2. `pip install --pre totalreclaw` — installs the Python tool implementations from PyPI. The `--pre` flag pulls the latest release candidate. Standard PyPA workflow: <https://pip.pypa.io/en/stable/cli/pip_install/>.
 3. `hermes tools disable memory` — disables Hermes' built-in `memory` tool to avoid intent collision with TotalReclaw's `_remember` / `_recall`. Reversible with `hermes tools enable memory`.
-4. After the gateway restart, you will call `totalreclaw_pair` (a tool the plugin registers) to mint a one-time URL + PIN. The user opens the URL in their own browser to enter or generate a recovery phrase. The phrase never enters chat or your shell.
+4. `/restart` — Hermes' built-in slash command (`CommandDef("restart", "Gracefully restart the gateway after draining active runs", ...)` from `hermes_cli/commands.py`). Drains active runs, reloads in-process. The agent issues this autonomously; the user does NOT have to run a shell command. Falls back to a manual user-prompted restart only if `/restart` is unavailable (very old Hermes pre-2026.4 or a managed service that strips slash commands).
+5. After the restart, you will call `totalreclaw_pair` (a tool the plugin registers) to mint a one-time URL + PIN. The user opens the URL in their own browser to enter or generate a recovery phrase. The phrase never enters chat or your shell.
 
 You are not asked to handle the recovery phrase. You are not asked to bypass auth. If the user pastes a phrase in chat anyway, refuse to proceed — see "Phrase safety" below.
 
@@ -47,8 +48,8 @@ Speak only these lines, in order. Do not narrate around them. Do not announce in
    > Installing TotalReclaw…
 2. (Step 1 — after install + verify pass)
    > ✓ Installed (totalreclaw &lt;version&gt;)
-3. (Step 2 — restart prompt)
-   > Please restart your Hermes gateway: &lt;restart-command&gt;. Reply `done` once it's back up.
+3. (Step 2 — autonomous restart confirmation)
+   > Restarting Hermes to load the plugin (auto-drains active runs)…
 4. (Step 3 — built-in-memory disable, only if the disable command succeeds)
    > I've disabled Hermes' built-in `memory` tool — TotalReclaw is now your primary memory. Re-enable any time with `hermes tools enable memory` (NOT recommended while TotalReclaw is installed). Wipe orphaned MEMORY.md / USER.md files with `hermes memory reset`.
 5. (Step 5a — explicit consent before account creation)
@@ -136,16 +137,18 @@ Before moving to Step 2, confirm the package resolves through `$HERMES_PYTHON`:
 
 If `pip show` reports the package, capture the version string and emit user-visible line 2 (`✓ Installed (totalreclaw <version>)`). If it errors with `Package(s) not found`, the install landed in a different environment — silently re-detect `$HERMES_PYTHON` and re-run Step 1b. Surface a line only if the second attempt also fails.
 
-### Step 2 — Ask the user to restart the gateway (emit user-visible line 3)
+### Step 2 — Restart the gateway autonomously via `/restart`
 
-Hermes does NOT auto-reload on plugin install. Pick the right restart command for the user's deploy and emit it as user-visible line 3:
+Hermes does NOT auto-reload on plugin install — you have to restart. The fastest, safest path is Hermes' built-in `/restart` slash command (registered in `hermes_cli/commands.py:162` as `CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session", ...)`). It drains in-flight runs, reloads the plugin layer, and is in-process — works from inside the gateway because it doesn't shell out. Issue it yourself; emit user-visible line 3 (`Restarting Hermes to load the plugin (auto-drains active runs)…`) as the single confirmation. Wait for Hermes to come back; resume at Step 3.
+
+**Fallback only if `/restart` is unavailable** (very old Hermes pre-2026.4, managed services that strip slash commands, or the user has explicitly requested manual control). Pick the right restart command for the user's deploy and emit it as a single line (`Please restart your Hermes gateway: <restart-command>. Reply \`done\` once it's back up.`):
 
 - Native: `hermes gateway restart`
 - Docker self-host: `docker restart <your-container-name>` — substitute the actual name; `docker ps` shows it.
 - Managed service: their restart control.
 - systemd / launchd supervised: `kill -USR1 $(cat ~/.hermes/gateway.pid)` triggers a graceful-drain restart.
 
-Do NOT invoke the restart yourself — your shell runs inside the gateway you'd be restarting. Wait for the user's `done`.
+Do NOT invoke any external `docker restart` / `kill` yourself — your shell runs inside the gateway you'd be restarting. The `/restart` slash command is the ONLY in-process restart path; everything else requires the user.
 
 ### Step 3 — Disable Hermes built-in memory tool (CRITICAL)
 

--- a/python/src/totalreclaw/hermes/SKILL.md
+++ b/python/src/totalreclaw/hermes/SKILL.md
@@ -32,8 +32,8 @@ Speak only these lines, in order. Substitute the bracketed placeholders.
    > Installing TotalReclaw…
 2. (Step 1 — after install + verify pass)
    > ✓ Installed (totalreclaw &lt;version&gt;)
-3. (Step 2 — restart prompt)
-   > Please restart your Hermes gateway: &lt;restart-command&gt;. Reply `done` once it's back up.
+3. (Step 2 — autonomous restart confirmation)
+   > Restarting Hermes to load the plugin (auto-drains active runs)…
 4. (Step 3 — only if `hermes tools disable memory` succeeded)
    > I've disabled Hermes' built-in `memory` tool — TotalReclaw is now your primary memory. Re-enable any time with `hermes tools enable memory` (NOT recommended while TotalReclaw is installed). Wipe orphaned MEMORY.md / USER.md files with `hermes memory reset`.
 5. (Step 6a — explicit consent before account creation)
@@ -75,13 +75,15 @@ If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jum
    - `pip: command not found` / `No module named pip` (Hermes container shipped without pip): bootstrap silently with `"$HERMES_PYTHON" -m ensurepip --upgrade`, then retry 1b.
    - `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment): break silence and tell the user verbatim *"Your environment doesn't expose the Hermes CLI to me. Please install `p-diogo/totalreclaw-hermes` and the `totalreclaw` Python package via your service's plugins UI, then reply `done`. Also disable Hermes' built-in `memory` tool in the same UI if available — running both creates a silent intent-stealing bug."* Wait for `done` and skip to step 4 (verify account-setup tool bound).
 
-2. **Restart the gateway — Hermes does NOT auto-reload on plugin install (emit user-visible line 3).** Pick the right restart command for the user's deploy and emit it as user-visible line 3 (`Please restart your Hermes gateway: <restart-command>. Reply \`done\` once it's back up.`):
+2. **Restart the gateway autonomously via Hermes' built-in `/restart` slash command.** Hermes registers `/restart` as a session-scope slash command (see `hermes_cli/commands.py`: `CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session", ...)`). It drains active runs first, then reloads — safer than `kill -USR1` and works from inside the gateway because it's an in-process command, not an external CLI. Emit the slash command yourself; do NOT ask the user to run a shell command. Surface a single user-visible line confirming the action: `Restarting Hermes to load the plugin (auto-drains active runs)…`. Hermes will return after the restart finishes; resume at step 3.
+
+   **Fallback only if `/restart` is unavailable** (very old Hermes pre-2026.4, managed services that strip slash commands, or the user has explicitly requested manual control): pick the right restart command for the user's deploy and emit it as a single user-visible line (`Please restart your Hermes gateway: <restart-command>. Reply \`done\` once it's back up.`):
    - Native: `hermes gateway restart`
    - Docker self-host: `docker restart <your-container-name>` — substitute the actual name; `docker ps` shows it.
    - Managed service: their restart control.
    - systemd / launchd supervised: `kill -USR1 $(cat ~/.hermes/gateway.pid)` triggers a graceful-drain restart.
 
-   Do NOT run the restart yourself — your shell is inside the gateway you'd be restarting. Wait for the user's `done`.
+   Do NOT run any external `docker restart` / `kill` yourself — your shell is inside the gateway you'd be restarting. The `/restart` slash command is the ONLY in-process restart path; everything else requires the user.
 
 3. **Disable Hermes built-in memory tool (CRITICAL).** (Silent unless the disable command succeeds; emit user-visible line 4 only on success.) Hermes ships with its own built-in `memory` tool that competes with TotalReclaw for "remember X" / "recall X" intents. Running both creates a silent bug where conversation context goes to MEMORY.md instead of TotalReclaw's encrypted vault. TotalReclaw and Hermes built-in memory solve the same problem — running both is an anti-pattern.
 
@@ -92,7 +94,7 @@ If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jum
 
    If the command succeeds, emit user-visible line 4 (the disable confirmation). If it errors with `command not found` or "tool not found" (older Hermes versions, managed services that don't expose the CLI, or the built-in `memory` tool was already removed), skip line 4 silently and continue — the rc.25 tool-description bias still steers the LLM toward `totalreclaw_remember` as a fallback. Do not surface the disable failure.
 
-4. **Verify `totalreclaw_pair` is bound (silent).** If still missing after restart, surface a one-line error: `Plugin installed but tools didn't bind after restart. Asking for a second restart.` and resend line 3. Do not loop the install.
+4. **Verify `totalreclaw_pair` is bound (silent).** If still missing after restart, surface a one-line error: `Plugin installed but tools didn't bind after restart. Issuing /restart again.` and re-issue `/restart` once. Do not loop the install. If the second `/restart` still doesn't bind tools, fall back to the manual user-prompted restart path (see step 2 fallback) once.
 
 5. **Check for existing credentials (silent).** Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, emit `✓ TotalReclaw is already set up.` and stop. Otherwise continue silently.
 
@@ -122,7 +124,7 @@ NEVER echo / generate / ask the user to paste a recovery phrase in chat. NEVER i
 
 ## Diagnostics
 
-- `totalreclaw_*` tools not visible → gateway not restarted after install; ask the user once to restart their gateway. Common patterns: `hermes gateway restart` (native), `docker restart <your-container-name>` (Docker self-host — replace with the user's actual container name), or the managed service's restart control. Wait for `done`.
+- `totalreclaw_*` tools not visible → gateway not restarted after install; issue Hermes' `/restart` slash command (in-process, drains active runs). If `/restart` is unavailable (very old Hermes, restricted managed service), fall back to asking the user once: `hermes gateway restart` (native), `docker restart <your-container-name>` (Docker self-host), or the managed service's restart control. Wait for `done`.
 - User says done but `credentials.json` missing → PIN expired or entered wrong phrase; call `totalreclaw_pair` again.
 - `onboarding required` → credentials missing; redo from the account-setup step.
 - `quota exceeded` → `totalreclaw_status`, then offer `totalreclaw_upgrade`.


### PR DESCRIPTION
## Why

User QA finding (2026-04-29): Pedro discovered Hermes ships a `/restart` slash command:

\`\`\`python
# hermes_cli/commands.py:162
CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session", ...)
\`\`\`

In-process command (drains active runs first, reloads). The agent should call this autonomously after install rather than asking the user to run a shell command.

This is the correct fix for the long-standing container-agent gap (referenced in #87 era): gateway needs reload after plugin install, but the agent runs INSIDE the gateway and can't shell out to restart it. `/restart` works exactly because it doesn't shell out.

## Changes

- `python/src/totalreclaw/hermes/SKILL.md` — Step 2 rewritten: agent issues `/restart` autonomously; manual user-prompted restart is fallback only (very old Hermes pre-2026.4 or managed services that strip slash commands). User-visible line 3 changed from "Please restart your Hermes gateway: …" to "Restarting Hermes to load the plugin (auto-drains active runs)…". Step 4 (verify-tools-bound) updated to re-issue `/restart` on miss. Troubleshooting section updated.
- `docs/guides/hermes-setup.md` — overview + Step 2 + line-3 user-visible prose updated to reflect autonomous `/restart`. Manual restart matrix preserved as fallback section.

## Scope

Hermes-only (rc.4). Plugin TS side unchanged. OpenClaw-side restart mechanism is separate (uses `openclaw gateway restart` CLI which has the inside-gateway-deadlock issue from #184) — needs separate investigation if there's an OpenClaw equivalent in-process slash command.

## Tests

72 doc-mirror + skill-parity tests pass (`test_skill_md_includes_disable_memory_step.py`, `test_hermes_plugin*.py`, `test_hermes_setup_cli.py`).

## Test plan

- [x] Mirror tests green
- [ ] Publish 2.3.2rc4 to PyPI; user re-installs + tests `/restart` works in real chat flow
- [ ] If GO, layer onto stable promote sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)