### PR TITLE
fix(hermes): honor Retry-After on 429 (#208 / 2.3.2rc6)

### DIFF
--- a/python/src/totalreclaw/agent/llm_client.py
+++ b/python/src/totalreclaw/agent/llm_client.py
@@ -934,6 +934,53 @@ def _default_retry_budget_s() -> float:
     return 60.0
 
 
+# Hard ceiling on a server-suggested Retry-After delay. zai / OpenAI / etc.
+# occasionally return Retry-After values in the minutes (e.g. 300s for a
+# daily-quota wall) — we don't want a single 429 to block a session for
+# 5 minutes. If the suggested delay exceeds this, surface an outage so the
+# caller can fall back to the heuristic extraction path immediately.
+_RETRY_AFTER_CEILING_S = 60.0
+
+
+def _parse_retry_after(response: "httpx.Response") -> Optional[float]:
+    """Parse RFC 7231 ``Retry-After`` from an httpx response.
+
+    Accepts the two standard formats: delta-seconds (e.g. ``"5"``) and an
+    HTTP-date (e.g. ``"Fri, 30 Apr 2026 18:30:00 GMT"``). Returns the
+    delay in seconds (always non-negative), or ``None`` when the header
+    is missing, malformed, or specifies a past timestamp.
+
+    Headers come from the upstream verbatim, so a buggy provider could
+    send anything; the parser swallows ValueError and returns ``None``
+    rather than raising — the caller falls back to the static backoff.
+    """
+    if response is None:
+        return None
+    raw = response.headers.get("retry-after") or response.headers.get("Retry-After")
+    if not raw:
+        return None
+    raw = raw.strip()
+    if not raw:
+        return None
+
+    try:
+        secs = float(raw)
+        return max(0.0, secs)
+    except ValueError:
+        pass
+
+    try:
+        from email.utils import parsedate_to_datetime
+        import datetime as _dt
+        target = parsedate_to_datetime(raw)
+        if target.tzinfo is None:
+            target = target.replace(tzinfo=_dt.timezone.utc)
+        delta = (target - _dt.datetime.now(tz=_dt.timezone.utc)).total_seconds()
+        return max(0.0, delta)
+    except (TypeError, ValueError):
+        return None
+
+
 class LLMUpstreamOutageError(RuntimeError):
     """Raised by :func:`chat_completion` when the extraction LLM upstream is
     unreachable after the full retry budget is exhausted.
@@ -976,6 +1023,13 @@ async def chat_completion(
     returning ``None`` so the extraction pipeline can differentiate from
     a parseable-but-empty response.
 
+    On a 429, the response's ``Retry-After`` header (delta-seconds OR
+    HTTP-date) is honored when it exceeds the static backoff for the
+    current attempt — capped at ``_RETRY_AFTER_CEILING_S``. A suggested
+    delay above the ceiling is treated as an outage and surfaces
+    ``LLMUpstreamOutageError`` immediately so the caller can fall back
+    to the heuristic extraction path instead of pinning the session.
+
     zai-specific: when a 429 response carries the "Insufficient balance"
     signature AND the current base URL is one of the two known zai
     endpoints, flips to the other endpoint and retries ONCE (separate
@@ -987,7 +1041,8 @@ async def chat_completion(
     Raises
     ------
     LLMUpstreamOutageError
-        After all retries are exhausted on retryable errors (429 / timeout).
+        After all retries are exhausted on retryable errors (429 / timeout),
+        or when a 429 ``Retry-After`` exceeds ``_RETRY_AFTER_CEILING_S``.
     """
     # Make a mutable copy so the zai fallback branch can swap base_url
     # without mutating the caller's dataclass.
@@ -1071,6 +1126,22 @@ async def chat_completion(
                 ) from e
 
             delay = _BACKOFF_DELAYS[min(attempt - 1, len(_BACKOFF_DELAYS) - 1)]
+            # Honor server-suggested Retry-After on 429s when it's longer
+            # than our static backoff. Most providers (zai, OpenAI, Anthropic,
+            # OpenRouter) return Retry-After on rate-limit responses; ignoring
+            # it means we hammer the wall and burn the retry budget on
+            # guaranteed-to-fail attempts. Capped at _RETRY_AFTER_CEILING_S
+            # so a daily-quota response (300s+) doesn't pin the session.
+            if e.response.status_code == 429:
+                retry_after = _parse_retry_after(e.response)
+                if retry_after is not None and retry_after > delay:
+                    if retry_after > _RETRY_AFTER_CEILING_S:
+                        raise LLMUpstreamOutageError(
+                            f"LLM upstream outage (Retry-After={retry_after:.0f}s exceeds ceiling {_RETRY_AFTER_CEILING_S:.0f}s): {err_str[:200]}",
+                            attempts=attempt,
+                            last_status=last_status,
+                        ) from e
+                    delay = retry_after
             if cumulative_delay_s + delay > budget_s:
                 raise LLMUpstreamOutageError(
                     f"LLM upstream outage (budget {budget_s:.0f}s exhausted after {attempt} attempts): {err_str[:200]}",

--- a/python/tests/test_issue_208_retry_after.py
+++ b/python/tests/test_issue_208_retry_after.py
@@ -1,0 +1,270 @@
+"""Issue #208 — chat_completion honors HTTP Retry-After on 429.
+
+Pre-fix behavior: the 429 retry path used a static
+[2,4,8,16,32]s backoff regardless of any ``Retry-After`` header the
+upstream sent. A 429 with ``Retry-After: 60`` was followed by a 2s retry,
+guaranteed to 429 again, burning the whole retry budget in seconds.
+
+Post-fix behavior:
+  - When a 429 response carries a parseable ``Retry-After`` and the
+    suggested delay is *longer* than the static backoff for that attempt,
+    the longer value is used (capped at ``_RETRY_AFTER_CEILING_S``).
+  - When ``Retry-After`` exceeds the ceiling (e.g. a daily-quota wall),
+    the call surfaces :class:`LLMUpstreamOutageError` immediately rather
+    than blocking the session for minutes.
+  - When ``Retry-After`` is shorter than the static backoff, the static
+    backoff still wins (we don't shorten waits — the static ladder is the
+    floor for stability).
+  - When the header is missing / malformed, the static backoff is used
+    unchanged (regression cover for the existing rc.3 behavior).
+"""
+from __future__ import annotations
+
+import datetime as dt
+import os
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from totalreclaw.agent.llm_client import (
+    LLMConfig,
+    LLMUpstreamOutageError,
+    _RETRY_AFTER_CEILING_S,
+    _parse_retry_after,
+    chat_completion,
+)
+
+
+def _http_error_with_retry_after(
+    status_code: int, body: str, retry_after: str | None
+) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://api.example.com/v1/chat/completions")
+    headers = {}
+    if retry_after is not None:
+        headers["Retry-After"] = retry_after
+    response = httpx.Response(
+        status_code,
+        content=body.encode("utf-8"),
+        request=request,
+        headers=headers,
+    )
+    return httpx.HTTPStatusError("rate limit", request=request, response=response)
+
+
+# ---------------------------------------------------------------------------
+# Pure helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseRetryAfter:
+    def _resp(self, headers: dict | None = None) -> httpx.Response:
+        request = httpx.Request("POST", "https://example.test/")
+        return httpx.Response(429, request=request, headers=headers or {})
+
+    def test_delta_seconds_integer(self):
+        assert _parse_retry_after(self._resp({"Retry-After": "5"})) == 5.0
+
+    def test_delta_seconds_float_string(self):
+        # Some providers send fractional seconds.
+        assert _parse_retry_after(self._resp({"Retry-After": "2.5"})) == 2.5
+
+    def test_delta_seconds_zero(self):
+        # Spec-legal: server says "retry now".
+        assert _parse_retry_after(self._resp({"Retry-After": "0"})) == 0.0
+
+    def test_negative_delta_clamped_to_zero(self):
+        # A bizarre but spec-violating "-1" should not produce a negative
+        # sleep duration.
+        assert _parse_retry_after(self._resp({"Retry-After": "-1"})) == 0.0
+
+    def test_http_date_future(self):
+        future = dt.datetime.now(tz=dt.timezone.utc) + dt.timedelta(seconds=10)
+        # RFC 1123 / IMF-fixdate
+        formatted = future.strftime("%a, %d %b %Y %H:%M:%S GMT")
+        parsed = _parse_retry_after(self._resp({"Retry-After": formatted}))
+        assert parsed is not None
+        assert 8.0 < parsed <= 11.0
+
+    def test_http_date_past_clamped_to_zero(self):
+        past = dt.datetime.now(tz=dt.timezone.utc) - dt.timedelta(seconds=10)
+        formatted = past.strftime("%a, %d %b %Y %H:%M:%S GMT")
+        parsed = _parse_retry_after(self._resp({"Retry-After": formatted}))
+        assert parsed == 0.0
+
+    def test_lowercase_header_name(self):
+        # httpx headers are case-insensitive but be explicit about it —
+        # provider proxies sometimes normalize the casing.
+        assert _parse_retry_after(self._resp({"retry-after": "7"})) == 7.0
+
+    def test_missing_header_returns_none(self):
+        assert _parse_retry_after(self._resp()) is None
+
+    def test_empty_header_returns_none(self):
+        assert _parse_retry_after(self._resp({"Retry-After": ""})) is None
+
+    def test_garbage_header_returns_none(self):
+        assert _parse_retry_after(self._resp({"Retry-After": "soonish"})) is None
+
+
+# ---------------------------------------------------------------------------
+# chat_completion behavior
+# ---------------------------------------------------------------------------
+
+
+class TestChatCompletionRetryAfter:
+    """Drives chat_completion with a stub upstream and asserts the wait
+    duration between retries matches the post-fix policy."""
+
+    def _config(self) -> LLMConfig:
+        return LLMConfig(
+            api_key="test",
+            base_url="https://api.example.com/v1",
+            model="test-model",
+            api_format="openai",
+        )
+
+    @pytest.mark.asyncio
+    async def test_retry_after_longer_than_static_is_honored(self):
+        """Server says 'wait 8s'; static backoff for attempt 1 is 2s.
+        chat_completion should sleep 8s, not 2s."""
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(secs):
+            sleep_calls.append(secs)
+
+        call_count = {"n": 0}
+
+        async def fake_openai(cfg, system_prompt, user_prompt, max_tokens, temperature):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise _http_error_with_retry_after(429, "rate limited", "8")
+            return "ok"
+
+        with patch(
+            "totalreclaw.agent.llm_client._call_openai", new=fake_openai
+        ), patch(
+            "totalreclaw.agent.llm_client._asyncio.sleep", new=fake_sleep
+        ), patch.dict(
+            os.environ, {"TOTALRECLAW_LLM_RETRY_BUDGET_MS": "60000"}
+        ):
+            result = await chat_completion(self._config(), "system", "user")
+
+        assert result == "ok"
+        assert sleep_calls == [8.0], (
+            f"Retry-After=8 should have produced an 8s sleep; got {sleep_calls}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_retry_after_shorter_than_static_uses_static_floor(self):
+        """Server says 'wait 1s' but static attempt-1 backoff is 2s.
+        chat_completion keeps the longer static delay (the static ladder
+        is the floor for stability — we don't shorten waits on a 429)."""
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(secs):
+            sleep_calls.append(secs)
+
+        call_count = {"n": 0}
+
+        async def fake_openai(cfg, system_prompt, user_prompt, max_tokens, temperature):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise _http_error_with_retry_after(429, "rate limited", "1")
+            return "ok"
+
+        with patch(
+            "totalreclaw.agent.llm_client._call_openai", new=fake_openai
+        ), patch(
+            "totalreclaw.agent.llm_client._asyncio.sleep", new=fake_sleep
+        ), patch.dict(
+            os.environ, {"TOTALRECLAW_LLM_RETRY_BUDGET_MS": "60000"}
+        ):
+            result = await chat_completion(self._config(), "system", "user")
+
+        assert result == "ok"
+        assert sleep_calls == [2.0]
+
+    @pytest.mark.asyncio
+    async def test_retry_after_above_ceiling_surfaces_outage(self):
+        """A 'come back tomorrow' Retry-After (e.g. 300s) should not
+        block the session — surface LLMUpstreamOutageError immediately
+        so the caller can fall back to heuristic extraction."""
+
+        async def fake_openai(cfg, system_prompt, user_prompt, max_tokens, temperature):
+            raise _http_error_with_retry_after(
+                429,
+                "daily quota exceeded",
+                str(int(_RETRY_AFTER_CEILING_S) + 1),
+            )
+
+        with patch(
+            "totalreclaw.agent.llm_client._call_openai", new=fake_openai
+        ), patch.dict(
+            os.environ, {"TOTALRECLAW_LLM_RETRY_BUDGET_MS": "60000"}
+        ):
+            with pytest.raises(LLMUpstreamOutageError) as excinfo:
+                await chat_completion(self._config(), "system", "user")
+
+        assert excinfo.value.attempts == 1
+        assert excinfo.value.last_status == 429
+        assert "Retry-After" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_no_retry_after_uses_static_backoff(self):
+        """Regression: when Retry-After is missing, behavior matches rc.3
+        (static [2, 4, ...] backoff)."""
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(secs):
+            sleep_calls.append(secs)
+
+        call_count = {"n": 0}
+
+        async def fake_openai(cfg, system_prompt, user_prompt, max_tokens, temperature):
+            call_count["n"] += 1
+            if call_count["n"] < 3:
+                raise _http_error_with_retry_after(429, "rate limited", None)
+            return "ok"
+
+        with patch(
+            "totalreclaw.agent.llm_client._call_openai", new=fake_openai
+        ), patch(
+            "totalreclaw.agent.llm_client._asyncio.sleep", new=fake_sleep
+        ), patch.dict(
+            os.environ, {"TOTALRECLAW_LLM_RETRY_BUDGET_MS": "60000"}
+        ):
+            result = await chat_completion(self._config(), "system", "user")
+
+        assert result == "ok"
+        assert sleep_calls == [2.0, 4.0]
+
+    @pytest.mark.asyncio
+    async def test_502_ignores_retry_after_header(self):
+        """Retry-After is honored only on 429. 5xx retries keep using the
+        static ladder so a flaky upstream's stray ``Retry-After`` on a
+        gateway error doesn't shift our backoff timing."""
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(secs):
+            sleep_calls.append(secs)
+
+        call_count = {"n": 0}
+
+        async def fake_openai(cfg, system_prompt, user_prompt, max_tokens, temperature):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise _http_error_with_retry_after(502, "bad gateway", "30")
+            return "ok"
+
+        with patch(
+            "totalreclaw.agent.llm_client._call_openai", new=fake_openai
+        ), patch(
+            "totalreclaw.agent.llm_client._asyncio.sleep", new=fake_sleep
+        ), patch.dict(
+            os.environ, {"TOTALRECLAW_LLM_RETRY_BUDGET_MS": "60000"}
+        ):
+            result = await chat_completion(self._config(), "system", "user")
+
+        assert result == "ok"
+        assert sleep_calls == [2.0]


### PR DESCRIPTION
## What broke
Auto-extraction occasionally tripped per-model rate limits on low-RPM models, then burned the whole retry budget on guaranteed-fail attempts because `chat_completion` ignored the upstream's `Retry-After` header.

## What's fixed
The 429 retry path now parses `Retry-After` (delta-seconds OR HTTP-date) and uses `max(static_backoff, retry_after)` capped at a 60s ceiling. A "come back tomorrow" Retry-After (>60s) surfaces `LLMUpstreamOutageError` immediately so the caller falls back to heuristic extraction instead of pinning the session for minutes. 5xx retries deliberately keep static backoff.

## Impact after fix
On a 429 + `Retry-After: 60`, the retry now waits 60s as the server requested instead of 2s. The static [2,4,8,16,32]s ladder is the floor — we never *shorten* waits a server suggested.

## Verification
- 15 new unit tests in `python/tests/test_issue_208_retry_after.py` (parser + 429 path + 502 negative-cover); all pass.
- 46 existing `test_llm_client_*` tests still green — no regression.
- Deterministic smoke-test against the published `totalreclaw==2.3.2rc6` wheel from PyPI drives all three branches (Retry-After honored / above-ceiling outage / no-header static backoff). [QA report](https://github.com/p-diogo/totalreclaw-internal/blob/main/docs/notes/QA-hermes-RC-2.3.2-rc6-issue-208.md).

## Notes on scope
Issue [#208](https://github.com/p-diogo/totalreclaw-internal/issues/208) hypothesized a per-candidate-sentence LLM fan-out at backlog drain (~25 calls/sec). Code-walk shows `_drain_into_state` runs ONE `extract_facts_llm` call across all queued messages (plus optional 1 rescore when ≥ 5 facts) — so the report's throttle suggestion would be a no-op against the real code. The Retry-After gap is the only piece of #208 that maps to a real, narrow fix. No other change.

Closes p-diogo/totalreclaw-internal#208