### PR TITLE
fix(plugin): 3.3.10-rc.4 — qr_ascii inline + quickstart split + lean FORBIDDEN

### DIFF
--- a/docs/guides/openclaw-setup-quickstart.md
+++ b/docs/guides/openclaw-setup-quickstart.md
@@ -1,0 +1,105 @@
+# TotalReclaw — OpenClaw quickstart (agent-executable)
+
+> Audience: the LLM agent fetching this URL during install. Human-readable rationale lives in `openclaw-setup.md`.
+> Stable contract: ~3 KB, copy-paste-runnable, all rules in scope.
+
+## Hard rules (read once, never break)
+
+1. Emit ONLY the four numbered user-visible lines below. No narration, no "let me check…", no version-lag commentary, no path-resolution prose.
+2. **Do NOT restart the gateway** (`/totalreclaw-restart`, `kill -USR1`, `docker restart`, `openclaw gateway restart`). The plugin self-patches and signals its own restart needs.
+3. **Do NOT write to `~/.openclaw/openclaw.json`**. The plugin's `patchOpenClawConfig()` already wrote `plugins.slots.memory`, `plugins.entries.totalreclaw.hooks.allowConversationAccess`, `channels.telegram.streaming.mode`. Any further write triggers a deferred SIGUSR1 reload that kills pair.
+4. **Do NOT save QR PNGs**. The `tr pair --json` payload returns `qr_ascii` — emit that inline in a code block. No `/tmp/totalreclaw-pair-qr.png`, no PNG decode, no `qr_png_b64` (legacy field, no longer exists).
+5. **`tr pair --json` MUST be invoked via `setsid -f`** so the WS-holding subprocess is in its own POSIX session and survives any subsequent gateway reload. Foreground `tr pair --json` is killed when your shell-tool exec returns → relay returns 502.
+
+## User-visible lines (the entire transcript)
+
+1. `Installing TotalReclaw…`
+2. `✓ Installed (totalreclaw <version>, hybrid mode)`
+3. *Triple-backticked `qr_ascii` payload, then:* `Open <url> in your browser. Enter PIN <pin>. Generate or paste a 12-word recovery phrase. Reply \`done\` once it's sealed.`
+4. `✓ You're set up on the TotalReclaw free tier — 500 memories/month, unlimited reads. https://totalreclaw.xyz/pricing. Ask me to remember anything.`
+
+If `~/.totalreclaw/credentials.json` already exists and is non-empty, emit only `✓ TotalReclaw is already set up.` and stop.
+
+## Steps (copy-paste verbatim)
+
+### 1. Install (silent — emit line 1 first)
+
+```bash
+openclaw plugins install @totalreclaw/totalreclaw@rc
+openclaw skills install totalreclaw
+```
+
+For stable use `@totalreclaw/totalreclaw` (no `@rc`). Plugin BEFORE skill — skill install triggers a config-driven reload that races a concurrent plugin install.
+
+If install reports `already exists` or non-zero on a re-run: add `--force`:
+```bash
+openclaw plugins install @totalreclaw/totalreclaw@rc --force
+openclaw skills install totalreclaw --force
+```
+
+If the shell call fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment): emit verbatim `Your environment doesn't expose the OpenClaw CLI to me. Please install \`totalreclaw\` from your service's plugins / skills UI, then reply \`done\`.` Wait for `done` and skip to step 3.
+
+### 2. Verify CLI + emit line 2
+
+```bash
+TR_CLI="$(ls -d ~/.openclaw/npm/node_modules/@totalreclaw/totalreclaw/dist/tr-cli.js ~/.openclaw/extensions/totalreclaw/dist/tr-cli.js 2>/dev/null | head -1)"
+node "$TR_CLI" status --json
+```
+
+Parse `{"version": "...", "hybrid_mode": true, ...}` → emit line 2 with `<version>` substituted.
+
+If `tr status` exits non-zero or `$TR_CLI` is empty:
+- 1st failure: sleep 5s, retry. The install may still be writing files.
+- 2nd failure: re-run the install commands from step 1 with `--force`, then retry.
+- 3rd failure: emit `Plugin install verification failed twice — the install staged on disk but didn't register. Try \`openclaw plugins install @totalreclaw/totalreclaw@rc --force\` from a terminal, then reply \`done\`.` Stop.
+
+### 3. Check existing credentials (silent unless found)
+
+```bash
+test -s ~/.totalreclaw/credentials.json
+```
+
+Exit 0 = exists → emit `✓ TotalReclaw is already set up.` and stop. Exit 1 = continue.
+
+### 4. Pair (DETACHED — survives gateway reload) + emit line 3
+
+```bash
+PAIR_OUT="/tmp/tr-pair-out-$(date +%s).json"
+setsid -f node "$TR_CLI" pair --json > "$PAIR_OUT" 2>&1 < /dev/null
+sleep 2
+cat "$PAIR_OUT"
+```
+
+The `setsid -f` is non-negotiable (rule 5). If the cat output is empty after 2s, sleep 2 more and retry once (cold-network handshake can take up to 4s).
+
+Parse the JSON `{"v":1,"sid":"...","url":"...","pin":"...","mode":"...","expires_at_ms":...,"qr_ascii":"..."}`. Emit a single chat message containing:
+
+````
+```
+<qr_ascii contents verbatim — 43 lines of block chars>
+```
+
+Open <url> in your browser. Enter PIN <pin>. Generate or paste a 12-word recovery phrase. Reply `done` once it's sealed.
+````
+
+The triple-backtick block renders the Unicode QR in monospace on Telegram / Slack / web / terminal — every transport. Do NOT attach a PNG. Do NOT save the QR anywhere. Do NOT re-render through another library.
+
+### 5. Confirm (silent until line 4)
+
+After the user replies `done`, recheck:
+
+```bash
+test -s ~/.totalreclaw/credentials.json
+```
+
+Exit 0 → emit line 4. Exit 1 → re-run step 4 once and resend line 3 (PIN expired or phrase mismatch).
+
+## CLI reference (post-setup)
+
+```bash
+node "$TR_CLI" status --json
+node "$TR_CLI" remember --json "<fact>"
+node "$TR_CLI" recall --json "<query>" --limit 5
+```
+
+Foreground for these is fine — they're single-shot HTTP calls, not WS-holding. Only `tr pair --json` needs `setsid -f`.

--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -1,5 +1,7 @@
 # TotalReclaw for OpenClaw
 
+> **Audience map.** This guide serves three readers — **(a) humans** wanting to understand what their agent is about to do, **(b) the agent itself** that just fetched this URL, and **(c) Pedro / future-Pedro doing QA on a fresh VM**. The lean agent-executable version (~5 KB, no rationale prose) lives at [`openclaw-setup-quickstart.md`](./openclaw-setup-quickstart.md). If you are an agent and the user only pasted this guide URL, prefer the quickstart for execution and use this file for context.
+
 TotalReclaw gives your OpenClaw agent encrypted, persistent memory. The fastest path is a single chat message — your agent fetches this guide, you and your agent install the plugin together, and the agent walks you through setting up your TotalReclaw account.
 
 ## What this is and where it comes from
@@ -124,7 +126,8 @@ Step 2 (`hooks.allowConversationAccess`) unblocks the plugin's `agent_end` hook 
 Both apply via hot-reload (no `/totalreclaw-restart` needed for either).
 
 Notes:
-- For an RC build, replace the first command with `openclaw plugins install @totalreclaw/totalreclaw@rc` (latest release candidate) or pin a version like `openclaw plugins install @totalreclaw/totalreclaw@3.3.10-rc.3`.
+- For an RC build, replace the first command with `openclaw plugins install @totalreclaw/totalreclaw@rc` (latest release candidate) or pin a version like `openclaw plugins install @totalreclaw/totalreclaw@3.3.10-rc.4`.
+- If install reports `already exists` or non-zero on a re-run (the plugin is already on disk from a previous attempt), add `--force`: `openclaw plugins install @totalreclaw/totalreclaw@rc --force` and `openclaw skills install totalreclaw --force`.
 - If either command fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment), STOP and tell the user verbatim: *"Your environment doesn't expose the OpenClaw CLI to me. Please install `totalreclaw` from your service's plugins / skills UI, then reply `done`."* Wait for `done` before continuing to Step 2.
 
 ### Step 2 — Verify CLI works (hybrid-primary, 3.3.9-rc.1+) — emit user-visible line 2 on success

--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.10-rc.4] — 2026-05-06
+
+Address OpenClaw's own meta-feedback on the rc.10-rc.3 setup guide (collected during a clean retest run by Pedro). Two functional fixes alongside doc cleanup:
+
+### Fixed
+
+- **QR delivery regression on Telegram.** rc.10-rc.3's FORBIDDEN list correctly banned saving the QR PNG to `/tmp/totalreclaw-pair-qr.png` (which OpenClaw's media-policy rejected with `LocalMediaAccessError`), but the existing "Rendering the QR on your transport" SKILL.md section still pointed agents at a non-existent `qr_png_b64` field and a `qr_unicode` field — leftover from an older skill/native-tool surface. The agent skipped QR entirely rather than render the wrong field. Fix: the section is rewritten around the actual `qr_ascii` field that `tr pair --json` returns. Single recommended path: emit `qr_ascii` inside a triple-backticked code block above user-visible line 3. Renders as block-char QR in monospace font on Telegram, Slack, web, and terminal — every transport. No PNG, no save-to-disk, no media-policy interaction.
+
+- **`--force` install path.** OpenClaw QA fed back that `openclaw plugins install` fails on a re-run when the plugin is already on disk. Both the quickstart and the long setup guide now document the `--force` flag for this case.
+
+- **`tr status --json` retry-fail escalation.** Quickstart spells out a three-level escalation: 1st failure → sleep 5s + retry; 2nd → re-run install with `--force`; 3rd → emit a tight error line and stop. The previous "retry once after 5s" guidance left the agent stranded when retry also failed.
+
+### Changed
+
+- **New file `docs/guides/openclaw-setup-quickstart.md` (~5 KB)** — agent-executable contract: hard rules, four user-visible lines, copy-paste shell snippets. No rationale prose. SKILL.md's header now points agents at the quickstart first; the long `openclaw-setup.md` is the human-readable companion. The 28 KB `openclaw-setup.md` was burning context on every agent fetch — quickstart cuts that ~5×.
+
+- **SKILL.md FORBIDDEN section trimmed.** OpenClaw's feedback noted the rc.3 list was patching past failures one by one with verbatim narration examples that bloated the skill without adding rules. The list is now four crisp action-bans (no gateway restart, no config write, no QR PNG save, mandatory `setsid -f` for pair) — the narration ban is folded into the existing top-level "emit only the numbered user-visible lines" rule.
+
+- **`openclaw-setup.md` audience map at top.** Explicit three-audience map (humans, agents, QA / Pedro) with cross-link to the quickstart, so agents that fetched the long URL by accident know to switch.
+
+### Implementation notes
+
+- `qr_ascii` already exists in `pair-cli-relay.ts` `PairCliJsonPayload`. No CLI change required.
+- The legacy SKILL.md QR-rendering section referenced the older native-`totalreclaw_pair` tool's payload shape (`qr_png_b64`, `qr_unicode`). The native tool surface is unchanged for back-compat — but it's deprioritized in 3.3.9-rc.1+ (issue #223 strips it). Hybrid CLI is now the documented path, and CLI returns `qr_ascii` only.
+- This RC is doc + SKILL.md only — no code changes. Same `tr-cli.js` binary as rc.3.
+
 ## [3.3.10-rc.3] — 2026-05-06
 
 Pedro's 2026-05-05 manual QA on rc.10-rc.2 confirmed that even with the `setsid -f` instruction in SKILL.md, the agent freelances during install + pair: it restarted the gateway unprompted, re-rendered the QR to `/tmp/` (which OpenClaw's media-access policy blocks → `LocalMediaAccessError` on Telegram), wrote extra config that triggered another deferred SIGUSR1 reload, and ran `tr pair` in the foreground — all of which killed the pair WS and produced the 502 on browser respond. Plus the CLI binary's hard-coded `PLUGIN_VERSION` constant lagged the package version (CLI reported `3.3.9-rc.1` while the install record was `3.3.10-rc.2`).

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "Install + set up TotalReclaw encrypted memory for OpenClaw, then use tr CLI for remember / recall. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', or any remember / recall request."
-version: 3.3.10-rc.3
+version: 3.3.10-rc.4
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz
@@ -24,7 +24,11 @@ metadata:
 
 # TotalReclaw — OpenClaw
 
-> The canonical install flow lives at <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md>. If a user pastes that URL in chat, fetch it and follow its agent-instructions section. This SKILL.md mirrors the same steps so you can act even if the URL is unreachable.
+> **Agent-executable quickstart (5 KB, copy-paste-runnable)**: <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup-quickstart.md>
+>
+> **Human-readable setup guide (full rationale, troubleshooting)**: <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md>
+>
+> If the user pastes either URL: prefer the quickstart for execution. Fetch the full guide only if the user asks for context or troubleshooting beyond what the quickstart covers. This SKILL.md mirrors the quickstart's hard rules so you can act even if the URL is unreachable.
 
 ## CRITICAL: Relay-based architecture (read before anything else)
 
@@ -46,30 +50,17 @@ If you find yourself about to say any of these, STOP. The correct statement is: 
 
 **Emit ONLY the user-visible lines listed below. Do not narrate tool calls. Do not describe what you're doing or about to do. Errors are the only allowed deviation, and only as a single tight line.** The expected user-facing transcript for a healthy install is **4–5 short lines TOTAL**. Anything more is a SKILL violation. Telegram and similar transports edit the bot's messages live as your tool calls progress — every interim "Let me check…" / "Plugin loaded. Let me verify…" line shows up to the user as awkward edit churn, even if you "delete" it. The fix is to never emit it in the first place.
 
-## ⛔ FORBIDDEN — do NOT do these (3.3.10-rc.3, hard rules from Pedro's 2026-05-05 QA)
+## ⛔ FORBIDDEN ACTIONS (4 hard rules from 2026-05-05 QA)
 
-These are the freelancing patterns that have broken pair flows and made transcripts noisy. They are FORBIDDEN, full stop:
+These specific actions break the pair flow. Everything else is governed by the "emit only the numbered user-visible lines" rule above.
 
-1. **Do NOT issue `/totalreclaw-restart`.** Do NOT send `kill -USR1`. Do NOT call `openclaw gateway restart`. Do NOT `docker restart`. The plugin auto-patches the gateway config and emits a single restart-required warn IF (and only if) the gateway needs one. The gateway will restart itself when its reload pipeline decides to. **You restarting it KILLS the in-flight `setsid -f` pair subprocess and surfaces as a 502 on the browser respond.**
+1. **Do NOT restart the gateway.** No `/totalreclaw-restart`, no `kill -USR1`, no `docker restart`, no `openclaw gateway restart`. The plugin self-patches and signals its own restart needs. You restarting it kills the in-flight `setsid -f` pair subprocess → 502 on browser respond.
 
-2. **Do NOT write to `~/.openclaw/openclaw.json`.** The plugin's `patchOpenClawConfig()` already wrote `plugins.slots.memory`, `plugins.entries.totalreclaw.hooks.allowConversationAccess`, and `channels.telegram.streaming.mode` for you. Any further config write triggers a fresh deferred reload that eventually fires SIGUSR1 and kills the pair subprocess. Forbidden tool calls: `openclaw config set …`, `jq … > openclaw.json`, any `cat > openclaw.json`, any `sed -i openclaw.json`.
+2. **Do NOT write to `~/.openclaw/openclaw.json`.** The plugin's `patchOpenClawConfig()` already wrote `plugins.slots.memory`, `plugins.entries.totalreclaw.hooks.allowConversationAccess`, `channels.telegram.streaming.mode`. Any further write triggers a deferred SIGUSR1 reload that kills pair. No `openclaw config set …`, no `jq …>openclaw.json`, no `sed -i openclaw.json`.
 
-3. **Do NOT re-render the QR.** `tr pair --json` already returns the QR as `qr_ascii` (Unicode block chars) AND the pair page itself renders a real PNG QR. Do NOT save the QR to `/tmp/totalreclaw-pair-qr.png` — OpenClaw's media-access policy blocks `/tmp/` paths and Telegram delivery fails with `LocalMediaAccessError: Local media path is not under an allowed directory`. The agent's only QR responsibility is to copy the URL+PIN into user-visible line 3. The transport (Telegram/web/CLI) renders the QR from the URL the user can already click.
+3. **Do NOT save QR PNGs.** `tr pair --json` returns `qr_ascii` — emit that inline in a triple-backticked code block. No `/tmp/totalreclaw-pair-qr.png` (OpenClaw media-policy blocks it: `LocalMediaAccessError`). No PNG decode. No `qr_png_b64` (legacy field, no longer exists in payload).
 
-4. **Do NOT invoke `tr pair --json` in the foreground.** A foreground pair subprocess is killed when your shell-tool exec returns (the agent runtime cleans up child PIDs). The pair WS dies → relay returns 502 on the browser respond. **The setup-flow Step 4 below uses `setsid -f` for exactly this reason — copy that block VERBATIM. Do not "simplify" it. Do not drop the `setsid -f`. Do not redirect stdout differently. Do not omit `< /dev/null`.**
-
-5. **Do NOT narrate.** Examples of narration that have appeared in past QAs and MUST NEVER appear again:
-   - "Now let me verify the CLI and check for existing credentials." → silent.
-   - "Gateway needs a restart to load the plugin. Let me restart it." → DO NOT RESTART.
-   - "The gateway is running but as a container process, not via systemd. Let me find and signal the gateway process to reload." → DO NOT SIGNAL.
-   - "The CLI is at the npm path, not the extensions path. Let me use the correct path." → silent (the `TR_CLI` resolver below already handles both paths).
-   - "Plugin is X.Y.Z, CLI reports itself as A.B.C (version string lag in the CLI binary)." → silent (don't reveal CLI internals).
-   - "Now let me also add the required post-install config and render the QR as an image." → DO NOT WRITE CONFIG. DO NOT RE-RENDER QR.
-   - "The pair response already has the QR data. Let me save the QR as a PNG using the existing skill's pair-qr module." → DO NOT SAVE QR ANYWHERE.
-
-If `tr status --json` returns version that disagrees with `openclaw plugins inspect totalreclaw`, **that is fine — do not narrate it**. The plugin's CLI reports its own packaged version which may lag the install record by one RC during a publish cycle. Both work.
-
-If you find yourself about to do anything in this list, STOP. Re-read this section. Then run the literal commands in the setup flow below — exactly as written.
+4. **`tr pair --json` MUST run via `setsid -f`** (exact form below). Foreground invocation is killed when your shell-tool exec returns → 502.
 
 ## Hybrid-primary architecture (3.3.9-rc.1)
 
@@ -162,13 +153,21 @@ node "$TR_CLI" recall --json "where does the user work" --limit 5
 
 **Note on tool names**: `totalreclaw_remember`, `totalreclaw_recall`, etc. may or may not appear in your toolset depending on OpenClaw version. Under hybrid-primary, you use the `tr` CLI instead. If native tools ARE available (older OpenClaw or future OC fix), they work too — but always prefer `tr` for reliability.
 
-## Rendering the QR on your transport (rc.5+)
+## Rendering the QR on your transport (3.3.10-rc.4 — corrected)
 
-When you receive the `totalreclaw_pair` payload (from tool OR `tr pair --json`), render the QR based on your chat transport:
+`tr pair --json` returns a `qr_ascii` field — Unicode block-char QR (43 lines × ~43 cols). That is the ONLY QR field in the payload. The legacy `qr_png_b64` and `qr_unicode` field names referenced by older skill docs no longer exist.
 
-- **Transport supports image attachments** (Telegram, Slack, web chat, any transport with file/image upload): decode `qr_png_b64` from base64 to bytes, save to a tempfile with a `.png` suffix, and attach the tempfile as an image. Also show the URL + PIN as text so users who prefer clicking can still do so.
-- **Terminal-only transport** (OpenClaw native CLI chat, bare SSH shell): emit `qr_unicode` inline in your reply. It renders as block characters in most terminal fonts; the user scans from their phone.
-- **Web chat with inline-image support**: embed as `<img src="data:image/png;base64,<qr_png_b64>" alt="TotalReclaw account-setup QR">` if the chat client renders HTML; otherwise fall back to attachment.
+The simplest path that works on every transport (Telegram, Slack, web, terminal SSH): emit `qr_ascii` INLINE inside a triple-backtick code block right above user-visible line 3. Block-char QR renders correctly in monospace fonts on every modern transport — the user scans from their phone. The pair PAGE itself renders a real PNG QR alongside, so users on a desktop browser see both.
+
+Format the line-3 message as:
+
+```
+<qr_ascii contents — 43 lines of ▄▀█▄▀█ block chars>
+```
+
+Open <url> in your browser. Enter PIN <pin>. Generate or paste a 12-word recovery phrase. Reply `done` once it's sealed.
+
+Do NOT decode `qr_png_b64` (does not exist), do NOT save a PNG to `/tmp/totalreclaw-pair-qr.png` (`LocalMediaAccessError` blocks delivery), do NOT re-render the QR through any other library. The `qr_ascii` field is the single source of truth.
 
 The QR encodes ONLY the account-setup URL. The 6-digit PIN is a separate out-of-band confirmation — deliberately NOT baked into the QR (dual-channel design: scan + type). Never log, print, or re-emit the PIN outside the user-facing reply. The PIN must NOT end up in any other tool call, log file, or memory store.
 

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.10-rc.3",
+  "version": "3.3.10-rc.4",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "3.3.10-rc.3",
+  "version": "3.3.10-rc.4",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",

--- a/skill/plugin/tr-cli.ts
+++ b/skill/plugin/tr-cli.ts
@@ -52,7 +52,7 @@ const STATE_PATH = CONFIG.onboardingStatePath;
 // Auto-synced by skill/scripts/sync-version.mjs from skill/plugin/package.json::version.
 // Do not edit by hand — running tests will catch drift but the publish workflow
 // rewrites this constant at the start of every npm/ClawHub publish.
-const PLUGIN_VERSION = '3.3.10-rc.3';
+const PLUGIN_VERSION = '3.3.10-rc.4';
 
 function die(msg: string, code = 1): never {
   process.stderr.write(`tr: ${msg}\n`);


### PR DESCRIPTION
## Summary

Address OpenClaw's own feedback on rc.10-rc.3 setup guide:

- **QR regression fix**: SKILL.md pointed at non-existent `qr_png_b64` field → agent skipped QR. Now uses `qr_ascii` inline in code block (single transport-agnostic path).
- **New `openclaw-setup-quickstart.md`** (~5 KB, agent-executable). Cuts agent context ~5× from the 28 KB long guide.
- **FORBIDDEN list trimmed** to 4 crisp actions (was bloated with verbatim narration examples).
- **`--force` install path** documented.
- **`tr status` 3-level escalation**: retry-once → re-install --force → emit error.

## Validation

- [x] 81/81 fs-helpers, 21/21 register-command-name, 10/10 manifest-shape, 37/37 skill-md-hybrid-primary, 21/21 tr-cli-json-output
- [x] check-scanner: 127 files, 0 flags
- [x] No code changes (same tr-cli.js as rc.3)

## Test plan

- [ ] Auto-merge → publish-plugin.yml `release-type=rc rc-number=4`
- [ ] Pedro retest with prompt pointing at quickstart URL — QR renders, no 502, no narration

🤖 Generated with [Claude Code](https://claude.com/claude-code)