### PR TITLE
ci: auto-merge L1 coding-agent PRs on green CI

### DIFF
--- a/.github/workflows/auto-merge-l1.yml
+++ b/.github/workflows/auto-merge-l1.yml
@@ -1,0 +1,64 @@
+name: Auto-merge L1 coding-agent PRs
+
+# Triggers on PRs labeled `auto-merge:L1` by the tr-implement-task skill.
+# Once all CI checks are green, squash-merges the PR + deletes the branch.
+#
+# This implements the Q1=B decision (Pedro 2026-05-08): L1 risk-tier PRs
+# (docs / isolated helpers / enum cleanup — no schema, reranker, or
+# security touch) auto-merge on green CI without coordinator review.
+# L2/L3 PRs go through the coordinator-review skill instead.
+#
+# Design doc: docs/plans/2026-05-08-autonomous-dispatch-design.md
+# Pipeline doc: docs/operations/autonomous-coding-pipeline.md (in totalreclaw-internal)
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, synchronize, opened, reopened]
+  pull_request_review:
+    types: [submitted]
+  check_suite:
+    types: [completed]
+  status: {}
+
+jobs:
+  auto-merge:
+    if: contains(github.event.pull_request.labels.*.name, 'auto-merge:L1')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: read
+    steps:
+      - name: Wait for all checks to complete
+        uses: poseidon/wait-for-status-checks@v0.6.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          delay: 30
+          interval: 30
+          # Don't include the auto-merge job's own status in what we wait for.
+          ignore: 'auto-merge'
+
+      - name: Verify PR is from a coding-agent branch
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if [[ ! "$HEAD_REF" =~ ^agent/ ]]; then
+            echo "Refusing to auto-merge: head ref ($HEAD_REF) is not from agent/* branch"
+            exit 1
+          fi
+
+      - name: Verify PR has canonical-roadmap-task label
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          if ! echo "$LABELS" | grep -q 'canonical-roadmap-task'; then
+            echo "Refusing to auto-merge: PR not labeled canonical-roadmap-task"
+            exit 1
+          fi
+
+      - name: Squash-merge the PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr merge "$PR_NUMBER" --squash --delete-branch


### PR DESCRIPTION
## Summary

New GitHub Action that auto-merges L1 coding-agent PRs on green CI.

Implements decision Q1=B from the autonomous coding-agent pipeline design (in `totalreclaw-internal`): L1 risk-tier PRs (docs / isolated helpers / enum cleanup — no schema, reranker, or security touch) skip coordinator review and merge directly on green CI. L2/L3 PRs get a different label and route through the coordinator-review skill instead.

## Trigger

PR has all three:
- `auto-merge:L1` label
- `canonical-roadmap-task` label  
- Head branch matches `agent/*`

## Safety guards

- Only fires on PRs with `auto-merge:L1` label
- Refuses if head ref isn't `agent/*`
- Refuses if PR not labeled `canonical-roadmap-task`
- Uses `GITHUB_TOKEN` (not bot PAT); permissions scoped to `contents:write`, `pull-requests:write`, `checks:read`

## Rollback

Remove the label from a PR OR delete this workflow file → action stops immediately.

## Test plan

Pilot dispatch on `imp-7` (canonical-roadmap issue [#249](https://github.com/p-diogo/totalreclaw-internal/issues/249), L1) will validate end-to-end:
1. Pedro flips the Project item to Status: In Progress
2. tr-triage-listener fires `tr-implement-task` skill on VPS
3. Skill implements, opens PR with `auto-merge:L1` label
4. CI runs, passes
5. This action fires, squash-merges, deletes branch
6. Skill closes loop, sets Project status to Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)