### PR TITLE
feat(mcp): 3.3.0-rc.1 — totalreclaw_pair tool for MCP-only install

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/mcp-server",
-  "version": "3.2.1",
+  "version": "3.3.0-rc.1",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. MCP server with XChaCha20-Poly1305 E2EE, semantic search, import/export, and on-chain storage",
   "homepage": "https://totalreclaw.xyz",
   "main": "dist/index.js",
@@ -43,7 +43,8 @@
     "permissionless": "^0.3.4",
     "porter-stemmer": "^0.9.1",
     "tslib": "^2.8.1",
-    "viem": "^2.47.0"
+    "viem": "^2.47.0",
+    "ws": "^8.18.3"
   },
   "overrides": {
     "permissionless": {
@@ -53,6 +54,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.0",
     "@types/node": "^20.11.0",
+    "@types/ws": "^8.5.12",
     "@typescript-eslint/eslint-plugin": "^6.19.0",
     "@typescript-eslint/parser": "^6.19.0",
     "eslint": "^8.56.0",

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -46,6 +46,8 @@ import {
   handleSupport,
   accountToolDefinition,
   handleAccount,
+  pairToolDefinition,
+  handlePair,
 } from './tools/index.js';
 import { getLastBillingResponse } from './tools/status.js';
 import { setOnRememberCallback } from './tools/remember.js';
@@ -1885,6 +1887,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     unpinToolDefinition,
     retypeToolDefinition,
     setScopeToolDefinition,
+    pairToolDefinition,
   ],
 }));
 
@@ -1919,6 +1922,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   if (name === 'totalreclaw_support') {
     const walletAddress = subgraphState?.smartAccountAddress ?? null;
     return handleSupport(walletAddress);
+  }
+
+  // Handle pair tool (available in all modes — primary unconfigured-mode entry
+  // point so a user with no credentials can run an MCP-only install end-to-end:
+  // host adds MCP server → agent calls totalreclaw_pair → tool returns URL+PIN
+  // → user pairs in browser → server writes ~/.totalreclaw/credentials.json
+  // → user restarts host → server boots in subgraph mode).
+  if (name === 'totalreclaw_pair') {
+    return await handlePair(args as Record<string, unknown> | undefined);
   }
 
   // In unconfigured mode, all other tools return setup guidance pointing at

--- a/mcp/src/pair-crypto.ts
+++ b/mcp/src/pair-crypto.ts
@@ -1,0 +1,302 @@
+/**
+ * pair-crypto — gateway-side cryptographic primitives for the relay-brokered
+ * pair flow.
+ *
+ * NOTE — this is a port of the plugin's `skill/plugin/pair-crypto.ts`
+ * (TotalReclaw plugin v3.3.1-rc.12+). Wire formats (base64url + AES-256-GCM
+ * + HKDF-SHA256 + x25519 ECDH) are byte-for-byte compatible with the plugin
+ * and the Hermes Python implementation, so all three gateway flavors talk to
+ * the same browser pair-page and the same `totalreclaw-relay` endpoints.
+ *
+ * Ported into mcp-server 3.3.0-rc.1 to enable the MCP-only install path:
+ * users add the MCP server, agent calls `totalreclaw_pair` tool, browser
+ * generates phrase, encrypted phrase flows back to the MCP process which
+ * decrypts and writes credentials.json — phrase NEVER crosses LLM context.
+ *
+ * Cipher suite (matches plugin / Hermes):
+ *   - x25519 ECDH for key agreement
+ *   - HKDF-SHA256 (info = "totalreclaw-pair-v2") for symmetric-key derivation
+ *   - AES-256-GCM AEAD with 12-byte nonce, 16-byte tag, sid as AD
+ *
+ * Phrase-safety invariants:
+ *   - This module ONLY runs on the gateway (MCP server) host.
+ *   - No `fs.*` calls, no env-var reads, no network primitives.
+ *   - Public surface emits only base64url-encoded raw 32-byte public keys.
+ *
+ * Future cleanup: pull `pair-crypto.ts` + `pair-remote-client.ts` into a
+ * shared `@totalreclaw/pair-client` package so plugin + mcp-server can share
+ * one source of truth. For now this is a verbatim copy — keep in sync with
+ * the plugin manually until the shared-package work lands.
+ */
+
+import {
+  createPrivateKey,
+  createPublicKey,
+  diffieHellman,
+  generateKeyPairSync,
+  hkdfSync,
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+  timingSafeEqual,
+} from 'node:crypto';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const HKDF_INFO = 'totalreclaw-pair-v2';
+export const AEAD_KEY_BYTES = 32;
+export const AEAD_NONCE_BYTES = 12;
+export const AEAD_TAG_BYTES = 16;
+export const X25519_KEY_BYTES = 32;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type PublicKeyB64 = string;
+export type PrivateKeyB64 = string;
+export type NonceB64 = string;
+export type CiphertextB64 = string;
+
+export interface GatewayKeypair {
+  skB64: PrivateKeyB64;
+  pkB64: PublicKeyB64;
+}
+
+export interface SessionKeys {
+  kEnc: Buffer;
+}
+
+export interface DecryptInputs {
+  skGatewayB64: PrivateKeyB64;
+  pkDeviceB64: PublicKeyB64;
+  sid: string;
+  nonceB64: NonceB64;
+  ciphertextB64: CiphertextB64;
+}
+
+export interface EncryptInputs {
+  skLocalB64: PrivateKeyB64;
+  pkRemoteB64: PublicKeyB64;
+  sid: string;
+  plaintext: Buffer | Uint8Array;
+  nonceB64?: NonceB64;
+}
+
+export interface EncryptOutput {
+  nonceB64: NonceB64;
+  ciphertextB64: CiphertextB64;
+}
+
+// ---------------------------------------------------------------------------
+// Key generation / conversion
+// ---------------------------------------------------------------------------
+
+export function generateGatewayKeypair(): GatewayKeypair {
+  const { publicKey, privateKey } = generateKeyPairSync('x25519');
+  return {
+    skB64: extractRawPrivate(privateKey),
+    pkB64: extractRawPublic(publicKey),
+  };
+}
+
+function publicKeyFromB64(pkB64: PublicKeyB64): ReturnType<typeof createPublicKey> {
+  const raw = Buffer.from(pkB64, 'base64url');
+  if (raw.length !== X25519_KEY_BYTES) {
+    throw new Error(`pair-crypto: public key must be ${X25519_KEY_BYTES} bytes (got ${raw.length})`);
+  }
+  return createPublicKey({
+    key: { kty: 'OKP', crv: 'X25519', x: raw.toString('base64url') },
+    format: 'jwk',
+  });
+}
+
+function privateKeyFromB64(skB64: PrivateKeyB64): ReturnType<typeof createPrivateKey> {
+  const raw = Buffer.from(skB64, 'base64url');
+  if (raw.length !== X25519_KEY_BYTES) {
+    throw new Error(`pair-crypto: private key must be ${X25519_KEY_BYTES} bytes (got ${raw.length})`);
+  }
+  const tempPriv = createPrivateKey({
+    key: { kty: 'OKP', crv: 'X25519', d: raw.toString('base64url'), x: '' },
+    format: 'jwk',
+  });
+  const pubObj = createPublicKey(tempPriv);
+  const pubJwk = pubObj.export({ format: 'jwk' }) as { x: string };
+  return createPrivateKey({
+    key: { kty: 'OKP', crv: 'X25519', d: raw.toString('base64url'), x: pubJwk.x },
+    format: 'jwk',
+  });
+}
+
+function extractRawPublic(pk: ReturnType<typeof createPublicKey>): PublicKeyB64 {
+  const jwk = pk.export({ format: 'jwk' }) as { x?: string };
+  if (!jwk.x) throw new Error('pair-crypto: public key JWK is missing the x field');
+  return jwk.x;
+}
+
+function extractRawPrivate(sk: ReturnType<typeof createPrivateKey>): PrivateKeyB64 {
+  const jwk = sk.export({ format: 'jwk' }) as { d?: string };
+  if (!jwk.d) throw new Error('pair-crypto: private key JWK is missing the d field');
+  return jwk.d;
+}
+
+export function derivePublicFromPrivate(skB64: PrivateKeyB64): PublicKeyB64 {
+  const sk = privateKeyFromB64(skB64);
+  const pk = createPublicKey(sk);
+  return extractRawPublic(pk);
+}
+
+// ---------------------------------------------------------------------------
+// ECDH + HKDF
+// ---------------------------------------------------------------------------
+
+export function computeSharedSecret(opts: {
+  skLocalB64: PrivateKeyB64;
+  pkRemoteB64: PublicKeyB64;
+}): Buffer {
+  const sk = privateKeyFromB64(opts.skLocalB64);
+  const pk = publicKeyFromB64(opts.pkRemoteB64);
+  const shared = diffieHellman({ privateKey: sk, publicKey: pk });
+  if (shared.length !== X25519_KEY_BYTES) {
+    throw new Error(
+      `pair-crypto: ECDH output wrong length (got ${shared.length}, expected ${X25519_KEY_BYTES})`,
+    );
+  }
+  return shared;
+}
+
+export function deriveSessionKeys(opts: {
+  sharedSecret: Buffer;
+  sid: string;
+}): SessionKeys {
+  if (opts.sharedSecret.length !== X25519_KEY_BYTES) {
+    throw new Error('pair-crypto: shared secret must be 32 bytes');
+  }
+  if (typeof opts.sid !== 'string' || opts.sid.length === 0) {
+    throw new Error('pair-crypto: sid is required for HKDF salt binding');
+  }
+  const salt = Buffer.from(opts.sid, 'utf-8');
+  const info = Buffer.from(HKDF_INFO, 'utf-8');
+  const okm = hkdfSync('sha256', opts.sharedSecret, salt, info, AEAD_KEY_BYTES);
+  return { kEnc: Buffer.from(okm) };
+}
+
+export function deriveAeadKeyFromEcdh(opts: {
+  skLocalB64: PrivateKeyB64;
+  pkRemoteB64: PublicKeyB64;
+  sid: string;
+}): SessionKeys {
+  const shared = computeSharedSecret({
+    skLocalB64: opts.skLocalB64,
+    pkRemoteB64: opts.pkRemoteB64,
+  });
+  return deriveSessionKeys({ sharedSecret: shared, sid: opts.sid });
+}
+
+// ---------------------------------------------------------------------------
+// AEAD
+// ---------------------------------------------------------------------------
+
+export function aeadDecrypt(opts: {
+  kEnc: Buffer;
+  nonceB64: NonceB64;
+  sid: string;
+  ciphertextB64: CiphertextB64;
+}): Buffer {
+  const nonce = Buffer.from(opts.nonceB64, 'base64url');
+  if (nonce.length !== AEAD_NONCE_BYTES) {
+    throw new Error(`pair-crypto: nonce must be ${AEAD_NONCE_BYTES} bytes (got ${nonce.length})`);
+  }
+  if (opts.kEnc.length !== AEAD_KEY_BYTES) {
+    throw new Error(`pair-crypto: AEAD key must be ${AEAD_KEY_BYTES} bytes`);
+  }
+  const combined = Buffer.from(opts.ciphertextB64, 'base64url');
+  if (combined.length < AEAD_TAG_BYTES) {
+    throw new Error('pair-crypto: ciphertext too short to contain tag');
+  }
+  const ct = combined.subarray(0, combined.length - AEAD_TAG_BYTES);
+  const tag = combined.subarray(combined.length - AEAD_TAG_BYTES);
+
+  const decipher = createDecipheriv('aes-256-gcm', opts.kEnc, nonce, {
+    authTagLength: AEAD_TAG_BYTES,
+  });
+  decipher.setAAD(Buffer.from(opts.sid, 'utf-8'), { plaintextLength: ct.length });
+  decipher.setAuthTag(tag);
+
+  const pt1 = decipher.update(ct);
+  const pt2 = decipher.final();
+  return Buffer.concat([pt1, pt2]);
+}
+
+export function decryptPairingPayload(inputs: DecryptInputs): Buffer {
+  const { kEnc } = deriveAeadKeyFromEcdh({
+    skLocalB64: inputs.skGatewayB64,
+    pkRemoteB64: inputs.pkDeviceB64,
+    sid: inputs.sid,
+  });
+  return aeadDecrypt({
+    kEnc,
+    nonceB64: inputs.nonceB64,
+    sid: inputs.sid,
+    ciphertextB64: inputs.ciphertextB64,
+  });
+}
+
+export function aeadEncryptWithSessionKey(opts: {
+  kEnc: Buffer;
+  sid: string;
+  plaintext: Buffer | Uint8Array;
+  nonceB64?: NonceB64;
+}): EncryptOutput {
+  if (opts.kEnc.length !== AEAD_KEY_BYTES) {
+    throw new Error(`pair-crypto: AEAD key must be ${AEAD_KEY_BYTES} bytes`);
+  }
+  const nonceBuf =
+    opts.nonceB64 !== undefined
+      ? Buffer.from(opts.nonceB64, 'base64url')
+      : randomBytes(AEAD_NONCE_BYTES);
+  if (nonceBuf.length !== AEAD_NONCE_BYTES) {
+    throw new Error(`pair-crypto: nonce must be ${AEAD_NONCE_BYTES} bytes`);
+  }
+
+  const pt = Buffer.isBuffer(opts.plaintext) ? opts.plaintext : Buffer.from(opts.plaintext);
+  const cipher = createCipheriv('aes-256-gcm', opts.kEnc, nonceBuf, {
+    authTagLength: AEAD_TAG_BYTES,
+  });
+  cipher.setAAD(Buffer.from(opts.sid, 'utf-8'), { plaintextLength: pt.length });
+  const ct = Buffer.concat([cipher.update(pt), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return {
+    nonceB64: nonceBuf.toString('base64url'),
+    ciphertextB64: Buffer.concat([ct, tag]).toString('base64url'),
+  };
+}
+
+export function encryptPairingPayload(inputs: EncryptInputs): EncryptOutput {
+  const { kEnc } = deriveAeadKeyFromEcdh({
+    skLocalB64: inputs.skLocalB64,
+    pkRemoteB64: inputs.pkRemoteB64,
+    sid: inputs.sid,
+  });
+  return aeadEncryptWithSessionKey({
+    kEnc,
+    sid: inputs.sid,
+    plaintext: inputs.plaintext,
+    nonceB64: inputs.nonceB64,
+  });
+}
+
+export function compareSecondaryCodesCT(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, 'utf-8');
+  const bBuf = Buffer.from(b, 'utf-8');
+  const lenMatch = aBuf.length === bBuf.length;
+  const max = Math.max(aBuf.length, bBuf.length, 6);
+  const aPad = Buffer.alloc(max);
+  const bPad = Buffer.alloc(max);
+  aBuf.copy(aPad);
+  bBuf.copy(bPad);
+  const byteMatch = timingSafeEqual(aPad, bPad);
+  return lenMatch && byteMatch;
+}

--- a/mcp/src/pair-remote-client.ts
+++ b/mcp/src/pair-remote-client.ts
@@ -1,0 +1,443 @@
+/**
+ * pair-remote-client — gateway-side WebSocket client for the relay-brokered
+ * pair flow.
+ *
+ * Ported from the plugin's `skill/plugin/pair-remote-client.ts` (TotalReclaw
+ * plugin v3.3.1-rc.11+) so the MCP server's `totalreclaw_pair` tool emits the
+ * same URL/PIN format the browser pair-page already understands.
+ *
+ * Flow (gateway side):
+ *   1. Generate ephemeral x25519 keypair.
+ *   2. Open WS to `wss://<relay>/pair/session/open`.
+ *   3. Send `{type:"open", gateway_pubkey, pin, client_id, mode}`.
+ *   4. Receive `{type:"opened", token, expires_at}` — build the user URL.
+ *   5. Block on the WS until the relay pushes `{type:"forward", client_pubkey, nonce, ciphertext}`.
+ *   6. Decrypt locally via x25519 ECDH + AES-256-GCM.
+ *   7. Hand the decrypted phrase to the caller's completePairing handler
+ *      (writes credentials.json) and ack/nack the relay.
+ *
+ * Phrase-safety:
+ *   - Relay sees only ciphertext.
+ *   - Phrase NEVER touches logs / stdout / agent context.
+ *   - PIN is on the tool return payload (required for the user to type into
+ *     the browser) but is never logged.
+ *
+ * Scope:
+ *   - No `fs.*` calls — caller passes a completePairing handler.
+ *   - No env-var reads — caller passes the relay base URL.
+ *
+ * See pair-crypto.ts for the cipher-suite header comment.
+ */
+
+import { randomBytes, randomInt } from 'node:crypto';
+
+import WebSocket from 'ws';
+
+import {
+  decryptPairingPayload,
+  generateGatewayKeypair,
+  type GatewayKeypair,
+} from './pair-crypto.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_RELAY_URL = 'wss://api.totalreclaw.xyz';
+
+const OPEN_TIMEOUT_MS = 10_000;
+
+const DEFAULT_AWAIT_TIMEOUT_MS = 5 * 60_000;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type PairRelayMode = 'generate' | 'import' | 'either';
+
+export interface RemotePairSession {
+  url: string;
+  pin: string;
+  token: string;
+  expiresAt: string;
+  keypair: GatewayKeypair;
+  mode: PairRelayMode;
+  _ws: WebSocket;
+}
+
+export interface RelayCompletionResult {
+  state: 'active' | 'error';
+  accountId?: string;
+  error?: string;
+}
+
+export type RelayCompletePairingHandler = (inputs: {
+  mnemonic: string;
+  session: RemotePairSession;
+}) => Promise<RelayCompletionResult>;
+
+export type PhraseValidator = (phrase: string) => boolean;
+
+function defaultBip39CountValidator(phrase: string): boolean {
+  const words = phrase.split(' ');
+  if (words.length !== 12 && words.length !== 24) return false;
+  return words.every((w) => /^[a-z]+$/.test(w));
+}
+
+function defaultPin(): string {
+  const n = randomInt(0, 1_000_000);
+  return n.toString(10).padStart(6, '0');
+}
+
+function defaultClientId(): string {
+  return 'mcp-' + randomBytes(8).toString('hex');
+}
+
+function buildUserUrl(relayBase: string, token: string, pkB64: string): string {
+  let httpBase = relayBase;
+  if (httpBase.startsWith('wss://')) {
+    httpBase = 'https://' + httpBase.slice('wss://'.length);
+  } else if (httpBase.startsWith('ws://')) {
+    httpBase = 'http://' + httpBase.slice('ws://'.length);
+  }
+  return `${httpBase}/pair/p/${token}#pk=${pkB64}`;
+}
+
+function wsConnectBase(relayBase: string): string {
+  let base = relayBase.replace(/\/+$/, '');
+  if (base.startsWith('https://')) {
+    base = 'wss://' + base.slice('https://'.length);
+  } else if (base.startsWith('http://')) {
+    base = 'ws://' + base.slice('http://'.length);
+  }
+  return base;
+}
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface OpenRemotePairOptions {
+  relayBaseUrl?: string;
+  pin?: string;
+  clientId?: string;
+  mode?: PairRelayMode;
+  keypair?: GatewayKeypair;
+  webSocketImpl?: typeof WebSocket;
+  now?: () => number;
+}
+
+export interface AwaitPhraseUploadOptions {
+  completePairing: RelayCompletePairingHandler;
+  phraseValidator?: PhraseValidator;
+  timeoutMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Open
+// ---------------------------------------------------------------------------
+
+export async function openRemotePairSession(
+  opts: OpenRemotePairOptions = {},
+): Promise<RemotePairSession> {
+  const relayBase = (opts.relayBaseUrl ?? DEFAULT_RELAY_URL).replace(/\/+$/, '');
+  const wsBase = wsConnectBase(relayBase);
+  const wsUrl = `${wsBase}/pair/session/open`;
+  const WebSocketImpl = opts.webSocketImpl ?? WebSocket;
+  const keypair = opts.keypair ?? generateGatewayKeypair();
+  const pin = opts.pin ?? defaultPin();
+  const clientId = opts.clientId ?? defaultClientId();
+  const mode: PairRelayMode = opts.mode ?? 'either';
+
+  const ws: WebSocket = new WebSocketImpl(wsUrl, {
+    handshakeTimeout: OPEN_TIMEOUT_MS,
+  });
+
+  try {
+    await waitOpen(ws, OPEN_TIMEOUT_MS);
+  } catch (err) {
+    safeClose(ws);
+    throw err;
+  }
+
+  try {
+    ws.send(
+      JSON.stringify({
+        type: 'open',
+        gateway_pubkey: keypair.pkB64,
+        pin,
+        client_id: clientId,
+        mode,
+      }),
+    );
+  } catch (err) {
+    safeClose(ws);
+    throw err instanceof Error ? err : new Error(String(err));
+  }
+
+  let raw: Buffer | ArrayBuffer | string;
+  try {
+    raw = await waitNextMessage(ws, OPEN_TIMEOUT_MS);
+  } catch (err) {
+    safeClose(ws);
+    throw err;
+  }
+
+  let msg: { type?: string; [k: string]: unknown };
+  try {
+    const text = typeof raw === 'string' ? raw : Buffer.from(raw as ArrayBuffer).toString('utf-8');
+    msg = JSON.parse(text);
+  } catch {
+    safeClose(ws);
+    throw new Error('pair-remote-client: opened frame not valid JSON');
+  }
+
+  if (msg.type === 'error') {
+    const errStr = typeof msg.error === 'string' ? msg.error : 'relay_error';
+    safeClose(ws);
+    throw new Error(`pair-remote-client: session/open failed: ${errStr}`);
+  }
+
+  if (msg.type !== 'opened') {
+    safeClose(ws);
+    throw new Error(`pair-remote-client: unexpected response type '${String(msg.type)}'`);
+  }
+
+  const token = typeof msg.token === 'string' ? msg.token : '';
+  const expiresAt = typeof msg.expires_at === 'string' ? msg.expires_at : '';
+  if (!token || !expiresAt) {
+    safeClose(ws);
+    throw new Error('pair-remote-client: opened frame missing token or expires_at');
+  }
+
+  const url = buildUserUrl(relayBase, token, keypair.pkB64);
+
+  return {
+    url,
+    pin,
+    token,
+    expiresAt,
+    keypair,
+    mode,
+    _ws: ws,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Await + decrypt + ack
+// ---------------------------------------------------------------------------
+
+export async function awaitPhraseUpload(
+  session: RemotePairSession,
+  opts: AwaitPhraseUploadOptions,
+): Promise<RelayCompletionResult> {
+  const validate = opts.phraseValidator ?? defaultBip39CountValidator;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_AWAIT_TIMEOUT_MS;
+  const ws = session._ws;
+
+  let raw: Buffer | ArrayBuffer | string;
+  try {
+    raw = await waitNextMessage(ws, timeoutMs);
+  } catch (err) {
+    safeClose(ws);
+    throw err;
+  }
+
+  let msg: { type?: string; [k: string]: unknown };
+  try {
+    const text = typeof raw === 'string' ? raw : Buffer.from(raw as ArrayBuffer).toString('utf-8');
+    msg = JSON.parse(text);
+  } catch {
+    safeSend(ws, { type: 'nack', error: 'bad_json' });
+    safeClose(ws);
+    throw new Error('pair-remote-client: forward frame not valid JSON');
+  }
+
+  if (msg.type !== 'forward') {
+    safeSend(ws, { type: 'nack', error: 'expected_forward' });
+    safeClose(ws);
+    throw new Error(`pair-remote-client: unexpected frame '${String(msg.type)}'`);
+  }
+
+  const clientPubkey = typeof msg.client_pubkey === 'string' ? msg.client_pubkey : '';
+  const nonce = typeof msg.nonce === 'string' ? msg.nonce : '';
+  const ciphertext = typeof msg.ciphertext === 'string' ? msg.ciphertext : '';
+  if (!clientPubkey || !nonce || !ciphertext) {
+    safeSend(ws, { type: 'nack', error: 'bad_forward_body' });
+    safeClose(ws);
+    throw new Error('pair-remote-client: forward frame missing required fields');
+  }
+
+  let plaintext: Buffer;
+  try {
+    plaintext = decryptPairingPayload({
+      skGatewayB64: session.keypair.skB64,
+      pkDeviceB64: clientPubkey,
+      sid: session.token,
+      nonceB64: nonce,
+      ciphertextB64: ciphertext,
+    });
+  } catch (err) {
+    safeSend(ws, { type: 'nack', error: 'decrypt_failed' });
+    safeClose(ws);
+    throw err instanceof Error ? err : new Error(String(err));
+  }
+
+  let mnemonic: string;
+  try {
+    mnemonic = plaintext
+      .toString('utf-8')
+      .normalize('NFKC')
+      .toLowerCase()
+      .trim()
+      .split(/\s+/)
+      .join(' ');
+  } catch (err) {
+    safeSend(ws, { type: 'nack', error: 'bad_utf8' });
+    safeClose(ws);
+    throw err instanceof Error ? err : new Error(String(err));
+  } finally {
+    plaintext.fill(0);
+  }
+
+  if (!validate(mnemonic)) {
+    safeSend(ws, { type: 'nack', error: 'invalid_mnemonic' });
+    safeClose(ws);
+    throw new Error('pair-remote-client: phrase failed BIP-39 validation');
+  }
+
+  let result: RelayCompletionResult;
+  try {
+    result = await opts.completePairing({ mnemonic, session });
+  } catch (err) {
+    safeSend(ws, { type: 'nack', error: 'completion_failed' });
+    safeClose(ws);
+    throw err instanceof Error ? err : new Error(String(err));
+  } finally {
+    mnemonic = '';
+  }
+
+  if (result.state !== 'active') {
+    safeSend(ws, { type: 'nack', error: result.error ?? 'completion_failed' });
+    safeClose(ws);
+    return result;
+  }
+
+  safeSend(ws, { type: 'ack' });
+  safeClose(ws);
+  return result;
+}
+
+export async function pairViaRelay(opts: {
+  completePairing: RelayCompletePairingHandler;
+  relayBaseUrl?: string;
+  pin?: string;
+  mode?: PairRelayMode;
+  phraseValidator?: PhraseValidator;
+  timeoutMs?: number;
+}): Promise<RelayCompletionResult> {
+  const session = await openRemotePairSession({
+    relayBaseUrl: opts.relayBaseUrl,
+    pin: opts.pin,
+    mode: opts.mode,
+  });
+  return awaitPhraseUpload(session, {
+    completePairing: opts.completePairing,
+    phraseValidator: opts.phraseValidator,
+    timeoutMs: opts.timeoutMs,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// WS helpers
+// ---------------------------------------------------------------------------
+
+function waitOpen(ws: WebSocket, timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (ws.readyState === WebSocket.OPEN) {
+      resolve();
+      return;
+    }
+    const onOpen = (): void => {
+      cleanup();
+      resolve();
+    };
+    const onError = (err: Error): void => {
+      cleanup();
+      reject(err instanceof Error ? err : new Error(String(err)));
+    };
+    const onClose = (code: number): void => {
+      cleanup();
+      reject(new Error(`pair-remote-client: ws closed before open (${code})`));
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error('pair-remote-client: ws open timeout'));
+    }, timeoutMs);
+    const cleanup = (): void => {
+      clearTimeout(timer);
+      ws.off('open', onOpen);
+      ws.off('error', onError);
+      ws.off('close', onClose);
+    };
+    ws.on('open', onOpen);
+    ws.on('error', onError);
+    ws.on('close', onClose);
+  });
+}
+
+function waitNextMessage(
+  ws: WebSocket,
+  timeoutMs: number,
+): Promise<Buffer | ArrayBuffer | string> {
+  return new Promise((resolve, reject) => {
+    const onMessage = (data: Buffer | ArrayBuffer | string): void => {
+      cleanup();
+      resolve(data);
+    };
+    const onError = (err: Error): void => {
+      cleanup();
+      reject(err instanceof Error ? err : new Error(String(err)));
+    };
+    const onClose = (code: number): void => {
+      cleanup();
+      reject(new Error(`pair-remote-client: ws closed before message (${code})`));
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error('pair-remote-client: ws message timeout'));
+    }, timeoutMs);
+    const cleanup = (): void => {
+      clearTimeout(timer);
+      ws.off('message', onMessage);
+      ws.off('error', onError);
+      ws.off('close', onClose);
+    };
+    ws.on('message', onMessage);
+    ws.on('error', onError);
+    ws.on('close', onClose);
+  });
+}
+
+function safeSend(ws: WebSocket, msg: unknown): void {
+  try {
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(msg));
+    }
+  } catch {
+    /* swallow */
+  }
+}
+
+function safeClose(ws: WebSocket): void {
+  try {
+    if (
+      ws.readyState === WebSocket.OPEN ||
+      ws.readyState === WebSocket.CONNECTING
+    ) {
+      ws.close();
+    }
+  } catch {
+    /* swallow */
+  }
+}

--- a/mcp/src/prompts.ts
+++ b/mcp/src/prompts.ts
@@ -209,6 +209,18 @@ WHEN NOT TO USE:
 - only billing → totalreclaw_status (lighter)
 - FULL recovery phrase → NEVER; password manager.`;
 
+export const PAIR_TOOL_DESCRIPTION = `Set up the user's TotalReclaw account (browser-side recovery-phrase generation or import).
+INVOKE WHEN USER SAYS:
+- "set up totalreclaw" / "set up my account"
+- "I don't have a totalreclaw recovery phrase yet" / "create a totalreclaw account"
+- ANY tool returns "not_configured" — propose this tool BEFORE asking the user to edit MCP config.
+DOES: opens a brief relay session, returns {url, pin, expires_at_ms}. Hand the URL + PIN to the user — they open the URL in any browser, the BROWSER generates (or imports) a 12-word phrase, encrypts it, uploads ciphertext to this MCP server. Server decrypts in-memory, writes ~/.totalreclaw/credentials.json (mode 0600). Phrase NEVER touches LLM context, chat transcript, stdout, or logs.
+AFTER PAIRING: tell the user to RESTART their MCP host (Claude Desktop / Cursor / Claude Code) so the server re-reads credentials.json and switches out of unconfigured mode.
+WHEN NOT TO USE:
+- user already has TOTALRECLAW_RECOVERY_PHRASE in env → tool will return URL but pairing is unnecessary
+- user explicitly wants terminal-only setup → point them at \`npx @totalreclaw/mcp-server setup\` (CLI wizard, runs OUTSIDE your shell tool)
+- NEVER ask the user to paste their phrase in chat. NEVER echo or print a phrase from any source.`;
+
 // ── Layer 5: Prompt Fallback Templates ───────────────────────────────────────
 
 export const PROMPT_DEFINITIONS = [

--- a/mcp/src/tools/index.ts
+++ b/mcp/src/tools/index.ts
@@ -13,6 +13,12 @@ export { debriefToolDefinition, handleDebrief, parseDebriefResponse, DEBRIEF_SYS
 export { supportToolDefinition, handleSupport } from './support.js';
 export { accountToolDefinition, handleAccount } from './account.js';
 export {
+  pairToolDefinition,
+  handlePair,
+  runPairBackgroundTask,
+  resolvePairRelayUrl,
+} from './pair.js';
+export {
   pinToolDefinition,
   unpinToolDefinition,
   handlePin,

--- a/mcp/src/tools/pair.ts
+++ b/mcp/src/tools/pair.ts
@@ -1,0 +1,430 @@
+/**
+ * TotalReclaw MCP — totalreclaw_pair tool
+ *
+ * Browser-mediated TotalReclaw account setup. The user opens the returned
+ * URL on their phone or another browser, the browser generates (or imports)
+ * a 12-word BIP-39 recovery phrase, encrypts it via x25519 ECDH + AES-256-GCM,
+ * and uploads the ciphertext to the same relay this MCP server already talks
+ * to. The MCP server decrypts the phrase locally and writes
+ * `~/.totalreclaw/credentials.json` so a host restart picks the user up in
+ * configured mode.
+ *
+ * Phrase-safety invariants (see project_phrase_safety_rule):
+ *   - The phrase NEVER appears in the tool's return payload.
+ *   - The phrase NEVER passes through stdout / stderr / logs.
+ *   - The phrase is generated in the browser; the MCP server only ever sees
+ *     the decrypted plaintext in-memory inside `completePairing` and writes
+ *     it to the 0600-mode credentials.json on disk.
+ *
+ * Flow:
+ *   1. Tool handler resolves the relay URL from
+ *      `TOTALRECLAW_PAIR_RELAY_URL` (preferred) or `TOTALRECLAW_SERVER_URL`
+ *      (rewrites http→ws / https→wss). Falls back to `wss://api.totalreclaw.xyz`.
+ *   2. Opens a relay pair session (`openRemotePairSession`) and returns
+ *      `{url, pin, expires_at_ms}` to the agent immediately.
+ *   3. Schedules a background `awaitPhraseUpload` task so the WS stays open
+ *      across the tool's return. When the browser POSTs the encrypted
+ *      phrase, completePairing decrypts, derives keys, registers with the
+ *      relay, and writes credentials.json.
+ *
+ * MCP-process lifecycle note: stdio MCP servers stay alive until the host
+ * disconnects, so the background WS-await runs to completion or the relay
+ * 5-minute TTL, whichever is first. There is a 60-second hard timeout
+ * (matching the plugin) so a slow / abandoned browser flow doesn't hold the
+ * process hostage. After completion the user must restart their MCP host
+ * (Claude Desktop / Cursor / Claude Code) for the server to re-read
+ * credentials.json and switch out of `unconfigured` mode.
+ *
+ * Reference implementation: `skill/plugin/index.ts` (totalreclaw_pair tool
+ * handler) and `skill/plugin/pair-cli-relay.ts` (CLI runner). The crypto +
+ * WS-client code in `pair-crypto.ts` and `pair-remote-client.ts` is a
+ * verbatim port of the plugin equivalents.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+import { validateMnemonic } from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english.js';
+
+import { PAIR_TOOL_DESCRIPTION } from '../prompts.js';
+import {
+  openRemotePairSession,
+  awaitPhraseUpload,
+  type RemotePairSession,
+} from '../pair-remote-client.js';
+import { deriveAuthKey, computeAuthKeyHash } from '../cli/setup.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CREDENTIALS_DIR = path.join(os.homedir(), '.totalreclaw');
+const CREDENTIALS_PATH = path.join(CREDENTIALS_DIR, 'credentials.json');
+
+/**
+ * Hard timeout for the background WS-await. Matches the plugin
+ * (`PAIR_TOOL_HARD_TIMEOUT_MS = 60_000`) — long enough for a slow
+ * scan-and-paste, short enough that a stuck browser doesn't hold the
+ * MCP process indefinitely.
+ */
+const PAIR_TOOL_HARD_TIMEOUT_MS = 60_000;
+
+const DEFAULT_RELAY_URL_WSS = 'wss://api.totalreclaw.xyz';
+
+// ---------------------------------------------------------------------------
+// Tool definition
+// ---------------------------------------------------------------------------
+
+export const pairToolDefinition = {
+  name: 'totalreclaw_pair',
+  description: PAIR_TOOL_DESCRIPTION,
+  inputSchema: {
+    type: 'object',
+    properties: {
+      mode: {
+        type: 'string',
+        enum: ['generate', 'import'],
+        description:
+          '"generate" = the browser will create a NEW recovery phrase. "import" = the ' +
+          'browser will accept an EXISTING phrase that the user pastes in their browser ' +
+          '(never through chat).',
+        default: 'generate',
+      },
+    },
+    additionalProperties: false,
+  },
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the relay base URL for the pair WS.
+ *
+ * Order:
+ *   1. `TOTALRECLAW_PAIR_RELAY_URL` if set (explicit override).
+ *   2. `TOTALRECLAW_SERVER_URL` rewritten http→ws / https→wss (matches
+ *      plugin's 3.3.12-rc.2 behavior — pair WS lives on the same host as
+ *      the rest of the API, so RC users on api-staging stay on staging).
+ *   3. Default `wss://api.totalreclaw.xyz`.
+ */
+export function resolvePairRelayUrl(env: NodeJS.ProcessEnv = process.env): string {
+  const explicit = env.TOTALRECLAW_PAIR_RELAY_URL;
+  if (explicit && explicit.trim().length > 0) {
+    return explicit.trim().replace(/\/+$/, '');
+  }
+  const serverUrl = env.TOTALRECLAW_SERVER_URL;
+  if (serverUrl && serverUrl.trim().length > 0) {
+    return serverUrl
+      .trim()
+      .replace(/^https:\/\//, 'wss://')
+      .replace(/^http:\/\//, 'ws://')
+      .replace(/\/+$/, '');
+  }
+  return DEFAULT_RELAY_URL_WSS;
+}
+
+/**
+ * Convert a wss:// or ws:// relay URL back to https:// or http:// for the
+ * REST `/v1/register` call. Used by the background completePairing handler.
+ */
+function relayBaseToHttps(relayBase: string): string {
+  return relayBase
+    .replace(/^wss:\/\//, 'https://')
+    .replace(/^ws:\/\//, 'http://')
+    .replace(/\/+$/, '');
+}
+
+/**
+ * Write credentials.json with 0600 permissions. Mirrors `cli/setup.ts`
+ * `saveCredentials` but accepts a richer payload (`mnemonic`, `salt` hex,
+ * `userId`, `serverUrl`).
+ */
+function writePairedCredentials(creds: {
+  userId: string;
+  salt: string;
+  serverUrl: string;
+  mnemonic: string;
+}): void {
+  if (!fs.existsSync(CREDENTIALS_DIR)) {
+    fs.mkdirSync(CREDENTIALS_DIR, { recursive: true, mode: 0o700 });
+  }
+  fs.writeFileSync(CREDENTIALS_PATH, JSON.stringify(creds, null, 2) + '\n', {
+    encoding: 'utf-8',
+    mode: 0o600,
+  });
+}
+
+/**
+ * POST /v1/register — best-effort. Returns user_id on success, or undefined
+ * on USER_EXISTS (in which case the caller derives userId from the
+ * auth-key hash). Other errors throw — the caller logs and continues with
+ * mnemonic-only credentials so the next MCP-host restart can retry.
+ */
+async function registerUser(
+  httpsBase: string,
+  authKeyHash: string,
+  saltHex: string,
+): Promise<string | undefined> {
+  const url = `${httpsBase}/v1/register`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      auth_key_hash: authKeyHash,
+      salt: saltHex,
+    }),
+  });
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    if (body.includes('USER_EXISTS') || response.status === 409) {
+      return undefined;
+    }
+    throw new Error(`register failed (HTTP ${response.status}): ${body || response.statusText}`);
+  }
+  const data = (await response.json()) as { user_id?: string };
+  if (!data.user_id) {
+    throw new Error('register: response missing user_id');
+  }
+  return data.user_id;
+}
+
+// ---------------------------------------------------------------------------
+// Background completion task
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the full WS-await + decrypt + register + write-credentials pipeline.
+ * Exported for testing — the tool handler schedules this as a background
+ * task so the agent can return URL/PIN to the user immediately.
+ *
+ * Phrase NEVER leaves this function. Logs only the relay token prefix +
+ * userId prefix.
+ */
+export async function runPairBackgroundTask(opts: {
+  session: RemotePairSession;
+  relayBaseUrl: string;
+  serverUrl: string;
+  hardTimeoutMs?: number;
+  log?: (level: 'info' | 'warn' | 'error', msg: string) => void;
+}): Promise<void> {
+  const log =
+    opts.log ??
+    ((level, msg) => {
+      // Default logger goes to stderr so MCP stdout (JSON-RPC framing) stays clean.
+      const prefix = `totalreclaw_pair[${level}]:`;
+      if (level === 'error') {
+        console.error(prefix, msg);
+      } else {
+        console.error(prefix, msg);
+      }
+    });
+  const hardTimeoutMs = opts.hardTimeoutMs ?? PAIR_TOOL_HARD_TIMEOUT_MS;
+  const httpsBase = relayBaseToHttps(opts.relayBaseUrl);
+  const tokenTail = opts.session.token.slice(0, 8);
+
+  const phraseUploadPromise = awaitPhraseUpload(opts.session, {
+    phraseValidator: (p: string) => validateMnemonic(p, wordlist),
+    completePairing: async ({ mnemonic }) => {
+      try {
+        // Derive auth key + salt — matches setup.ts deriveAuthKey shape.
+        const { authKeyHex, saltHex } = deriveAuthKey(mnemonic);
+        const authKeyHash = computeAuthKeyHash(authKeyHex);
+
+        // Register with relay — best-effort. USER_EXISTS → derive userId
+        // deterministically from the auth-key hash so credentials are
+        // still complete. Other errors → continue with mnemonic-only
+        // creds and let the next host restart retry register.
+        let registeredUserId: string | undefined;
+        try {
+          registeredUserId = await registerUser(httpsBase, authKeyHash, saltHex);
+          if (registeredUserId) {
+            log('info', `pair: registered user_id=${registeredUserId.slice(0, 8)}…`);
+          } else {
+            registeredUserId = authKeyHash.slice(0, 32);
+            log('info', `pair: USER_EXISTS — using derived userId=${registeredUserId.slice(0, 8)}…`);
+          }
+        } catch (regErr) {
+          const m = regErr instanceof Error ? regErr.message : String(regErr);
+          log('warn', `pair: /v1/register failed (best-effort, will retry on host restart): ${m}`);
+          registeredUserId = authKeyHash.slice(0, 32);
+        }
+
+        try {
+          writePairedCredentials({
+            userId: registeredUserId,
+            salt: saltHex,
+            serverUrl: opts.serverUrl,
+            mnemonic,
+          });
+        } catch (writeErr) {
+          const m = writeErr instanceof Error ? writeErr.message : String(writeErr);
+          log('error', `pair: credentials.json write failed: ${m}`);
+          return { state: 'error', error: 'credentials_write_failed' };
+        }
+
+        log(
+          'info',
+          `pair: session ${tokenTail}… completed; credentials written (userId=${registeredUserId.slice(0, 8)}…)`,
+        );
+        return { state: 'active' };
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log('error', `pair: completePairing failed: ${msg}`);
+        return { state: 'error', error: msg };
+      }
+    },
+    timeoutMs: hardTimeoutMs,
+  });
+
+  // Outer race against a hard timeout — covers the case where the WS stays
+  // open but the browser never POSTs (rare; matches plugin's 3.3.4-rc.2 fix).
+  const TIMEOUT_SENTINEL = {
+    status: 'timed_out' as const,
+    message: `Pair flow timed out (${hardTimeoutMs / 1000}s) — generate a new URL with totalreclaw_pair.`,
+  };
+  let hardTimer: ReturnType<typeof setTimeout> | undefined;
+  const hardTimeoutPromise = new Promise<typeof TIMEOUT_SENTINEL>((resolve) => {
+    hardTimer = setTimeout(() => resolve(TIMEOUT_SENTINEL), hardTimeoutMs);
+  });
+
+  try {
+    const raced = await Promise.race([phraseUploadPromise, hardTimeoutPromise]);
+    if (
+      raced &&
+      typeof raced === 'object' &&
+      (raced as { status?: unknown }).status === 'timed_out'
+    ) {
+      log('warn', `pair: hard timeout (token=${tokenTail}…)`);
+    }
+  } catch (bgErr: unknown) {
+    const bgMsg = bgErr instanceof Error ? bgErr.message : String(bgErr);
+    log('warn', `pair: background task ended for token=${tokenTail}…: ${bgMsg}`);
+  } finally {
+    if (hardTimer) clearTimeout(hardTimer);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tool handler
+// ---------------------------------------------------------------------------
+
+export interface HandlePairOptions {
+  /** Override relay URL — for tests. */
+  relayBaseUrl?: string;
+  /** Override server URL written into credentials.json — defaults to env. */
+  serverUrl?: string;
+  /**
+   * If true, await the background task before returning. Used by tests so
+   * they can assert on the post-completion state. In production this is
+   * false — the tool handler returns immediately after URL/PIN emit so the
+   * agent can hand the URL to the user.
+   */
+  awaitBackground?: boolean;
+  /** Logger override (tests). Default writes to stderr. */
+  log?: (level: 'info' | 'warn' | 'error', msg: string) => void;
+}
+
+/**
+ * Handle a totalreclaw_pair tool call. Returns the URL + PIN + expires_at_ms
+ * structured payload immediately and schedules the encrypted-phrase WS-await
+ * as a background task.
+ */
+export async function handlePair(
+  args: Record<string, unknown> | undefined,
+  opts: HandlePairOptions = {},
+): Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }> {
+  const rawMode = args?.mode;
+  const mode: 'generate' | 'import' = rawMode === 'import' ? 'import' : 'generate';
+
+  const relayBaseUrl = opts.relayBaseUrl ?? resolvePairRelayUrl();
+  const serverUrl = opts.serverUrl ?? process.env.TOTALRECLAW_SERVER_URL ?? 'https://api.totalreclaw.xyz';
+
+  let session: RemotePairSession;
+  try {
+    session = await openRemotePairSession({
+      relayBaseUrl,
+      mode: mode === 'generate' ? 'generate' : 'import',
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            error: 'pair_session_open_failed',
+            message: `Failed to open relay pair session: ${msg}`,
+            relay_base_url: relayBaseUrl,
+          }),
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  // ISO-8601 → ms for tool-payload parity with the plugin.
+  const parsedExpiresMs = Date.parse(session.expiresAt);
+  const expiresAtMs = Number.isFinite(parsedExpiresMs)
+    ? parsedExpiresMs
+    : Date.now() + 5 * 60_000;
+
+  // Schedule the background WS-await. In production we DO NOT await it —
+  // the tool returns URL+PIN immediately so the agent can hand the URL to
+  // the user. The MCP server process stays alive (stdio host child) so the
+  // background task can run to completion.
+  const bgPromise = runPairBackgroundTask({
+    session,
+    relayBaseUrl,
+    serverUrl,
+    log: opts.log,
+  });
+
+  if (opts.awaitBackground) {
+    await bgPromise;
+  } else {
+    // Detach; surface unhandled rejections via the same logger.
+    bgPromise.catch((err) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      const log =
+        opts.log ??
+        ((level: string, m: string) => console.error(`totalreclaw_pair[${level}]:`, m));
+      log('warn', `pair: background task rejected: ${msg}`);
+    });
+  }
+
+  const instructions =
+    mode === 'generate'
+      ? `The browser will generate a NEW 12-word recovery phrase and ask the user to write it down + retype 3 words before finalizing.`
+      : `The browser will accept an EXISTING phrase that the user pastes in the browser (never through chat).`;
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify({
+          url: session.url,
+          pin: session.pin,
+          expires_at_ms: expiresAtMs,
+          mode,
+          relay_base_url: relayBaseUrl,
+          instructions: [
+            `Open the URL above on the user's phone or another browser (copy-paste).`,
+            instructions,
+            `Enter the 6-digit PIN shown above into the browser.`,
+            `The encrypted phrase uploads to this MCP server — it NEVER touches the LLM.`,
+            `After the browser shows "Pairing complete", restart the MCP host (Claude Desktop / Cursor / Claude Code) so the server re-reads ~/.totalreclaw/credentials.json. The session expires in ~5 minutes.`,
+          ],
+        }),
+      },
+    ],
+  };
+}

--- a/mcp/tests/pair-tool.test.ts
+++ b/mcp/tests/pair-tool.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for the totalreclaw_pair tool — definition shape, env-var resolution,
+ * and URL/PIN format the tool emits to the agent.
+ *
+ * The full WS round-trip is exercised by the plugin-side
+ * `pair-remote-client.test.ts` and the relay's own conformance suite — both
+ * are byte-compatible with this module since `pair-remote-client.ts` and
+ * `pair-crypto.ts` are verbatim ports.
+ */
+
+import {
+  pairToolDefinition,
+  resolvePairRelayUrl,
+} from '../src/tools/pair';
+
+describe('pairToolDefinition', () => {
+  it('has the canonical tool name', () => {
+    expect(pairToolDefinition.name).toBe('totalreclaw_pair');
+  });
+
+  it('has a non-empty description', () => {
+    expect(typeof pairToolDefinition.description).toBe('string');
+    expect(pairToolDefinition.description.length).toBeGreaterThan(0);
+  });
+
+  it('description references browser-side phrase generation', () => {
+    // Phrase-safety hard rail signal — the description MUST NOT imply the
+    // agent generates the phrase. It MUST tell the agent the browser does it.
+    expect(pairToolDefinition.description).toMatch(/browser/i);
+    expect(pairToolDefinition.description).toMatch(/never/i);
+  });
+
+  it('has an inputSchema with optional `mode` enum', () => {
+    expect(pairToolDefinition.inputSchema.type).toBe('object');
+    const props = pairToolDefinition.inputSchema.properties as Record<string, unknown>;
+    expect(props.mode).toBeDefined();
+    const mode = props.mode as { type?: string; enum?: string[]; default?: string };
+    expect(mode.type).toBe('string');
+    expect(mode.enum).toEqual(['generate', 'import']);
+    expect(mode.default).toBe('generate');
+  });
+
+  it('has the standard tool annotations', () => {
+    expect(pairToolDefinition.annotations).toBeDefined();
+    expect(typeof pairToolDefinition.annotations.readOnlyHint).toBe('boolean');
+    expect(typeof pairToolDefinition.annotations.destructiveHint).toBe('boolean');
+    expect(typeof pairToolDefinition.annotations.idempotentHint).toBe('boolean');
+    // Pair is NOT idempotent (each call opens a fresh relay session) and is
+    // NOT destructive — but it DOES write credentials.json so it's not
+    // read-only either.
+    expect(pairToolDefinition.annotations.readOnlyHint).toBe(false);
+    expect(pairToolDefinition.annotations.destructiveHint).toBe(false);
+    expect(pairToolDefinition.annotations.idempotentHint).toBe(false);
+  });
+});
+
+describe('resolvePairRelayUrl', () => {
+  it('prefers TOTALRECLAW_PAIR_RELAY_URL when set', () => {
+    const result = resolvePairRelayUrl({
+      TOTALRECLAW_PAIR_RELAY_URL: 'wss://relay-explicit.example.com',
+      TOTALRECLAW_SERVER_URL: 'https://api-staging.totalreclaw.xyz',
+    });
+    expect(result).toBe('wss://relay-explicit.example.com');
+  });
+
+  it('strips trailing slashes from the explicit override', () => {
+    const result = resolvePairRelayUrl({
+      TOTALRECLAW_PAIR_RELAY_URL: 'wss://relay.example.com/',
+    });
+    expect(result).toBe('wss://relay.example.com');
+  });
+
+  it('rewrites https TOTALRECLAW_SERVER_URL to wss', () => {
+    const result = resolvePairRelayUrl({
+      TOTALRECLAW_SERVER_URL: 'https://api-staging.totalreclaw.xyz',
+    });
+    expect(result).toBe('wss://api-staging.totalreclaw.xyz');
+  });
+
+  it('rewrites http TOTALRECLAW_SERVER_URL to ws (self-hosted plain HTTP)', () => {
+    const result = resolvePairRelayUrl({
+      TOTALRECLAW_SERVER_URL: 'http://localhost:8080',
+    });
+    expect(result).toBe('ws://localhost:8080');
+  });
+
+  it('falls back to wss://api.totalreclaw.xyz when neither env var is set', () => {
+    const result = resolvePairRelayUrl({});
+    expect(result).toBe('wss://api.totalreclaw.xyz');
+  });
+
+  it('treats an empty TOTALRECLAW_PAIR_RELAY_URL as unset', () => {
+    const result = resolvePairRelayUrl({
+      TOTALRECLAW_PAIR_RELAY_URL: '   ',
+      TOTALRECLAW_SERVER_URL: 'https://api-staging.totalreclaw.xyz',
+    });
+    expect(result).toBe('wss://api-staging.totalreclaw.xyz');
+  });
+});
+
+describe('phrase-safety contract', () => {
+  it('tool description does NOT instruct the agent to generate or paste a phrase', () => {
+    const desc = pairToolDefinition.description.toLowerCase();
+    // Negative guards — these strings would signal an LLM-context phrase
+    // path, which is the rule we explicitly forbid.
+    expect(desc).not.toMatch(/paste your phrase in chat/);
+    expect(desc).not.toMatch(/generate the phrase here/);
+    expect(desc).not.toMatch(/return the phrase/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `totalreclaw_pair` to `@totalreclaw/mcp-server` so users can install via MCP config alone — no out-of-band recovery-phrase paste, no need to run a separate CLI before adding the MCP server. The agent calls the tool, gets `{url, pin, expires_at_ms}`, hands those to the user, the user pairs in their browser, the MCP server decrypts the encrypted phrase and writes `~/.totalreclaw/credentials.json`.

- Ports `pair-crypto.ts` + `pair-remote-client.ts` from the plugin (`skill/plugin/`) — wire formats are byte-compatible (x25519 ECDH + HKDF-SHA256 + AES-256-GCM, sid bound as AD).
- Tool is reachable in `unconfigured` mode (alongside `totalreclaw_support`) so a fresh MCP-only install can complete end-to-end through chat.
- Phrase-safety preserved: phrase generated browser-side, decrypted in-process inside `completePairing`, written to 0600 credentials.json. Never enters tool output / stdout / logs.
- 60s hard timeout on the background WS-await matches the plugin's `PAIR_TOOL_HARD_TIMEOUT_MS` (3.3.4-rc.2).
- Bumps `@totalreclaw/mcp-server` 3.2.1 → 3.3.0-rc.1, adds `ws` + `@types/ws` deps.

After the browser completes pairing, the user must restart their MCP host (Claude Desktop / Cursor / Claude Code) so the server re-reads credentials.json and switches out of unconfigured mode.

## Test plan

- [x] `npm run build` clean.
- [x] `npm test tests/pair-tool.test.ts` — 12/12 pass (definition shape + relay URL resolution + phrase-safety description guards).
- [x] Full `npm test` — pre-existing failures unchanged (verified with stash-toggle); pair-tool test suite is strictly additive.
- [x] Stdio smoke: `tools/list` over JSON-RPC exposes `totalreclaw_pair` as the 19th tool.
- [ ] VPS smoke: dispatch the agent in a fresh session against `/tmp/<pkg>/dist/index.js` and confirm `totalreclaw_pair` returns URL + PIN. (Pedro to verify locally; left out of this PR since the WS round-trip test stack is on the relay side.)
- [ ] Browser-side completion lifecycle on stdio MCP — open question: stdio MCP servers stay alive only as long as the host child-process keeps the pipe open, so a host quit during the 60s WS-await drops the session. In practice the agent finishes responding within a few seconds of returning the URL, but if the host idle-kills the server before the user pairs, the user gets a "session expired" in the browser. Investigated and considered acceptable for rc.1 — Claude Desktop / Cursor / Claude Code keep stdio MCP servers alive for the full session.

## Phrase-safety check

- Phrase NEVER crosses LLM context — generated in browser, decrypted in `completePairing` only.
- Tool description tells the agent the browser does generation + that the phrase NEVER touches the LLM.
- Tests assert the description does NOT contain phrases like "paste your phrase in chat" / "return the phrase".

## Future work (separate PR)

Extract `pair-crypto.ts` + `pair-remote-client.ts` into a shared `@totalreclaw/pair-client` package so plugin + mcp-server + Hermes don't keep three copies in sync manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)