### PR TITLE
fix(plugin): 3.3.11-rc.5 — cap extractions per poll + skip stale trajectory files

### DIFF
--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.11-rc.5] — 2026-05-07
+
+Trajectory poller hardening: cap extractions per poll iteration + skip stale trajectory files. Pedro's 2026-05-07 zai 429 cascade was caused by ~5 old session files all crossing the extract threshold in the same poll → 5 back-to-back LLM calls in seconds → daily quota tripped. Today's chat memories were lost because every extraction call returned 0 facts (LLM rejected with rate-limit).
+
+### Changed
+
+- **Cap = 1 extraction per poll iteration.** When multiple session files cross the extract-interval threshold in the same 60 s poll, only the first fires the LLM call. The rest defer to subsequent polls. Their `turnsAccum` and `offset` state is preserved, so they don't lose progress — they just stagger. With the default 60 s poll interval, 5 backlogged files take 5 minutes to drain instead of 5 seconds. Free-tier LLM rate limits don't trip.
+- **Stale-trajectory skip (>7 days mtime).** A user installing TotalReclaw on a host with months of OpenClaw session log history won't get a retroactive extraction backlog. Files with mtime older than 7 days are baseline-snapshotted (offset captured) but skip the extraction path entirely. If the user later resumes an old session, the offset is current and only net-new content extracts.
+
+### Implementation notes
+
+- `MAX_EXTRACTIONS_PER_POLL = 1` constant in `trajectory-poller.ts`. Sequential `for` loop already guarantees serialization within a poll; the cap just stops issuing additional LLM calls once the first one completes.
+- `STALE_TRAJECTORY_AGE_MS = 7 * 24 * 60 * 60 * 1000`. Stale files get a one-time offset record (`state[file] = {offset: stat.size, turnsAccum: 0}`) so they're never re-stat'd repeatedly. If the user re-engages an old session (writes new content → mtime refreshes), the stale-skip check fails and normal extraction resumes from the recorded offset.
+- 4 new test cases in `trajectory-poller.test.ts`: cap=1 multi-session deferral, second-poll-no-op-after-deferred-cap, stale-file skip (>7 days), recent-file (<7 days) NOT skipped. 44/44 green.
+- 92/92 fs-helpers + 21/21 register-command-name + 37/37 skill-md + 21/21 tr-cli-json + 44/44 trajectory-poller + 10/10 manifest-shape. check-scanner: 129 files, 0 flags.
+
+### Won't fix here
+
+- Pop-os specific delayed-load anomaly (~58 min from rc.4 install to plugin first-load) — couldn't reproduce in fresh container; pop-os has accumulated state from many install/wipe cycles. Auto-QA confirmed clean fresh-install path.
+- The retroactive-backlog scenario itself remains: if a user has ACTIVE sessions (mtime < 7 days) with high turn counts, they'll still drain over multiple polls. With cap=1 and 60 s interval, 5 active-but-backlogged files = 5 minutes to drain. Acceptable.
+
 ## [3.3.11-rc.4] — 2026-05-07
 
 Fix #4 added to `patchOpenClawConfig()`: the **populated-allowlist plugin-skip bug** that broke every realistic install path.

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "Install + set up TotalReclaw encrypted memory for OpenClaw, then use tr CLI for remember / recall. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', or any remember / recall request."
-version: 3.3.11-rc.4
+version: 3.3.11-rc.5
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.11-rc.4",
+  "version": "3.3.11-rc.5",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "3.3.11-rc.4",
+  "version": "3.3.11-rc.5",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",

--- a/skill/plugin/tr-cli.ts
+++ b/skill/plugin/tr-cli.ts
@@ -52,7 +52,7 @@ const STATE_PATH = CONFIG.onboardingStatePath;
 // Auto-synced by skill/scripts/sync-version.mjs from skill/plugin/package.json::version.
 // Do not edit by hand — running tests will catch drift but the publish workflow
 // rewrites this constant at the start of every npm/ClawHub publish.
-const PLUGIN_VERSION = '3.3.11-rc.4';
+const PLUGIN_VERSION = '3.3.11-rc.5';
 
 function die(msg: string, code = 1): never {
   process.stderr.write(`tr: ${msg}\n`);

--- a/skill/plugin/trajectory-poller.test.ts
+++ b/skill/plugin/trajectory-poller.test.ts
@@ -454,7 +454,10 @@ async function runTests(): Promise<void> {
     });
   }
 
-  // 5f. Two independent session files — both polled in same iteration.
+  // 5f. Two independent session files — both crossing threshold in same poll.
+  // 3.3.11-rc.5 cap=1: only ONE extraction per poll iteration to avoid
+  // burst-firing the LLM rate-limiter. The deferred file's offset is
+  // preserved so the next poll picks it up.
   {
     const home = path.join(TMP, 'home-multi-session');
     writeTrajectoryFile(home, 'sess-a', [
@@ -467,7 +470,59 @@ async function runTests(): Promise<void> {
     ]);
     await withPoller(home, {}, async (h, calls) => {
       await h.pollOnce();
-      assertEq(calls.extraction, 2, 'pollOnce multi-session: extraction fires once per session that meets threshold');
+      assertEq(
+        calls.extraction,
+        1,
+        'pollOnce multi-session cap=1: only ONE extraction per poll, deferred file picks up next poll',
+      );
+      // Second poll: no new content on either file. Deferred file from poll-1
+      // already advanced its offset (cap-deferred files DO still record
+      // newOffset to avoid re-parsing the same lines).
+      await h.pollOnce();
+      // Cap-deferred files are at offset = newOffset, turnsAccum = N (preserved).
+      // Their content was already consumed; they don't re-extract until net-new
+      // messages arrive. So second poll is no-op extraction-wise.
+      assertEq(
+        calls.extraction,
+        1,
+        'pollOnce multi-session cap=1: second poll on unchanged files no-ops',
+      );
+    });
+  }
+
+  // 5g. Stale-file skip — trajectory file with mtime > 7 days old gets
+  // baseline offset captured but extraction skipped, preventing retroactive
+  // backlog burst on hosts with months of session-log history.
+  {
+    const home = path.join(TMP, 'home-stale-skip');
+    const file = writeTrajectoryFile(home, 'old-session', [
+      ['old user 1', 'old assistant 1'],
+      ['old user 2', 'old assistant 2'],
+    ]);
+    // Backdate mtime to 30 days ago.
+    const past = Date.now() - 30 * 24 * 60 * 60 * 1000;
+    fs.utimesSync(file, past / 1000, past / 1000);
+    await withPoller(home, {}, async (h, calls) => {
+      await h.pollOnce();
+      assertEq(calls.extraction, 0, 'pollOnce stale-skip: extraction NOT called for >7-day-old trajectory');
+      assertEq(calls.persisted, 0, 'pollOnce stale-skip: nothing persisted');
+    });
+  }
+
+  // 5h. Recent file (within 7 days) is NOT skipped — sanity check that
+  // stale-skip only catches truly old files.
+  {
+    const home = path.join(TMP, 'home-recent-not-skipped');
+    const file = writeTrajectoryFile(home, 'recent-session', [
+      ['recent user 1', 'recent assistant 1'],
+      ['recent user 2', 'recent assistant 2'],
+    ]);
+    // Backdate to 3 days ago (within 7-day window).
+    const recent = Date.now() - 3 * 24 * 60 * 60 * 1000;
+    fs.utimesSync(file, recent / 1000, recent / 1000);
+    await withPoller(home, {}, async (h, calls) => {
+      await h.pollOnce();
+      assertEq(calls.extraction, 1, 'pollOnce recent-not-skipped: extraction fires for <7-day-old trajectory');
     });
   }
 }

--- a/skill/plugin/trajectory-poller.ts
+++ b/skill/plugin/trajectory-poller.ts
@@ -127,6 +127,15 @@ export interface TrajectoryPollerHandle {
 
 const DEFAULT_POLL_INTERVAL_MS = 60_000;
 const STATE_FILE = path.join(os.homedir(), '.totalreclaw', 'extract-state.json');
+/**
+ * Skip trajectory files older than this. A user who installs
+ * TotalReclaw on a host with months of OpenClaw session log history
+ * shouldn't get a retroactive extraction backlog — we only care about
+ * ongoing chat from now forward (3.3.11-rc.5). Files with mtime older
+ * than this threshold get a one-time offset snapshot so they're never
+ * re-scanned, and skip the extraction path entirely.
+ */
+const STALE_TRAJECTORY_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 /**
  * Start the trajectory poller. Runs an initial poll after 5 s, then
@@ -152,17 +161,54 @@ export function startTrajectoryPoller(
 
       const extractInterval = deps.getExtractInterval();
       let stateChanged = false;
+      // 3.3.11-rc.5: cap extractions per poll iteration. Pedro's
+      // 2026-05-07 zai 429 cascade was caused by N session files all
+      // crossing the extract threshold in the same poll → N back-to-back
+      // LLM calls trip the rate-limiter (especially on free tiers).
+      // With cap=1, extra files defer to the next poll iteration
+      // (60 s later by default). Their turnsAccum is preserved across
+      // polls so they don't lose progress.
+      let extractionsThisPoll = 0;
+      const MAX_EXTRACTIONS_PER_POLL = 1;
 
       for (const file of files) {
+        // Stale-file skip: trajectory files untouched for STALE_TRAJECTORY_AGE_MS
+        // are likely abandoned sessions (old test runs, dead chats). Skip them
+        // entirely — don't burn LLM budget on extraction from stale content
+        // that the user has effectively forgotten about.
+        let mtimeMs = 0;
+        try {
+          mtimeMs = fs.statSync(file).mtimeMs;
+        } catch {
+          continue;
+        }
+        if (Date.now() - mtimeMs > STALE_TRAJECTORY_AGE_MS) {
+          // Lazy-record offset so we don't repeatedly re-scan stale files —
+          // if the user later resumes this session, the offset is already
+          // current and we'll only extract net-new content.
+          if (!state[file]) {
+            try {
+              state[file] = { offset: fs.statSync(file).size, turnsAccum: 0 };
+              stateChanged = true;
+            } catch { /* ignore */ }
+          }
+          continue;
+        }
+
         const lastEntry = state[file] ?? { offset: 0, turnsAccum: 0 };
         const { messages, newOffset } = parseNewMessages(file, lastEntry.offset);
         if (newOffset === lastEntry.offset) continue; // nothing new
 
         const turnsAdded = countTurns(messages);
         const turnsAccum = lastEntry.turnsAccum + turnsAdded;
-        const shouldExtract = turnsAccum >= extractInterval && messages.length >= 2;
+        const shouldExtract =
+          turnsAccum >= extractInterval &&
+          messages.length >= 2 &&
+          extractionsThisPoll < MAX_EXTRACTIONS_PER_POLL;
 
         if (shouldExtract) {
+          extractionsThisPoll++;
+
           deps.logger.info(
             `extractd: ${path.basename(file)} -> ${turnsAccum}/${extractInterval} turns; running extraction (${messages.length} messages)`,
           );


### PR DESCRIPTION
Address Pedro's 2026-05-07 zai 429 cascade. Cap = 1 extraction per poll iteration; stale (>7d mtime) files skip extraction path entirely.