### PR TITLE
fix(plugin): 3.3.12-rc.1 — prose-rewrite quickstart + F flip + compat bump

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -420,75 +420,14 @@ jobs:
           console.log('RC version:', p.version);
           "
 
-      # 3.3.3-rc.1 (PR #165 implementation): bind stable artifacts to
-      # production, leave RC artifacts on staging. Source-of-truth in
-      # `dist/` after `npm run build` references `api-staging.totalreclaw.xyz`
-      # everywhere (per the staging-default flip in
-      # config.ts/index.ts/subgraph-store.ts/skill.json). For
-      # `release-type=stable`, sed-replace `api-staging.totalreclaw.xyz`
-      # -> `api.totalreclaw.xyz` across `dist/`, `skill.json`, and the
-      # SKILL.md / CLAWHUB.md / CHANGELOG.md / README.md prose. RC builds
-      # leave the staging URL intact. Subsequent `Stable URL guard` step
-      # asserts the artifact's invariants.
-      - name: Bind stable artifacts to production URLs (release-type=stable)
-        if: inputs.release-type == 'stable'
-        run: |
-          cd skill/plugin
-          # Files in scope: built JS (dist/), shipped manifests (skill.json,
-          # SKILL.md, CHANGELOG.md, CLAWHUB.md, README.md), and the
-          # checked-in package.json — anything that ships in the npm tarball
-          # via the `files` array.
-          FILES=$(find dist -type f \( -name '*.js' -o -name '*.d.ts' -o -name '*.cjs' -o -name '*.mjs' \) 2>/dev/null)
-          FILES="${FILES} skill.json SKILL.md CHANGELOG.md CLAWHUB.md README.md"
-          MISSING_FILES=""
-          for f in $FILES; do
-            if [ ! -f "$f" ]; then
-              MISSING_FILES="${MISSING_FILES} $f"
-              continue
-            fi
-            # Substring sed: matches both `https://api-staging` and `wss://api-staging`.
-            sed -i.bak 's|api-staging\.totalreclaw\.xyz|api.totalreclaw.xyz|g' "$f"
-            rm -f "$f.bak"
-          done
-          if [ -n "$MISSING_FILES" ]; then
-            echo "WARN: missing files (not bound):${MISSING_FILES}"
-          fi
-          echo "Stable URL bind complete. Verifying no api-staging remains in shipped artifacts:"
-          # Whitelist: the env-binding block in config.ts is allowed to MENTION
-          # api-staging in comments; built dist/config.js gets the comment
-          # stripped by tsc --noCheck so dist/config.js cannot mention it.
-          if grep -rn 'api-staging\.totalreclaw\.xyz' dist/ skill.json 2>/dev/null; then
-            echo "ERROR: api-staging.totalreclaw.xyz still present in stable artifacts after bind"
-            exit 1
-          fi
-
-      # Stable URL guard — fail-fast at publish time if the artifact is
-      # mode-incorrect. Stable: dist/ + skill.json must contain
-      # `api.totalreclaw.xyz` and ZERO `api-staging.totalreclaw.xyz`.
-      # RC: dist/ + skill.json must contain `api-staging.totalreclaw.xyz`.
-      - name: Stable / RC URL guard (env-binding rule per PR #165)
-        run: |
-          cd skill/plugin
-          MODE="${{ inputs.release-type }}"
-          if [ "$MODE" = "stable" ]; then
-            if grep -rqF 'api-staging.totalreclaw.xyz' dist/ skill.json 2>/dev/null; then
-              echo "GUARD FAIL: stable artifact contains api-staging.totalreclaw.xyz"
-              grep -rnF 'api-staging.totalreclaw.xyz' dist/ skill.json
-              exit 1
-            fi
-            if ! grep -rqF 'api.totalreclaw.xyz' dist/ skill.json 2>/dev/null; then
-              echo "GUARD FAIL: stable artifact missing api.totalreclaw.xyz reference"
-              exit 1
-            fi
-            echo "GUARD OK: stable artifact bound to api.totalreclaw.xyz"
-          else
-            # RC mode
-            if ! grep -rqF 'api-staging.totalreclaw.xyz' dist/ skill.json 2>/dev/null; then
-              echo "GUARD FAIL: RC artifact missing api-staging.totalreclaw.xyz default"
-              exit 1
-            fi
-            echo "GUARD OK: RC artifact retains api-staging.totalreclaw.xyz default"
-          fi
+      # 3.3.12-rc.1 (F flip): source already binds to production for both
+      # release-types. No publish-time URL rewrite is needed. The guard
+      # below delegates to skill/scripts/check-url-binding.mjs which
+      # enforces: skill.json default field = production; no JS-side
+      # default-URL literal bound to staging; production URL present
+      # somewhere in the artifact tree.
+      - name: Stable / RC URL guard (post-F-flip — production for both)
+        run: node skill/scripts/check-url-binding.mjs --release-type=${{ inputs.release-type }}
 
       # Propagate the (possibly RC-mutated) package.json::version into
       # SKILL.md frontmatter and skill.json, then GATE the publish on

--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -144,50 +144,11 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "release_type=${RELEASE_TYPE}" >> "$GITHUB_OUTPUT"
 
-      # 3.3.3-rc.1 (PR #165 implementation): bind stable artifacts to
-      # production, leave RC artifacts on staging. Mirrors the npm-publish.yml
-      # "Bind stable artifacts to production URLs" + "Stable / RC URL guard"
-      # steps. ClawHub publishes the source tree (with built dist/) opaquely,
-      # so the same sed needs to run before `clawhub publish`.
-      - name: Bind stable artifacts to production URLs (release-type=stable)
-        if: steps.resolve.outputs.release_type == 'stable'
-        run: |
-          cd skill/plugin
-          FILES=$(find dist -type f \( -name '*.js' -o -name '*.d.ts' -o -name '*.cjs' -o -name '*.mjs' \) 2>/dev/null)
-          FILES="${FILES} skill.json SKILL.md CHANGELOG.md CLAWHUB.md README.md"
-          for f in $FILES; do
-            [ -f "$f" ] || continue
-            sed -i.bak 's|api-staging\.totalreclaw\.xyz|api.totalreclaw.xyz|g' "$f"
-            rm -f "$f.bak"
-          done
-          if grep -rqF 'api-staging.totalreclaw.xyz' dist/ skill.json 2>/dev/null; then
-            echo "ERROR: api-staging.totalreclaw.xyz still present in stable artifact"
-            grep -rnF 'api-staging.totalreclaw.xyz' dist/ skill.json
-            exit 1
-          fi
-          echo "Stable URL bind complete."
-
-      - name: Stable / RC URL guard (env-binding rule per PR #165)
-        run: |
-          cd skill/plugin
-          MODE="${{ steps.resolve.outputs.release_type }}"
-          if [ "$MODE" = "stable" ]; then
-            if grep -rqF 'api-staging.totalreclaw.xyz' dist/ skill.json 2>/dev/null; then
-              echo "GUARD FAIL: stable artifact contains api-staging.totalreclaw.xyz"
-              exit 1
-            fi
-            if ! grep -rqF 'api.totalreclaw.xyz' dist/ skill.json 2>/dev/null; then
-              echo "GUARD FAIL: stable artifact missing api.totalreclaw.xyz reference"
-              exit 1
-            fi
-            echo "GUARD OK: stable artifact bound to api.totalreclaw.xyz"
-          else
-            if ! grep -rqF 'api-staging.totalreclaw.xyz' dist/ skill.json 2>/dev/null; then
-              echo "GUARD FAIL: RC artifact missing api-staging.totalreclaw.xyz default"
-              exit 1
-            fi
-            echo "GUARD OK: RC artifact retains api-staging.totalreclaw.xyz default"
-          fi
+      # 3.3.12-rc.1 (F flip): source already binds to production for both
+      # release-types. No publish-time sed-rewrite is needed. Guard
+      # delegates to skill/scripts/check-url-binding.mjs.
+      - name: Stable / RC URL guard (post-F-flip — production for both)
+        run: node skill/scripts/check-url-binding.mjs --release-type=${{ steps.resolve.outputs.release_type }}
 
       - name: Publish to ClawHub
         env:

--- a/.github/workflows/publish-python-client.yml
+++ b/.github/workflows/publish-python-client.yml
@@ -28,21 +28,16 @@ on:
 #     `pip install totalreclaw==2.1.0rc1`.
 #   - Mutation is ephemeral; not committed back to main.
 #
-# Environment-binding rule (codified in PR #165, enforced from 2.3.3-rc.1
-# onward — see docs/guides/release-process.md):
-#   - The canonical default-URL site lives at ``_HARDCODED_DEFAULT_URL`` in
-#     ``python/src/totalreclaw/relay.py``. Source-of-truth on ``main`` holds
-#     the STAGING URL so dev / test / RC builds default to staging without
-#     extra build steps.
-#   - When ``release-type=stable`` we sed-replace
-#     ``api-staging.totalreclaw.xyz`` -> ``api.totalreclaw.xyz`` in
-#     ``relay.py`` BEFORE ``python -m build`` so the published wheel binds
-#     real users to production by default.
-#   - When ``release-type=rc`` we leave the staging literal in place.
-#   - A pre-publish CI guard fails the build if a stable wheel still
-#     contains ``api-staging`` OR an RC wheel contains ``api.totalreclaw``
-#     (production). User env (``TOTALRECLAW_SERVER_URL=...``) always wins
-#     at runtime — the rule only changes the default.
+# Environment-binding rule (post-F-flip, 2.3.12-rc.1):
+#   - BOTH stable and RC wheels default to PRODUCTION
+#     (``api.totalreclaw.xyz``). No publish-time URL rewrite is needed —
+#     the canonical default-URL site at ``_HARDCODED_DEFAULT_URL`` in
+#     ``python/src/totalreclaw/relay.py`` already binds to production.
+#   - Staging access is opt-in via
+#     ``TOTALRECLAW_SERVER_URL=https://api-staging.totalreclaw.xyz`` at
+#     runtime. The rule only changes the default.
+#   - A pre-publish CI guard fails the build if any wheel still contains
+#     ``api-staging`` (stranded staging defaults are forbidden).
 
 jobs:
   build:
@@ -82,34 +77,17 @@ jobs:
           print('\n'.join(new_text.splitlines()[:10]))
           PY
 
-      # 2.3.3-rc.1 (PR #165) — bind the wheel's default relay URL to the
-      # right environment for the release type. Source on ``main`` holds
-      # staging; rewrite to production for stable. RC builds skip this
-      # step entirely so staging stays baked in.
-      - name: Inject production URL (stable only)
-        if: inputs.release-type == 'stable'
-        run: |
-          cd python
-          set -euo pipefail
-          target="src/totalreclaw/relay.py"
-          if ! grep -q '_HARDCODED_DEFAULT_URL = "https://api-staging.totalreclaw.xyz"' "$target"; then
-            echo "::error::Expected staging literal in $target but did not find it. Source layout drift?"
-            grep -n '_HARDCODED_DEFAULT_URL' "$target" || true
-            exit 1
-          fi
-          sed -i 's|_HARDCODED_DEFAULT_URL = "https://api-staging.totalreclaw.xyz"|_HARDCODED_DEFAULT_URL = "https://api.totalreclaw.xyz"|' "$target"
-          echo "Post-rewrite literal:"
-          grep -n '_HARDCODED_DEFAULT_URL' "$target"
+      # 2.3.12-rc.1 (F flip): no URL rewrite needed — the source at
+      # `_HARDCODED_DEFAULT_URL` already binds to production for both
+      # release types.
 
       - name: Build sdist and wheel
         run: cd python && python -m build
 
-      # 2.3.3-rc.1 (PR #165) — pre-publish CI guard. A stable wheel that
-      # still contains ``api-staging`` would point real users at staging;
-      # an RC wheel that contains the production URL (sans staging) would
-      # point QA at production. Either case is a release-blocker — fail
-      # the workflow before the publish job runs.
-      - name: Verify wheel default-URL binding matches release-type
+      # 2.3.12-rc.1 (F flip) pre-publish CI guard. Both stable and RC
+      # wheels MUST default to production. Any stranded ``api-staging``
+      # literal is a release-blocker.
+      - name: Verify wheel default-URL binding (post-F-flip — production for both)
         run: |
           cd python
           set -euo pipefail
@@ -119,50 +97,21 @@ jobs:
             python -m zipfile -e "$whl" /tmp/wheel-check/
           done
           echo "Scanning extracted wheel for URL literals..."
-          # Match any totalreclaw.xyz occurrence then partition by host.
-          staging_hits=$(grep -RIn "api-staging\.totalreclaw\.xyz" /tmp/wheel-check/ \
-            --include='*.py' || true)
-          # Production = api.totalreclaw.xyz NOT preceded by ``-staging``.
-          # The negative lookbehind keeps the ``api-staging`` URL from also
-          # being reported as production.
-          prod_hits=$(grep -RIn -P "(?<!-staging\.)(?<!-staging)api\.totalreclaw\.xyz" /tmp/wheel-check/ \
-            --include='*.py' || true)
-          echo "Staging literal hits:"
-          echo "${staging_hits:-<none>}"
-          echo "Production literal hits:"
-          echo "${prod_hits:-<none>}"
-          # Pull the canonical default-URL line specifically — we only enforce
-          # binding on the ``_HARDCODED_DEFAULT_URL`` site. Other strings
-          # (docstrings, comments) may still mention either URL legitimately.
           default_url_line=$(grep -RIn '^_HARDCODED_DEFAULT_URL\s*=' /tmp/wheel-check/ --include='*.py' || true)
           echo "Canonical default-URL line: ${default_url_line:-<not-found>}"
           if [ -z "$default_url_line" ]; then
             echo "::error::Canonical _HARDCODED_DEFAULT_URL line not found in wheel."
             exit 1
           fi
-          case "${{ inputs.release-type }}" in
-            stable)
-              if echo "$default_url_line" | grep -q "api-staging\.totalreclaw\.xyz"; then
-                echo "::error::Stable wheel still defaults to staging. Build-time injection did not run or failed."
-                exit 1
-              fi
-              if ! echo "$default_url_line" | grep -q "https://api\.totalreclaw\.xyz"; then
-                echo "::error::Stable wheel default-URL is neither staging nor production. Inspect the line above."
-                exit 1
-              fi
-              echo "OK: stable wheel binds to production by default."
-              ;;
-            rc)
-              if ! echo "$default_url_line" | grep -q "api-staging\.totalreclaw\.xyz"; then
-                echo "::error::RC wheel does not default to staging. Source-of-truth in relay.py changed?"
-                exit 1
-              fi
-              echo "OK: RC wheel binds to staging by default."
-              ;;
-            *)
-              echo "::warning::Unknown release-type '${{ inputs.release-type }}' — skipping URL-binding guard."
-              ;;
-          esac
+          if echo "$default_url_line" | grep -q "api-staging\.totalreclaw\.xyz"; then
+            echo "::error::Wheel default-URL still binds to staging. Both stable and RC must default to production."
+            exit 1
+          fi
+          if ! echo "$default_url_line" | grep -q "https://api\.totalreclaw\.xyz"; then
+            echo "::error::Wheel default-URL is neither staging nor production. Inspect the line above."
+            exit 1
+          fi
+          echo "OK (${{ inputs.release-type }}): wheel binds to production by default."
 
       - uses: actions/upload-artifact@v4
         with:

--- a/docs/guides/openclaw-setup-quickstart.md
+++ b/docs/guides/openclaw-setup-quickstart.md
@@ -1,133 +1,65 @@
-# TotalReclaw — OpenClaw quickstart (agent-executable)
+# TotalReclaw — OpenClaw quickstart
 
-> Audience: the LLM agent fetching this URL during install. Human-readable rationale lives in `openclaw-setup.md`.
-> Stable contract: ~3 KB, copy-paste-runnable, all rules in scope.
+TotalReclaw is end-to-end encrypted, decentralized memory for AI agents. Memories are encrypted on your device with a key derived from your 12-word recovery phrase, then submitted on-chain via Account Abstraction. Storage lives across a public blockchain (Base Sepolia for the free tier, Gnosis mainnet for paid). Only your recovery phrase can decrypt them.
 
-## Hard rules (read once, never break)
+This page is a short summary for humans. The full setup guide with rationale and troubleshooting is at [`openclaw-setup.md`](./openclaw-setup.md).
 
-1. **Emit ONLY the four numbered user-visible lines below.** No narration, no "let me check…", no "Now let me X", no "Need to Y", no "Standing by", no version-lag commentary, no path-resolution prose. The transcript Pedro sees during a healthy install is exactly four messages.
-2. **Never use the word "pair" / "pairing" / "paired" in user-facing text.** It's internal jargon. The user-facing word is **"set up an account"** / "your account". (Behind the scenes the CLI command is still `tr pair`; that's an implementation detail.)
-3. **Don't claim memories are "stored on a relay server" / "TotalReclaw's server" / any centralized-custody phrasing.** Memories are encrypted with a key derived from the recovery phrase, submitted on-chain (Account Abstraction), stored across a decentralized network, indexed via The Graph subgraph. The relay only forwards encrypted bundles. See "How does this work?" section below for the canonical answer.
-4. **Do NOT restart the gateway** (`/totalreclaw-restart`, `kill -USR1`, `docker restart`, `openclaw gateway restart`). The plugin self-patches and signals its own restart needs.
-5. **Do NOT write to `~/.openclaw/openclaw.json`**. The plugin's `patchOpenClawConfig()` already wrote everything it needs.
-6. **Do NOT save QR PNGs**. The `tr pair --json` payload returns `qr_ascii` — emit that inline in a code block. No `/tmp/totalreclaw-pair-qr.png`, no PNG decode, no `qr_png_b64` (legacy field, no longer exists).
-7. **The `tr pair --json` command MUST be invoked via `setsid -f`** so the WS-holding subprocess is in its own POSIX session and survives any subsequent gateway reload. Foreground invocation is killed when your shell-tool exec returns → relay returns 502.
+## Install
 
-## User-visible lines (the entire transcript)
+If you already have OpenClaw running, install the plugin and the skill from the OpenClaw CLI:
 
-1. `Installing TotalReclaw…`
-2. `✓ Installed (totalreclaw <version>, hybrid mode)`
-3. *Triple-backticked `qr_ascii` payload, then:* `Open <url> in your browser. Enter PIN <pin>. Generate or paste a 12-word recovery phrase. Reply \`done\` once it's sealed.`
-4. `✓ You're set up on the TotalReclaw free tier — 500 memories/month, unlimited reads. https://totalreclaw.xyz/pricing. Ask me to remember anything.`
+```bash
+openclaw plugins install @totalreclaw/totalreclaw
+openclaw skills install totalreclaw
+```
 
-If `~/.totalreclaw/credentials.json` already exists and is non-empty, emit only `✓ TotalReclaw is already set up.` and stop.
-
-## Steps (copy-paste verbatim)
-
-### 1. Install (silent — emit line 1 first)
+For release-candidate builds (newer features, may be unstable), append `@rc` to the plugin name:
 
 ```bash
 openclaw plugins install @totalreclaw/totalreclaw@rc
 openclaw skills install totalreclaw
 ```
 
-For stable use `@totalreclaw/totalreclaw` (no `@rc`). Plugin BEFORE skill — skill install triggers a config-driven reload that races a concurrent plugin install.
+The plugin is published by `p-diogo` on npm under the `@totalreclaw` scope. Source code: <https://github.com/p-diogo/totalreclaw>.
 
-If install reports `already exists` or non-zero on a re-run: add `--force`:
+## Set up your account
+
+After install, ask your agent something like *"set up TotalReclaw"* or just *"remember that I prefer Italian food"* — the agent will hand you an account-setup URL and a 6-digit PIN. Open the URL in your browser. You will:
+
+1. **Enter the PIN** the agent showed you.
+2. **Generate or paste a 12-word recovery phrase** — the browser handles this end-to-end encrypted, so the phrase never enters the chat or the relay. Pick *Set up* for a fresh phrase, or *Log in* if you already have one from another device.
+3. **Confirm.** The browser will tell you when you are all set.
+
+You are then on the free tier (500 memories per month, unlimited reads). Paid tiers and custom relays are at <https://totalreclaw.xyz/pricing>.
+
+## Write down the recovery phrase
+
+Your 12-word recovery phrase is the only key to your memories. Treat it like a password to a bank account:
+
+- Save it somewhere durable — paper, a password manager, or an encrypted note.
+- Do **not** paste it into the chat with your agent.
+- Do **not** screenshot it to a cloud-synced photo library.
+- If you lose it, you lose access to your memories forever.
+
+If TotalReclaw the company shuts down, your memories are still on a public blockchain. Any compatible relay (or your own self-hosted one) can read them with your recovery phrase.
+
+## Use it
+
+Once set up, just talk to your agent normally. It will pull relevant memories into context when you ask things like *"what did I tell you about my dog?"* or *"what's my work email?"*. You can also explicitly say *"remember X"* or *"forget the last thing I said about Y"*.
+
+## Privacy and decentralization
+
+TotalReclaw is end-to-end encrypted. The TotalReclaw relay only forwards encrypted bundles between your device and the blockchain — it never sees plaintext, can't read your memories, and could be replaced by any compatible relay without losing data. Storage lives on a public blockchain (Base Sepolia for free, Gnosis mainnet for Pro), indexed by The Graph. No single company controls or can read your memories.
+
+## Troubleshooting
+
+If the install command reports `already exists` on a re-run, add `--force`:
+
 ```bash
-openclaw plugins install @totalreclaw/totalreclaw@rc --force
+openclaw plugins install @totalreclaw/totalreclaw --force
 openclaw skills install totalreclaw --force
 ```
 
-If the shell call fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment): emit verbatim `Your environment doesn't expose the OpenClaw CLI to me. Please install \`totalreclaw\` from your service's plugins / skills UI, then reply \`done\`.` Wait for `done` and skip to step 3.
+If your environment doesn't expose the OpenClaw CLI to the agent (managed-service or sandboxed shell), install `totalreclaw` from your service's plugins / skills UI and then ask your agent to set you up.
 
-### 2. Verify CLI + emit line 2
-
-```bash
-TR_CLI="$(ls -d ~/.openclaw/npm/node_modules/@totalreclaw/totalreclaw/dist/tr-cli.js ~/.openclaw/extensions/totalreclaw/dist/tr-cli.js 2>/dev/null | head -1)"
-node "$TR_CLI" status --json
-```
-
-Parse `{"version": "...", "hybrid_mode": true, ...}` → emit line 2 with `<version>` substituted.
-
-If `tr status` exits non-zero or `$TR_CLI` is empty:
-- 1st failure: sleep 5s, retry. The install may still be writing files.
-- 2nd failure: re-run the install commands from step 1 with `--force`, then retry.
-- 3rd failure: emit `Plugin install verification failed twice — the install staged on disk but didn't register. Try \`openclaw plugins install @totalreclaw/totalreclaw@rc --force\` from a terminal, then reply \`done\`.` Stop.
-
-### 3. Check existing credentials (silent unless found)
-
-```bash
-test -s ~/.totalreclaw/credentials.json
-```
-
-Exit 0 = exists → emit `✓ TotalReclaw is already set up.` and stop. Exit 1 = continue.
-
-### 4. Pair (DETACHED — survives gateway reload) + emit line 3
-
-```bash
-PAIR_OUT="/tmp/tr-pair-out-$(date +%s).json"
-setsid -f node "$TR_CLI" pair --json > "$PAIR_OUT" 2>&1 < /dev/null
-sleep 2
-cat "$PAIR_OUT"
-```
-
-The `setsid -f` is non-negotiable (rule 5). If the cat output is empty after 2s, sleep 2 more and retry once (cold-network handshake can take up to 4s).
-
-Parse the JSON `{"v":1,"sid":"...","url":"...","pin":"...","mode":"...","expires_at_ms":...,"qr_ascii":"..."}`. Emit a single chat message containing:
-
-````
-```
-<qr_ascii contents verbatim — 43 lines of block chars>
-```
-
-Open <url> in your browser. Enter PIN <pin>. Generate or paste a 12-word recovery phrase. Reply `done` once it's sealed.
-````
-
-The triple-backtick block renders the Unicode QR in monospace on Telegram / Slack / web / terminal — every transport. Do NOT attach a PNG. Do NOT save the QR anywhere. Do NOT re-render through another library.
-
-### 5. Confirm (silent until line 4)
-
-After the user replies `done`, recheck:
-
-```bash
-test -s ~/.totalreclaw/credentials.json
-```
-
-Exit 0 → emit line 4. Exit 1 → re-run step 4 once and resend line 3 (PIN expired or phrase mismatch).
-
-## Browser flow context (don't narrate; recover gracefully on user question)
-
-After line 3 the user opens the URL and walks through a 3-step browser wizard. Know it so you can answer questions and recover from issues:
-
-1. **Step 1 of 3 — Enter PIN.** Six PIN cells, 10-min countdown in corner. Continue button enables when all 6 digits match.
-2. **Step 2 of 3 — Recovery phrase.** Default tab **Set up** generates a fresh 12-word BIP-39 phrase in-browser; **Log in** tab accepts a pasted existing phrase. User must check "I've written this down…" and click **Set up TotalReclaw**. Phrase encrypted in browser → relay only sees ciphertext → forwarded to plugin.
-3. **Step 3 of 3 — You're all set.** Confirmation. Browser already POSTed; relay completed forward; plugin wrote `~/.totalreclaw/credentials.json`.
-
-Common user issues — emit ONE tight line, don't pre-narrate:
-- "Page won't load" → check URL host (`api-staging.totalreclaw.xyz` for RC, `api.totalreclaw.xyz` for stable). Wrong host → generate fresh URL.
-- "PIN expired" / countdown ran out → re-run step 4, resend line 3.
-- "Invalid phrase" on Log in → typo or wrong-source phrase. User re-checks paste OR switches to **Set up** for a fresh one (loses existing memories).
-- "Clicked Set up but nothing happened" / 502 → wait 30s for any deferred gateway reload to complete; if persists, re-run step 4.
-- "Where do I write down the phrase?" → paper, password manager, encrypted note. NOT this chat. NOT cloud-synced screenshot. Phrase IS the account.
-
-## "How does this work?" — canonical answer for user questions
-
-When the user asks "how does this work?" / "where are my memories stored?" / "is this safe?" — answer with this content. Do NOT say "stored on a relay server", "stored on TotalReclaw's server", or any phrasing that implies single-company custody.
-
-> **End-to-end encrypted, decentralized memory.** When you tell me to remember something, I encrypt it locally with a key derived from your 12-word recovery phrase, then submit it on-chain via Account Abstraction (a UserOperation). It lives on a public blockchain (Base Sepolia for free tier, Gnosis mainnet for paid). The Graph subgraph indexes it for fast retrieval. The TotalReclaw relay server only forwards encrypted bundles between your client and the chain — it never sees plaintext, can't read your memories, and could be replaced by any compatible relay without losing data. Your recovery phrase is the only thing that can decrypt the memories.
-
-Shorter slices:
-- **"Where are memories stored?"** → "Encrypted, on-chain (Base or Gnosis depending on tier), indexed by The Graph. Not on any single company's server."
-- **"Is the relay reading my data?"** → "No. The relay only forwards encrypted bundles. Plaintext never leaves your device. Only your recovery phrase can decrypt them."
-- **"What if TotalReclaw shuts down?"** → "Your memories survive. They're on a public blockchain. Any compatible relay (or self-hosted relay) can read them with your recovery phrase."
-
-## CLI reference (post-setup)
-
-```bash
-node "$TR_CLI" status --json
-node "$TR_CLI" remember --json "<fact>"
-node "$TR_CLI" recall --json "<query>" --limit 5
-```
-
-Foreground for these is fine — they're single-shot HTTP calls, not WS-holding. Only `tr pair --json` needs `setsid -f`.
+For more troubleshooting and the full setup rationale, see [`openclaw-setup.md`](./openclaw-setup.md).

--- a/python/src/totalreclaw/relay.py
+++ b/python/src/totalreclaw/relay.py
@@ -38,20 +38,18 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
-# 2.3.3-rc.1 — environment-binding rule (PR #165): RC artifacts default to
-# STAGING, stable artifacts default to PRODUCTION. The checked-in literal is
-# STAGING; the publish-python-client.yml workflow rewrites this single line
-# to the production URL when ``release-type=stable`` before
-# ``python -m build``. A pre-publish CI guard fails the build if a stable
-# wheel still contains ``api-staging`` or an RC wheel contains
-# ``api.totalreclaw.xyz`` (sans staging) — see the workflow for the regex.
+# 2.3.12-rc.1 (F flip) — environment-binding rule: BOTH stable and RC
+# wheels default to PRODUCTION. The publish-time rewrite that previously
+# differentiated stable vs. RC defaults is removed. Staging access is
+# opt-in via TOTALRECLAW_SERVER_URL=https://api-staging.totalreclaw.xyz
+# at runtime. A pre-publish CI guard fails the build if any wheel
+# contains ``api-staging`` (stranded staging defaults are forbidden).
 #
 # This is THE canonical default-URL site for the Python package. Every
 # other module that resolves a default URL imports
 # ``_HARDCODED_DEFAULT_URL`` (or calls ``_default_relay_url()``) from here.
-# Adding a second hardcoded URL elsewhere will silently desync the wheel
-# from the build-time injection rule. Don't.
-_HARDCODED_DEFAULT_URL = "https://api-staging.totalreclaw.xyz"
+# Adding a second hardcoded URL elsewhere will silently desync the wheel.
+_HARDCODED_DEFAULT_URL = "https://api.totalreclaw.xyz"
 
 
 def _default_relay_url() -> str:
@@ -62,9 +60,8 @@ def _default_relay_url() -> str:
     import) so env changes after import take effect.
 
     The fallback returned when the env var is unset is the value baked into
-    ``_HARDCODED_DEFAULT_URL`` at build time — staging for RC artifacts,
-    production for stable artifacts. See the module docstring for the
-    workflow that performs the substitution.
+    ``_HARDCODED_DEFAULT_URL`` — production for both stable and RC builds
+    (post-F-flip, 2.3.12-rc.1). Staging access is opt-in via the env var.
     """
     return os.environ.get("TOTALRECLAW_SERVER_URL") or _HARDCODED_DEFAULT_URL
 

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "Install + set up TotalReclaw encrypted memory for OpenClaw, then use tr CLI for remember / recall. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', or any remember / recall request."
-version: 3.3.11-rc.6
+version: 3.3.12-rc.1
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz
@@ -226,7 +226,7 @@ After you emit user-visible line 3, the user opens the URL on their phone or des
 
 Common user-side issues during pair (recover gracefully — emit ONE tight line, don't pre-narrate):
 
-- **"The page won't load"** → check the URL is the staging URL (`api-staging.totalreclaw.xyz` for RC builds, `api.totalreclaw.xyz` for stable). If they used the wrong stub host, generate a fresh URL.
+- **"The page won't load"** → confirm the URL host is `api.totalreclaw.xyz` (the default for both stable and RC post-3.3.12-rc.1). If a `TOTALRECLAW_SERVER_URL` env override was set, the host might be `api-staging.totalreclaw.xyz` (staging, opt-in) or a self-hosted relay. Wrong stub host → generate a fresh URL.
 - **"PIN says expired"** or countdown ran out → re-run the pair block (Step 4 above) and emit line 3 again with the fresh URL+PIN. The previous session is dead.
 - **"It says invalid phrase"** during Log in → the user pasted a phrase that isn't BIP-39 valid (typo or wrong source). Tell them to double-check and re-paste; or switch to **Set up** tab to generate a fresh one (loses existing memories).
 - **"I clicked Set up TotalReclaw but nothing happened"** / **502** → the gateway WS dropped before respond. The pair subprocess is alive (you used `setsid -f`). Wait 30s; if the user still sees the 502, re-run Step 4 (the deferred reload should have completed by then).

--- a/skill/plugin/config.ts
+++ b/skill/plugin/config.ts
@@ -138,15 +138,14 @@ export const CONFIG = {
   get sessionId(): string | null {
     return getSessionId();
   },
-  // 3.3.3-rc.1: source default is `api-staging.totalreclaw.xyz` per the
-  // codified RC=staging / stable=production rule (PR #165). The workflow
-  // step "Bind stable to production URLs" in `npm-publish.yml` /
-  // `publish-clawhub.yml` sed-replaces `api-staging.totalreclaw.xyz` ->
-  // `api.totalreclaw.xyz` across the built `dist/` tree (and skill.json /
-  // SKILL.md / CHANGELOG / CLAWHUB.md / package.json) when
-  // `release-type=stable`. RC publishes leave the staging URL untouched.
+  // 3.3.12-rc.1 (F flip): source default is `api.totalreclaw.xyz` (production)
+  // for BOTH stable and RC builds. Previously RC defaulted to staging, which
+  // stranded users who picked `@rc` with their memories on staging. Staging
+  // access is now opt-in via `TOTALRECLAW_SERVER_URL=https://api-staging.totalreclaw.xyz`.
+  // No more publish-time URL rewrites — both release-types ship the same
+  // production default, and the workflow guard rails simply assert that.
   // User overrides via `TOTALRECLAW_SERVER_URL=...` always win.
-  serverUrl: (process.env.TOTALRECLAW_SERVER_URL || 'https://api-staging.totalreclaw.xyz').replace(/\/+$/, ''),
+  serverUrl: (process.env.TOTALRECLAW_SERVER_URL || 'https://api.totalreclaw.xyz').replace(/\/+$/, ''),
   selfHosted: process.env.TOTALRECLAW_SELF_HOSTED === 'true',
   credentialsPath: process.env.TOTALRECLAW_CREDENTIALS_PATH || path.join(home, '.totalreclaw', 'credentials.json'),
   // 3.2.0 onboarding state file — separate from credentials.json so it
@@ -172,7 +171,7 @@ export const CONFIG = {
   // 3.3.1-rc.11 — relay base URL for the WebSocket-brokered pair flow.
   // `wss://` preferred; `https://` is rewritten in the remote-client.
   pairRelayUrl: (process.env.TOTALRECLAW_PAIR_RELAY_URL
-    || 'wss://api-staging.totalreclaw.xyz').replace(/\/+$/, ''),
+    || 'wss://api.totalreclaw.xyz').replace(/\/+$/, ''),
 
   // Chain — chainId is no longer user-configurable. It is auto-detected from
   // the relay billing response (free = Base Sepolia / 84532, Pro = Gnosis /

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -807,9 +807,9 @@ let stagingBannerLogged = false;
  * directs the caller to `openclaw totalreclaw onboard`.
  */
 async function initialize(logger: OpenClawPluginApi['logger']): Promise<void> {
-  // 3.3.3-rc.1: staging is the source default per #165. Stable build-time
-  // sed-replace flips `api-staging` -> `api` in dist/.
-  const serverUrl = CONFIG.serverUrl || 'https://api-staging.totalreclaw.xyz';
+  // 3.3.12-rc.1 (F flip): production is the source default for all builds.
+  // Staging is opt-in via TOTALRECLAW_SERVER_URL=https://api-staging.totalreclaw.xyz.
+  const serverUrl = CONFIG.serverUrl || 'https://api.totalreclaw.xyz';
   let masterPassword = CONFIG.recoveryPhrase;
 
   // 3.2.0: if the env var is unset, probe credentials.json for a
@@ -6262,24 +6262,28 @@ const plugin = {
           let stagingBannerSuppressed = false;
           if (!stagingBannerShown) {
             try {
-              const usingStagingDefault = CONFIG.serverUrl.includes('api-staging.totalreclaw.xyz');
-              const userOverrode = CONFIG.serverUrlEnvOverridden;
-              if (usingStagingDefault && !userOverrode) {
+              // 3.3.12-rc.1 (F flip): banner now fires when serverUrl resolves
+              // to api-staging.totalreclaw.xyz, which under the new contract
+              // can ONLY happen if (a) user opted in via env override, or
+              // (b) the artifact is broken / accidentally bound to staging.
+              // Either way the user benefits from seeing the warning.
+              const usingStaging = CONFIG.serverUrl.includes('api-staging.totalreclaw.xyz');
+              if (usingStaging) {
                 stagingBannerBlock =
-                  '## ⚠️ TotalReclaw is running in RC / staging mode\n\n' +
-                  'This build is bound to `api-staging.totalreclaw.xyz`. Staging has **no SLA** ' +
+                  '## ⚠️ TotalReclaw is running in staging mode\n\n' +
+                  'This session is bound to `api-staging.totalreclaw.xyz`. Staging has **no SLA** ' +
                   'and may be wiped between QA cycles. Do **NOT** use this build for real data.\n\n' +
-                  'For production, install the stable release: `openclaw plugins install ' +
-                  '@totalreclaw/totalreclaw` (no `@rc` suffix). To pin a custom server, set ' +
-                  '`TOTALRECLAW_SERVER_URL=https://api.totalreclaw.xyz` in your env.\n\n';
-                // Do NOT set stagingBannerShown=true here — see comment above.
-                // Logger emits once per gateway process; this is fine to
-                // gate on the same flag because the logger is operator-
-                // facing, not user-facing.
+                  'The default relay is `api.totalreclaw.xyz` (production). To return to production, ' +
+                  'unset `TOTALRECLAW_SERVER_URL`. To stay on staging, leave it set to ' +
+                  '`https://api-staging.totalreclaw.xyz`.\n\n';
+                // Do NOT set stagingBannerShown=true here — see comment in
+                // staging-banner-gate.test.ts. Banner-shown flips only via
+                // consumeBannerForPrepend() once a return path actually
+                // delivers the block.
                 stagingBannerSuppressed = true;
               } else {
-                // Non-RC artifact OR user override — never fire the banner this
-                // gateway-process lifetime.
+                // Production default OR custom URL — never fire the banner
+                // this gateway-process lifetime.
                 stagingBannerShown = true;
               }
             } catch {
@@ -6287,14 +6291,13 @@ const plugin = {
               stagingBannerShown = true;
             }
           }
-          // Operator-facing log: once per process, when we DETECT the
-          // staging build (banner-shown semantics are about user
-          // delivery; this log is independent).
+          // Operator-facing log: once per process, when we DETECT staging.
           if (stagingBannerSuppressed && !stagingBannerLogged) {
             stagingBannerLogged = true;
             api.logger.warn(
-              'TotalReclaw: RC/staging build active (api-staging.totalreclaw.xyz). ' +
-              'See docs/guides/release-process.md for the RC=staging / stable=production rule.',
+              'TotalReclaw: staging mode active (api-staging.totalreclaw.xyz). ' +
+              'Default is production (api.totalreclaw.xyz); staging is opt-in via ' +
+              'TOTALRECLAW_SERVER_URL.',
             );
           }
           /**

--- a/skill/plugin/package-lock.json
+++ b/skill/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.7-rc.2",
+  "version": "3.3.12-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/totalreclaw",
-      "version": "3.3.7-rc.2",
+      "version": "3.3.12-rc.1",
       "license": "MIT",
       "dependencies": {
         "@scure/bip39": "^2.2.0",
@@ -17,6 +17,9 @@
         "qrcode": "^1.5.4",
         "qrcode-terminal": "^0.12.0",
         "ws": "^8.18.3"
+      },
+      "bin": {
+        "tr": "dist/tr-cli.js"
       },
       "devDependencies": {
         "@huggingface/transformers": "^4.0.1",
@@ -41,9 +44,9 @@
       }
     },
     "node_modules/@huggingface/jinja": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.7.tgz",
-      "integrity": "sha512-OosMEbF/R6zkKNNzqhI7kvKYCpo1F0UeIv46/h4D4UjVEKKd6k3TiV8sgu6fkreX4lbBiRI+lZG8UnXnqVQmEQ==",
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.8.tgz",
+      "integrity": "sha512-ZdElB7DPS7QQS8ZnFc5RPPtkg+eN11z8AmIZWAyes6pSbwXqiFB/POVevvm01begdSX1ho9Gxln/F6qlQMsuaA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -56,16 +59,95 @@
       "license": "Apache-2.0"
     },
     "node_modules/@huggingface/transformers": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-4.1.0.tgz",
-      "integrity": "sha512-WiMf9eyvF6V2pj4gs12A7GQV3svyFIBtB/W+Hn5lT5E5DyqWUno1ZrWoAfJv69X1RNv/0GoOo6DFmL6NOYd+rg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-4.2.0.tgz",
+      "integrity": "sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/jinja": "^0.5.6",
         "@huggingface/tokenizers": "^0.1.3",
         "onnxruntime-node": "1.24.3",
-        "onnxruntime-web": "1.26.0-dev.20260410-5e55544225",
+        "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c",
         "sharp": "^0.34.5"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/onnxruntime-common": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
+      "integrity": "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==",
+      "license": "MIT"
+    },
+    "node_modules/@huggingface/transformers/node_modules/onnxruntime-node": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.24.3.tgz",
+      "integrity": "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "adm-zip": "^0.5.16",
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.24.3"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@img/colour": {
@@ -626,9 +708,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -654,9 +736,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -672,9 +754,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@scure/base": {
@@ -1347,17 +1429,16 @@
       }
     },
     "node_modules/global-agent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
-      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-4.1.3.tgz",
+      "integrity": "sha512-KUJEViiuFT3I97t+GYMikLPJS2Lfo/S2F+DQuBWzuzaMPnvt5yyZePzArx36fBzpGTxZjIpDbXLeySLgh+k76g==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "boolean": "^3.0.1",
-        "es6-error": "^4.1.1",
-        "matcher": "^3.0.0",
-        "roarr": "^2.15.3",
-        "semver": "^7.3.2",
-        "serialize-error": "^7.0.1"
+        "globalthis": "^1.0.2",
+        "matcher": "^4.0.0",
+        "semver": "^7.3.5",
+        "serialize-error": "^8.1.0"
       },
       "engines": {
         "node": ">=10.0"
@@ -1565,15 +1646,19 @@
       }
     },
     "node_modules/matcher": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
-      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-4.0.0.tgz",
+      "integrity": "sha512-S6x5wmcDmsDRRU/c2dkccDwQPXoFczc5+HpQ2lON8pnvHlnvHAHj5WlLVvw6n6vNyHuVugYrFohYxbS+pvFpKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mimic-response": {
@@ -1678,9 +1763,9 @@
       "optional": true
     },
     "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1772,15 +1857,17 @@
       }
     },
     "node_modules/onnxruntime-common": {
-      "version": "1.24.3",
-      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
-      "integrity": "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==",
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.25.1.tgz",
+      "integrity": "sha512-kKvYQFdos4LWJqhZ+nmKu3NT8NXzw8I5x9fNUKe1rNKcPfNKnYXUtW7JBpcKFsvLtrJashRgVYSbFap4cHxvNg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/onnxruntime-node": {
-      "version": "1.24.3",
-      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.24.3.tgz",
-      "integrity": "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==",
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.25.1.tgz",
+      "integrity": "sha512-N0M58CGTiTsLkPpx9bxmRFi24GT6r67Qei/GrBEIiDyntcYdXU5vQZp112ypydG9vEKRFgbgUYQJnEi+jll8dg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "os": [
@@ -1790,14 +1877,14 @@
       ],
       "dependencies": {
         "adm-zip": "^0.5.16",
-        "global-agent": "^3.0.0",
-        "onnxruntime-common": "1.24.3"
+        "global-agent": "^4.1.3",
+        "onnxruntime-common": "1.25.1"
       }
     },
     "node_modules/onnxruntime-web": {
-      "version": "1.26.0-dev.20260410-5e55544225",
-      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.26.0-dev.20260410-5e55544225.tgz",
-      "integrity": "sha512-hHd9n8DzIfGSAjM4Dvslesc8i6h9HEEcl8qt7X3LfhUxMgls6FBJ32j2xrDtJjKJFEehFeJmyB/pvad1I8KS8w==",
+      "version": "1.26.0-dev.20260416-b7804b056c",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.26.0-dev.20260416-b7804b056c.tgz",
+      "integrity": "sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==",
       "license": "MIT",
       "dependencies": {
         "flatbuffers": "^25.1.24",
@@ -1813,6 +1900,70 @@
       "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.0-dev.20251116-b39e144322.tgz",
       "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
       "license": "MIT"
+    },
+    "node_modules/ox": {
+      "version": "0.14.20",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.20.tgz",
+      "integrity": "sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ox/node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ox/node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/p-limit": {
       "version": "2.3.0",
@@ -1927,22 +2078,22 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },
@@ -2103,12 +2254,13 @@
       "license": "MIT"
     },
     "node_modules/serialize-error": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
+      "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "type-fest": "^0.13.1"
+        "type-fest": "^0.20.2"
       },
       "engines": {
         "node": ">=10"
@@ -2353,9 +2505,10 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
@@ -2368,7 +2521,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -2391,9 +2544,9 @@
       "license": "MIT"
     },
     "node_modules/viem": {
-      "version": "2.48.3",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.48.3.tgz",
-      "integrity": "sha512-KFuwd5GN5bXiqOrv8amWiim2kR+tS/NveG/MtURSRS7PsuS9RFKUaCNlg+3nFx6bF/2pcOQVAVwUX4dkQ9/JqA==",
+      "version": "2.48.8",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.48.8.tgz",
+      "integrity": "sha512-Xj3Nrt66SKtn06kczU91ELn9Difr84ZM5A62BTlaisT5lpgt058i2mBkfMZCXHGb1ocOLjzC2ztPhD0Lvky7uQ==",
       "funding": [
         {
           "type": "github",
@@ -2408,7 +2561,7 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.14.17",
+        "ox": "0.14.20",
         "ws": "8.18.3"
       },
       "peerDependencies": {
@@ -2454,32 +2607,23 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/viem/node_modules/ox": {
-      "version": "0.14.17",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.17.tgz",
-      "integrity": "sha512-jOzNb2Wlfzsr8z/GoCtd1bf6OSRuWuysvbhnHGD+7fV1WRbcBR6B0RYoe3xWnUedF7zp4l5APmS7CzAhUok/lA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
+    "node_modules/viem/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "^1.11.0",
-        "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "1.9.1",
-        "@noble/hashes": "^1.8.0",
-        "@scure/bip32": "^1.7.0",
-        "@scure/bip39": "^1.6.0",
-        "abitype": "^1.2.3",
-        "eventemitter3": "5.0.1"
+      "engines": {
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
-        "typescript": ">=5.4.0"
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
-        "typescript": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
           "optional": true
         }
       }
@@ -2536,9 +2680,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.11-rc.6",
+  "version": "3.3.12-rc.1",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [
@@ -81,7 +81,7 @@
       "./dist/index.js"
     ],
     "compat": {
-      "pluginApi": ">=2026.3.22"
+      "pluginApi": ">=2026.5.5"
     },
     "build": {
       "openclawVersion": "2026.4.24"

--- a/skill/plugin/pair-remote-client.ts
+++ b/skill/plugin/pair-remote-client.ts
@@ -57,7 +57,7 @@ import {
 // ---------------------------------------------------------------------------
 
 /** Default relay endpoint. Caller passes `TOTALRECLAW_PAIR_RELAY_URL` via config. */
-export const DEFAULT_RELAY_URL = 'wss://api-staging.totalreclaw.xyz';
+export const DEFAULT_RELAY_URL = 'wss://api.totalreclaw.xyz';
 
 /** WebSocket connect + handshake timeout (ms). */
 const OPEN_TIMEOUT_MS = 10_000;

--- a/skill/plugin/scope-address-visible.test.ts
+++ b/skill/plugin/scope-address-visible.test.ts
@@ -188,7 +188,7 @@ const SAMPLE_SCOPE = '0x1234567890abcdef1234567890abcdef12345678';
   try {
     const { statusTool } = await import('../src/tools/status.js');
     const result = await statusTool(
-      'https://api-staging.totalreclaw.xyz',
+      'https://api.totalreclaw.xyz',
       'deadbeef',
       SAMPLE_SCOPE,
     );

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "3.3.11-rc.6",
+  "version": "3.3.12-rc.1",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",
@@ -141,8 +141,9 @@
     }
   ],
   "openclaw": {
-    "minVersion": "0.1.0",
-    "maxVersion": "1.0.0",
+    "compat": {
+      "pluginApi": ">=2026.5.5"
+    },
     "requires": {
       "env": [],
       "bins": []
@@ -318,8 +319,8 @@
     "config": {
       "serverUrl": {
         "type": "string",
-        "default": "https://api-staging.totalreclaw.xyz",
-        "description": "TotalReclaw server URL (only change for self-hosted mode). Source default points at staging; stable releases swap to https://api.totalreclaw.xyz at publish time per PR #165."
+        "default": "https://api.totalreclaw.xyz",
+        "description": "TotalReclaw server URL. Both stable and RC builds default to production (api.totalreclaw.xyz). Set TOTALRECLAW_SERVER_URL=https://api-staging.totalreclaw.xyz to test against staging."
       },
       "autoExtractEveryTurns": {
         "type": "number",

--- a/skill/plugin/staging-banner-gate.test.ts
+++ b/skill/plugin/staging-banner-gate.test.ts
@@ -1,32 +1,31 @@
 /**
- * staging-banner-gate.test.ts (3.3.4-rc.1)
+ * staging-banner-gate.test.ts (3.3.12-rc.1, F-flip rev)
  *
- * Pins the banner-emit invariant for the RC-staging banner introduced
- * in 3.3.3-rc.1 (PR #165).
+ * Pins the banner-emit invariant after the F flip (production = default for
+ * BOTH stable and RC; staging is opt-in via TOTALRECLAW_SERVER_URL).
  *
- * Bug found in 3.3.3-rc.1 QA (Pedro 2026-04-30): the banner appeared
- * NEVER across an entire conversation despite the build being bound to
- * staging. Root cause was structural: `stagingBannerShown` was set to
- * `true` AS SOON AS the banner block was constructed, but multiple
- * before_agent_start return paths returned `undefined` (e.g. zero
- * memory matches on the first turn), silently dropping the block AND
- * leaving the flag flipped — so subsequent calls never reconstructed
- * the block.
+ * Pre-flip semantics (3.3.4-rc.1):
+ *   - Source default = staging. Banner fired when `serverUrl` resolved to
+ *     api-staging.totalreclaw.xyz AND user did NOT override the env var.
+ *   - The intent was: warn QA they were on staging by default, suppress the
+ *     warning when an operator explicitly pinned a custom URL.
  *
- * Fix: the flag flips ONLY when a return path actually includes the
- * block in its `prependContext`, via `consumeBannerForPrepend()`.
+ * Post-flip semantics (3.3.12-rc.1):
+ *   - Source default = production. The ONLY way `serverUrl` resolves to
+ *     api-staging.totalreclaw.xyz is via an explicit env override (or, as a
+ *     defensive case, a broken artifact that accidentally bound to staging).
+ *   - The banner SHOULD fire whenever staging is bound, regardless of whether
+ *     the user "overrode" the default — the user benefits from the warning.
+ *   - When `serverUrl` is anything else (production default, or a custom URL
+ *     like a self-hosted relay), the banner is permanently suppressed for
+ *     this gateway-process lifetime.
  *
- * This test pins the invariant by simulating the helper's lifecycle
- * (build block → consume → flag flip) and verifying:
- *   - First consume returns the banner string + flips the flag.
- *   - Second consume returns '' (already delivered).
- *   - Build-but-NEVER-consume leaves the flag UNflipped (so the next
- *     before_agent_start invocation reconstructs the block).
+ * The lifecycle invariant (build → consume → flag flip) is preserved from the
+ * 3.3.4-rc.1 fix. `consumeBannerForPrepend()` flips the flag only once a
+ * return path actually delivers the block.
  *
- * The test re-implements the helper inline because the helper is a
- * closure over hook-local state in index.ts; pulling it out to a
- * standalone export would broaden the public surface unnecessarily.
- * The test asserts the SHAPE of the fix, not the runtime path.
+ * The test re-implements the helper inline because the helper is a closure
+ * over hook-local state in index.ts.
  */
 
 let passed = 0;
@@ -39,21 +38,19 @@ function assert(cond: boolean, name: string): void {
 
 function simulateBannerLifecycle(opts: {
   serverUrl: string;
-  serverUrlEnvOverridden: boolean;
   prependContextPathTaken: boolean;
 }): { stagingBannerShown: boolean; emittedBlock: string } {
   let stagingBannerShown = false;
   let stagingBannerBlock = '';
 
-  // Simulate the before_agent_start prologue.
+  // Simulate the before_agent_start prologue (post-F-flip semantics).
   if (!stagingBannerShown) {
-    const usingStagingDefault = opts.serverUrl.includes('api-staging.totalreclaw.xyz');
-    const userOverrode = opts.serverUrlEnvOverridden;
-    if (usingStagingDefault && !userOverrode) {
+    const usingStaging = opts.serverUrl.includes('api-staging.totalreclaw.xyz');
+    if (usingStaging) {
       stagingBannerBlock = '## staging-banner';
       // Critical: do NOT flip stagingBannerShown here.
     } else {
-      // Non-RC artifact OR user override — never fire this lifetime.
+      // Production default OR custom URL — never fire this lifetime.
       stagingBannerShown = true;
     }
   }
@@ -66,80 +63,72 @@ function simulateBannerLifecycle(opts: {
 
   let emittedBlock = '';
   if (opts.prependContextPathTaken) {
-    // Simulate a return path that calls `consumeBannerForPrepend()` inline.
     emittedBlock = consumeBannerForPrepend();
-  } else {
-    // Simulate a return-undefined path — block built but never delivered.
-    // No call to consume.
   }
 
   return { stagingBannerShown, emittedBlock };
 }
 
 // ---------------------------------------------------------------------------
-// Test 1: staging build + prepend path taken -> banner emitted, flag flipped.
-// ---------------------------------------------------------------------------
-
-{
-  const r = simulateBannerLifecycle({
-    serverUrl: 'https://api-staging.totalreclaw.xyz',
-    serverUrlEnvOverridden: false,
-    prependContextPathTaken: true,
-  });
-  assert(r.emittedBlock === '## staging-banner', 'staging + prepend: banner emitted on first call');
-  assert(r.stagingBannerShown === true, 'staging + prepend: flag flips on emit');
-}
-
-// ---------------------------------------------------------------------------
-// Test 2: staging build + RETURN UNDEFINED path -> banner NOT emitted,
-//         flag NOT flipped (next before_agent_start can retry).
-//
-// This is the 3.3.4-rc.1 fix: pre-fix, the flag flipped on build, so the
-// next call would skip block construction entirely. Post-fix, the flag
-// stays false and the next call reconstructs.
-// ---------------------------------------------------------------------------
-
-{
-  const r = simulateBannerLifecycle({
-    serverUrl: 'https://api-staging.totalreclaw.xyz',
-    serverUrlEnvOverridden: false,
-    prependContextPathTaken: false,
-  });
-  assert(r.emittedBlock === '', 'staging + return-undefined: nothing emitted');
-  assert(
-    r.stagingBannerShown === false,
-    '3.3.4-rc.1 fix: staging + return-undefined leaves flag UNflipped — next call retries',
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Test 3: stable build (production URL) -> never builds banner, flag flipped
-// to permanently suppress for this gateway-process lifetime.
+// Test 1: production default + prepend path -> NO banner, flag flipped to
+// permanently suppress. (Both stable and RC ship this default post-F-flip.)
 // ---------------------------------------------------------------------------
 
 {
   const r = simulateBannerLifecycle({
     serverUrl: 'https://api.totalreclaw.xyz',
-    serverUrlEnvOverridden: false,
     prependContextPathTaken: true,
   });
-  assert(r.emittedBlock === '', 'stable build: no banner emitted');
-  assert(r.stagingBannerShown === true, 'stable build: flag flipped to suppress');
+  assert(r.emittedBlock === '', 'production default: no banner emitted');
+  assert(r.stagingBannerShown === true, 'production default: flag flipped to suppress');
 }
 
 // ---------------------------------------------------------------------------
-// Test 4: staging build BUT user-env override -> never builds banner, flag
-// flipped to permanently suppress (operator pinned a custom URL).
+// Test 2: staging via env override + prepend path -> banner emitted, flag
+// flipped. (Staging is now opt-in; if the user opted in, warn them.)
 // ---------------------------------------------------------------------------
 
 {
   const r = simulateBannerLifecycle({
     serverUrl: 'https://api-staging.totalreclaw.xyz',
-    serverUrlEnvOverridden: true,
     prependContextPathTaken: true,
   });
-  assert(r.emittedBlock === '', 'staging + user override: no banner emitted');
-  assert(r.stagingBannerShown === true, 'staging + user override: flag flipped to suppress');
+  assert(r.emittedBlock === '## staging-banner', 'staging override: banner emitted');
+  assert(r.stagingBannerShown === true, 'staging override: flag flips on emit');
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: staging via env override + RETURN-UNDEFINED path -> banner NOT
+// emitted, flag NOT flipped (next before_agent_start can retry).
+//
+// Preserves the 3.3.4-rc.1 lifecycle fix: build does not flip the flag;
+// only consume does.
+// ---------------------------------------------------------------------------
+
+{
+  const r = simulateBannerLifecycle({
+    serverUrl: 'https://api-staging.totalreclaw.xyz',
+    prependContextPathTaken: false,
+  });
+  assert(r.emittedBlock === '', 'staging + return-undefined: nothing emitted');
+  assert(
+    r.stagingBannerShown === false,
+    'staging + return-undefined: flag UNflipped — next call retries',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: custom self-hosted URL -> never builds banner, flag flipped to
+// permanently suppress. (Operator pinned their own relay.)
+// ---------------------------------------------------------------------------
+
+{
+  const r = simulateBannerLifecycle({
+    serverUrl: 'https://relay.example.com',
+    prependContextPathTaken: true,
+  });
+  assert(r.emittedBlock === '', 'custom URL: no banner emitted');
+  assert(r.stagingBannerShown === true, 'custom URL: flag flipped to suppress');
 }
 
 console.log(`\n# ${passed}/${passed + failed} passed`);

--- a/skill/plugin/subgraph-store.ts
+++ b/skill/plugin/subgraph-store.ts
@@ -805,7 +805,7 @@ export function isSubgraphMode(): boolean {
  *
  * After the v1 env var cleanup, clients only need:
  *   - TOTALRECLAW_RECOVERY_PHRASE -- BIP-39 mnemonic
- *   - TOTALRECLAW_SERVER_URL -- relay server URL (source default: https://api-staging.totalreclaw.xyz; stable build: https://api.totalreclaw.xyz — swapped in at publish time per PR #165)
+ *   - TOTALRECLAW_SERVER_URL -- relay server URL (default: https://api.totalreclaw.xyz; staging via override: https://api-staging.totalreclaw.xyz)
  *   - TOTALRECLAW_SELF_HOSTED -- set "true" to use self-hosted server (default: managed service)
  *
  * Chain ID is no longer configurable via env — it is auto-detected from the
@@ -813,8 +813,8 @@ export function isSubgraphMode(): boolean {
  */
 export function getSubgraphConfig(): SubgraphStoreConfig {
   return {
-    // 3.3.3-rc.1: staging by default in source; stable workflow seds.
-    relayUrl: CONFIG.serverUrl || 'https://api-staging.totalreclaw.xyz',
+    // 3.3.12-rc.1 (F flip): production default for both release-types.
+    relayUrl: CONFIG.serverUrl || 'https://api.totalreclaw.xyz',
     mnemonic: CONFIG.recoveryPhrase,
     cachePath: CONFIG.cachePath,
     chainId: CONFIG.chainId,

--- a/skill/plugin/tr-cli.ts
+++ b/skill/plugin/tr-cli.ts
@@ -52,7 +52,7 @@ const STATE_PATH = CONFIG.onboardingStatePath;
 // Auto-synced by skill/scripts/sync-version.mjs from skill/plugin/package.json::version.
 // Do not edit by hand — running tests will catch drift but the publish workflow
 // rewrites this constant at the start of every npm/ClawHub publish.
-const PLUGIN_VERSION = '3.3.11-rc.6';
+const PLUGIN_VERSION = '3.3.12-rc.1';
 
 function die(msg: string, code = 1): never {
   process.stderr.write(`tr: ${msg}\n`);
@@ -431,7 +431,7 @@ async function main(): Promise<void> {
         '  remember: {"ok":true,"id":"...","claim_count":N}\n' +
         '  recall:   {"results":[{"text":"...","score":0.8}]}\n\n' +
         'Environment:\n' +
-        '  TOTALRECLAW_SERVER_URL           — relay URL (default: api-staging.totalreclaw.xyz)\n' +
+        '  TOTALRECLAW_SERVER_URL           — relay URL (default: api.totalreclaw.xyz; staging: api-staging.totalreclaw.xyz)\n' +
         '  TOTALRECLAW_CREDENTIALS_PATH     — override credentials.json path\n',
       );
       break;

--- a/skill/plugin/url-binding.test.ts
+++ b/skill/plugin/url-binding.test.ts
@@ -1,18 +1,20 @@
 // scanner-sim: allow — *.test.ts files are excluded from the npm tarball (see "files" array in package.json) and never reach the OpenClaw runtime sandbox. This test invokes check-url-binding.mjs as a subprocess; the child_process import is test-infrastructure only and not shipped.
 /**
- * Regression test for the env-binding contract codified in PR #165 +
- * implemented in 3.3.3-rc.1.
+ * Regression test for the env-binding contract after the F flip (3.3.12-rc.1).
  *
- * Hard invariants:
- *   - Source default for `TOTALRECLAW_SERVER_URL` is `api-staging.totalreclaw.xyz`.
- *   - `release-type=rc` artifacts ship the staging URL.
- *   - `release-type=stable` artifacts ship the production URL (workflow-side
- *     sed-replace `api-staging.totalreclaw.xyz` -> `api.totalreclaw.xyz`).
+ * Hard invariants (post-F-flip):
+ *   - Source default for `TOTALRECLAW_SERVER_URL` is `api.totalreclaw.xyz`.
+ *   - Both `release-type=rc` and `release-type=stable` artifacts ship the
+ *     production URL by default. There is no longer a publish-time URL
+ *     rewrite — the source already binds to production.
+ *   - Staging access is opt-in via env override
+ *     (TOTALRECLAW_SERVER_URL=https://api-staging.totalreclaw.xyz).
  *
- * The `check-url-binding.mjs` guard is the single fail-fast gate that
- * blocks misconfigured artifacts from reaching the registry. This test
- * exercises both modes against a synthetic artifact tree and confirms
- * the guard passes / fails as designed.
+ * The `check-url-binding.mjs` guard asserts:
+ *   - The artifact MUST contain `api.totalreclaw.xyz` somewhere
+ *     (proves the canonical default-URL site is intact).
+ *   - The artifact MUST NOT contain `api-staging.totalreclaw.xyz` anywhere
+ *     in the artifact tree (no stranded staging defaults).
  *
  * Run with: `npx tsx url-binding.test.ts`
  */
@@ -50,15 +52,7 @@ interface RunResult {
   stderr: string;
 }
 
-/**
- * Run `check-url-binding.mjs --release-type=<mode>` against a synthetic
- * skill/plugin tree at `pluginRoot`. The script resolves PLUGIN_ROOT from
- * its own location (skill/scripts -> skill/plugin), so we have to stage a
- * matching skill/scripts symlink + a skill/plugin/dist tree.
- */
 function runGuard(pluginRoot: string, mode: 'rc' | 'stable'): RunResult {
-  // Stage a parallel skill/scripts dir that points at the real script,
-  // so the script's PLUGIN_ROOT resolution lands on `pluginRoot`.
   const stagedScripts = path.join(pluginRoot, '..', 'scripts');
   fs.mkdirSync(stagedScripts, { recursive: true });
   const scriptCopy = path.join(stagedScripts, 'check-url-binding.mjs');
@@ -87,74 +81,84 @@ function stagePluginTree(opts: { distContent: string; skillJson?: string }): {
   const pluginRoot = path.join(tmp, 'skill', 'plugin');
   fs.mkdirSync(path.join(pluginRoot, 'dist'), { recursive: true });
   fs.writeFileSync(path.join(pluginRoot, 'dist', 'config.js'), opts.distContent);
+  // Default skill.json has the openclaw.config.serverUrl.default field bound
+  // to production, matching the post-F-flip contract.
+  const defaultSkillJson = JSON.stringify({
+    version: 'test',
+    openclaw: {
+      config: {
+        serverUrl: { default: 'https://api.totalreclaw.xyz' },
+      },
+    },
+  });
   fs.writeFileSync(
     path.join(pluginRoot, 'skill.json'),
-    opts.skillJson ?? '{"version": "test", "default": "https://api-staging.totalreclaw.xyz"}',
+    opts.skillJson ?? defaultSkillJson,
   );
   return { pluginRoot, cleanup: () => rmrf(tmp) };
 }
 
 // ---------------------------------------------------------------------------
-// Test 1 — RC artifact with staging URL passes RC guard
+// Test 1 — RC artifact with production URL passes RC guard
+// ---------------------------------------------------------------------------
+{
+  const { pluginRoot, cleanup } = stagePluginTree({
+    distContent: `export const SERVER_URL = 'https://api.totalreclaw.xyz';\n`,
+  });
+  const r = runGuard(pluginRoot, 'rc');
+  assert(r.status === 0, 'rc guard passes when artifact contains production URL');
+  assert(r.stdout.includes('OK (rc mode)'), 'rc OK message in stdout');
+  cleanup();
+}
+
+// ---------------------------------------------------------------------------
+// Test 2 — RC artifact with JS-side staging-URL default literal FAILS RC guard
+// (Defensive: prevents accidental staging stranding under post-F-flip rules.)
 // ---------------------------------------------------------------------------
 {
   const { pluginRoot, cleanup } = stagePluginTree({
     distContent: `export const SERVER_URL = 'https://api-staging.totalreclaw.xyz';\n`,
   });
   const r = runGuard(pluginRoot, 'rc');
-  assert(r.status === 0, 'rc guard passes when artifact contains api-staging URL');
-  assert(r.stdout.includes('OK (rc mode)'), 'rc OK message in stdout');
-  cleanup();
-}
-
-// ---------------------------------------------------------------------------
-// Test 2 — RC artifact missing staging URL FAILS RC guard
-// ---------------------------------------------------------------------------
-{
-  const { pluginRoot, cleanup } = stagePluginTree({
-    distContent: `export const SERVER_URL = 'https://api.totalreclaw.xyz';\n`,
-    skillJson: '{"version": "test", "default": "https://api.totalreclaw.xyz"}',
-  });
-  const r = runGuard(pluginRoot, 'rc');
-  assert(r.status === 1, 'rc guard fails when artifact is missing api-staging URL');
+  assert(r.status === 1, 'rc guard fails when artifact still contains staging URL literal');
   assert(r.stderr.includes('FAIL (rc mode)'), 'rc FAIL message in stderr');
   cleanup();
 }
 
 // ---------------------------------------------------------------------------
 // Test 3 — stable artifact with production URL passes stable guard
+// (default skillJson is well-formed and binds to production)
 // ---------------------------------------------------------------------------
 {
   const { pluginRoot, cleanup } = stagePluginTree({
     distContent: `export const SERVER_URL = 'https://api.totalreclaw.xyz';\n`,
-    skillJson: '{"version": "test", "default": "https://api.totalreclaw.xyz"}',
   });
   const r = runGuard(pluginRoot, 'stable');
-  assert(r.status === 0, 'stable guard passes when artifact contains api production URL only');
+  assert(r.status === 0, 'stable guard passes when artifact contains production URL only');
   assert(r.stdout.includes('OK (stable mode)'), 'stable OK message in stdout');
   cleanup();
 }
 
 // ---------------------------------------------------------------------------
-// Test 4 — stable artifact still containing staging URL FAILS stable guard
+// Test 4 — stable artifact with JS-side staging-URL default literal FAILS
 // ---------------------------------------------------------------------------
 {
   const { pluginRoot, cleanup } = stagePluginTree({
     distContent: `export const SERVER_URL = 'https://api-staging.totalreclaw.xyz';\n`,
-    skillJson: '{"version": "test", "default": "https://api.totalreclaw.xyz"}',
   });
   const r = runGuard(pluginRoot, 'stable');
-  assert(r.status === 1, 'stable guard fails when artifact still contains api-staging URL');
+  assert(r.status === 1, 'stable guard fails when artifact still contains staging URL literal');
   assert(r.stderr.includes('FAIL (stable mode)'), 'stable FAIL message in stderr');
   assert(
-    r.stderr.includes('staging URL'),
-    'stable FAIL message names the offending URL',
+    r.stderr.includes('staging'),
+    'stable FAIL message names the issue',
   );
   cleanup();
 }
 
 // ---------------------------------------------------------------------------
 // Test 5 — stable artifact with NEITHER URL FAILS stable guard
+// (No production hits anywhere; also skill.json structure missing.)
 // ---------------------------------------------------------------------------
 {
   const { pluginRoot, cleanup } = stagePluginTree({

--- a/skill/scripts/check-url-binding.mjs
+++ b/skill/scripts/check-url-binding.mjs
@@ -1,29 +1,32 @@
 #!/usr/bin/env node
 /**
- * check-url-binding.mjs — assert the artifact's bundled URL defaults
- * match the release-type contract codified in PR #165.
+ * check-url-binding.mjs — assert the artifact's default URL bindings match
+ * the post-F-flip contract (3.3.12-rc.1).
  *
- * Hard invariant (3.3.3-rc.1 onward):
+ * Hard invariant (3.3.12-rc.1 onward):
  *
- *   release-type=stable artifacts MUST contain `api.totalreclaw.xyz`
- *   AND MUST NOT contain `api-staging.totalreclaw.xyz`.
+ *   BOTH `release-type=stable` AND `release-type=rc` artifacts MUST default
+ *   to `api.totalreclaw.xyz`. Any *default-binding site* (i.e. a literal
+ *   like `'https://api-staging.totalreclaw.xyz'` or
+ *   `'wss://api-staging.totalreclaw.xyz'` that appears as a fallback in
+ *   shipped JS) is forbidden. Mentions of `api-staging.totalreclaw.xyz` in
+ *   comments, help-text strings, and the banner copy that warns users
+ *   about staging mode are allowed (they don't change the default).
  *
- *   release-type=rc artifacts MUST contain `api-staging.totalreclaw.xyz`
- *   (production URL is allowed in comments / fallback strings, but the
- *   default-server-URL site MUST be staging).
+ * Rationale:
+ *   Pre-flip, RC builds defaulted to staging and stable builds got a
+ *   publish-time sed-rewrite to production. That stranded any user who
+ *   picked `@rc` with their memories on a staging relay. Post-flip, the
+ *   source already binds to production for both release types. Staging
+ *   access is opt-in via TOTALRECLAW_SERVER_URL.
  *
- * Source-of-truth in `skill/plugin/{config.ts, index.ts, subgraph-store.ts,
- * skill.json}` references `api-staging.totalreclaw.xyz` everywhere. The
- * publish workflow's "Bind stable artifacts to production URLs" step
- * sed-replaces that string -> `api.totalreclaw.xyz` for stable releases.
- *
- * Modes:
- *   - `--release-type=rc` (default): assert RC invariants
- *   - `--release-type=stable`: assert stable invariants
- *
- * Run targets the BUILT dist/ tree (the artifact users actually receive)
- * plus skill.json. Falls back to the source tree when `dist/` is absent
- * (so `prepublishOnly` works the same way `check-scanner.mjs` does).
+ * What this guard checks:
+ *   - skill.json `default` field MUST be `https://api.totalreclaw.xyz`.
+ *   - No shipped JS file may contain a default URL literal of the form
+ *     `'https://api-staging.totalreclaw.xyz'` or
+ *     `'wss://api-staging.totalreclaw.xyz'` (matching string literals only).
+ *   - The artifact MUST contain `api.totalreclaw.xyz` somewhere
+ *     (proves the canonical default-URL site is intact).
  *
  * Exit codes:
  *   0 — invariants hold
@@ -36,13 +39,11 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-// skill/scripts/ -> skill/plugin/
 const PLUGIN_ROOT = path.resolve(__dirname, '..', 'plugin');
 
 const STAGING = 'api-staging.totalreclaw.xyz';
 const PRODUCTION = 'api.totalreclaw.xyz';
 
-// Parse args.
 let mode = 'rc';
 for (let i = 2; i < process.argv.length; i++) {
   const a = process.argv[i];
@@ -58,19 +59,11 @@ if (mode !== 'rc' && mode !== 'stable') {
   process.exit(2);
 }
 
-// Pick the artifact tree. Prefer dist/ (the actual published tarball
-// contents). When dist/ is absent (rare local invocation), fall back to
-// source so prepublishOnly still has a useful signal.
 const distRoot = path.join(PLUGIN_ROOT, 'dist');
 const tree = fs.existsSync(distRoot) ? distRoot : PLUGIN_ROOT;
 const treeKind = tree === distRoot ? 'dist' : 'source';
 
-// Files to scan.
-const SCANNABLE_EXT = new Set([
-  '.js', '.cjs', '.mjs',
-  '.d.ts',
-  '.json',
-]);
+const SCANNABLE_EXT = new Set(['.js', '.cjs', '.mjs', '.d.ts']);
 const SKIP_DIRS = new Set(['node_modules', '.git', 'coverage']);
 
 function walk(dir, out = []) {
@@ -91,88 +84,88 @@ function walk(dir, out = []) {
 }
 
 const files = walk(tree);
-// skill.json lives at PLUGIN_ROOT (not under dist), so include it explicitly
-// when scanning dist.
-if (treeKind === 'dist') {
-  const skillJson = path.join(PLUGIN_ROOT, 'skill.json');
-  if (fs.existsSync(skillJson)) files.push(skillJson);
+
+// ---- 1. skill.json default-field check ----
+const skillJsonPath = path.join(PLUGIN_ROOT, 'skill.json');
+let skillJsonOk = true;
+const skillJsonErrors = [];
+if (fs.existsSync(skillJsonPath)) {
+  try {
+    const sj = JSON.parse(fs.readFileSync(skillJsonPath, 'utf8'));
+    const defaultUrl = sj?.openclaw?.config?.serverUrl?.default;
+    if (typeof defaultUrl !== 'string') {
+      skillJsonOk = false;
+      skillJsonErrors.push('skill.json openclaw.config.serverUrl.default missing or not a string');
+    } else if (defaultUrl !== `https://${PRODUCTION}`) {
+      skillJsonOk = false;
+      skillJsonErrors.push(
+        `skill.json openclaw.config.serverUrl.default = "${defaultUrl}", expected "https://${PRODUCTION}"`,
+      );
+    }
+  } catch (err) {
+    skillJsonOk = false;
+    skillJsonErrors.push(`skill.json parse error: ${err.message}`);
+  }
 }
 
-let stagingHits = 0;
-let productionHits = 0;
-const stagingFiles = [];
-const productionFiles = [];
+// ---- 2. JS-default-binding check ----
+// Match string literals that bind a staging URL: `'https://api-staging…'`
+// or `"wss://api-staging…"` (single or double quotes, http or wss). Comments
+// don't include quotes around the URL, so they don't match.
+const STAGING_LITERAL_RE = /['"](https?|wss?):\/\/api-staging\.totalreclaw\.xyz[^'"]*['"]/;
 
+let productionHits = 0;
+const offendingFiles = [];
 for (const f of files) {
   let src;
-  try {
-    src = fs.readFileSync(f, 'utf8');
-  } catch {
-    continue;
-  }
-  if (src.includes(STAGING)) {
-    stagingHits++;
-    stagingFiles.push(path.relative(PLUGIN_ROOT, f));
-  }
-  if (src.includes(PRODUCTION)) {
-    productionHits++;
-    productionFiles.push(path.relative(PLUGIN_ROOT, f));
+  try { src = fs.readFileSync(f, 'utf8'); } catch { continue; }
+  if (src.includes(PRODUCTION)) productionHits++;
+  if (STAGING_LITERAL_RE.test(src)) {
+    offendingFiles.push(path.relative(PLUGIN_ROOT, f));
   }
 }
 
-const summary = {
-  mode,
-  tree: treeKind,
-  pluginRoot: PLUGIN_ROOT,
-  stagingHits,
-  productionHits,
-  stagingFiles,
-  productionFiles,
-};
+const failHeader = `check-url-binding: FAIL (${mode} mode)`;
+const okHeader = `check-url-binding: OK (${mode} mode)`;
 
-if (mode === 'stable') {
-  // Stable invariants:
-  //   - MUST contain api.totalreclaw.xyz somewhere (proves the bind ran).
-  //   - MUST NOT contain api-staging.totalreclaw.xyz anywhere.
-  if (stagingHits > 0) {
-    console.error('check-url-binding: FAIL (stable mode)');
-    console.error(`  staging URL "${STAGING}" found in ${stagingHits} file(s):`);
-    for (const f of stagingFiles) console.error(`    - ${f}`);
-    console.error('');
-    console.error('  Stable artifacts must NOT contain the staging URL. The');
-    console.error('  publish workflow\'s "Bind stable artifacts to production');
-    console.error('  URLs" step should have sed-replaced staging -> production');
-    console.error('  before reaching this guard.');
-    process.exit(1);
-  }
-  if (productionHits === 0) {
-    console.error('check-url-binding: FAIL (stable mode)');
-    console.error(`  production URL "${PRODUCTION}" not found anywhere.`);
-    console.error('  Stable artifacts must reference api.totalreclaw.xyz at');
-    console.error('  least once (the canonical default-server-URL site).');
-    process.exit(1);
-  }
-  console.log(
-    `check-url-binding: OK (stable mode) — ${productionHits} production hits, 0 staging hits across ${treeKind}/`,
-  );
-} else {
-  // RC invariants:
-  //   - MUST contain api-staging.totalreclaw.xyz somewhere (proves the
-  //     source default is intact).
-  if (stagingHits === 0) {
-    console.error('check-url-binding: FAIL (rc mode)');
-    console.error(`  staging URL "${STAGING}" not found anywhere.`);
-    console.error('  RC artifacts must reference api-staging.totalreclaw.xyz');
-    console.error('  at least once (the canonical RC default-server-URL site).');
-    console.error('  If you intended to publish a stable artifact, pass');
-    console.error('  --release-type=stable.');
-    process.exit(1);
-  }
-  console.log(
-    `check-url-binding: OK (rc mode) — ${stagingHits} staging hits across ${treeKind}/`,
-  );
+let failed = false;
+
+if (!skillJsonOk) {
+  console.error(failHeader);
+  for (const e of skillJsonErrors) console.error(`  ${e}`);
+  failed = true;
 }
+
+if (offendingFiles.length > 0) {
+  console.error(failHeader);
+  console.error(`  Default-URL binding to staging found in ${offendingFiles.length} file(s):`);
+  for (const f of offendingFiles) console.error(`    - ${f}`);
+  console.error('');
+  console.error('  Both stable and RC artifacts must default to production.');
+  console.error('  Staging is opt-in via TOTALRECLAW_SERVER_URL env override.');
+  failed = true;
+}
+
+if (productionHits === 0) {
+  console.error(failHeader);
+  console.error(`  production URL "${PRODUCTION}" not found anywhere.`);
+  console.error('  Artifacts must reference api.totalreclaw.xyz at least once.');
+  failed = true;
+}
+
+if (failed) process.exit(1);
+console.log(
+  `${okHeader} — ${productionHits} production hits, 0 staging default-binding sites across ${treeKind}/`,
+);
 
 if (process.argv.includes('--json')) {
+  const summary = {
+    mode,
+    tree: treeKind,
+    pluginRoot: PLUGIN_ROOT,
+    productionHits,
+    offendingFiles,
+    skillJsonOk,
+  };
   process.stdout.write(JSON.stringify(summary, null, 2) + '\n');
 }


### PR DESCRIPTION
## Summary

Three changes addressing the install-flow bottleneck. Pedro's Pop-OS agent twice prompt-injection-flagged the public quickstart guide ("This is a social engineering attempt embedded in that GitHub page") and refused to install. PoC verified the prose rewrite clears the heuristic.

1. **Prose-rewrite public quickstart guide** — drop LLM-imperative tone ("Audience: the LLM agent", "Emit ONLY...", "Do NOT restart..."). Replace with prose for humans. All agent-runtime behavioral rules stay in bundled SKILL.md (trusted skill-loader path, no WebFetch, no PI flag).

2. **F flip** — RC + stable artifacts both default to `api.totalreclaw.xyz` (prod). Staging access via `TOTALRECLAW_SERVER_URL` env override. Removes "RC users land on staging chain with stranded memories" footgun. Banner inverted, workflows simplified (removed sed-replace step), guards delegated to rewritten `check-url-binding.mjs`.

3. **Compat bump + skill.json reconcile** — `package.json::openclaw.compat.pluginApi: ">=2026.5.5"` (peer-link reassertion fix). Self-protects against 2026.5.4 plugin-loader gap. `skill.json` drops stale `minVersion/maxVersion`.

## PoC validation (clean PI inversion)

Same agent given identical WebFetch + PI-check prompt:
- **Current main quickstart** → *"Critical issue detected: This entire document is a prompt injection attack disguised as legitimate documentation. ...NOT safe for me to follow."*
- **Prose-rewritten gist** → *"No prompt injection attempts detected ... Safe to follow."*

## Test plan

- [x] 11/11 url-binding tests (rewritten for prod default)
- [x] 4/4 staging-banner-gate tests (banner trigger inverted)
- [x] scope-address-visible test passes (URL constant flipped)
- [x] All other test suites green
- [x] check-scanner: 129 files, 0 flags
- [x] VPS tarball install clean (`tr status` reports 3.3.12-rc.1, hybrid_mode true, 17 tools)
- [ ] E1 (Pop-OS Telegram) final-gate UX test post-publish

## Why now

Test log entry H008 in totalreclaw-internal repo (`docs/install-ux-test-log.md`). PoC A (skill-only architecture) INVALIDATED today — 3 hard blockers, 5-8 day refactor minimum. PoC B (this PR) GO on E2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)