### PR TITLE
fix(hermes): 2.3.5-rc.1 — drop yes-gate + tighten silence rules + strengthen /restart imperative

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -26,7 +26,7 @@ This guide is the playbook your agent follows; you can read along to see what ea
 
 ## Agent instructions (read this if you are a Hermes agent that just fetched this URL)
 
-You have been asked to install TotalReclaw. **Run all install / verify steps silently** except for the user-visible lines explicitly listed below — those are the ONLY things you should write in chat. Tool calls happen; narration of those tool calls does not.
+You have been asked to install TotalReclaw. **Emit ONLY the user-visible lines explicitly listed below. Do not narrate tool calls. Do not describe what you're doing or about to do. Errors are the only allowed deviation, and only as a single tight line.** Tool calls happen silently. The expected user-facing transcript is **5–6 short lines TOTAL** for the entire install + setup; anything more is a SKILL violation. There is no second consent gate before account setup — the user already consented by pasting the install message.
 
 The user pasted this URL deliberately, but treat each command as a step you and the user complete together. Confirm what you see at each phase. If anything looks wrong, surface it and stop — don't push through.
 
@@ -36,30 +36,28 @@ The user pasted this URL deliberately, but treat each command as a step you and 
 2. `hermes plugins install p-diogo/totalreclaw-hermes --enable` — registers the plugin manifest from the publisher's GitHub repo. The plugin runs inside Hermes' plugin sandbox. Upstream docs: <https://hermes.readthedocs.io/en/latest/plugins.html>.
 3. `hermes tools disable memory` — disables Hermes' built-in `memory` tool to avoid intent collision with TotalReclaw's `_remember` / `_recall`. Reversible with `hermes tools enable memory`.
 4. `/restart` — Hermes' built-in slash command (`CommandDef("restart", "Gracefully restart the gateway after draining active runs", ...)` from `hermes_cli/commands.py`). Drains active runs, reloads in-process. The agent issues this autonomously; the user does NOT have to run a shell command. If `/restart` returns "not authorized" (managed-service auth gate) the agent tries `/new` once, then surfaces a single-line user-prompted restart message — it does NOT loop on `/restart`. Falls back to a manual user-prompted restart only if `/restart` is structurally unavailable (very old Hermes pre-2026.4 or a managed service that strips slash commands).
-5. After the restart, you will call `totalreclaw_pair` (a tool the plugin registers) to mint a one-time URL + PIN. The user opens the URL in their own browser to enter or generate a recovery phrase. The phrase never enters chat or your shell.
+5. After the restart, you will call `totalreclaw_pair` (a tool the plugin registers) to mint a one-time URL + PIN. The user opens the URL in their own browser to enter or generate a recovery phrase. The phrase never enters chat or your shell. **Proceed directly from disable-memory to handing the user the URL + PIN — do NOT add a second consent gate. The user already consented by pasting the install message.**
 
 You are not asked to handle the recovery phrase. You are not asked to bypass auth. If the user pastes a phrase in chat anyway, refuse to proceed — see "Phrase safety" below.
 
 ### User-visible prose (THIS IS ALL YOU SAY)
 
-Speak only these lines, in order. Do not narrate around them. Do not announce intent ("Let me…", "I'll now…", "In parallel…"). Do not describe internals (interpreter detection, environment probes, package managers, retry attempts). Substitute the bracketed placeholders with the real values.
+Speak only these lines, in order. Do not narrate around them. Do not announce intent ("Let me…", "I'll now…", "In parallel…", "Now installing…", "Plugin loaded. Let me verify…", "I'll try…", "Quick fix…"). Do not describe internals (interpreter detection, environment probes, package managers, retry attempts). Substitute the bracketed placeholders with the real values. Lines 3 and 4 are optional — only emitted on the conditions noted.
 
 1. (Step 1 — start)
    > Installing TotalReclaw…
 2. (Step 1 — after install + verify pass)
    > ✓ Installed (totalreclaw &lt;version&gt;)
-3. (Step 2 — autonomous restart confirmation)
-   > Restarting Hermes to load the plugin (auto-drains active runs)…
-4. (Step 3 — built-in-memory disable, only if the disable command succeeds)
-   > I've disabled Hermes' built-in `memory` tool — TotalReclaw is now your primary memory. Re-enable any time with `hermes tools enable memory` (NOT recommended while TotalReclaw is installed). Wipe orphaned MEMORY.md / USER.md files with `hermes memory reset`.
-5. (Step 5a — explicit consent before account creation)
-   > Ready to set up your TotalReclaw account on `api-staging.totalreclaw.xyz` (free tier). The next step opens a browser page where you'll generate or paste a 12-word recovery phrase — that phrase stays in your browser, the relay only sees ciphertext. Reply `yes` to continue, or `no` to stop here.
-6. (Step 5b — account setup, after the user confirms)
-   > Open &lt;url&gt; in your browser. Generate a new 12-word recovery phrase there or paste an existing one. Confirm PIN &lt;pin&gt;. Reply `done` once the page says it's sealed.
-7. (Step 6 — done + free-tier confirmation)
-   > ✓ You're set up on the TotalReclaw **free tier**: 500 memories per month, unlimited reads + searches, encrypted at rest on Base Sepolia testnet (testnet may reset; for permanent storage on Gnosis mainnet see <https://totalreclaw.xyz/pricing>). Check usage anytime by asking *"what's my TotalReclaw status?"* (calls `totalreclaw_status`). I'll warn you automatically if you cross 80% of the monthly limit. Ask me to remember or recall anything.
+3. (optional, only on auto-restart fail / when the agent had to issue `/restart`)
+   > Restarting Hermes to load the plugin…
+4. (optional, only if `hermes tools disable memory` succeeded)
+   > Disabled Hermes' built-in `memory` tool — TotalReclaw is now your primary memory.
+5. (Step 5 — account setup; emit immediately after disable-memory, no consent gate)
+   > Open &lt;url&gt; in your browser. Enter PIN &lt;pin&gt;. Generate or paste a 12-word recovery phrase. Reply `done` once it's sealed.
+6. (Step 6 — done + free-tier confirmation)
+   > ✓ You're set up on the TotalReclaw free tier — 500 memories/month, unlimited reads. <https://totalreclaw.xyz/pricing>. Ask me to remember anything.
 
-That is the complete user-facing transcript for a healthy install. Expected line count for a fresh install + setup is **6–7 lines** (line 3 collapses to a one-line confirmation if the gateway already auto-reloaded; line 4 is skipped silently when the disable command isn't available; line 6 may repeat once if the PIN expires).
+That is the complete user-facing transcript for a healthy install. Expected line count for a fresh install + setup is **5–6 lines TOTAL** (line 3 is skipped silently when the gateway auto-reloads on plugin install; line 4 is skipped silently when the disable command isn't available; line 5 may repeat once if the PIN expires). 5–6 lines max. No filler.
 
 ### When to break silence (errors only)
 
@@ -73,7 +71,14 @@ Do NOT pre-narrate diagnostics that succeed. Do NOT narrate retries that succeed
 
 ### Forbidden vocabulary in agent prose
 
-Unless the user explicitly asks how the install works, the following words must not appear in your chat output during install + setup: `Python`, `interpreter`, `venv`, `virtual environment`, `pip`, `ensurepip`, `bootstrap`, `find`, `lookup`, `detect`, `probing`, `let me try`, `in parallel`, `got it`, `now installing`, `Step 1a/1b/1c`. These are tool-call mechanics, not user-facing prose.
+Unless the user explicitly asks how the install works, the following words / phrases must not appear in your chat output during install + setup: `Python`, `interpreter`, `venv`, `virtual environment`, `pip`, `ensurepip`, `bootstrap`, `find`, `lookup`, `detect`, `probing`, `let me try`, `in parallel`, `got it`, `now installing`, `Step 1a/1b/1c`. Also forbidden — narration patterns Pedro saw in 2026-05-01 QA Telegram transcripts:
+
+- "Let me check that…" / "Let me check if…" / "Let me verify…" / "Let me try…"
+- "Now installing…" / "Plugin loaded. Let me verify…" / "I'll try…"
+- "Quick fix…" / "One sec…" / "Got it, doing X…"
+- Any "I'm going to do X" / "About to do X" pre-narration of a tool call
+
+These are tool-call mechanics, not user-facing prose. The Telegram bot edit-and-delete behavior makes interim "doing X…" lines look broken to the user even when they get edited away.
 
 If the user explicitly asks ("what's it doing?", "why so quiet?", "show me the commands"), then narrate freely.
 
@@ -140,19 +145,24 @@ If `pip show` reports the package, capture the version string and emit user-visi
 
 ### Step 2 — Restart the gateway autonomously via `/restart`
 
-Hermes does NOT auto-reload on plugin install — you have to restart. The fastest, safest path is Hermes' built-in `/restart` slash command (registered in `hermes_cli/commands.py:162` as `CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session", ...)`). It drains in-flight runs, reloads the plugin layer, and is in-process — works from inside the gateway because it doesn't shell out. Issue it yourself **autonomously** (do NOT ask the user "should I /restart?" — see the deny-list below); emit user-visible line 3 (`Restarting Hermes to load the plugin (auto-drains active runs)…`) as the single confirmation. Wait for Hermes to come back; resume at Step 3.
+Hermes does NOT auto-reload on plugin install — you have to restart. The fastest, safest path is Hermes' built-in `/restart` slash command (registered in `hermes_cli/commands.py:162` as `CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session", ...)`). It drains in-flight runs, reloads the plugin layer, and is in-process — works from inside the gateway because it doesn't shell out.
 
-**`/restart` returned "not authorized" / "command not found" / refused (2.3.4-rc.1 hardening):** managed Hermes deployments may gate session-scope slash commands behind a role / RBAC layer. Do NOT loop on `/restart` after an unauthorized response — the gate isn't going to flip mid-session and the loop just spams. Try `/new` once instead — `/new` opens a fresh session within the same gateway and may pick up freshly-bound tools without requiring a full reload. If `/new` also returns "not authorized", break silence with one line surfacing the restart-yourself instruction:
+**When tools are missing post-install, your IMMEDIATE next message must be the literal slash command `/restart` — nothing else. Do not narrate. Do not ask permission. Do not describe what /restart does. Just send `/restart`.** After Hermes returns, emit user-visible line 3 (`Restarting Hermes to load the plugin…`) as the single confirmation. Resume at Step 3.
 
-> *"Your Hermes deployment doesn't expose `/restart` to me (managed-service auth gate or shell-restricted environment). Please restart the gateway yourself — `hermes gateway restart` (native), `docker restart <your-hermes-container>` (Docker self-host — `docker ps` shows the name), or your service's restart control. Reply `done` once it's back up."*
+**If `/restart` returns "You are not authorized to use this command" / "command not found" / refused (2.3.4-rc.1 hardening, strengthened in 2.3.5-rc.1):** managed Hermes deployments may gate session-scope slash commands behind a role / RBAC layer. Surface this verbatim as a single tight user-visible line:
 
-Wait for `done`, then resume.
+> *"Your Hermes deployment doesn't expose `/restart` to me. Run on your host: `hermes gateway restart` (native) OR `docker restart <your-hermes-container>` (Docker self-host — `docker ps` shows the name). Reply `done` after."*
 
-**Anti-pattern phrases that the agent must NEVER write in chat at this step** (deny-list — 2.3.4-rc.1):
+Then wait for `done`. **Do NOT loop /restart calls.** Do NOT try `/restart` again after an unauthorized response — the gate isn't going to flip mid-session and the loop just spams the user. (Optional preceding hop: try `/new` once — `/new` opens a fresh session within the same gateway and may pick up freshly-bound tools without a reload. Skip straight to the user-prompted line if `/new` is unavailable.)
+
+**Anti-pattern phrases that the agent must NEVER write in chat at this step** (deny-list — 2.3.4-rc.1, strengthened in 2.3.5-rc.1):
 
 - "Should I /restart?" / "Want me to restart?" / "Do you want me to restart?"
+- "I need permission to /restart" / "Do you authorize /restart?" / "Confirming before I /restart…"
 - "Do you have a public URL?" / "Can you give me a URL?" (no URL is needed at restart-time)
 - "Let me check if the tool is bound." / "Let me verify…" (verification is a silent shell call, not a chat line)
+- "Is it OK if I restart?" / "I'll /restart now if that's OK"
+- Describing what `/restart` does ("This will drain runs and reload…") — just send the slash command
 
 The correct pattern is: issue `/restart` immediately, emit user-visible line 3, then move on.
 
@@ -175,25 +185,25 @@ Run via your shell tool (silent):
 hermes tools disable memory
 ```
 
-If the command succeeds, emit user-visible line 4 (the built-in-memory disable confirmation). If it errors with `command not found` or "tool not found" (older Hermes versions, managed services that don't expose the CLI, or the built-in `memory` tool was already removed), skip line 4 silently and continue — the rc.25 tool-description bias still steers the LLM toward `totalreclaw_remember` as a fallback. Do not surface the disable failure to the user.
+If the command succeeds, emit user-visible line 4 (the built-in-memory disable confirmation — `Disabled Hermes' built-in `memory` tool — TotalReclaw is now your primary memory.`). The shipped line is intentionally short to fit the 5–6-line transcript budget. The longer disabled Hermes' built-in `memory` tool warning text — re-enable instructions (`hermes tools enable memory`, NOT recommended while TotalReclaw is installed) and orphaned-file cleanup (`hermes memory reset` for stale MEMORY.md / USER.md) — is documented in the Compatibility section near the bottom of this guide; the agent does not need to recite that in chat. If it errors with `command not found` or "tool not found" (older Hermes versions, managed services that don't expose the CLI, or the built-in `memory` tool was already removed), skip line 4 silently and continue — the rc.25 tool-description bias still steers the LLM toward `totalreclaw_remember` as a fallback. Do not surface the disable failure to the user.
 
 ### Step 4 — Check for existing credentials (silent)
 
 Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, emit `✓ TotalReclaw is already set up.` and stop. Otherwise continue silently.
 
-### Step 5 — Pair (account setup — browser flow, NEVER ask the user to type their phrase in chat) (emit user-visible lines 5 + 6)
+### Step 5 — Pair (account setup — browser flow, NEVER ask the user to type their phrase in chat) (emit user-visible line 5)
 
 > *(Heading retains "Pair" for backward compatibility with the QA harness; the user-facing terminology is "set up your TotalReclaw account". The tool registered as `totalreclaw_pair` is the account-setup tool.)*
 
-**Step 5a — Ask for explicit consent first (emit user-visible line 5).** Account setup will create a new TotalReclaw account on `api-staging.totalreclaw.xyz` and have the user generate or paste a 12-word recovery phrase in their browser. Emit user-visible line 5 verbatim. Wait for the user's `yes` (or any clear affirmative). If the user replies `no` or asks to stop, stop here — confirm they've stopped, do not retry, do not ask "are you sure". Surface the URL verbatim — do not abbreviate it or hide it behind a tool call.
+No second consent prompt — the user already consented by pasting the install message. Proceed directly from Step 4 (no credentials yet) to handing them the pair URL + PIN as a single user-visible line.
 
-**Step 5b — Daemon-mode preflight, then call the tool (emit user-visible line 6).** Before calling the tool, check whether you are running inside a one-shot agent process (e.g. `hermes chat -q "..."`, single-prompt CLI). If so, break silence and surface the [account-setup-requires-daemon-mode caveat](#account-setup-requires-daemon-mode) to the user verbatim and ask them to switch to daemon / interactive mode before continuing — the WebSocket session this step opens will die before the user can finish entering their phrase otherwise.
+**Daemon-mode preflight before calling the tool.** Before calling the tool, check whether you are running inside a one-shot agent process (e.g. `hermes chat -q "..."`, single-prompt CLI). If so, break silence and surface the [account-setup-requires-daemon-mode caveat](#account-setup-requires-daemon-mode) to the user verbatim and ask them to switch to daemon / interactive mode before continuing — the WebSocket session this step opens will die before the user can finish entering their phrase otherwise.
 
-Call the `totalreclaw_pair` tool silently (the account-setup tool — name kept for backward compatibility). It returns `{url, pin, expires_at_ms}`. Then emit user-visible line 6 with `<url>` and `<pin>` substituted. Do not pre-narrate ("I'll walk you through…", "Setting up your account now…") — line 6 itself is the only thing the user needs to see.
+Call the `totalreclaw_pair` tool silently (the account-setup tool — name kept for backward compatibility). It returns `{url, pin, expires_at_ms}`. Then emit user-visible line 5 with `<url>` and `<pin>` substituted. Do not pre-narrate ("I'll walk you through…", "Setting up your account now…", "Let me generate the URL…") — line 5 itself is the only thing the user needs to see.
 
-### Step 6 — Verify and confirm (silent until line 7)
+### Step 6 — Verify and confirm (silent until line 6)
 
-After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN likely expired — call `totalreclaw_pair` again and resend line 6 once. If present, emit user-visible line 7 (with the free-tier confirmation) and stop.
+After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN likely expired — call `totalreclaw_pair` again and resend line 5 once. If present, emit user-visible line 6 (with the free-tier confirmation) and stop.
 
 ### Phrase safety (HARD — never break)
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,117 @@ Hermes Agent plugin are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.5rc1] — 2026-05-01
+
+Coordinated bundle with plugin `3.3.5-rc.1`. SKILL.md UX hardening pass —
+no Python runtime / API changes. The 2.3.4-rc.1 `/restart` autonomy +
+unauthorized fallback (PR #172) and the install-ordering fix carry over
+unchanged.
+
+Pedro QA on 2026-05-01 (Telegram-channel Hermes deployment) surfaced
+three UX issues with the install + setup transcript that mirror the
+plugin-side findings.
+
+### Drop the explicit-consent gate before account setup (Fix 1)
+
+User feedback verbatim: *"do I really need to say 'yes' to continue
+to the pairing/setup phase?"* The `yes/no` consent prompt was added
+in PR #160 / inherited via PR #172 hardening for safety-trained-LLM
+compliance. It is now redundant: the user has already consented by
+pasting *"Install TotalReclaw, see <URL>"* — that IS the consent.
+Adding a second gate adds friction without security value.
+
+`SKILL.md` and `docs/guides/hermes-setup.md` Step 5 / Step 6:
+
+- Removed the consent prompt + verbatim *"Reply `yes` to continue,
+  or `no` to stop here"* line.
+- Removed Step 5a / Step 6a / Step 5b / Step 6b sub-steps; Step 5
+  is now a single step that hands the user the URL + PIN
+  immediately after disable-memory.
+- Updated the agent-instructions overview to call out *"Proceed
+  directly from disable-memory to handing the user the URL + PIN
+  — do NOT add a second consent gate."*
+- Updated provenance preamble: *"The user already consented by
+  pasting the install message; do NOT add a second consent gate
+  before account setup."*
+
+### Tighten silence rules with new forbidden phrases (Fix 2)
+
+User feedback: *"I see a bunch of temporary commands on my Telegram
+conversation which then seem to be deleted/edited by the bot as it
+progresses, but it looks awful and confusing"*. Telegram bots edit
+or delete interim messages mid-tool-call — *"Now installing…"*,
+*"Plugin loaded. Let me verify…"*, *"I'll try…"* — and the
+edit/delete dance looks broken even when the final state is correct.
+
+`SKILL.md` and `docs/guides/hermes-setup.md`:
+
+- New top-level rule in the silence-rules preamble: *"Emit ONLY the
+  user-visible lines listed below. Do not narrate tool calls. Do
+  not describe what you're doing or about to do. Errors are the
+  only allowed deviation, and only as a single tight line."*
+- Forbidden-vocabulary deny-list extended with the exact phrases
+  Pedro saw in his 2026-05-01 Telegram transcripts: *"Let me check
+  that…"*, *"Now installing…"*, *"Plugin loaded. Let me verify…"*,
+  *"I'll try…"*, *"Quick fix…"*, *"One sec…"*, *"Got it, doing X…"*,
+  any *"I'm going to do X"* / *"About to do X"* pre-narration.
+- Expected line count for a healthy install + setup explicitly
+  reduced from **6–7 lines** (rc.4) to **5–6 lines TOTAL** —
+  anything more is now framed as a SKILL violation.
+
+### Strengthen `/restart` imperative (Fix 3)
+
+User feedback: even with rc.4's `/restart` autonomy hardening, the
+agent in Pedro's QA still asked *"should I /restart"* / *"I need
+permission"* before issuing the slash command. The 2.3.4-rc.1
+deny-list was good but the positive rule was soft.
+
+`SKILL.md` and `docs/guides/hermes-setup.md` Step 2:
+
+- Restated as an explicit imperative: *"When tools are missing
+  post-install, your IMMEDIATE next message must be the literal
+  slash command `/restart` — nothing else. Do not narrate. Do
+  not ask permission. Do not describe what /restart does. Just
+  send `/restart`."*
+- Deny-list extended with: *"I need permission to /restart"*,
+  *"Do you authorize /restart?"*, *"Confirming before I /restart…"*,
+  *"Is it OK if I restart?"*, *"I'll /restart now if that's OK"*,
+  and any prose describing what `/restart` does ("This will drain
+  runs and reload…") — just send the slash command.
+- Unauthorized-response handling restated as a single tight line
+  surfacing the underlying gate verbatim, then *"Do NOT loop
+  /restart calls."* The `/new` retry is now framed as an optional
+  preceding hop, not a mandatory one — some managed deployments
+  strip both.
+
+### Test coverage
+
+- `python/tests/test_skill_md_includes_disable_memory_step.py`
+  continues to pass — the rc.26 disable-memory step is preserved.
+- `python/tests/test_skill_md_restart_hardening_2_3_4.py` continues
+  to pass — the deny-list section heading, *"Should I /restart"*
+  literal, *"Do you have a public URL"* literal, *"Let me check if
+  the tool is bound"* literal, install-ordering Python-first
+  contract, and user-guide mirror are all preserved (this PR adds
+  to the deny-list, doesn't remove from it).
+- No test pinned the *"Reply `yes` to continue"* substring or the
+  Step 5a / 5b / 6a / 6b sub-step labels, so removing them does
+  not break any existing pin.
+
+### Out of scope
+
+- No PyPI publish here — this PR opens for review only. Pedro QAs
+  2.3.5-rc.1 alongside plugin 3.3.5-rc.1; PyPI publish goes through
+  `publish-python-client.yml` once the bundle is GO.
+- TS plugin (`skill/`), `npm-publish.yml`, `publish-clawhub.yml`,
+  Hermes Dockerfile (`tools/qa-stack/hermes/` in the internal repo)
+  are owned by the parallel plugin agent / cross-repo follow-ups
+  — untouched here.
+- Phrase-safety invariant: untouched. Dropping the `yes/no` consent
+  gate does NOT relax the recovery-phrase isolation contract — the
+  phrase still never crosses LLM context. Browser-side crypto and
+  the `totalreclaw_pair` account-setup tool are unchanged.
+
 ## [2.3.4rc1] — 2026-04-30
 
 Coordinated bundle with plugin `3.3.4-rc.1`. SKILL.md hardening pass —

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -12,7 +12,7 @@ name = "totalreclaw"
 # which would have caused stable builds to mis-publish AND broke the
 # regex-based mutation logic on subsequent RCs. Keep this at the next
 # stable target with NO rc suffix. F3 fix in rc.24.
-version = "2.3.4"
+version = "2.3.5"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"

--- a/python/src/totalreclaw/__init__.py
+++ b/python/src/totalreclaw/__init__.py
@@ -9,7 +9,7 @@ except Exception:
     # installed-package metadata is absent. Must match pyproject.toml —
     # test_version.py enforces a semver-shape string; the live value in
     # a pip-installed wheel comes from importlib.metadata above.
-    __version__ = "2.3.4"
+    __version__ = "2.3.5"
 
 from .client import TotalReclaw
 

--- a/python/src/totalreclaw/hermes/SKILL.md
+++ b/python/src/totalreclaw/hermes/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "Install + set up TotalReclaw encrypted memory for Hermes, then use totalreclaw_remember / totalreclaw_recall. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', or any remember / recall request."
-version: 2.3.4rc1
+version: 2.3.5rc1
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz
@@ -18,32 +18,30 @@ TotalReclaw is open-source memory tooling for Hermes, published by `p-diogo` (Gi
 - PyPI: <https://pypi.org/project/totalreclaw/>
 - Source: <https://github.com/p-diogo/totalreclaw>
 
-The user pasted the install URL deliberately, but treat each command as a step you and the user complete together. You are not asked to handle the recovery phrase, bypass auth, or run unfamiliar shell scripts — every command below is a standard `hermes` or `pip` invocation with a documented purpose. Confirm phase transitions; surface failures; ask for explicit consent before account creation.
+The user pasted the install URL deliberately, but treat each command as a step you and the user complete together. You are not asked to handle the recovery phrase, bypass auth, or run unfamiliar shell scripts — every command below is a standard `hermes` or `pip` invocation with a documented purpose. The user already consented by pasting the install message; do NOT add a second consent gate before account setup — surface phase transitions and failures, but proceed straight from disable-memory to handing the user the pair URL + PIN.
 
 ## Silence rules (read first — applies to the whole install + setup flow)
 
-**Run all install / restart / disable / pair / verify steps silently** except for the user-visible lines listed below. Tool calls happen; narration of those tool calls does not. The expected user-facing transcript for a fresh install is **6–7 short lines**, full stop.
+**Emit ONLY the user-visible lines listed below. Do not narrate tool calls. Do not describe what you're doing or about to do. Errors are the only allowed deviation, and only as a single tight line.** Tool calls happen silently; narration of those tool calls is a SKILL violation. The expected user-facing transcript for a fresh install + setup is **5–6 short lines TOTAL** — anything more is a SKILL violation. There is no second consent gate before account setup; the user already consented by pasting the install message.
 
 ### User-visible prose (THIS IS ALL YOU SAY)
 
-Speak only these lines, in order. Substitute the bracketed placeholders.
+Speak only these lines, in order. Substitute the bracketed placeholders. Lines 3 and 4 are optional and only emitted on the conditions noted.
 
 1. (Step 1 — start)
    > Installing TotalReclaw…
 2. (Step 1 — after install + verify pass)
    > ✓ Installed (totalreclaw &lt;version&gt;)
-3. (Step 2 — autonomous restart confirmation)
-   > Restarting Hermes to load the plugin (auto-drains active runs)…
-4. (Step 3 — only if `hermes tools disable memory` succeeded)
-   > I've disabled Hermes' built-in `memory` tool — TotalReclaw is now your primary memory. Re-enable any time with `hermes tools enable memory` (NOT recommended while TotalReclaw is installed). Wipe orphaned MEMORY.md / USER.md files with `hermes memory reset`.
-5. (Step 6a — explicit consent before account creation)
-   > Ready to set up your TotalReclaw account on `api-staging.totalreclaw.xyz` (free tier). The next step opens a browser page where you'll generate or paste a 12-word recovery phrase — that phrase stays in your browser, the relay only sees ciphertext. Reply `yes` to continue, or `no` to stop here.
-6. (Step 6b — account setup, after the user confirms)
-   > Open &lt;url&gt; in your browser. Generate a new 12-word recovery phrase there or paste an existing one. Confirm PIN &lt;pin&gt;. Reply `done` once the page says it's sealed.
-7. (Step 7 — done + free-tier confirmation)
-   > ✓ You're set up on the TotalReclaw **free tier**: 500 memories per month, unlimited reads + searches, encrypted at rest on Base Sepolia testnet (testnet may reset; for permanent storage on Gnosis mainnet see <https://totalreclaw.xyz/pricing>). Check usage anytime by asking *"what's my TotalReclaw status?"* (calls `totalreclaw_status`). I'll warn you automatically if you cross 80% of the monthly limit. Ask me to remember or recall anything.
+3. (optional, only if the agent had to issue `/restart` because tools didn't auto-bind)
+   > Restarting Hermes to load the plugin…
+4. (optional, only if `hermes tools disable memory` succeeded)
+   > Disabled Hermes' built-in `memory` tool — TotalReclaw is now your primary memory.
+5. (Step 5 — account setup; emit immediately after disable-memory, no consent gate)
+   > Open &lt;url&gt; in your browser. Enter PIN &lt;pin&gt;. Generate or paste a 12-word recovery phrase. Reply `done` once it's sealed.
+6. (Step 6 — done + free-tier confirmation)
+   > ✓ You're set up on the TotalReclaw free tier — 500 memories/month, unlimited reads. <https://totalreclaw.xyz/pricing>. Ask me to remember anything.
 
-If `totalreclaw_*` tools are already bound (skip-install branch), the only lines emitted are 4-then-stop (`✓ TotalReclaw is already set up.` from Step 5) OR lines 5+6+7 (skip-to-account-setup branch).
+If `totalreclaw_*` tools are already bound (skip-install branch), the only lines emitted are `✓ TotalReclaw is already set up.` (skip-to-stop) OR lines 5+6 (skip-to-account-setup branch). 5–6 lines max for a fresh install. No filler.
 
 ### Errors break silence — but tightly
 
@@ -51,18 +49,27 @@ If a step actually fails, surface a one-line error + the action being taken. Exa
 
 ### Forbidden vocabulary in agent prose
 
-Do not write these words in chat during install + setup unless the user explicitly asks how the install works: `Python`, `interpreter`, `venv`, `virtual environment`, `pip`, `ensurepip`, `bootstrap`, `find`, `lookup`, `detect`, `probing`, `let me try`, `in parallel`, `got it`, `now installing`, `Step 1a/1b/1c`. These are tool-call mechanics, not user-facing prose. If the user asks ("what's it doing?", "show me the commands"), narrate freely — the silence rule only governs the default install path.
+Do not write these words / phrases in chat during install + setup unless the user explicitly asks how the install works: `Python`, `interpreter`, `venv`, `virtual environment`, `pip`, `ensurepip`, `bootstrap`, `find`, `lookup`, `detect`, `probing`, `let me try`, `in parallel`, `got it`, `now installing`, `Step 1a/1b/1c`. Also forbidden — narration patterns Pedro saw in 2026-05-01 QA Telegram transcripts:
 
-### Forbidden phrases when tools fail to bind (deny-list — 2.3.4-rc.1)
+- "Let me check that…" / "Let me check if…" / "Let me verify…" / "Let me try…"
+- "Now installing…" / "Plugin loaded. Let me verify…" / "I'll try…"
+- "Quick fix…" / "One sec…" / "Got it, doing X…"
+- Any "I'm going to do X" / "About to do X" pre-narration of a tool call
+
+These are tool-call mechanics, not user-facing prose. The Telegram bot edit-and-delete behavior makes interim "doing X…" lines look broken to the user even when they get edited away. If the user asks ("what's it doing?", "show me the commands"), narrate freely — the silence rule only governs the default install path.
+
+### Forbidden phrases when tools fail to bind (deny-list — 2.3.4-rc.1, strengthened in 2.3.5-rc.1)
 
 When `totalreclaw_*` tools are missing post-install, you MUST issue `/restart` (or `/new` as fallback) **autonomously** and announce the action — never ask the user to authorize it, never stall, never hedge. The following phrases are anti-patterns and MUST NOT appear in chat in that situation:
 
 - "Should I /restart?" / "Should I issue /restart?" / "Want me to restart?" / "Do you want me to restart?"
+- "I need permission to /restart" / "Do you authorize /restart?" / "Confirming before I /restart…"
 - "Do you have a public URL?" / "Can you give me a URL?" (the install is local; no URL is needed at restart-time)
 - "Let me check if the tool is bound." / "Let me verify…" (verification is a silent shell call, not a chat line)
-- "Is it OK if I restart?" / "Confirming before I restart…"
+- "Is it OK if I restart?" / "I'll /restart now if that's OK"
+- Describing what `/restart` does ("This will drain runs and reload…") — just send the slash command
 
-The correct pattern is to issue `/restart` immediately and emit user-visible line 3 (the autonomous restart confirmation) as the single chat line. Step 2 of the setup flow is explicit about this — re-read it if you find yourself drafting any of the phrases above.
+The correct pattern is to issue `/restart` immediately and emit user-visible line 3 (`Restarting Hermes to load the plugin…`) as the single chat line. Step 2 of the setup flow is explicit about this — re-read it if you find yourself drafting any of the phrases above.
 
 ## Setup flow
 
@@ -97,11 +104,15 @@ If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jum
    - `pip: command not found` / `No module named pip` (Hermes container shipped without pip): bootstrap silently with `"$HERMES_PYTHON" -m ensurepip --upgrade`, then retry 1b.
    - `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment): break silence and tell the user verbatim *"Your environment doesn't expose the Hermes CLI to me. Please install `p-diogo/totalreclaw-hermes` and the `totalreclaw` Python package via your service's plugins UI, then reply `done`. Also disable Hermes' built-in `memory` tool in the same UI if available — running both creates a silent intent-stealing bug."* Wait for `done` and skip to step 4 (verify account-setup tool bound).
 
-2. **Restart the gateway autonomously via Hermes' built-in `/restart` slash command.** Hermes registers `/restart` as a session-scope slash command (see `hermes_cli/commands.py`: `CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session", ...)`). It drains active runs first, then reloads — safer than `kill -USR1` and works from inside the gateway because it's an in-process command, not an external CLI. Emit the slash command yourself; do NOT ask the user to run a shell command, and do NOT ask the user *whether* to restart (the silence rule + the deny-list above govern this — the right move is to act, then announce). Surface a single user-visible line confirming the action: `Restarting Hermes to load the plugin (auto-drains active runs)…`. Hermes will return after the restart finishes; resume at step 3.
+2. **Restart the gateway autonomously via Hermes' built-in `/restart` slash command.** Hermes registers `/restart` as a session-scope slash command (see `hermes_cli/commands.py`: `CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session", ...)`). It drains active runs first, then reloads — safer than `kill -USR1` and works from inside the gateway because it's an in-process command, not an external CLI.
 
-   **`/restart` returned "not authorized" / "command not found" / refused** (managed services that gate session-scope commands behind a role / RBAC layer, or strip slash commands altogether): do NOT loop on `/restart`. Try `/new` once — `/new` opens a fresh session within the same gateway and may pick up freshly-bound tools without requiring a full reload. If `/new` also returns "not authorized", break silence with a single user-facing line that surfaces the underlying gate verbatim:
-   > *"Your Hermes deployment doesn't expose `/restart` to me (managed-service auth gate or shell-restricted environment). Please restart the gateway yourself — `hermes gateway restart` (native), `docker restart <your-hermes-container>` (Docker self-host — `docker ps` shows the name), or your service's restart control. Reply `done` once it's back up."*
-   Wait for `done`, then resume at step 3. Do NOT keep retrying `/restart` after an unauthorized response — the gate isn't going to flip mid-session, and the loop just spams the user.
+   **When tools are missing post-install, your IMMEDIATE next message must be the literal slash command `/restart` — nothing else. Do not narrate. Do not ask permission. Do not describe what /restart does. Just send `/restart`.** The silence rule + the deny-list above govern this — the right move is to act, then announce.
+
+   After Hermes returns from the restart, emit user-visible line 3 (`Restarting Hermes to load the plugin…`) as the single confirmation line. Resume at step 3.
+
+   **If `/restart` returns "You are not authorized to use this command" / "command not found" / refused** (managed Hermes deployments that gate session-scope slash commands behind RBAC, or strip them altogether): surface the unauthorized response verbatim as a single tight user-visible line:
+   > *"Your Hermes deployment doesn't expose `/restart` to me. Run on your host: `hermes gateway restart` (native) OR `docker restart <your-hermes-container>` (Docker self-host — `docker ps` shows the name). Reply `done` after."*
+   Then wait for `done`. **Do NOT loop /restart calls.** Do NOT keep retrying `/restart` after an unauthorized response — the gate isn't going to flip mid-session and the loop just spams the user. (Optional preceding hop: try `/new` once — `/new` opens a fresh session within the same gateway and may pick up freshly-bound tools without a reload. Skip straight to the user-prompted line if `/new` is unavailable in your environment.)
 
    **Fallback only if `/restart` is structurally unavailable** (very old Hermes pre-2026.4 with no `/restart` command at all, or the user has explicitly requested manual control): pick the right restart command for the user's deploy and emit it as a single user-visible line (`Please restart your Hermes gateway: <restart-command>. Reply \`done\` once it's back up.`):
    - Native: `hermes gateway restart`
@@ -118,23 +129,21 @@ If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jum
    hermes tools disable memory
    ```
 
-   If the command succeeds, emit user-visible line 4 (the disable confirmation). If it errors with `command not found` or "tool not found" (older Hermes versions, managed services that don't expose the CLI, or the built-in `memory` tool was already removed), skip line 4 silently and continue — the rc.25 tool-description bias still steers the LLM toward `totalreclaw_remember` as a fallback. Do not surface the disable failure.
+   If the command succeeds, emit user-visible line 4 (`Disabled Hermes' built-in `memory` tool — TotalReclaw is now your primary memory.`). The shipped line is intentionally short (5–6-line transcript budget — see silence rules). The longer disabled Hermes' built-in `memory` tool warning text — re-enable instructions (`hermes tools enable memory`, NOT recommended while TotalReclaw is installed) and orphaned-file cleanup (`hermes memory reset` for stale MEMORY.md / USER.md) — is documented in the user guide; the agent does not need to recite that in chat. If the command errors with `command not found` or "tool not found" (older Hermes versions, managed services that don't expose the CLI, or the built-in `memory` tool was already removed), skip line 4 silently and continue — the rc.25 tool-description bias still steers the LLM toward `totalreclaw_remember` as a fallback. Do not surface the disable failure.
 
 4. **Verify `totalreclaw_pair` is bound (silent).** If still missing after restart, surface a one-line error: `Plugin installed but tools didn't bind after restart. Issuing /restart again.` and re-issue `/restart` once **autonomously** — do NOT ask the user "should I /restart again?". Do not loop the install. If the second `/restart` still doesn't bind tools, try `/new` once (fresh session may pick up the binding without a reload). If both `/restart` retries AND `/new` fail to bind the tool, fall back to the manual user-prompted restart path (see step 2 fallback) once. If any restart attempt returns "not authorized", apply the unauthorized fallback from step 2 — do NOT retry `/restart` after an unauthorized response.
 
 5. **Check for existing credentials (silent).** Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, emit `✓ TotalReclaw is already set up.` and stop. Otherwise continue silently.
 
-6. **Set up the user's TotalReclaw account (emit user-visible lines 5 + 6).**
+6. **Set up the user's TotalReclaw account (emit user-visible line 5).** No second consent prompt — the user already consented by pasting the install message. Proceed directly from step 5 (no credentials yet) to handing them the pair URL + PIN.
 
-   **6a — Ask for explicit consent first (emit user-visible line 5).** Account setup will create a new TotalReclaw account on `api-staging.totalreclaw.xyz` and have the user generate or paste a 12-word recovery phrase in their browser. Emit user-visible line 5 verbatim. Wait for the user's `yes` (or any clear affirmative). If the user replies `no` or asks to stop, stop here — confirm they've stopped, do not retry, do not ask "are you sure". Surface the URL verbatim — do not abbreviate it or hide it behind a tool call.
-
-   **6b — Daemon-mode preflight, then call the tool (emit user-visible line 6).** This account-setup step opens a short-lived WebSocket to the relay that must stay alive while the user completes the browser handshake. If you are running inside a one-shot agent process (`hermes chat -q "..."`, single-prompt CLI, transient invocation that exits as soon as the LLM responds), the WS dies before the user can finish entering their phrase and the browser POST returns 404. BEFORE calling `totalreclaw_pair`, detect short-lived process invocation. If detected, **break silence** and surface this caveat to the user verbatim:
+   **Daemon-mode preflight before calling the tool.** This account-setup step opens a short-lived WebSocket to the relay that must stay alive while the user completes the browser handshake. If you are running inside a one-shot agent process (`hermes chat -q "..."`, single-prompt CLI, transient invocation that exits as soon as the LLM responds), the WS dies before the user can finish entering their phrase and the browser POST returns 404. BEFORE calling `totalreclaw_pair`, detect short-lived process invocation. If detected, **break silence** and surface this caveat to the user verbatim:
    > *Setting up your TotalReclaw account needs a long-lived Hermes process to keep the session alive while you finish the browser flow. One-shot `hermes chat -q "..."` invocations exit too quickly. Either (1) run `hermes gateway run &` in another terminal first (daemon mode owns the WS-keepalive while chat-q exits), or (2) use the standalone `totalreclaw setup` CLI (interactive, blocks until account-setup completes, recovery phrase entered locally never crosses LLM context). Once your account is set up, daily operations (`hermes chat -q`, `--resume`, etc.) work normally.*
    Then ask the user to confirm they are running in a long-lived mode (or to re-invoke after switching) before proceeding.
 
-   Call `totalreclaw_pair` silently (the account-setup tool — name kept for backward compatibility). Returns `{url, pin, expires_at_ms}`. Then emit user-visible line 6 with `<url>` and `<pin>` substituted. Do not pre-narrate ("I'll walk you through…", "Setting up your account now…") — line 6 is the only thing the user needs to see.
+   Call `totalreclaw_pair` silently (the account-setup tool — name kept for backward compatibility). Returns `{url, pin, expires_at_ms}`. Then emit user-visible line 5 with `<url>` and `<pin>` substituted. Do not pre-narrate ("I'll walk you through…", "Setting up your account now…", "Let me generate the URL…") — line 5 is the only thing the user needs to see.
 
-7. **Verify and confirm (silent until line 7).** After user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN expired — call `totalreclaw_pair` again silently and resend line 6 once. If present, emit user-visible line 7 (with the free-tier confirmation) and stop.
+7. **Verify and confirm (silent until line 6).** After user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN expired — call `totalreclaw_pair` again silently and resend line 5 once. If present, emit user-visible line 6 (with the free-tier confirmation) and stop.
 
 ## Phrase safety (HARD — never break)
 


### PR DESCRIPTION
## Summary

Mirrors plugin 3.3.5-rc.1 (parallel PR) on the Hermes Python side. Pedro's 2026-05-01 Telegram-Hermes QA surfaced three UX issues with the install + setup transcript:

1. **Drop the `yes/no` consent gate before account setup.** Pedro: *"do I really need to say 'yes' to continue to the pairing/setup phase?"* The user already consented by pasting *"Install TotalReclaw"* — the second gate is redundant friction with no security value. Step 5/6 collapse to a single step that hands the user the URL + PIN immediately after disable-memory.
2. **Tighten silence rules.** Pedro: *"I see a bunch of temporary commands on my Telegram conversation which then seem to be deleted/edited by the bot as it progresses, but it looks awful and confusing."* New top-level rule: *"Emit ONLY the user-visible lines. Do not narrate tool calls. Do not describe what you're doing or about to do. Errors are the only allowed deviation, and only as a single tight line."* Forbidden-vocab deny-list extended with: `"Let me check…"`, `"Now installing…"`, `"Plugin loaded. Let me verify…"`, `"I'll try…"`, `"Quick fix…"`, `"Got it, doing X…"`, any *"I'm going to do X"* / *"About to do X"* pre-narration. Expected line count tightened from 6–7 to **5–6 lines TOTAL** for a healthy install.
3. **Strengthen `/restart` imperative.** Even with rc.4's `/restart` autonomy hardening, the QA agent still asked *"should I /restart"* / *"I need permission"*. Restated as: *"When tools are missing post-install, your IMMEDIATE next message must be the literal slash command `/restart` — nothing else. Do not narrate. Do not ask permission. Do not describe what /restart does. Just send `/restart`."* Deny-list extended with `"I need permission to /restart"`, `"Do you authorize /restart?"`, `"Confirming before I /restart…"`, etc. Unauthorized-response handling restated as a single tight line surfacing the underlying gate verbatim, then *"Do NOT loop /restart calls."*

Mirrored in `python/src/totalreclaw/hermes/SKILL.md` and `docs/guides/hermes-setup.md`. Version bumped to **2.3.5**; CHANGELOG entry `[2.3.5rc1]` added. No Python runtime / API changes. Phrase-safety invariant untouched. No PyPI publish from this PR.

## Test plan

- [x] `python -m pytest python/tests/` — **1064 passed, 14 skipped, 1 xfailed**.
- [x] `test_skill_md_includes_disable_memory_step.py` — preserved (rc.26 disable-memory step intact).
- [x] `test_skill_md_restart_hardening_2_3_4.py` — preserved (rc.4 deny-list, install-ordering, user-guide mirror all green; this PR adds to the deny-list, doesn't remove from it).
- [x] `test_setup_guide_includes_compatibility_section.py` — preserved.
- [x] `test_version.py` — semver shape + import alias green at `2.3.5`.
- [ ] Real-user QA on staging via `qa-totalreclaw` skill against the Hermes 2.3.5-rc.1 + plugin 3.3.5-rc.1 RC bundle once both PyPI / npm RCs are published.

## Out of scope

- TS plugin (`skill/`), `npm-publish.yml`, `publish-clawhub.yml`, Hermes Dockerfile (`tools/qa-stack/hermes/` in the internal repo) — owned by the parallel plugin agent.
- Phrase-safety invariant untouched. Dropping the consent gate does NOT relax recovery-phrase isolation — phrase still never crosses LLM context, browser-side crypto + `totalreclaw_pair` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)