### PR TITLE
fix(plugin): 3.3.10-rc.1 — detach tr pair into own process group

### DIFF
--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.10-rc.1] — 2026-05-05
+
+Critical fix for the persistent 502 `gateway_disconnected` Pedro hit on the pair `/respond` endpoint after rc.4 published. Relay PR #14 (5s + immediate WS keepalive ping) was already deployed but did not fix the issue — root cause was different.
+
+### Fixed
+
+- **`tr pair` now detaches into a child process group; WS survives gateway restarts.** OpenClaw's `openclaw plugins install <pkg>` writes `plugins.installs.totalreclaw.*` into `~/.openclaw/openclaw.json`. The gateway's reload pipeline classifies that as `requires gateway restart` and defers a SIGUSR1 self-restart until active operations complete. When the agent immediately runs `tr pair --json` after install, the pair subprocess is part of the active operation set — restart is deferred until tr pair returns, but the gateway's reload heuristic sometimes fires the SIGUSR1 anyway (when other operations finish first), killing the pair subprocess and dropping its WS to the relay. Pedro's browser then POSTs `/respond` with the encrypted phrase, the relay finds the gateway WS gone, and returns 502.
+
+  **Fix:** `cmdPair` in `tr-cli.ts` now runs in two modes. The PARENT mode (default) forks itself with `detached: true`, `stdio: 'ignore'`, and `unref()` — placing the child in its own process group, untethered from the agent shell-tool's process. The CHILD mode (sentinel `--detached-child`) opens the relay WS, writes the URL+PIN payload to a tmp file, then blocks on `awaitPhraseUpload`. The parent polls the handoff file (100 ms cadence, 15 s cap) and prints URL+PIN to stdout the moment the child writes it. Parent exits 0 in <500 ms typical — agent's tool call returns immediately. Child holds the WS independently of any subsequent gateway restart, agent restart, or shell-tool kill.
+
+  Verified locally: parent exits in 100-300 ms with URL+PIN; killing the parent process leaves the child running and the WS open; `kill -9 <child-pid>` is required to drop it. Handoff file is auto-cleaned by the parent after read; child writes an error payload on early failure so the parent doesn't hang.
+
+### Implementation notes
+
+- Sentinel arg `--detached-child` + env var `TR_PAIR_HANDOFF=<tmpfile>` carry the handoff path from parent to child.
+- Child intercepts the first `process.stdout.write` whose chunk contains `"url"` / `"pair_url"` and writes that line to the handoff file before letting the rest pass through (which goes to /dev/null since stdio is ignored).
+- 15 s parent timeout: a slow relay handshake / network blip surfaces as `pair handoff timed out — child failed to open relay session within 15s` instead of an indefinite hang.
+- Phrase-safety unchanged: the mnemonic still flows browser → relay → child via the existing x25519 envelope; the parent never sees ciphertext, plaintext, or any phrase-derived material. The handoff file carries only the URL+PIN payload (the same data the agent used to receive synchronously).
+
 ## [3.3.9-rc.4] — 2026-05-05
 
 Defensive patch hardening `patchOpenClawConfig()` Fix #1 against a startup crash loop observed on Pedro's pop-os QA host on 2026-05-05.

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.9-rc.4",
+  "version": "3.3.10-rc.1",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [

--- a/skill/plugin/register-command-name.test.ts
+++ b/skill/plugin/register-command-name.test.ts
@@ -272,18 +272,19 @@ assert(
 const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'), 'utf8'));
 const skillJson = JSON.parse(fs.readFileSync(path.join(__dirname, 'skill.json'), 'utf8'));
 
-// Accept 3.3.7-rc.3+ OR 3.3.8-rc.N+ OR 3.3.9-rc.N+ (versions bump with each patch wave;
-// 3.3.9 series ships the hybrid-primary pivot + hallucination guards + CLI JSON-first output).
-const validVersionPattern = /^3\.3\.(7-rc\.[3-9]\d*|8-rc\.\d+|9-rc\.\d+|[89]\d*\.\d+|[1-9]\d{2,}.*)$/;
+// Accept 3.3.7-rc.3+ OR 3.3.8-rc.N+ OR 3.3.9-rc.N+ OR 3.3.10-rc.N+ OR
+// 3.3.<11+>.N (versions bump with each patch wave; 3.3.10 series ships
+// the `tr pair` detached-child fix for the persistent 502).
+const validVersionPattern = /^3\.3\.(7-rc\.[3-9]\d*|8-rc\.\d+|9-rc\.\d+|1\d-rc\.\d+|[2-9]\d-rc\.\d+|[1-9]\d*\.\d+|[1-9]\d{2,}.*)$/;
 
 assert(
   validVersionPattern.test(packageJson.version),
-  `package.json: version is 3.3.7-rc.3+ or 3.3.8-rc.1+ or 3.3.9-rc.1+ (got ${packageJson.version})`,
+  `package.json: version is 3.3.7-rc.3+ / 3.3.8-rc.1+ / 3.3.9-rc.1+ / 3.3.10-rc.1+ (got ${packageJson.version})`,
 );
 
 assert(
   validVersionPattern.test(skillJson.version),
-  `skill.json: version is 3.3.7-rc.3+ or 3.3.8-rc.1+ or 3.3.9-rc.1+ (got ${skillJson.version})`,
+  `skill.json: version is 3.3.7-rc.3+ / 3.3.8-rc.1+ / 3.3.9-rc.1+ / 3.3.10-rc.1+ (got ${skillJson.version})`,
 );
 
 // ---------------------------------------------------------------------------

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "3.3.9-rc.4",
+  "version": "3.3.10-rc.1",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",

--- a/skill/plugin/tr-cli.ts
+++ b/skill/plugin/tr-cli.ts
@@ -26,7 +26,10 @@
  */
 
 import path from 'node:path';
+import fs from 'node:fs';
 import os from 'node:os';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import { randomUUID } from 'node:crypto';
 
 import { CONFIG } from './config.js';
@@ -49,7 +52,16 @@ import { createApiClient } from './api-client.js';
 const CREDENTIALS_PATH = CONFIG.credentialsPath;
 const SERVER_URL = CONFIG.serverUrl;
 const STATE_PATH = CONFIG.onboardingStatePath;
-const PLUGIN_VERSION = '3.3.9-rc.1';
+const PLUGIN_VERSION = '3.3.10-rc.1';
+
+// Sentinel for the detached-child re-spawn used by `cmdPair`. The parent
+// invocation forks a child with this flag, the child holds the WS until
+// the browser uploads the encrypted phrase. Survives the parent
+// (agent shell tool) exit AND any subsequent gateway SIGUSR1 restart
+// — the child runs in its own process group via `detached: true` and
+// is `unref()`ed so the parent's event loop does not wait on it.
+const PAIR_DETACH_FLAG = '--detached-child';
+const PAIR_HANDOFF_ENV = 'TR_PAIR_HANDOFF';
 
 function die(msg: string, code = 1): never {
   process.stderr.write(`tr: ${msg}\n`);
@@ -222,15 +234,121 @@ async function cmdStatus(jsonMode: boolean): Promise<void> {
 // ---------------------------------------------------------------------------
 
 async function cmdPair(args: string[]): Promise<void> {
-  // Delegate to the existing pair-cli-relay.ts via a thin wrapper.
-  // The pair flow is relay-brokered (works through Docker NAT).
-  // Phrase-safety: pair-cli-relay.ts is x25519-only; mnemonic never appears.
+  // Outcome flags. `--detached-child` is a sentinel set by the
+  // parent re-spawn — the child runs the actual pair flow and holds
+  // the WS until the browser uploads the encrypted phrase. The parent
+  // (which the agent shell-tool waits on) prints URL+PIN and exits 0
+  // immediately so the agent can respond to the user without holding
+  // a 5-minute open shell-tool.
+  const isDetachedChild = args.includes(PAIR_DETACH_FLAG);
   const outputMode = args.includes('--json') ? 'json' : args.includes('--url-pin') ? 'url-pin' : 'human';
+
+  if (!isDetachedChild) {
+    // PARENT MODE: fork self detached, wait for handoff line on a
+    // tmp file, print it to stdout, exit. This shape — agent-facing
+    // tool returns immediately with URL+PIN — was forced by Pedro's
+    // 2026-05-05 502 QA: each `openclaw plugins install` writes a
+    // config-change that the gateway eventually applies via SIGUSR1
+    // restart, killing any in-flight subprocess. With the WS in a
+    // detached child (own process group), it survives the gateway
+    // restart that kills the agent's shell-tool subprocess.
+    await runPairParent(outputMode);
+    return;
+  }
+
+  // CHILD MODE: hold the WS until the browser uploads the encrypted
+  // phrase, write credentials.json, exit. Output goes to a handoff
+  // file the parent reads, then to /dev/null.
+  await runPairDetachedChild(outputMode, args);
+}
+
+async function runPairParent(outputMode: string): Promise<void> {
+  // Disk-handoff path — child writes URL+PIN here, parent polls.
+  // Crypto-random suffix keeps concurrent invocations non-colliding.
+  const handoffPath = path.join(os.tmpdir(), `tr-pair-handoff-${randomUUID()}.json`);
+  // Pre-touch the file so the child can `appendFile`/`writeFile`
+  // without a race against a non-existent parent dir.
+  fs.writeFileSync(handoffPath, '');
+
+  const selfPath = fileURLToPath(import.meta.url);
+  const childArgs = ['pair'];
+  if (outputMode === 'json') childArgs.push('--json');
+  else if (outputMode === 'url-pin') childArgs.push('--url-pin');
+  childArgs.push(PAIR_DETACH_FLAG);
+
+  const child = spawn(process.execPath, [selfPath, ...childArgs], {
+    detached: true,
+    stdio: ['ignore', 'ignore', 'ignore'],
+    env: { ...process.env, [PAIR_HANDOFF_ENV]: handoffPath },
+  });
+  child.unref();
+
+  // Poll the handoff file. `tr pair` typical wall-clock to URL+PIN
+  // is 100-500ms (one WS open + one frame round-trip). Cap the wait
+  // at 15s — beyond that the child has either failed (relay down,
+  // network issue) or gateway killed it before it could write.
+  const start = Date.now();
+  const POLL_INTERVAL_MS = 100;
+  const MAX_WAIT_MS = 15_000;
+  while (Date.now() - start < MAX_WAIT_MS) {
+    let payload: string;
+    try {
+      payload = fs.readFileSync(handoffPath, 'utf-8');
+    } catch {
+      payload = '';
+    }
+    if (payload.trim().length > 0) {
+      process.stdout.write(payload);
+      // Best-effort cleanup — if the child is still active, it'll
+      // re-write or it doesn't matter (we're about to exit).
+      try { fs.unlinkSync(handoffPath); } catch { /* ignore */ }
+      // Parent exits 0 — agent's tool call returns. Detached child
+      // continues holding WS until phrase upload or relay TTL.
+      process.exit(0);
+    }
+    await new Promise<void>((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+
+  // Timed out — child never wrote URL+PIN. Surface the failure.
+  try { fs.unlinkSync(handoffPath); } catch { /* ignore */ }
+  die('pair handoff timed out — child failed to open relay session within 15s', 1);
+}
+
+async function runPairDetachedChild(outputMode: string, _args: string[]): Promise<void> {
+  // We're the detached child. Open WS, write URL+PIN to the handoff
+  // file (parent polls + prints), then block on phrase upload.
+  const handoffPath = process.env[PAIR_HANDOFF_ENV];
+  if (!handoffPath) {
+    process.stderr.write(`tr-pair-child: missing ${PAIR_HANDOFF_ENV}\n`);
+    process.exit(1);
+  }
 
   const { runRelayPairCli } = await import('./pair-cli-relay.js');
   const { defaultRenderQr, buildDefaultPairCliIo } = await import('./pair-cli.js');
 
+  // Capture stdout writes so we can route the URL+PIN line to the
+  // handoff file before passing through to the (ignored) child stdout.
   const io = buildDefaultPairCliIo();
+  const realStdout = process.stdout.write.bind(process.stdout);
+  let handoffWritten = false;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process.stdout as any).write = (chunk: any, ...rest: any[]): boolean => {
+    if (!handoffWritten) {
+      const text = typeof chunk === 'string' ? chunk : (chunk?.toString?.('utf-8') ?? String(chunk));
+      // The pair-cli-relay's first stdout write in --json/--url-pin
+      // mode is the URL+PIN payload as a single line.
+      if (text.trim().length > 0 && (text.includes('"url"') || text.includes('"pair_url"'))) {
+        try {
+          fs.writeFileSync(handoffPath, text);
+          handoffWritten = true;
+        } catch (err) {
+          process.stderr.write(`tr-pair-child: handoff write failed: ${String(err)}\n`);
+        }
+      }
+    }
+    return realStdout(chunk, ...rest);
+  };
+
   const outcome = await runRelayPairCli('generate', {
     relayBaseUrl: CONFIG.pairRelayUrl,
     credentialsPath: CREDENTIALS_PATH,
@@ -247,12 +365,22 @@ async function cmdPair(args: string[]): Promise<void> {
     outputMode: outputMode as import('./pair-cli.js').PairCliOutputMode,
   });
 
+  // If the child exits before parent has read the handoff file
+  // (the WS open frame failed before any URL+PIN to write), make sure
+  // the parent doesn't hang on its 15s poll — write an error payload.
+  if (!handoffWritten) {
+    try {
+      fs.writeFileSync(handoffPath, JSON.stringify({ error: `pair_failed:${outcome.status}` }) + '\n');
+    } catch { /* ignore */ }
+  }
+
   if (outcome.status !== 'completed' && outcome.status !== 'canceled') {
-    die(`Pairing ${outcome.status}`, 1);
+    process.exit(1);
   }
   if (outcome.status === 'canceled') {
     process.exit(130);
   }
+  process.exit(0);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Critical 502 fix. Pedro hit persistent `gateway_disconnected` on /respond after rc.4 published. Relay PR #14 (5s WS keepalive) was deployed but did not fix it.

Real cause: `openclaw plugins install` triggers a deferred SIGUSR1 self-restart of the gateway. The restart kills the agent's shell-tool subprocess that's holding the pair WS. Pedro's browser POSTs encrypted phrase → relay's stored WS is null → 502.

Fix: `tr pair` now forks itself detached. Parent prints URL+PIN and exits in <500ms. Child holds WS in its own process group, survives gateway restart, completes pair flow when phrase arrives.

## Validation

- [x] Detach mechanism smoke-tested: parent reads payload in ~50ms, child outlives parent
- [x] 81/81 fs-helpers tests green
- [x] 21/21 register-command-name tests green
- [x] 10/10 manifest-shape tests green
- [x] Phrase-safety unchanged (handoff file carries only URL+PIN; mnemonic still browser→relay→child via x25519)

## Test plan

- [ ] Auto-merge → publish-plugin.yml `release-type=rc rc-number=1`
- [ ] Pedro retest on pop-os: install rc.10-rc.1, run `tr pair --json`, verify URL+PIN returns immediately AND browser respond completes (no 502)
- [ ] Promote 3.3.10 to stable if QA returns GO

🤖 Generated with [Claude Code](https://claude.com/claude-code)