### PR TITLE
fix(plugin): 3.3.11-rc.2 — UX hardening (no pair jargon, no relay-server claim, no inter-line narration)

### DIFF
--- a/docs/guides/openclaw-setup-quickstart.md
+++ b/docs/guides/openclaw-setup-quickstart.md
@@ -5,11 +5,13 @@
 
 ## Hard rules (read once, never break)
 
-1. Emit ONLY the four numbered user-visible lines below. No narration, no "let me check…", no version-lag commentary, no path-resolution prose.
-2. **Do NOT restart the gateway** (`/totalreclaw-restart`, `kill -USR1`, `docker restart`, `openclaw gateway restart`). The plugin self-patches and signals its own restart needs.
-3. **Do NOT write to `~/.openclaw/openclaw.json`**. The plugin's `patchOpenClawConfig()` already wrote `plugins.slots.memory`, `plugins.entries.totalreclaw.hooks.allowConversationAccess`, `channels.telegram.streaming.mode`. Any further write triggers a deferred SIGUSR1 reload that kills pair.
-4. **Do NOT save QR PNGs**. The `tr pair --json` payload returns `qr_ascii` — emit that inline in a code block. No `/tmp/totalreclaw-pair-qr.png`, no PNG decode, no `qr_png_b64` (legacy field, no longer exists).
-5. **`tr pair --json` MUST be invoked via `setsid -f`** so the WS-holding subprocess is in its own POSIX session and survives any subsequent gateway reload. Foreground `tr pair --json` is killed when your shell-tool exec returns → relay returns 502.
+1. **Emit ONLY the four numbered user-visible lines below.** No narration, no "let me check…", no "Now let me X", no "Need to Y", no "Standing by", no version-lag commentary, no path-resolution prose. The transcript Pedro sees during a healthy install is exactly four messages.
+2. **Never use the word "pair" / "pairing" / "paired" in user-facing text.** It's internal jargon. The user-facing word is **"set up an account"** / "your account". (Behind the scenes the CLI command is still `tr pair`; that's an implementation detail.)
+3. **Don't claim memories are "stored on a relay server" / "TotalReclaw's server" / any centralized-custody phrasing.** Memories are encrypted with a key derived from the recovery phrase, submitted on-chain (Account Abstraction), stored across a decentralized network, indexed via The Graph subgraph. The relay only forwards encrypted bundles. See "How does this work?" section below for the canonical answer.
+4. **Do NOT restart the gateway** (`/totalreclaw-restart`, `kill -USR1`, `docker restart`, `openclaw gateway restart`). The plugin self-patches and signals its own restart needs.
+5. **Do NOT write to `~/.openclaw/openclaw.json`**. The plugin's `patchOpenClawConfig()` already wrote everything it needs.
+6. **Do NOT save QR PNGs**. The `tr pair --json` payload returns `qr_ascii` — emit that inline in a code block. No `/tmp/totalreclaw-pair-qr.png`, no PNG decode, no `qr_png_b64` (legacy field, no longer exists).
+7. **The `tr pair --json` command MUST be invoked via `setsid -f`** so the WS-holding subprocess is in its own POSIX session and survives any subsequent gateway reload. Foreground invocation is killed when your shell-tool exec returns → relay returns 502.
 
 ## User-visible lines (the entire transcript)
 
@@ -108,6 +110,17 @@ Common user issues — emit ONE tight line, don't pre-narrate:
 - "Invalid phrase" on Log in → typo or wrong-source phrase. User re-checks paste OR switches to **Set up** for a fresh one (loses existing memories).
 - "Clicked Set up but nothing happened" / 502 → wait 30s for any deferred gateway reload to complete; if persists, re-run step 4.
 - "Where do I write down the phrase?" → paper, password manager, encrypted note. NOT this chat. NOT cloud-synced screenshot. Phrase IS the account.
+
+## "How does this work?" — canonical answer for user questions
+
+When the user asks "how does this work?" / "where are my memories stored?" / "is this safe?" — answer with this content. Do NOT say "stored on a relay server", "stored on TotalReclaw's server", or any phrasing that implies single-company custody.
+
+> **End-to-end encrypted, decentralized memory.** When you tell me to remember something, I encrypt it locally with a key derived from your 12-word recovery phrase, then submit it on-chain via Account Abstraction (a UserOperation). It lives on a public blockchain (Base Sepolia for free tier, Gnosis mainnet for paid). The Graph subgraph indexes it for fast retrieval. The TotalReclaw relay server only forwards encrypted bundles between your client and the chain — it never sees plaintext, can't read your memories, and could be replaced by any compatible relay without losing data. Your recovery phrase is the only thing that can decrypt the memories.
+
+Shorter slices:
+- **"Where are memories stored?"** → "Encrypted, on-chain (Base or Gnosis depending on tier), indexed by The Graph. Not on any single company's server."
+- **"Is the relay reading my data?"** → "No. The relay only forwards encrypted bundles. Plaintext never leaves your device. Only your recovery phrase can decrypt them."
+- **"What if TotalReclaw shuts down?"** → "Your memories survive. They're on a public blockchain. Any compatible relay (or self-hosted relay) can read them with your recovery phrase."
 
 ## CLI reference (post-setup)
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -24,21 +24,18 @@ metadata:
 
 # TotalReclaw Skill
 
-## CRITICAL: Relay-based architecture — read before anything else
+## CRITICAL: How TotalReclaw actually stores memories — read before anything else
 
-**TotalReclaw is RELAY-BASED. All memories require a paired account on the staging or production relay (depending on RC vs stable). There is NO local-only mode. NEVER claim memories are stored locally without an account.**
+**TotalReclaw is end-to-end encrypted memory stored across a DECENTRALIZED NETWORK — not on a single company server.** Memories are encrypted with keys derived from the user's 12-word recovery phrase, submitted as Account Abstraction UserOps, and persisted on a public blockchain (Base / Gnosis depending on tier). The Graph subgraph indexes them. The TotalReclaw relay only forwards encrypted bundles to the bundler and proxies subgraph reads — it never sees plaintext, can't read memories, and could be replaced by any compatible relay without losing data. No single company controls or can read user memories.
 
-Forbidden vocabulary — these claims are FALSE and MUST NEVER appear in your responses:
-- "local"
-- "local-only"
-- "stored locally"
-- "on disk"
-- "without an account"
-- "local memory"
-- "local storage"
-- any phrasing suggesting memories can be stored without pairing a relay account
+Forbidden vocabulary — these claims are WRONG (some imply local-only storage; some imply a single-company server):
+- "local", "local-only", "stored locally", "on disk", "local memory", "local storage" — wrong direction (implies local-only). Memories require an account; they're encrypted and submitted on-chain.
+- "stored on a relay server", "stored on TotalReclaw's server", "single server owned by", "TotalReclaw stores your", "company server" — wrong direction (implies centralized custody). The relay forwards ciphertext; storage is decentralized on-chain.
+- "without an account" — wrong (an account is required to derive the encryption key).
 
-If you find yourself about to say any of these, STOP. The correct statement is: "TotalReclaw requires a paired relay account to store memories."
+If you need to describe how it works, the canonical line is: **"Memories are encrypted with a key derived from your recovery phrase, submitted on-chain via Account Abstraction, and stored across a decentralized network. The relay only forwards encrypted bundles — it never sees plaintext. Only you can decrypt them, and only with your recovery phrase."**
+
+> Legacy phrasing (preserved for back-compat): TotalReclaw is RELAY-BASED — there is NO local-only mode and an account is required to store memories. Both phrasings are accurate; the rc.11-rc.2 update emphasizes that the relay forwards ciphertext but storage is on-chain decentralized.
 
 ## Hybrid-primary CLI (3.3.9-rc.1+)
 

--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.11-rc.2] — 2026-05-06
+
+UX hardening on top of rc.1's trajectory-poller. Pedro's first install attempt on rc.1 surfaced two agent-prose violations the prior FORBIDDEN ACTIONS list didn't catch:
+
+1. **Inter-line narration during install.** The agent emitted "Now let me verify the install:", "Now let me check if you already have credentials:", and "Need to pair. Let me kick that off:" between the four numbered user-visible lines. Each was edit churn the user shouldn't see — and the third leaked the internal word "pair", which the user doesn't know.
+2. **"Stored on a relay server" architectural claim.** When asked "how does this work?", the agent replied that memories are stored on a relay server. WRONG. Memories are encrypted with a key derived from the recovery phrase, submitted on-chain via Account Abstraction (UserOps), persisted on a public blockchain (Base for free tier, Gnosis for paid), and indexed by The Graph. The relay only forwards encrypted bundles — it never sees plaintext, can't read memories, and could be replaced by any compatible relay without losing data.
+
+### Changed
+
+- **SKILL.md "CRITICAL" section rewritten as "How TotalReclaw actually stores memories"** — leads with the on-chain decentralized architecture, not the relay. Forbidden vocabulary list expanded with centralized-custody phrasings ("stored on a relay server", "TotalReclaw's server", "single server owned by", "company server", etc.) alongside the existing local-only ban list.
+- **New "User-facing vocabulary" translation table.** Maps internal jargon (pair, relay, WS, trapdoor, subgraph, bundler, UserOp, mnemonic file, `setsid -f`) to user-facing phrases ("set up an account", "your account", "your recovery phrase"). The word "pair" is now explicitly forbidden in user-visible prose — it's an internal CLI command, not a user concept.
+- **New "Hard silence rules between numbered lines"** subsection with verbatim bad examples from this QA: "Now let me verify the install" / "Now let me check if you already have credentials" / "Need to pair. Let me kick that off" / "Standing by." / any "Let me X" prelude. The transcript the user sees is exactly the four numbered lines, nothing in between.
+- **New "How does TotalReclaw work?" canonical answer section.** Provides the long-form explanation plus three short slices ("Where are memories stored?" / "Is the relay reading my data?" / "What if TotalReclaw shuts down?") so the agent has a paste-ready truthful answer for common user questions. Mirrored in `openclaw-setup-quickstart.md`.
+- **Quickstart rules bumped from 5 to 7** with the same "no pair word" + "no centralized-custody phrasing" hard rules.
+
+This RC is doc + SKILL.md only — same `tr-cli.js` and `trajectory-poller.js` binaries as rc.1. The trajectory poller verified end-to-end (40/40 unit tests + live container smoke) in rc.1 ships unchanged.
+
 ## [3.3.11-rc.1] — 2026-05-06
 
 Auto-extraction restored without waiting on upstream OpenClaw. Pedro's pop-os QA on rc.10-rc.5 produced 0 extraction events across 2 h of Telegram chat — root cause confirmed in fresh canonical container (OpenClaw 2026.5.4): the `agent_end` hook is silently rejected for non-bundled plugins despite `plugins.entries.totalreclaw.hooks.allowConversationAccess=true` in config. Reproduces every gateway boot + every SIGUSR1 in-process restart. Plugin's `api.on('agent_end', handler)` call returns without error but the gateway never dispatches the event.

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "Install + set up TotalReclaw encrypted memory for OpenClaw, then use tr CLI for remember / recall. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', or any remember / recall request."
-version: 3.3.11-rc.1
+version: 3.3.11-rc.2
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz
@@ -30,21 +30,32 @@ metadata:
 >
 > If the user pastes either URL: prefer the quickstart for execution. Fetch the full guide only if the user asks for context or troubleshooting beyond what the quickstart covers. This SKILL.md mirrors the quickstart's hard rules so you can act even if the URL is unreachable.
 
-## CRITICAL: Relay-based architecture (read before anything else)
+## CRITICAL: How TotalReclaw actually stores memories (read before anything else)
 
-**TotalReclaw is RELAY-BASED. All memories require a paired account on the staging or production relay (depending on RC vs stable). There is NO local-only mode. NEVER claim memories are stored locally without an account.**
+**TotalReclaw is end-to-end encrypted memory stored across a DECENTRALIZED NETWORK — not on a single company server.** Memories are encrypted with keys derived from the user's 12-word recovery phrase, submitted as Account Abstraction UserOps, and persisted on a public blockchain (Base / Gnosis depending on tier). The Graph subgraph indexes them. The TotalReclaw relay only forwards encrypted bundles to the bundler and proxies subgraph reads — it never sees plaintext, can't read memories, and could be replaced by any compatible relay without losing data. No single company controls or can read user memories.
 
-Forbidden vocabulary — these claims are FALSE and MUST NEVER appear in your responses:
-- "local"
-- "local-only"
-- "stored locally"
-- "on disk"
-- "without an account"
-- "local memory"
-- "local storage"
-- any phrasing suggesting memories can be stored without pairing a relay account
+Forbidden vocabulary — these claims are WRONG (some imply local-only storage; some imply a single-company server):
+- "local", "local-only", "stored locally", "on disk", "local memory", "local storage" — wrong direction (implies local-only). Memories require an account; they're encrypted and submitted on-chain.
+- "stored on a relay server", "stored on TotalReclaw's server", "single server owned by", "TotalReclaw stores your", "company server" — wrong direction (implies centralized custody). The relay forwards ciphertext; storage is decentralized on-chain.
+- "without an account" — wrong (an account is required to derive the encryption key).
 
-If you find yourself about to say any of these, STOP. The correct statement is: "TotalReclaw requires a paired relay account to store memories — run `tr pair` to set one up."
+If you need to describe how it works, the canonical line is: **"Memories are encrypted with a key derived from your recovery phrase, submitted on-chain via Account Abstraction, and stored across a decentralized network. The relay only forwards encrypted bundles — it never sees plaintext. Only you can decrypt them, and only with your recovery phrase."**
+
+## User-facing vocabulary (substitute internal jargon for plain words)
+
+Internal terms that the user does NOT know — translate when you must speak:
+
+| Internal term | Say to the user |
+|---|---|
+| pair / pairing / paired account | "set up an account" / "your TotalReclaw account" |
+| relay / relay server | (don't mention; if forced, say "the encrypted-bundle forwarder") |
+| WS / WebSocket / handshake | (don't mention) |
+| trapdoor / blind index / dedup-key | (don't mention) |
+| subgraph / bundler / UserOp / Account Abstraction | (don't mention; if forced, "submitted on-chain to a decentralized network") |
+| credentials.json / mnemonic file | "your recovery phrase" |
+| `tr pair --json` / `setsid -f` / shell exec | (don't mention; just do the work silently) |
+
+The word "pair" is internal jargon — never use it in user-visible prose. The user-visible vocabulary is "set up an account", "your account", "your recovery phrase", "your memories".
 
 ## Top-level rule (read this before anything else)
 
@@ -93,6 +104,30 @@ Speak only these lines, in order. Substitute the bracketed placeholders with the
 
 If existing credentials are detected (step "Check for existing credentials" below), emit ONLY this line and stop:
    > ✓ TotalReclaw is already set up.
+
+### Hard silence rules between numbered lines
+
+Do NOT emit transitional / narrative lines between any of the four user-visible lines above. Specifically forbidden (verbatim examples from Pedro's 2026-05-06 QA):
+
+- ❌ "Now let me verify the install:" → silent. Just run `tr status --json`. Emit line 2 when it returns.
+- ❌ "Now let me check if you already have credentials:" → silent. Just run `test -s ~/.totalreclaw/credentials.json`.
+- ❌ "Need to pair. Let me kick that off:" → silent. Just run the `setsid -f` block. Emit line 3 when URL+PIN returns. ALSO never use the word "pair" in user-facing text — see vocabulary table above.
+- ❌ "Standing by." → silent. Acknowledgements between lines are noise.
+- ❌ Any "Let me X" / "Now I'll Y" / "Just give me a second" prelude.
+
+The transcript Pedro should see is exactly four messages — the four numbered lines, nothing in between.
+
+## How does TotalReclaw work? (canonical answer for user questions)
+
+When the user asks "how does this work?" / "where are my memories stored?" / "is this safe?" / similar — answer with this content. Do NOT say "stored on a relay server", "stored on TotalReclaw's server", or any phrasing that implies single-company custody. The actual architecture:
+
+> **End-to-end encrypted, decentralized memory.** When you tell me to remember something, I encrypt it locally with a key derived from your 12-word recovery phrase, then submit it on-chain via Account Abstraction (a UserOperation). It lives on a public blockchain (Base Sepolia for free tier, Gnosis mainnet for paid). The Graph subgraph indexes it for fast retrieval. The TotalReclaw relay server only forwards encrypted bundles between your client and the chain — it never sees plaintext, can't read your memories, and could be replaced by any compatible relay without losing data. Your recovery phrase is the only thing that can decrypt the memories. Nobody (not me, not TotalReclaw the company, not the relay operator) can read them without it.
+
+If the user asks shorter questions, reply with the relevant slice:
+
+- **"Where are memories stored?"** → "Encrypted, on-chain (Base or Gnosis depending on your tier), indexed by The Graph. Not on any single company's server."
+- **"Is the relay reading my data?"** → "No. The relay only forwards encrypted bundles. Plaintext never leaves your device. Only your recovery phrase can decrypt them."
+- **"What if TotalReclaw shuts down?"** → "Your memories survive. They're on a public blockchain. Any compatible relay (or self-hosted relay) can read them with your recovery phrase."
 
 ## Setup flow (hybrid-primary)
 

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.11-rc.1",
+  "version": "3.3.11-rc.2",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [

--- a/skill/plugin/skill-md-hybrid-primary.test.ts
+++ b/skill/plugin/skill-md-hybrid-primary.test.ts
@@ -46,24 +46,50 @@ const topLevelSkillMd = fs.readFileSync(topLevelSkillMdPath, 'utf8');
 // 1. Relay-based architecture assertion (both files)
 // ---------------------------------------------------------------------------
 
-assert(
-  pluginSkillMd.includes('TotalReclaw is RELAY-BASED'),
-  'skill/plugin/SKILL.md: contains relay-based architecture assertion',
-);
+// 3.3.11-rc.2: phrasing migrated from "RELAY-BASED + NO local-only mode"
+// to the more accurate "decentralized network" framing — relay forwards
+// ciphertext but storage is on-chain. Tests now accept either phrasing
+// (older versions kept the relay-based framing; rc.2+ adds decentralized).
+const HAS_ARCHITECTURE_TRUTH_PLUGIN =
+  pluginSkillMd.includes('TotalReclaw is RELAY-BASED') ||
+  pluginSkillMd.includes('DECENTRALIZED NETWORK') ||
+  pluginSkillMd.includes('decentralized network');
 
 assert(
-  topLevelSkillMd.includes('TotalReclaw is RELAY-BASED'),
-  'skill/SKILL.md: contains relay-based architecture assertion',
+  HAS_ARCHITECTURE_TRUTH_PLUGIN,
+  'skill/plugin/SKILL.md: contains architecture truth (RELAY-BASED or DECENTRALIZED NETWORK)',
 );
 
-assert(
-  pluginSkillMd.includes('NO local-only mode'),
-  'skill/plugin/SKILL.md: explicitly states NO local-only mode',
-);
+const HAS_ARCHITECTURE_TRUTH_TOPLEVEL =
+  topLevelSkillMd.includes('TotalReclaw is RELAY-BASED') ||
+  topLevelSkillMd.includes('DECENTRALIZED NETWORK') ||
+  topLevelSkillMd.includes('decentralized network');
 
 assert(
-  topLevelSkillMd.includes('NO local-only mode'),
-  'skill/SKILL.md: explicitly states NO local-only mode',
+  HAS_ARCHITECTURE_TRUTH_TOPLEVEL,
+  'skill/SKILL.md: contains architecture truth (RELAY-BASED or DECENTRALIZED NETWORK)',
+);
+
+// rc.2 added centralized-custody bans alongside the existing local-only bans.
+// At least one of the two anti-centralization claims must be present.
+const HAS_NO_LOCAL_OR_NO_SERVER_PLUGIN =
+  pluginSkillMd.includes('NO local-only mode') ||
+  pluginSkillMd.includes('not on a single company server') ||
+  pluginSkillMd.includes('not on any single company');
+
+assert(
+  HAS_NO_LOCAL_OR_NO_SERVER_PLUGIN,
+  'skill/plugin/SKILL.md: anti-centralized-custody / no-local-only assertion present',
+);
+
+const HAS_NO_LOCAL_OR_NO_SERVER_TOPLEVEL =
+  topLevelSkillMd.includes('NO local-only mode') ||
+  topLevelSkillMd.includes('not on a single company server') ||
+  topLevelSkillMd.includes('not on any single company');
+
+assert(
+  HAS_NO_LOCAL_OR_NO_SERVER_TOPLEVEL,
+  'skill/SKILL.md: anti-centralized-custody / no-local-only assertion present',
 );
 
 // ---------------------------------------------------------------------------

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "3.3.11-rc.1",
+  "version": "3.3.11-rc.2",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",

--- a/skill/plugin/tr-cli.ts
+++ b/skill/plugin/tr-cli.ts
@@ -52,7 +52,7 @@ const STATE_PATH = CONFIG.onboardingStatePath;
 // Auto-synced by skill/scripts/sync-version.mjs from skill/plugin/package.json::version.
 // Do not edit by hand — running tests will catch drift but the publish workflow
 // rewrites this constant at the start of every npm/ClawHub publish.
-const PLUGIN_VERSION = '3.3.11-rc.1';
+const PLUGIN_VERSION = '3.3.11-rc.2';
 
 function die(msg: string, code = 1): never {
   process.stderr.write(`tr: ${msg}\n`);


### PR DESCRIPTION
Doc + SKILL.md only. Same binaries as rc.1. Address Pedro's UX feedback from rc.1 install attempt.