### PR TITLE
fix(3.3.7-rc.2 + 2.3.6rc2): rename /restart to /totalreclaw-restart (OpenClaw reserves /restart)

### DIFF
--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -48,7 +48,7 @@ Speak only these lines, in order. Substitute the bracketed placeholders with the
    > Installing TotalReclaw…
 2. (Step 2 — after install + auto-reload + tool-bind verification)
    > ✓ Installed (totalreclaw &lt;version&gt;)
-3. (Step 2b — optional, only if auto-reload didn't fire and you have to issue `/restart`)
+3. (Step 2b — optional, only if auto-reload didn't fire and you have to issue `/totalreclaw-restart`)
    > Restarting OpenClaw to load the plugin…
 4. (Step 3 — only if existing credentials were detected, then stop)
    > ✓ TotalReclaw is already set up.
@@ -57,7 +57,7 @@ Speak only these lines, in order. Substitute the bracketed placeholders with the
 6. (Step 6 — done + free-tier confirmation)
    > ✓ You're set up on the TotalReclaw free tier — 500 memories/month, unlimited reads. https://totalreclaw.xyz/pricing. Ask me to remember anything.
 
-That is the complete user-facing transcript for a healthy install. Expected line count for a fresh install + setup is **5–6 lines** (line 4 is mutually exclusive with lines 5-6; line 3 only fires if `/restart` was needed).
+That is the complete user-facing transcript for a healthy install. Expected line count for a fresh install + setup is **5–6 lines** (line 4 is mutually exclusive with lines 5-6; line 3 only fires if `/totalreclaw-restart` was needed).
 
 ### When to break silence (errors only)
 
@@ -79,7 +79,7 @@ Unless the user explicitly asks how the install works, the following words / pat
 - "Quick fix…"
 - "However, I don't see…"
 - "I need to use…"
-- "Should I /restart" / "Want me to restart" / "Let me check if the tool is bound" / "I need permission to restart" / "Do you have a public URL"
+- "Should I /totalreclaw-restart" / "Want me to restart" / "Let me check if the tool is bound" / "I need permission to restart" / "Do you have a public URL"
 - "Now installing…" / "Got it" / "In parallel…" / "Step 1a/1b/1c"
 - `manifest`, `descriptor`, `file-watcher`, `polling`, `auto-reload-detect`, `find`, `lookup`, `detect`, `probing`, `let me try`
 
@@ -112,25 +112,25 @@ When `totalreclaw_pair` is bound, capture the version string from `openclaw plug
 
 Hybrid auto-reload didn't fire (likely `gateway.reload.mode = off`). The protocol is rigid:
 
-> **Your IMMEDIATE next message must be the literal slash command `/restart` — nothing else. Do not narrate. Do not ask permission. Do not describe what `/restart` does. Do not propose alternatives. Just send `/restart`.**
+> **Your IMMEDIATE next message must be the literal slash command `/totalreclaw-restart` — nothing else. Do not narrate. Do not ask permission. Do not describe what `/totalreclaw-restart` does. Do not propose alternatives. Just send `/totalreclaw-restart`.**
 
-You may emit user-visible line 3 (`Restarting OpenClaw to load the plugin…`) ONCE in the same turn before sending `/restart`. Nothing else. After `/restart`, wait ~3s and re-run `openclaw plugins list`.
+You may emit user-visible line 3 (`Restarting OpenClaw to load the plugin…`) ONCE in the same turn before sending `/totalreclaw-restart`. Nothing else. After `/totalreclaw-restart`, wait ~3s and re-run `openclaw plugins list`.
 
-`/restart` is registered in OpenClaw's commands registry alongside `/help /model /new /plugins /reset /status /tools /usage` and reloads the gateway in-process — it works from inside the gateway because it doesn't shell out (unlike `openclaw gateway restart`).
+`/totalreclaw-restart` is the plugin-registered slash command (3.3.7-rc.2+; renamed from `/restart` because OpenClaw's plugin registry reserves the bare name `restart` for the built-in). It reloads the gateway in-process — works from inside the gateway because it doesn't shell out (unlike `openclaw gateway restart`). The 5-tier auth fallback (issue #215, see below) attaches to this command name; the OpenClaw built-in `/restart` retains its allow-from-only semantics unchanged.
 
-#### If `/restart` returns "You are not authorized to use this command"
+#### If `/totalreclaw-restart` returns "You are not authorized to use this command"
 
-3.3.7-rc.1 (issue #215) ships a 5-tier auth fallback for the plugin's `/restart` override, so default-config installs no longer hit this. The plugin's `register()` registers its own `/restart` slash command (overriding OpenClaw's built-in) with a fallback chain that allows a default-config user IF: they're explicitly listed in `commands.ownerAllowFrom` OR `channels.<provider>.allowFrom` OR they're the same identity the channel is bound to OR `credentials.json` exists + the channel was paired through OR the gateway has only seen ONE inbound user (the lone-user heuristic for fresh installs). Rejection only fires when an explicit allow-from is configured AND excludes the invoker.
+3.3.7-rc.1 (issue #215) shipped a 5-tier auth fallback for the plugin's restart override; rc.2 attached it to `/totalreclaw-restart` (rc.1 attempted to override the built-in `/restart`, which the registry hard-rejected — the fallback never ran). Default-config installs no longer hit this path. The plugin's `register()` registers `/totalreclaw-restart` with a fallback chain that allows a default-config user IF: they're explicitly listed in `commands.ownerAllowFrom` OR `channels.<provider>.allowFrom` OR they're the same identity the channel is bound to OR `credentials.json` exists + the channel was paired through OR the gateway has only seen ONE inbound user (the lone-user heuristic for fresh installs). Rejection only fires when an explicit allow-from is configured AND excludes the invoker.
 
-For 3.3.7-rc.1+ users the unauthorized message should not appear in the default install path. If it DOES appear, it means the user's config already specifies `commands.ownerAllowFrom` or `channels.<provider>.allowFrom` and excludes their channel id. Surface verbatim and stop. Do NOT loop `/restart` calls. Do NOT keep retrying. Do NOT propose alternatives.
+For 3.3.7-rc.2+ users the unauthorized message should not appear in the default install path. If it DOES appear, it means the user's config already specifies `commands.ownerAllowFrom` or `channels.<provider>.allowFrom` and excludes their channel id. Surface verbatim and stop. Do NOT loop `/totalreclaw-restart` calls. Do NOT keep retrying. Do NOT propose alternatives.
 
-> Your config restricts `/restart` to a specific allow-list and your channel id is not in it. Run on your host: `jq '.channels.<channel>.allowFrom = ["<your-id>"]' ~/.openclaw/openclaw.json | sponge ~/.openclaw/openclaw.json && docker restart <your-container-name>`. Substitute `<channel>` with your channel name (e.g. `telegram`, `slack`), `<your-id>` with your user ID for that channel (Telegram: `@username` or numeric `chat_id`; Slack: workspace member ID), and `<your-container-name>` with your gateway container name (`docker ps` shows it). For non-Docker installs substitute `openclaw gateway restart` for the `docker restart` portion. On a managed service, ask the service's support to enable slash commands for your channel. Reply `done` after.
+> Your config restricts `/totalreclaw-restart` to a specific allow-list and your channel id is not in it. Run on your host: `jq '.channels.<channel>.allowFrom = ["<your-id>"]' ~/.openclaw/openclaw.json | sponge ~/.openclaw/openclaw.json && docker restart <your-container-name>`. Substitute `<channel>` with your channel name (e.g. `telegram`, `slack`), `<your-id>` with your user ID for that channel (Telegram: `@username` or numeric `chat_id`; Slack: workspace member ID), and `<your-container-name>` with your gateway container name (`docker ps` shows it). For non-Docker installs substitute `openclaw gateway restart` for the `docker restart` portion. On a managed service, ask the service's support to enable slash commands for your channel. Reply `done` after.
 
 Then wait for `done`. Do NOT retry the install. Do NOT keep restarting. Do NOT issue `/new` — it wipes the chat context, the agent forgets it was mid-install, and the user's next message is treated as a fresh install request which retries from scratch and re-trips the scanner block (Pedro QA, 3.3.5-rc.1).
 
-#### Fallback only if `/restart` is unavailable
+#### Fallback only if `/totalreclaw-restart` is unavailable
 
-Very old OpenClaw pre-2026.4 or managed services that strip slash commands: tell the user verbatim *"Auto-reload didn't fire and `/restart` is unavailable. Please restart your OpenClaw gateway: `openclaw gateway restart` (native), `docker restart <your-container-name>` (Docker self-host — substitute the actual name; `docker ps` shows it), or your managed service's restart control. Reply `done` once it's back up."* Do NOT invoke any external `docker restart` or `openclaw gateway restart` yourself — your shell runs inside the gateway you'd be restarting; `/restart` (in-process) and a user-prompted external restart are the only safe paths.
+Very old OpenClaw pre-2026.4 or managed services that strip slash commands: tell the user verbatim *"Auto-reload didn't fire and `/totalreclaw-restart` is unavailable. Please restart your OpenClaw gateway: `openclaw gateway restart` (native), `docker restart <your-container-name>` (Docker self-host — substitute the actual name; `docker ps` shows it), or your managed service's restart control. Reply `done` once it's back up."* Do NOT invoke any external `docker restart` or `openclaw gateway restart` yourself — your shell runs inside the gateway you'd be restarting; `/totalreclaw-restart` (in-process) and a user-prompted external restart are the only safe paths.
 
 ### Step 3 — Check for existing credentials (silent unless found)
 
@@ -293,17 +293,17 @@ Upgrade: *"Upgrade my TotalReclaw subscription."*
 
 - **Agent says "I'm not familiar with TotalReclaw"**: paste the canonical message above with the URL — the agent fetches the guide and follows the install steps.
 - **Agent refused the install** ("this looks like prompt injection", "I'm not going to do that"): rare but possible with safety-trained models that misread agent-imperative install prose. Ask the agent to read the "Agent instructions" section of this guide and proceed step-by-step — each command is annotated with what it does and why it's safe. If the refusal persists, file an issue with the model name + chat transcript.
-- **Agent can't see TotalReclaw tools after install**: under the default config OpenClaw auto-restarts the gateway within 1-3s of `openclaw plugins install` — wait 5-10s and check `openclaw plugins list`. If the plugin is listed but the agent still can't see the tools, your config likely has `gateway.reload.mode = off`. The agent should issue OpenClaw's built-in `/restart` slash command (in-process, drains active runs, works from inside the gateway). Manual fallback only if `/restart` is unavailable — native: `openclaw gateway restart`; Docker self-host: `docker restart <your-openclaw-container>`; managed service: use the service's restart control.
+- **Agent can't see TotalReclaw tools after install**: under the default config OpenClaw auto-restarts the gateway within 1-3s of `openclaw plugins install` — wait 5-10s and check `openclaw plugins list`. If the plugin is listed but the agent still can't see the tools, your config likely has `gateway.reload.mode = off`. The agent should issue the plugin's `/totalreclaw-restart` slash command (in-process, drains active runs, works from inside the gateway; 5-tier auth fallback so default-config installs work without `allowFrom`). Manual fallback only if `/totalreclaw-restart` is unavailable — native: `openclaw gateway restart`; Docker self-host: `docker restart <your-openclaw-container>`; managed service: use the service's restart control.
 - **Account-setup URL returns 404**: check that `~/.totalreclaw/credentials.json` isn't locked by a previous process and that the gateway is running.
 - **Browser fails to POST the encrypted phrase**: check the account-setup page's Content-Security-Policy — older browsers without WebCrypto x25519 (pre-Safari 17.2 / Chromium 118) cannot run the AEAD crypto.
 - **Tool calls return "onboarding required"**: paste the canonical message again so the agent re-runs `totalreclaw_pair`.
 - **"Not authenticated" / 401**: check your phrase — exact words, exact order, lowercase, single spaces.
 - **Agent narrating internals during install** ("Let me check that…", "Plugin loaded. Let me verify…", "I'll now…", "Quick fix…", "However, I don't see…", "I need to use…", "let me find…", "in parallel…", "manifest detected…"): the agent missed the silence rule in §"Agent instructions". Reply *"Don't narrate the install internals — just tell me when it's installed and when to set up my account."* and the next session should silence. On transports like Telegram, these intermediate lines visibly edit the bot's message live as tool calls progress, which is what makes them disruptive.
-- **Agent says "Should I /restart?" or stalls instead of restarting** (3.3.5-rc.1 hardening note): the agent missed the restart-imperative deny-list in the SKILL.md / Step 2. Reply *"Issue /restart yourself — don't ask"* and the next session should act autonomously. If it persists across sessions, the published RC's SKILL.md is stale — file an issue.
+- **Agent says "Should I /totalreclaw-restart?" or stalls instead of restarting** (3.3.5-rc.1 hardening note, 3.3.7-rc.2 rename): the agent missed the restart-imperative deny-list in the SKILL.md / Step 2. Reply *"Issue /totalreclaw-restart yourself — don't ask"* and the next session should act autonomously. If it persists across sessions, the published RC's SKILL.md is stale — file an issue.
 - **`openclaw` CLI hangs / exits 124 inside the gateway agent shell** (issue [#184](https://github.com/p-diogo/totalreclaw-internal/issues/184)): on some Docker setups the agent's shell-execution of `openclaw plugins list` / `openclaw plugins install` etc. deadlocks (every subcommand exits 124). When this happens the agent can bypass the CLI wrapper by invoking the plugin's own JS entries directly via `node`. The plugin ships pair-flow + version-probe entries that work without any CLI:
   - **Plugin install probe** — read the plugin's filesystem manifests to confirm the install completed: `cat ~/.openclaw/extensions/totalreclaw/.loaded.json` (issue [#186](https://github.com/p-diogo/totalreclaw-internal/issues/186)) reports `{ loadedAt, tools, version }` if `register()` ran cleanly. `.error.json` reports a structured failure if it didn't. These files are the canonical filesystem signal — they don't depend on the deadlocking CLI.
   - **Pair-flow direct-node fallback** — when `openclaw` CLI hangs during `totalreclaw_pair`, the agent (or a shell helper) can run `node ~/.openclaw/extensions/totalreclaw/dist/pair-cli.js --url-pin-only` directly to obtain the universal-relay pair URL. This bypasses the gateway tool-router entirely and writes the resulting URL to stdout (one JSON line, no prompts). Surface that URL to the user the same way `totalreclaw_pair` would.
-  - **Restart fallback** — `/restart` slash command is the autonomous path; manual fallbacks (`openclaw gateway restart`, `docker restart`) require user-side terminal access and are documented above.
+  - **Restart fallback** — `/totalreclaw-restart` slash command is the autonomous path; manual fallbacks (`openclaw gateway restart`, `docker restart`) require user-side terminal access and are documented above.
 
 ---
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,24 @@ Hermes Agent plugin are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.6rc2] — 2026-05-04
+
+Coordinated bundle with plugin `3.3.7-rc.2`. Hermes side of the `/totalreclaw-restart` rename (issue #215, follow-up).
+
+### Changed — rename future-wired plugin command from `restart` to `totalreclaw-restart`
+
+The OpenClaw plugin renamed `/restart` → `/totalreclaw-restart` in 3.3.7-rc.2 because OpenClaw's plugin registry hard-rejected the bare name (`RESERVED_COMMANDS`). Hermes' command registry is independent of OpenClaw's, but we use the same namespaced name preemptively so a future Hermes wiring lands without re-rolling the docs / SKILL.md contract on both sides.
+
+The 5-tier resolver in `totalreclaw.hermes.restart_auth` is byte-identical to 2.3.6rc1 — the matrix is name-agnostic; only the docstring + CHANGELOG mention the new target command name. When Hermes adds `register_command`, the plugin's `register()` will wire `/totalreclaw-restart` (NOT `/restart`).
+
+### Tests
+
+`python/tests/test_restart_auth_5_tier_2_3_6.py` (21 assertions) all pass — resolver is name-agnostic. All pre-existing Hermes tests remain green.
+
+### Doc updates
+
+No Hermes setup-guide / SKILL.md changes — Hermes' own built-in `/restart` is still upstream and unrelated to the plugin's rename. The setup-guide references to `/restart` continue to point at Hermes' built-in slash command (`hermes_cli/commands.py::CommandDef("restart", ...)`) since the plugin does not yet override it (no `register_command` API). When upstream Hermes ships the API and we wire `/totalreclaw-restart`, the SKILL.md contract will fork and we'll document the migration in a subsequent RC.
+
 ## [2.3.6rc1] — 2026-05-03
 
 Coordinated bundle with plugin `3.3.7-rc.1`. Hermes side of the `/restart` 5-tier auth fallback (issue #215).

--- a/python/src/totalreclaw/hermes/restart_auth.py
+++ b/python/src/totalreclaw/hermes/restart_auth.py
@@ -1,8 +1,18 @@
-"""5-tier auth fallback for /restart (issue #215, 2.3.6rc1).
+"""5-tier auth fallback for /totalreclaw-restart (issue #215, 2.3.6rc2).
 
 Hermes plugin parity with the OpenClaw plugin's
 ``skill/plugin/restart-auth.ts``. The matrix is identical so a future
 Hermes upstream change can plug this in directly.
+
+2.3.6rc2 (2026-05-04) renamed the target command from ``restart`` to
+``totalreclaw-restart`` matching the OpenClaw plugin rename in
+3.3.7-rc.2. Pedro caught the original problem in rc.1 manual integration
+testing on the OpenClaw side: registry hard-rejects the bare name
+``restart`` as reserved (see upstream ``RESERVED_COMMANDS``), so the
+fallback never ran. Hermes' command registry is independent of
+OpenClaw's, but we use the same namespaced name preemptively so a
+future Hermes wiring lands without re-rolling the docs / SKILL.md
+contract on both sides.
 
 NOTE on Hermes-side wiring: as of Hermes ``hermes-agent`` 2026.4.x the
 plugin context API does NOT expose ``register_command()`` (the Hermes
@@ -12,7 +22,7 @@ an exported util** so:
 
   * The matrix is unit-testable + version-pinned.
   * When Hermes adds ``register_command``, the plugin's
-    ``register()`` can wire ``/restart`` in two lines.
+    ``register()`` can wire ``/totalreclaw-restart`` in two lines.
   * Documentation surfaces (SKILL.md, hermes-setup.md) can link the
     user to the per-tier reasoning if their config rejects them.
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -26,7 +26,7 @@ metadata:
 
 > Canonical install + account-setup flow lives at <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md> (OpenClaw) and <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md> (Hermes). When a user pastes one of those URLs in chat, fetch it and follow its agent-instructions section verbatim. The "Post-Install Setup" section below mirrors the same account-setup flow as a fallback.
 
-> **Gateway restart after install**: OpenClaw's default `gateway.reload.mode = "hybrid"` auto-restarts within 1-3s of plugin install — no agent action needed. If auto-reload doesn't fire (`gateway.reload.mode = off`), issue OpenClaw's built-in `/restart` slash command yourself (in-process, drains active runs). Manual user-prompted restart is fallback only if `/restart` is unavailable. NEVER invoke external `docker restart` or `openclaw gateway restart` — your shell runs inside the gateway.
+> **Gateway restart after install**: OpenClaw's default `gateway.reload.mode = "hybrid"` auto-restarts within 1-3s of plugin install — no agent action needed. If auto-reload doesn't fire (`gateway.reload.mode = off`), issue the plugin's `/totalreclaw-restart` slash command yourself (in-process, drains active runs; 5-tier auth fallback in 3.3.7-rc.2+ so default-config installs work without `allowFrom`). Manual user-prompted restart is fallback only if `/totalreclaw-restart` is unavailable. NEVER invoke external `docker restart` or `openclaw gateway restart` — your shell runs inside the gateway.
 
 > **CLI deadlock fallback** (issue [#184](https://github.com/p-diogo/totalreclaw-internal/issues/184)): on some Docker setups your shell calls to `openclaw plugins list` / `openclaw plugins install` deadlock and exit 124. When that happens DO NOT keep retrying the CLI — switch to the direct-node fallbacks:
 > - To verify install completed, read `~/.openclaw/extensions/totalreclaw/.loaded.json` (success: `{loadedAt, tools, version}`) or `.error.json` (failure: `{loadedAt, error, stack}`). These manifests are the canonical filesystem signal independent of the CLI.
@@ -58,7 +58,7 @@ This matters because Telegram and similar transports edit the bot's messages liv
 - "Quick fix…"
 - "However, I don't see…"
 - "I need to use…"
-- "Should I /restart" / "Want me to restart" / "Let me check if the tool is bound" / "I need permission to restart" / "Do you have a public URL"
+- "Should I /totalreclaw-restart" / "Want me to restart" / "Let me check if the tool is bound" / "I need permission to restart" / "Do you have a public URL"
 - "Now installing…" / "Got it" / "In parallel…" / "Step 1a/1b/1c"
 - "manifest", "descriptor", "file-watcher", "polling", "auto-reload-detect", "find", "lookup", "detect", "probing", "let me try"
 

--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.7-rc.2] — 2026-05-04
+
+Follow-up to 3.3.7-rc.1, caught in Pedro's manual integration testing on the OpenClaw side 2026-05-03. The 5-tier auth fix shipped DEAD-CODE in rc.1: gateway logs surfaced `[gateway] [plugins] command registration failed: Command name "restart" is reserved by a built-in command (plugin=totalreclaw, source=/home/pdiogo/.openclaw/extensions/totalreclaw/dist/index.js)`. The plugin's `/restart` registration was rejected because OpenClaw's plugin registry hard-rejects `restart` (and the rest of `RESERVED_COMMANDS` — see `node_modules/openclaw/dist/registry-*.js` — `help`, `commands`, `status`, `whoami`, `context`, `stop`, `restart`, `reset`, `new`, `compact`, `config`, `debug`, `allowlist`, `activation`, `skill`, `subagents`, `kill`, `steer`, `tell`, `model`, `models`, `queue`, `send`, `bash`, `exec`, `think`, `verbose`, `reasoning`, `elevated`, `usage`). Built-in `/restart` retains its allow-from-only semantics, which is what gave Pedro the original "You are not authorized" — and our 5-tier fallback never ran because plugin registration never succeeded.
+
+### Fixed — rename plugin slash command to `/totalreclaw-restart` (issue #215, follow-up)
+
+**Fix:** plugin command name renamed from `restart` to `totalreclaw-restart`. The 5-tier auth resolver from rc.1 (`restart-auth.ts`, `inbound-user-tracker.ts`) is unchanged — it's the correct logic, just needed to attach to a non-reserved name. SKILL.md / setup-guide both tell the agent to issue `/totalreclaw-restart` so end-users never type `/restart` directly. The OpenClaw built-in `/restart` keeps its allow-from-only semantics — both commands coexist; the plugin's namespaced form is the recommended path for default-config users.
+
+The SIGUSR1 emit path (`process.kill(process.pid, 'SIGUSR1')`) is unchanged — gateway accepts iff `commands.restart=true` (default), and the policy keys on the gateway-level config flag, NOT on the plugin command name. So `/totalreclaw-restart` triggers a real gateway restart end-to-end.
+
+**Upstream FR (filed alongside this PR):** OpenClaw should allow plugins to override built-in command names with an explicit precedence flag (e.g. `registerCommand({ name: 'restart', overrideBuiltIn: true, ... })`). Until that lands, the namespaced workaround is canonical. Reference back to issue #215 architectural concerns.
+
+Implementation:
+- `skill/plugin/index.ts` — `api.registerCommand({ name: 'totalreclaw-restart', ... })` (was `'restart'`). Log lines updated to `/totalreclaw-restart` for cross-grep with the new SKILL.md instructions.
+- `skill/plugin/restart-auth.ts` — docstring header reflects the rename + the rc.1 → rc.2 trail. The resolver matrix is byte-identical to rc.1.
+- `skill/plugin/inbound-user-tracker.ts` — comment refers to the new command name.
+- `skill/plugin/SKILL.md` — every user-facing instance of `/restart` (in agent-instructions: "issue `/restart` autonomously…") replaced with `/totalreclaw-restart`. Added a one-line note explaining why we renamed.
+- `skill/SKILL.md` — same.
+- `docs/guides/openclaw-setup.md` — same. The "If `/restart` returns unauthorized" section is now keyed on `/totalreclaw-restart`. The rare-but-real built-in `/restart` referenced as the OpenClaw-shipped command (which the user does NOT type for our path).
+
+### Tests
+
+- Plugin: existing `restart-auth.test.ts` (29 assertions) + `inbound-user-tracker.test.ts` (14 assertions) all pass against the new command name (the resolver doesn't know its caller's name — it's pure). New regression test `register-command-name.test.ts` asserts the registered name is `totalreclaw-restart` (NOT `restart`) and asserts the plugin would not trip OpenClaw's `RESERVED_COMMANDS` check (parses the upstream `validateCommandName` rule directly from `node_modules/openclaw/dist/registry-*.js`). All pre-existing tests remain green.
+- Hermes: `python/tests/test_restart_auth_5_tier_2_3_6.py` (21 assertions) all pass — the resolver is name-agnostic. CHANGELOG entry on the Hermes side notes the matching rename for the future Hermes `register_command` wiring.
+
 ## [3.3.7-rc.1] — 2026-05-03
 
 Patch wave from Pedro's QA on 3.3.6-rc.1 (real-user Telegram → Pop OS Docker container → OpenClaw 2026.4.22 + plugin 3.3.6-rc.1). Two ship-stoppers, both architectural rather than config-drift:

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "Install + set up TotalReclaw encrypted memory for OpenClaw, then use totalreclaw_remember / totalreclaw_recall. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', or any remember / recall request."
-version: 3.3.7-rc.1
+version: 3.3.7-rc.2
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz
@@ -38,7 +38,7 @@ Speak only these lines, in order. Substitute the bracketed placeholders with the
    > Installing TotalReclaw…
 2. (after install + auto-reload + `totalreclaw_pair` is bound)
    > ✓ Installed (totalreclaw &lt;version&gt;)
-3. (optional — only if auto-reload didn't fire and you need to issue `/restart`)
+3. (optional — only if auto-reload didn't fire and you need to issue `/totalreclaw-restart`)
    > Restarting OpenClaw to load the plugin…
 4. (optional — only if you successfully disabled the built-in memory tool to prevent dual-write)
    > Disabled built-in memory tool.
@@ -63,15 +63,15 @@ If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jum
 
    If either shell call fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment), tell the user verbatim *"Your environment doesn't expose the OpenClaw CLI to me. Please install `totalreclaw` from your service's plugins / skills UI, then reply `done`."* Wait for `done` and skip to step 3.
 
-2. **Wait for auto-reload — then issue `/restart` autonomously if needed (silent — emit user-visible line 2 on success, line 3 only if you had to restart).** OpenClaw's default config (`gateway.reload.mode = "hybrid"`) auto-restarts the gateway via a file-watcher within 1-3 seconds. Wait ~5s, then run `openclaw plugins list | grep totalreclaw` and confirm `totalreclaw_pair` is in your toolset. When bound, emit user-visible line 2 and proceed.
+2. **Wait for auto-reload — then issue `/totalreclaw-restart` autonomously if needed (silent — emit user-visible line 2 on success, line 3 only if you had to restart).** OpenClaw's default config (`gateway.reload.mode = "hybrid"`) auto-restarts the gateway via a file-watcher within 1-3 seconds. Wait ~5s, then run `openclaw plugins list | grep totalreclaw` and confirm `totalreclaw_pair` is in your toolset. When bound, emit user-visible line 2 and proceed.
 
    **If `totalreclaw_pair` is NOT visible after 10s — restart imperative (read carefully):**
 
-   > Your IMMEDIATE next message must be the literal slash command `/restart` — nothing else. Do not narrate. Do not ask permission. Do not describe what `/restart` does. Do not propose alternatives. Just send `/restart`. You may emit user-visible line 3 (`Restarting OpenClaw to load the plugin…`) ONCE in the same turn, then issue `/restart`. Nothing else.
+   > Your IMMEDIATE next message must be the literal slash command `/totalreclaw-restart` — nothing else. Do not narrate. Do not ask permission. Do not describe what `/totalreclaw-restart` does. Do not propose alternatives. Just send `/totalreclaw-restart`. You may emit user-visible line 3 (`Restarting OpenClaw to load the plugin…`) ONCE in the same turn, then issue `/totalreclaw-restart`. Nothing else.
 
-   `/restart` is in-process — it drains active runs cleanly; your shell is NOT shelling out to `docker restart` or `openclaw gateway restart` (those would suicide the host). After `/restart`, wait ~3s and re-run `openclaw plugins list`.
+   `/totalreclaw-restart` is in-process — it drains active runs cleanly; your shell is NOT shelling out to `docker restart` or `openclaw gateway restart` (those would suicide the host). After `/totalreclaw-restart`, wait ~3s and re-run `openclaw plugins list`. (3.3.7-rc.2 renamed this from `/restart` because OpenClaw reserves `/restart` for its built-in — the plugin-side fallback can only attach to a unique name. The 5-tier auth resolver is unchanged; only the command name moved.)
 
-   **If `/restart` returns "You are not authorized to use this command":** surface this verbatim and stop. Do NOT loop `/restart` calls. Do NOT propose alternatives.
+   **If `/totalreclaw-restart` returns "You are not authorized to use this command":** surface this verbatim and stop. Do NOT loop `/totalreclaw-restart` calls. Do NOT propose alternatives.
 
    > Your Telegram channel needs `allowFrom` configured. Run on your host: `jq '.channels.<channel>.allowFrom = ["<your-id>"]' ~/.openclaw/openclaw.json | sponge ~/.openclaw/openclaw.json && docker restart <your-container-name>`. Substitute `<channel>` (e.g. `telegram`, `slack`), `<your-id>` (Telegram: `@username` or numeric `chat_id`; Slack: workspace member ID), and `<your-container-name>` (`docker ps` shows it). For non-Docker installs substitute `openclaw gateway restart` for the `docker restart` portion. On a managed service, ask the service's support to enable slash commands. Reply `done` after.
 
@@ -84,12 +84,12 @@ If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jum
    - "Quick fix…"
    - "However, I don't see…"
    - "I need to use…"
-   - "Should I /restart" / "Do you have a public URL" / "Want me to restart" / "Let me check if the tool is bound" / "I need permission to restart"
+   - "Should I /totalreclaw-restart" / "Do you have a public URL" / "Want me to restart" / "Let me check if the tool is bound" / "I need permission to restart"
    - "Now installing…" / "Got it" / "In parallel…" / "Step 1a/1b/1c"
 
    Substitute all of these with silence — the next user-visible line in the set, or nothing.
 
-3. **Verify `totalreclaw_pair` is bound.** If still missing after `/restart` (or after the user fixed allowFrom and said `done`), tell them the restart didn't take effect and ask them to retry. Do not loop the install.
+3. **Verify `totalreclaw_pair` is bound.** If still missing after `/totalreclaw-restart` (or after the user fixed allowFrom and said `done`), tell them the restart didn't take effect and ask them to retry. Do not loop the install.
 
 4. **Check for existing credentials (silent unless found).** Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, emit *"✓ TotalReclaw is already set up."* and stop.
 

--- a/skill/plugin/inbound-user-tracker.ts
+++ b/skill/plugin/inbound-user-tracker.ts
@@ -1,7 +1,7 @@
 /**
  * Per-channel inbound-user tracker (issue #215, 3.3.7-rc.1).
  *
- * Tier 3 + Tier 5 of the `/restart` 5-tier auth fallback need to know
+ * Tier 3 + Tier 5 of the `/totalreclaw-restart` 5-tier auth fallback need to know
  * "how many distinct users have ever messaged this gateway on channel X".
  *
  * This module implements a simple disk-backed counter. Persistence

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -3430,7 +3430,7 @@ const plugin = {
             // <pluginDir>/.loaded.json` from the host shell. Both
             // surfaces should agree; if chat says boot=N but the
             // file says boot=N+1, the chat session is stale and a
-            // /restart is warranted.
+            // /totalreclaw-restart is warranted.
             try {
               const m = _pluginDirForManifest
                 ? readPluginLoadedManifest(_pluginDirForManifest)
@@ -3472,26 +3472,42 @@ const plugin = {
       });
 
       // ---------------------------------------------------------------
-      // 3.3.7-rc.1 (issue #215) — `/restart` plugin command override
+      // 3.3.7-rc.2 (issue #215, follow-up) — `/totalreclaw-restart`
       // ---------------------------------------------------------------
       //
-      // Replaces OpenClaw's built-in `/restart` so we can apply the
-      // 5-tier auth fallback. Plugin commands match BEFORE built-ins
-      // (see upstream `auto-reply/reply/commands-plugin.ts`), so this
-      // takes precedence whenever the plugin is loaded. We use
-      // `requireAuth: false` to bypass the channel-layer auth check —
-      // the 5-tier fallback in `restart-auth.ts` decides allow / reject.
+      // Originally rc.1 registered this as `/restart` to override the
+      // OpenClaw built-in. That was wrong: OpenClaw's plugin registry
+      // hard-rejects the name on the reserved list (see upstream
+      // `RESERVED_COMMANDS` in `dist/registry-*.js`) — registration
+      // fails with `Command name "restart" is reserved by a built-in
+      // command` and the 5-tier fallback never runs. Pedro caught this
+      // in 3.3.7-rc.1 manual integration testing 2026-05-03; gateway
+      // logs surfaced the rejection, so the rc.1 fix shipped DEAD-CODE.
+      //
+      // Workaround until upstream lands a plugin-override-precedence
+      // flag (FR filed alongside this PR): use a unique, namespaced
+      // command name. Plugin handles `/totalreclaw-restart`; the
+      // built-in `/restart` keeps its allow-from-only semantics
+      // unchanged. SKILL.md tells the agent to issue the namespaced
+      // form, so end-users never type `restart` directly.
+      //
+      // We still use `requireAuth: false` to bypass the channel-layer
+      // auth check — the 5-tier fallback in `restart-auth.ts` decides
+      // allow / reject per the same matrix as rc.1.
       //
       // If allow → fire `process.kill(process.pid, 'SIGUSR1')`. The
       // gateway accepts SIGUSR1 iff `commands.restart=true` (the
       // default) — see upstream `setGatewaySigusr1RestartPolicy`.
+      // (The SIGUSR1 policy still keys on `commands.restart`, NOT on
+      // the plugin command name — gateways only honour one restart
+      // signal.)
       //
       // If reject → return a short non-shaming message via
       // `rejectMessageFor` that points the user at the right config
       // key (no infinite loop — agent will follow the unauthorized
       // fallback path documented in SKILL.md instead).
       api.registerCommand({
-        name: 'restart',
+        name: 'totalreclaw-restart',
         description: 'Restart OpenClaw gracefully (drains active runs first).',
         acceptsArgs: false,
         requireAuth: false,
@@ -3542,13 +3558,13 @@ const plugin = {
 
           if (verdict.allow === false) {
             api.logger.info(
-              `TotalReclaw: /restart rejected (channel=${channel || '<none>'} sender=${senderId || '<none>'} reason=${verdict.reason})`,
+              `TotalReclaw: /totalreclaw-restart rejected (channel=${channel || '<none>'} sender=${senderId || '<none>'} reason=${verdict.reason})`,
             );
             return { text: rejectMessageFor(verdict.reason) };
           }
 
           api.logger.info(
-            `TotalReclaw: /restart allowed (channel=${channel || '<none>'} sender=${senderId || '<none>'} tier=${verdict.reason})`,
+            `TotalReclaw: /totalreclaw-restart allowed (channel=${channel || '<none>'} sender=${senderId || '<none>'} tier=${verdict.reason})`,
           );
 
           // Trigger the gateway's SIGUSR1 restart path. Wrap in
@@ -3558,7 +3574,7 @@ const plugin = {
             process.kill(process.pid, 'SIGUSR1');
           } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
-            api.logger.warn(`TotalReclaw: /restart SIGUSR1 emit failed: ${msg}`);
+            api.logger.warn(`TotalReclaw: /totalreclaw-restart SIGUSR1 emit failed: ${msg}`);
             return {
               text: `Restart request acknowledged but the gateway didn't accept the signal (${msg}). Try \`docker restart <container>\` if running in Docker.`,
             };
@@ -3572,11 +3588,11 @@ const plugin = {
     // 3.3.7-rc.1 (issue #215) — track distinct inbound users per channel
     // ---------------------------------------------------------------
     //
-    // Tier 3 + tier 5 of the `/restart` 5-tier auth fallback need to
-    // know how many distinct users have messaged this gateway on
-    // each channel. We instrument `message_received` to record every
-    // (channel, senderId) pair to disk; the count survives gateway
-    // restarts (see `inbound-user-tracker.ts`).
+    // Tier 3 + tier 5 of the `/totalreclaw-restart` 5-tier auth
+    // fallback need to know how many distinct users have messaged this
+    // gateway on each channel. We instrument `message_received` to
+    // record every (channel, senderId) pair to disk; the count
+    // survives gateway restarts (see `inbound-user-tracker.ts`).
     //
     // Best-effort: we never throw out of this hook even if the disk
     // write fails — the auth fallback degrades gracefully (a stale

--- a/skill/plugin/package-lock.json
+++ b/skill/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.6-rc.1",
+  "version": "3.3.7-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/totalreclaw",
-      "version": "3.3.6-rc.1",
+      "version": "3.3.7-rc.2",
       "license": "MIT",
       "dependencies": {
         "@scure/bip39": "^2.2.0",

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.7-rc.1",
+  "version": "3.3.7-rc.2",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [
@@ -64,7 +64,7 @@
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.json --noCheck",
     "verify-tarball": "node ../scripts/verify-tarball.mjs",
-    "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx config.test.ts && npx tsx relay-headers.test.ts && npx tsx scope-address-visible.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx llm-client-retry.test.ts && npx tsx gateway-url.test.ts && npx tsx retype-setscope.test.ts && npx tsx tool-gating.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts && npx tsx pair-qr.test.ts && npx tsx pair-remote-client.test.ts && npx tsx qa-bug-report.test.ts && npx tsx nonce-serialization.test.ts && npx tsx phrase-safety-registry.test.ts && npx tsx test_issue_92_onnx_download_ux.test.ts && npx tsx onboard-pair-only.test.ts && npx tsx import-time-smoke.test.ts && npx tsx install-staging-cleanup.test.ts && npx tsx partial-install-detection.test.ts && npx tsx install-reload-idempotency.test.ts && npx tsx json-stdout-cleanliness.test.ts && npx tsx load-manifest.test.ts && npx tsx url-binding.test.ts && npx tsx fs-helpers.test.ts && npx tsx pair-cli-default-mode.test.ts && npx tsx embedding-fallback-tag.test.ts && npx tsx staging-banner-gate.test.ts && npx tsx restart-auth.test.ts && npx tsx inbound-user-tracker.test.ts",
+    "test": "npx tsx manifest-shape.test.ts && npx tsx config-schema.test.ts && npx tsx config.test.ts && npx tsx relay-headers.test.ts && npx tsx scope-address-visible.test.ts && npx tsx llm-profile-reader.test.ts && npx tsx llm-client.test.ts && npx tsx llm-client-retry.test.ts && npx tsx gateway-url.test.ts && npx tsx retype-setscope.test.ts && npx tsx tool-gating.test.ts && npx tsx onboarding-noninteractive.test.ts && npx tsx pair-cli-json.test.ts && npx tsx pair-qr.test.ts && npx tsx pair-remote-client.test.ts && npx tsx qa-bug-report.test.ts && npx tsx nonce-serialization.test.ts && npx tsx phrase-safety-registry.test.ts && npx tsx test_issue_92_onnx_download_ux.test.ts && npx tsx onboard-pair-only.test.ts && npx tsx import-time-smoke.test.ts && npx tsx install-staging-cleanup.test.ts && npx tsx partial-install-detection.test.ts && npx tsx install-reload-idempotency.test.ts && npx tsx json-stdout-cleanliness.test.ts && npx tsx load-manifest.test.ts && npx tsx url-binding.test.ts && npx tsx fs-helpers.test.ts && npx tsx pair-cli-default-mode.test.ts && npx tsx embedding-fallback-tag.test.ts && npx tsx staging-banner-gate.test.ts && npx tsx restart-auth.test.ts && npx tsx inbound-user-tracker.test.ts && npx tsx register-command-name.test.ts",
     "smoke:dist": "npx tsx dist-esm-smoke.test.ts",
     "check-scanner": "node ../scripts/check-scanner.mjs",
     "check-version-drift": "node ../scripts/check-version-drift.mjs",

--- a/skill/plugin/register-command-name.test.ts
+++ b/skill/plugin/register-command-name.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Regression test for issue #215 follow-up (3.3.7-rc.2).
+ *
+ * 3.3.7-rc.1 registered the plugin's restart command as `name: 'restart'`,
+ * which OpenClaw's plugin registry hard-rejects (`Command name "restart"
+ * is reserved by a built-in command`). The 5-tier auth fallback never
+ * ran because `register()` failed at the registry boundary. Pedro caught
+ * this in manual integration testing 2026-05-03 — gateway log:
+ *
+ *   [gateway] [plugins] command registration failed: Command name
+ *   "restart" is reserved by a built-in command
+ *   (plugin=totalreclaw,
+ *    source=/home/pdiogo/.openclaw/extensions/totalreclaw/dist/index.js)
+ *
+ * 3.3.7-rc.2 renamed the command to `totalreclaw-restart`. This test
+ * locks the rename in two ways:
+ *
+ *   1. Static analysis of `index.ts`: every `api.registerCommand({...})`
+ *      block whose handler-region mentions `resolveRestartAuth` MUST
+ *      have `name: 'totalreclaw-restart'`. (This is the resolver's
+ *      fingerprint — only the rc.1/rc.2 restart command uses it. Tests
+ *      a NEW occurrence of `name: 'restart'` would not pass even if
+ *      added by accident.)
+ *
+ *   2. Cross-check against OpenClaw's RESERVED_COMMANDS list: parse the
+ *      installed `node_modules/openclaw/dist/registry-*.js` to extract
+ *      the literal reserved-name set and assert our chosen name is
+ *      NOT in it. If a future OpenClaw release adds
+ *      `totalreclaw-restart` (unlikely — our namespace) or another
+ *      reserved name we accidentally collide with, this test trips.
+ *
+ * Plus assertions on the SKILL.md / setup-guide user-facing prompts so
+ * the agent isn't told to type `/restart` (which would land on the
+ * built-in's allow-from gate, NOT our fallback).
+ *
+ * Run with: `npx tsx register-command-name.test.ts`
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond: boolean, name: string): void {
+  const n = passed + failed + 1;
+  if (cond) {
+    console.log(`ok ${n} - ${name}`);
+    passed++;
+  } else {
+    console.log(`not ok ${n} - ${name}`);
+    failed++;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 1. index.ts — assert the registerCommand call uses 'totalreclaw-restart'
+// ---------------------------------------------------------------------------
+
+const indexTsPath = path.join(__dirname, 'index.ts');
+const indexTsSrc = fs.readFileSync(indexTsPath, 'utf8');
+
+// Find every `api.registerCommand({` block and slice up to the next `});`.
+// We look for the block that mentions `resolveRestartAuth` (the resolver's
+// import name) — that uniquely fingerprints the restart command.
+function findRegisterCommandBlocks(src: string): string[] {
+  const blocks: string[] = [];
+  const re = /api\.registerCommand\(\{[\s\S]*?\}\);/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(src)) !== null) {
+    blocks.push(m[0]);
+  }
+  return blocks;
+}
+
+const allBlocks = findRegisterCommandBlocks(indexTsSrc);
+const restartBlocks = allBlocks.filter((b) => b.includes('resolveRestartAuth'));
+
+assert(
+  restartBlocks.length === 1,
+  'index.ts: exactly one registerCommand block uses resolveRestartAuth ' +
+    `(found ${restartBlocks.length})`,
+);
+
+if (restartBlocks.length === 1) {
+  const block = restartBlocks[0];
+
+  assert(
+    /name:\s*['"]totalreclaw-restart['"]/.test(block),
+    "index.ts: restart-auth block registers as name: 'totalreclaw-restart'",
+  );
+
+  assert(
+    !/name:\s*['"]restart['"]/.test(block),
+    "index.ts: restart-auth block does NOT register as the reserved name 'restart'",
+  );
+
+  assert(
+    /requireAuth:\s*false/.test(block),
+    'index.ts: restart-auth block keeps requireAuth: false (channel-layer auth bypass)',
+  );
+
+  assert(
+    block.includes('SIGUSR1'),
+    'index.ts: restart-auth block still fires SIGUSR1 on allow',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 2. Cross-check the chosen name against OpenClaw's RESERVED_COMMANDS list
+// ---------------------------------------------------------------------------
+//
+// Parse the installed openclaw dist to extract the literal reserved set.
+// If the file isn't present (skill/ does not ship a node_modules in the
+// worktree-run case), skip with a warning rather than fail — the test
+// still passes the static-analysis check above. But in the canonical run
+// (after `npm install`) the file is present and we assert the name is
+// genuinely free.
+
+function findOpenClawRegistryFile(): string | null {
+  // Primary location: skill/node_modules/openclaw/dist/registry-*.js
+  const skillRoot = path.resolve(__dirname, '..');
+  const distDir = path.join(skillRoot, 'node_modules', 'openclaw', 'dist');
+  if (!fs.existsSync(distDir)) return null;
+
+  const candidates = fs
+    .readdirSync(distDir)
+    .filter((f) => /^registry-[A-Za-z0-9_-]+\.js$/.test(f))
+    .map((f) => path.join(distDir, f));
+
+  // Prefer the file that contains the RESERVED_COMMANDS literal; multiple
+  // chunks may match the registry-*.js name pattern.
+  for (const candidate of candidates) {
+    const src = fs.readFileSync(candidate, 'utf8');
+    if (src.includes('RESERVED_COMMANDS = new Set([')) return candidate;
+  }
+  return null;
+}
+
+function parseReservedNames(registrySrc: string): string[] {
+  const m = /RESERVED_COMMANDS\s*=\s*new Set\(\[([\s\S]*?)\]\)/.exec(registrySrc);
+  if (!m) return [];
+  const body = m[1];
+  const names: string[] = [];
+  const re = /["']([a-z0-9_-]+)["']/g;
+  let nm: RegExpExecArray | null;
+  while ((nm = re.exec(body)) !== null) {
+    names.push(nm[1]);
+  }
+  return names;
+}
+
+const registryFile = findOpenClawRegistryFile();
+
+if (registryFile == null) {
+  console.log(
+    '# skip - openclaw dist not installed in skill/node_modules; ' +
+      'static check above is sufficient. Run after `npm install` for the ' +
+      'reserved-name cross-check.',
+  );
+} else {
+  const registrySrc = fs.readFileSync(registryFile, 'utf8');
+  const reservedNames = parseReservedNames(registrySrc);
+
+  assert(
+    reservedNames.length > 0,
+    `parsed RESERVED_COMMANDS from ${path.basename(registryFile)} ` +
+      `(${reservedNames.length} names)`,
+  );
+
+  assert(
+    reservedNames.includes('restart'),
+    "RESERVED_COMMANDS includes 'restart' (the bug we're working around)",
+  );
+
+  assert(
+    !reservedNames.includes('totalreclaw-restart'),
+    "RESERVED_COMMANDS does NOT include 'totalreclaw-restart' (chosen name is free)",
+  );
+
+  // Validate that the OpenClaw command-name regex accepts our name —
+  // the upstream check is /^[a-z][a-z0-9_-]*$/.
+  const validNameRe = /^[a-z][a-z0-9_-]*$/;
+  assert(
+    validNameRe.test('totalreclaw-restart'),
+    "'totalreclaw-restart' matches OpenClaw's name validator regex",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 3. SKILL.md — agent-facing prompts must use the new name
+// ---------------------------------------------------------------------------
+
+const skillMdPath = path.join(__dirname, 'SKILL.md');
+const skillMdSrc = fs.readFileSync(skillMdPath, 'utf8');
+
+assert(
+  skillMdSrc.includes('/totalreclaw-restart'),
+  "skill/plugin/SKILL.md: mentions /totalreclaw-restart (agent's restart imperative)",
+);
+
+// The literal slash command "next message must be the literal slash command
+// `/totalreclaw-restart`" is the canonical imperative. Lock it.
+assert(
+  /literal slash command\s+`\/totalreclaw-restart`/.test(skillMdSrc),
+  'skill/plugin/SKILL.md: restart imperative tells the agent the literal ' +
+    '`/totalreclaw-restart` command (not `/restart`)',
+);
+
+// ---------------------------------------------------------------------------
+// 4. docs/guides/openclaw-setup.md — user-facing setup guide
+// ---------------------------------------------------------------------------
+
+const guidePath = path.resolve(__dirname, '..', '..', 'docs', 'guides', 'openclaw-setup.md');
+const guideSrc = fs.readFileSync(guidePath, 'utf8');
+
+assert(
+  guideSrc.includes('/totalreclaw-restart'),
+  'docs/guides/openclaw-setup.md: mentions /totalreclaw-restart',
+);
+
+assert(
+  /literal slash command\s+`\/totalreclaw-restart`/.test(guideSrc),
+  'docs/guides/openclaw-setup.md: restart imperative uses the new command name',
+);
+
+// ---------------------------------------------------------------------------
+// 5. CHANGELOG entry exists for [3.3.7-rc.2]
+// ---------------------------------------------------------------------------
+
+const changelogPath = path.join(__dirname, 'CHANGELOG.md');
+const changelogSrc = fs.readFileSync(changelogPath, 'utf8');
+
+assert(
+  /\[3\.3\.7-rc\.2\]/.test(changelogSrc),
+  'CHANGELOG: [3.3.7-rc.2] entry present',
+);
+
+assert(
+  /reserved by a built-in command/.test(changelogSrc),
+  'CHANGELOG: rc.2 entry references the upstream "reserved by a built-in command" rejection',
+);
+
+// ---------------------------------------------------------------------------
+// 6. package.json + skill.json version bumps
+// ---------------------------------------------------------------------------
+
+const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'), 'utf8'));
+const skillJson = JSON.parse(fs.readFileSync(path.join(__dirname, 'skill.json'), 'utf8'));
+
+assert(
+  packageJson.version === '3.3.7-rc.2',
+  `package.json: version === 3.3.7-rc.2 (got ${packageJson.version})`,
+);
+
+assert(
+  skillJson.version === '3.3.7-rc.2',
+  `skill.json: version === 3.3.7-rc.2 (got ${skillJson.version})`,
+);
+
+// ---------------------------------------------------------------------------
+
+console.log(`\n# ${passed} passed, ${failed} failed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/skill/plugin/restart-auth.ts
+++ b/skill/plugin/restart-auth.ts
@@ -1,5 +1,5 @@
 /**
- * /restart slash command — 5-tier auth fallback (issue #215)
+ * /totalreclaw-restart slash command — 5-tier auth fallback (issue #215)
  *
  * Architectural fix shipped 3.3.7-rc.1 after 3.3.6-rc.1 QA found that
  * default-config users (no `commands.ownerAllowFrom`, no
@@ -7,14 +7,24 @@
  * this command." when they typed `/restart` to recover from the plugin
  * tool-binding race (the dominant first-run install path).
  *
- * The plugin's `/restart` registration overrides OpenClaw's built-in
- * `/restart` (plugin commands are matched BEFORE built-ins; see
- * upstream `auto-reply/reply/commands-plugin.ts`). With
- * `requireAuth: false` the channel-layer auth check is skipped, and
- * this module's `resolveRestartAuth` decides allow-vs-reject using a
- * five-tier fallback. If the result is `allow`, the caller fires
+ * 3.3.7-rc.2 (2026-05-04) renamed the plugin command from `restart` to
+ * `totalreclaw-restart` after Pedro caught — in rc.1 manual integration
+ * testing — that OpenClaw's plugin registry hard-rejects names on
+ * `RESERVED_COMMANDS` (gateway log: `Command name "restart" is reserved
+ * by a built-in command`). The 5-tier matrix below is unchanged from
+ * rc.1; only the command name attached to it changed. SKILL.md /
+ * setup-guide both tell the agent to issue the namespaced form, so
+ * end-users never type `restart` directly. An upstream FR is open
+ * asking for a plugin-override-precedence flag.
+ *
+ * Plugin handles `/totalreclaw-restart` (validation passes — hyphenated
+ * names are allowed and the name is unique). With `requireAuth: false`
+ * the channel-layer auth check is skipped, and this module's
+ * `resolveRestartAuth` decides allow-vs-reject using a five-tier
+ * fallback. If the result is `allow`, the caller fires
  * `process.kill(process.pid, 'SIGUSR1')` — which the gateway accepts
- * iff `commands.restart=true` (the default).
+ * iff `commands.restart=true` (the default; the SIGUSR1 policy keys on
+ * the gateway-level config flag, NOT on the plugin command name).
  *
  * Tier order (highest priority first):
  *   1. `commands.ownerAllowFrom` explicitly lists invoker → allow
@@ -120,7 +130,7 @@ export interface RestartAuthInput {
 }
 
 /**
- * Resolve whether the given invoker may run `/restart`.
+ * Resolve whether the given invoker may run `/totalreclaw-restart`.
  *
  * Tier order: see file header.
  *

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "3.3.7-rc.1",
+  "version": "3.3.7-rc.2",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- 3.3.7-rc.1 (PR #178, merged) shipped a 5-tier auth fallback for `/restart` to fix issue #215. Pedro caught in manual integration testing 2026-05-03 that the fallback was DEAD-CODE: gateway log surfaced `[gateway] [plugins] command registration failed: Command name "restart" is reserved by a built-in command (plugin=totalreclaw, source=/home/pdiogo/.openclaw/extensions/totalreclaw/dist/index.js)`. OpenClaw's plugin registry hard-rejects names on `RESERVED_COMMANDS` (`restart`, `help`, `status`, `model`, ~30 others; see `node_modules/openclaw/dist/registry-*.js`). Built-in `/restart` retains its allow-from-only semantics — which is what produced Pedro's original "You are not authorized" — and our fallback never ran because plugin registration never succeeded.
- This PR renames the plugin command to `totalreclaw-restart`. Validation passes (hyphenated names allowed by OpenClaw's `validateCommandName` regex; the namespaced name is not in the reserved set). The 5-tier auth resolver in `restart-auth.ts` is byte-identical to rc.1 — it's the correct logic, just needed to attach to a non-reserved name. The SIGUSR1 emit path is unchanged: the gateway's `commands.restart=true` flag governs whether SIGUSR1 is honoured, NOT the plugin command name, so `/totalreclaw-restart` triggers a real gateway restart end-to-end.
- User-facing flow: old "Run /restart" → registry rejects → user stuck. New "Run /totalreclaw-restart" → 5-tier auth → SIGUSR1.

## Why a fresh RC and not amend

rc.1 is already MERGED to main (PR #178, SHA d39ca25). Cutting a clean rc.2 keeps the trail honest — the dead-code rc.1 is publicly tagged on npm with the broken behaviour, and rc.2 is the first version of `/totalreclaw-restart` that actually runs end-to-end.

## Hermes (2.3.6rc2) parity

`python/src/totalreclaw/hermes/restart_auth.py` is currently util-only — Hermes does not yet expose `register_command()` to plugins (Hermes roadmap; see `website/docs/guides/build-a-hermes-plugin.md` line 240). The docstring + Python CHANGELOG entry note that the future Hermes wiring will use the matching `totalreclaw-restart` name preemptively. Hermes' own built-in `/restart` is upstream and unrelated to this rename — `docs/guides/hermes-setup.md` references continue to point at it unchanged.

## Touched files

- `skill/plugin/index.ts` — `name: 'restart'` → `name: 'totalreclaw-restart'`; log lines + comments
- `skill/plugin/restart-auth.ts` — docstring header; resolver byte-identical
- `skill/plugin/inbound-user-tracker.ts` — comment update
- `skill/plugin/SKILL.md` — agent imperative, forbidden-vocabulary list
- `skill/plugin/CHANGELOG.md` — new `[3.3.7-rc.2]` entry
- `skill/plugin/package.json` + `skill.json` + `package-lock.json` — version bumps
- `skill/plugin/register-command-name.test.ts` — NEW regression (17 assertions): locks the rename, parses upstream `RESERVED_COMMANDS` to cross-check our chosen name is genuinely free, asserts SKILL.md / setup-guide use the new name
- `skill/SKILL.md` — agent prompts
- `docs/guides/openclaw-setup.md` — user-facing transcript line 3, restart imperative, troubleshooting
- `python/CHANGELOG.md` — new `[2.3.6rc2]` entry
- `python/src/totalreclaw/hermes/restart_auth.py` — docstring update

## Test plan

- [x] `cd skill/plugin && bun run test` → 909 passing assertions, 0 failed
- [x] `cd python && pytest` → 1085 passed, 14 skipped, 1 xfailed
- [x] `node ../scripts/check-scanner.mjs` → OK (124 files scanned, 0 flags)
- [x] `node ../scripts/check-version-drift.mjs` → OK (all three sites = 3.3.7-rc.2)
- [x] `node ../scripts/check-url-binding.mjs --release-type=rc` → OK
- [x] `bun run build` → dist/index.js contains `totalreclaw-restart` x8 and zero `name: 'restart'`
- [x] `bun run smoke:dist` → 4/4 passed
- [ ] Auto-QA: this PR will be the FIRST RC tested by the Discord-transport auto-QA infra once that's online. Test scaffolding asserts the gateway log `command registration failed` line does NOT appear in plugin init.

## Upstream FR (filed alongside this PR)

OpenClaw should allow plugins to override built-in command names with an explicit precedence flag — e.g. `registerCommand({ name: 'restart', overrideBuiltIn: true, ... })`, with the gateway log warning when an override happens. The current registry-locks-out behaviour means plugins can't replace built-ins to apply more-permissive auth (issue #215's architectural goal: managed-service / fresh-install users without `commands.ownerAllowFrom` ought to be able to type `/restart` to recover from a tool-binding race). Until upstream lands plugin-override-precedence, the namespaced workaround (`/totalreclaw-restart`) is canonical.

Reference: this PR is the working workaround until that upstream change lands. The 5-tier auth resolver is reusable on `/restart` directly the day it does — only the registration line in `index.ts` would change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)