### PR TITLE
[cred-1] Phase 1: threat model docs + plugin startup checks

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,6 +1,6 @@
 # TotalReclaw security model
 
-> Last reviewed: 2026-05-06 (3.3.11-rc.3)
+> Last reviewed: 2026-05-09 (cred-1)
 > If you find a vulnerability, please email security@totalreclaw.xyz with details. Do not file public issues for live exploits.
 
 ## What's protected (in-transit + on-chain)
@@ -51,7 +51,7 @@ This is a deliberate tradeoff. The plugin's daemon-mode auto-extraction needs th
 
 The plaintext-at-rest tradeoff is documented and being addressed in phases. See [totalreclaw-internal#229](https://github.com/p-diogo/totalreclaw-internal/issues/229) for the full UX matrix and phasing.
 
-- **Phase 1 (this RC family, 3.3.x)** — Document the threat model (this file) and audit chmod 600 enforcement. Plugin will refuse to load if credentials.json mode is broader than 600.
+- **Phase 1 (cred-1 — shipped)** — Document the threat model (this file) and enforce chmod 600 at plugin startup. The plugin now **refuses to load** if `credentials.json` is found with permissions broader than `0600`. Fix: `chmod 600 ~/.totalreclaw/credentials.json` then restart the gateway. The plugin also warns if the file is detected on a tmpfs or shared-volume mount (`/tmp/`, `/dev/shm/`, `/run/`, `/var/run/`).
 - **Phase 2 (3.4.0)** — Desktop OS-keychain wrap (macOS Keychain, Linux libsecret, Windows Credential Manager). Container deployments fall back to status quo.
 - **Phase 3 (3.4.x)** — Container deployment patterns. Documented LUKS / dm-crypt setup, plus optional `TOTALRECLAW_CREDENTIALS_PROVIDER=vault` config for HashiCorp Vault / Railway secrets / AWS Secrets Manager / GCP Secret Manager.
 - **Phase 4 (optional, 3.5+)** — TPM / Secure Enclave hardware-bound wrap. Defeats `docker save` and disk theft completely, at the cost of platform-specific code paths.

--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -327,10 +327,39 @@ Upgrade: *"Upgrade my TotalReclaw subscription."*
 
 ---
 
+## Threat model
+
+After a successful pair, your recovery phrase is stored in plaintext at `~/.totalreclaw/credentials.json` with mode `0600` (owner read/write only). Understanding what this does and doesn't protect is important.
+
+**`chmod 600` protects against:**
+
+- Other Unix user accounts on the same host reading your phrase directly.
+- Web server processes, CI runners, or container daemons running as different OS users.
+
+**`chmod 600` does NOT protect against:**
+
+- Root / sudo — system administrators can read any file.
+- Same-user processes — any process running as your Unix user can read the file. This includes every shell session, script, and agent running as you.
+- Physical disk access (stolen drive, VM snapshot, cloud-provider disk clone).
+- Tmpfs / shared-volume mounts — if `credentials.json` is on `/tmp/`, `/dev/shm/`, or similar, it may be readable by other processes in the same container namespace or lost on reboot. The plugin warns on startup if this is detected.
+- Cloud-backup leakage — if `~/.totalreclaw/` is inside a folder synced to iCloud, Dropbox, Backblaze, or similar, add it to your backup exclude list.
+
+**Fail-closed enforcement:** The plugin refuses to load if `credentials.json` is found with permissions broader than `0600`. If you see a startup error about insecure permissions, fix it with:
+
+```bash
+chmod 600 ~/.totalreclaw/credentials.json
+# Then restart your OpenClaw gateway.
+```
+
+For the full threat model, mitigations, and the credentials-at-rest roadmap, see [SECURITY.md](../SECURITY.md).
+
+---
+
 ## Further reading
 
 - [Feature Comparison](feature-comparison.md)
 - [Importing Memories](importing-memories.md)
 - [Memory types guide](memory-types-guide.md) — v1 taxonomy
 - [Detailed reference](beta-tester-guide-detailed.md) — env vars, extraction tuning, architecture
+- [Security](../SECURITY.md) — threat model and at-rest credential protection
 - [totalreclaw.xyz](https://totalreclaw.xyz)

--- a/skill/plugin/fs-helpers.test.ts
+++ b/skill/plugin/fs-helpers.test.ts
@@ -23,6 +23,7 @@ import {
   deleteFileIfExists,
   readPluginVersion,
   patchOpenClawConfig,
+  checkCredentialsFileMode,
   type CredentialsFile,
 } from './fs-helpers.js';
 
@@ -832,6 +833,91 @@ const TEST_HEADER = '# Memory\n\n> TotalReclaw is active. Test header.\n\n';
     'off',
     'patchOpenClawConfig: pop-os scenario also sets telegram streaming.mode=off',
   );
+}
+
+// ---------------------------------------------------------------------------
+// checkCredentialsFileMode — permission gate (cred-1)
+// ---------------------------------------------------------------------------
+
+{
+  // Mode tests need a non-tmpfs directory so the tmpfs-prefix warning doesn't
+  // fire for legitimately-secure (0600) files. /var/tmp is a persistent temp
+  // location that is NOT in TMPFS_PREFIXES.
+  const MODE_TMP = fs.mkdtempSync('/var/tmp/tr-mode-test-');
+
+  const warnings: string[] = [];
+  const errors: string[] = [];
+  const logger = {
+    warn: (m: string) => { warnings.push(m); },
+    error: (m: string) => { errors.push(m); },
+  };
+
+  // 1. File absent → 'ok' with no logging
+  {
+    warnings.length = 0; errors.length = 0;
+    const result = checkCredentialsFileMode(path.join(MODE_TMP, 'nonexistent-creds.json'), logger);
+    assertEq(result, 'ok', 'checkCredentialsFileMode: absent file returns ok');
+    assert(warnings.length === 0 && errors.length === 0, 'checkCredentialsFileMode: absent file no logging');
+  }
+
+  // 2. File with mode 0600 → 'ok'
+  {
+    warnings.length = 0; errors.length = 0;
+    const p = path.join(MODE_TMP, 'creds-600.json');
+    fs.writeFileSync(p, '{}');
+    fs.chmodSync(p, 0o600);
+    const result = checkCredentialsFileMode(p, logger);
+    assertEq(result, 'ok', 'checkCredentialsFileMode: mode 0600 returns ok');
+    assert(warnings.length === 0 && errors.length === 0, 'checkCredentialsFileMode: mode 0600 no logging');
+  }
+
+  // 3. File with mode 0644 → 'insecure' with error logged
+  {
+    warnings.length = 0; errors.length = 0;
+    const p = path.join(MODE_TMP, 'creds-644.json');
+    fs.writeFileSync(p, '{}');
+    fs.chmodSync(p, 0o644);
+    const result = checkCredentialsFileMode(p, logger);
+    assertEq(result, 'insecure', 'checkCredentialsFileMode: mode 0644 returns insecure');
+    assert(errors.length > 0, 'checkCredentialsFileMode: mode 0644 logs error');
+    assert(errors[0].includes('STARTUP REFUSED'), 'checkCredentialsFileMode: error mentions STARTUP REFUSED');
+    assert(errors[0].includes('chmod 600'), 'checkCredentialsFileMode: error includes fix command');
+  }
+
+  // 4. File with mode 0755 → 'insecure'
+  {
+    warnings.length = 0; errors.length = 0;
+    const p = path.join(MODE_TMP, 'creds-755.json');
+    fs.writeFileSync(p, '{}');
+    fs.chmodSync(p, 0o755);
+    const result = checkCredentialsFileMode(p, logger);
+    assertEq(result, 'insecure', 'checkCredentialsFileMode: mode 0755 returns insecure');
+  }
+
+  // 5. File with mode 0400 (read-only, more restrictive than 600) → 'ok'
+  {
+    warnings.length = 0; errors.length = 0;
+    const p = path.join(MODE_TMP, 'creds-400.json');
+    fs.writeFileSync(p, '{}');
+    fs.chmodSync(p, 0o400);
+    const result = checkCredentialsFileMode(p, logger);
+    assertEq(result, 'ok', 'checkCredentialsFileMode: mode 0400 (more restrictive) returns ok');
+    fs.chmodSync(p, 0o600); // restore so cleanup can delete
+  }
+
+  // 6. File in /tmp/ → 'warned' (tmpfs/shared-volume heuristic)
+  {
+    warnings.length = 0; errors.length = 0;
+    const p = path.join(TMP, 'creds-tmpfs.json');
+    fs.writeFileSync(p, '{}');
+    fs.chmodSync(p, 0o600);
+    const result = checkCredentialsFileMode(p, logger);
+    assertEq(result, 'warned', 'checkCredentialsFileMode: /tmp/ path returns warned');
+    assert(warnings.length > 0, 'checkCredentialsFileMode: /tmp/ path logs warning');
+    assert(warnings[0].includes('volatile'), 'checkCredentialsFileMode: warning mentions volatile');
+  }
+
+  try { fs.rmSync(MODE_TMP, { recursive: true, force: true }); } catch { /* ignore */ }
 }
 
 // ---------------------------------------------------------------------------

--- a/skill/plugin/fs-helpers.ts
+++ b/skill/plugin/fs-helpers.ts
@@ -1415,3 +1415,71 @@ export function patchOpenClawConfig(
     return 'error';
   }
 }
+
+// ---------------------------------------------------------------------------
+// Credentials file permission check (cred-1 security hardening)
+// ---------------------------------------------------------------------------
+
+/** Subset of the OpenClaw logger used by the permission check. */
+export interface PermissionCheckLogger {
+  warn(msg: string): void;
+  error(msg: string): void;
+}
+
+/**
+ * Result of `checkCredentialsFileMode`.
+ *
+ * - `'ok'` — file absent (not yet created) or permissions are exactly 0600.
+ * - `'insecure'` — file present with mode broader than 0600; caller must refuse to continue.
+ * - `'warned'` — file is 0600 but lives on a tmpfs / shared-volume path; logged.
+ * - `'stat_error'` — `fs.statSync` failed for an unexpected reason; caller should warn + continue.
+ */
+export type CredentialsPermissionResult = 'ok' | 'insecure' | 'warned' | 'stat_error';
+
+const TMPFS_PREFIXES = ['/tmp/', '/dev/shm/', '/run/', '/var/run/'];
+
+export function checkCredentialsFileMode(
+  credPath: string,
+  logger: PermissionCheckLogger,
+): CredentialsPermissionResult {
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(credPath);
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return 'ok';
+    logger.warn(`TotalReclaw: could not stat credentials file (${code ?? String(err)}); skipping permission check`);
+    return 'stat_error';
+  }
+
+  const mode = stat.mode & 0o777;
+  if (mode > 0o600) {
+    const modeStr = '0' + mode.toString(8);
+    logger.error(
+      `TotalReclaw: STARTUP REFUSED — credentials file has insecure permissions (${modeStr}).\n` +
+      `  File: ${credPath}\n` +
+      `  Fix:  chmod 600 "${credPath}"\n` +
+      `  Then restart your OpenClaw gateway.\n` +
+      `  Current mode ${modeStr} allows other OS users to read your recovery phrase.`,
+    );
+    return 'insecure';
+  }
+
+  try {
+    const real = fs.realpathSync(credPath);
+    for (const prefix of TMPFS_PREFIXES) {
+      if (real.startsWith(prefix)) {
+        logger.warn(
+          `TotalReclaw: credentials file is on a volatile/shared path (${real}). ` +
+          `It may be lost on reboot or be readable by other processes. ` +
+          `Consider moving it to a persistent private directory and updating TOTALRECLAW_CREDENTIALS_PATH.`,
+        );
+        return 'warned';
+      }
+    }
+  } catch {
+    // realpathSync can fail on unusual mounts — not actionable here
+  }
+
+  return 'ok';
+}

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -170,6 +170,7 @@ import {
   writePluginManifest,
   writePluginError,
   readPluginLoadedManifest,
+  checkCredentialsFileMode,
   type OnboardingState,
 } from './fs-helpers.js';
 import { isRcBuild } from './qa-bug-report.js';
@@ -3219,6 +3220,23 @@ const plugin = {
       }
     } catch {
       rcMode = false;
+    }
+
+    // ---------------------------------------------------------------
+    // Credentials file permission check (cred-1 — fail-closed security gate)
+    // ---------------------------------------------------------------
+    // Must run before any tool registration so that a misconfigured host
+    // is rejected immediately rather than silently operating with an exposed
+    // credentials file. checkCredentialsFileMode returns 'insecure' if the
+    // file mode is broader than 0600 — throw to abort plugin load.
+    {
+      const permResult = checkCredentialsFileMode(CREDENTIALS_PATH, api.logger);
+      if (permResult === 'insecure') {
+        throw new Error(
+          `TotalReclaw refused to load: credentials file has insecure permissions. ` +
+          `Run: chmod 600 "${CREDENTIALS_PATH}" then restart the gateway.`,
+        );
+      }
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements cred-1 per canonical-roadmap issue p-diogo/totalreclaw-internal#261.

**Risk tier:** L2
**Files changed:** 5
**Net diff:** +203 lines, -2 lines

## Done criteria (from issue)

- [ ] `docs/SECURITY.md` published
- [ ] `openclaw-setup.md` has Threat model section
- [ ] Plugin refuses to load if mode > 600 (with clear error message + fix instructions)

## What was implemented

- **`docs/SECURITY.md`** — updated Phase 1 status to shipped; added fail-closed startup-refusal description and `chmod 600` fix instructions
- **`docs/guides/openclaw-setup.md`** — new "Threat model" section explaining what `chmod 600` does and doesn't protect, with fix command for insecure-permissions error
- **`skill/plugin/fs-helpers.ts`** — new `checkCredentialsFileMode()` helper: stats the credentials file, returns `'insecure'` (mode > 0600), `'warned'` (tmpfs prefix), `'ok'`, or `'stat_error'`
- **`skill/plugin/index.ts`** — calls helper early in `register()` and throws to abort plugin load on `'insecure'` result; warn-only for tmpfs
- **`skill/plugin/fs-helpers.test.ts`** — 12 new TAP tests: absent file, mode 600/644/755/400, tmpfs path

## Test results

fs-helpers.test.ts: 105/105 passed (all pre-existing tests + 12 new permission-check tests)

Pre-existing `retype-setscope.test.ts` failure (missing `@totalreclaw/core` module) is unrelated to this change — reproduces on `main` before this branch.

Closes p-diogo/totalreclaw-internal#261