### PR TITLE
fix(plugin): 3.3.11-rc.6 — mandatory ack before first install tool call

### DIFF
--- a/docs/guides/openclaw-setup-quickstart.md
+++ b/docs/guides/openclaw-setup-quickstart.md
@@ -15,16 +15,23 @@
 
 ## User-visible lines (the entire transcript)
 
-1. `Installing TotalReclaw…`
+1. `Setting up TotalReclaw — this takes about a minute…`
 2. `✓ Installed (totalreclaw <version>, hybrid mode)`
 3. *Triple-backticked `qr_ascii` payload, then:* `Open <url> in your browser. Enter PIN <pin>. Generate or paste a 12-word recovery phrase. Reply \`done\` once it's sealed.`
 4. `✓ You're set up on the TotalReclaw free tier — 500 memories/month, unlimited reads. https://totalreclaw.xyz/pricing. Ask me to remember anything.`
 
 If `~/.totalreclaw/credentials.json` already exists and is non-empty, emit only `✓ TotalReclaw is already set up.` and stop.
 
+### ⚡ Line 1 fires BEFORE the first shell tool call — not after
+
+Install + setup runs ~1 minute of silent shell work. Without an immediate ack the user assumes the prompt didn't register. Emit line 1 the moment you decide to install — before resolving `TR_CLI`, before `openclaw plugins install`, before any tool call. Then start work silently.
+
+❌ Forbidden order: `openclaw plugins install` → 60 s silent → emit line 1.
+✅ Required order: emit line 1 → `openclaw plugins install` → … → emit line 2 when `tr status` returns.
+
 ## Steps (copy-paste verbatim)
 
-### 1. Install (silent — emit line 1 first)
+### 1. Install (emit line 1 FIRST, then run install silently)
 
 ```bash
 openclaw plugins install @totalreclaw/totalreclaw@rc

--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.11-rc.6] — 2026-05-07
+
+UX fix: mandatory ack-before-first-tool-call on install. Pedro's rc.5 user QA found the agent went silent for ~60 s while running `openclaw plugins install` before emitting the first user-visible line. From the user's POV the prompt looked unanswered. This RC strengthens SKILL.md + the quickstart guide to require line 1 BEFORE the first shell tool call, with reassuring wait-time copy.
+
+### Changed
+
+- **SKILL.md user-visible line 1 reworded** from `Installing TotalReclaw…` to `Setting up TotalReclaw — this takes about a minute…` — adds explicit wait-time signal so the user knows to wait rather than resend.
+- **New "MANDATORY ACK BEFORE FIRST TOOL CALL" section** in SKILL.md top-level rules. Calls out forbidden vs required ordering: line 1 must precede any shell tool call (no `openclaw plugins install` → 60 s silent → emit line 1).
+- **Silence rules updated**: skipping line 1 entirely is now explicitly forbidden (previously the rule only forbade extra narration between lines, not omission of line 1).
+- **`docs/guides/openclaw-setup-quickstart.md` mirrors the change** with the same wait-time copy and an explicit "Line 1 fires BEFORE the first shell tool call — not after" sub-section.
+
+### Implementation notes
+
+- 4 new assertions in `skill-md-hybrid-primary.test.ts`: MANDATORY ACK section present, line 1 wait-time wording, Forbidden vs Required order documented, "Skipping line 1 entirely" listed as forbidden. 41/41 green.
+- All other test suites unchanged: 92/92 fs-helpers + 21/21 register-command-name + 21/21 tr-cli-json + 44/44 trajectory-poller + 10/10 manifest-shape. check-scanner: 129 files, 0 flags.
+- Pure documentation + spec change. No runtime code modified. Same poller behavior as rc.5.
+
 ## [3.3.11-rc.5] — 2026-05-07
 
 Trajectory poller hardening: cap extractions per poll iteration + skip stale trajectory files. Pedro's 2026-05-07 zai 429 cascade was caused by ~5 old session files all crossing the extract threshold in the same poll → 5 back-to-back LLM calls in seconds → daily quota tripped. Today's chat memories were lost because every extraction call returned 0 facts (LLM rejected with rate-limit).

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "Install + set up TotalReclaw encrypted memory for OpenClaw, then use tr CLI for remember / recall. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', or any remember / recall request."
-version: 3.3.11-rc.5
+version: 3.3.11-rc.6
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz
@@ -61,6 +61,15 @@ The word "pair" is internal jargon — never use it in user-visible prose. The u
 
 **Emit ONLY the user-visible lines listed below. Do not narrate tool calls. Do not describe what you're doing or about to do. Errors are the only allowed deviation, and only as a single tight line.** The expected user-facing transcript for a healthy install is **4–5 short lines TOTAL**. Anything more is a SKILL violation. Telegram and similar transports edit the bot's messages live as your tool calls progress — every interim "Let me check…" / "Plugin loaded. Let me verify…" line shows up to the user as awkward edit churn, even if you "delete" it. The fix is to never emit it in the first place.
 
+### ⚡ MANDATORY ACK BEFORE FIRST TOOL CALL
+
+**User-visible line 1 MUST be your FIRST output — emitted BEFORE you run any shell tool, plugin install, or `tr` command.** Install + setup takes 1–2 minutes of silent tool-execution; without an immediate ack the user assumes the request didn't register and may resend or abandon. The ack tells them work is happening.
+
+The ack is unconditional. It fires the moment you decide to install / set up TotalReclaw — even before you've resolved `TR_CLI`, even before you've checked whether the plugin is already installed, even before the first `openclaw plugins install` shell call. Send line 1, THEN start the work.
+
+Forbidden order (silent-then-narrate): ❌ run `openclaw plugins install` → wait 60s → emit line 1.
+Required order (ack-then-work): ✅ emit line 1 → run `openclaw plugins install` silently → emit line 2 when `tr status` returns.
+
 ## ⛔ FORBIDDEN ACTIONS (4 hard rules from 2026-05-05 QA)
 
 These specific actions break the pair flow. Everything else is governed by the "emit only the numbered user-visible lines" rule above.
@@ -93,8 +102,8 @@ Then invoke as `node "$TR_CLI" <cmd> [--json]`.
 
 Speak only these lines, in order. Substitute the bracketed placeholders with the real values. No prefaces. No suffixes. No narration.
 
-1. (start of install)
-   > Installing TotalReclaw…
+1. (FIRST output, emitted BEFORE any shell tool call — see "MANDATORY ACK" rule above)
+   > Setting up TotalReclaw — this takes about a minute…
 2. (after install + CLI verify — `tr status` works)
    > ✓ Installed (totalreclaw &lt;version&gt;, hybrid mode)
 3. (account-setup URL + PIN, IMMEDIATELY after `tr pair --json` returns — no consent gate)
@@ -114,8 +123,9 @@ Do NOT emit transitional / narrative lines between any of the four user-visible 
 - ❌ "Need to pair. Let me kick that off:" → silent. Just run the `setsid -f` block. Emit line 3 when URL+PIN returns. ALSO never use the word "pair" in user-facing text — see vocabulary table above.
 - ❌ "Standing by." → silent. Acknowledgements between lines are noise.
 - ❌ Any "Let me X" / "Now I'll Y" / "Just give me a second" prelude.
+- ❌ **Skipping line 1 entirely and going straight to shell tool calls.** Line 1 ack must precede the first tool call. Silent install = user thinks the prompt didn't register.
 
-The transcript Pedro should see is exactly four messages — the four numbered lines, nothing in between.
+The transcript Pedro should see is exactly four messages — the four numbered lines, nothing in between. Line 1 fires immediately. Lines 2–4 fire as work completes. No prose between.
 
 ## How does TotalReclaw work? (canonical answer for user questions)
 

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.11-rc.5",
+  "version": "3.3.11-rc.6",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [

--- a/skill/plugin/skill-md-hybrid-primary.test.ts
+++ b/skill/plugin/skill-md-hybrid-primary.test.ts
@@ -231,6 +231,38 @@ assert(
 );
 
 // ---------------------------------------------------------------------------
+// 8. MANDATORY ACK BEFORE FIRST TOOL CALL (3.3.11-rc.6 — Pedro 2026-05-07)
+// ---------------------------------------------------------------------------
+//
+// Pedro reported on rc.5 that the agent ran `openclaw plugins install` silently
+// for ~60s before emitting any user-visible line. From the user's POV the prompt
+// looked dead. SKILL.md must explicitly require line 1 BEFORE the first shell
+// tool call, with reassuring wait-time copy.
+
+assert(
+  /MANDATORY ACK BEFORE FIRST TOOL CALL/i.test(pluginSkillMd),
+  'skill/plugin/SKILL.md: contains MANDATORY ACK BEFORE FIRST TOOL CALL rule',
+);
+
+// Line 1 wording must include a wait-time signal so user knows to wait
+assert(
+  /Setting up TotalReclaw — this takes about a minute/.test(pluginSkillMd),
+  'skill/plugin/SKILL.md: line 1 includes wait-time signal "Setting up TotalReclaw — this takes about a minute…"',
+);
+
+// Forbidden order must be called out explicitly
+assert(
+  pluginSkillMd.includes('Forbidden order') && pluginSkillMd.includes('Required order'),
+  'skill/plugin/SKILL.md: documents Forbidden vs Required ack order explicitly',
+);
+
+// Skipping line 1 must be added to the silence-rules forbidden list
+assert(
+  /Skipping line 1 entirely/i.test(pluginSkillMd),
+  'skill/plugin/SKILL.md: silence rules forbid "skipping line 1 entirely"',
+);
+
+// ---------------------------------------------------------------------------
 
 console.log(`\n# ${passed} passed, ${failed} failed`);
 process.exit(failed === 0 ? 0 : 1);

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "3.3.11-rc.5",
+  "version": "3.3.11-rc.6",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",

--- a/skill/plugin/tr-cli.ts
+++ b/skill/plugin/tr-cli.ts
@@ -52,7 +52,7 @@ const STATE_PATH = CONFIG.onboardingStatePath;
 // Auto-synced by skill/scripts/sync-version.mjs from skill/plugin/package.json::version.
 // Do not edit by hand — running tests will catch drift but the publish workflow
 // rewrites this constant at the start of every npm/ClawHub publish.
-const PLUGIN_VERSION = '3.3.11-rc.5';
+const PLUGIN_VERSION = '3.3.11-rc.6';
 
 function die(msg: string, code = 1): never {
   process.stderr.write(`tr: ${msg}\n`);


### PR DESCRIPTION
## Summary

- SKILL.md line 1 reworded to include wait-time signal: `Setting up TotalReclaw — this takes about a minute…`
- New "MANDATORY ACK BEFORE FIRST TOOL CALL" section requires line 1 BEFORE first shell tool call
- Quickstart guide mirrors the rule with same copy
- 4 new regression assertions in skill-md-hybrid-primary.test.ts (41/41 green)

## Why

Pedro's rc.5 user QA found the agent ran \`openclaw plugins install\` silently for ~60 s before emitting any user-visible line. From the user's POV the prompt looked unanswered. This RC requires line 1 BEFORE the first tool call so the user knows work is happening.

## Test plan

- [x] 41/41 skill-md-hybrid-primary tests green
- [x] All other test suites unchanged: 92/92 fs-helpers + 21/21 register-command-name + 21/21 tr-cli-json + 44/44 trajectory-poller + 10/10 manifest-shape
- [x] check-scanner: 129 files, 0 flags
- [ ] Pop-os user QA confirms agent emits line 1 immediately on install

🤖 Generated with [Claude Code](https://claude.com/claude-code)