### PR TITLE
fix(hermes): 2.3.4-rc.1 — SKILL.md /restart hardening + unauthorized fallback + install-ordering doc

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -32,10 +32,10 @@ The user pasted this URL deliberately, but treat each command as a step you and 
 
 ### What you will run, and why each step is safe
 
-1. `hermes plugins install p-diogo/totalreclaw-hermes --enable` — registers the plugin manifest from the publisher's GitHub repo. The plugin runs inside Hermes' plugin sandbox. Upstream docs: <https://hermes.readthedocs.io/en/latest/plugins.html>.
-2. `pip install --pre totalreclaw` — installs the Python tool implementations from PyPI. The `--pre` flag pulls the latest release candidate. Standard PyPA workflow: <https://pip.pypa.io/en/stable/cli/pip_install/>.
+1. `pip install --pre totalreclaw` — installs the Python tool implementations from PyPI. The `--pre` flag pulls the latest release candidate. Standard PyPA workflow: <https://pip.pypa.io/en/stable/cli/pip_install/>. Run this BEFORE the plugin manifest registers (see step 2) so the implementations are on disk when the gateway reloads.
+2. `hermes plugins install p-diogo/totalreclaw-hermes --enable` — registers the plugin manifest from the publisher's GitHub repo. The plugin runs inside Hermes' plugin sandbox. Upstream docs: <https://hermes.readthedocs.io/en/latest/plugins.html>.
 3. `hermes tools disable memory` — disables Hermes' built-in `memory` tool to avoid intent collision with TotalReclaw's `_remember` / `_recall`. Reversible with `hermes tools enable memory`.
-4. `/restart` — Hermes' built-in slash command (`CommandDef("restart", "Gracefully restart the gateway after draining active runs", ...)` from `hermes_cli/commands.py`). Drains active runs, reloads in-process. The agent issues this autonomously; the user does NOT have to run a shell command. Falls back to a manual user-prompted restart only if `/restart` is unavailable (very old Hermes pre-2026.4 or a managed service that strips slash commands).
+4. `/restart` — Hermes' built-in slash command (`CommandDef("restart", "Gracefully restart the gateway after draining active runs", ...)` from `hermes_cli/commands.py`). Drains active runs, reloads in-process. The agent issues this autonomously; the user does NOT have to run a shell command. If `/restart` returns "not authorized" (managed-service auth gate) the agent tries `/new` once, then surfaces a single-line user-prompted restart message — it does NOT loop on `/restart`. Falls back to a manual user-prompted restart only if `/restart` is structurally unavailable (very old Hermes pre-2026.4 or a managed service that strips slash commands).
 5. After the restart, you will call `totalreclaw_pair` (a tool the plugin registers) to mint a one-time URL + PIN. The user opens the URL in their own browser to enter or generate a recovery phrase. The phrase never enters chat or your shell.
 
 You are not asked to handle the recovery phrase. You are not asked to bypass auth. If the user pastes a phrase in chat anyway, refuse to proceed — see "Phrase safety" below.
@@ -110,17 +110,18 @@ echo "Hermes Python: $HERMES_PYTHON"
 
 If you can't determine the Hermes Python interpreter from the shell context (managed service, restricted shell), skip to the managed-service fallback below — do NOT guess and install into a random Python.
 
-#### Step 1b — Install the plugin + the Python package together (silent)
+#### Step 1b — Install the Python package + the plugin manifest together (silent)
 
-Run via your shell tool, in this order:
+Run via your shell tool, in this order — Python package FIRST, plugin manifest SECOND:
 
 ```bash
-hermes plugins install p-diogo/totalreclaw-hermes --enable
 "$HERMES_PYTHON" -m pip install --pre totalreclaw
+hermes plugins install p-diogo/totalreclaw-hermes --enable
 ```
 
 Notes:
-- Hermes 2026.4.16+ uses Git-based plugin discovery: the first command registers the plugin manifest, the second installs the Python tool implementations into Hermes' venv. Using `"$HERMES_PYTHON" -m pip ...` (instead of bare `pip install`) guarantees the package lands in the SAME environment Hermes will load tools from after restart — this is the rc.23 fix for the F5 "outside-venv install" bug.
+- Hermes 2026.4.16+ uses Git-based plugin discovery: the second command registers the plugin manifest, the first installs the Python tool implementations into Hermes' venv. Using `"$HERMES_PYTHON" -m pip ...` (instead of bare `pip install`) guarantees the package lands in the SAME environment Hermes will load tools from after restart — this is the rc.23 fix for the F5 "outside-venv install" bug.
+- **Order matters (2.3.4-rc.1 hardening):** Python package FIRST, plugin manifest SECOND. Some Hermes deploys (and OpenClaw 2026.4.16+ on the parallel skill+plugin bundle — observed in plugin-side QA on 2026-04-30) trigger a gateway-config-driven SIGUSR1 reload as soon as the plugin manifest registers. If the Python package isn't on disk by the time that reload fires, the gateway loads the manifest, finds no `totalreclaw_*` implementations, silently fails to bind, and the agent loops on the restart step. Installing the Python package first lands the implementations before the manifest registers — the reload sees both halves and binds cleanly. Do not invert this order.
 - DO NOT use bare `pip install --pre totalreclaw` unless you have already verified that `which pip` resolves to the same venv as `$HERMES_PYTHON`. On containerized Hermes the system `pip` may not even exist (`pip: command not found`) and the bare command would target the host's Python anyway, leaving Hermes' venv empty.
 - On Ubuntu / Debian / Docker you may hit `externally-managed-environment` if `$HERMES_PYTHON` points at a system Python (no venv). Retry the `pip install` line with `--break-system-packages`. Stay silent on the retry unless it also fails — only break silence if the second attempt errors. Last-resort alternative: ask the user to recreate Hermes inside a venv.
 - If the `pip install` line errors with `pip: command not found` or `No module named pip` (Hermes container shipped without pip), bootstrap silently with `"$HERMES_PYTHON" -m ensurepip --upgrade` and retry 1b. Do not narrate this — only break silence if `ensurepip` itself fails.
@@ -139,9 +140,23 @@ If `pip show` reports the package, capture the version string and emit user-visi
 
 ### Step 2 — Restart the gateway autonomously via `/restart`
 
-Hermes does NOT auto-reload on plugin install — you have to restart. The fastest, safest path is Hermes' built-in `/restart` slash command (registered in `hermes_cli/commands.py:162` as `CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session", ...)`). It drains in-flight runs, reloads the plugin layer, and is in-process — works from inside the gateway because it doesn't shell out. Issue it yourself; emit user-visible line 3 (`Restarting Hermes to load the plugin (auto-drains active runs)…`) as the single confirmation. Wait for Hermes to come back; resume at Step 3.
+Hermes does NOT auto-reload on plugin install — you have to restart. The fastest, safest path is Hermes' built-in `/restart` slash command (registered in `hermes_cli/commands.py:162` as `CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session", ...)`). It drains in-flight runs, reloads the plugin layer, and is in-process — works from inside the gateway because it doesn't shell out. Issue it yourself **autonomously** (do NOT ask the user "should I /restart?" — see the deny-list below); emit user-visible line 3 (`Restarting Hermes to load the plugin (auto-drains active runs)…`) as the single confirmation. Wait for Hermes to come back; resume at Step 3.
 
-**Fallback only if `/restart` is unavailable** (very old Hermes pre-2026.4, managed services that strip slash commands, or the user has explicitly requested manual control). Pick the right restart command for the user's deploy and emit it as a single line (`Please restart your Hermes gateway: <restart-command>. Reply \`done\` once it's back up.`):
+**`/restart` returned "not authorized" / "command not found" / refused (2.3.4-rc.1 hardening):** managed Hermes deployments may gate session-scope slash commands behind a role / RBAC layer. Do NOT loop on `/restart` after an unauthorized response — the gate isn't going to flip mid-session and the loop just spams. Try `/new` once instead — `/new` opens a fresh session within the same gateway and may pick up freshly-bound tools without requiring a full reload. If `/new` also returns "not authorized", break silence with one line surfacing the restart-yourself instruction:
+
+> *"Your Hermes deployment doesn't expose `/restart` to me (managed-service auth gate or shell-restricted environment). Please restart the gateway yourself — `hermes gateway restart` (native), `docker restart <your-hermes-container>` (Docker self-host — `docker ps` shows the name), or your service's restart control. Reply `done` once it's back up."*
+
+Wait for `done`, then resume.
+
+**Anti-pattern phrases that the agent must NEVER write in chat at this step** (deny-list — 2.3.4-rc.1):
+
+- "Should I /restart?" / "Want me to restart?" / "Do you want me to restart?"
+- "Do you have a public URL?" / "Can you give me a URL?" (no URL is needed at restart-time)
+- "Let me check if the tool is bound." / "Let me verify…" (verification is a silent shell call, not a chat line)
+
+The correct pattern is: issue `/restart` immediately, emit user-visible line 3, then move on.
+
+**Fallback only if `/restart` is structurally unavailable** (very old Hermes pre-2026.4 with no `/restart` command at all, or the user has explicitly requested manual control). Pick the right restart command for the user's deploy and emit it as a single line (`Please restart your Hermes gateway: <restart-command>. Reply \`done\` once it's back up.`):
 
 - Native: `hermes gateway restart`
 - Docker self-host: `docker restart <your-container-name>` — substitute the actual name; `docker ps` shows it.
@@ -244,19 +259,22 @@ The browser-side crypto and account-setup flow are identical to self-hosted setu
 
 ## Fully manual (CLI only — last resort)
 
-If you can't or won't use the chat flow (self-hosted only — managed services don't expose the host shell):
+If you can't or won't use the chat flow (self-hosted only — managed services don't expose the host shell). **Order matters (2.3.4-rc.1):** install the Python package first so the implementations are on disk before the plugin manifest registers; otherwise a config-driven SIGUSR1 reload may fire mid-install and bind the manifest with no implementations.
 
 ```bash
-hermes plugins install p-diogo/totalreclaw-hermes --enable
-
 # Use the SAME Python that Hermes runs from — never bare `pip install` unless
-# you already know `which pip` and Hermes' interpreter agree.
+# you already know `which pip` and Hermes' interpreter agree. Run BEFORE
+# `hermes plugins install` so the package is on disk before the manifest
+# registers and any reload-trigger arrives.
 #   Native venv install:
 ~/.hermes/venv/bin/python3 -m pip install --pre totalreclaw
 #   Containerized Hermes (run from inside the container shell):
 python3 -m pip install --pre totalreclaw
 #   System-Python install (no venv, may need --break-system-packages):
 python3 -m pip install --pre totalreclaw
+
+# THEN register the plugin manifest:
+hermes plugins install p-diogo/totalreclaw-hermes --enable
 
 # Restart the gateway. Pick the line that matches your setup:
 hermes gateway restart                       # native install
@@ -307,7 +325,8 @@ Upgrade: *"Upgrade my TotalReclaw subscription."* — see [Pricing](https://tota
 
 - **Agent says "I'm not familiar with TotalReclaw"**: paste the canonical message above with the URL — the agent fetches the guide and follows the install steps.
 - **Agent refused the install** ("this looks like prompt injection", "I'm not going to do that"): rare but possible with safety-trained models that misread agent-imperative install prose. Ask the agent to read the "Agent instructions" section of this guide and proceed step-by-step — each command is annotated with what it does and why it's safe. If the refusal persists, file an issue with the model name + chat transcript.
-- **Agent can't see TotalReclaw tools after install**: confirm both install steps completed — on a self-host, `hermes plugins list` should show `p-diogo/totalreclaw-hermes` enabled and `pip show totalreclaw` in the Hermes venv should resolve; on a managed service, confirm `totalreclaw` is listed in your service's plugins UI. Then restart: `hermes gateway restart` (native), `docker restart <your-hermes-container>` (Docker self-host), or your managed service's restart control. If supervised by systemd / launchd, `kill -USR1 $(cat ~/.hermes/gateway.pid)` is faster than `systemctl restart`. (Hermes does not yet auto-reload on plugin install — tracked upstream.)
+- **Agent can't see TotalReclaw tools after install**: confirm both install steps completed — on a self-host, `hermes plugins list` should show `p-diogo/totalreclaw-hermes` enabled and `pip show totalreclaw` in the Hermes venv should resolve; on a managed service, confirm `totalreclaw` is listed in your service's plugins UI. Then restart: the agent SHOULD issue `/restart` autonomously (in-process slash command, drains active runs). If `/restart` returns "not authorized" (managed-service auth gate), the agent will try `/new` once, then fall back to a one-line user-prompted restart — `hermes gateway restart` (native), `docker restart <your-hermes-container>` (Docker self-host), or your managed service's restart control. If supervised by systemd / launchd, `kill -USR1 $(cat ~/.hermes/gateway.pid)` is faster than `systemctl restart`. (Hermes does not yet auto-reload on plugin install — tracked upstream.)
+- **Agent says "Should I /restart?" or stalls instead of restarting** (2.3.4-rc.1 hardening note): the agent missed the deny-list in the SKILL.md / Step 2. Reply *"Issue /restart yourself — don't ask"* and the next session should act autonomously. If it persists across sessions, the published RC's SKILL.md is stale — file an issue.
 - **Account-setup URL returns 404**: check that `~/.totalreclaw/credentials.json` isn't locked by a previous process and that the gateway is running. If you invoked `hermes chat -q "..."` (one-shot) for account setup, the WebSocket the relay needs may have died before the browser POST landed — see [Account setup requires daemon mode](#account-setup-requires-daemon-mode).
 - **Browser fails to POST the encrypted phrase**: check the account-setup page's Content-Security-Policy — older browsers without WebCrypto x25519 (pre-Safari 17.2 / Chromium 118) cannot run the AEAD crypto.
 - **"No LLM available for auto-extraction"**: configure a provider in Hermes (`hermes login` or set `ZAI_API_KEY` / `OPENAI_API_KEY` in `~/.hermes/.env`). TotalReclaw reuses it automatically.

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,98 @@ Hermes Agent plugin are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.4rc1] — 2026-04-30
+
+Coordinated bundle with plugin `3.3.4-rc.1`. SKILL.md hardening pass —
+no Python runtime / API changes. The 2.3.3-rc.1 build-time env binding
+(PR #165) and the `Retry-After` honoring fix (PR #170) carry over
+unchanged.
+
+Pedro had not yet QA'd 2.3.3-rc.1 when plugin-side QA against
+3.3.3-rc.1 surfaced three skill-instruction gaps. Bumping Hermes to
+2.3.4-rc.1 alongside plugin 3.3.4-rc.1 lets both halves get QA'd
+together. The Hermes-side gaps mirror the plugin-side findings.
+
+### `/restart` autonomy + deny-list (Fix 1)
+
+Plugin-side QA on 2026-04-30 (zai/glm-5-turbo against plugin
+3.3.3-rc.1) showed the agent asking the user *"Should I /restart?"*
+instead of issuing the slash command itself, then stalling when
+`/restart` returned `"You are not authorized to use this command"`
+on a Telegram-channel deployment. PR #162 (rc.4) had hardened the
+restart step to "issue autonomously, never ask" but the language was
+soft enough for a less-capable model to backslide.
+
+`SKILL.md` and `docs/guides/hermes-setup.md` Step 2 now spell out:
+
+- A **forbidden-vocabulary deny-list** for the restart step:
+  *"Should I /restart?"*, *"Want me to restart?"*, *"Do you have a
+  public URL?"*, *"Let me check if the tool is bound."* — these phrases
+  must never appear in chat at restart-time. The agent must act, then
+  announce.
+- An **unauthorized fallback** when `/restart` returns *"not
+  authorized"* / *"command not found"* (managed Hermes deployments
+  that gate session-scope slash commands behind RBAC, or strip them
+  altogether): try `/new` once (fresh session in the same gateway,
+  may pick up freshly-bound tools), then escalate to a single-line
+  user-prompted restart message. Do NOT loop on `/restart` after an
+  unauthorized response — the gate isn't going to flip mid-session.
+  This mirrors the plugin-side fix for the OpenClaw `tier: power`
+  Telegram `allowFrom` auth gate (Hermes itself does not have an
+  equivalent power-tier gate today, but managed-service deployments
+  may impose one externally — research/hot-reload-hermes-openclaw
+  notes confirm Hermes' own `/restart` is unrestricted on stock
+  installs).
+- The Step 4 verify-bound retry path now matches: re-issue `/restart`
+  autonomously (no "should I?"), try `/new` once, then user-prompted
+  restart — never loop on `/restart` after an unauthorized response.
+
+### Install ordering — Python package first, plugin manifest second (Fix 2)
+
+Plugin-side QA on 2026-04-30 also surfaced an install race: a
+gateway-config-driven SIGUSR1 reload can fire as soon as
+`hermes plugins install ... --enable` registers the manifest. If the
+Python package isn't on disk by the time the reload fires, the gateway
+binds the manifest with no implementations and the agent loops on the
+restart step.
+
+The new canonical order in `SKILL.md` Step 1b and
+`docs/guides/hermes-setup.md` Step 1b is:
+
+1. `"$HERMES_PYTHON" -m pip install --pre totalreclaw` — implementations land first.
+2. `hermes plugins install p-diogo/totalreclaw-hermes --enable` — manifest registers second.
+
+The `Fully manual (CLI only)` section is updated to match. Inverted-
+order installs that already shipped continue to work — they just race
+the reload-trigger and may need a second restart to bind cleanly.
+
+### Test coverage
+
+- Re-ran `python/tests/test_env_binding_and_rc_banner.py` (PR #169) —
+  all 7 assertions still green; no behavior change to the
+  `_HARDCODED_DEFAULT_URL` site or the RC/staging banner path.
+- New `python/tests/test_skill_md_restart_hardening_2_3_4.py` pins the
+  forbidden-vocabulary deny-list, the `/restart` unauthorized fallback
+  prose, the `/new` retry hop, and the install-ordering note in
+  SKILL.md so a future refactor can't silently regress 2.3.4-rc.1's
+  hardening.
+- Existing `test_skill_md_includes_disable_memory_step.py` and
+  `test_hermes_plugin*.py` continue to pass — the rc.26 disable-memory
+  step is preserved verbatim.
+
+### Out of scope
+
+- No PyPI publish here — this PR opens for review only. Pedro QAs
+  2.3.4-rc.1 alongside plugin 3.3.4-rc.1 tomorrow; PyPI publish goes
+  through `publish-python-client.yml` once the bundle is GO.
+- TS plugin (`skill/`), `npm-publish.yml`, `publish-clawhub.yml`,
+  Hermes Dockerfile (`tools/qa-stack/hermes/` in the internal repo)
+  are owned by the parallel plugin agent / cross-repo follow-ups
+  — untouched here.
+- Phrase-safety invariant: untouched. The recovery-phrase isolation
+  contract from rc.4 (no `totalreclaw setup` / `hermes setup` shell
+  invocations from the agent) carries through unchanged.
+
 ## [2.3.3rc1] — 2026-04-30
 
 Coordinated bundle with plugin `3.3.3-rc.1`. Implements the build-time

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -12,7 +12,7 @@ name = "totalreclaw"
 # which would have caused stable builds to mis-publish AND broke the
 # regex-based mutation logic on subsequent RCs. Keep this at the next
 # stable target with NO rc suffix. F3 fix in rc.24.
-version = "2.3.3"
+version = "2.3.4"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"

--- a/python/src/totalreclaw/__init__.py
+++ b/python/src/totalreclaw/__init__.py
@@ -9,7 +9,7 @@ except Exception:
     # installed-package metadata is absent. Must match pyproject.toml —
     # test_version.py enforces a semver-shape string; the live value in
     # a pip-installed wheel comes from importlib.metadata above.
-    __version__ = "2.3.3"
+    __version__ = "2.3.4"
 
 from .client import TotalReclaw
 

--- a/python/src/totalreclaw/hermes/SKILL.md
+++ b/python/src/totalreclaw/hermes/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "Install + set up TotalReclaw encrypted memory for Hermes, then use totalreclaw_remember / totalreclaw_recall. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', or any remember / recall request."
-version: 2.3.1rc10
+version: 2.3.4rc1
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz
@@ -53,6 +53,17 @@ If a step actually fails, surface a one-line error + the action being taken. Exa
 
 Do not write these words in chat during install + setup unless the user explicitly asks how the install works: `Python`, `interpreter`, `venv`, `virtual environment`, `pip`, `ensurepip`, `bootstrap`, `find`, `lookup`, `detect`, `probing`, `let me try`, `in parallel`, `got it`, `now installing`, `Step 1a/1b/1c`. These are tool-call mechanics, not user-facing prose. If the user asks ("what's it doing?", "show me the commands"), narrate freely — the silence rule only governs the default install path.
 
+### Forbidden phrases when tools fail to bind (deny-list — 2.3.4-rc.1)
+
+When `totalreclaw_*` tools are missing post-install, you MUST issue `/restart` (or `/new` as fallback) **autonomously** and announce the action — never ask the user to authorize it, never stall, never hedge. The following phrases are anti-patterns and MUST NOT appear in chat in that situation:
+
+- "Should I /restart?" / "Should I issue /restart?" / "Want me to restart?" / "Do you want me to restart?"
+- "Do you have a public URL?" / "Can you give me a URL?" (the install is local; no URL is needed at restart-time)
+- "Let me check if the tool is bound." / "Let me verify…" (verification is a silent shell call, not a chat line)
+- "Is it OK if I restart?" / "Confirming before I restart…"
+
+The correct pattern is to issue `/restart` immediately and emit user-visible line 3 (the autonomous restart confirmation) as the single chat line. Step 2 of the setup flow is explicit about this — re-read it if you find yourself drafting any of the phrases above.
+
 ## Setup flow
 
 If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jump to step 5. Otherwise run all steps in order. Numbered steps are internal procedure; user prose is only the lines listed in §"User-visible prose" above.
@@ -64,8 +75,19 @@ If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jum
    HERMES_PYTHON="$(command -v python3)"
 
    # 1b. Install both halves into the right env. Silent.
-   hermes plugins install p-diogo/totalreclaw-hermes --enable
+   # Order matters: Python package FIRST, plugin manifest SECOND. Some
+   # Hermes deploys (and OpenClaw 2026.4.16+ on the parallel skill+plugin
+   # bundle — finding from today's plugin-side QA) trigger a
+   # gateway-config-driven SIGUSR1 reload as soon as the plugin manifest
+   # registers via `hermes plugins install ... --enable`. If the Python
+   # package isn't on disk by the time that reload fires, the gateway
+   # loads the manifest, finds no `totalreclaw_*` implementations,
+   # silently fails to bind, and the agent then loops on Step 2 trying
+   # to restart again. Installing the Python package FIRST guarantees
+   # the implementations are present before the manifest registers and
+   # any reload-trigger arrives. Do not invert this order.
    "$HERMES_PYTHON" -m pip install --pre totalreclaw
+   hermes plugins install p-diogo/totalreclaw-hermes --enable
 
    # 1c. Confirm the package resolved through Hermes' interpreter. Silent.
    "$HERMES_PYTHON" -m pip show totalreclaw | head -2
@@ -75,9 +97,13 @@ If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jum
    - `pip: command not found` / `No module named pip` (Hermes container shipped without pip): bootstrap silently with `"$HERMES_PYTHON" -m ensurepip --upgrade`, then retry 1b.
    - `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment): break silence and tell the user verbatim *"Your environment doesn't expose the Hermes CLI to me. Please install `p-diogo/totalreclaw-hermes` and the `totalreclaw` Python package via your service's plugins UI, then reply `done`. Also disable Hermes' built-in `memory` tool in the same UI if available — running both creates a silent intent-stealing bug."* Wait for `done` and skip to step 4 (verify account-setup tool bound).
 
-2. **Restart the gateway autonomously via Hermes' built-in `/restart` slash command.** Hermes registers `/restart` as a session-scope slash command (see `hermes_cli/commands.py`: `CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session", ...)`). It drains active runs first, then reloads — safer than `kill -USR1` and works from inside the gateway because it's an in-process command, not an external CLI. Emit the slash command yourself; do NOT ask the user to run a shell command. Surface a single user-visible line confirming the action: `Restarting Hermes to load the plugin (auto-drains active runs)…`. Hermes will return after the restart finishes; resume at step 3.
+2. **Restart the gateway autonomously via Hermes' built-in `/restart` slash command.** Hermes registers `/restart` as a session-scope slash command (see `hermes_cli/commands.py`: `CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session", ...)`). It drains active runs first, then reloads — safer than `kill -USR1` and works from inside the gateway because it's an in-process command, not an external CLI. Emit the slash command yourself; do NOT ask the user to run a shell command, and do NOT ask the user *whether* to restart (the silence rule + the deny-list above govern this — the right move is to act, then announce). Surface a single user-visible line confirming the action: `Restarting Hermes to load the plugin (auto-drains active runs)…`. Hermes will return after the restart finishes; resume at step 3.
 
-   **Fallback only if `/restart` is unavailable** (very old Hermes pre-2026.4, managed services that strip slash commands, or the user has explicitly requested manual control): pick the right restart command for the user's deploy and emit it as a single user-visible line (`Please restart your Hermes gateway: <restart-command>. Reply \`done\` once it's back up.`):
+   **`/restart` returned "not authorized" / "command not found" / refused** (managed services that gate session-scope commands behind a role / RBAC layer, or strip slash commands altogether): do NOT loop on `/restart`. Try `/new` once — `/new` opens a fresh session within the same gateway and may pick up freshly-bound tools without requiring a full reload. If `/new` also returns "not authorized", break silence with a single user-facing line that surfaces the underlying gate verbatim:
+   > *"Your Hermes deployment doesn't expose `/restart` to me (managed-service auth gate or shell-restricted environment). Please restart the gateway yourself — `hermes gateway restart` (native), `docker restart <your-hermes-container>` (Docker self-host — `docker ps` shows the name), or your service's restart control. Reply `done` once it's back up."*
+   Wait for `done`, then resume at step 3. Do NOT keep retrying `/restart` after an unauthorized response — the gate isn't going to flip mid-session, and the loop just spams the user.
+
+   **Fallback only if `/restart` is structurally unavailable** (very old Hermes pre-2026.4 with no `/restart` command at all, or the user has explicitly requested manual control): pick the right restart command for the user's deploy and emit it as a single user-visible line (`Please restart your Hermes gateway: <restart-command>. Reply \`done\` once it's back up.`):
    - Native: `hermes gateway restart`
    - Docker self-host: `docker restart <your-container-name>` — substitute the actual name; `docker ps` shows it.
    - Managed service: their restart control.
@@ -94,7 +120,7 @@ If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jum
 
    If the command succeeds, emit user-visible line 4 (the disable confirmation). If it errors with `command not found` or "tool not found" (older Hermes versions, managed services that don't expose the CLI, or the built-in `memory` tool was already removed), skip line 4 silently and continue — the rc.25 tool-description bias still steers the LLM toward `totalreclaw_remember` as a fallback. Do not surface the disable failure.
 
-4. **Verify `totalreclaw_pair` is bound (silent).** If still missing after restart, surface a one-line error: `Plugin installed but tools didn't bind after restart. Issuing /restart again.` and re-issue `/restart` once. Do not loop the install. If the second `/restart` still doesn't bind tools, fall back to the manual user-prompted restart path (see step 2 fallback) once.
+4. **Verify `totalreclaw_pair` is bound (silent).** If still missing after restart, surface a one-line error: `Plugin installed but tools didn't bind after restart. Issuing /restart again.` and re-issue `/restart` once **autonomously** — do NOT ask the user "should I /restart again?". Do not loop the install. If the second `/restart` still doesn't bind tools, try `/new` once (fresh session may pick up the binding without a reload). If both `/restart` retries AND `/new` fail to bind the tool, fall back to the manual user-prompted restart path (see step 2 fallback) once. If any restart attempt returns "not authorized", apply the unauthorized fallback from step 2 — do NOT retry `/restart` after an unauthorized response.
 
 5. **Check for existing credentials (silent).** Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, emit `✓ TotalReclaw is already set up.` and stop. Otherwise continue silently.
 
@@ -124,7 +150,7 @@ NEVER echo / generate / ask the user to paste a recovery phrase in chat. NEVER i
 
 ## Diagnostics
 
-- `totalreclaw_*` tools not visible → gateway not restarted after install; issue Hermes' `/restart` slash command (in-process, drains active runs). If `/restart` is unavailable (very old Hermes, restricted managed service), fall back to asking the user once: `hermes gateway restart` (native), `docker restart <your-container-name>` (Docker self-host), or the managed service's restart control. Wait for `done`.
+- `totalreclaw_*` tools not visible → gateway not restarted after install; issue Hermes' `/restart` slash command (in-process, drains active runs) **autonomously** — never ask the user for permission to restart. If `/restart` returns "not authorized" / "command not found", DO NOT loop on `/restart`; try `/new` once (fresh session may pick up freshly-bound tools), then escalate to a one-line user-prompted restart per step 2's unauthorized fallback. Wait for `done`.
 - User says done but `credentials.json` missing → PIN expired or entered wrong phrase; call `totalreclaw_pair` again.
 - `onboarding required` → credentials missing; redo from the account-setup step.
 - `quota exceeded` → `totalreclaw_status`, then offer `totalreclaw_upgrade`.

--- a/python/tests/test_skill_md_restart_hardening_2_3_4.py
+++ b/python/tests/test_skill_md_restart_hardening_2_3_4.py
@@ -1,0 +1,363 @@
+"""2.3.4-rc.1 SKILL.md hardening pins.
+
+Why this file exists
+====================
+
+Plugin-side QA against 3.3.3-rc.1 on 2026-04-30 surfaced three
+skill-instruction gaps:
+
+1. The agent (zai/glm-5-turbo) asked the user *"Should I /restart?"*
+   instead of issuing the slash command autonomously — PR #162's
+   restart-step prose was too soft for a less-capable model to follow
+   reliably.
+2. When `/restart` returned *"You are not authorized to use this
+   command"* (the OpenClaw-side `tier: power` Telegram `allowFrom`
+   auth gate), the agent didn't know how to recover and looped.
+3. A gateway-config-driven SIGUSR1 reload can race a plugin install:
+   if the Python package isn't on disk by the time the manifest
+   registers, the gateway binds the manifest with no implementations.
+
+Hermes mirrors the same skill instructions, so the same gaps apply.
+2.3.4-rc.1 hardens both ``SKILL.md`` and ``docs/guides/hermes-setup.md``
+with:
+
+* A forbidden-vocabulary deny-list at the restart step ("Should I
+  /restart?" etc.) — the agent must act autonomously and announce.
+* An ``/restart`` unauthorized fallback chain: try ``/new`` once (fresh
+  session may pick up freshly-bound tools), then escalate to a
+  single-line user-prompted restart. Do NOT loop on ``/restart``.
+* Install order: Python package FIRST, plugin manifest SECOND. The
+  manifest registration is the reload-trigger; landing the Python
+  package first means the implementations are present when the reload
+  fires.
+
+This test file pins those pieces against silent regressions in future
+SKILL.md / guide refactors. The assertions are deliberately literal —
+they compare against the exact phrases the plan asked for so that a
+contributor reading the test sees the contract.
+
+Companion to ``test_skill_md_includes_disable_memory_step.py`` (rc.26
+disable-memory step) and ``test_setup_guide_includes_compatibility_section.py``
+(rc.26 user-guide compatibility section). Together those three test
+files cover the load-bearing prose in the install + setup flow.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_MD = (
+    _REPO_ROOT / "python" / "src" / "totalreclaw" / "hermes" / "SKILL.md"
+)
+USER_GUIDE = _REPO_ROOT / "docs" / "guides" / "hermes-setup.md"
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"{path} not found — has it been moved or renamed?"
+    return path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Section 1 — Forbidden-vocabulary deny-list at the restart step
+# ---------------------------------------------------------------------------
+
+
+def test_skill_md_has_forbidden_phrases_section_for_restart():
+    """SKILL.md must include a deny-list section that spells out the
+    anti-pattern phrases the agent is forbidden from writing in chat
+    when tools fail to bind post-install. Without the explicit list,
+    a soft "issue autonomously" instruction is not enough — plugin-side
+    QA on 2026-04-30 showed less-capable models drafting "Should I
+    /restart?" despite the existing prose.
+    """
+    body = _read(SKILL_MD)
+    assert "Forbidden phrases when tools fail to bind" in body, (
+        "SKILL.md must contain a 'Forbidden phrases when tools fail to "
+        "bind' deny-list section. The 2.3.4-rc.1 hardening codifies "
+        "the deny-list explicitly so soft 'issue autonomously' prose "
+        "isn't the only signal to the agent."
+    )
+
+
+def test_skill_md_denies_should_i_restart_phrasing():
+    """The exact 'Should I /restart?' phrase must be in the deny-list.
+
+    Plugin-side QA on 2026-04-30 caught zai/glm-5-turbo writing exactly
+    this line when tools didn't bind after install. The fix is to make
+    the phrase a literal item in the deny-list so the model has a
+    direct match-and-avoid signal.
+    """
+    body = _read(SKILL_MD)
+    assert '"Should I /restart' in body, (
+        'SKILL.md deny-list must include the literal "Should I /restart" '
+        "phrase — that is the anti-pattern the 2.3.4-rc.1 fix was "
+        "scoped to eliminate."
+    )
+
+
+def test_skill_md_denies_url_question_phrasing():
+    """'Do you have a public URL?' must be in the deny-list.
+
+    The install is local; there is no URL the agent should be asking
+    the user for at restart-time. This question came up in the same
+    QA run and indicates the model has lost the thread of what step
+    it's on.
+    """
+    body = _read(SKILL_MD)
+    assert '"Do you have a public URL' in body, (
+        'SKILL.md deny-list must include "Do you have a public URL" — '
+        "agents that drift to that phrase have lost track of the install "
+        "step they are on and need a direct match-and-avoid signal."
+    )
+
+
+def test_skill_md_denies_let_me_check_phrasing():
+    """'Let me check if the tool is bound.' must be in the deny-list.
+
+    Verification of tool-binding is a silent shell call (the existing
+    silence rule), not a chat line. Narrating it breaks the silence
+    rule and adds noise.
+    """
+    body = _read(SKILL_MD)
+    assert '"Let me check if the tool is bound' in body, (
+        'SKILL.md deny-list must include "Let me check if the tool is '
+        'bound" — verification is silent, not a chat line.'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section 2 — `/restart` unauthorized fallback (try `/new`, then user)
+# ---------------------------------------------------------------------------
+
+
+def test_skill_md_documents_restart_unauthorized_fallback():
+    """SKILL.md must describe what to do when `/restart` returns
+    'not authorized'. Without this, the agent loops on `/restart`
+    forever — exactly what plugin-side QA caught.
+    """
+    body = _read(SKILL_MD)
+    assert "not authorized" in body, (
+        "SKILL.md must describe the `/restart` 'not authorized' "
+        "failure mode — managed Hermes deployments that gate "
+        "session-scope slash commands behind RBAC return this string "
+        "and the agent must know how to recover."
+    )
+    assert "do NOT loop on `/restart`" in body or "Do NOT keep retrying `/restart`" in body, (
+        "SKILL.md must explicitly forbid looping on `/restart` after "
+        "an unauthorized response — the gate isn't going to flip "
+        "mid-session and the loop just spams the user."
+    )
+
+
+def test_skill_md_uses_slash_new_as_first_unauthorized_fallback():
+    """When `/restart` is gated, the agent should try `/new` once
+    before asking the user to restart. `/new` opens a fresh session
+    in the same gateway, which may pick up freshly-bound tools without
+    requiring a full reload — cheaper than a user-prompted restart.
+    """
+    body = _read(SKILL_MD)
+    assert "/new" in body, (
+        "SKILL.md must mention the `/new` slash command as the next "
+        "fallback after `/restart` returns unauthorized. `/new` opens "
+        "a fresh session in the same gateway and may pick up freshly-"
+        "bound tools without requiring a full reload."
+    )
+
+
+def test_skill_md_user_prompted_restart_is_last_resort():
+    """The unauthorized chain must end at a single-line user-prompted
+    restart message, NOT at another `/restart` retry. The whole point
+    is to break out of the slash-command path when the gate is closed.
+    """
+    body = _read(SKILL_MD)
+    # The user-prompted fallback must reference at least one external
+    # restart command so the user has actionable guidance.
+    assert "hermes gateway restart" in body
+    assert "docker restart" in body
+
+
+# ---------------------------------------------------------------------------
+# Section 3 — Step 4 retry chain matches Step 2 (no "should I /restart again?")
+# ---------------------------------------------------------------------------
+
+
+def test_skill_md_step_4_retry_is_autonomous():
+    """Step 4 (verify-bound) must re-issue `/restart` autonomously —
+    the same autonomy contract Step 2 has. The 2.3.3-rc.1 prose said
+    "re-issue /restart once" but did not explicitly forbid the
+    "should I?" prefix; some models added it anyway.
+    """
+    body = _read(SKILL_MD)
+    # Locate Step 4 ("Verify ``totalreclaw_pair`` is bound") prose.
+    assert "re-issue `/restart` once **autonomously**" in body, (
+        "Step 4 must say `/restart` is re-issued autonomously — match "
+        "Step 2's autonomy contract so the deny-list applies at "
+        "verify-bound retry time too."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section 4 — Install ordering: Python package FIRST, manifest SECOND
+# ---------------------------------------------------------------------------
+
+
+def test_skill_md_install_order_python_first_then_manifest():
+    """SKILL.md Step 1b must show the pip install line BEFORE the
+    `hermes plugins install` line. The reverse order races a
+    config-driven SIGUSR1 reload — the manifest registers, the reload
+    fires, the gateway finds no implementations, binding fails.
+    """
+    body = _read(SKILL_MD)
+    pip_idx = body.find('"$HERMES_PYTHON" -m pip install --pre totalreclaw')
+    plugin_idx = body.find("hermes plugins install p-diogo/totalreclaw-hermes")
+    assert pip_idx > 0, (
+        "SKILL.md must contain the canonical `$HERMES_PYTHON -m pip "
+        "install --pre totalreclaw` line in Step 1b."
+    )
+    assert plugin_idx > 0, (
+        "SKILL.md must contain the canonical `hermes plugins install "
+        "p-diogo/totalreclaw-hermes` line in Step 1b."
+    )
+    assert pip_idx < plugin_idx, (
+        "SKILL.md Step 1b ordering regressed: pip install must precede "
+        "`hermes plugins install` so the Python package is on disk "
+        "before the manifest registration triggers a reload. See the "
+        "2.3.4-rc.1 install-race finding from plugin-side QA."
+    )
+
+
+def test_skill_md_install_order_has_explanatory_comment():
+    """The order isn't obvious — without an inline comment a future
+    refactor will swap it back to plugin-then-pip. Pin the comment.
+    """
+    body = _read(SKILL_MD)
+    assert "Order matters" in body, (
+        "SKILL.md must explain why pip install precedes `hermes "
+        "plugins install` — without the comment a future refactor "
+        "will reorder them and silently re-introduce the install race."
+    )
+    assert "SIGUSR1" in body, (
+        "SKILL.md ordering comment must reference SIGUSR1 / config-"
+        "driven reload — that is the specific failure mode and naming "
+        "it makes the comment self-explanatory to a future contributor."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section 5 — User-guide mirror: same hardening lands in hermes-setup.md
+# ---------------------------------------------------------------------------
+
+
+def test_user_guide_mirrors_unauthorized_fallback_prose():
+    """`docs/guides/hermes-setup.md` must mirror the SKILL.md
+    unauthorized fallback so a user reading the guide learns the same
+    contract. Drift between SKILL.md (agent-facing) and the user
+    guide (human-facing) was a recurring rc.x finding pre-rc.20.
+    """
+    body = _read(USER_GUIDE)
+    assert "not authorized" in body, (
+        "hermes-setup.md must describe the `/restart` 'not authorized' "
+        "failure mode and recovery path so users on managed Hermes "
+        "deployments understand what they are seeing."
+    )
+    assert "/new" in body, (
+        "hermes-setup.md must reference `/new` as the unauthorized "
+        "fallback hop, mirroring SKILL.md."
+    )
+
+
+def test_user_guide_mirrors_install_ordering():
+    """The pip-then-manifest order must also be in the user guide so
+    a user copy-pasting from the manual section doesn't race the
+    reload. Drift between SKILL.md and the user guide is a known
+    failure mode.
+
+    The check is scoped to the Step 1b code block (the canonical
+    copy-paste target), NOT the agent-instructions overview list at
+    the top of the guide which simply describes what each command
+    does and is not a copy-paste source.
+    """
+    body = _read(USER_GUIDE)
+    # Locate the Step 1b code block — that's the user-facing canonical
+    # copy-paste target; the agent-instructions overview list at the
+    # top of the guide just describes commands and is not the source
+    # of truth for ordering.
+    step_1b_marker = "#### Step 1b"
+    step_1b_idx = body.find(step_1b_marker)
+    assert step_1b_idx > 0, (
+        "hermes-setup.md must contain a 'Step 1b' subsection with the "
+        "canonical install commands. Search for '#### Step 1b' returned "
+        "no match — has the section heading been renamed?"
+    )
+    # Also bound the search at the next top-level step heading so we
+    # don't accidentally pick up the manual-CLI block lower in the doc.
+    step_1c_idx = body.find("#### Step 1c", step_1b_idx)
+    step_1b_block = (
+        body[step_1b_idx:step_1c_idx] if step_1c_idx > 0 else body[step_1b_idx:]
+    )
+
+    pip_idx = step_1b_block.find('"$HERMES_PYTHON" -m pip install --pre totalreclaw')
+    plugin_idx = step_1b_block.find("hermes plugins install p-diogo/totalreclaw-hermes")
+    assert pip_idx > 0 and plugin_idx > 0, (
+        "hermes-setup.md Step 1b must contain both the pip install and "
+        "the `hermes plugins install` canonical lines."
+    )
+    assert pip_idx < plugin_idx, (
+        "hermes-setup.md Step 1b ordering regressed: pip install must "
+        "precede `hermes plugins install`. See the 2.3.4-rc.1 install-"
+        "race finding from plugin-side QA."
+    )
+
+    # Also pin ordering in the 'Fully manual (CLI only)' section — that
+    # block is the other copy-paste target and the original 2.3.3 prose
+    # had it in plugin-then-pip order. The 2.3.4-rc.1 fix re-ordered it.
+    manual_marker = "## Fully manual (CLI only"
+    manual_idx = body.find(manual_marker)
+    assert manual_idx > 0, (
+        "hermes-setup.md must retain the 'Fully manual (CLI only)' "
+        "section — that is the second copy-paste target users hit."
+    )
+    # Bound the search so we don't run off into Upgrading / Targeting.
+    next_section_idx = body.find("\n---\n", manual_idx)
+    manual_block = (
+        body[manual_idx:next_section_idx] if next_section_idx > 0 else body[manual_idx:]
+    )
+    manual_pip = manual_block.find("pip install --pre totalreclaw")
+    manual_plugin = manual_block.find("hermes plugins install p-diogo/totalreclaw-hermes")
+    assert manual_pip > 0 and manual_plugin > 0
+    assert manual_pip < manual_plugin, (
+        "'Fully manual (CLI only)' section must show pip install BEFORE "
+        "`hermes plugins install` — same install-race rationale as "
+        "Step 1b."
+    )
+
+
+def test_user_guide_calls_out_order_change_with_version_marker():
+    """The order change is part of 2.3.4-rc.1 hardening — the marker
+    helps a user reading the guide trace why the order is what it is
+    if they remember a different order from earlier RCs."""
+    body = _read(USER_GUIDE)
+    assert "2.3.4-rc.1" in body, (
+        "hermes-setup.md must mention '2.3.4-rc.1' as the version "
+        "anchor for the install-order change so a user with stale "
+        "memory of pre-rc.X order can trace why it changed."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section 6 — Sanity: rc.26 disable-memory step is unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_skill_md_still_disables_built_in_memory():
+    """Defensive cross-check — the 2.3.4-rc.1 hardening MUST NOT
+    delete the rc.26 disable-memory step. Belt-and-suspenders next to
+    `test_skill_md_includes_disable_memory_step.py` because the
+    edit-by-large-blocks pattern of this PR could have accidentally
+    truncated the disable-memory section.
+    """
+    body = _read(SKILL_MD)
+    assert "hermes tools disable memory" in body
+    assert "Disable Hermes built-in memory" in body
+    assert "(CRITICAL)" in body


### PR DESCRIPTION
## Summary

Coordinated Hermes-side bundle for the 2.3.4-rc.1 / plugin 3.3.4-rc.1 RC pair. SKILL.md hardening pass — no Python runtime / API changes. Pedro QAs 2.3.4-rc.1 alongside plugin 3.3.4-rc.1 tomorrow.

Plugin-side QA against 3.3.3-rc.1 on 2026-04-30 (zai/glm-5-turbo) surfaced three skill-instruction gaps. This PR mirrors the plugin-side hardening on the Hermes side so both halves get QA'd together rather than chasing 2.3.3-rc.1 + 2.3.4-rc.1 individually.

## Fixes

### 1. `/restart` autonomy + deny-list

PR #162 made the agent issue `/restart` autonomously after install. Today's plugin-side QA showed less-capable models still drafting *"Should I /restart?"* despite that prose, then stalling when `/restart` returned `"You are not authorized to use this command"` on a Telegram-channel deployment.

- **Forbidden-vocabulary deny-list** at the restart step in both `SKILL.md` and `docs/guides/hermes-setup.md` — explicit literal phrases the agent must never write in chat: *"Should I /restart?"*, *"Want me to restart?"*, *"Do you have a public URL?"*, *"Let me check if the tool is bound."*
- **Unauthorized fallback** when `/restart` returns *"not authorized"* / *"command not found"* / refused: do NOT loop on `/restart`. Try `/new` once (fresh session in the same gateway may pick up freshly-bound tools), then escalate to a single-line user-prompted restart message. The Hermes case mirrors the plugin-side OpenClaw `tier: power` Telegram `allowFrom` auth-gate finding — Hermes itself does not have an equivalent power-tier gate today (per `research/hot-reload-hermes-openclaw-2026-04-25.md`), but managed-service deployments may impose one externally.
- Step 4 verify-bound retry path matches Step 2: re-issue `/restart` autonomously, try `/new` once, then user-prompted restart.

### 2. Install ordering — Python package FIRST, plugin manifest SECOND

A gateway-config-driven SIGUSR1 reload can fire as soon as `hermes plugins install ... --enable` registers the manifest. If the Python package isn't on disk by the time the reload fires, the gateway binds the manifest with no implementations and the agent loops on the restart step.

New canonical order (SKILL.md Step 1b + hermes-setup.md Step 1b + Fully-manual section + agent-instructions overview):

1. `\"$HERMES_PYTHON\" -m pip install --pre totalreclaw`
2. `hermes plugins install p-diogo/totalreclaw-hermes --enable`

Inverted-order installs that already shipped continue to work — they just race the reload-trigger and may need a second restart to bind cleanly.

### 3. Env-binding regression test re-verified

`python/tests/test_env_binding_and_rc_banner.py` (PR #169) — all 7 assertions still green. No regression to the `_HARDCODED_DEFAULT_URL` site or the RC/staging banner path.

### 4. Version bump

- `python/pyproject.toml`: `2.3.3` → `2.3.4`
- `python/src/totalreclaw/__init__.py` fallback `__version__`: `2.3.4`
- `python/src/totalreclaw/hermes/SKILL.md` frontmatter: `2.3.4rc1`
- `python/CHANGELOG.md`: new `[2.3.4rc1]` entry

## Test plan

- [x] `python/tests/test_skill_md_restart_hardening_2_3_4.py` — 14 new tests pin the deny-list, the `/restart` unauthorized fallback, the `/new` retry hop, and the install-ordering note in SKILL.md + user guide.
- [x] `python/tests/test_env_binding_and_rc_banner.py` — re-ran, all green (Fix 3).
- [x] Full Python suite: **1064 passed**, 14 skipped (env-gated integration), 1 xfailed in 65s.
- [ ] Pedro real-user QA against 2.3.4-rc.1 wheel + plugin 3.3.4-rc.1 (tomorrow, paired auto-QA + manual chat-flow run).
- [ ] If GO: dispatch `publish-python-client.yml` with `release-type: stable` after the parallel plugin promote.

## Out of scope

- TS plugin (`skill/`), `npm-publish.yml`, `publish-clawhub.yml`, Hermes Dockerfile (`tools/qa-stack/hermes/` in the internal repo) untouched — parallel plugin agent + cross-repo follow-ups own those.
- Phrase-safety invariant unchanged (rc.4 contract preserved — no `totalreclaw setup` / `hermes setup` agent-shell invocations).
- No PyPI publish here. PR opens for review only.
- **Do not auto-merge.** Pedro reviews + QAs first.

## References

- PR #162 — original `/restart` autonomous fix (rc.4)
- PR #169 — 2.3.3-rc.1 env-binding (build-time inject + RC staging banner)
- PR #170 — `Retry-After` 429 handling (rc.6)
- Parallel plugin 3.3.4-rc.1 PR (sibling for the OpenClaw side of the same hardening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)