### PR TITLE
ci(promote-rc): stamp stable version into ClawHub tarball before publish (#206)

### DIFF
--- a/.github/workflows/promote-rc.yml
+++ b/.github/workflows/promote-rc.yml
@@ -347,6 +347,31 @@ jobs:
         # See publish-clawhub.yml comment for full context.
         run: npm install -g clawhub@0.8.0
 
+      # Issue #206: without this step, `clawhub publish ./skill/plugin
+      # --version <stable>` shipped a tarball whose internal
+      # package.json / SKILL.md / skill.json still carried the prior
+      # `-rc.<N>` strings. The catalog tag moved to stable, but
+      # `clawhub install totalreclaw` users saw `"version": "X.Y.Z-rc.N"`
+      # inside the artifact. Mirror publish-clawhub.yml's "Resolve version
+      # + propagate to bundled tarball files" step so the promoted artifact
+      # is internally consistent with its stable tag.
+      - name: Stamp stable version into bundled tarball files
+        run: |
+          set -e
+          STABLE="${{ needs.derive-versions.outputs.stable-version }}"
+
+          node -e "
+          const fs = require('fs');
+          const p = require('./skill/plugin/package.json');
+          p.version = '${STABLE}';
+          fs.writeFileSync('./skill/plugin/package.json', JSON.stringify(p, null, 2) + '\n');
+          console.log('package.json::version =', p.version);
+          "
+
+          # Propagate into SKILL.md frontmatter + skill.json, then GATE.
+          node skill/scripts/sync-version.mjs
+          node skill/scripts/check-version-drift.mjs
+
       - name: Publish stable tags over the promoted version
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}


### PR DESCRIPTION
## What broke
After `promote-rc.yml` runs the ClawHub job (rc.N → stable), the catalog tag points at the stable version, but `clawhub install totalreclaw` users see the artifact's internal `package.json` still reading `X.Y.Z-rc.N`.

## What's fixed
Adds a pre-publish "Stamp stable version into bundled tarball files" step in `promote-rc.yml`'s `promote-clawhub` job that mirrors `publish-clawhub.yml`'s 2026-04-25 pattern:
1. Rewrite `skill/plugin/package.json::version` → `$STABLE` via `node -e`,
2. `node skill/scripts/sync-version.mjs` to propagate to `SKILL.md` frontmatter + `skill.json`,
3. `node skill/scripts/check-version-drift.mjs` to gate (a propagation regression fails the job before publish).

## Impact after fix
On the next stable promote, the ClawHub artifact's internal `package.json` / `SKILL.md` / `skill.json` will all read the stable version string. No more user-visible drift between `clawhub install` output and the artifact's self-reported version.

## Verification
- YAML parse: OK (`python3 -c "import yaml; yaml.safe_load(...)"`).
- Local smoke of the `node -e` rewrite snippet against the current main tree (`package.json::version: 3.3.2-rc.4` → `3.3.2`).
- **No end-to-end QA was performed**: this is a workflow-only change. Verifying it requires actually dispatching `promote-rc.yml` against an RC, which is outside the auto-triage skill's publish ceiling (`release-type=rc`). The drift gate in step 3 is the structural protection that makes the job fail rather than silently regress.

Closes #206