### PR TITLE
fix(plugin): 3.3.9-rc.4 — gate slot patch on installs.totalreclaw presence

### DIFF
--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.9-rc.4] — 2026-05-05
+
+Defensive patch hardening `patchOpenClawConfig()` Fix #1 against a startup crash loop observed on Pedro's pop-os QA host on 2026-05-05.
+
+### Fixed
+
+- **Slot patch crash-loop guard:** `patchOpenClawConfig()` previously wrote `plugins.slots.memory = "totalreclaw"` whenever the slot was unset. On 2026-05-05 pop-os crashed in a restart loop (~13 attempts, 12:10–12:23 UTC) with `Gateway failed to start: Error: Invalid config at openclaw.json. plugins.slots.memory: plugin not found: totalreclaw. Run "openclaw doctor --fix" to repair, then retry.` Root cause: a previous register() invocation had written the slot, but a later config reset / migration wiped `plugins.installs.totalreclaw` while leaving `plugins.slots.memory` behind. OpenClaw's startup validator hard-fails when `slots.memory` points to a name with no install record. The crash self-resolved at 12:24 once the user re-ran `openclaw plugins install`.
+
+  **Fix:** Slot patch is now gated on `cfg.plugins.installs?.totalreclaw?.version` being a non-empty string. Without an install record we leave `slots.memory` alone — neither writing it (preventing future crash loops) nor cleaning it up (not our responsibility). The hooks (Fix #2) and Telegram streaming (Fix #3) patches are unchanged — they write under `plugins.entries` and `channels` which are inert without an install record and cannot trip the validator.
+
+### Implementation notes
+
+- `cfg.plugins.installs.totalreclaw.version` is the install pipeline's authoritative signal that the plugin is on disk and registered with the gateway. It's populated by `openclaw plugins install` and survives gateway restarts; a config reset that drops it indicates the plugin install record is no longer valid and slot should not point to it.
+- 7 new tests in `fs-helpers.test.ts`: empty-config-no-installs (slot NOT written), empty-config-with-installs (slot WRITTEN), installs-without-version (slot still gated), stale-slot-no-install (we don't auto-clean), plus updated fixtures across the existing 4 cases. 81/81 green.
+- Pre-existing tests for the hooks and Telegram streaming patches continue to pass unchanged — those code paths are not gated.
+
 ## [3.3.9-rc.3] — 2026-05-05
 
 Patch release silencing the verbose Telegram streaming output Pedro reported during 3.3.9-rc.2 manual QA ("Krilling… 🔧 Exec: run openclaw skills" repeated 3-4× per shell command in the same chat bubble).

--- a/skill/plugin/fs-helpers.test.ts
+++ b/skill/plugin/fs-helpers.test.ts
@@ -406,22 +406,43 @@ const TEST_HEADER = '# Memory\n\n> TotalReclaw is active. Test header.\n\n';
 }
 
 {
-  // 'patched' on empty config — both keys written
+  // 'patched' on empty config — hooks written, but slot NOT touched
+  // (no `plugins.installs.totalreclaw` → slot patch is gated off, see
+  // 3.3.9-rc.4 defensive gate).
   const cfgPath = path.join(TMP, 'openclaw-empty.json');
   fs.writeFileSync(cfgPath, JSON.stringify({}));
-  assertEq(patchOpenClawConfig(cfgPath), 'patched', 'patchOpenClawConfig: patches empty config');
+  assertEq(patchOpenClawConfig(cfgPath), 'patched', 'patchOpenClawConfig: patches empty config (hooks only)');
   const written = JSON.parse(fs.readFileSync(cfgPath, 'utf-8')) as Record<string, unknown>;
   const plugins = written.plugins as Record<string, unknown>;
-  assertEq((plugins.slots as Record<string, unknown>)?.memory, 'totalreclaw', 'patchOpenClawConfig: slots.memory set to totalreclaw');
+  assertEq((plugins.slots as Record<string, unknown>)?.memory, undefined, 'patchOpenClawConfig: slot NOT written without installs.totalreclaw (rc.4 gate)');
   const tr = (plugins.entries as Record<string, Record<string, unknown>>)?.totalreclaw;
-  assertEq((tr?.hooks as Record<string, unknown>)?.allowConversationAccess, true, 'patchOpenClawConfig: allowConversationAccess set to true');
+  assertEq((tr?.hooks as Record<string, unknown>)?.allowConversationAccess, true, 'patchOpenClawConfig: allowConversationAccess set to true (no install gate)');
 }
 
 {
-  // 'unchanged' when both keys already correct
+  // 'patched' on empty config WITH installs.totalreclaw present —
+  // slot AND hooks both written.
+  const cfgPath = path.join(TMP, 'openclaw-empty-with-installs.json');
+  const initial = {
+    plugins: {
+      installs: { totalreclaw: { version: '3.3.9-rc.4' } },
+    },
+  };
+  fs.writeFileSync(cfgPath, JSON.stringify(initial));
+  assertEq(patchOpenClawConfig(cfgPath), 'patched', 'patchOpenClawConfig: patches when installs.totalreclaw present');
+  const written = JSON.parse(fs.readFileSync(cfgPath, 'utf-8')) as Record<string, unknown>;
+  const plugins = written.plugins as Record<string, unknown>;
+  assertEq((plugins.slots as Record<string, unknown>)?.memory, 'totalreclaw', 'patchOpenClawConfig: slot WRITTEN with installs.totalreclaw');
+  const tr = (plugins.entries as Record<string, Record<string, unknown>>)?.totalreclaw;
+  assertEq((tr?.hooks as Record<string, unknown>)?.allowConversationAccess, true, 'patchOpenClawConfig: hooks written with installs');
+}
+
+{
+  // 'unchanged' when both keys already correct AND installs present
   const cfgPath = path.join(TMP, 'openclaw-complete.json');
   const initial = {
     plugins: {
+      installs: { totalreclaw: { version: '3.3.9-rc.4' } },
       slots: { memory: 'totalreclaw' },
       entries: { totalreclaw: { hooks: { allowConversationAccess: true } } },
     },
@@ -435,10 +456,11 @@ const TEST_HEADER = '# Memory\n\n> TotalReclaw is active. Test header.\n\n';
 }
 
 {
-  // 'patched' when only slot is missing (allowConversationAccess already set)
+  // 'patched' when only slot is missing (allowConversationAccess + installs present)
   const cfgPath = path.join(TMP, 'openclaw-missing-slot.json');
   const initial = {
     plugins: {
+      installs: { totalreclaw: { version: '3.3.9-rc.4' } },
       entries: { totalreclaw: { hooks: { allowConversationAccess: true } } },
     },
   };
@@ -446,7 +468,7 @@ const TEST_HEADER = '# Memory\n\n> TotalReclaw is active. Test header.\n\n';
   assertEq(patchOpenClawConfig(cfgPath), 'patched', 'patchOpenClawConfig: patches when only slot missing');
   const after = JSON.parse(fs.readFileSync(cfgPath, 'utf-8')) as Record<string, unknown>;
   const afterPlugins = after.plugins as Record<string, unknown>;
-  assertEq((afterPlugins.slots as Record<string, unknown>)?.memory, 'totalreclaw', 'patchOpenClawConfig: slot written when only slot missing');
+  assertEq((afterPlugins.slots as Record<string, unknown>)?.memory, 'totalreclaw', 'patchOpenClawConfig: slot written when installs + entries present');
 }
 
 {
@@ -463,6 +485,90 @@ const TEST_HEADER = '# Memory\n\n> TotalReclaw is active. Test header.\n\n';
   const afterPlugins = after.plugins as Record<string, unknown>;
   const tr = (afterPlugins.entries as Record<string, Record<string, unknown>>)?.totalreclaw;
   assertEq((tr?.hooks as Record<string, unknown>)?.allowConversationAccess, true, 'patchOpenClawConfig: hooks written when only hooks missing');
+}
+
+// --- Fix #1 install-gate regression tests (3.3.9-rc.4) ---
+
+{
+  // REGRESSION: empty config WITHOUT installs.totalreclaw must NOT
+  // write `plugins.slots.memory = "totalreclaw"`. This is the
+  // 2026-05-05 pop-os crash-loop scenario — writing the slot without
+  // an install record produces "plugin not found: totalreclaw" at
+  // gateway startup and the container restart-loops indefinitely
+  // until `openclaw plugins install` repopulates installs.totalreclaw.
+  const cfgPath = path.join(TMP, 'openclaw-no-installs.json');
+  fs.writeFileSync(cfgPath, JSON.stringify({ plugins: {} }));
+  assertEq(
+    patchOpenClawConfig(cfgPath),
+    'patched',
+    'patchOpenClawConfig: no-installs config returns patched (hooks written)',
+  );
+  const after = JSON.parse(fs.readFileSync(cfgPath, 'utf-8')) as Record<string, unknown>;
+  const plugins = after.plugins as Record<string, unknown>;
+  // The crash-loop test: slot must NOT be set when installs missing
+  assertEq(
+    (plugins.slots as Record<string, unknown> | undefined)?.memory,
+    undefined,
+    'patchOpenClawConfig: slot NOT set when installs.totalreclaw missing (crash-loop guard)',
+  );
+  // But hooks ARE set — they're inert without an install record so safe
+  const tr = (plugins.entries as Record<string, Record<string, unknown>>)?.totalreclaw;
+  assertEq(
+    (tr?.hooks as Record<string, unknown>)?.allowConversationAccess,
+    true,
+    'patchOpenClawConfig: hooks still written without installs (no validator gate)',
+  );
+}
+
+{
+  // REGRESSION: installs.totalreclaw with empty/non-string version → slot still gated.
+  // The version field is what the install pipeline writes; an empty
+  // installs.totalreclaw object is not authoritative enough to gate on.
+  const cfgPath = path.join(TMP, 'openclaw-installs-no-version.json');
+  fs.writeFileSync(cfgPath, JSON.stringify({
+    plugins: { installs: { totalreclaw: {} } },
+  }));
+  assertEq(
+    patchOpenClawConfig(cfgPath),
+    'patched',
+    'patchOpenClawConfig: installs without version returns patched (hooks)',
+  );
+  const after = JSON.parse(fs.readFileSync(cfgPath, 'utf-8')) as Record<string, unknown>;
+  const plugins = after.plugins as Record<string, unknown>;
+  assertEq(
+    (plugins.slots as Record<string, unknown> | undefined)?.memory,
+    undefined,
+    'patchOpenClawConfig: slot still gated when installs.totalreclaw lacks version',
+  );
+}
+
+{
+  // REGRESSION: stale slot=totalreclaw + NO installs (the actual
+  // 2026-05-05 crash-loop disk state). Patch must NOT add to the
+  // problem — it already exists; we're not the cleaner. Slot stays
+  // (whoever wrote it earlier owns the cleanup), but we write hooks.
+  const cfgPath = path.join(TMP, 'openclaw-stale-slot-no-install.json');
+  const initial = {
+    plugins: {
+      slots: { memory: 'totalreclaw' },
+      // no installs.totalreclaw — the crash state on pop-os 12:10-12:23
+    },
+  };
+  fs.writeFileSync(cfgPath, JSON.stringify(initial));
+  assertEq(
+    patchOpenClawConfig(cfgPath),
+    'patched',
+    'patchOpenClawConfig: stale-slot + no-install returns patched (hooks only)',
+  );
+  const after = JSON.parse(fs.readFileSync(cfgPath, 'utf-8')) as Record<string, unknown>;
+  const plugins = after.plugins as Record<string, unknown>;
+  // Slot is still there but we did not re-write it — and we did not
+  // create a new mutation for it either (mutated only via hooks).
+  assertEq(
+    (plugins.slots as Record<string, unknown>)?.memory,
+    'totalreclaw',
+    'patchOpenClawConfig: pre-existing stale slot preserved (we do not auto-clean)',
+  );
 }
 
 {

--- a/skill/plugin/fs-helpers.ts
+++ b/skill/plugin/fs-helpers.ts
@@ -1149,9 +1149,14 @@ export type OpenClawConfigPatchResult = 'patched' | 'unchanged' | 'skipped' | 'e
  * Auto-patch `~/.openclaw/openclaw.json` with the entries required by
  * OpenClaw 2026.5.x for clean operation (issues #225 + #226 + verbosity):
  *
- *   1. `plugins.slots.memory = "totalreclaw"`
+ *   1. `plugins.slots.memory = "totalreclaw"` (gated on install record)
  *      Claim the memory slot so the plugin loads instead of deferring to
- *      the built-in `memory-core` tenant.
+ *      the built-in `memory-core` tenant. As of 3.3.9-rc.4 this fix is
+ *      gated on `plugins.installs.totalreclaw.version` being present —
+ *      writing the slot without an install record produces a startup
+ *      crash loop ("plugins.slots.memory: plugin not found: totalreclaw")
+ *      that survives container restarts until `openclaw plugins install`
+ *      repopulates the install record.
  *
  *   2. `plugins.entries.totalreclaw.hooks.allowConversationAccess = true`
  *      Grant the plugin access to `agent_end` and `before_agent_start`
@@ -1207,13 +1212,50 @@ export function patchOpenClawConfig(
 
     let mutated = false;
 
-    // --- Fix #1: plugins.slots.memory = "totalreclaw" ---
-    if (typeof cfg.plugins.slots !== 'object' || cfg.plugins.slots === null) {
-      cfg.plugins.slots = {};
-    }
-    if (cfg.plugins.slots.memory !== 'totalreclaw') {
-      cfg.plugins.slots.memory = 'totalreclaw';
-      mutated = true;
+    // --- Fix #1: plugins.slots.memory = "totalreclaw" (gated on install) ---
+    //
+    // DEFENSIVE GATE (3.3.9-rc.4 — 2026-05-05): only write the slot when
+    // the plugin is genuinely INSTALLED (`plugins.installs.totalreclaw`
+    // present with a `version`). Writing the slot unconditionally
+    // produced a startup crash loop on Pedro's pop-os QA host on
+    // 2026-05-05 — after a config reset, `plugins.installs.totalreclaw`
+    // was missing but a previously-written `slots.memory = "totalreclaw"`
+    // had survived. OpenClaw's startup validator refuses to start with
+    //
+    //   Gateway failed to start: Error: Invalid config at openclaw.json.
+    //   plugins.slots.memory: plugin not found: totalreclaw
+    //   Run "openclaw doctor --fix" to repair, then retry.
+    //
+    // The container restart-loop drained ~13 attempts (12:10-12:23 UTC)
+    // until `openclaw plugins install` was re-run and re-populated
+    // `plugins.installs.totalreclaw`. With this gate, future installs
+    // that wipe `plugins.installs` (config reset, `doctor --fix`,
+    // migration tools) cannot regress into the same boot loop — slot is
+    // only ever written when the install record exists, and the install
+    // record is the install pipeline's authoritative signal that the
+    // plugin is on disk and registered with the gateway.
+    //
+    // The hooks patch (Fix #2) and Telegram streaming patch (Fix #3) are
+    // not gated this way — they write under `plugins.entries` and
+    // `channels` which are inert without an install record, so they can
+    // never trip the validator.
+    const installsRoot = cfg.plugins.installs;
+    const installEntry = typeof installsRoot === 'object' && installsRoot !== null
+      ? installsRoot.totalreclaw
+      : undefined;
+    const pluginIsInstalled = typeof installEntry === 'object'
+      && installEntry !== null
+      && typeof installEntry.version === 'string'
+      && installEntry.version.length > 0;
+
+    if (pluginIsInstalled) {
+      if (typeof cfg.plugins.slots !== 'object' || cfg.plugins.slots === null) {
+        cfg.plugins.slots = {};
+      }
+      if (cfg.plugins.slots.memory !== 'totalreclaw') {
+        cfg.plugins.slots.memory = 'totalreclaw';
+        mutated = true;
+      }
     }
 
     // --- Fix #2: plugins.entries.totalreclaw.hooks.allowConversationAccess = true ---

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.9-rc.3",
+  "version": "3.3.9-rc.4",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "3.3.9-rc.3",
+  "version": "3.3.9-rc.4",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- 2026-05-05: Pedro's pop-os QA host hit a startup crash loop (~13 attempts, 12:10–12:23 UTC) — `Gateway failed to start: Error: Invalid config at openclaw.json. plugins.slots.memory: plugin not found: totalreclaw. Run "openclaw doctor --fix" to repair, then retry.`
- Root cause: `patchOpenClawConfig()` wrote `plugins.slots.memory = "totalreclaw"` whenever the slot was unset; a later config reset wiped `plugins.installs.totalreclaw` but left the slot pointer behind, and OpenClaw's startup validator refuses to start with a dangling slot. Self-resolved at 12:24 once `openclaw plugins install` re-populated the install record.
- Fix: gate Fix #1 (slot patch) on `cfg.plugins.installs?.totalreclaw?.version` being a non-empty string. Without an install record, slot is left untouched. Hooks (Fix #2) and Telegram streaming (Fix #3) patches are unchanged.

## Validation

- [x] 7 new tests in `fs-helpers.test.ts` (81/81 green)
- [x] `register-command-name.test.ts` 21/21 green (rc.4 accepted)
- [x] `manifest-shape.test.ts` 10/10 green
- [x] `npm run build` clean
- [x] Pre-existing slot fixtures updated to inject `installs.totalreclaw`

## Test plan

- [ ] Auto-merge → publish-plugin.yml `release-type=rc rc-number=4`
- [ ] Auto-QA fires
- [ ] Pedro retest on pop-os: install rc.4, verify no slot crash on next config reset / wipe
- [ ] Promote 3.3.9-rc.4 to stable if QA returns GO

🤖 Generated with [Claude Code](https://claude.com/claude-code)