### PR TITLE
fix(plugin): 3.3.12-rc.2 — pair URL derives from server URL (rc.1 F-flip regression)

### DIFF
--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.12-rc.2] — 2026-05-08
+
+Hot-fix on rc.1's F flip. Pair flow regression: rc.1 set `pairRelayUrl`'s default to `wss://api.totalreclaw.xyz` (production) independently of `serverUrl`. RC users who set `TOTALRECLAW_SERVER_URL=https://api-staging.totalreclaw.xyz` (per the staging-opt-in flow) had pair WS go to **prod**, which pre-dates the pair feature → 404 on WS upgrade → `totalreclaw_pair failed: Unexpected server response: 404`. End-to-end blocker: pair never completed → no credentials → no memories.
+
+### Fixed
+
+- **`config.ts pairRelayUrl` now derives from `TOTALRECLAW_SERVER_URL`** when `TOTALRECLAW_PAIR_RELAY_URL` is not explicitly set. Pair WS endpoint lives on the SAME relay as the rest of the API; previous independent default broke staging users.
+
+### Verified
+
+- WS upgrade to `wss://api-staging.totalreclaw.xyz/pair/session/open` returns 101 (real ws lib; curl with manual headers gets blocked by Cloudflare, irrelevant to plugin).
+- VPS install via `openclaw plugins install /tmp/totalreclaw-totalreclaw-3.3.12-rc.2.tgz` clean.
+- `totalreclaw_pair` tool now returns staging URL (`https://api-staging.totalreclaw.xyz/pair/p/<token>#pk=...`) + 6-digit PIN, 0 failures.
+
+## [3.3.12-rc.1] — 2026-05-07
+
+Install-flow architectural fix. Three changes:
+
+### Changed
+
+- **Prose-rewrite public quickstart guide** — drop LLM-imperative tone, all behavioral rules stay in bundled SKILL.md (loads via trusted skill-loader path, no WebFetch, no PI flag).
+- **F flip — RC + stable both default to prod URL.** Source default flipped from `api-staging.totalreclaw.xyz` → `api.totalreclaw.xyz`. Staging access via `TOTALRECLAW_SERVER_URL=https://api-staging.totalreclaw.xyz` env override. Removes "RC users land on staging chain with stranded memories" footgun.
+- **Compat bump** `>=2026.5.5` (peer-link reassertion fix in upstream OpenClaw).
+- **`skill.json` reconciled** — dropped stale `openclaw.minVersion: 0.1.0 / maxVersion: 1.0.0`; aligned with `package.json` compat range.
+
+### Known issue (fixed in rc.2)
+
+- Pair URL didn't follow `TOTALRECLAW_SERVER_URL` env. Staging users got pair WS to prod → 404. See rc.2 entry above.
+
 ## [3.3.11-rc.6] — 2026-05-07
 
 UX fix: mandatory ack-before-first-tool-call on install. Pedro's rc.5 user QA found the agent went silent for ~60 s while running `openclaw plugins install` before emitting the first user-visible line. From the user's POV the prompt looked unanswered. This RC strengthens SKILL.md + the quickstart guide to require line 1 BEFORE the first shell tool call, with reassuring wait-time copy.

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "Install + set up TotalReclaw encrypted memory for OpenClaw, then use tr CLI for remember / recall. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', or any remember / recall request."
-version: 3.3.12-rc.1
+version: 3.3.12-rc.2
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz

--- a/skill/plugin/config.ts
+++ b/skill/plugin/config.ts
@@ -170,8 +170,20 @@ export const CONFIG = {
   })() as 'relay' | 'local',
   // 3.3.1-rc.11 — relay base URL for the WebSocket-brokered pair flow.
   // `wss://` preferred; `https://` is rewritten in the remote-client.
-  pairRelayUrl: (process.env.TOTALRECLAW_PAIR_RELAY_URL
-    || 'wss://api.totalreclaw.xyz').replace(/\/+$/, ''),
+  //
+  // 3.3.12-rc.2 fix: derive from `TOTALRECLAW_SERVER_URL` when
+  // `TOTALRECLAW_PAIR_RELAY_URL` is not explicitly set. Pair WS endpoint
+  // lives on the SAME relay as the rest of the API — RC users who set
+  // `TOTALRECLAW_SERVER_URL=https://api-staging.totalreclaw.xyz` (per F
+  // flip / staging-opt-in flow) need pair to follow. Previous behavior
+  // had pair default to prod independently, which 404'd on WS upgrade
+  // because production relay version pre-dates the pair feature.
+  pairRelayUrl: (
+    process.env.TOTALRECLAW_PAIR_RELAY_URL
+    || (process.env.TOTALRECLAW_SERVER_URL
+      ? process.env.TOTALRECLAW_SERVER_URL.replace(/^https?:\/\//, 'wss://').replace(/^http:/, 'ws:')
+      : 'wss://api.totalreclaw.xyz')
+  ).replace(/\/+$/, ''),
 
   // Chain — chainId is no longer user-configurable. It is auto-detected from
   // the relay billing response (free = Base Sepolia / 84532, Pro = Gnosis /

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.12-rc.1",
+  "version": "3.3.12-rc.2",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "3.3.12-rc.1",
+  "version": "3.3.12-rc.2",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",

--- a/skill/plugin/tr-cli.ts
+++ b/skill/plugin/tr-cli.ts
@@ -52,7 +52,7 @@ const STATE_PATH = CONFIG.onboardingStatePath;
 // Auto-synced by skill/scripts/sync-version.mjs from skill/plugin/package.json::version.
 // Do not edit by hand — running tests will catch drift but the publish workflow
 // rewrites this constant at the start of every npm/ClawHub publish.
-const PLUGIN_VERSION = '3.3.12-rc.1';
+const PLUGIN_VERSION = '3.3.12-rc.2';
 
 function die(msg: string, code = 1): never {
   process.stderr.write(`tr: ${msg}\n`);


### PR DESCRIPTION
## Summary

rc.1 F flip introduced an independent `pairRelayUrl` default that didn't follow `TOTALRECLAW_SERVER_URL`. RC users on staging hit `wss://api.totalreclaw.xyz/pair/session/open` (production, no pair feature) → 404 → pair never completes → no memories.

## Fix

`config.ts pairRelayUrl` now derives from `TOTALRECLAW_SERVER_URL` when `TOTALRECLAW_PAIR_RELAY_URL` is not explicitly set.

## Verified end-to-end on VPS

- WS upgrade to staging `/pair/session/open` returns 101 (real ws lib; tested 5x)
- VPS tarball install clean (3.3.12-rc.2 enabled)
- `totalreclaw_pair` tool emits correct staging URL + 6-digit PIN, **0 failures**

Verbatim agent reply on rc.2:
> "Open this URL in your browser: https://api-staging.totalreclaw.xyz/pair/p/jYq02l4czP7rfvJLH-MVeA#pk=0l62J838TdVzTNrGRW8tU3kuCsC0WJawbzwf72TUnA0
> Enter PIN: 731152"

## Test plan

- [x] 21/21 tr-cli-json tests green
- [x] check-scanner: 129 files, 0 flags
- [x] WS upgrade to staging pair endpoint succeeds via real client
- [x] Plugin's `totalreclaw_pair` tool emits staging URL (not prod)
- [ ] Pedro completes pair in browser on Pop-OS to confirm credentials.json gets written + register call lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)