### PR TITLE
fix(plugin): 3.3.4-rc.1 — relay-mode CLI default + version fix + embedder URL fix + skill-prompt strengthening

### DIFF
--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -73,15 +73,17 @@ If the user explicitly asks ("what's it doing?", "why so quiet?", "show me the c
 
 ### Step 1 — Install the skill + plugin (silent — emit user-visible line 1, then no prose until line 2)
 
-Run via your shell tool, in this order, **without writing prose about them**. Emit user-visible line 1 (`Installing TotalReclaw…`) once at the start, then stay silent until both commands succeed.
+Run via your shell tool, in this exact order, **without writing prose about them**. Emit user-visible line 1 (`Installing TotalReclaw…`) once at the start, then stay silent until both commands succeed.
 
 ```bash
-openclaw skills install totalreclaw
 openclaw plugins install @totalreclaw/totalreclaw
+openclaw skills install totalreclaw
 ```
 
+**Plugin BEFORE skill is deliberate** (3.3.4-rc.1, post-Pedro QA): the skill install triggers a config-driven SIGUSR1 gateway reload that can race a concurrent plugin install. Plugin-first lets the plugin land cleanly, then the skill's reload picks it up on the next gateway loop. If you accidentally do skill-first and the plugin install dies mid-flight, just retry `openclaw plugins install @totalreclaw/totalreclaw` once — it's idempotent.
+
 Notes:
-- For an RC build, replace the second command with `openclaw plugins install @totalreclaw/totalreclaw@rc` (latest release candidate) or pin a version like `openclaw plugins install @totalreclaw/totalreclaw@3.3.2-rc.2`.
+- For an RC build, replace the first command with `openclaw plugins install @totalreclaw/totalreclaw@rc` (latest release candidate) or pin a version like `openclaw plugins install @totalreclaw/totalreclaw@3.3.4-rc.1`.
 - If either command fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment), STOP and tell the user verbatim: *"Your environment doesn't expose the OpenClaw CLI to me. Please install `totalreclaw` from your service's plugins / skills UI, then reply `done`."* Wait for `done` before continuing to Step 2.
 
 ### Step 2 — Wait for auto-reload + verify tool bind (silent — emit user-visible line 2 on success)
@@ -90,9 +92,17 @@ OpenClaw's default config (`gateway.reload.mode = "hybrid"`) auto-restarts the g
 
 When `totalreclaw_pair` is bound, capture the version string from `openclaw plugins list` (the line for `@totalreclaw/totalreclaw`) and emit user-visible line 2 (`✓ Installed (totalreclaw <version>)`).
 
-If `totalreclaw_pair` is not bound within 10 seconds, hybrid auto-reload didn't fire (likely `gateway.reload.mode = off`). Issue OpenClaw's built-in `/restart` slash command yourself — it is registered in OpenClaw's commands registry alongside `/help /model /new /plugins /reset /status /tools /usage` and reloads the gateway in-process (works from inside the gateway because it doesn't shell out, unlike `openclaw gateway restart`). Surface a single user-visible line: `Auto-reload didn't fire. Restarting via /restart…`. Resume verification after the slash command returns.
+If `totalreclaw_pair` is not bound within 10 seconds, hybrid auto-reload didn't fire (likely `gateway.reload.mode = off`). Issue OpenClaw's built-in `/restart` slash command yourself **autonomously and immediately** — it is registered in OpenClaw's commands registry alongside `/help /model /new /plugins /reset /status /tools /usage` and reloads the gateway in-process (works from inside the gateway because it doesn't shell out, unlike `openclaw gateway restart`). Surface a single user-visible line: `Auto-reload didn't fire. Restarting via /restart…`. Resume verification after the slash command returns.
 
-**Fallback only if `/restart` is unavailable** (very old OpenClaw pre-2026.4 or managed services that strip slash commands): tell the user verbatim *"Auto-reload didn't fire and /restart is unavailable. Please restart your OpenClaw gateway: `openclaw gateway restart` (native), `docker restart <your-container-name>` (Docker self-host — substitute the actual name; `docker ps` shows it), or your managed service's restart control. Reply `done` once it's back up."* Do NOT invoke any external `docker restart` or `openclaw gateway restart` yourself — your shell runs inside the gateway you'd be restarting; both `/restart` (in-process) and a user-prompted external restart are the only safe paths.
+**Forbidden vocabulary** when a tool is missing post-install (3.3.4-rc.1): "Should I /restart", "Do you have a public URL", "Want me to restart", "Let me check if the tool is bound", "I need permission to restart". Just issue `/restart` and announce. Asking the user kills the silent-flow target.
+
+**If `/restart` returns "You are not authorized to use this command":** the gateway's `channels.<channel>.allowFrom` allowlist for the channel you're chatting through is empty. **Do NOT loop the install. Do NOT keep retrying.** Surface this one-line user-facing fix verbatim and stop:
+
+> Your channel needs to be allowlisted for slash commands. Run on the gateway host: `jq '.channels.<channel>.allowFrom = ["<your-id>"]' ~/.openclaw/openclaw.json | sponge ~/.openclaw/openclaw.json && docker restart <your-container-name>` (Docker self-host) — substitute `<channel>` with your channel name (e.g. `telegram`, `slack`), `<your-id>` with your user ID for that channel (Telegram: `@username` or numeric `chat_id`; Slack: workspace member ID), and `<your-container-name>` with your gateway container name (`docker ps` shows it). On a managed service, ask the service's support to enable slash commands for your channel. Reply `done` once it's back up.
+
+For non-Docker / native deployments substitute `openclaw gateway restart` for the `docker restart` portion. As a session-level fallback while restart is gated, try `/new` (starts a fresh session within the same gateway process — may pick up freshly-bound tools without a full restart).
+
+**Fallback only if both `/restart` and `/new` are unavailable** (very old OpenClaw pre-2026.4 or managed services that strip slash commands): tell the user verbatim *"Auto-reload didn't fire and /restart is unavailable. Please restart your OpenClaw gateway: `openclaw gateway restart` (native), `docker restart <your-container-name>` (Docker self-host — substitute the actual name; `docker ps` shows it), or your managed service's restart control. Reply `done` once it's back up."* Do NOT invoke any external `docker restart` or `openclaw gateway restart` yourself — your shell runs inside the gateway you'd be restarting; `/restart` (in-process) and a user-prompted external restart are the only safe paths.
 
 ### Step 3 — Check for existing credentials (silent unless found)
 

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "Install + set up TotalReclaw encrypted memory for OpenClaw, then use totalreclaw_remember / totalreclaw_recall. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', or any remember / recall request."
-version: 3.3.3-rc.1
+version: 3.3.4-rc.1
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz
@@ -30,16 +30,28 @@ metadata:
 
 If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jump to step 4. Otherwise run all steps in order.
 
-1. **Install skill + plugin.** Run via your shell tool, in this order:
+1. **Install plugin first, skill second.** Run via your shell tool, in this exact order:
    ```
-   openclaw skills install totalreclaw
    openclaw plugins install @totalreclaw/totalreclaw
+   openclaw skills install totalreclaw
    ```
-   For RC: replace the second command with `openclaw plugins install @totalreclaw/totalreclaw@rc`. If either shell call fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment), tell the user verbatim *"Your environment doesn't expose the OpenClaw CLI to me. Please install `totalreclaw` from your service's plugins / skills UI, then reply `done`."* Wait for `done` and skip to step 3.
+   For RC: replace the first command with `openclaw plugins install @totalreclaw/totalreclaw@rc`. **Plugin BEFORE skill is deliberate** (3.3.4-rc.1 — issue from Pedro's QA on rc.3): the skill install triggers a config-driven SIGUSR1 gateway reload that can race a concurrent plugin install. Plugin-first lets the plugin land cleanly, then the skill's reload picks it up on the next gateway loop. If you accidentally do skill-first and the plugin install dies mid-flight, just retry `openclaw plugins install @totalreclaw/totalreclaw` once — it's idempotent.
 
-2. **Wait for auto-reload — do NOT restart the gateway yourself.** OpenClaw's default config (`gateway.reload.mode = "hybrid"`) auto-restarts the gateway via a file-watcher within 1-3 seconds. Wait ~5s, then run `openclaw plugins list | grep totalreclaw` and confirm `totalreclaw_pair` is in your toolset. If it does NOT appear within 10s, the user has `gateway.reload.mode = off` — fall back: tell the user verbatim *"Auto-reload didn't fire. Please restart your OpenClaw gateway: `openclaw gateway restart` (native), `docker restart <your-container-name>` (Docker self-host — substitute the actual name; `docker ps` shows it), or your managed service's restart control. Reply `done` once it's back up."* Do NOT invoke the restart yourself — your shell is running inside the gateway you'd be restarting (catch-22). Wait for the user's `done`.
+   If either shell call fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment), tell the user verbatim *"Your environment doesn't expose the OpenClaw CLI to me. Please install `totalreclaw` from your service's plugins / skills UI, then reply `done`."* Wait for `done` and skip to step 3.
 
-3. **Verify `totalreclaw_pair` is bound.** If still missing after the user said `done`, tell them the restart didn't take effect and to retry. Do not loop the install.
+2. **Wait for auto-reload — then issue `/restart` autonomously if needed.** OpenClaw's default config (`gateway.reload.mode = "hybrid"`) auto-restarts the gateway via a file-watcher within 1-3 seconds. Wait ~5s, then run `openclaw plugins list | grep totalreclaw` and confirm `totalreclaw_pair` is in your toolset.
+
+   **If `totalreclaw_pair` is NOT visible after 10s:** issue OpenClaw's built-in `/restart` slash-command immediately and silently. **DO NOT ask the user "should I restart" / "do you want me to restart" / "let me check if the tool is bound" — just issue `/restart` and announce "Reloading gateway..." once.** This is in-process and drains active runs cleanly; your shell is NOT shelling out to `docker restart` or `openclaw gateway restart` (which would suicide the host). After `/restart`, wait ~3s and re-run `openclaw plugins list`.
+
+   **If `/restart` returns "You are not authorized to use this command":** the gateway's `channels.<your-channel>.allowFrom` allowlist is empty. **Do NOT keep retrying.** Surface this one-line user-facing fix and stop:
+
+   > Your channel needs to be allowlisted for slash commands. Run on the gateway host: `jq '.channels.<channel>.allowFrom = ["<your-id>"]' ~/.openclaw/openclaw.json | sponge ~/.openclaw/openclaw.json && docker restart <your-container-name>` (Docker self-host) — substitute `<channel>` with your channel name (e.g. `telegram`, `slack`), `<your-id>` with your user ID for that channel (Telegram: `@username` or numeric `chat_id`; Slack: workspace member ID), and `<your-container-name>` with your gateway container name (`docker ps` shows it). On a managed service, ask the service's support to enable slash commands for your channel. Reply `done` once it's back up.
+
+   For non-Docker / native deployments substitute `openclaw gateway restart` for the `docker restart` portion. As a session-level fallback while restart is gated, try `/new` (starts a fresh session within the same gateway process, may pick up freshly-bound tools without a full restart).
+
+   **Forbidden vocabulary** (these are anti-patterns when a tool is missing post-install): "Should I /restart", "Do you have a public URL", "Want me to restart", "Let me check if the tool is bound", "I need permission to restart". Just issue `/restart` immediately and announce.
+
+3. **Verify `totalreclaw_pair` is bound.** If still missing after `/restart` (or after the user fixed allowFrom and said `done`), tell them the restart didn't take effect and ask them to retry. Do not loop the install.
 
 4. **Check for existing credentials.** Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, confirm *"TotalReclaw is already set up."* and stop.
 

--- a/skill/plugin/embedding-fallback-tag.test.ts
+++ b/skill/plugin/embedding-fallback-tag.test.ts
@@ -1,0 +1,116 @@
+/**
+ * embedding-fallback-tag.test.ts (3.3.4-rc.1)
+ *
+ * Asserts the embedder runtime config has a fallback `rcTag` that
+ * resolves to a real GitHub Release.
+ *
+ * Bug: 3.3.3-rc.1 used the literal string `'0.0.0-dev'` as the
+ * fallback when `readPluginVersion()` returned null. That URL is
+ * `https://github.com/p-diogo/totalreclaw/releases/download/v0.0.0-dev/...`
+ * which 404s. QA on 3.3.3-rc.1 (Pedro 2026-04-30) caught this because
+ * the cascade-cause (broken `readPluginVersion()` resolution) made the
+ * fallback fire on every cold start, so `prefetchEmbedderBundle` failed
+ * silently and the first `generateEmbedding()` retried the network.
+ *
+ * Fix: the fallback now points at `LAST_KNOWN_GOOD_RC_TAG` — pinned to
+ * the most recent RC with a published bundle at fix-time.
+ *
+ * What this test pins:
+ *   - The fallback tag matches `^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$`
+ *     (a real RC tag, not a dev placeholder).
+ *   - `buildBundleUrl()` + the fallback tag form a URL whose origin is
+ *     `https://github.com/p-diogo/totalreclaw/releases/download/v<tag>/...`
+ *     — i.e. the publish workflow's canonical layout.
+ */
+
+import { configureEmbedder } from './embedding.js';
+import { buildBundleUrl, buildManifestUrl } from './embedder-network.js';
+
+let passed = 0;
+let failed = 0;
+function assert(cond: boolean, name: string): void {
+  const n = passed + failed + 1;
+  if (cond) { console.log(`ok ${n} - ${name}`); passed++; }
+  else { console.log(`not ok ${n} - ${name}`); failed++; }
+}
+
+// ---------------------------------------------------------------------------
+// Fallback tag shape — semver -rc.N or PEP-440 rcN, never a placeholder.
+// ---------------------------------------------------------------------------
+
+// We can't import the constant directly (it's module-private). Read the
+// module source to assert the shape — same approach as scanner / drift
+// guards. This keeps the constant private to embedding.ts while letting
+// the test pin the invariant.
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const embeddingSrc = fs.readFileSync(path.join(here, 'embedding.ts'), 'utf-8');
+
+const constMatch = embeddingSrc.match(/LAST_KNOWN_GOOD_RC_TAG\s*=\s*'([^']+)'/);
+assert(
+  constMatch !== null,
+  'embedding.ts: LAST_KNOWN_GOOD_RC_TAG constant present',
+);
+const tag = constMatch?.[1] ?? '';
+assert(
+  tag.length > 0,
+  'embedding.ts: LAST_KNOWN_GOOD_RC_TAG is non-empty',
+);
+assert(
+  /^\d+\.\d+\.\d+-rc\.\d+$/.test(tag),
+  `embedding.ts: LAST_KNOWN_GOOD_RC_TAG ("${tag}") matches a real RC tag (^x.y.z-rc.N$, not a placeholder)`,
+);
+assert(
+  tag !== '0.0.0-dev',
+  `embedding.ts: fallback tag is NOT the broken placeholder "0.0.0-dev" (3.3.3-rc.1 regression)`,
+);
+
+// ---------------------------------------------------------------------------
+// URL shape — bundle + manifest URLs use the GitHub-Releases canonical layout.
+// ---------------------------------------------------------------------------
+
+{
+  const bundleUrl = buildBundleUrl({ rcTag: tag, bundleVersion: 'v1' });
+  const manifestUrl = buildManifestUrl({ rcTag: tag, bundleVersion: 'v1' });
+  const expectedPrefix = `https://github.com/p-diogo/totalreclaw/releases/download/v${tag}/`;
+  assert(
+    bundleUrl.startsWith(expectedPrefix),
+    'buildBundleUrl: prefix matches GitHub Releases canonical layout',
+  );
+  assert(
+    manifestUrl.startsWith(expectedPrefix),
+    'buildManifestUrl: prefix matches GitHub Releases canonical layout',
+  );
+  assert(
+    bundleUrl.endsWith('/embedder-v1.tar.gz'),
+    'buildBundleUrl: emits embedder-v1.tar.gz',
+  );
+  assert(
+    manifestUrl.endsWith('/embedder-v1.manifest.json'),
+    'buildManifestUrl: emits embedder-v1.manifest.json',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// configureEmbedder is callable + accepts a real RC tag — pure smoke.
+// ---------------------------------------------------------------------------
+
+{
+  let crashed = false;
+  try {
+    configureEmbedder({ cacheRoot: '/tmp/__never_used__', rcTag: '3.3.4-rc.1' });
+  } catch {
+    crashed = true;
+  }
+  assert(!crashed, 'configureEmbedder: accepts a real RC tag without throwing');
+}
+
+console.log(`\n# ${passed}/${passed + failed} passed`);
+if (failed > 0) {
+  console.log('\nSOME TESTS FAILED');
+  process.exit(1);
+}
+console.log('\nALL TESTS PASSED');

--- a/skill/plugin/embedding.ts
+++ b/skill/plugin/embedding.ts
@@ -86,9 +86,26 @@ function defaultCacheRoot(): string {
   return path.join(os.homedir(), '.totalreclaw', 'embedder');
 }
 
+/**
+ * Last-known-good embedder bundle tag. Used ONLY as a hard-fallback when
+ * `configureEmbedder()` is never called by the orchestrator (defensive
+ * path — production code always wires it via index.ts register()).
+ *
+ * 3.3.4-rc.1 — pinned to v3.3.3-rc.1 because that is the most recent
+ * release at fix-time with a published `embedder-v1.tar.gz` asset. Earlier
+ * fallback `'0.0.0-dev'` (rc.22 → 3.3.3-rc.1) hard-coded a placeholder
+ * that resolved to a 404 GitHub Release URL; QA on 3.3.3-rc.1 (Pedro
+ * 2026-04-30) caught it because the cascade-cause (broken
+ * `readPluginVersion()` resolution) made the fallback fire on every cold
+ * start. Bumping this constant per RC is fine — the publish workflow auto-
+ * publishes the bundle for every RC tag (see scripts/build-embedder-
+ * bundle.mjs in the public repo).
+ */
+const LAST_KNOWN_GOOD_RC_TAG = '3.3.3-rc.1';
+
 function activeRuntimeConfig(): EmbedderRuntimeConfig {
   if (runtimeConfig) return runtimeConfig;
-  return { cacheRoot: defaultCacheRoot(), rcTag: '0.0.0-dev' };
+  return { cacheRoot: defaultCacheRoot(), rcTag: LAST_KNOWN_GOOD_RC_TAG };
 }
 
 /**

--- a/skill/plugin/fs-helpers.test.ts
+++ b/skill/plugin/fs-helpers.test.ts
@@ -21,6 +21,7 @@ import {
   deleteCredentialsFile,
   isRunningInDocker,
   deleteFileIfExists,
+  readPluginVersion,
   type CredentialsFile,
 } from './fs-helpers.js';
 
@@ -285,6 +286,105 @@ const TEST_HEADER = '# Memory\n\n> TotalReclaw is active. Test header.\n\n';
   // Directory may still exist — deleteFileIfExists makes no guarantee for dirs.
   // The contract is only "no throw + best-effort on files".
   fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+// ---------------------------------------------------------------------------
+// readPluginVersion — direct hit, walk-up from dist/, mismatched name guard
+// ---------------------------------------------------------------------------
+
+{
+  // Direct hit: package.json sits next to the caller-provided dir.
+  const root = fs.mkdtempSync(path.join(TMP, 'rpv-direct-'));
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({ name: '@totalreclaw/totalreclaw', version: '3.3.4-rc.1' }),
+  );
+  assertEq(
+    readPluginVersion(root),
+    '3.3.4-rc.1',
+    'readPluginVersion: direct hit returns version',
+  );
+}
+
+{
+  // Walk-up: caller passes the dist/ dir, package.json one level up.
+  // 3.3.4-rc.1 fix — without the walk-up, this scenario returned null
+  // and the .loaded.json manifest read `version=unknown`.
+  const root = fs.mkdtempSync(path.join(TMP, 'rpv-walkup-'));
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({ name: '@totalreclaw/totalreclaw', version: '3.3.4-rc.1' }),
+  );
+  const distDir = path.join(root, 'dist');
+  fs.mkdirSync(distDir);
+  assertEq(
+    readPluginVersion(distDir),
+    '3.3.4-rc.1',
+    'readPluginVersion: walks up from dist/ to find plugin package.json',
+  );
+}
+
+{
+  // Walk-up bound: 5 levels deep, package.json at the 4th level — found.
+  const root = fs.mkdtempSync(path.join(TMP, 'rpv-deep-'));
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({ name: '@totalreclaw/totalreclaw', version: '3.3.4-rc.1' }),
+  );
+  const deep = path.join(root, 'a', 'b', 'c', 'd');
+  fs.mkdirSync(deep, { recursive: true });
+  assertEq(
+    readPluginVersion(deep),
+    '3.3.4-rc.1',
+    'readPluginVersion: walks up to 5 levels (4-level descent works)',
+  );
+}
+
+{
+  // Wrong package.json (name mismatch) at first hit -> keeps walking.
+  // Without the name-guard, this would return the wrong version.
+  const root = fs.mkdtempSync(path.join(TMP, 'rpv-wrong-name-'));
+  // Outer = the right plugin
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({ name: '@totalreclaw/totalreclaw', version: '3.3.4-rc.1' }),
+  );
+  const distDir = path.join(root, 'dist');
+  fs.mkdirSync(distDir);
+  // Inner = a foreign package.json that should be skipped
+  fs.writeFileSync(
+    path.join(distDir, 'package.json'),
+    JSON.stringify({ name: '@some-other/lib', version: '99.0.0' }),
+  );
+  assertEq(
+    readPluginVersion(distDir),
+    '3.3.4-rc.1',
+    'readPluginVersion: skips wrong-name package.json and walks up to plugin',
+  );
+}
+
+{
+  // No package.json anywhere on the walk path -> null.
+  const root = fs.mkdtempSync(path.join(TMP, 'rpv-missing-'));
+  assertEq(
+    readPluginVersion(root),
+    null,
+    'readPluginVersion: returns null when no package.json found',
+  );
+}
+
+{
+  // Legacy / minimal package.json without `name` field — fallback accepts it.
+  const root = fs.mkdtempSync(path.join(TMP, 'rpv-no-name-'));
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({ version: '1.0.0' }),
+  );
+  assertEq(
+    readPluginVersion(root),
+    '1.0.0',
+    'readPluginVersion: accepts package.json without name (legacy fallback)',
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/skill/plugin/fs-helpers.ts
+++ b/skill/plugin/fs-helpers.ts
@@ -124,9 +124,17 @@ export function ensureMemoryHeaderFile(
  * Read the plugin's own version string from `package.json`.
  *
  * Behaviour:
- *   - Resolves `package.json` next to the caller-provided directory
+ *   - Tries `package.json` next to the caller-provided directory first
  *     (typically `path.dirname(fileURLToPath(import.meta.url))` from the
- *     caller).
+ *     caller — i.e., the directory of the running ESM module).
+ *   - If that misses, walks up to 5 parent directories looking for a
+ *     `package.json` whose `name` is `@totalreclaw/totalreclaw`. This
+ *     covers the OpenClaw plugin sandbox case where the loaded module
+ *     lives at `<pluginRoot>/dist/index.js` while `package.json` lives
+ *     at `<pluginRoot>/package.json` (3.3.4-rc.1 fix — without this
+ *     walk-up, the `.loaded.json` manifest gets `version=unknown` and
+ *     all RC-gated logic that depends on the version string fails
+ *     silently in production OpenClaw deployments).
  *   - Returns the `version` field, or `null` on any I/O / parse error.
  *
  * Used by the RC-gated `totalreclaw_report_qa_bug` tool registration in
@@ -137,12 +145,48 @@ export function ensureMemoryHeaderFile(
  * helper — see the file-header guardrail.
  */
 export function readPluginVersion(packageJsonDir: string): string | null {
+  // Direct hit (source-tree dev path; tests).
+  const direct = tryReadPluginPackageJson(path.join(packageJsonDir, 'package.json'));
+  if (direct) return direct;
+
+  // Walk up — the running ESM module typically lives at
+  // `<pluginRoot>/dist/index.js`, so `packageJsonDir` is `<pluginRoot>/dist`
+  // and `package.json` is one level up. Bound the walk so a misconfigured
+  // path doesn't traverse the entire filesystem; 5 levels is more than
+  // enough for any realistic plugin layout (dist/, dist/cjs/, build/lib/).
+  let current = packageJsonDir;
+  for (let depth = 0; depth < 5; depth++) {
+    const parent = path.dirname(current);
+    if (parent === current) break; // root reached
+    const candidate = path.join(parent, 'package.json');
+    const version = tryReadPluginPackageJson(candidate);
+    if (version) return version;
+    current = parent;
+  }
+  return null;
+}
+
+/**
+ * Try to read `package.json` at `pkgPath`. Returns the `version` only if
+ * the file's `name` field matches `@totalreclaw/totalreclaw` — guards
+ * against accidentally returning the version of an outer host-package
+ * (e.g. when the plugin is bundled inside a parent app's tree).
+ *
+ * If `name` is absent (legacy / minimal package.json), accept the version
+ * anyway as a fallback — this is the existing behaviour preserved for
+ * anyone who manually trimmed their package.json.
+ */
+function tryReadPluginPackageJson(pkgPath: string): string | null {
   try {
-    const pkgPath = path.join(packageJsonDir, 'package.json');
     if (!fs.existsSync(pkgPath)) return null;
     const raw = fs.readFileSync(pkgPath, 'utf-8');
-    const parsed = JSON.parse(raw) as { version?: string };
-    return typeof parsed.version === 'string' ? parsed.version : null;
+    const parsed = JSON.parse(raw) as { version?: string; name?: string };
+    if (typeof parsed.version !== 'string') return null;
+    if (typeof parsed.name === 'string' && parsed.name !== '@totalreclaw/totalreclaw') {
+      // Wrong package — keep walking.
+      return null;
+    }
+    return parsed.version;
   } catch {
     return null;
   }

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -759,10 +759,27 @@ let firstRunWelcomeShown = false;
  *
  * Goal: a fresh QA tester can't accidentally use an RC build for real data
  * without seeing a clear "RC = staging, no SLA, may be wiped" warning.
- * One-shot at the first `before_agent_start` after register(); never spams
- * per-turn. A fresh gateway restart re-fires it once.
+ * One-shot at the first `before_agent_start` whose `prependContext` actually
+ * lands on the LLM (3.3.4-rc.1 — see fix below). A fresh gateway restart
+ * re-fires it once.
+ *
+ * 3.3.4-rc.1 fix: through 3.3.3-rc.1 this flag was set to true as soon as
+ * the banner BLOCK was built — but multiple hook return paths returned
+ * `undefined` (zero-match cases), so the banner block was silently dropped
+ * AND the flag was flipped, suppressing all subsequent attempts. Now the
+ * flag flips ONLY when a return path actually includes the block in its
+ * `prependContext`, via the `markBannerDelivered()` closure.
  */
 let stagingBannerShown = false;
+
+/**
+ * 3.3.4-rc.1 — operator-facing "this is an RC build" log fires once per
+ * gateway process, independent of whether the user-facing banner has
+ * been delivered yet. Without this split, the warn-log was tied to the
+ * same flag as the user-facing banner and got dropped together when
+ * the hook returned `undefined`.
+ */
+let stagingBannerLogged = false;
 
 /**
  * Derive keys from the recovery phrase, load credentials, and register with
@@ -2972,17 +2989,32 @@ const plugin = {
 
       // 3.3.1-rc.22 — wire the lazy-embedder runtime config so the first
       // `generateEmbedding()` call knows where to cache the bundle and
-      // which RC's GitHub Release to fetch from. `pluginVersion` may be
-      // `null` if package.json is unreadable; the embedder defaults to
-      // a "0.0.0-dev" tag in that case.
-      try {
-        configureEmbedder({
-          cacheRoot: CONFIG.embedderCachePath,
-          rcTag: pluginVersion ?? '0.0.0-dev',
-        });
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        api.logger.warn(`TotalReclaw: configureEmbedder failed (will use defaults): ${msg}`);
+      // which RC's GitHub Release to fetch from.
+      //
+      // 3.3.4-rc.1 — when readPluginVersion() returns null (rare, but
+      // possible if package.json is unreadable inside the OpenClaw
+      // sandbox), we previously passed the literal `'0.0.0-dev'` which
+      // resolves to a 404 GitHub Release URL. Now we let `embedding.ts`
+      // fall back to its `LAST_KNOWN_GOOD_RC_TAG` constant by SKIPPING
+      // the configure call entirely in the null case — the
+      // `activeRuntimeConfig()` helper picks the constant up. This way
+      // the constant lives in one place (embedding.ts) and the orch-
+      // estrator just doesn't fight it.
+      if (pluginVersion) {
+        try {
+          configureEmbedder({
+            cacheRoot: CONFIG.embedderCachePath,
+            rcTag: pluginVersion,
+          });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          api.logger.warn(`TotalReclaw: configureEmbedder failed (will use defaults): ${msg}`);
+        }
+      } else {
+        api.logger.warn(
+          'TotalReclaw: pluginVersion unresolved — embedder will fall back to LAST_KNOWN_GOOD_RC_TAG. ' +
+            'Investigate package.json resolution; see fs-helpers.readPluginVersion docs.',
+        );
       }
 
       // 3.3.3-rc.1 (issue #187 — ONNX decouple): kick off a non-blocking
@@ -3151,11 +3183,39 @@ const plugin = {
           });
           // 3.3.0 — `openclaw totalreclaw pair [generate|import]` attaches
           // alongside the existing `onboard` + `status` subcommands.
+          //
+          // 3.3.4-rc.1 — wire `runRelayPairCli` so the CLI defaults to the
+          // same relay-brokered URL surface the agent tool uses. The local
+          // (gateway-loopback) flow is still available via `--local`. See
+          // pair-cli.ts header for the rationale.
           const { registerPairCli } = await import('./pair-cli.js');
           registerPairCli(program as import('commander').Command, {
             sessionsPath: CONFIG.pairSessionsPath,
             renderPairingUrl: (session) => buildPairingUrl(api, session),
             logger: api.logger,
+            runRelayPairCli: async (cliMode, runOpts) => {
+              const { runRelayPairCli } = await import('./pair-cli-relay.js');
+              return runRelayPairCli(cliMode, {
+                relayBaseUrl: CONFIG.pairRelayUrl,
+                credentialsPath: CREDENTIALS_PATH,
+                onboardingStatePath: CONFIG.onboardingStatePath,
+                logger: api.logger,
+                pluginVersion: pluginVersion ?? '3.3.4-rc.1',
+                deriveScopeAddress: async (mnemonic: string) => {
+                  try {
+                    return await deriveSmartAccountAddress(mnemonic, CONFIG.chainId);
+                  } catch (err) {
+                    api.logger.warn(
+                      `relay pair-cli: scope-address derivation failed (will retry lazily): ${
+                        err instanceof Error ? err.message : String(err)
+                      }`,
+                    );
+                    return undefined;
+                  }
+                },
+                ...runOpts,
+              });
+            },
           });
         },
         { commands: ['totalreclaw'] },
@@ -5834,7 +5894,24 @@ const plugin = {
           // Build a one-shot prefix when the bundled default points at staging
           // AND the user hasn't overridden via env. This prefix is prepended
           // to whichever context block the rest of the hook produces.
+          //
+          // 3.3.4-rc.1 — fix: previously `stagingBannerShown` was set to
+          // `true` AS SOON AS the block was built. If the rest of the hook
+          // then returned `undefined` (e.g. zero memory matches on the first
+          // turn — multiple paths around lines 6103-6325 do this), the
+          // banner block was silently discarded AND the flag was already
+          // flipped, so subsequent before_agent_start invocations never
+          // reconstructed it. Net effect: QA on 3.3.3-rc.1 (Pedro
+          // 2026-04-30) saw NO banner emitted across an entire conversation
+          // even though the build was bound to staging.
+          //
+          // Fix: build the block on every call until it is actually
+          // delivered (i.e., until at least one return path included it
+          // in `prependContext`). The flag flips at the bottom of this
+          // hook in `markBannerDelivered()` once we know the prependContext
+          // path was taken.
           let stagingBannerBlock = '';
+          let stagingBannerSuppressed = false;
           if (!stagingBannerShown) {
             try {
               const usingStagingDefault = CONFIG.serverUrl.includes('api-staging.totalreclaw.xyz');
@@ -5847,11 +5924,11 @@ const plugin = {
                   'For production, install the stable release: `openclaw plugins install ' +
                   '@totalreclaw/totalreclaw` (no `@rc` suffix). To pin a custom server, set ' +
                   '`TOTALRECLAW_SERVER_URL=https://api.totalreclaw.xyz` in your env.\n\n';
-                stagingBannerShown = true;
-                api.logger.warn(
-                  'TotalReclaw: RC/staging build active (api-staging.totalreclaw.xyz). ' +
-                  'See docs/guides/release-process.md for the RC=staging / stable=production rule.',
-                );
+                // Do NOT set stagingBannerShown=true here — see comment above.
+                // Logger emits once per gateway process; this is fine to
+                // gate on the same flag because the logger is operator-
+                // facing, not user-facing.
+                stagingBannerSuppressed = true;
               } else {
                 // Non-RC artifact OR user override — never fire the banner this
                 // gateway-process lifetime.
@@ -5862,6 +5939,34 @@ const plugin = {
               stagingBannerShown = true;
             }
           }
+          // Operator-facing log: once per process, when we DETECT the
+          // staging build (banner-shown semantics are about user
+          // delivery; this log is independent).
+          if (stagingBannerSuppressed && !stagingBannerLogged) {
+            stagingBannerLogged = true;
+            api.logger.warn(
+              'TotalReclaw: RC/staging build active (api-staging.totalreclaw.xyz). ' +
+              'See docs/guides/release-process.md for the RC=staging / stable=production rule.',
+            );
+          }
+          /**
+           * Helper — invoked inline at any `prependContext` site that
+           * wants to lead with the staging banner. Returns the banner
+           * string AND atomically marks the banner as delivered, so
+           * subsequent hook calls in the same gateway-process lifetime
+           * skip re-emission. Returns '' (empty) when no banner is due
+           * (stable build, user override, or already delivered).
+           *
+           * Use this at every prependContext callsite that takes the
+           * banner; do NOT inline `stagingBannerBlock` on its own — the
+           * 3.3.4-rc.1 bug fix requires the marker flip to be coupled
+           * to the actual delivery.
+           */
+          const consumeBannerForPrepend = (): string => {
+            if (stagingBannerBlock === '') return '';
+            stagingBannerShown = true;
+            return stagingBannerBlock;
+          };
 
           await ensureInitialized(api.logger);
 
@@ -5892,7 +5997,7 @@ const plugin = {
             }
             return {
               prependContext:
-                stagingBannerBlock +
+                consumeBannerForPrepend() +
                 welcomeBlock +
                 '## TotalReclaw setup pending\n\n' +
                 'TotalReclaw encrypted memory is installed but not yet set up on this machine. ' +
@@ -5994,7 +6099,7 @@ const plugin = {
                   api.logger.info(`Digest injection: state=${injectResult.state}`);
                   return {
                     prependContext:
-                      stagingBannerBlock +
+                      consumeBannerForPrepend() +
                       `## Your Memory\n\n${injectResult.promptText}` + welcomeBack + billingWarning,
                   };
                 }
@@ -6041,7 +6146,7 @@ const plugin = {
                 const lines = cachedFacts.slice(0, 8).map((f, i) =>
                   `${i + 1}. ${f.text} (importance: ${f.importance}/10, cached)`,
                 );
-                return { prependContext: stagingBannerBlock + `## Relevant Memories\n\n${lines.join('\n')}` + welcomeBack + billingWarning };
+                return { prependContext: consumeBannerForPrepend() + `## Relevant Memories\n\n${lines.join('\n')}` + welcomeBack + billingWarning };
               }
             }
 
@@ -6054,7 +6159,7 @@ const plugin = {
               const lines = cachedFacts.slice(0, 8).map((f, i) =>
                 `${i + 1}. ${f.text} (importance: ${f.importance}/10, cached)`,
               );
-              return { prependContext: stagingBannerBlock + `## Relevant Memories\n\n${lines.join('\n')}` + welcomeBack + billingWarning };
+              return { prependContext: consumeBannerForPrepend() + `## Relevant Memories\n\n${lines.join('\n')}` + welcomeBack + billingWarning };
             }
 
             if (allTrapdoors.length === 0) return undefined;
@@ -6071,7 +6176,7 @@ const plugin = {
                 const lines = cachedFacts.slice(0, 8).map((f, i) =>
                   `${i + 1}. ${f.text} (importance: ${f.importance}/10, cached)`,
                 );
-                return { prependContext: stagingBannerBlock + `## Relevant Memories\n\n${lines.join('\n')}` + welcomeBack + billingWarning };
+                return { prependContext: consumeBannerForPrepend() + `## Relevant Memories\n\n${lines.join('\n')}` + welcomeBack + billingWarning };
               }
               return undefined;
             }
@@ -6098,7 +6203,7 @@ const plugin = {
               const lines = cachedFacts.slice(0, 8).map((f, i) =>
                 `${i + 1}. ${f.text} (importance: ${f.importance}/10, cached)`,
               );
-              return { prependContext: stagingBannerBlock + `## Relevant Memories\n\n${lines.join('\n')}` + welcomeBack + billingWarning };
+              return { prependContext: consumeBannerForPrepend() + `## Relevant Memories\n\n${lines.join('\n')}` + welcomeBack + billingWarning };
             }
 
             // 5. Decrypt subgraph results and build reranker input.
@@ -6188,7 +6293,7 @@ const plugin = {
             });
             const contextString = `## Relevant Memories\n\n${lines.join('\n')}`;
 
-            return { prependContext: stagingBannerBlock + contextString + welcomeBack + billingWarning };
+            return { prependContext: consumeBannerForPrepend() + contextString + welcomeBack + billingWarning };
           }
 
           // --- Server mode (existing behavior) ---
@@ -6292,7 +6397,7 @@ const plugin = {
           });
           const contextString = `## Relevant Memories\n\n${lines.join('\n')}`;
 
-          return { prependContext: stagingBannerBlock + contextString + welcomeBack + billingWarning };
+          return { prependContext: consumeBannerForPrepend() + contextString + welcomeBack + billingWarning };
         } catch (err: unknown) {
           // The hook must NEVER throw -- log and return undefined.
           const message = err instanceof Error ? err.message : String(err);

--- a/skill/plugin/package-lock.json
+++ b/skill/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.3-rc.1",
+  "version": "3.3.4-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/totalreclaw",
-      "version": "3.3.3-rc.1",
+      "version": "3.3.4-rc.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.3-rc.1",
+  "version": "3.3.4-rc.1",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [
@@ -63,7 +63,7 @@
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.json --noCheck",
     "verify-tarball": "node ../scripts/verify-tarball.mjs",
-    "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx config.test.ts && npx tsx relay-headers.test.ts && npx tsx scope-address-visible.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx llm-client-retry.test.ts && npx tsx gateway-url.test.ts && npx tsx retype-setscope.test.ts && npx tsx tool-gating.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts && npx tsx pair-qr.test.ts && npx tsx pair-remote-client.test.ts && npx tsx qa-bug-report.test.ts && npx tsx nonce-serialization.test.ts && npx tsx phrase-safety-registry.test.ts && npx tsx test_issue_92_onnx_download_ux.test.ts && npx tsx onboard-pair-only.test.ts && npx tsx import-time-smoke.test.ts && npx tsx install-staging-cleanup.test.ts && npx tsx partial-install-detection.test.ts && npx tsx install-reload-idempotency.test.ts && npx tsx json-stdout-cleanliness.test.ts && npx tsx load-manifest.test.ts && npx tsx url-binding.test.ts",
+    "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx config.test.ts && npx tsx relay-headers.test.ts && npx tsx scope-address-visible.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx llm-client-retry.test.ts && npx tsx gateway-url.test.ts && npx tsx retype-setscope.test.ts && npx tsx tool-gating.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts && npx tsx pair-qr.test.ts && npx tsx pair-remote-client.test.ts && npx tsx qa-bug-report.test.ts && npx tsx nonce-serialization.test.ts && npx tsx phrase-safety-registry.test.ts && npx tsx test_issue_92_onnx_download_ux.test.ts && npx tsx onboard-pair-only.test.ts && npx tsx import-time-smoke.test.ts && npx tsx install-staging-cleanup.test.ts && npx tsx partial-install-detection.test.ts && npx tsx install-reload-idempotency.test.ts && npx tsx json-stdout-cleanliness.test.ts && npx tsx load-manifest.test.ts && npx tsx url-binding.test.ts && npx tsx fs-helpers.test.ts && npx tsx pair-cli-default-mode.test.ts && npx tsx embedding-fallback-tag.test.ts && npx tsx staging-banner-gate.test.ts",
     "smoke:dist": "npx tsx dist-esm-smoke.test.ts",
     "check-scanner": "node ../scripts/check-scanner.mjs",
     "check-version-drift": "node ../scripts/check-version-drift.mjs",

--- a/skill/plugin/pair-cli-default-mode.test.ts
+++ b/skill/plugin/pair-cli-default-mode.test.ts
@@ -1,0 +1,174 @@
+/**
+ * pair-cli-default-mode.test.ts (3.3.4-rc.1)
+ *
+ * Asserts the 3.3.4-rc.1 invariant: the `openclaw totalreclaw pair`
+ * CLI defaults to relay-mode. Without `--local`, the action picks the
+ * relay runner. With `--local`, it picks the legacy local flow.
+ *
+ * QA on 3.3.3-rc.1 (Pedro 2026-04-30) found the CLI fallback emitted
+ * `http://localhost:18789/...` — unreachable from a remote browser on
+ * Docker deployments. This test pins the fix (relay default) so a
+ * future refactor doesn't silently regress.
+ *
+ * Two layers of coverage:
+ *
+ *   1. `shouldUseRelayMode` (pure decision function): canonical truth
+ *      table for the relay-vs-local selection.
+ *
+ *   2. The wired `registerPairCli` action: when the relay runner is
+ *      wired AND no `--local` flag is set, the action invokes
+ *      `runRelayPairCli` BEFORE attempting any local-flow surface.
+ *      Asserted by counting calls to the stub relay runner — the test
+ *      stub returns `'completed'` so the action exits cleanly without
+ *      touching the local flow.
+ */
+
+import {
+  registerPairCli,
+  shouldUseRelayMode,
+  type PairCliOutcome,
+} from './pair-cli.js';
+
+let passed = 0;
+let failed = 0;
+function assert(cond: boolean, name: string): void {
+  const n = passed + failed + 1;
+  if (cond) { console.log(`ok ${n} - ${name}`); passed++; }
+  else { console.log(`not ok ${n} - ${name}`); failed++; }
+}
+
+// ---------------------------------------------------------------------------
+// shouldUseRelayMode — pure truth-table.
+// ---------------------------------------------------------------------------
+
+assert(
+  shouldUseRelayMode({ hasRelayRunner: true }) === true,
+  'shouldUseRelayMode: no flags + relay runner wired -> relay (3.3.4-rc.1 default)',
+);
+assert(
+  shouldUseRelayMode({ local: true, hasRelayRunner: true }) === false,
+  'shouldUseRelayMode: --local + relay runner wired -> local (explicit opt-in)',
+);
+assert(
+  shouldUseRelayMode({ hasRelayRunner: false }) === false,
+  'shouldUseRelayMode: no flags + no relay runner wired -> local (back-compat)',
+);
+assert(
+  shouldUseRelayMode({ local: true, hasRelayRunner: false }) === false,
+  'shouldUseRelayMode: --local + no relay runner -> local',
+);
+
+// ---------------------------------------------------------------------------
+// registerPairCli wired action — relay runner invoked in default-mode.
+// ---------------------------------------------------------------------------
+
+interface MockCommand {
+  _name: string;
+  _action: ((...args: unknown[]) => Promise<void> | void) | null;
+  commands: MockCommand[];
+  name(): string;
+  command(name: string): MockCommand;
+  description(text: string): MockCommand;
+  option(flags: string, description: string, defaultValue?: unknown): MockCommand;
+  action(fn: (...args: unknown[]) => Promise<void> | void): MockCommand;
+}
+
+function mkMockCommand(name: string): MockCommand {
+  const cmd: MockCommand = {
+    _name: name,
+    _action: null,
+    commands: [],
+    name() { return this._name; },
+    command(n: string) {
+      const child = mkMockCommand(n);
+      this.commands.push(child);
+      return child;
+    },
+    description() { return this; },
+    option() { return this; },
+    action(fn) { this._action = fn; return this; },
+  };
+  return cmd;
+}
+
+function findPairCommand(program: MockCommand): MockCommand | null {
+  const tr = program.commands.find((c) => c.name() === 'totalreclaw');
+  if (!tr) return null;
+  return tr.commands.find((c) => c.name().startsWith('pair')) ?? null;
+}
+
+interface RelayCall {
+  mode: string;
+  outputMode?: string;
+}
+
+async function runActionDefaultMode(opts: {
+  flags: { json?: boolean; urlPinOnly?: boolean };
+}): Promise<RelayCall[]> {
+  const relayCalls: RelayCall[] = [];
+
+  const program = mkMockCommand('openclaw');
+
+  registerPairCli(program as unknown as Parameters<typeof registerPairCli>[0], {
+    sessionsPath: '/tmp/__never_used__',
+    renderPairingUrl: () => '__never_used__',
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+    runRelayPairCli: async (mode, runOpts): Promise<PairCliOutcome> => {
+      relayCalls.push({ mode, outputMode: runOpts.outputMode });
+      // 'completed' status means the action does NOT call process.exit.
+      return { status: 'completed', sid: 'relay-stub-token' };
+    },
+  });
+
+  const pairCmd = findPairCommand(program);
+  if (!pairCmd || !pairCmd._action) throw new Error('pair command not registered');
+  await pairCmd._action('generate', opts.flags, pairCmd);
+  return relayCalls;
+}
+
+// Default flags -> relay runner invoked exactly once.
+{
+  const calls = await runActionDefaultMode({ flags: {} });
+  assert(
+    calls.length === 1,
+    'action: default flags + relay runner wired -> relay runner invoked once',
+  );
+  assert(
+    calls[0]?.mode === 'generate',
+    'action: pair mode "generate" forwarded to relay runner',
+  );
+}
+
+// --json flag -> relay runner invoked, outputMode='json'.
+{
+  const calls = await runActionDefaultMode({ flags: { json: true } });
+  assert(
+    calls.length === 1 && calls[0]?.outputMode === 'json',
+    'action: --json flag forwarded as outputMode="json" to relay runner',
+  );
+}
+
+// --url-pin-only flag -> outputMode='url-pin' (subset of --json).
+{
+  const calls = await runActionDefaultMode({ flags: { urlPinOnly: true } });
+  assert(
+    calls.length === 1 && calls[0]?.outputMode === 'url-pin',
+    'action: --url-pin-only flag forwarded as outputMode="url-pin" to relay runner',
+  );
+}
+
+// --url-pin-only + --json -> --url-pin-only wins (it's the tighter surface).
+{
+  const calls = await runActionDefaultMode({ flags: { json: true, urlPinOnly: true } });
+  assert(
+    calls.length === 1 && calls[0]?.outputMode === 'url-pin',
+    'action: --url-pin-only beats --json when both passed (tighter surface wins)',
+  );
+}
+
+console.log(`\n# ${passed}/${passed + failed} passed`);
+if (failed > 0) {
+  console.log('\nSOME TESTS FAILED');
+  process.exit(1);
+}
+console.log('\nALL TESTS PASSED');

--- a/skill/plugin/pair-cli-relay.ts
+++ b/skill/plugin/pair-cli-relay.ts
@@ -1,0 +1,336 @@
+/**
+ * pair-cli-relay — relay-mode runner for the `openclaw totalreclaw pair`
+ * CLI subcommand (3.3.4-rc.1).
+ *
+ * Background
+ * ----------
+ * The CLI default through 3.3.3-rc.1 was the loopback / LAN URL flow
+ * (`pair-cli.ts` `runPairCli` + `pair-session-store`). On Docker
+ * deployments — i.e. the rc.6+ default — that emits `http://localhost:18789/…`
+ * which is unreachable from the user's browser. QA on 3.3.3-rc.1 (Pedro
+ * 2026-04-30) confirmed this is the *primary* CLI-fallback failure mode:
+ * agent loses the `totalreclaw_pair` tool binding, falls back to
+ * `openclaw totalreclaw pair generate --url-pin-only`, gets a localhost
+ * URL, user can't open it.
+ *
+ * 3.3.4-rc.1 flips the CLI default to relay-mode. This file implements
+ * the runner. It mirrors the relay flow already used by the agent tool
+ * (`index.ts` `totalreclaw_pair` handler) so the CLI and the tool emit
+ * URLs from the same relay (`api-staging.totalreclaw.xyz` / `api.…`).
+ *
+ * Output formats
+ * --------------
+ * Same `PairCliOutputMode` surface as the local flow:
+ *   - `human` — multi-line banner + QR ASCII + URL + PIN (default)
+ *   - `json` — single-line `{v:1,sid,url,pin,mode,expires_at_ms,qr_ascii}`
+ *   - `url-pin` — single-line `{v:1,url,pin,expires_at_ms}` (no QR)
+ *   - `pair-only` — single-line `{v:1,pair_url,pin,expires_at_ms}` (no QR)
+ *
+ * The `sid` field in JSON mode carries the relay token (relay-issued
+ * opaque session id) so the agent can correlate emit + completion.
+ *
+ * Phrase safety
+ * -------------
+ * The same invariant the agent-tool path enforces: relay sees only
+ * ciphertext, gateway decrypts locally via x25519 ECDH + AES-GCM, the
+ * mnemonic is written to credentials.json by `completePairing` and never
+ * crosses any logger / stdout. PIN is on stdout (required) but never
+ * logged.
+ *
+ * Scanner / scope
+ * ---------------
+ * Touches `fs` indirectly via the credential-write completion handler
+ * passed in. No env-var reads here — caller resolves URL / paths from
+ * `CONFIG`. See `index.ts` wire-up.
+ */
+
+import { validateMnemonic } from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english';
+
+import {
+  loadCredentialsJson,
+  writeCredentialsJson,
+  writeOnboardingState,
+} from './fs-helpers.js';
+import {
+  awaitPhraseUpload,
+  openRemotePairSession,
+} from './pair-remote-client.js';
+import { setRecoveryPhraseOverride } from './config.js';
+import { encodePng, encodeUnicode } from './pair-qr.js';
+import type {
+  PairCliIo,
+  PairCliJsonPayload,
+  PairCliMode,
+  PairCliOutcome,
+  PairCliOutputMode,
+  PairCliPairOnlyPayload,
+  PairCliUrlPinPayload,
+} from './pair-cli.js';
+
+export interface RelayPairCliRunnerOpts {
+  /** Relay base URL (`wss://api-staging.totalreclaw.xyz` for RC, `wss://api.…` for stable). */
+  relayBaseUrl: string;
+  /** Where credentials.json lives — written by completePairing. */
+  credentialsPath: string;
+  /** Where onboarding-state.json lives — flipped to `active` on success. */
+  onboardingStatePath: string;
+  /** Plugin version stamped into onboarding-state.json. */
+  pluginVersion: string;
+  /** Scope-address derivation. Best-effort — null on failure. */
+  deriveScopeAddress: (mnemonic: string) => Promise<string | undefined>;
+  /** Logger — never receives PIN / phrase / token-tail material. */
+  logger: { info(msg: string): void; warn(msg: string): void; error(msg: string): void };
+  /** QR ASCII renderer — same callback shape as `qrcode-terminal`. */
+  renderQr: (payload: string, cb: (ascii: string) => void) => void;
+  /** stdio surface for stdout / stderr / Ctrl+C. */
+  io: PairCliIo;
+  /** Output mode — defaults to `'human'`. */
+  outputMode?: PairCliOutputMode;
+  /**
+   * 3.3.4-rc.1 — currently informational. The relay-side TTL is set by the
+   * relay; this runner accepts the option for surface parity with the local
+   * runner. We do not extend it past the relay default because the relay is
+   * authoritative for session expiry.
+   */
+  ttlSeconds?: number;
+}
+
+/**
+ * Run the relay-mode pair CLI. Mirrors `runPairCli`'s exit-code semantics:
+ *   - `completed` (status 0)
+ *   - `canceled` (Ctrl+C — status 130)
+ *   - `expired` / `rejected` / `error` (status 1)
+ *
+ * Resolves with the outcome; the caller (`registerPairCli` action) maps
+ * the outcome to `process.exit(...)`.
+ */
+export async function runRelayPairCli(
+  mode: PairCliMode,
+  opts: RelayPairCliRunnerOpts,
+): Promise<PairCliOutcome> {
+  const outputMode: PairCliOutputMode = opts.outputMode ?? 'human';
+  const stdout = opts.io.stdout;
+
+  // 1. Open the relay session. The relay returns the user-facing URL +
+  //    PIN + token + expiresAt. The keypair stays in-process.
+  let session: Awaited<ReturnType<typeof openRemotePairSession>>;
+  try {
+    session = await openRemotePairSession({
+      relayBaseUrl: opts.relayBaseUrl,
+      mode: mode === 'generate' ? 'generate' : 'import',
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    opts.io.stderr.write(
+      `\nFailed to open relay pairing session: ${msg}\n` +
+        `If the relay is unreachable from this gateway, retry with --local for the loopback URL flow.\n`,
+    );
+    return { status: 'error', error: msg };
+  }
+
+  // ISO-8601 → ms for tool-payload parity with the agent tool.
+  const parsedExpiresMs = Date.parse(session.expiresAt);
+  const expiresAtMs = Number.isFinite(parsedExpiresMs)
+    ? parsedExpiresMs
+    : Date.now() + 5 * 60_000;
+
+  // 2. Render the QR ASCII (skipped in url-pin / pair-only modes — the
+  //    same as `runPairCli`). 10s timeout guard against a renderer that
+  //    never fires its callback.
+  const skipsQr = outputMode === 'url-pin' || outputMode === 'pair-only';
+  const qrAscii = skipsQr
+    ? ''
+    : await new Promise<string>((resolve) => {
+        let settled = false;
+        const t = setTimeout(() => {
+          if (!settled) {
+            settled = true;
+            resolve('');
+          }
+        }, 10_000);
+        try {
+          opts.renderQr(session.url, (ascii) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(t);
+            resolve(ascii);
+          });
+        } catch (err) {
+          if (settled) return;
+          settled = true;
+          clearTimeout(t);
+          resolve(`(QR renderer crashed: ${err instanceof Error ? err.message : String(err)})`);
+        }
+      });
+
+  // 3. Emit the visible surface — single JSON line for non-human modes,
+  //    multi-line banner + QR for human mode. Identical layout to the
+  //    local-mode runner so callers can swap transparently.
+  if (outputMode === 'url-pin') {
+    const payload: PairCliUrlPinPayload = {
+      v: 1,
+      url: session.url,
+      pin: session.pin,
+      expires_at_ms: expiresAtMs,
+    };
+    stdout.write(JSON.stringify(payload) + '\n');
+  } else if (outputMode === 'pair-only') {
+    const payload: PairCliPairOnlyPayload = {
+      v: 1,
+      pair_url: session.url,
+      pin: session.pin,
+      expires_at_ms: expiresAtMs,
+    };
+    stdout.write(JSON.stringify(payload) + '\n');
+  } else if (outputMode === 'json') {
+    const payload: PairCliJsonPayload = {
+      v: 1,
+      sid: session.token,
+      url: session.url,
+      pin: session.pin,
+      mode,
+      expires_at_ms: expiresAtMs,
+      qr_ascii: qrAscii,
+    };
+    stdout.write(JSON.stringify(payload) + '\n');
+  } else {
+    // Human-mode banner. Mirror `pair-cli.ts` COPY surface, but tweak the
+    // header so operators see "Relay" not "Local" (so it's obvious the
+    // URL is universal-reachable, not gateway-loopback).
+    stdout.write(
+      '\nTotalReclaw — Relay pairing\n\n' +
+        'Your TotalReclaw recovery phrase will be created (or imported) in your\n' +
+        'BROWSER and delivered to this gateway encrypted end-to-end via the\n' +
+        'relay (the relay only sees ciphertext). The phrase never touches the\n' +
+        'LLM, the session transcript, or the relay server in plaintext.\n\n' +
+        'Scan the QR code below with your phone, or open the URL on any device\n' +
+        '(no LAN / Tailscale / port-forward required). Then type the 6-digit\n' +
+        'code shown here into the browser.\n',
+    );
+    stdout.write(
+      mode === 'generate'
+        ? '\nMode: GENERATE — your browser will create a NEW 12-word recovery phrase.\n' +
+            'You will be asked to write it down and retype 3 words before the\n' +
+            'gateway accepts it.\n'
+        : '\nMode: IMPORT — your browser will accept an existing TotalReclaw\n' +
+            'recovery phrase that you already have. Paste it in the browser; it\n' +
+            'will be validated locally and encrypted before upload.\n',
+    );
+    if (qrAscii) {
+      stdout.write('\n' + qrAscii + '\n');
+    } else {
+      stdout.write('\n(QR not rendered — use the URL below)\n');
+    }
+    stdout.write(
+      '\nSecondary code (type this into the browser):\n\n    ' +
+        session.pin.split('').join(' ') +
+        '\n\nURL (QR encodes this plus a one-time public key):\n\n    ' +
+        session.url +
+        '\n\nSecurity:\n' +
+        '  * Do NOT share your screen during pairing.\n' +
+        '  * Do NOT screenshot this terminal.\n' +
+        '  * The browser page will warn you never to reuse this recovery\n' +
+        '    phrase for wallets, banking, email, or any other service.\n' +
+        '\nWaiting for browser to connect… (press Ctrl+C to cancel)\n',
+    );
+  }
+
+  // 4. Optional PNG / Unicode QR for richer transports — same as the
+  //    agent tool. Best-effort; non-fatal on encode failure.
+  if (!skipsQr && outputMode !== 'human') {
+    // JSON consumers already have qr_ascii; PNG/Unicode would belong in
+    // a separate response shape. Keeping the runner surface in-band with
+    // the local runner means we don't add fields here. Skip silently.
+    void encodePng;
+    void encodeUnicode;
+  }
+
+  // 5. Set up Ctrl+C cancellation. The relay session can't be
+  //    server-side rejected from the client (no rejectPairSession-equivalent
+  //    over the WS), but closing the WebSocket terminates the session.
+  let canceled = false;
+  const releaseInterrupt = opts.io.onInterrupt(() => {
+    canceled = true;
+    try {
+      session._ws.close();
+    } catch {
+      /* ignore */
+    }
+  });
+
+  // 6. Block on the relay until the browser uploads the encrypted
+  //    phrase, then write credentials + flip onboarding-state. Mirrors
+  //    the agent-tool's `awaitPhraseUpload` callback inline so we have a
+  //    single source of truth for credential persistence.
+  const emitStatus = (text: string): void => {
+    if (outputMode === 'human') stdout.write(text);
+  };
+
+  try {
+    const result = await awaitPhraseUpload(session, {
+      phraseValidator: (p: string) => validateMnemonic(p, wordlist),
+      completePairing: async ({ mnemonic }) => {
+        try {
+          let scopeAddress: string | undefined;
+          try {
+            scopeAddress = await opts.deriveScopeAddress(mnemonic);
+          } catch (deriveErr) {
+            opts.logger.warn(
+              `pair-cli (relay): scope_address derivation failed (will retry lazily): ${
+                deriveErr instanceof Error ? deriveErr.message : String(deriveErr)
+              }`,
+            );
+          }
+          const creds = loadCredentialsJson(opts.credentialsPath) ?? {};
+          const next: typeof creds = { ...creds, mnemonic };
+          if (scopeAddress) next.scope_address = scopeAddress;
+          if (!writeCredentialsJson(opts.credentialsPath, next)) {
+            return { state: 'error', error: 'credentials_write_failed' };
+          }
+          setRecoveryPhraseOverride(mnemonic);
+          writeOnboardingState(opts.onboardingStatePath, {
+            onboardingState: 'active',
+            createdBy: mode === 'generate' ? 'generate' : 'import',
+            credentialsCreatedAt: new Date().toISOString(),
+            version: opts.pluginVersion,
+          });
+          opts.logger.info(
+            `pair-cli (relay): session ${session.token.slice(0, 8)}… completed; credentials written` +
+              (scopeAddress ? ` (scope_address=${scopeAddress})` : ''),
+          );
+          return { state: 'active' };
+        } catch (err: unknown) {
+          const msg = err instanceof Error ? err.message : String(err);
+          opts.logger.error(`pair-cli (relay): completePairing failed: ${msg}`);
+          return { state: 'error', error: msg };
+        }
+      },
+    });
+
+    if (canceled) {
+      emitStatus('\nCanceled. Pairing session invalidated.\n');
+      return { status: 'canceled', sid: session.token };
+    }
+    if (result.state === 'active') {
+      emitStatus('\nPairing complete. Account is active.\n');
+      return { status: 'completed', sid: session.token };
+    }
+    emitStatus(`\nPairing failed: ${result.error ?? 'unknown_error'}\n`);
+    return { status: 'error', sid: session.token, error: result.error ?? 'unknown_error' };
+  } catch (err) {
+    if (canceled) {
+      emitStatus('\nCanceled. Pairing session invalidated.\n');
+      return { status: 'canceled', sid: session.token };
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes('timeout')) {
+      emitStatus('\nSession expired. Run the command again to restart.\n');
+      return { status: 'expired', sid: session.token };
+    }
+    emitStatus(`\nPairing error: ${msg}\n`);
+    return { status: 'error', sid: session.token, error: msg };
+  } finally {
+    releaseInterrupt();
+  }
+}

--- a/skill/plugin/pair-cli.ts
+++ b/skill/plugin/pair-cli.ts
@@ -3,20 +3,34 @@
  *
  * Purpose
  * -------
- * Starts a remote-onboarding session FROM the gateway host's terminal.
- * Creates a pair-session, renders the QR + URL + 6-digit secondary code
- * to stdout, then polls /status until the browser completes the flow.
+ * Starts a pairing session from the gateway host's terminal and renders
+ * the URL + 6-digit PIN + ASCII QR. The user opens the URL in a browser
+ * (on phone or laptop), confirms the PIN, and uploads their recovery
+ * phrase end-to-end-encrypted.
  *
- * This is the gateway-operator's surface. The operator reads the QR
- * with their phone (or opens the URL on their laptop browser); the
- * browser takes over from there.
+ * Two URL flavours
+ * ----------------
+ * * **Relay mode (3.3.4-rc.1 default).** The CLI opens a WebSocket against
+ *   the relay (`api-staging.totalreclaw.xyz` for RC, `api.totalreclaw.xyz`
+ *   for stable) and gets back a `https://<relay>/pair/p/<token>#pk=…` URL
+ *   the user can reach from any device on any network. This is the same
+ *   surface the agent-tool `totalreclaw_pair` uses. It works behind NAT,
+ *   in Docker, on managed services — anywhere outbound HTTPS works.
+ *
+ * * **Local mode (`--local`).** The legacy loopback flow: a session lands
+ *   in `pair-session-store` and the URL points at the gateway's own
+ *   bound interface (`http://localhost:18789/...`, or LAN/Tailscale IP
+ *   if autodetected). Required for fully-air-gapped operators who want
+ *   the relay out of the loop. Browser must be on a network that can
+ *   reach the gateway.
  *
  * Scope and scanner surface
  * -------------------------
  * Has `fetch` (for status polling) AND `POST` (never actually POSTs,
  * but the word lives in comments describing the paired browser POST).
  * MUST NOT also read disk or env vars. All state operations delegate
- * to pair-session-store; the CLI itself is a thin coordinator.
+ * to pair-session-store / pair-remote-client; the CLI itself is a thin
+ * coordinator.
  *
  * Zero logging of secret material. The secondary code IS printed to
  * stdout (required for the user to type), but never logged to file
@@ -444,6 +458,15 @@ export function registerPairCli(
     sessionsPath: string;
     renderPairingUrl(session: PairSession): string;
     logger: { info(msg: string): void; warn(msg: string): void; error(msg: string): void };
+    /**
+     * 3.3.4-rc.1 — relay-mode runner. When supplied, the CLI defaults to
+     * relay-mode (relay-brokered URL via `api-staging.totalreclaw.xyz` /
+     * `api.totalreclaw.xyz`). The runner is responsible for opening the
+     * WS session and polling the relay, mirroring `runPairCli`'s exit
+     * codes. If absent (very old plugin loader), the CLI silently falls
+     * back to local-mode and warns.
+     */
+    runRelayPairCli?: (mode: PairCliMode, opts: RelayPairCliOpts) => Promise<PairCliOutcome>;
   },
 ): void {
   // If the onboarding-cli already attached `totalreclaw`, reuse it.
@@ -459,15 +482,23 @@ export function registerPairCli(
 
   tr.command('pair [mode]')
     .description(
-      'Pair a remote browser device to this gateway (mode = generate | import; default generate)',
+      'Pair a remote browser device to this gateway via the relay (default; ' +
+      'works through NAT and inside Docker). Use --local to fall back to ' +
+      'gateway-loopback URLs for air-gapped setups.',
     )
-    .option('--json', 'Emit a single JSON payload (url/pin/sid/qr_ascii) instead of the human-readable banner. Enables agent-driven pairing.')
+    .option('--json', 'Emit a single JSON payload (url/pin/qr_ascii) instead of the human-readable banner. Enables agent-driven pairing.')
     .option('--url-pin-only', 'Emit ONLY {v,url,pin,expires_at_ms} — no QR ASCII, no SID, no mode echo. Headless fallback for container-based agents where the totalreclaw_pair tool is not injected (issue #87). Zero phrase exposure on stdout.')
+    .option('--local', '(3.3.4-rc.1) Use the loopback / LAN URL flow instead of the relay. URLs point at this gateway\'s bound interface (e.g. http://localhost:18789/…) and require the user\'s browser to be on a reachable network. Default since rc.6 was relay; this flag preserves the air-gapped path.')
     .option('--timeout <sec>', 'Session TTL in seconds (default: 900 = 15 min, matches pair-session-store default)')
     .action(async (...args: unknown[]) => {
       // commander passes: [modeArg, options, cmd]
       const modeRaw = typeof args[0] === 'string' ? args[0] : undefined;
-      const opts = (args[1] ?? {}) as { json?: boolean; urlPinOnly?: boolean; timeout?: string | number };
+      const opts = (args[1] ?? {}) as {
+        json?: boolean;
+        urlPinOnly?: boolean;
+        local?: boolean;
+        timeout?: string | number;
+      };
       const mode: PairCliMode =
         modeRaw === 'import' || modeRaw === 'imp' ? 'import' : 'generate';
       // --url-pin-only wins over --json when both are passed, since it is
@@ -483,15 +514,57 @@ export function registerPairCli(
         if (Number.isFinite(parsed) && parsed > 0) ttlSeconds = parsed;
       }
       const io = buildDefaultPairCliIo();
+      // 3.3.4-rc.1 — flip the default to relay-mode. The agent tool
+      // `totalreclaw_pair` has used the relay since rc.11; the CLI was
+      // the last surface still defaulting to gateway-loopback URLs,
+      // which are unreachable from a remote browser when the gateway
+      // runs in Docker (the rc.6+ default deployment). `--local`
+      // restores the legacy flow for air-gapped operators.
+      const useRelay = shouldUseRelayMode({
+        local: opts.local,
+        hasRelayRunner: typeof deps.runRelayPairCli === 'function',
+      });
       try {
-        const outcome = await runPairCli(mode, {
-          sessionsPath: deps.sessionsPath,
-          renderPairingUrl: deps.renderPairingUrl,
-          renderQr: defaultRenderQr,
-          io,
-          outputMode,
-          ttlSeconds,
-        });
+        let outcome: PairCliOutcome;
+        if (useRelay) {
+          outcome = await deps.runRelayPairCli!(mode, {
+            renderQr: defaultRenderQr,
+            io,
+            outputMode,
+            ttlSeconds,
+          });
+        } else {
+          if (opts.local) {
+            // Tell the operator they explicitly opted in. Suppress in
+            // JSON modes — the JSON contract must stay stdout-clean.
+            if (outputMode === 'human') {
+              io.stderr.write(
+                '\n[--local] Using gateway-loopback URL flow. The user\'s browser ' +
+                  'must be reachable from this gateway\'s bound interface (LAN, Tailscale, ' +
+                  'or localhost on the same machine).\n',
+              );
+            }
+          } else if (!deps.runRelayPairCli) {
+            // No relay runner wired — older composition. Warn once on
+            // stderr in human mode so the operator knows why URLs may
+            // be unreachable from a remote browser.
+            if (outputMode === 'human') {
+              io.stderr.write(
+                '\n[pair-cli] relay-mode runner not available — falling back to local-mode. ' +
+                  'Pair URLs will use this gateway\'s bound interface. Upgrade the plugin ' +
+                  'or pass --local to silence this warning.\n',
+              );
+            }
+          }
+          outcome = await runPairCli(mode, {
+            sessionsPath: deps.sessionsPath,
+            renderPairingUrl: deps.renderPairingUrl,
+            renderQr: defaultRenderQr,
+            io,
+            outputMode,
+            ttlSeconds,
+          });
+        }
         if (outcome.status !== 'completed') {
           process.exit(outcome.status === 'canceled' ? 130 : 1);
         }
@@ -501,6 +574,33 @@ export function registerPairCli(
         process.exit(2);
       }
     });
+}
+
+/**
+ * 3.3.4-rc.1 — options for the relay-mode CLI runner. Mirrors the human
+ * surface of `runPairCli` (output mode, QR renderer, IO, TTL) but does
+ * NOT take `sessionsPath` / `renderPairingUrl` because the relay flow
+ * mints its own URL via the relay's `opened` frame.
+ */
+export interface RelayPairCliOpts {
+  renderQr: (payload: string, cb: (ascii: string) => void) => void;
+  io: PairCliIo;
+  outputMode?: PairCliOutputMode;
+  ttlSeconds?: number;
+}
+
+/**
+ * 3.3.4-rc.1 — pure decision function: given the parsed action flags
+ * and whether a relay runner is wired, return whether the relay path
+ * should be taken. Exported for unit-testing the default-mode flip
+ * without invoking either runner.
+ */
+export function shouldUseRelayMode(opts: {
+  local?: boolean;
+  hasRelayRunner: boolean;
+}): boolean {
+  if (opts.local) return false;
+  return opts.hasRelayRunner;
 }
 
 // ---------------------------------------------------------------------------

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "3.3.3-rc.1",
+  "version": "3.3.4-rc.1",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",

--- a/skill/plugin/staging-banner-gate.test.ts
+++ b/skill/plugin/staging-banner-gate.test.ts
@@ -1,0 +1,150 @@
+/**
+ * staging-banner-gate.test.ts (3.3.4-rc.1)
+ *
+ * Pins the banner-emit invariant for the RC-staging banner introduced
+ * in 3.3.3-rc.1 (PR #165).
+ *
+ * Bug found in 3.3.3-rc.1 QA (Pedro 2026-04-30): the banner appeared
+ * NEVER across an entire conversation despite the build being bound to
+ * staging. Root cause was structural: `stagingBannerShown` was set to
+ * `true` AS SOON AS the banner block was constructed, but multiple
+ * before_agent_start return paths returned `undefined` (e.g. zero
+ * memory matches on the first turn), silently dropping the block AND
+ * leaving the flag flipped — so subsequent calls never reconstructed
+ * the block.
+ *
+ * Fix: the flag flips ONLY when a return path actually includes the
+ * block in its `prependContext`, via `consumeBannerForPrepend()`.
+ *
+ * This test pins the invariant by simulating the helper's lifecycle
+ * (build block → consume → flag flip) and verifying:
+ *   - First consume returns the banner string + flips the flag.
+ *   - Second consume returns '' (already delivered).
+ *   - Build-but-NEVER-consume leaves the flag UNflipped (so the next
+ *     before_agent_start invocation reconstructs the block).
+ *
+ * The test re-implements the helper inline because the helper is a
+ * closure over hook-local state in index.ts; pulling it out to a
+ * standalone export would broaden the public surface unnecessarily.
+ * The test asserts the SHAPE of the fix, not the runtime path.
+ */
+
+let passed = 0;
+let failed = 0;
+function assert(cond: boolean, name: string): void {
+  const n = passed + failed + 1;
+  if (cond) { console.log(`ok ${n} - ${name}`); passed++; }
+  else { console.log(`not ok ${n} - ${name}`); failed++; }
+}
+
+function simulateBannerLifecycle(opts: {
+  serverUrl: string;
+  serverUrlEnvOverridden: boolean;
+  prependContextPathTaken: boolean;
+}): { stagingBannerShown: boolean; emittedBlock: string } {
+  let stagingBannerShown = false;
+  let stagingBannerBlock = '';
+
+  // Simulate the before_agent_start prologue.
+  if (!stagingBannerShown) {
+    const usingStagingDefault = opts.serverUrl.includes('api-staging.totalreclaw.xyz');
+    const userOverrode = opts.serverUrlEnvOverridden;
+    if (usingStagingDefault && !userOverrode) {
+      stagingBannerBlock = '## staging-banner';
+      // Critical: do NOT flip stagingBannerShown here.
+    } else {
+      // Non-RC artifact OR user override — never fire this lifetime.
+      stagingBannerShown = true;
+    }
+  }
+
+  const consumeBannerForPrepend = (): string => {
+    if (stagingBannerBlock === '') return '';
+    stagingBannerShown = true;
+    return stagingBannerBlock;
+  };
+
+  let emittedBlock = '';
+  if (opts.prependContextPathTaken) {
+    // Simulate a return path that calls `consumeBannerForPrepend()` inline.
+    emittedBlock = consumeBannerForPrepend();
+  } else {
+    // Simulate a return-undefined path — block built but never delivered.
+    // No call to consume.
+  }
+
+  return { stagingBannerShown, emittedBlock };
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: staging build + prepend path taken -> banner emitted, flag flipped.
+// ---------------------------------------------------------------------------
+
+{
+  const r = simulateBannerLifecycle({
+    serverUrl: 'https://api-staging.totalreclaw.xyz',
+    serverUrlEnvOverridden: false,
+    prependContextPathTaken: true,
+  });
+  assert(r.emittedBlock === '## staging-banner', 'staging + prepend: banner emitted on first call');
+  assert(r.stagingBannerShown === true, 'staging + prepend: flag flips on emit');
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: staging build + RETURN UNDEFINED path -> banner NOT emitted,
+//         flag NOT flipped (next before_agent_start can retry).
+//
+// This is the 3.3.4-rc.1 fix: pre-fix, the flag flipped on build, so the
+// next call would skip block construction entirely. Post-fix, the flag
+// stays false and the next call reconstructs.
+// ---------------------------------------------------------------------------
+
+{
+  const r = simulateBannerLifecycle({
+    serverUrl: 'https://api-staging.totalreclaw.xyz',
+    serverUrlEnvOverridden: false,
+    prependContextPathTaken: false,
+  });
+  assert(r.emittedBlock === '', 'staging + return-undefined: nothing emitted');
+  assert(
+    r.stagingBannerShown === false,
+    '3.3.4-rc.1 fix: staging + return-undefined leaves flag UNflipped — next call retries',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: stable build (production URL) -> never builds banner, flag flipped
+// to permanently suppress for this gateway-process lifetime.
+// ---------------------------------------------------------------------------
+
+{
+  const r = simulateBannerLifecycle({
+    serverUrl: 'https://api.totalreclaw.xyz',
+    serverUrlEnvOverridden: false,
+    prependContextPathTaken: true,
+  });
+  assert(r.emittedBlock === '', 'stable build: no banner emitted');
+  assert(r.stagingBannerShown === true, 'stable build: flag flipped to suppress');
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: staging build BUT user-env override -> never builds banner, flag
+// flipped to permanently suppress (operator pinned a custom URL).
+// ---------------------------------------------------------------------------
+
+{
+  const r = simulateBannerLifecycle({
+    serverUrl: 'https://api-staging.totalreclaw.xyz',
+    serverUrlEnvOverridden: true,
+    prependContextPathTaken: true,
+  });
+  assert(r.emittedBlock === '', 'staging + user override: no banner emitted');
+  assert(r.stagingBannerShown === true, 'staging + user override: flag flipped to suppress');
+}
+
+console.log(`\n# ${passed}/${passed + failed} passed`);
+if (failed > 0) {
+  console.log('\nSOME TESTS FAILED');
+  process.exit(1);
+}
+console.log('\nALL TESTS PASSED');


### PR DESCRIPTION
## Summary

Bundle of fixes from Pedro's QA on 3.3.3-rc.1 (2026-04-30 / 2026-05-01). Plugin-only — Hermes is untouched.

| # | Area | Notes |
|---|------|-------|
| 1 | **CLI default → relay-mode** | Primary UX fix. CLI fallback (`openclaw totalreclaw pair`) emitted `http://localhost:18789/...` on Docker — unreachable from a remote browser. Default flipped to relay; `--local` opt-in for air-gapped operators. |
| 2 | Skill-side `totalreclaw_pair` binding | Investigation: tool IS in `skill.json` (rc.18 / PR #154). Pedro's "not available in this session" symptom is the OpenClaw container-agent gap (issue #87) — declared tools need a gateway restart to bind to a running session. Documented in SKILL.md / setup guide as part of Fix 7. **No plugin code change.** |
| 3 | Embedder URL `v0.0.0-dev` placeholder | Cascade-fix with #4. Fallback now points at `LAST_KNOWN_GOOD_RC_TAG = '3.3.3-rc.1'` (verified bundle exists). When `pluginVersion` is null, `index.ts` skips `configureEmbedder` so the embedding runtime falls through to the constant — single source of truth. |
| 4 | `readPluginVersion()` walk-up | In the OpenClaw plugin sandbox, the loaded ESM module lives at `<pluginRoot>/dist/index.js` while `package.json` sits at `<pluginRoot>/package.json`. Helper now tries direct hit first, then walks up to 5 parent directories looking for a `package.json` whose `name` is `@totalreclaw/totalreclaw`. |
| 5 | RC staging banner now actually emits | Fix #4 cascade-cause was a separate issue: through 3.3.3-rc.1, `stagingBannerShown` flipped to `true` AS SOON AS the banner block was constructed. But multiple `before_agent_start` paths (zero memory matches, trapdoor mismatches) returned `undefined`, silently dropping the block AND leaving the flag flipped. New `consumeBannerForPrepend()` helper atomically returns the string AND flips the flag, so flip happens ONLY on actual delivery. |
| 6 | Skill+plugin install ordering | Documented plugin-FIRST, skill-SECOND in setup guide + plugin SKILL.md to minimize race surface. |
| 7 | SKILL.md `/restart` strengthening | Forbidden-vocabulary list explicitly called out (\"Should I /restart\", \"Want me to restart\", \"Let me check if the tool is bound\"). Unauthorized-restart fallback documented: surface a one-line user-facing `jq` fix for `channels.<channel>.allowFrom`. `/new` documented as session-level fallback. Forbidden vocabulary + unauthorized fix mirrored to `docs/guides/openclaw-setup.md`. |

## Files

| File | Why |
|------|-----|
| `skill/plugin/pair-cli.ts` | Add `--local` flag, `runRelayPairCli` injection, `shouldUseRelayMode()` helper. Default flipped to relay. |
| `skill/plugin/pair-cli-relay.ts` (new) | Relay-mode CLI runner — mirrors agent-tool relay path. |
| `skill/plugin/index.ts` | Wire `runRelayPairCli` into `registerPairCli`; flip banner-flag lifecycle to `consumeBannerForPrepend()`; replace 8 prependContext sites; gate `configureEmbedder` on non-null `pluginVersion`. |
| `skill/plugin/fs-helpers.ts` | `readPluginVersion()` walk-up + name-guard. |
| `skill/plugin/embedding.ts` | `LAST_KNOWN_GOOD_RC_TAG = '3.3.3-rc.1'` (replaces `'0.0.0-dev'`). |
| `skill/plugin/SKILL.md` | Install-order, `/restart` autonomy, forbidden vocab, unauthorized-`/restart` fallback. |
| `docs/guides/openclaw-setup.md` | Mirror of SKILL.md updates. |
| `skill/plugin/{package,skill}.json` | Version 3.3.3-rc.1 → 3.3.4-rc.1. |
| `skill/plugin/{fs-helpers,pair-cli-default-mode,embedding-fallback-tag,staging-banner-gate}.test.ts` | New + updated tests. |

## Test plan

- [x] `npm test` — full plugin suite green (all existing tests + 4 new test files).
- [x] `node skill/scripts/check-version-drift.mjs` — OK (3.3.4-rc.1 across all three sites).
- [x] `node skill/scripts/check-scanner.mjs` — OK (119 files, 0 flags).
- [x] `node skill/scripts/check-url-binding.mjs --release-type=rc` — OK (7 staging hits in dist/).
- [x] `npm run build` — clean.
- [ ] **Real-user QA on staging** (post-merge / pre-stable, per `qa-totalreclaw` skill).

## QA references

* QA findings: Pedro 2026-04-30 / 2026-05-01 against 3.3.3-rc.1 (#171).
* Issue #187 — ONNX decouple (Fix 3 cascade context).
* Issue #87 — container-agent tool-binding gap (Fix 2 / 7 context).
* PR #163 — `/restart` slash-command autonomous reload (Fix 7 context).
* PR #165 — RC=staging / stable=production rule (Fix 5 context).

## Notes

* Do NOT auto-merge. Do NOT auto-publish to npm or auto-update `docs/release-pipeline.md` — Pedro flagged the prior agent's tracker push as overscope. Tracker update is a separate human-driven step.
* Phrase-safety invariant preserved: phrase / mnemonic / credentials code unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)