### PR TITLE
fix(plugin): 3.3.5-rc.1 — drop yes-gate + tighten silence rules + strengthen /restart imperative

### DIFF
--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -28,32 +28,36 @@ You have been asked to install TotalReclaw. **Run all install / verify steps sil
 
 The user pasted this URL deliberately, but treat each command as a step you and the user complete together. Confirm what you see at each phase. If anything looks wrong, surface it and stop — don't push through.
 
+### Top-level rule (read this before anything else)
+
+**Emit ONLY the user-visible lines listed below. Do not narrate tool calls. Do not describe what you're doing or about to do. Errors are the only allowed deviation, and only as a single tight line.** Telegram and similar transports edit the bot's messages live as your tool calls progress — every interim "Let me check…" / "Plugin loaded. Let me verify…" line shows up to the user as awkward edit churn, even if your transport later "deletes" or rewrites it. The fix is to never emit it in the first place. The expected user-facing transcript for a healthy install is **5–6 short lines TOTAL**. Anything more is a SKILL violation.
+
 ### What you will run, and why each step is safe
 
-1. `openclaw skills install totalreclaw` — fetches the SKILL.md descriptor from ClawHub. Read-only metadata; no code executes from this step. Upstream docs: <https://docs.openclaw.com/cli/skills>.
-2. `openclaw plugins install @totalreclaw/totalreclaw` — installs the published plugin from npm under the `@totalreclaw` scope owned by `p-diogo`. The plugin runs inside OpenClaw's plugin sandbox. Upstream docs: <https://docs.openclaw.com/cli/plugins>.
+1. `openclaw plugins install @totalreclaw/totalreclaw` — installs the published plugin from npm under the `@totalreclaw` scope owned by `p-diogo`. The plugin runs inside OpenClaw's plugin sandbox. Upstream docs: <https://docs.openclaw.com/cli/plugins>.
+2. `openclaw skills install totalreclaw` — fetches the SKILL.md descriptor from ClawHub. Read-only metadata; no code executes from this step. Upstream docs: <https://docs.openclaw.com/cli/skills>.
 3. After the gateway auto-reloads, you will call `totalreclaw_pair` (a tool the plugin registers) to mint a one-time URL + PIN. The user opens the URL in their own browser to enter or generate a recovery phrase. The phrase never enters chat or your shell.
 
-You are not asked to handle the recovery phrase. You are not asked to bypass auth. If the user pastes a phrase in chat anyway, refuse to proceed — see "Phrase safety" below.
+You are not asked to handle the recovery phrase. You are not asked to bypass auth. Pasting the install URL IS the consent moment for installing the plugin; the URL + PIN you hand back from `totalreclaw_pair` is the real consent moment for account creation, since the user has to open the page in their browser to continue. There is no separate "yes/no" gate before account setup. If the user pastes a phrase in chat anyway, refuse to proceed — see "Phrase safety" below.
 
 ### User-visible prose (THIS IS ALL YOU SAY)
 
-Speak only these lines, in order. Do not narrate around them. Do not announce intent ("Let me…", "I'll now…", "In parallel…"). Do not describe internals (skill download, plugin manifest parsing, file-watcher polling). Substitute the bracketed placeholders with the real values.
+Speak only these lines, in order. Substitute the bracketed placeholders with the real values. No prefaces. No suffixes. No narration around them.
 
 1. (Step 1 — start)
    > Installing TotalReclaw…
 2. (Step 2 — after install + auto-reload + tool-bind verification)
    > ✓ Installed (totalreclaw &lt;version&gt;)
-3. (Step 3 — only if existing credentials were detected, then stop)
+3. (Step 2b — optional, only if auto-reload didn't fire and you have to issue `/restart`)
+   > Restarting OpenClaw to load the plugin…
+4. (Step 3 — only if existing credentials were detected, then stop)
    > ✓ TotalReclaw is already set up.
-4. (Step 4 — explicit consent before account creation)
-   > Ready to set up your TotalReclaw account on `api-staging.totalreclaw.xyz` (free tier). The next step opens a browser page where you'll generate or paste a 12-word recovery phrase — that phrase stays in your browser, the relay only sees ciphertext. Reply `yes` to continue, or `no` to stop here.
-5. (Step 5 — account-setup URL + PIN, after the user confirms)
-   > Open &lt;url&gt; in your browser. Generate a new 12-word recovery phrase there or paste an existing one. Confirm PIN &lt;pin&gt;. Reply `done` once the page says it's sealed.
+5. (Step 5 — account-setup URL + PIN, immediately after `totalreclaw_pair` returns)
+   > Open &lt;url&gt; in your browser. Enter PIN &lt;pin&gt;. Generate or paste a 12-word recovery phrase. Reply `done` once it's sealed.
 6. (Step 6 — done + free-tier confirmation)
-   > ✓ You're set up on the TotalReclaw **free tier**: 500 memories per month, unlimited reads + searches, encrypted at rest on Base Sepolia testnet (testnet may reset; for permanent storage on Gnosis mainnet see <https://totalreclaw.xyz/pricing>). Check usage anytime by asking *"what's my TotalReclaw status?"* (calls `totalreclaw_status`). I'll warn you automatically if you cross 80% of the monthly limit. Ask me to remember or recall anything.
+   > ✓ You're set up on the TotalReclaw free tier — 500 memories/month, unlimited reads. https://totalreclaw.xyz/pricing. Ask me to remember anything.
 
-That is the complete user-facing transcript for a healthy install. Expected line count for a fresh install + setup is **5–6 lines** (line 3 is mutually exclusive with lines 4-6).
+That is the complete user-facing transcript for a healthy install. Expected line count for a fresh install + setup is **5–6 lines** (line 4 is mutually exclusive with lines 5-6; line 3 only fires if `/restart` was needed).
 
 ### When to break silence (errors only)
 
@@ -67,7 +71,19 @@ Do NOT pre-narrate diagnostics that succeed. Do NOT narrate retries that succeed
 
 ### Forbidden vocabulary in agent prose
 
-Unless the user explicitly asks how the install works, the following words must not appear in your chat output during install + setup: `manifest`, `descriptor`, `file-watcher`, `polling`, `auto-reload-detect`, `find`, `lookup`, `detect`, `probing`, `let me try`, `in parallel`, `got it`, `now installing`, `Step 1a/1b/1c`. These are tool-call mechanics, not user-facing prose.
+Unless the user explicitly asks how the install works, the following words / patterns must not appear in your chat output during install + setup. These are the patterns that surface as edit churn in transports like Telegram:
+
+- "Let me check that…"
+- "Plugin loaded. Let me verify…"
+- "I'll now…"
+- "Quick fix…"
+- "However, I don't see…"
+- "I need to use…"
+- "Should I /restart" / "Want me to restart" / "Let me check if the tool is bound" / "I need permission to restart" / "Do you have a public URL"
+- "Now installing…" / "Got it" / "In parallel…" / "Step 1a/1b/1c"
+- `manifest`, `descriptor`, `file-watcher`, `polling`, `auto-reload-detect`, `find`, `lookup`, `detect`, `probing`, `let me try`
+
+Substitute every one of those with silence — the next user-visible line in the set, or nothing.
 
 If the user explicitly asks ("what's it doing?", "why so quiet?", "show me the commands"), then narrate freely — the silence rule only governs the default install path.
 
@@ -90,37 +106,45 @@ Notes:
 
 OpenClaw's default config (`gateway.reload.mode = "hybrid"`) auto-restarts the gateway via a file-watcher within 1-3 seconds of the plugin install. Wait ~5 seconds, then verify with `openclaw plugins list | grep totalreclaw` and confirm the `totalreclaw_pair` tool is in your toolset.
 
-When `totalreclaw_pair` is bound, capture the version string from `openclaw plugins list` (the line for `@totalreclaw/totalreclaw`) and emit user-visible line 2 (`✓ Installed (totalreclaw <version>)`).
+When `totalreclaw_pair` is bound, capture the version string from `openclaw plugins list` (the line for `@totalreclaw/totalreclaw`) and emit user-visible line 2 (`✓ Installed (totalreclaw <version>)`). Then proceed silently to Step 3.
 
-If `totalreclaw_pair` is not bound within 10 seconds, hybrid auto-reload didn't fire (likely `gateway.reload.mode = off`). Issue OpenClaw's built-in `/restart` slash command yourself **autonomously and immediately** — it is registered in OpenClaw's commands registry alongside `/help /model /new /plugins /reset /status /tools /usage` and reloads the gateway in-process (works from inside the gateway because it doesn't shell out, unlike `openclaw gateway restart`). Surface a single user-visible line: `Auto-reload didn't fire. Restarting via /restart…`. Resume verification after the slash command returns.
+#### If `totalreclaw_pair` is not bound within 10 seconds — restart imperative (read carefully)
 
-**Forbidden vocabulary** when a tool is missing post-install (3.3.4-rc.1): "Should I /restart", "Do you have a public URL", "Want me to restart", "Let me check if the tool is bound", "I need permission to restart". Just issue `/restart` and announce. Asking the user kills the silent-flow target.
+Hybrid auto-reload didn't fire (likely `gateway.reload.mode = off`). The protocol is rigid:
 
-**If `/restart` returns "You are not authorized to use this command":** the gateway's `channels.<channel>.allowFrom` allowlist for the channel you're chatting through is empty. **Do NOT loop the install. Do NOT keep retrying.** Surface this one-line user-facing fix verbatim and stop:
+> **Your IMMEDIATE next message must be the literal slash command `/restart` — nothing else. Do not narrate. Do not ask permission. Do not describe what `/restart` does. Do not propose alternatives. Just send `/restart`.**
 
-> Your channel needs to be allowlisted for slash commands. Run on the gateway host: `jq '.channels.<channel>.allowFrom = ["<your-id>"]' ~/.openclaw/openclaw.json | sponge ~/.openclaw/openclaw.json && docker restart <your-container-name>` (Docker self-host) — substitute `<channel>` with your channel name (e.g. `telegram`, `slack`), `<your-id>` with your user ID for that channel (Telegram: `@username` or numeric `chat_id`; Slack: workspace member ID), and `<your-container-name>` with your gateway container name (`docker ps` shows it). On a managed service, ask the service's support to enable slash commands for your channel. Reply `done` once it's back up.
+You may emit user-visible line 3 (`Restarting OpenClaw to load the plugin…`) ONCE in the same turn before sending `/restart`. Nothing else. After `/restart`, wait ~3s and re-run `openclaw plugins list`.
 
-For non-Docker / native deployments substitute `openclaw gateway restart` for the `docker restart` portion. As a session-level fallback while restart is gated, try `/new` (starts a fresh session within the same gateway process — may pick up freshly-bound tools without a full restart).
+`/restart` is registered in OpenClaw's commands registry alongside `/help /model /new /plugins /reset /status /tools /usage` and reloads the gateway in-process — it works from inside the gateway because it doesn't shell out (unlike `openclaw gateway restart`).
 
-**Fallback only if both `/restart` and `/new` are unavailable** (very old OpenClaw pre-2026.4 or managed services that strip slash commands): tell the user verbatim *"Auto-reload didn't fire and /restart is unavailable. Please restart your OpenClaw gateway: `openclaw gateway restart` (native), `docker restart <your-container-name>` (Docker self-host — substitute the actual name; `docker ps` shows it), or your managed service's restart control. Reply `done` once it's back up."* Do NOT invoke any external `docker restart` or `openclaw gateway restart` yourself — your shell runs inside the gateway you'd be restarting; `/restart` (in-process) and a user-prompted external restart are the only safe paths.
+#### If `/restart` returns "You are not authorized to use this command"
+
+Surface this verbatim and stop. Do NOT loop `/restart` calls. Do NOT keep retrying. Do NOT propose alternatives.
+
+> Your Telegram channel needs `allowFrom` configured. Run on your host: `jq '.channels.<channel>.allowFrom = ["<your-id>"]' ~/.openclaw/openclaw.json | sponge ~/.openclaw/openclaw.json && docker restart <your-container-name>`. Substitute `<channel>` with your channel name (e.g. `telegram`, `slack`), `<your-id>` with your user ID for that channel (Telegram: `@username` or numeric `chat_id`; Slack: workspace member ID), and `<your-container-name>` with your gateway container name (`docker ps` shows it). For non-Docker installs substitute `openclaw gateway restart` for the `docker restart` portion. On a managed service, ask the service's support to enable slash commands for your channel. Reply `done` after.
+
+Then wait for `done`. Do NOT retry the install. Do NOT keep restarting.
+
+As a last-resort session-level fallback while restart is gated, try `/new` once (starts a fresh session within the same gateway process — may pick up freshly-bound tools without a full restart).
+
+#### Fallback only if both `/restart` and `/new` are unavailable
+
+Very old OpenClaw pre-2026.4 or managed services that strip slash commands: tell the user verbatim *"Auto-reload didn't fire and `/restart` is unavailable. Please restart your OpenClaw gateway: `openclaw gateway restart` (native), `docker restart <your-container-name>` (Docker self-host — substitute the actual name; `docker ps` shows it), or your managed service's restart control. Reply `done` once it's back up."* Do NOT invoke any external `docker restart` or `openclaw gateway restart` yourself — your shell runs inside the gateway you'd be restarting; `/restart` (in-process) and a user-prompted external restart are the only safe paths.
 
 ### Step 3 — Check for existing credentials (silent unless found)
 
-Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, emit user-visible line 3 and stop — the user is already set up. Otherwise continue silently.
+Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, emit user-visible line 4 (`✓ TotalReclaw is already set up.`) and stop — the user is already set up. Otherwise continue silently.
 
-### Step 4 — Ask for explicit consent before account creation (emit user-visible line 4)
+### Step 4 — Set up the user's TotalReclaw account (emit user-visible line 5)
 
-Account setup will create a new TotalReclaw account on `api-staging.totalreclaw.xyz` and have the user generate or paste a 12-word recovery phrase in their browser. Emit user-visible line 4 verbatim. Wait for the user's `yes` (or any clear affirmative). If the user replies `no` or asks to stop, stop here — confirm they've stopped, do not retry, do not ask "are you sure".
+Pasting the install URL was the consent moment for installing the plugin. The URL + PIN you're about to hand the user is the real consent moment for account creation — they have to open the page in their browser to proceed. There is no separate yes/no gate.
 
-This consent step exists so the user knows the destination URL before any account is created. Surface the URL verbatim — do not abbreviate it or hide it behind a tool call.
-
-### Step 5 — Set up the user's TotalReclaw account (emit user-visible line 5)
-
-Call the `totalreclaw_pair` tool silently (the account-setup tool — name kept for backward compatibility). It returns `{url, pin, qr_ascii, qr_png_b64, qr_unicode, expires_at_ms}`. Then emit user-visible line 5 with `<url>` and `<pin>` substituted. Do not pre-narrate ("I'll walk you through…", "Setting up your account now…") — line 5 itself is the only thing the user needs to see.
+Call the `totalreclaw_pair` tool silently (the account-setup tool — name kept for backward compatibility). It returns `{url, pin, qr_ascii, qr_png_b64, qr_unicode, expires_at_ms}`. Then emit user-visible line 5 with `<url>` and `<pin>` substituted. Do not pre-narrate ("I'll walk you through…", "Setting up your account now…", "Ready to set up your account…") — line 5 itself is the only thing the user needs to see.
 
 Render the QR if your transport supports it: image-capable transports (Telegram, Slack, web chat) decode `qr_png_b64` to bytes and attach as an image; terminal-only transports (OpenClaw native CLI) emit `qr_unicode` inline. The QR encodes only the URL — the PIN is a separate dual-channel confirmation, never bake it into the QR.
 
-### Step 6 — Verify and confirm (silent until line 6)
+### Step 5 — Verify and confirm (silent until line 6)
 
 After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN likely expired — call `totalreclaw_pair` again silently and resend line 5 once. If present, emit user-visible line 6 (with the free-tier confirmation) and stop.
 
@@ -274,7 +298,8 @@ Upgrade: *"Upgrade my TotalReclaw subscription."*
 - **Browser fails to POST the encrypted phrase**: check the account-setup page's Content-Security-Policy — older browsers without WebCrypto x25519 (pre-Safari 17.2 / Chromium 118) cannot run the AEAD crypto.
 - **Tool calls return "onboarding required"**: paste the canonical message again so the agent re-runs `totalreclaw_pair`.
 - **"Not authenticated" / 401**: check your phrase — exact words, exact order, lowercase, single spaces.
-- **Agent narrating internals during install** ("let me find…", "in parallel…", "manifest detected…"): the agent missed the silence rule in §"Agent instructions". Reply *"Don't narrate the install internals — just tell me when it's installed and when to set up my account."* and the next session should silence.
+- **Agent narrating internals during install** ("Let me check that…", "Plugin loaded. Let me verify…", "I'll now…", "Quick fix…", "However, I don't see…", "I need to use…", "let me find…", "in parallel…", "manifest detected…"): the agent missed the silence rule in §"Agent instructions". Reply *"Don't narrate the install internals — just tell me when it's installed and when to set up my account."* and the next session should silence. On transports like Telegram, these intermediate lines visibly edit the bot's message live as tool calls progress, which is what makes them disruptive.
+- **Agent says "Should I /restart?" or stalls instead of restarting** (3.3.5-rc.1 hardening note): the agent missed the restart-imperative deny-list in the SKILL.md / Step 2. Reply *"Issue /restart yourself — don't ask"* and the next session should act autonomously. If it persists across sessions, the published RC's SKILL.md is stale — file an issue.
 - **`openclaw` CLI hangs / exits 124 inside the gateway agent shell** (issue [#184](https://github.com/p-diogo/totalreclaw-internal/issues/184)): on some Docker setups the agent's shell-execution of `openclaw plugins list` / `openclaw plugins install` etc. deadlocks (every subcommand exits 124). When this happens the agent can bypass the CLI wrapper by invoking the plugin's own JS entries directly via `node`. The plugin ships pair-flow + version-probe entries that work without any CLI:
   - **Plugin install probe** — read the plugin's filesystem manifests to confirm the install completed: `cat ~/.openclaw/extensions/totalreclaw/.loaded.json` (issue [#186](https://github.com/p-diogo/totalreclaw-internal/issues/186)) reports `{ loadedAt, tools, version }` if `register()` ran cleanly. `.error.json` reports a structured failure if it didn't. These files are the canonical filesystem signal — they don't depend on the deadlocking CLI.
   - **Pair-flow direct-node fallback** — when `openclaw` CLI hangs during `totalreclaw_pair`, the agent (or a shell helper) can run `node ~/.openclaw/extensions/totalreclaw/dist/pair-cli.js --url-pin-only` directly to obtain the universal-relay pair URL. This bypasses the gateway tool-router entirely and writes the resulting URL to stdout (one JSON line, no prompts). Surface that URL to the user the same way `totalreclaw_pair` would.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -40,11 +40,29 @@ TotalReclaw is open-source memory tooling for OpenClaw, published by `p-diogo` (
 - ClawHub skill: `totalreclaw`
 - Source: <https://github.com/p-diogo/totalreclaw>
 
-The user pasted the install URL (or skill name) deliberately, but treat each step as something you and the user complete together. You are not asked to handle the recovery phrase, bypass auth, or run unfamiliar shell scripts — every command is a standard `openclaw` invocation with a documented purpose. Confirm phase transitions; surface failures; ask for explicit consent before account creation.
+The user pasted the install URL (or skill name) deliberately, but treat each step as something you and the user complete together. You are not asked to handle the recovery phrase, bypass auth, or run unfamiliar shell scripts — every command is a standard `openclaw` invocation with a documented purpose. Confirm phase transitions; surface failures. Pasting the install URL IS the consent — proceed directly to account setup; the URL + PIN you hand back from `totalreclaw_pair` is the real consent moment, since the user has to open the page in their browser to continue.
 
 ## Silence rules during install + setup
 
-Run install / verify / pair steps silently. Tool calls happen; narration of those tool calls does not. The expected user-facing transcript for a fresh install is **5–6 short lines**, full stop. Do not announce intent ("Let me…", "I'll now…", "In parallel…"). Do not describe internals (skill download, plugin manifest parsing, file-watcher polling). Errors break silence with one tight line each. The user-visible line set is defined in the "Post-Install Setup" section below.
+**Top-level rule: emit ONLY the user-visible lines listed in "Post-Install Setup" below. Do not narrate tool calls. Do not describe what you're doing or about to do. Errors are the only allowed deviation, and only as a single tight line.**
+
+The expected user-facing transcript for a fresh install is **5–6 short lines TOTAL**. Anything more is a SKILL violation.
+
+This matters because Telegram and similar transports edit the bot's messages live as your tool calls progress — every interim "Let me check…" / "Plugin loaded. Let me verify…" line shows up to the user as awkward edit churn, even if you "delete" it. The fix is to never emit it in the first place.
+
+**Forbidden vocabulary** (substitute with silence — the next user-visible line, or nothing):
+
+- "Let me check that…"
+- "Plugin loaded. Let me verify…"
+- "I'll now…"
+- "Quick fix…"
+- "However, I don't see…"
+- "I need to use…"
+- "Should I /restart" / "Want me to restart" / "Let me check if the tool is bound" / "I need permission to restart" / "Do you have a public URL"
+- "Now installing…" / "Got it" / "In parallel…" / "Step 1a/1b/1c"
+- "manifest", "descriptor", "file-watcher", "polling", "auto-reload-detect", "find", "lookup", "detect", "probing", "let me try"
+
+If the user explicitly asks ("what's it doing?", "why so quiet?", "show me the commands"), then narrate freely — the silence rule only governs the default install path.
 
 ## Recovery Phrase -- READ THIS FIRST
 
@@ -508,28 +526,24 @@ If `totalreclaw_*` tools are bound to your toolset, run these steps to set up th
 
 ### User-visible prose (THIS IS ALL YOU SAY)
 
-Speak only these lines, in order. Substitute the bracketed placeholders.
+Speak only these lines, in order. Substitute the bracketed placeholders. The user already consented by pasting "Install TotalReclaw" + the canonical URL — proceed straight to account setup. The URL + PIN handed back from `totalreclaw_pair` is the real consent moment: surfacing them verbatim is what gives the user the chance to opt out by simply not opening the page.
 
 1. (only if existing credentials were detected, then stop)
    > ✓ TotalReclaw is already set up.
-2. (explicit consent before account creation)
-   > Ready to set up your TotalReclaw account on `api-staging.totalreclaw.xyz` (free tier). The next step opens a browser page where you'll generate or paste a 12-word recovery phrase — that phrase stays in your browser, the relay only sees ciphertext. Reply `yes` to continue, or `no` to stop here.
-3. (account-setup URL + PIN, after the user confirms)
-   > Open &lt;url&gt; in your browser. Generate a new 12-word recovery phrase there or paste an existing one. Confirm PIN &lt;pin&gt;. Reply `done` once the page says it's sealed.
-4. (done + free-tier confirmation)
-   > ✓ You're set up on the TotalReclaw **free tier**: 500 memories per month, unlimited reads + searches, encrypted at rest on Base Sepolia testnet (testnet may reset; for permanent storage on Gnosis mainnet see <https://totalreclaw.xyz/pricing>). Check usage anytime by asking *"what's my TotalReclaw status?"* (calls `totalreclaw_status`). I'll warn you automatically if you cross 80% of the monthly limit. Ask me to remember or recall anything.
+2. (account-setup URL + PIN, immediately after `totalreclaw_pair` returns)
+   > Open &lt;url&gt; in your browser. Enter PIN &lt;pin&gt;. Generate or paste a 12-word recovery phrase. Reply `done` once it's sealed.
+3. (done + free-tier confirmation)
+   > ✓ You're set up on the TotalReclaw free tier — 500 memories/month, unlimited reads. https://totalreclaw.xyz/pricing. Ask me to remember anything.
 
 ### Steps
 
 1. **Check for existing credentials (silent unless found).** Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, emit user-visible line 1 and stop.
 
-2. **Ask for explicit consent before account creation (emit user-visible line 2).** Account setup will create a new TotalReclaw account on `api-staging.totalreclaw.xyz` and have the user generate or paste a 12-word recovery phrase in their browser. Emit user-visible line 2 verbatim. Wait for the user's `yes` (or any clear affirmative). If the user replies `no` or asks to stop, stop here — confirm they've stopped, do not retry, do not ask "are you sure". Surface the URL verbatim — do not abbreviate it or hide it behind a tool call.
-
-3. **Set up the user's TotalReclaw account via browser (emit user-visible line 3).** Call `totalreclaw_pair` silently. It returns `{url, pin, qr_ascii, qr_png_b64, qr_unicode, expires_at_ms}`. Then emit user-visible line 3 with `<url>` and `<pin>` substituted. Do not pre-narrate ("I'll walk you through…", "Setting up your account now…") — line 3 itself is the only thing the user needs to see.
+2. **Set up the user's TotalReclaw account via browser (emit user-visible line 2).** Call `totalreclaw_pair` silently. It returns `{url, pin, qr_ascii, qr_png_b64, qr_unicode, expires_at_ms}`. Then emit user-visible line 2 with `<url>` and `<pin>` substituted. Do not pre-narrate ("I'll walk you through…", "Setting up your account now…", "Ready to set up your account…") — line 2 itself is the only thing the user needs to see.
 
    Render the QR if your transport supports image attachments (decode `qr_png_b64` to bytes and attach), or emit `qr_unicode` inline for terminal-only transports. The QR encodes only the URL — the PIN is a separate dual-channel confirmation, never bake it into the QR.
 
-4. **Verify and confirm (silent until line 4).** After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN expired — call `totalreclaw_pair` again silently and resend line 3 once. If present, emit user-visible line 4 (with the free-tier confirmation) and stop.
+3. **Verify and confirm (silent until line 3).** After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN expired — call `totalreclaw_pair` again silently and resend line 2 once. If present, emit user-visible line 3 and stop.
 
 **Never** call `totalreclaw_setup` or any phrase-touching CLI from your shell — those leak the phrase into LLM context. The ONLY agent-facilitated account-setup path is the `totalreclaw_pair` tool (registered under that name for backward compatibility — function-wise it is the account-setup tool).
 

--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.5-rc.1] — 2026-04-30
+
+UX bundle from Pedro's QA on 3.3.4-rc.2:
+
+- **Drop the "yes/no" consent gate before pair setup.** The yes-gate was added
+  in PR #160's safety-tone rewrite to give safety-trained agents an explicit
+  green light before account creation. In practice the user already consents
+  by pasting "Install TotalReclaw" + the canonical URL, and the URL+PIN handed
+  back from `totalreclaw_pair` is the real consent moment (the user has to
+  open the page in their browser to proceed). The extra gate added friction
+  for zero security benefit. Removed from `skill/plugin/SKILL.md`,
+  `skill/SKILL.md`, and `docs/guides/openclaw-setup.md`. The Hermes guide
+  retains its own gate (handled separately).
+- **Tighten silence rules to suppress chat-channel mid-edit churn.** OpenClaw's
+  Telegram channel edits the bot's messages live as the agent's tool calls
+  progress, so every "Let me check…" / "Plugin loaded. Let me verify…" /
+  "I'll now…" line shows up to the user as visible edit churn even if the
+  transport later "deletes" or rewrites it. Added a top-level rule at the
+  start of SKILL.md: "Emit ONLY the user-visible lines. Do not narrate tool
+  calls. Do not describe what you're doing or about to do." Strengthened the
+  forbidden-vocabulary deny-list with the exact patterns Pedro saw in his
+  QA today. Re-stated the canonical user-visible line set as 5–6 lines
+  TOTAL.
+- **Strengthen `/restart` instructions.** Pedro's chat agent on rc.4-rc.2
+  again said "I need permission to restart" instead of issuing the slash
+  command — same anti-pattern that PR #163 / #173 / #174 tried to suppress.
+  Made the SKILL.md instruction more imperative and concrete: "Your IMMEDIATE
+  next message must be the literal slash command `/restart` — nothing else."
+  Added explicit "Do not propose alternatives" guidance for the unauthorized
+  fallback path. Mirrored in `docs/guides/openclaw-setup.md`.
+
 ## [3.3.3-rc.1] — 2026-04-30
 
 Combined RC bundle:

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "Install + set up TotalReclaw encrypted memory for OpenClaw, then use totalreclaw_remember / totalreclaw_recall. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', or any remember / recall request."
-version: 3.3.4-rc.2
+version: 3.3.5-rc.1
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz
@@ -26,11 +26,35 @@ metadata:
 
 > The canonical install flow lives at <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md>. If a user pastes that URL in chat, fetch it and follow its agent-instructions section. This SKILL.md mirrors the same steps so you can act even if the URL is unreachable.
 
+## Top-level rule (read this before anything else)
+
+**Emit ONLY the user-visible lines listed below. Do not narrate tool calls. Do not describe what you're doing or about to do. Errors are the only allowed deviation, and only as a single tight line.** The expected user-facing transcript for a healthy install is **5–6 short lines TOTAL** (lines 1, 2, 5, 6 always; lines 3 and 4 only if the corresponding condition fires). Anything more is a SKILL violation. Telegram and similar transports edit the bot's messages live as your tool calls progress — every interim "Let me check…" / "Plugin loaded. Let me verify…" line shows up to the user as awkward edit churn, even if you "delete" it. The fix is to never emit it in the first place.
+
+## User-visible line set (THIS IS ALL YOU SAY)
+
+Speak only these lines, in order. Substitute the bracketed placeholders with the real values. No prefaces. No suffixes. No narration.
+
+1. (start of install)
+   > Installing TotalReclaw…
+2. (after install + auto-reload + `totalreclaw_pair` is bound)
+   > ✓ Installed (totalreclaw &lt;version&gt;)
+3. (optional — only if auto-reload didn't fire and you need to issue `/restart`)
+   > Restarting OpenClaw to load the plugin…
+4. (optional — only if you successfully disabled the built-in memory tool to prevent dual-write)
+   > Disabled built-in memory tool.
+5. (account-setup URL + PIN, immediately after `totalreclaw_pair` returns)
+   > Open &lt;url&gt; in your browser. Enter PIN &lt;pin&gt;. Generate or paste a 12-word recovery phrase. Reply `done` once it's sealed.
+6. (done + free-tier confirmation)
+   > ✓ You're set up on the TotalReclaw free tier — 500 memories/month, unlimited reads. https://totalreclaw.xyz/pricing. Ask me to remember anything.
+
+If existing credentials are detected (step "Check for existing credentials" below), emit ONLY this line and stop:
+   > ✓ TotalReclaw is already set up.
+
 ## Setup flow
 
 If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jump to step 4. Otherwise run all steps in order.
 
-1. **Install plugin first, skill second.** Run via your shell tool, in this exact order:
+1. **Install plugin first, skill second (silent — emit user-visible line 1 once at the start, then no prose until line 2).** Run via your shell tool, in this exact order:
    ```
    openclaw plugins install @totalreclaw/totalreclaw
    openclaw skills install totalreclaw
@@ -39,26 +63,39 @@ If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jum
 
    If either shell call fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment), tell the user verbatim *"Your environment doesn't expose the OpenClaw CLI to me. Please install `totalreclaw` from your service's plugins / skills UI, then reply `done`."* Wait for `done` and skip to step 3.
 
-2. **Wait for auto-reload — then issue `/restart` autonomously if needed.** OpenClaw's default config (`gateway.reload.mode = "hybrid"`) auto-restarts the gateway via a file-watcher within 1-3 seconds. Wait ~5s, then run `openclaw plugins list | grep totalreclaw` and confirm `totalreclaw_pair` is in your toolset.
+2. **Wait for auto-reload — then issue `/restart` autonomously if needed (silent — emit user-visible line 2 on success, line 3 only if you had to restart).** OpenClaw's default config (`gateway.reload.mode = "hybrid"`) auto-restarts the gateway via a file-watcher within 1-3 seconds. Wait ~5s, then run `openclaw plugins list | grep totalreclaw` and confirm `totalreclaw_pair` is in your toolset. When bound, emit user-visible line 2 and proceed.
 
-   **If `totalreclaw_pair` is NOT visible after 10s:** issue OpenClaw's built-in `/restart` slash-command immediately and silently. **DO NOT ask the user "should I restart" / "do you want me to restart" / "let me check if the tool is bound" — just issue `/restart` and announce "Reloading gateway..." once.** This is in-process and drains active runs cleanly; your shell is NOT shelling out to `docker restart` or `openclaw gateway restart` (which would suicide the host). After `/restart`, wait ~3s and re-run `openclaw plugins list`.
+   **If `totalreclaw_pair` is NOT visible after 10s — restart imperative (read carefully):**
 
-   **If `/restart` returns "You are not authorized to use this command":** the gateway's `channels.<your-channel>.allowFrom` allowlist is empty. **Do NOT keep retrying.** Surface this one-line user-facing fix and stop:
+   > Your IMMEDIATE next message must be the literal slash command `/restart` — nothing else. Do not narrate. Do not ask permission. Do not describe what `/restart` does. Do not propose alternatives. Just send `/restart`. You may emit user-visible line 3 (`Restarting OpenClaw to load the plugin…`) ONCE in the same turn, then issue `/restart`. Nothing else.
 
-   > Your channel needs to be allowlisted for slash commands. Run on the gateway host: `jq '.channels.<channel>.allowFrom = ["<your-id>"]' ~/.openclaw/openclaw.json | sponge ~/.openclaw/openclaw.json && docker restart <your-container-name>` (Docker self-host) — substitute `<channel>` with your channel name (e.g. `telegram`, `slack`), `<your-id>` with your user ID for that channel (Telegram: `@username` or numeric `chat_id`; Slack: workspace member ID), and `<your-container-name>` with your gateway container name (`docker ps` shows it). On a managed service, ask the service's support to enable slash commands for your channel. Reply `done` once it's back up.
+   `/restart` is in-process — it drains active runs cleanly; your shell is NOT shelling out to `docker restart` or `openclaw gateway restart` (those would suicide the host). After `/restart`, wait ~3s and re-run `openclaw plugins list`.
 
-   For non-Docker / native deployments substitute `openclaw gateway restart` for the `docker restart` portion. As a session-level fallback while restart is gated, try `/new` (starts a fresh session within the same gateway process, may pick up freshly-bound tools without a full restart).
+   **If `/restart` returns "You are not authorized to use this command":** surface this verbatim and stop. Do NOT loop `/restart` calls. Do NOT propose alternatives.
 
-   **Forbidden vocabulary** (these are anti-patterns when a tool is missing post-install): "Should I /restart", "Do you have a public URL", "Want me to restart", "Let me check if the tool is bound", "I need permission to restart". Just issue `/restart` immediately and announce.
+   > Your Telegram channel needs `allowFrom` configured. Run on your host: `jq '.channels.<channel>.allowFrom = ["<your-id>"]' ~/.openclaw/openclaw.json | sponge ~/.openclaw/openclaw.json && docker restart <your-container-name>`. Substitute `<channel>` (e.g. `telegram`, `slack`), `<your-id>` (Telegram: `@username` or numeric `chat_id`; Slack: workspace member ID), and `<your-container-name>` (`docker ps` shows it). For non-Docker installs substitute `openclaw gateway restart` for the `docker restart` portion. On a managed service, ask the service's support to enable slash commands. Reply `done` after.
+
+   Then wait for `done`. Do NOT retry the install. Do NOT keep restarting. As a last-resort session-level fallback while restart is gated, try `/new` once (fresh session within the same gateway process, may pick up freshly-bound tools without a full restart).
+
+   **Forbidden vocabulary** (these are anti-patterns — they show up to the user even if your transport edits them later, and they violate the silence rule):
+   - "Let me check that…"
+   - "Plugin loaded. Let me verify…"
+   - "I'll now…"
+   - "Quick fix…"
+   - "However, I don't see…"
+   - "I need to use…"
+   - "Should I /restart" / "Do you have a public URL" / "Want me to restart" / "Let me check if the tool is bound" / "I need permission to restart"
+   - "Now installing…" / "Got it" / "In parallel…" / "Step 1a/1b/1c"
+
+   Substitute all of these with silence — the next user-visible line in the set, or nothing.
 
 3. **Verify `totalreclaw_pair` is bound.** If still missing after `/restart` (or after the user fixed allowFrom and said `done`), tell them the restart didn't take effect and ask them to retry. Do not loop the install.
 
-4. **Check for existing credentials.** Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, confirm *"TotalReclaw is already set up."* and stop.
+4. **Check for existing credentials (silent unless found).** Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, emit *"✓ TotalReclaw is already set up."* and stop.
 
-5. **Set up the user's TotalReclaw account.** Tell the user: *"I'll walk you through setting up your TotalReclaw account."* Then call `totalreclaw_pair` (the account-setup tool — name kept for backward compatibility). Returns `{url, pin, qr_ascii, qr_png_b64, qr_unicode, expires_at_ms}` (see "Rendering the QR" below). Relay verbatim:
-   > *Open <url> in your browser. Generate a new 12-word recovery phrase there or paste an existing one — the phrase stays in your browser, the relay only sees ciphertext. Confirm PIN <pin>. Reply `done` once the page says it's sealed.*
+5. **Set up the user's TotalReclaw account (emit user-visible line 5 once, after `totalreclaw_pair` returns).** Call `totalreclaw_pair` silently (the account-setup tool — name kept for backward compatibility). It returns `{url, pin, qr_ascii, qr_png_b64, qr_unicode, expires_at_ms}` (see "Rendering the QR" below). Then emit user-visible line 5 with `<url>` and `<pin>` substituted. Do not pre-narrate ("I'll walk you through…", "Setting up your account now…") — line 5 itself is the only thing the user needs to see. The URL + PIN itself is the real consent moment: surfacing them verbatim is what gives the user the chance to opt out by simply not opening the page.
 
-6. **Verify and confirm.** After user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN expired — call `totalreclaw_pair` again and resend. If present, confirm *"Your TotalReclaw account is set up. Ask me to remember or recall anything."*
+6. **Verify and confirm (silent until line 6).** After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN expired — call `totalreclaw_pair` again silently and resend line 5 once. If present, emit user-visible line 6 and stop.
 
 ## Rendering the QR on your transport (rc.5+)
 

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.4-rc.2",
+  "version": "3.3.5-rc.1",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "3.3.4-rc.2",
+  "version": "3.3.5-rc.1",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Plugin-only UX bundle off Pedro's 2026-05-01 QA on 3.3.4-rc.2. Three issues addressed:

1. **Drop the yes/no consent gate before pair setup.** Pedro's verbatim feedback: *"do I really need to say 'yes' to continue to the pairing/setup phase? […] if not, move on immediately to the next step"*. The gate was added in PR #160's safety-tone rewrite to give safety-trained LLMs explicit consent before account creation, but the user already consents by pasting "Install TotalReclaw" + the canonical URL, and the URL+PIN handed back from `totalreclaw_pair` is the real consent moment. The extra gate was friction for zero security benefit. Removed from `skill/plugin/SKILL.md`, `skill/SKILL.md`, and `docs/guides/openclaw-setup.md`. Hermes guide retains its own gate — that lives in a separate Hermes RC and is out of scope here.
2. **Tighten silence rules to suppress chat-channel mid-edit churn.** Pedro: *"I see a bunch of temporary commands on my telegram conversation which then seem to be deleted/edited by the bot as it progresses, but it looks awful and confusing to the user."* Added a top-level rule at the start of SKILL.md: "Emit ONLY the user-visible lines. Do not narrate tool calls. Do not describe what you're doing or about to do. Errors are the only allowed deviation, and only as a single tight line." Strengthened the forbidden-vocabulary deny-list with the exact patterns Pedro saw today: "Let me check that…", "Plugin loaded. Let me verify…", "I'll now…", "Quick fix…", "However, I don't see…", "I need to use…". Re-stated the canonical user-visible line set as **5–6 lines TOTAL** for the entire install + setup.
3. **Strengthen `/restart` instructions.** Pedro's agent again said "I need permission to restart" instead of issuing the slash command — same anti-pattern that PR #163 / #173 / #174 keep failing to suppress. Made the SKILL.md instruction more imperative and concrete: "Your IMMEDIATE next message must be the literal slash command `/restart` — nothing else. Do not narrate. Do not ask permission. Do not describe what /restart does. Do not propose alternatives. Just send /restart." Same imperative mirrored in `docs/guides/openclaw-setup.md`.

Version bumped to 3.3.5-rc.1 via `sync-version` (package.json, SKILL.md frontmatter, skill.json all aligned).

### Files touched (plugin only)

- `skill/plugin/SKILL.md` — top-level emit-only rule, line set, deny-list, restart imperative
- `skill/plugin/package.json` — version 3.3.4-rc.2 → 3.3.5-rc.1
- `skill/plugin/skill.json` — version sync
- `skill/plugin/CHANGELOG.md` — 3.3.5-rc.1 entry
- `skill/SKILL.md` — wrapping skill manifest, mirror silence rules + drop yes-gate
- `docs/guides/openclaw-setup.md` — agent-instructions section, drop yes-gate, restart imperative, forbidden-vocabulary deny-list, troubleshooting bullet for the new patterns

`python/` (Hermes), `src/routes/` (relay), and `docs/guides/hermes-setup.md` deliberately untouched.

## Test plan

Local guards (all green):

- [x] `npm run check-scanner` — 119 files scanned, 0 flags
- [x] `npm run check-version-drift` — all three sites = 3.3.5-rc.1
- [x] `npm run check-url-binding` (rc mode) — 7 staging hits, 0 production hits in dist/
- [x] `npm test` — full staged gauntlet passing (44 + 9 + 9 + 8 across the suite)
- [x] `npx tsx terminology-parity.test.ts` — 50 files scanned, 0 user-facing hits
- [x] `bash scripts/check-phrase-safety.sh` — 73 artifacts clean

Post-merge:

- [ ] Dispatch `publish-npm.yml` with `release-type=rc` and `rc-number=1` (cuts 3.3.5-rc.1 on the `rc` dist-tag)
- [ ] Auto-QA on staging via `qa-totalreclaw` simulating natural-language Telegram chat (focus: confirm 5–6 line transcript, no edit churn, agent issues `/restart` autonomously without permission-asking, no yes/no gate before pair URL)

Do NOT auto-merge. Do NOT push tracker updates from this PR — that happens on the publish-rc dispatch event per the release-pipeline tracker rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)