### PR TITLE
fix(crypto): silent-skip + log-once for legacy too-short ciphertext blobs (3.3.2-rc.4 / 2.3.2rc5)

### DIFF
--- a/python/src/totalreclaw/claims_helper.py
+++ b/python/src/totalreclaw/claims_helper.py
@@ -543,6 +543,35 @@ def is_digest_blob(decrypted: str) -> bool:
     return isinstance(obj, dict) and obj.get("c") == DIGEST_CATEGORY
 
 
+def is_stub_blob_hex(blob_hex: str) -> bool:
+    """Is this subgraph-stored ``encryptedBlob`` hex a supersede tombstone?
+
+    Mirror of ``isStubBlob`` in ``skill/plugin/digest-sync.ts``. A real
+    XChaCha20-Poly1305 ciphertext requires at least 40 bytes (24 nonce +
+    16 tag), so any hex that decodes to a tombstone-shaped payload — empty,
+    or a run of all-zero bytes — cannot plausibly be a real claim and
+    SHOULD be filtered pre-decrypt to avoid noisy "Encrypted data too
+    short" warnings on every recall.
+
+    Conservative on purpose: short-but-non-stub blobs (e.g. a stray 30-byte
+    payload) still fall through to decrypt so a genuine wire-format break
+    still surfaces as a WARN rather than being silently swallowed.
+
+    Stubs detected:
+
+    * Empty string
+    * Bare ``0x`` / ``0X`` prefix
+    * All-zero hex of any length (e.g. ``0x00``, ``0000``) — explicit
+      tombstone shape the relay emits when superseding a fact.
+    """
+    if not isinstance(blob_hex, str):
+        return True
+    stripped = blob_hex[2:] if blob_hex.startswith(("0x", "0X")) else blob_hex
+    if not stripped:
+        return True
+    return all(c == "0" for c in stripped)
+
+
 def build_digest_claim(
     digest_json: str,
     compiled_at: str,

--- a/python/src/totalreclaw/operations.py
+++ b/python/src/totalreclaw/operations.py
@@ -38,6 +38,7 @@ from .claims_helper import (
     build_canonical_claim_v1,
     compute_entity_trapdoors,
     is_digest_blob,
+    is_stub_blob_hex,
     read_blob_unified,
     read_claim_from_blob,
 )
@@ -591,9 +592,22 @@ async def search_facts(
 
     # Decrypt candidates and build reranker input
     candidates: list[RerankerCandidate] = []
+    skipped_stub_ids: list[str] = []
     for fact_id, fact in all_facts.items():
         try:
             encrypted_blob_hex = fact.get("encryptedBlob", "")
+            # Stub / tombstone blobs (encryptedBlob == "0x00" or all-zero
+            # hex) are supersede markers the relay writes when a fact is
+            # auto-resolved.  Decrypting them always fails with
+            # "Encrypted data too short" and pollutes recall logs with a
+            # WARN per stale ID per recall — observed on legacy QA vault
+            # with ~9 stubs from rc-era pin/supersede flows.  Filter
+            # pre-decrypt; emit a single aggregate INFO at the end.
+            #
+            # Mirrors ``isStubBlob`` in ``skill/plugin/digest-sync.ts``.
+            if is_stub_blob_hex(encrypted_blob_hex):
+                skipped_stub_ids.append(fact_id)
+                continue
             # Subgraph returns 0x-prefixed hex
             if encrypted_blob_hex.startswith("0x"):
                 encrypted_blob_hex = encrypted_blob_hex[2:]
@@ -654,6 +668,18 @@ async def search_facts(
         except Exception as e:
             logger.warning("Failed to decrypt candidate %s: %s", fact_id, e)
             continue
+
+    if skipped_stub_ids:
+        # Aggregate INFO instead of per-fact WARN spam.  Truncate to keep
+        # log lines reasonable when a vault has many tombstones.
+        sample = ", ".join(skipped_stub_ids[:5])
+        suffix = f" (+{len(skipped_stub_ids) - 5} more)" if len(skipped_stub_ids) > 5 else ""
+        logger.info(
+            "Skipped %d stub/tombstone blob(s) during recall: %s%s",
+            len(skipped_stub_ids),
+            sample,
+            suffix,
+        )
 
     if not candidates:
         return []

--- a/python/tests/test_claims_helper.py
+++ b/python/tests/test_claims_helper.py
@@ -39,6 +39,7 @@ from totalreclaw.claims_helper import (
     hours_since,
     is_digest_blob,
     is_digest_stale,
+    is_stub_blob_hex,
     is_v1_blob,
     map_type_to_category,
     read_blob_unified,
@@ -644,6 +645,51 @@ def test_is_digest_blob_legacy_doc_returns_false() -> None:
 def test_is_digest_blob_garbage_returns_false() -> None:
     assert is_digest_blob("not json at all") is False
     assert is_digest_blob("") is False
+
+
+# ---------------------------------------------------------------------------
+# is_stub_blob_hex — supersede tombstone detection (mirror of TS isStubBlob)
+# ---------------------------------------------------------------------------
+
+
+def test_is_stub_blob_hex_empty() -> None:
+    assert is_stub_blob_hex("") is True
+
+
+def test_is_stub_blob_hex_bare_prefix() -> None:
+    assert is_stub_blob_hex("0x") is True
+    assert is_stub_blob_hex("0X") is True
+
+
+def test_is_stub_blob_hex_single_zero_byte() -> None:
+    # Exact shape observed on the QA wallet — supersede stub == "0x00".
+    assert is_stub_blob_hex("0x00") is True
+    assert is_stub_blob_hex("00") is True
+
+
+def test_is_stub_blob_hex_all_zero_run() -> None:
+    assert is_stub_blob_hex("0x0000") is True
+    assert is_stub_blob_hex("000000000000000000000000") is True
+
+
+def test_is_stub_blob_hex_real_ciphertext_returns_false() -> None:
+    # Synthetic 40-byte (= NONCE 24 + TAG 16) all-ones blob — minimum
+    # plausible XChaCha20-Poly1305 ciphertext envelope.
+    real_blob = "0x" + "ff" * 40
+    assert is_stub_blob_hex(real_blob) is False
+
+
+def test_is_stub_blob_hex_short_nonzero_returns_false() -> None:
+    # Conservative: a 30-byte non-zero blob is suspicious but NOT a stub —
+    # let the decrypt path log it as a real WARN so wire-format breaks
+    # surface instead of being silently swallowed.
+    assert is_stub_blob_hex("0x" + "ab" * 30) is False
+
+
+def test_is_stub_blob_hex_non_string_returns_true() -> None:
+    # Defensive: any non-string input is treated as a stub.
+    assert is_stub_blob_hex(None) is True  # type: ignore[arg-type]
+    assert is_stub_blob_hex(42) is True  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_operations.py
+++ b/python/tests/test_operations.py
@@ -139,6 +139,98 @@ class TestSearchFacts:
         assert len(results) >= 1
         assert "Pedro prefers dark mode" in results[0].text
 
+    @pytest.mark.asyncio
+    async def test_search_skips_stub_blob_silently(self, keys, caplog):
+        """Recall MUST silently skip 0x00 supersede tombstones, not WARN per ID.
+
+        Regression test for the legacy QA-vault recall noise where ~9 facts
+        with ``encryptedBlob == "0x00"`` produced one
+        ``Failed to decrypt candidate <id>: ... Encrypted data too short``
+        WARN per recall per stale ID. The fix filters stub blobs
+        pre-decrypt and emits a single aggregate INFO instead.
+        """
+        import logging
+
+        # One real fact + one tombstone stub. The stub MUST be filtered
+        # out before any decrypt attempt (no WARN), and the real fact
+        # MUST still be returned.
+        encrypted_b64 = encrypt("Pedro prefers dark mode", keys.encryption_key)
+        encrypted_hex = "0x" + base64.b64decode(encrypted_b64).hex()
+
+        relay = AsyncMock(spec=RelayClient)
+        relay.query_subgraph = AsyncMock(
+            return_value={
+                "data": {
+                    "blindIndexes": [
+                        {
+                            "id": "idx-real",
+                            "fact": {
+                                "id": "fact-real",
+                                "encryptedBlob": encrypted_hex,
+                                "encryptedEmbedding": None,
+                                "decayScore": "0.5",
+                                "timestamp": "2026-03-29T10:00:00.000Z",
+                                "isActive": True,
+                                "contentFp": "abc",
+                            },
+                        },
+                        {
+                            "id": "idx-stub",
+                            "fact": {
+                                "id": "fact-stub-tombstone",
+                                # Exact shape observed on the QA wallet —
+                                # supersede stub written by the relay.
+                                "encryptedBlob": "0x00",
+                                "encryptedEmbedding": None,
+                                "decayScore": "0.5",
+                                "timestamp": "2026-03-29T10:00:00.000Z",
+                                "isActive": True,
+                                "contentFp": "def",
+                            },
+                        },
+                    ]
+                }
+            }
+        )
+
+        with caplog.at_level(logging.DEBUG, logger="totalreclaw.operations"):
+            results = await search_facts(
+                query="Pedro dark mode preferences",
+                keys=keys,
+                owner="0x1234",
+                relay=relay,
+            )
+
+        # The real fact still comes back.
+        assert len(results) >= 1
+        assert any("Pedro prefers dark mode" in r.text for r in results)
+
+        # No per-stub WARN spam.  Specifically: the legacy
+        # "Failed to decrypt candidate <stub-id>" WARN must NOT appear —
+        # the pre-decrypt filter caught it.  The aggregate INFO (checked
+        # below) is allowed to mention the ID.
+        warn_msgs = [
+            r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING
+        ]
+        for msg in warn_msgs:
+            assert "fact-stub-tombstone" not in msg, (
+                f"Stub fact triggered a >=WARN log: {msg}"
+            )
+            assert "Encrypted data too short" not in msg, (
+                f"Pre-filter missed a stub: WARN-level decrypt failure leaked through: {msg}"
+            )
+
+        # And there's exactly one aggregate INFO summarising the skip.
+        info_msgs = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelno == logging.INFO and "stub/tombstone" in r.getMessage()
+        ]
+        assert len(info_msgs) == 1, (
+            f"Expected exactly one aggregate stub-skip INFO, got {len(info_msgs)}: {info_msgs}"
+        )
+        assert "fact-stub-tombstone" in info_msgs[0]
+
 
 class TestForgetFact:
     @pytest.mark.asyncio

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "Install + set up TotalReclaw encrypted memory for OpenClaw, then use totalreclaw_remember / totalreclaw_recall. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', or any remember / recall request."
-version: 3.3.2-rc.1
+version: 3.3.2-rc.4
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz

--- a/skill/plugin/package-lock.json
+++ b/skill/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.2-rc.1",
+  "version": "3.3.2-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/totalreclaw",
-      "version": "3.3.2-rc.1",
+      "version": "3.3.2-rc.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.2-rc.3",
+  "version": "3.3.2-rc.4",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "3.3.2-rc.1",
+  "version": "3.3.2-rc.4",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",


### PR DESCRIPTION
## Diagnosis

QA vault on staging emits this WARN on every recall, ~9 times per call:

```
WARNING totalreclaw.operations: Failed to decrypt candidate <id>: crypto error: Encrypted data too short
```

Reproduced byte-for-byte on the live vault — the 9 ID list is below. **Every blob is exactly 1 byte = `0x00`.** That's the supersede-tombstone shape the relay writes when a fact is auto-resolved (e.g. via the pin/supersede flow). Block range `40825765–40854209`, written days/weeks before the current rc.3/rc.4 path. Current rc.3/rc.4 writes round-trip cleanly — this is **legacy data, not a current write-path bug**.

| ID | block | len | first 32B |
|---|---|---|---|
| `0ed0ae7d…` | 40846436 | 1 | `00` |
| `fddafa42…` | 40826450 | 1 | `00` |
| `18ce0189…` | 40826154 | 1 | `00` |
| `8067b0e3…` | 40826084 | 1 | `00` |
| `b405f7b7…` | 40825851 | 1 | `00` |
| `93755116…` | 40825777 | 1 | `00` |
| `2dc453e8…` | 40825765 | 1 | `00` |
| `ff64bd07…` | 40846636 | 1 | `00` |
| `3feaebc5…` | 40854209 | 1 | `00` |

The TS plugin already handles this — `skill/plugin/digest-sync.ts::isStubBlob` filters the stub shape pre-decrypt in both `loadLatestDigest` and `fetchAllActiveClaims`. The Python recall path was missing that filter.

## Patch

* **`claims_helper.is_stub_blob_hex`** — Python mirror of TS `isStubBlob`. Skips empty / bare-prefix (`0x`) / all-zero hex blobs. Conservative on short-but-non-zero blobs so genuine wire-format breaks still WARN.
* **`operations.search_facts`** — calls `is_stub_blob_hex` pre-decrypt. Collects skipped IDs and emits a single aggregate INFO at end of loop (`Skipped N stub/tombstone blob(s) during recall: <first 5>(+M more)`) instead of per-fact WARN spam. Real decrypt failures still WARN unchanged.

No on-chain migration (Pedro: staging-only, no users in production).

## Tests

* 7 unit tests for `is_stub_blob_hex` (empty / bare-prefix / single-zero / all-zero run / 40-byte real / 30-byte short-non-zero / non-string defensive).
* 1 integration test on `search_facts` (`test_search_skips_stub_blob_silently`) asserting the legacy `Failed to decrypt candidate` WARN is gone for stub IDs, exactly one aggregate INFO fires, and the real candidate still ranks normally.
* Full local Python suite: **104/104 pass** (`tests/test_operations.py` + `tests/test_claims_helper.py`).
* Plugin `digest-stub-skip.test.ts`: **19/19 still pass** — TS-side parity intact.
* `check-version-drift`: green.

## Versions

| Site | Before | After |
|---|---|---|
| `python/pyproject.toml::version` | `2.3.2` | `2.3.2` (unchanged — workflow appends `rc5`) |
| `skill/plugin/package.json::version` | `3.3.2-rc.3` | `3.3.2-rc.4` |
| `skill/plugin/SKILL.md` frontmatter `version:` | (synced by workflow) | `3.3.2-rc.4` (manually synced for local drift gate) |
| `skill/plugin/skill.json::version` | (synced by workflow) | `3.3.2-rc.4` (ditto) |

## Test plan

- [ ] CI: `python` test suite green
- [ ] CI: `plugin` test suite + `check-version-drift` green
- [ ] After merge: dispatch `publish-python-client.yml` (`release-type: rc`, `rc-number: 5`) and `publish-skill-plugin.yml` (rc.4) → auto-QA
- [ ] Verify recall on QA vault: zero `Failed to decrypt candidate` WARNs, one `Skipped N stub/tombstone blob(s)` INFO

## Notes

- `is_stub_blob_hex` is intentionally conservative — only `0x00`-shaped tombstones are filtered. A 30-byte stray blob would still WARN, so a real wire-format break would still surface.
- Closes the WARN-spam noise blocking 3.3.2 stable promote.