### PR TITLE
ci: fix auto-merge-l1 — pass -R to gh pr merge

### DIFF
--- a/.github/workflows/auto-merge-l1.yml
+++ b/.github/workflows/auto-merge-l1.yml
@@ -61,4 +61,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr merge "$PR_NUMBER" --squash --delete-branch
+          gh pr merge "$PR_NUMBER" -R "$GITHUB_REPOSITORY" --squash --delete-branch


### PR DESCRIPTION
Pilot dispatch (PR #205) found this bug: `gh pr merge $PR_NUMBER` failed with `fatal: not a git repository` because workflow doesn't check out the repo. Fix: pass `-R $GITHUB_REPOSITORY` so gh CLI knows which repo.