### PR TITLE
fix(plugin): 3.3.9-rc.3 — auto-silence Telegram streaming verbosity

### DIFF
--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.9-rc.3] — 2026-05-05
+
+Patch release silencing the verbose Telegram streaming output Pedro reported during 3.3.9-rc.2 manual QA ("Krilling… 🔧 Exec: run openclaw skills" repeated 3-4× per shell command in the same chat bubble).
+
+### Fixed
+
+- **Telegram chat noise during agent runs:** OpenClaw 2026.5.x defaults `channels.telegram.streaming.mode` to a verbose preview mode that prints every mid-task tool-progress chunk into chat. The plugin's `patchOpenClawConfig()` now adds a third idempotent fix: when `channels.telegram.enabled === true` and `streaming.mode` is unset, default it to `"off"`. Existing explicit values (`"partial"`, `"block"`, `"progress"`) are preserved — only first-run defaults are touched. Restart required for the new key to take effect (logged via `api.logger.warn`).
+
+### Implementation notes
+
+- `patchOpenClawConfig()` extended in `fs-helpers.ts` with Fix #3. Fully namespaced to Telegram — does not touch Discord, Slack, or other channels' streaming defaults.
+- New tests in `fs-helpers.test.ts` cover: telegram enabled+streaming-unset (patched), streaming-exists-but-mode-missing (patched), explicit mode preserved (unchanged), telegram disabled (unchanged), telegram absent entirely (unchanged). 71/71 green.
+- The same warn message that fired for slot/hooks now also covers streaming.mode in the `'patched'` path, so users see one restart prompt per first install.
+
 ## [3.3.9-rc.2] — 2026-05-02
 
 Patch release fixing the two OpenClaw 2026.5.x compatibility blockers discovered during 3.3.9-rc.1 auto-QA ([umbrella #224](https://github.com/p-diogo/totalreclaw-internal/issues/224)).

--- a/skill/plugin/fs-helpers.test.ts
+++ b/skill/plugin/fs-helpers.test.ts
@@ -488,6 +488,106 @@ const TEST_HEADER = '# Memory\n\n> TotalReclaw is active. Test header.\n\n';
   assertEq((entries['memory-core'] as Record<string, unknown>)?.enabled, false, 'patchOpenClawConfig: preserves memory-core entry');
 }
 
+// --- Fix #3: channels.telegram.streaming.mode = "off" (3.3.10-rc.1) ---
+
+{
+  // patches telegram streaming.mode when telegram is enabled and streaming is unset
+  const cfgPath = path.join(TMP, 'openclaw-telegram-no-streaming.json');
+  const initial = {
+    channels: { telegram: { enabled: true, botToken: 'BOT' } },
+  };
+  fs.writeFileSync(cfgPath, JSON.stringify(initial));
+  assertEq(
+    patchOpenClawConfig(cfgPath),
+    'patched',
+    'patchOpenClawConfig: patches when telegram enabled + streaming unset',
+  );
+  const after = JSON.parse(fs.readFileSync(cfgPath, 'utf-8')) as Record<string, unknown>;
+  const tg = (after.channels as Record<string, unknown>).telegram as Record<string, unknown>;
+  const streaming = tg.streaming as Record<string, unknown>;
+  assertEq(streaming?.mode, 'off', 'patchOpenClawConfig: telegram streaming.mode set to "off"');
+  assertEq(tg.botToken, 'BOT', 'patchOpenClawConfig: preserves telegram.botToken');
+}
+
+{
+  // patches when streaming exists as object but mode is missing
+  const cfgPath = path.join(TMP, 'openclaw-telegram-streaming-no-mode.json');
+  const initial = {
+    channels: { telegram: { enabled: true, streaming: { chunkMode: 'newline' } } },
+  };
+  fs.writeFileSync(cfgPath, JSON.stringify(initial));
+  assertEq(
+    patchOpenClawConfig(cfgPath),
+    'patched',
+    'patchOpenClawConfig: patches when streaming exists but mode missing',
+  );
+  const after = JSON.parse(fs.readFileSync(cfgPath, 'utf-8')) as Record<string, unknown>;
+  const tg = (after.channels as Record<string, unknown>).telegram as Record<string, unknown>;
+  const streaming = tg.streaming as Record<string, unknown>;
+  assertEq(streaming.mode, 'off', 'patchOpenClawConfig: streaming.mode added');
+  assertEq(streaming.chunkMode, 'newline', 'patchOpenClawConfig: preserves existing streaming.chunkMode');
+}
+
+{
+  // does NOT overwrite an explicit streaming.mode (power-user choice preserved)
+  const cfgPath = path.join(TMP, 'openclaw-telegram-explicit-mode.json');
+  const initial = {
+    plugins: {
+      slots: { memory: 'totalreclaw' },
+      entries: { totalreclaw: { hooks: { allowConversationAccess: true } } },
+    },
+    channels: { telegram: { enabled: true, streaming: { mode: 'partial' } } },
+  };
+  fs.writeFileSync(cfgPath, JSON.stringify(initial));
+  assertEq(
+    patchOpenClawConfig(cfgPath),
+    'unchanged',
+    'patchOpenClawConfig: does not overwrite explicit streaming.mode',
+  );
+  const after = JSON.parse(fs.readFileSync(cfgPath, 'utf-8')) as Record<string, unknown>;
+  const tg = (after.channels as Record<string, unknown>).telegram as Record<string, unknown>;
+  const streaming = tg.streaming as Record<string, unknown>;
+  assertEq(streaming.mode, 'partial', 'patchOpenClawConfig: explicit "partial" preserved');
+}
+
+{
+  // does NOT add streaming when telegram is not enabled
+  const cfgPath = path.join(TMP, 'openclaw-telegram-disabled.json');
+  const initial = {
+    plugins: {
+      slots: { memory: 'totalreclaw' },
+      entries: { totalreclaw: { hooks: { allowConversationAccess: true } } },
+    },
+    channels: { telegram: { enabled: false, botToken: 'BOT' } },
+  };
+  fs.writeFileSync(cfgPath, JSON.stringify(initial));
+  assertEq(
+    patchOpenClawConfig(cfgPath),
+    'unchanged',
+    'patchOpenClawConfig: skips telegram patch when channel disabled',
+  );
+  const after = JSON.parse(fs.readFileSync(cfgPath, 'utf-8')) as Record<string, unknown>;
+  const tg = (after.channels as Record<string, unknown>).telegram as Record<string, unknown>;
+  assertEq(tg.streaming, undefined, 'patchOpenClawConfig: streaming not added for disabled channel');
+}
+
+{
+  // does NOT add streaming when channels.telegram is absent entirely
+  const cfgPath = path.join(TMP, 'openclaw-no-telegram.json');
+  const initial = {
+    plugins: {
+      slots: { memory: 'totalreclaw' },
+      entries: { totalreclaw: { hooks: { allowConversationAccess: true } } },
+    },
+  };
+  fs.writeFileSync(cfgPath, JSON.stringify(initial));
+  assertEq(
+    patchOpenClawConfig(cfgPath),
+    'unchanged',
+    'patchOpenClawConfig: skips telegram patch when channel absent',
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Integration: round-trip write → load → delete → reload
 // ---------------------------------------------------------------------------

--- a/skill/plugin/fs-helpers.ts
+++ b/skill/plugin/fs-helpers.ts
@@ -1146,8 +1146,8 @@ export function resolveOnboardingState(
 export type OpenClawConfigPatchResult = 'patched' | 'unchanged' | 'skipped' | 'error';
 
 /**
- * Auto-patch `~/.openclaw/openclaw.json` with the two entries required by
- * OpenClaw 2026.5.x for `kind: memory` plugins (issues #225 + #226):
+ * Auto-patch `~/.openclaw/openclaw.json` with the entries required by
+ * OpenClaw 2026.5.x for clean operation (issues #225 + #226 + verbosity):
  *
  *   1. `plugins.slots.memory = "totalreclaw"`
  *      Claim the memory slot so the plugin loads instead of deferring to
@@ -1158,6 +1158,12 @@ export type OpenClawConfigPatchResult = 'patched' | 'unchanged' | 'skipped' | 'e
  *      hooks. Without this flag OpenClaw 2026.5.x silently blocks both
  *      hooks for non-bundled plugins, disabling auto-extraction and
  *      recall injection.
+ *
+ *   3. `channels.telegram.streaming.mode = "off"` (only if unset)
+ *      OpenClaw 2026.5.x defaults to a verbose streaming mode that prints
+ *      every mid-task tool-progress preview into Telegram chat. Default
+ *      this to "off" on first run for a clean UX. Existing explicit values
+ *      ("partial", "block", "progress") are preserved.
  *
  * Design constraints
  * ------------------
@@ -1223,6 +1229,34 @@ export function patchOpenClawConfig(
     if (cfg.plugins.entries.totalreclaw.hooks.allowConversationAccess !== true) {
       cfg.plugins.entries.totalreclaw.hooks.allowConversationAccess = true;
       mutated = true;
+    }
+
+    // --- Fix #3: channels.telegram.streaming.mode = "off" (3.3.10-rc.1) ---
+    //
+    // OpenClaw 2026.5.x defaults to a verbose streaming mode that prints every
+    // mid-task tool-progress preview into Telegram chat ("Krilling... 🔧 Exec:
+    // run openclaw skills" repeated 3-4× per command). Pedro reported this on
+    // 2026-05-05 with screenshots showing extreme noise during agent install.
+    //
+    // Fix: when the key is COMPLETELY UNSET, default it to "off". Power users
+    // who explicitly chose "partial" / "progress" / "block" keep their setting
+    // — we only intervene on first-run defaults.
+    //
+    // This is namespaced to telegram only; other channels (Discord, Slack)
+    // keep their own defaults. We touch the Telegram subtree only if it's
+    // already enabled (so we don't accidentally configure a channel the user
+    // never set up).
+    if (typeof cfg.channels === 'object' && cfg.channels !== null) {
+      const tg = cfg.channels.telegram;
+      if (typeof tg === 'object' && tg !== null && tg.enabled === true) {
+        if (typeof tg.streaming !== 'object' || tg.streaming === null) {
+          tg.streaming = { mode: 'off' };
+          mutated = true;
+        } else if (tg.streaming.mode === undefined) {
+          tg.streaming.mode = 'off';
+          mutated = true;
+        }
+      }
     }
 
     if (!mutated) return 'unchanged';

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -3125,7 +3125,13 @@ const plugin = {
       //      agent_end and before_agent_start hooks. Without it, auto-
       //      extraction and recall injection are silently disabled. #226.
       //
-      // The patch is idempotent — if both keys are already correct the
+      //   3. channels.telegram.streaming.mode = "off" (only if unset)
+      //      OpenClaw 2026.5.x defaults Telegram to a verbose streaming
+      //      mode that prints every mid-task tool-progress preview into
+      //      chat. Default this to "off" on first run for a clean UX.
+      //      Existing explicit values are preserved (3.3.10-rc.1).
+      //
+      // The patch is idempotent — if all keys are already correct the
       // file is not touched. When the file IS mutated a restart is
       // required for the new keys to take effect (OpenClaw reads
       // openclaw.json at startup, not dynamically). We emit a warn so
@@ -3135,7 +3141,8 @@ const plugin = {
         if (patchResult === 'patched') {
           api.logger.warn(
             'TotalReclaw: updated openclaw.json with required 2026.5.x keys ' +
-              '(plugins.slots.memory + hooks.allowConversationAccess). ' +
+              '(plugins.slots.memory + hooks.allowConversationAccess + ' +
+              'channels.telegram.streaming.mode). ' +
               'Gateway restart required for the changes to take effect. ' +
               'Run `/totalreclaw-restart` or restart the gateway manually.',
           );

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.9-rc.2",
+  "version": "3.3.9-rc.3",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "3.3.9-rc.2",
+  "version": "3.3.9-rc.3",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Pedro's manual QA on 3.3.9-rc.2 (2026-05-05) reported extreme verbosity in Telegram chat during agent runs: every shell exec produced 3-4 "Krilling… 🔧 Exec: <command>" preview lines stacked into the same message bubble.
- Cause: OpenClaw 2026.5.x defaults `channels.telegram.streaming.mode` to a verbose preview mode.
- Fix: extend `patchOpenClawConfig()` with Fix #3 — when `channels.telegram.enabled === true` and `streaming.mode` is unset, default it to `"off"`. Existing explicit values preserved.

## Validation

- [x] Verified live on pop-os: `openclaw config set channels.telegram.streaming.mode off` → applied → restart → confirmed clean Telegram output
- [x] `fs-helpers.test.ts`: 71/71 green (5 new cases)
- [x] `register-command-name.test.ts`: 21/21 green (rc.3 accepted)
- [x] `manifest-shape.test.ts`: 10/10 green
- [x] `npm run build` clean

## Test plan

- [ ] Auto-merge → publish-plugin.yml `release-type=rc rc-number=3`
- [ ] Auto-QA on staging fires automatically (per `/qa-totalreclaw` trigger)
- [ ] Pedro manual re-test on pop-os: install rc.3 fresh, run agent, verify Telegram output is clean
- [ ] Promote 3.3.9-rc.3 to stable if QA returns GO

🤖 Generated with [Claude Code](https://claude.com/claude-code)