### PR TITLE
feat(plugin): 3.3.8-rc.1 hybrid architecture — kind:memory cold-start fix + tr CLI fallback

### DIFF
--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -119,9 +119,48 @@ NEVER echo / generate / ask the user to paste a recovery phrase in chat. NEVER i
 - "status" → `totalreclaw_status`. "upgrade" → `totalreclaw_upgrade` (paste Stripe URL verbatim). Post-upgrade testnet → mainnet: `totalreclaw_migrate` with `dry_run` first.
 - "import / export / consolidate" → `totalreclaw_import_from` (`dry_run=true` first; `_import_batch` for >50 chunks) · `totalreclaw_export` · `totalreclaw_consolidate` (`dry_run` first).
 
+## OpenClaw 2026.5.2 hybrid mode (issue #223 workaround — plugin 3.3.8-rc.1+)
+
+OpenClaw 2026.5.2 has a tool-policy-pipeline bug (issue #223) that strips non-bundled plugin tools before they reach the agent toolset. Plugin 3.3.8-rc.1 ships a hybrid workaround:
+
+- **Hooks still fire**: `before_agent_start`, `agent_end`, `message_received`, `before_reset` use a separate code path not affected by issue #223. Auto-extraction, digest injection, preloading, and billing checks all work normally.
+- **Tools replaced by `tr` CLI**: instead of `totalreclaw_remember`, `totalreclaw_recall`, etc., use the `tr` binary installed with the plugin. The agent runs it via shell tool.
+
+**Agent usage under hybrid mode** (check `tr status` output for `hybrid-mode: yes`):
+
+```
+# remember a fact
+node ~/.openclaw/extensions/totalreclaw/dist/tr-cli.js remember "I work at Graph Foundation"
+# → outputs {"ok":true,"id":"...","text":"..."}
+
+# recall facts
+node ~/.openclaw/extensions/totalreclaw/dist/tr-cli.js recall "where does the user work"
+# → outputs {"ok":true,"count":1,"query":"...","memories":[...]}
+
+# status check
+node ~/.openclaw/extensions/totalreclaw/dist/tr-cli.js status
+```
+
+Note: the `tr` bin name conflicts with the system `tr` utility; always invoke via full path `node ~/.openclaw/extensions/totalreclaw/dist/tr-cli.js <cmd>` or the gateway host's equivalent path.
+
+**Required post-install config** (add to `~/.openclaw/openclaw.json`):
+```json
+{
+  "plugins": {
+    "entries": {
+      "totalreclaw": {
+        "hooks": { "allowConversationAccess": true }
+      }
+    }
+  }
+}
+```
+
+This unlocks typed hooks (`agent_end`, etc.) for non-bundled plugins. Without it, auto-extraction still works (extraction runs in `message_received`) but the `agent_end` hook that writes the digest is silently blocked.
+
 ## Diagnostics
 
-- `totalreclaw_*` tools not visible → plugin not installed or auto-reload didn't fire. Verify via `openclaw plugins list | grep totalreclaw` (or, on a managed service that doesn't expose the CLI, ask the user to confirm via their service's plugins UI). If `totalreclaw` is listed but tools are still absent, the gateway probably hasn't completed its auto-restart yet (give it 5-10s) OR `gateway.reload.mode = off` is set — instruct manual restart as fallback: `openclaw gateway restart` (native), `docker restart <your-container-name>` (Docker self-host), or the managed service's restart control. If the plugin is listed and the gateway has been restarted but tools are still missing (container-agent gap, issue #87), shell out to `openclaw totalreclaw pair generate --url-pin-only` on the gateway host and hand the user the `url` + `pin` from the JSON payload — OR `openclaw totalreclaw onboard --pair-only` (same flow, returns `pair_url` instead of `url`, issue #95). If your shell doesn't reach the gateway host (managed service), tell the user to install/enable the plugin via their service's plugins UI and restart the gateway via the service's restart control. Do NOT suggest the bare `openclaw totalreclaw onboard` (leaks phrase on stdout — deprecated in rc.18, removed next RC).
+- `totalreclaw_*` tools not visible → plugin not installed or auto-reload didn't fire. Verify via `openclaw plugins list | grep totalreclaw` (or, on a managed service that doesn't expose the CLI, ask the user to confirm via their service's plugins UI). If `totalreclaw` is listed but tools are still absent, the gateway probably hasn't completed its auto-restart yet (give it 5-10s) OR `gateway.reload.mode = off` is set — instruct manual restart as fallback: `openclaw gateway restart` (native), `docker restart <your-container-name>` (Docker self-host), or the managed service's restart control. If the plugin is listed and the gateway has been restarted but tools are still missing (container-agent gap, issue #87 / OC 2026.5.2 issue #223), switch to hybrid mode: use `node ~/.openclaw/extensions/totalreclaw/dist/tr-cli.js <cmd>` for remember/recall/pair/status. If your shell doesn't reach the gateway host (managed service), tell the user to install/enable the plugin via their service's plugins UI and restart the gateway via the service's restart control. Do NOT suggest the bare `openclaw totalreclaw onboard` (leaks phrase on stdout — deprecated in rc.18, removed next RC).
 - User says done but `credentials.json` missing → PIN expired or entered wrong phrase; call `totalreclaw_pair` again.
 - `onboarding required` → credentials missing; redo from the account-setup step.
 - `quota exceeded` → `totalreclaw_status`, then offer `totalreclaw_upgrade`.

--- a/skill/plugin/fs-helpers.ts
+++ b/skill/plugin/fs-helpers.ts
@@ -594,6 +594,18 @@ export interface PluginLoadManifest {
    * verify the manifest is from the currently-running container vs a
    * stale-mounted copy. */
   pid?: number;
+  /**
+   * 3.3.8-rc.1 — true when registerTool() calls are no-op'd due to the
+   * OC 2026.5.2 issue #223 hybrid workaround. Tools in `tools[]` are
+   * exposed via the `tr` CLI binary instead of via the plugin API.
+   */
+  hybridMode?: boolean;
+  /**
+   * 3.3.8-rc.1 — CLI commands that replace the tool registrations
+   * when hybridMode=true. Agent runs these from shell instead of using
+   * tool calls.
+   */
+  hybridCliTools?: string[];
 }
 
 /** Schema written to `.error.json` when register() throws. */

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -2926,6 +2926,29 @@ const plugin = {
     // write would race that freeze.
     const _registeredToolNames: string[] = [];
     const _originalRegisterTool = api.registerTool.bind(api);
+    // 3.3.8-rc.1 HYBRID MODE (OpenClaw 2026.5.2 issue #223 workaround):
+    // The tool-policy-pipeline in OC 2026.5.2 strips non-bundled plugin tools
+    // before they reach the agent's session toolset. registerTool() calls
+    // succeed and tools are declared in contracts.tools, so the PLUGIN LOADS.
+    // But tool calls never reach execute() — the pipeline discards them before
+    // the agent's toolset is built.
+    //
+    // Strategy: keep all registerTool() calls intact so the plugin loader can
+    // verify the contracts.tools declaration and load the plugin (hooks fire).
+    // The `tr` CLI binary (dist/tr-cli.js) provides the alternative execution
+    // path. Agent runs `tr remember|recall|status|pair` from shell; tool calls
+    // are dead-letter but hooks (before_agent_start, agent_end, message_received,
+    // before_reset) still fire via the unbroken hook code path.
+    //
+    // NOTE: do NOT no-op registerTool here — OC 2026.5.2 validates the
+    // contracts.tools declaration against registered tools at load time and
+    // drops the plugin (unloads it) if no tools match. Confirmed empirically:
+    // no-op'ing registerTool causes the gateway to log "4 plugins" instead of
+    // "5 plugins" after restart (plugin excluded from active set).
+    //
+    // TODO: when OC ships a fix for issue #223, restore tool-call routing
+    // and remove the tr-cli.ts CLI layer. The bin/tr field in package.json
+    // can stay as a convenience CLI regardless.
     api.registerTool = (tool: unknown, opts?: { name?: string; names?: string[] }) => {
       try {
         const t = tool as { name?: unknown } | null | undefined;
@@ -6917,10 +6940,15 @@ const plugin = {
           loadedAt: Date.now(),
           tools: _registeredToolNames.slice(),
           version: pluginVersion ?? 'unknown',
+          // 3.3.8-rc.1 hybrid mode annotation: tools ARE registered with the
+          // SDK (required for plugin loader validation), but tool calls are
+          // dead-letter on OC 2026.5.2 due to issue #223. Use `tr <cmd>` CLI.
+          hybridMode: true,
+          hybridCliTools: ['tr status', 'tr pair', 'tr remember', 'tr recall'],
         });
         if (ok) {
           api.logger.info(
-            `TotalReclaw: wrote .loaded.json manifest (${_registeredToolNames.length} tools, version=${pluginVersion ?? 'unknown'})`,
+            `TotalReclaw: wrote .loaded.json manifest (${_registeredToolNames.length} tools + hybridCli=tr, version=${pluginVersion ?? 'unknown'})`,
           );
         }
       } catch {

--- a/skill/plugin/manifest-shape.test.ts
+++ b/skill/plugin/manifest-shape.test.ts
@@ -1,23 +1,26 @@
 /**
- * manifest-shape.test.ts — Regression guard for the intentional manifest/JS
- * asymmetry introduced in 3.3.0-rc.6.
+ * manifest-shape.test.ts — Regression guard for the manifest/JS symmetry
+ * required on OpenClaw 2026.5.2+ (re-added in 3.3.8-rc.1).
  *
- * Background (OpenClaw startup registry bug):
- *   `resolveGatewayStartupPluginIds` excludes plugins with `kind: "memory"`
- *   from the gateway's startup set unless they also declare a configured
- *   channel. TotalReclaw has no channel, so the gateway startup path took an
- *   empty-list early return in `loadGatewayPlugins`, pinned an empty HTTP
- *   route registry, and never exposed the 4 pair routes — even though the
- *   plugin loaded later and registered them.
+ * Background — 2026.5.2 cold-start gate REVERSED the 3.3.0-rc.6 rule:
+ *   OpenClaw 2026.5.2's `resolveGatewayStartupPluginPlanFromRegistry` calls
+ *   `shouldConsiderForGatewayStartup()` which checks `plugin.startup.memory`,
+ *   derived from `hasKind(record.kind, "memory")`. Without `"kind": "memory"`
+ *   in the manifest, the plugin gets `startup.memory = false` and is
+ *   EXCLUDED from the cold-start loading plan. It only loaded via SIGTERM
+ *   hot-reload (different code path that bypasses the startup planner).
  *
- *   Fix: drop `"kind": "memory"` from `openclaw.plugin.json` (manifest) only.
- *   The JS plugin definition in `index.ts` still returns `kind: 'memory' as const`
- *   because the OpenClaw loader re-merges the JS definition into `record.kind`
- *   at line 2090, preserving memory-slot matching via
- *   `config.slots.memory === "totalreclaw"`.
+ *   Fix (3.3.8-rc.1): re-add `"kind": "memory"` to `openclaw.plugin.json`.
+ *   The JS plugin definition in `index.ts` already declares
+ *   `kind: 'memory' as const`. Manifest now matches — gateway includes the
+ *   plugin in its cold-start plan and loads it on every boot.
  *
- * This test asserts BOTH sides of the asymmetry:
- *   1. The manifest does NOT declare `kind: "memory"` (startup registry fix).
+ *   This reverses the 3.3.0-rc.6 removal. The upstream OpenClaw condition
+ *   flipped between 2026.4.x (excluded memory plugins from startup unless
+ *   they had a channel) and 2026.5.2 (REQUIRES kind=memory for cold-start).
+ *
+ * This test asserts BOTH sides of the new symmetry:
+ *   1. The manifest DOES declare `kind: "memory"` (cold-start gate on 2026.5.2).
  *   2. The JS plugin source DOES declare `kind: 'memory' as const` (memory-slot
  *      behaviour preserved).
  *
@@ -91,33 +94,40 @@ let manifest: Record<string, unknown>;
 }
 
 {
-  // 1a. The manifest must NOT have "kind": "memory".
-  // Presence of this field causes resolveGatewayStartupPluginIds to exclude
-  // the plugin from the startup set, pinning an empty HTTP route registry.
+  // 1a. (3.3.8-rc.1 reversal) OpenClaw 2026.5.2's
+  // `resolveGatewayStartupPluginPlanFromRegistry` calls
+  // `shouldConsiderForGatewayStartup()` which checks `plugin.startup.memory`,
+  // derived from `hasKind(record.kind, "memory")`. Without `"kind": "memory"`,
+  // the plugin gets `startup.memory = false` and is EXCLUDED from cold-start.
+  // Plugin only loaded via SIGTERM hot-reload (which bypasses startup planner).
+  // Re-adding `"kind": "memory"` to the manifest restores cold-start loading
+  // on every gateway boot. This reverses the 3.3.0-rc.6 removal — the
+  // upstream condition flipped between 2026.4.x and 2026.5.2.
   assert(
-    !('kind' in manifest),
-    'openclaw.plugin.json does NOT contain "kind" field (startup registry fix)',
+    'kind' in manifest,
+    'openclaw.plugin.json contains "kind" field (cold-start loading on 2026.5.2)',
   );
 }
 
 {
-  // 1b. Absence of "kind" in manifest is intentional — document the expected
-  // shape to catch accidental re-addition.
+  // 1b. Manifest "kind" === "memory" so the gateway treats this as a memory
+  // plugin and includes it in the cold-start plan.
   const kindValue = manifest['kind'];
-  assert(
-    kindValue === undefined,
-    'openclaw.plugin.json "kind" is undefined (not "memory" or any other value)',
+  assertEq(
+    kindValue,
+    'memory',
+    'openclaw.plugin.json "kind" === "memory"',
   );
 }
 
 {
-  // 1c. The string "memory" must not appear as a JSON value for any field
-  // named "kind" — raw-string check as an extra guard.
+  // 1c. Raw-string guard: regex must MATCH `"kind": "memory"` in the source
+  // to catch silent removals via merge or accidental edits.
   const raw = fs.readFileSync(manifestPath, 'utf8');
   const hasKindMemory = /"kind"\s*:\s*"memory"/.test(raw);
   assert(
-    !hasKindMemory,
-    'openclaw.plugin.json source does NOT match /"kind"\\s*:\\s*"memory"/ (raw regex guard)',
+    hasKindMemory,
+    'openclaw.plugin.json source matches /"kind"\\s*:\\s*"memory"/ (raw regex guard)',
   );
 }
 

--- a/skill/plugin/openclaw.plugin.json
+++ b/skill/plugin/openclaw.plugin.json
@@ -2,6 +2,7 @@
   "id": "totalreclaw",
   "name": "TotalReclaw",
   "description": "End-to-end encrypted memory vault for AI agents",
+  "kind": "memory",
   "contracts": {
     "tools": [
       "totalreclaw_remember",

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.7-rc.3",
+  "version": "3.3.8-rc.1",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [
@@ -48,6 +48,9 @@
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "tr": "./dist/tr-cli.js"
+  },
   "files": [
     "dist/",
     "*.ts",

--- a/skill/plugin/register-command-name.test.ts
+++ b/skill/plugin/register-command-name.test.ts
@@ -262,17 +262,18 @@ assert(
 const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'), 'utf8'));
 const skillJson = JSON.parse(fs.readFileSync(path.join(__dirname, 'skill.json'), 'utf8'));
 
-// Accept rc.3 or any later RC (the version bumps with each patch wave).
-const validVersionPattern = /^3\.3\.7-rc\.[3-9]\d*$/;
+// Accept 3.3.7-rc.3+ OR 3.3.8-rc.N+ (versions bump with each patch wave;
+// 3.3.8 series ships the kind:memory cold-start fix + hybrid CLI).
+const validVersionPattern = /^3\.3\.(7-rc\.[3-9]\d*|8-rc\.\d+|[89]\d*\.\d+|[1-9]\d{2,}.*)$/;
 
 assert(
   validVersionPattern.test(packageJson.version),
-  `package.json: version is 3.3.7-rc.3+ (got ${packageJson.version})`,
+  `package.json: version is 3.3.7-rc.3+ or 3.3.8-rc.1+ (got ${packageJson.version})`,
 );
 
 assert(
   validVersionPattern.test(skillJson.version),
-  `skill.json: version is 3.3.7-rc.3+ (got ${skillJson.version})`,
+  `skill.json: version is 3.3.7-rc.3+ or 3.3.8-rc.1+ (got ${skillJson.version})`,
 );
 
 // ---------------------------------------------------------------------------

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "3.3.7-rc.3",
+  "version": "3.3.8-rc.1",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",

--- a/skill/plugin/tr-cli.ts
+++ b/skill/plugin/tr-cli.ts
@@ -1,0 +1,375 @@
+#!/usr/bin/env node
+/**
+ * tr — TotalReclaw hybrid CLI (3.3.8-rc.1 workaround for OpenClaw 2026.5.2 issue #223)
+ *
+ * OpenClaw 2026.5.2 has a tool-policy-pipeline bug that strips non-bundled plugin tools
+ * before they reach the agent toolset. This CLI bypasses the broken tool-registration
+ * path entirely. The agent runs `tr <cmd>` from shell; the plugin keeps its hooks
+ * (before_agent_start, agent_end, message_received) via the unbroken hook code path.
+ *
+ * Phrase-safety: this CLI reads credentials.json (mnemonic at rest) but NEVER
+ * prints the mnemonic to stdout, stderr, or any log. Phrase only enters via QR-pair
+ * browser tier (pair-cli.ts / pair-cli-relay.ts — unchanged).
+ *
+ * Commands:
+ *   tr status               — print onboarding + credentials state
+ *   tr pair [--json]        — start a relay pairing session, print URL+PIN+QR
+ *   tr remember <text>      — store a memory in the encrypted vault
+ *   tr recall <query>       — search the encrypted vault, print results as JSON
+ *
+ * Install: wired via package.json `bin.tr` → dist/tr-cli.js
+ * Usage from container: `docker exec tr-openclaw tr status`
+ */
+
+import path from 'node:path';
+import os from 'node:os';
+import { randomUUID } from 'node:crypto';
+
+import { CONFIG } from './config.js';
+import { loadCredentialsJson } from './fs-helpers.js';
+import { printStatus } from './onboarding-cli.js';
+import {
+  deriveKeys,
+  computeAuthKeyHash,
+  encrypt,
+  decrypt,
+  generateBlindIndices,
+  generateContentFingerprint,
+} from './crypto.js';
+import { createApiClient } from './api-client.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CREDENTIALS_PATH = CONFIG.credentialsPath;
+const SERVER_URL = CONFIG.serverUrl;
+const STATE_PATH = CONFIG.onboardingStatePath;
+
+function die(msg: string, code = 1): never {
+  process.stderr.write(`tr: ${msg}\n`);
+  process.exit(code);
+}
+
+function log(msg: string): void {
+  process.stdout.write(msg + '\n');
+}
+
+// ---------------------------------------------------------------------------
+// Core init — minimal version of index.ts initialize()
+// ---------------------------------------------------------------------------
+
+interface CliContext {
+  authKeyHex: string;
+  encryptionKey: Buffer;
+  dedupKey: Buffer;
+  apiClient: ReturnType<typeof createApiClient>;
+  userId: string;
+}
+
+async function buildContext(): Promise<CliContext> {
+  const creds = loadCredentialsJson(CREDENTIALS_PATH);
+  if (!creds) {
+    die('TotalReclaw is not set up. Run: openclaw totalreclaw onboard\n(or: tr pair)');
+  }
+
+  const mnemonic =
+    (typeof creds.mnemonic === 'string' && creds.mnemonic.trim()) ||
+    (typeof creds.recovery_phrase === 'string' && creds.recovery_phrase.trim()) ||
+    '';
+
+  if (!mnemonic) {
+    die('No recovery phrase in credentials.json. Run: openclaw totalreclaw onboard');
+  }
+
+  // Parse existing salt/userId from credentials.json
+  let existingSalt: Buffer | undefined;
+  let existingUserId: string | undefined;
+
+  const saltStr = typeof creds.salt === 'string' ? creds.salt : undefined;
+  if (saltStr) {
+    if (/^[0-9a-f]{64}$/i.test(saltStr)) {
+      existingSalt = Buffer.from(saltStr, 'hex');
+    } else {
+      existingSalt = Buffer.from(saltStr, 'base64');
+    }
+  }
+  existingUserId = typeof creds.userId === 'string' ? creds.userId : undefined;
+
+  const keys = deriveKeys(mnemonic, existingSalt);
+  const authKeyHex = keys.authKey.toString('hex');
+
+  const apiClient = createApiClient(SERVER_URL);
+
+  let userId: string;
+  if (existingUserId) {
+    userId = existingUserId;
+  } else {
+    // Register to get userId (idempotent on relay)
+    const authHash = computeAuthKeyHash(keys.authKey);
+    const saltHex = keys.salt.toString('hex');
+    try {
+      const result = await apiClient.register(authHash, saltHex);
+      userId = result.user_id;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('USER_EXISTS')) {
+        userId = authHash.slice(0, 32);
+      } else {
+        die(`Relay registration failed: ${msg}`);
+      }
+    }
+  }
+
+  return {
+    authKeyHex,
+    encryptionKey: keys.encryptionKey,
+    dedupKey: keys.dedupKey,
+    apiClient,
+    userId,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Command: status
+// ---------------------------------------------------------------------------
+
+async function cmdStatus(): Promise<void> {
+  // Print onboarding + credentials state (never prints mnemonic — same as
+  // the `openclaw totalreclaw status` subcommand surface).
+  printStatus(CREDENTIALS_PATH, STATE_PATH, process.stdout);
+
+  // Additional: loaded.json check to confirm plugin hooks are active.
+  // Reads manifest written by register() in index.ts.
+  // Probe both install paths: extensions/ (local tgz installs) and npm/ (registry installs).
+  try {
+    const fs = await import('node:fs');
+    const candidatePaths = [
+      // extensions-path (local tgz / --force install) — .loaded.json sits at root, not dist/
+      path.join(os.homedir(), '.openclaw', 'extensions', 'totalreclaw', '.loaded.json'),
+      // npm-path (registry install) — .loaded.json inside dist/
+      path.join(os.homedir(), '.openclaw', 'npm', 'node_modules', '@totalreclaw', 'totalreclaw', 'dist', '.loaded.json'),
+    ];
+    const resolvedPath = candidatePaths.find((p) => fs.existsSync(p));
+    if (resolvedPath) {
+      const raw = fs.readFileSync(resolvedPath, 'utf-8');
+      const manifest = JSON.parse(raw) as {
+        version?: string;
+        bootCount?: number;
+        loadedAt?: number;
+        hybridMode?: boolean;
+        tools?: string[];
+      };
+      const ageMs = Date.now() - (manifest.loadedAt ?? 0);
+      const ageSec = Math.round(ageMs / 1000);
+      process.stdout.write(
+        `\n  plugin:      loaded (version=${manifest.version ?? '?'} bootCount=${manifest.bootCount ?? '?'} loaded=${ageSec}s ago)\n` +
+        `  hybrid-mode: ${manifest.hybridMode ? 'yes (use tr <cmd>)' : 'no'}\n` +
+        `  hooks:       before_agent_start, agent_end, message_received, before_reset\n` +
+        `  note:        tools from .loaded.json are STRIPPED by OC 2026.5.2 issue #223;\n` +
+        `               use \`tr <cmd>\` from shell instead\n`,
+      );
+    } else {
+      process.stdout.write('\n  plugin:      .loaded.json not found — plugin may not be loaded\n');
+    }
+  } catch {
+    // Best-effort
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command: pair
+// ---------------------------------------------------------------------------
+
+async function cmdPair(args: string[]): Promise<void> {
+  // Delegate to the existing pair-cli-relay.ts via a thin wrapper.
+  // The pair flow is relay-brokered (works through Docker NAT).
+  // Phrase-safety: pair-cli-relay.ts is x25519-only; mnemonic never appears.
+  const outputMode = args.includes('--json') ? 'json' : args.includes('--url-pin') ? 'url-pin' : 'human';
+
+  const { runRelayPairCli } = await import('./pair-cli-relay.js');
+  const { defaultRenderQr, buildDefaultPairCliIo } = await import('./pair-cli.js');
+
+  const io = buildDefaultPairCliIo();
+  const outcome = await runRelayPairCli('generate', {
+    relayBaseUrl: CONFIG.pairRelayUrl,
+    credentialsPath: CREDENTIALS_PATH,
+    onboardingStatePath: STATE_PATH,
+    logger: {
+      info: (m: string) => process.stderr.write(`[info] ${m}\n`),
+      warn: (m: string) => process.stderr.write(`[warn] ${m}\n`),
+      error: (m: string) => process.stderr.write(`[error] ${m}\n`),
+    },
+    pluginVersion: '3.3.8-rc.1',
+    deriveScopeAddress: undefined,
+    renderQr: defaultRenderQr,
+    io,
+    outputMode: outputMode as import('./pair-cli.js').PairCliOutputMode,
+  });
+
+  if (outcome.status !== 'completed' && outcome.status !== 'canceled') {
+    die(`Pairing ${outcome.status}`, 1);
+  }
+  if (outcome.status === 'canceled') {
+    process.exit(130);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command: remember
+// ---------------------------------------------------------------------------
+
+async function cmdRemember(args: string[]): Promise<void> {
+  const text = args.join(' ').trim();
+  if (!text) {
+    die('Usage: tr remember <text>');
+  }
+
+  const ctx = await buildContext();
+
+  // Build a minimal MemoryTaxonomy v1 claim blob (same format as storeExtractedFacts)
+  const now = new Date().toISOString();
+  const factId = randomUUID().replace(/-/g, '');
+
+  // Encrypt the memory text
+  const blob = JSON.stringify({
+    text,
+    type: 'claim',
+    source: 'user',
+    scope: 'unspecified',
+    importance: 8,
+    metadata: {
+      type: 'claim',
+      source: 'user',
+      scope: 'unspecified',
+      importance: 8,
+    },
+    timestamp: now,
+    version: 'v1',
+  });
+  const encrypted_blob = encrypt(blob, ctx.encryptionKey);
+  const blind_indices = generateBlindIndices(text);
+  const content_fp = generateContentFingerprint(text, ctx.dedupKey);
+
+  const payload = {
+    id: factId,
+    timestamp: now,
+    encrypted_blob,
+    blind_indices,
+    decay_score: 8,
+    source: 'cli:tr-remember',
+    content_fp,
+  };
+
+  try {
+    await ctx.apiClient.store(ctx.userId, [payload], ctx.authKeyHex);
+    log(JSON.stringify({ ok: true, id: factId, text }));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    die(`remember failed: ${msg}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command: recall
+// ---------------------------------------------------------------------------
+
+async function cmdRecall(args: string[]): Promise<void> {
+  const query = args.join(' ').trim();
+  if (!query) {
+    die('Usage: tr recall <query>');
+  }
+
+  const ctx = await buildContext();
+
+  // Generate word trapdoors for blind search
+  const trapdoors = generateBlindIndices(query);
+
+  if (trapdoors.length === 0) {
+    log(JSON.stringify({ ok: true, count: 0, memories: [] }));
+    return;
+  }
+
+  try {
+    const candidates = await ctx.apiClient.search(ctx.userId, trapdoors, 12, ctx.authKeyHex);
+
+    const memories: Array<{ id: string; text: string; score: number; timestamp: string }> = [];
+
+    for (const c of candidates) {
+      try {
+        const raw = decrypt(c.encrypted_blob, ctx.encryptionKey);
+        const parsed = JSON.parse(raw) as { text?: string };
+        if (parsed.text) {
+          memories.push({
+            id: c.fact_id,
+            text: parsed.text,
+            score: c.decay_score,
+            timestamp: new Date(c.timestamp).toISOString(),
+          });
+        }
+      } catch {
+        // Skip undecryptable
+      }
+    }
+
+    // Simple relevance sort by decay_score (descending)
+    memories.sort((a, b) => b.score - a.score);
+
+    log(JSON.stringify({ ok: true, count: memories.length, query, memories }));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    die(`recall failed: ${msg}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const cmd = args[0];
+
+  switch (cmd) {
+    case 'status':
+      await cmdStatus();
+      break;
+
+    case 'pair':
+      await cmdPair(args.slice(1));
+      break;
+
+    case 'remember':
+      await cmdRemember(args.slice(1));
+      break;
+
+    case 'recall':
+      await cmdRecall(args.slice(1));
+      break;
+
+    case undefined:
+    case '--help':
+    case '-h':
+      process.stdout.write(
+        'TotalReclaw hybrid CLI (OpenClaw 2026.5.2 issue #223 workaround)\n\n' +
+        'Usage:\n' +
+        '  tr status              — onboarding + plugin load state\n' +
+        '  tr pair [--json]       — start a relay pairing session\n' +
+        '  tr remember <text>     — store a memory\n' +
+        '  tr recall <query>      — search memories (outputs JSON)\n\n' +
+        'Environment:\n' +
+        '  TOTALRECLAW_SERVER_URL — relay URL (default: api-staging.totalreclaw.xyz)\n' +
+        '  TOTALRECLAW_CREDENTIALS_PATH — override credentials.json path\n',
+      );
+      break;
+
+    default:
+      die(`Unknown command: ${cmd}. Run \`tr --help\` for usage.`);
+  }
+}
+
+main().catch((err) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`tr: fatal: ${msg}\n`);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

- **Root-cause fix for cold-start loading**: adds `"kind": "memory"` to `openclaw.plugin.json`. OpenClaw 2026.5.2's `resolveGatewayStartupPluginPlanFromRegistry` uses `shouldConsiderForGatewayStartup()` which checks `plugin.startup.memory`, derived from `hasKind(record.kind, "memory")`. Without `"kind": "memory"`, plugin was excluded from cold-start loading plan; loaded only via SIGTERM hot-reload path.
- **Hybrid CLI fallback** for OpenClaw 2026.5.2's tool-binding race ([#223](https://github.com/p-diogo/totalreclaw-internal/issues/223)): `tr-cli.ts` exposes `status`, `pair`, `remember`, `recall` as standalone shell commands. Plugin keeps hooks (auto-extraction, recall-injection, welcome). Agent shells out to `tr <cmd>` when tool not bound to session.
- **SKILL.md** documents OC 2026.5.2 hybrid-mode section: full-path `node` invocation, `allowConversationAccess` config requirement.

## Changes

- `skill/plugin/openclaw.plugin.json` — `kind: "memory"` added (root-cause fix)
- `skill/plugin/tr-cli.ts` (NEW) — standalone CLI: `tr status | pair | remember | recall`
- `skill/plugin/package.json` — version bump 3.3.7-rc.3 → 3.3.8-rc.1, `bin.tr` declared
- `skill/plugin/fs-helpers.ts` — `hybridMode?` + `hybridCliTools?` to `PluginLoadManifest`
- `skill/plugin/index.ts` — `.loaded.json` includes `hybridMode: true`
- `skill/plugin/SKILL.md` — OC 2026.5.2 hybrid-mode section

## Verified on pop-os tr-openclaw (OC 2026.5.2)

- 5 plugins on 3 consecutive cold starts (totalreclaw included after `kind:memory` fix)
- No hook-block warnings after `allowConversationAccess=true` config
- `tr status` → `loaded (version=3.3.8-rc.1 bootCount=6), hybrid-mode: yes`
- E2E pair flow via qa-channel: agent fell back to CLI, returned real pair URL + PIN against staging relay (token `5QDcJyup`)

## Required user-side post-install config

```json
plugins.entries.totalreclaw.hooks.allowConversationAccess = true
```

## Cross-link

- Issue [#223](https://github.com/p-diogo/totalreclaw-internal/issues/223) — OpenClaw 2026.5.2 tool-policy strip race upstream
- Hybrid CLI is workaround until upstream fix lands; native tool path stays as primary when binding works