### PR TITLE
fix(plugin): 3.3.4-rc.2 — declare @scure/bip39 dependency + 60s pair-tool timeout

### DIFF
--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "Install + set up TotalReclaw encrypted memory for OpenClaw, then use totalreclaw_remember / totalreclaw_recall. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', or any remember / recall request."
-version: 3.3.4-rc.1
+version: 3.3.4-rc.2
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -5496,9 +5496,23 @@ const plugin = {
               // Background task — writes credentials.json + flips state when
               // the browser completes the flow. Tool handler returns
               // immediately so the agent can tell the user the URL + PIN.
+              //
+              // 3.3.4-rc.2 (Pedro QA — pair flow stuck-session) — wrap the
+              // WS-await in a 60s hard timeout. The relay drops sessions on
+              // `ws_close` (separately patched relay-side); without this
+              // bound the background task hangs in `waitNextMessage` for the
+              // full 5-minute session TTL before resolving, and downstream
+              // tooling that polls the gateway for completion sees stale
+              // `processing` state at 129s/159s/189s. 60s is the user-side
+              // deadline we surface in chat: long enough for a slow scan-
+              // and-paste, short enough that a fresh URL request is the
+              // obvious next step. Structured `timed_out` error in the log
+              // lets ops grep for the failure mode independently of generic
+              // ws-close errors.
+              const PAIR_TOOL_HARD_TIMEOUT_MS = 60_000;
               void (async () => {
                 try {
-                  await awaitPhraseUpload(remoteSession, {
+                  const phraseUploadPromise = awaitPhraseUpload(remoteSession, {
                     phraseValidator: (p: string) =>
                       validateMnemonic(p, wordlist),
                     completePairing: async ({ mnemonic }) => {
@@ -5546,7 +5560,48 @@ const plugin = {
                         return { state: 'error', error: msg };
                       }
                     },
+                    // 3.3.4-rc.2 — also pass through to awaitPhraseUpload so its
+                    // internal `waitNextMessage` timer matches the outer race.
+                    timeoutMs: PAIR_TOOL_HARD_TIMEOUT_MS,
                   });
+                  // 3.3.4-rc.2 — outer Promise.race guard. Resolves to a
+                  // sentinel ({ status: 'timed_out', ... }) so the catch
+                  // handler can distinguish a hard-timeout from a generic
+                  // ws-close error and surface it explicitly.
+                  const TIMEOUT_SENTINEL: {
+                    status: 'timed_out';
+                    message: string;
+                  } = {
+                    status: 'timed_out',
+                    message:
+                      `Pair flow timed out (${PAIR_TOOL_HARD_TIMEOUT_MS / 1000}s) — generate a new URL with totalreclaw_pair.`,
+                  };
+                  let hardTimer: ReturnType<typeof setTimeout> | undefined;
+                  const hardTimeoutPromise = new Promise<typeof TIMEOUT_SENTINEL>(
+                    (resolve) => {
+                      hardTimer = setTimeout(
+                        () => resolve(TIMEOUT_SENTINEL),
+                        PAIR_TOOL_HARD_TIMEOUT_MS,
+                      );
+                    },
+                  );
+                  try {
+                    const raced = await Promise.race([
+                      phraseUploadPromise,
+                      hardTimeoutPromise,
+                    ]);
+                    if (
+                      raced &&
+                      typeof raced === 'object' &&
+                      (raced as { status?: unknown }).status === 'timed_out'
+                    ) {
+                      api.logger.warn(
+                        `totalreclaw_pair(relay): hard timeout — ${(raced as typeof TIMEOUT_SENTINEL).message} (token=${remoteSession.token.slice(0, 8)}…)`,
+                      );
+                    }
+                  } finally {
+                    if (hardTimer) clearTimeout(hardTimer);
+                  }
                 } catch (bgErr: unknown) {
                   // Expected on TTL expiry / user-aborts — log at warn, not error.
                   const bgMsg = bgErr instanceof Error ? bgErr.message : String(bgErr);

--- a/skill/plugin/package-lock.json
+++ b/skill/plugin/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.4-rc.1",
+  "version": "3.3.4-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/totalreclaw",
-      "version": "3.3.4-rc.1",
+      "version": "3.3.4-rc.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@scure/bip39": "^2.2.0",
         "@totalreclaw/client": "^1.2.0",
         "@totalreclaw/core": "^2.1.1",
         "@types/qrcode": "^1.5.6",

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.4-rc.1",
+  "version": "3.3.4-rc.2",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [
@@ -31,6 +31,7 @@
   "author": "TotalReclaw Team",
   "license": "MIT",
   "dependencies": {
+    "@scure/bip39": "^2.2.0",
     "@totalreclaw/client": "^1.2.0",
     "@totalreclaw/core": "^2.1.1",
     "@types/qrcode": "^1.5.6",

--- a/skill/plugin/pair-cli-relay.ts
+++ b/skill/plugin/pair-cli-relay.ts
@@ -45,7 +45,7 @@
  */
 
 import { validateMnemonic } from '@scure/bip39';
-import { wordlist } from '@scure/bip39/wordlists/english';
+import { wordlist } from '@scure/bip39/wordlists/english.js';
 
 import {
   loadCredentialsJson,

--- a/skill/plugin/pair-remote-client.test.ts
+++ b/skill/plugin/pair-remote-client.test.ts
@@ -672,6 +672,180 @@ async function testTwoSequentialPairsSucceed(): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
+// 3.3.4-rc.2 — pair-tool 60s hard timeout (Pedro QA, stuck-session bug)
+// ---------------------------------------------------------------------------
+
+/**
+ * Stub that opens normally but NEVER sends a `forward` frame. Mirrors the
+ * relay-side bug Pedro saw in 3.3.4-rc.1: the relay accepted `open`, replied
+ * `opened`, then dropped the session on `ws_close` before the browser could
+ * complete pair. Plugin-side, the background task hung in `waitNextMessage`
+ * for the full 5-minute session TTL. The 3.3.4-rc.2 fix wraps the WS-await
+ * in a 60s hard timeout — this test asserts it fires and produces a
+ * recognisable structured error.
+ */
+async function startSilentRelayStub(): Promise<{
+  wssUrl: string;
+  close: () => Promise<void>;
+}> {
+  const http: HttpServer = createServer();
+  const wss = new WebSocketServer({ server: http });
+
+  wss.on('connection', (ws) => {
+    ws.on('message', (raw) => {
+      try {
+        const text =
+          typeof raw === 'string'
+            ? raw
+            : Buffer.from(raw as ArrayBuffer).toString('utf-8');
+        const msg = JSON.parse(text) as Record<string, unknown>;
+        if (msg.type === 'open') {
+          ws.send(
+            JSON.stringify({
+              type: 'opened',
+              token: 'silent-tok-1',
+              short_url: '/pair/p/silent-tok-1',
+              expires_at: new Date(Date.now() + 60_000).toISOString(),
+            }),
+          );
+          // Deliberately do NOT send `forward` — simulate the relay
+          // dropping/silencing the session before phrase upload completes.
+        }
+      } catch {
+        /* swallow */
+      }
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    http.listen(0, '127.0.0.1', () => resolve());
+  });
+  const addr = http.address() as AddressInfo;
+  return {
+    wssUrl: `ws://127.0.0.1:${addr.port}`,
+    close: () =>
+      new Promise<void>((resolve) => {
+        try {
+          wss.close(() => http.close(() => resolve()));
+        } catch {
+          resolve();
+        }
+      }),
+  };
+}
+
+/**
+ * Asserts that `awaitPhraseUpload` honors the `timeoutMs` option (the inner
+ * leg of the rc.2 fix) and that the outer Promise.race sentinel pattern used
+ * in the plugin's `totalreclaw_pair` background task surfaces a structured
+ * `{status: 'timed_out'}` value when the WS-await never receives a forward
+ * frame. Uses a 200 ms timeout to keep test runtime bounded — the production
+ * value is 60_000 ms (PAIR_TOOL_HARD_TIMEOUT_MS in index.ts).
+ */
+async function testPairToolHardTimeout(): Promise<void> {
+  const stub = await startSilentRelayStub();
+  try {
+    const session = await openRemotePairSession({
+      relayBaseUrl: stub.wssUrl,
+      pin: '424242',
+    });
+
+    // Inner leg: awaitPhraseUpload with short timeout must reject (the
+    // existing 5-minute default would hang the whole test process).
+    const SHORT_MS = 200;
+    let innerThrew = false;
+    let innerErrMsg = '';
+    try {
+      await awaitPhraseUpload(session, {
+        completePairing: async () => ({ state: 'active' }),
+        timeoutMs: SHORT_MS,
+      });
+    } catch (err) {
+      innerThrew = true;
+      innerErrMsg = err instanceof Error ? err.message : String(err);
+    }
+    ok(
+      'pair-timeout: awaitPhraseUpload threw on timeoutMs',
+      innerThrew,
+    );
+    ok(
+      'pair-timeout: awaitPhraseUpload error message identifies timeout',
+      /timeout/i.test(innerErrMsg),
+      innerErrMsg,
+    );
+
+    // Outer leg: the Promise.race sentinel pattern used inside index.ts'
+    // `totalreclaw_pair` background task. When the awaitPhraseUpload promise
+    // rejects (or stalls), the outer hard-timer must produce a structured
+    // `{status: 'timed_out', message: ...}` shape that the catch handler
+    // can recognise. We re-open a fresh session so the WS is healthy.
+    const session2 = await openRemotePairSession({
+      relayBaseUrl: stub.wssUrl,
+      pin: '535353',
+    });
+    const phraseUploadPromise = awaitPhraseUpload(session2, {
+      completePairing: async () => ({ state: 'active' }),
+      // long enough that the OUTER race is the one that wins
+      timeoutMs: 5_000,
+    }).catch((err) => {
+      // Inner leg may reject too — swallow so the race resolves cleanly.
+      return { _innerRejected: true, _innerErr: err };
+    });
+    const TIMEOUT_SENTINEL = {
+      status: 'timed_out' as const,
+      message:
+        'Pair flow timed out (60s) — generate a new URL with totalreclaw_pair.',
+    };
+    let hardTimer: ReturnType<typeof setTimeout> | undefined;
+    const hardTimeoutPromise = new Promise<typeof TIMEOUT_SENTINEL>(
+      (resolve) => {
+        hardTimer = setTimeout(() => resolve(TIMEOUT_SENTINEL), 150);
+      },
+    );
+    let raced: unknown;
+    try {
+      raced = await Promise.race([phraseUploadPromise, hardTimeoutPromise]);
+    } finally {
+      if (hardTimer) clearTimeout(hardTimer);
+    }
+    ok(
+      'pair-timeout: outer race resolves to a structured value (not unhandled)',
+      raced != null && typeof raced === 'object',
+      typeof raced === 'object' ? JSON.stringify(raced) : String(raced),
+    );
+    const racedObj = raced as { status?: unknown; message?: unknown };
+    ok(
+      'pair-timeout: structured error has status: "timed_out"',
+      racedObj.status === 'timed_out',
+      JSON.stringify(racedObj),
+    );
+    ok(
+      'pair-timeout: structured error message references generating a new URL',
+      typeof racedObj.message === 'string' &&
+        /totalreclaw_pair/.test(racedObj.message as string) &&
+        /timed out/i.test(racedObj.message as string),
+      typeof racedObj.message === 'string' ? racedObj.message : 'non-string',
+    );
+
+    // Clean up: close the WS that the second awaitPhraseUpload still holds.
+    try {
+      session2._ws.close();
+    } catch {
+      /* noop */
+    }
+    // Drain the inner promise so node doesn't warn about pending handles.
+    await phraseUploadPromise.catch(() => undefined);
+    try {
+      session._ws.close();
+    } catch {
+      /* noop */
+    }
+  } finally {
+    await stub.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Run
 // ---------------------------------------------------------------------------
 
@@ -682,6 +856,7 @@ async function main(): Promise<void> {
   await testDecryptFailureSendsNack();
   await testHttpsInputConvertedToWss();
   await testTwoSequentialPairsSucceed();
+  await testPairToolHardTimeout();
 
   // eslint-disable-next-line no-console
   console.log(`# fail: ${_failed}`);

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "3.3.4-rc.1",
+  "version": "3.3.4-rc.2",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Hotfix RC for 3.3.4-rc.1 issues Pedro surfaced in QA.

- **Fix 1 — `@scure/bip39` phantom dependency.** Imported directly in 5 source files (`index.ts`, `generate-mnemonic.ts`, `onboarding-cli.ts`, `pair-cli-relay.ts`, `pair-page.ts`) but **not** declared in `package.json::dependencies`. Currently resolves on Pedro's pop-os install via transitive (viem ships `@scure/bip39@1.6.0`). Fragile — stricter ESM resolvers or different transitive trees would break. Pin to `^2.2.0` (matches the resolved version actually running in QA).
- **Fix 2 — 60s pair-tool hard timeout.** The `totalreclaw_pair` background task hung in `awaitPhraseUpload` for the full 5-minute session TTL when the relay dropped sessions on `ws_close` (relay-side bug, separately patched in `totalreclaw-relay`). Watcher saw stuck-session at 129s/159s/189s. Now: `Promise.race` against a 60s timer that resolves to `{status: 'timed_out', message: 'Pair flow timed out (60s) — generate a new URL with totalreclaw_pair.'}`, logged at warn level. The 60s value is also passed through to `awaitPhraseUpload(timeoutMs)` so the inner `waitNextMessage` timer matches.
- **Fix 3 — ESM extension on `pair-cli-relay.ts:48`.** That one file imported `@scure/bip39/wordlists/english` without the `.js` extension while the 4 sister files used `.js`. Per `@scure/bip39@2.x`'s `exports` field (only `./wordlists/english.js` is declared), the bare-subpath form does NOT match exports and gets rejected by strict ESM resolvers (Node 20+, Bun, Deno). Was resolving on Pedro's tree via fall-through, but his QA chat-side error pointed straight at this file. Add `.js` so all 5 source files (and dist) consistently use the exports-matching form.
- **Fix 4 — version bump.** `3.3.4-rc.1` → `3.3.4-rc.2` via `sync-version` (touches `package.json`, `SKILL.md`, `skill.json`).

Tool handler still returns URL+PIN immediately — only the background completion task is bounded. No user-visible behavior change for the happy path.

## Provenance

Pedro's QA: 3.3.4-rc.1 install on pop-os, multi-turn chat with the agent. Two issues surfaced; the watcher's diagnosis confirmed Bug 1 (phantom dep) on plugin side and traced Bug 2 (pair session) to the relay side. The relay-side patch ships in a separate `totalreclaw-relay` PR. This PR is the plugin-side safety net so any future relay flakiness can't hang downstream tooling.

The QA chat-side claim that some `@scure/bip39` imports lacked the `.js` extension was **partially right** — 4 of 5 source files used `.js`, but `pair-cli-relay.ts:48` did not. Originally flagged for a follow-up PR; now bundled into this hotfix per Pedro's instruction since strict ESM resolvers reject the bare path.

## Changes

| File | Change |
| --- | --- |
| `skill/plugin/package.json` | Add `@scure/bip39: ^2.2.0` to `dependencies`; bump version to `3.3.4-rc.2` |
| `skill/plugin/package-lock.json` | Regenerated to record the direct dep |
| `skill/plugin/index.ts` | Wrap `awaitPhraseUpload` in 60s Promise.race + structured `timed_out` sentinel; pass `timeoutMs: 60_000` through to inner await |
| `skill/plugin/pair-cli-relay.ts` | Add `.js` to `@scure/bip39/wordlists/english` import (line 48) — matches sister files + exports field |
| `skill/plugin/pair-remote-client.test.ts` | New `testPairToolHardTimeout` (4 assertions) — silent-relay stub, asserts inner reject + outer race surfaces the structured shape |
| `skill/plugin/SKILL.md` | Frontmatter version bump |
| `skill/plugin/skill.json` | Version bump |

## Test plan

- [x] `cd skill/plugin && npm test` — 18/18 test files green, 0 failures (39/39 pair-remote-client tests pass)
- [x] `cd skill/plugin && npm run build` — tsc clean
- [x] All 5 dist files now consistently use `.js` extension on `@scure/bip39/wordlists/english` import (verified via `grep -n` on `dist/*.js`)
- [ ] Auto-QA dispatched on RC publish (per `RC auto-QA policy`) — covers a real pair flow against staging relay
- [ ] Pedro user-QA re-run on staging once RC publishes

## Constraints respected

- Plugin-only — no `python/`, `Dockerfile`, or relay code touched.
- Phrase-safety invariant — recovery phrase still never crosses LLM context. The structured timeout payload contains zero phrase material.
- Not auto-merged. Not auto-published. Tracker not updated by this PR (will update on RC publish per `Release pipeline tracker` rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)