### PR TITLE
fix(plugin): 3.3.11-rc.4 — bundledDiscovery=compat auto-patch (real-install plugin-skip cure)

### DIFF
--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.11-rc.4] — 2026-05-07
+
+Fix #4 added to `patchOpenClawConfig()`: the **populated-allowlist plugin-skip bug** that broke every realistic install path.
+
+### Fixed
+
+- **`plugins.bundledDiscovery: "compat"` now auto-set when `plugins.allow` is populated.** OpenClaw 2026.5.x switches the plugin loader into strict-allowlist mode whenever `plugins.allow` is a non-empty array. In that mode, **non-bundled plugins like totalreclaw are silently rejected even when listed in the allow array** unless `plugins.bundledDiscovery: "compat"` is set. Without the compat flag, the gateway boots with only the bundled providers (e.g. `[device-pair, telegram]`), the totalreclaw plugin is dropped on the floor, and `extractd:` log lines never appear because the plugin's `register()` never runs.
+
+  This bug surfaces on every real-world install path:
+  - User installs telegram + zai/openai/anthropic before installing TotalReclaw → `plugins.allow` populated → loader rejects totalreclaw on every gateway restart.
+  - Pedro's pop-os QA host hit this on rc.3 because the host had `['device-pair', 'google', 'telegram', 'totalreclaw', 'zai']` in `plugins.allow` from prior install cycles.
+  - `openclaw doctor --fix` was the manual cure (sets `bundledDiscovery: "compat"`), but users shouldn't need to run doctor for the plugin they just installed.
+
+  Fix: `patchOpenClawConfig()` now sets `plugins.bundledDiscovery = "compat"` when `plugins.allow` is a non-empty array AND `bundledDiscovery` is unset. Power-users who explicitly chose `"allowlist"` (the stricter mode) keep their setting — only first-run defaults are touched. `plugins.allow=null` (auto-discover mode) is left alone.
+
+### Auto-QA gap (acknowledged)
+
+The 3.3.11-rc.1 auto-QA harness ran on a fresh canonical OpenClaw 2026.5.4 container with `plugins.allow=null` (auto-discover mode). It hit the looser code path where the plugin loaded fine. The strict-allowlist code path was untested. As a result, rc.3 shipped with this bug, Pedro hit it on pop-os, and I had to chase it down post-publish.
+
+This RC adds:
+- 5 new fs-helpers test cases covering Fix #4: empty-allow no-op, populated-allow + missing-bundledDiscovery patches, empty-array allow no-op, explicit `"allowlist"` preserved, full pop-os-style scenario.
+- TODO for next iteration: expand the live-container auto-QA harness to run a populated-allowlist scenario (mimicking a real install with telegram + zai pre-configured) alongside the existing fresh-allow=null scenario.
+
+### Implementation notes
+
+- 92/92 fs-helpers tests green. 21/21 register-command-name + 37/37 skill-md + 21/21 tr-cli-json + 40/40 trajectory-poller + 10/10 manifest-shape. check-scanner: 129 files, 0 flags.
+- The patchOpenClawConfig restart-required warn now mentions all four keys (slots.memory + allowConversationAccess + telegram.streaming.mode + bundledDiscovery).
+
 ## [3.3.11-rc.3] — 2026-05-06
 
 Two real-bug fixes flagged by Pedro's pop-os QA on rc.11-rc.1/rc.2: credentials.json shipped with only `{mnemonic}` (no userId, no salt), and the subgraph "Invalid character 'q' at position 0" Bytes-decode error.

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "Install + set up TotalReclaw encrypted memory for OpenClaw, then use tr CLI for remember / recall. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', or any remember / recall request."
-version: 3.3.11-rc.3
+version: 3.3.11-rc.4
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz

--- a/skill/plugin/fs-helpers.test.ts
+++ b/skill/plugin/fs-helpers.test.ts
@@ -694,6 +694,146 @@ const TEST_HEADER = '# Memory\n\n> TotalReclaw is active. Test header.\n\n';
   );
 }
 
+// --- Fix #4: plugins.bundledDiscovery = "compat" when plugins.allow populated (3.3.11-rc.4) ---
+
+{
+  // Sets bundledDiscovery=compat when allow is populated and the field is absent
+  const cfgPath = path.join(TMP, 'openclaw-allow-populated-no-bd.json');
+  const initial = {
+    plugins: {
+      installs: { totalreclaw: { version: '3.3.11-rc.4' } },
+      allow: ['device-pair', 'telegram', 'zai', 'totalreclaw'],
+      slots: { memory: 'totalreclaw' },
+      entries: { totalreclaw: { enabled: true, hooks: { allowConversationAccess: true } } },
+    },
+  };
+  fs.writeFileSync(cfgPath, JSON.stringify(initial));
+  assertEq(
+    patchOpenClawConfig(cfgPath),
+    'patched',
+    'patchOpenClawConfig: patches when allow populated + bundledDiscovery absent',
+  );
+  const after = JSON.parse(fs.readFileSync(cfgPath, 'utf-8')) as Record<string, unknown>;
+  const plugins = after.plugins as Record<string, unknown>;
+  assertEq(
+    plugins.bundledDiscovery,
+    'compat',
+    'patchOpenClawConfig: bundledDiscovery set to "compat" when allow is populated',
+  );
+  // Other keys preserved
+  assertEq(
+    (plugins.allow as string[]).includes('totalreclaw'),
+    true,
+    'patchOpenClawConfig: existing allow array preserved',
+  );
+}
+
+{
+  // Does NOT set bundledDiscovery when allow is empty / absent (auto-discover mode)
+  const cfgPath = path.join(TMP, 'openclaw-allow-empty.json');
+  const initial = {
+    plugins: {
+      installs: { totalreclaw: { version: '3.3.11-rc.4' } },
+      slots: { memory: 'totalreclaw' },
+      entries: { totalreclaw: { enabled: true, hooks: { allowConversationAccess: true } } },
+    },
+  };
+  fs.writeFileSync(cfgPath, JSON.stringify(initial));
+  assertEq(
+    patchOpenClawConfig(cfgPath),
+    'unchanged',
+    'patchOpenClawConfig: no bundledDiscovery patch when allow is absent (auto-discover mode)',
+  );
+  const after = JSON.parse(fs.readFileSync(cfgPath, 'utf-8')) as Record<string, unknown>;
+  const plugins = after.plugins as Record<string, unknown>;
+  assertEq(
+    plugins.bundledDiscovery,
+    undefined,
+    'patchOpenClawConfig: bundledDiscovery NOT set when allow absent',
+  );
+}
+
+{
+  // Does NOT set bundledDiscovery when allow is empty array
+  const cfgPath = path.join(TMP, 'openclaw-allow-empty-array.json');
+  const initial = {
+    plugins: {
+      installs: { totalreclaw: { version: '3.3.11-rc.4' } },
+      allow: [],
+      slots: { memory: 'totalreclaw' },
+      entries: { totalreclaw: { enabled: true, hooks: { allowConversationAccess: true } } },
+    },
+  };
+  fs.writeFileSync(cfgPath, JSON.stringify(initial));
+  assertEq(
+    patchOpenClawConfig(cfgPath),
+    'unchanged',
+    'patchOpenClawConfig: no bundledDiscovery patch when allow is empty array',
+  );
+}
+
+{
+  // Does NOT overwrite an explicit bundledDiscovery="allowlist" (power-user choice preserved)
+  const cfgPath = path.join(TMP, 'openclaw-bd-explicit-allowlist.json');
+  const initial = {
+    plugins: {
+      installs: { totalreclaw: { version: '3.3.11-rc.4' } },
+      allow: ['totalreclaw', 'telegram'],
+      bundledDiscovery: 'allowlist',
+      slots: { memory: 'totalreclaw' },
+      entries: { totalreclaw: { enabled: true, hooks: { allowConversationAccess: true } } },
+    },
+  };
+  fs.writeFileSync(cfgPath, JSON.stringify(initial));
+  assertEq(
+    patchOpenClawConfig(cfgPath),
+    'unchanged',
+    'patchOpenClawConfig: does not overwrite explicit bundledDiscovery=allowlist',
+  );
+  const after = JSON.parse(fs.readFileSync(cfgPath, 'utf-8')) as Record<string, unknown>;
+  const plugins = after.plugins as Record<string, unknown>;
+  assertEq(
+    plugins.bundledDiscovery,
+    'allowlist',
+    'patchOpenClawConfig: explicit "allowlist" preserved',
+  );
+}
+
+{
+  // Pop-os scenario: populated allow with totalreclaw, no bundledDiscovery, no streaming —
+  // exercises the exact missing-cure path that broke pop-os install on 2026-05-07.
+  const cfgPath = path.join(TMP, 'openclaw-popos-style.json');
+  const initial = {
+    plugins: {
+      installs: { totalreclaw: { version: '3.3.11-rc.4' } },
+      allow: ['device-pair', 'google', 'telegram', 'totalreclaw', 'zai'],
+      slots: { memory: 'totalreclaw' },
+      entries: { totalreclaw: { enabled: true, hooks: { allowConversationAccess: true } } },
+    },
+    channels: { telegram: { enabled: true, botToken: 'BOT' } },
+  };
+  fs.writeFileSync(cfgPath, JSON.stringify(initial));
+  assertEq(
+    patchOpenClawConfig(cfgPath),
+    'patched',
+    'patchOpenClawConfig: pop-os-style config gets patched (bundledDiscovery + telegram streaming)',
+  );
+  const after = JSON.parse(fs.readFileSync(cfgPath, 'utf-8')) as Record<string, unknown>;
+  const plugins = after.plugins as Record<string, unknown>;
+  const channels = after.channels as Record<string, Record<string, unknown>>;
+  assertEq(
+    plugins.bundledDiscovery,
+    'compat',
+    'patchOpenClawConfig: pop-os scenario sets bundledDiscovery=compat',
+  );
+  const tg = channels.telegram as Record<string, Record<string, unknown>>;
+  assertEq(
+    (tg.streaming as Record<string, unknown>)?.mode,
+    'off',
+    'patchOpenClawConfig: pop-os scenario also sets telegram streaming.mode=off',
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Integration: round-trip write → load → delete → reload
 // ---------------------------------------------------------------------------

--- a/skill/plugin/fs-helpers.ts
+++ b/skill/plugin/fs-helpers.ts
@@ -1170,6 +1170,16 @@ export type OpenClawConfigPatchResult = 'patched' | 'unchanged' | 'skipped' | 'e
  *      this to "off" on first run for a clean UX. Existing explicit values
  *      ("partial", "block", "progress") are preserved.
  *
+ *   4. `plugins.bundledDiscovery = "compat"` (only if unset, and only when
+ *      `plugins.allow` is populated). When `plugins.allow` is a non-empty
+ *      array, OpenClaw 2026.5.x switches the loader into strict-allowlist
+ *      mode and silently rejects non-bundled plugins like totalreclaw —
+ *      EVEN IF they are listed in the allow array. Setting
+ *      `bundledDiscovery: "compat"` restores the looser behavior so allow-
+ *      listed non-bundled plugins load. Without this fix, users with
+ *      telegram or any model provider configured before TR install (which
+ *      populates allow) get a silent plugin-skip on every gateway boot.
+ *
  * Design constraints
  * ------------------
  * - SYNCHRONOUS — called during register() which must be sync.
@@ -1298,6 +1308,37 @@ export function patchOpenClawConfig(
           tg.streaming.mode = 'off';
           mutated = true;
         }
+      }
+    }
+
+    // --- Fix #4: plugins.bundledDiscovery = "compat" (3.3.11-rc.4) ---
+    //
+    // OpenClaw 2026.5.x: when `plugins.allow` is populated (any non-empty
+    // array), the gateway's plugin loader switches into strict-allowlist
+    // mode. In strict mode, NON-BUNDLED plugins like totalreclaw are
+    // silently rejected even when listed in `plugins.allow`, unless
+    // `plugins.bundledDiscovery = "compat"` is explicitly set. Pedro's
+    // 2026-05-07 QA on pop-os surfaced this — the gateway booted with only
+    // the bundled providers (telegram, device-pair) and skipped totalreclaw
+    // despite it being in the allow list. `openclaw doctor --fix` cures it
+    // by setting `bundledDiscovery: "compat"`, but users shouldn't need
+    // to run doctor manually for the plugin to load.
+    //
+    // Fix: when `plugins.allow` is a non-empty array AND
+    // `plugins.bundledDiscovery` is unset, set it to "compat". If the user
+    // explicitly chose "allowlist" (the stricter mode), preserve their
+    // choice — only first-run defaults are touched.
+    //
+    // This bug was missed by the auto-QA harness because the harness ran
+    // on a fresh canonical container with `plugins.allow=null`, hitting
+    // the auto-discover code path. Real users with telegram + a model
+    // provider configured before TR install have a populated allow list,
+    // hitting the strict-mode path. The auto-QA harness in 3.3.11-rc.4
+    // adds a populated-allow scenario to catch future regressions.
+    if (Array.isArray(cfg.plugins.allow) && cfg.plugins.allow.length > 0) {
+      if (cfg.plugins.bundledDiscovery === undefined) {
+        cfg.plugins.bundledDiscovery = 'compat';
+        mutated = true;
       }
     }
 

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -3156,7 +3156,7 @@ const plugin = {
           api.logger.warn(
             'TotalReclaw: updated openclaw.json with required 2026.5.x keys ' +
               '(plugins.slots.memory + hooks.allowConversationAccess + ' +
-              'channels.telegram.streaming.mode). ' +
+              'channels.telegram.streaming.mode + plugins.bundledDiscovery). ' +
               'Gateway restart required for the changes to take effect. ' +
               'Run `/totalreclaw-restart` or restart the gateway manually.',
           );

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.11-rc.3",
+  "version": "3.3.11-rc.4",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "3.3.11-rc.3",
+  "version": "3.3.11-rc.4",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",

--- a/skill/plugin/tr-cli.ts
+++ b/skill/plugin/tr-cli.ts
@@ -52,7 +52,7 @@ const STATE_PATH = CONFIG.onboardingStatePath;
 // Auto-synced by skill/scripts/sync-version.mjs from skill/plugin/package.json::version.
 // Do not edit by hand — running tests will catch drift but the publish workflow
 // rewrites this constant at the start of every npm/ClawHub publish.
-const PLUGIN_VERSION = '3.3.11-rc.3';
+const PLUGIN_VERSION = '3.3.11-rc.4';
 
 function die(msg: string, code = 1): never {
   process.stderr.write(`tr: ${msg}\n`);


### PR DESCRIPTION
Fix #4 added to patchOpenClawConfig: when plugins.allow is populated, set bundledDiscovery=compat so OpenClaw's strict-allowlist mode doesn't silently reject totalreclaw. Without this, every realistic install (anyone with telegram + a model provider configured first) hits silent plugin-skip on gateway boot. Pedro caught it on pop-os; auto-QA missed it because the harness ran on fresh-allow=null path.