### PR TITLE
[imp-5] RAM pre-flight + 500MB hard cap

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -55,6 +55,9 @@ dependencies = [
     # ``totalreclaw.pair.remote_client`` for the transport, and the
     # rc.10 blueprint in the internal repo for the full design.
     "websockets>=12.0,<14",
+    # imp-5 — RAM pre-flight check in import adapters uses psutil.virtual_memory()
+    # to detect available memory before loading large files.
+    "psutil>=5.9",
 ]
 
 [project.optional-dependencies]

--- a/python/src/totalreclaw/import_adapters/chatgpt_adapter.py
+++ b/python/src/totalreclaw/import_adapters/chatgpt_adapter.py
@@ -5,10 +5,13 @@ Ported from skill/plugin/import-adapters/chatgpt-adapter.ts
 """
 
 import json
+import math
 import os
 import re
 from datetime import datetime, timezone
 from typing import Optional, Callable, List, Any
+
+import psutil
 
 from .base_adapter import BaseImportAdapter
 from .types import AdapterParseResult, ConversationChunk
@@ -37,6 +40,30 @@ class ChatGPTAdapter(BaseImportAdapter):
         elif file_path:
             try:
                 resolved = os.path.expanduser(file_path)
+                stat = os.stat(resolved)
+                file_size_mb = stat.st_size / (1024 * 1024)
+                if file_size_mb > 500:
+                    errors.append(
+                        f'File is too large to import: {file_size_mb:.1f}MB exceeds the 500MB cap. '
+                        'Split the file into smaller chunks and import each separately.',
+                    )
+                    return AdapterParseResult(
+                        facts=[], chunks=[], total_messages=0,
+                        warnings=warnings, errors=errors,
+                    )
+                free_mem = psutil.virtual_memory().available
+                if free_mem < stat.st_size * 2:
+                    free_mb = free_mem / (1024 * 1024)
+                    need_mb = math.ceil(stat.st_size * 2 / (1024 * 1024))
+                    errors.append(
+                        f'Not enough free memory: {free_mb:.0f}MB available, '
+                        f'~{need_mb}MB needed (2× file size). '
+                        'Close other applications or split the file.',
+                    )
+                    return AdapterParseResult(
+                        facts=[], chunks=[], total_messages=0,
+                        warnings=warnings, errors=errors,
+                    )
                 with open(resolved, 'r', encoding='utf-8') as f:
                     raw = f.read()
             except Exception as e:

--- a/python/src/totalreclaw/import_adapters/claude_adapter.py
+++ b/python/src/totalreclaw/import_adapters/claude_adapter.py
@@ -4,9 +4,12 @@ Claude import adapter -- parses plain text memories (one per line, optional date
 Ported from skill/plugin/import-adapters/claude-adapter.ts
 """
 
+import math
 import os
 import re
 from typing import Optional, Callable, List
+
+import psutil
 
 from .base_adapter import BaseImportAdapter
 from .types import AdapterParseResult, ConversationChunk
@@ -45,6 +48,30 @@ class ClaudeAdapter(BaseImportAdapter):
         elif file_path:
             try:
                 resolved = os.path.expanduser(file_path)
+                stat = os.stat(resolved)
+                file_size_mb = stat.st_size / (1024 * 1024)
+                if file_size_mb > 500:
+                    errors.append(
+                        f'File is too large to import: {file_size_mb:.1f}MB exceeds the 500MB cap. '
+                        'Split the file into smaller chunks and import each separately.',
+                    )
+                    return AdapterParseResult(
+                        facts=[], chunks=[], total_messages=0,
+                        warnings=warnings, errors=errors,
+                    )
+                free_mem = psutil.virtual_memory().available
+                if free_mem < stat.st_size * 2:
+                    free_mb = free_mem / (1024 * 1024)
+                    need_mb = math.ceil(stat.st_size * 2 / (1024 * 1024))
+                    errors.append(
+                        f'Not enough free memory: {free_mb:.0f}MB available, '
+                        f'~{need_mb}MB needed (2× file size). '
+                        'Close other applications or split the file.',
+                    )
+                    return AdapterParseResult(
+                        facts=[], chunks=[], total_messages=0,
+                        warnings=warnings, errors=errors,
+                    )
                 with open(resolved, 'r', encoding='utf-8') as f:
                     raw = f.read()
             except Exception as e:

--- a/python/src/totalreclaw/import_adapters/gemini_adapter.py
+++ b/python/src/totalreclaw/import_adapters/gemini_adapter.py
@@ -4,11 +4,14 @@ Gemini import adapter -- parses Google Takeout HTML (My Activity.html).
 Ported from skill/plugin/import-adapters/gemini-adapter.ts
 """
 
+import math
 import os
 import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Optional, Callable, List
+
+import psutil
 
 from .base_adapter import BaseImportAdapter
 from .types import AdapterParseResult, ConversationChunk
@@ -112,6 +115,30 @@ class GeminiAdapter(BaseImportAdapter):
         elif file_path:
             try:
                 resolved = os.path.expanduser(file_path)
+                stat = os.stat(resolved)
+                file_size_mb = stat.st_size / (1024 * 1024)
+                if file_size_mb > 500:
+                    errors.append(
+                        f'File is too large to import: {file_size_mb:.1f}MB exceeds the 500MB cap. '
+                        'Split the file into smaller chunks and import each separately.',
+                    )
+                    return AdapterParseResult(
+                        facts=[], chunks=[], total_messages=0,
+                        warnings=warnings, errors=errors,
+                    )
+                free_mem = psutil.virtual_memory().available
+                if free_mem < stat.st_size * 2:
+                    free_mb = free_mem / (1024 * 1024)
+                    need_mb = math.ceil(stat.st_size * 2 / (1024 * 1024))
+                    errors.append(
+                        f'Not enough free memory: {free_mb:.0f}MB available, '
+                        f'~{need_mb}MB needed (2× file size). '
+                        'Close other applications or split the file.',
+                    )
+                    return AdapterParseResult(
+                        facts=[], chunks=[], total_messages=0,
+                        warnings=warnings, errors=errors,
+                    )
                 with open(resolved, 'r', encoding='utf-8') as f:
                     html = f.read()
             except Exception as e:

--- a/python/src/totalreclaw/import_adapters/mem0_adapter.py
+++ b/python/src/totalreclaw/import_adapters/mem0_adapter.py
@@ -19,8 +19,11 @@ add it in a follow-up (TODO flagged in README).
 from __future__ import annotations
 
 import json
+import math
 import os
 from typing import Any, Callable, Dict, List, Optional
+
+import psutil
 
 from .base_adapter import BaseImportAdapter
 from .types import AdapterParseResult
@@ -69,6 +72,30 @@ class Mem0Adapter(BaseImportAdapter):
         elif file_path:
             try:
                 resolved = os.path.expanduser(file_path)
+                stat = os.stat(resolved)
+                file_size_mb = stat.st_size / (1024 * 1024)
+                if file_size_mb > 500:
+                    errors.append(
+                        f'File is too large to import: {file_size_mb:.1f}MB exceeds the 500MB cap. '
+                        'Split the file into smaller chunks and import each separately.',
+                    )
+                    return AdapterParseResult(
+                        facts=[], chunks=[], total_messages=0,
+                        warnings=warnings, errors=errors,
+                    )
+                free_mem = psutil.virtual_memory().available
+                if free_mem < stat.st_size * 2:
+                    free_mb = free_mem / (1024 * 1024)
+                    need_mb = math.ceil(stat.st_size * 2 / (1024 * 1024))
+                    errors.append(
+                        f'Not enough free memory: {free_mb:.0f}MB available, '
+                        f'~{need_mb}MB needed (2× file size). '
+                        'Close other applications or split the file.',
+                    )
+                    return AdapterParseResult(
+                        facts=[], chunks=[], total_messages=0,
+                        warnings=warnings, errors=errors,
+                    )
                 with open(resolved, 'r', encoding='utf-8') as f:
                     raw = f.read()
             except Exception as e:

--- a/python/tests/test_import_adapter_preflight.py
+++ b/python/tests/test_import_adapter_preflight.py
@@ -1,0 +1,147 @@
+"""Tests for the file-size + RAM preflight checks added in imp-5.
+
+Covers all four file-based adapters: Claude, ChatGPT, Gemini, Mem0.
+Uses monkeypatching (pytest's built-in) to avoid creating 500MB files.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_stat(size_bytes: int):
+    """Return a real os.stat_result with the given size, reusing /dev/null's stat."""
+    real = os.stat('/dev/null')
+    # os.stat_result is immutable but we can build a fake via os.stat_result((mode,...))
+    # Simpler: use unittest.mock.MagicMock
+    from unittest.mock import MagicMock
+    m = MagicMock()
+    m.st_size = size_bytes
+    return m
+
+
+# ---------------------------------------------------------------------------
+# 500MB hard cap
+# ---------------------------------------------------------------------------
+
+class TestFileSizeCap:
+    def _assert_size_error(self, result, adapter_name: str) -> None:
+        assert len(result.errors) > 0, f'{adapter_name}: oversized file must return error'
+        assert '500MB' in result.errors[0], (
+            f'{adapter_name}: error must mention 500MB cap, got: {result.errors[0]}'
+        )
+        assert len(result.facts) == 0
+        assert len(result.chunks) == 0
+
+    def test_claude_adapter_rejects_oversized_file(self, monkeypatch) -> None:
+        from totalreclaw.import_adapters.claude_adapter import ClaudeAdapter
+        monkeypatch.setattr(os, 'stat', lambda _: _make_stat(501 * 1024 * 1024))
+        result = ClaudeAdapter().parse(file_path='/tmp/fake-large.txt')
+        self._assert_size_error(result, 'Claude')
+        assert '501' in result.errors[0] or '500MB' in result.errors[0]
+
+    def test_chatgpt_adapter_rejects_oversized_file(self, monkeypatch) -> None:
+        from totalreclaw.import_adapters.chatgpt_adapter import ChatGPTAdapter
+        monkeypatch.setattr(os, 'stat', lambda _: _make_stat(600 * 1024 * 1024))
+        result = ChatGPTAdapter().parse(file_path='/tmp/fake-large.json')
+        self._assert_size_error(result, 'ChatGPT')
+
+    def test_gemini_adapter_rejects_oversized_file(self, monkeypatch) -> None:
+        from totalreclaw.import_adapters.gemini_adapter import GeminiAdapter
+        monkeypatch.setattr(os, 'stat', lambda _: _make_stat(510 * 1024 * 1024))
+        result = GeminiAdapter().parse(file_path='/tmp/fake-large.html')
+        self._assert_size_error(result, 'Gemini')
+
+    def test_mem0_adapter_rejects_oversized_file(self, monkeypatch) -> None:
+        from totalreclaw.import_adapters.mem0_adapter import Mem0Adapter
+        monkeypatch.setattr(os, 'stat', lambda _: _make_stat(520 * 1024 * 1024))
+        result = Mem0Adapter().parse(file_path='/tmp/fake-large.json')
+        self._assert_size_error(result, 'Mem0')
+
+    def test_error_message_names_actual_size(self, monkeypatch) -> None:
+        from totalreclaw.import_adapters.claude_adapter import ClaudeAdapter
+        monkeypatch.setattr(os, 'stat', lambda _: _make_stat(501 * 1024 * 1024))
+        result = ClaudeAdapter().parse(file_path='/tmp/fake-large.txt')
+        # Error should name the actual file size (501.0MB)
+        assert '501' in result.errors[0], (
+            f'Error should name actual size: {result.errors[0]}'
+        )
+
+
+# ---------------------------------------------------------------------------
+# RAM preflight
+# ---------------------------------------------------------------------------
+
+class TestRamPreflight:
+    def test_claude_adapter_rejects_on_low_ram(self, monkeypatch) -> None:
+        import psutil
+        from totalreclaw.import_adapters.claude_adapter import ClaudeAdapter
+
+        # 10MB file, but only 1MB free (< 2x = 20MB needed)
+        monkeypatch.setattr(os, 'stat', lambda _: _make_stat(10 * 1024 * 1024))
+        mock_vm = type('VM', (), {'available': 1 * 1024 * 1024})()
+        monkeypatch.setattr(psutil, 'virtual_memory', lambda: mock_vm)
+
+        result = ClaudeAdapter().parse(file_path='/tmp/fake-low-mem.txt')
+        assert len(result.errors) > 0, 'Low RAM must return error'
+        assert 'memory' in result.errors[0].lower(), (
+            f'Error must mention memory: {result.errors[0]}'
+        )
+
+    def test_ram_error_names_available_and_needed(self, monkeypatch) -> None:
+        import psutil
+        from totalreclaw.import_adapters.chatgpt_adapter import ChatGPTAdapter
+
+        # 100MB file, 50MB free → needs 200MB
+        monkeypatch.setattr(os, 'stat', lambda _: _make_stat(100 * 1024 * 1024))
+        mock_vm = type('VM', (), {'available': 50 * 1024 * 1024})()
+        monkeypatch.setattr(psutil, 'virtual_memory', lambda: mock_vm)
+
+        result = ChatGPTAdapter().parse(file_path='/tmp/fake-low-mem.json')
+        assert len(result.errors) > 0
+        err = result.errors[0]
+        assert '50' in err, f'Error should name available RAM (50MB): {err}'
+        assert '200' in err, f'Error should name needed RAM (200MB): {err}'
+
+
+# ---------------------------------------------------------------------------
+# Normal-sized files pass preflight (end-to-end with real temp file)
+# ---------------------------------------------------------------------------
+
+class TestPreflightPassthrough:
+    def test_claude_normal_file_passes_preflight(self) -> None:
+        from totalreclaw.import_adapters.claude_adapter import ClaudeAdapter
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+            f.write('User prefers dark mode\nUser works remotely\n')
+            path = f.name
+
+        try:
+            result = ClaudeAdapter().parse(file_path=path)
+            assert len(result.errors) == 0, f'Normal file should have no errors: {result.errors}'
+            assert len(result.chunks) > 0, 'Normal file should produce chunks'
+        finally:
+            os.unlink(path)
+
+    def test_mem0_normal_file_passes_preflight(self) -> None:
+        import json
+        from totalreclaw.import_adapters.mem0_adapter import Mem0Adapter
+
+        data = {'results': [{'id': '1', 'memory': 'User prefers TypeScript', 'categories': ['preference']}]}
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump(data, f)
+            path = f.name
+
+        try:
+            result = Mem0Adapter().parse(file_path=path)
+            assert len(result.errors) == 0, f'Normal file should have no errors: {result.errors}'
+            assert len(result.facts) == 1
+        finally:
+            os.unlink(path)

--- a/python/tests/test_import_adapter_preflight.py
+++ b/python/tests/test_import_adapter_preflight.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import os
 import tempfile
-from unittest.mock import patch
 
 import pytest
 
@@ -16,15 +15,36 @@ import pytest
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_stat(size_bytes: int):
-    """Return a real os.stat_result with the given size, reusing /dev/null's stat."""
-    real = os.stat('/dev/null')
-    # os.stat_result is immutable but we can build a fake via os.stat_result((mode,...))
-    # Simpler: use unittest.mock.MagicMock
+# Sentinel path prefix used in size/RAM tests so the mock knows which calls
+# to intercept vs. delegate to the real os.stat.
+_FAKE_PATH_PREFIX = '/tmp/totalreclaw-preflight-fake-'
+
+
+def _make_fake_stat(size_bytes: int):
     from unittest.mock import MagicMock
     m = MagicMock()
     m.st_size = size_bytes
+    # Make st_mode look like a regular file (0o100644) so any S_ISDIR() checks
+    # on the mock return False rather than blowing up.
+    m.st_mode = 0o100644
     return m
+
+
+def _patched_stat(size_bytes: int):
+    """Return a drop-in replacement for os.stat that fakes size for preflight paths."""
+    _real_stat = os.stat
+
+    def _mock(*args, **kwargs):
+        path = str(args[0]) if args else str(kwargs.get('path', ''))
+        if _FAKE_PATH_PREFIX in path:
+            return _make_fake_stat(size_bytes)
+        return _real_stat(*args, **kwargs)
+
+    return _mock
+
+
+def _fake_path(suffix: str) -> str:
+    return f'{_FAKE_PATH_PREFIX}{suffix}'
 
 
 # ---------------------------------------------------------------------------
@@ -42,36 +62,35 @@ class TestFileSizeCap:
 
     def test_claude_adapter_rejects_oversized_file(self, monkeypatch) -> None:
         from totalreclaw.import_adapters.claude_adapter import ClaudeAdapter
-        monkeypatch.setattr(os, 'stat', lambda _: _make_stat(501 * 1024 * 1024))
-        result = ClaudeAdapter().parse(file_path='/tmp/fake-large.txt')
+        monkeypatch.setattr(os, 'stat', _patched_stat(501 * 1024 * 1024))
+        result = ClaudeAdapter().parse(file_path=_fake_path('claude.txt'))
         self._assert_size_error(result, 'Claude')
-        assert '501' in result.errors[0] or '500MB' in result.errors[0]
+        assert '501' in result.errors[0]
 
     def test_chatgpt_adapter_rejects_oversized_file(self, monkeypatch) -> None:
         from totalreclaw.import_adapters.chatgpt_adapter import ChatGPTAdapter
-        monkeypatch.setattr(os, 'stat', lambda _: _make_stat(600 * 1024 * 1024))
-        result = ChatGPTAdapter().parse(file_path='/tmp/fake-large.json')
+        monkeypatch.setattr(os, 'stat', _patched_stat(600 * 1024 * 1024))
+        result = ChatGPTAdapter().parse(file_path=_fake_path('chatgpt.json'))
         self._assert_size_error(result, 'ChatGPT')
 
     def test_gemini_adapter_rejects_oversized_file(self, monkeypatch) -> None:
         from totalreclaw.import_adapters.gemini_adapter import GeminiAdapter
-        monkeypatch.setattr(os, 'stat', lambda _: _make_stat(510 * 1024 * 1024))
-        result = GeminiAdapter().parse(file_path='/tmp/fake-large.html')
+        monkeypatch.setattr(os, 'stat', _patched_stat(510 * 1024 * 1024))
+        result = GeminiAdapter().parse(file_path=_fake_path('gemini.html'))
         self._assert_size_error(result, 'Gemini')
 
     def test_mem0_adapter_rejects_oversized_file(self, monkeypatch) -> None:
         from totalreclaw.import_adapters.mem0_adapter import Mem0Adapter
-        monkeypatch.setattr(os, 'stat', lambda _: _make_stat(520 * 1024 * 1024))
-        result = Mem0Adapter().parse(file_path='/tmp/fake-large.json')
+        monkeypatch.setattr(os, 'stat', _patched_stat(520 * 1024 * 1024))
+        result = Mem0Adapter().parse(file_path=_fake_path('mem0.json'))
         self._assert_size_error(result, 'Mem0')
 
     def test_error_message_names_actual_size(self, monkeypatch) -> None:
         from totalreclaw.import_adapters.claude_adapter import ClaudeAdapter
-        monkeypatch.setattr(os, 'stat', lambda _: _make_stat(501 * 1024 * 1024))
-        result = ClaudeAdapter().parse(file_path='/tmp/fake-large.txt')
-        # Error should name the actual file size (501.0MB)
+        monkeypatch.setattr(os, 'stat', _patched_stat(501 * 1024 * 1024))
+        result = ClaudeAdapter().parse(file_path=_fake_path('claude-size.txt'))
         assert '501' in result.errors[0], (
-            f'Error should name actual size: {result.errors[0]}'
+            f'Error should name actual size (501MB): {result.errors[0]}'
         )
 
 
@@ -84,12 +103,12 @@ class TestRamPreflight:
         import psutil
         from totalreclaw.import_adapters.claude_adapter import ClaudeAdapter
 
-        # 10MB file, but only 1MB free (< 2x = 20MB needed)
-        monkeypatch.setattr(os, 'stat', lambda _: _make_stat(10 * 1024 * 1024))
+        # 10MB file, only 1MB free (< 2x = 20MB needed)
+        monkeypatch.setattr(os, 'stat', _patched_stat(10 * 1024 * 1024))
         mock_vm = type('VM', (), {'available': 1 * 1024 * 1024})()
         monkeypatch.setattr(psutil, 'virtual_memory', lambda: mock_vm)
 
-        result = ClaudeAdapter().parse(file_path='/tmp/fake-low-mem.txt')
+        result = ClaudeAdapter().parse(file_path=_fake_path('claude-lowram.txt'))
         assert len(result.errors) > 0, 'Low RAM must return error'
         assert 'memory' in result.errors[0].lower(), (
             f'Error must mention memory: {result.errors[0]}'
@@ -100,11 +119,11 @@ class TestRamPreflight:
         from totalreclaw.import_adapters.chatgpt_adapter import ChatGPTAdapter
 
         # 100MB file, 50MB free → needs 200MB
-        monkeypatch.setattr(os, 'stat', lambda _: _make_stat(100 * 1024 * 1024))
+        monkeypatch.setattr(os, 'stat', _patched_stat(100 * 1024 * 1024))
         mock_vm = type('VM', (), {'available': 50 * 1024 * 1024})()
         monkeypatch.setattr(psutil, 'virtual_memory', lambda: mock_vm)
 
-        result = ChatGPTAdapter().parse(file_path='/tmp/fake-low-mem.json')
+        result = ChatGPTAdapter().parse(file_path=_fake_path('chatgpt-lowram.json'))
         assert len(result.errors) > 0
         err = result.errors[0]
         assert '50' in err, f'Error should name available RAM (50MB): {err}'

--- a/skill/plugin/import-adapters/chatgpt-adapter.ts
+++ b/skill/plugin/import-adapters/chatgpt-adapter.ts
@@ -59,6 +59,24 @@ export class ChatGPTAdapter extends BaseImportAdapter {
     } else if (input.file_path) {
       try {
         const resolvedPath = input.file_path.replace(/^~/, os.homedir());
+        const fileStat = fs.statSync(resolvedPath);
+        const fileSizeMB = fileStat.size / (1024 * 1024);
+        if (fileSizeMB > 500) {
+          errors.push(
+            `File is too large to import: ${fileSizeMB.toFixed(1)}MB exceeds the 500MB cap. ` +
+            'Split the file into smaller chunks and import each separately.',
+          );
+          return { facts: [], chunks: [], totalMessages: 0, warnings, errors };
+        }
+        const freeMem = os.freemem();
+        if (freeMem < fileStat.size * 2) {
+          errors.push(
+            `Not enough free memory: ${(freeMem / (1024 * 1024)).toFixed(0)}MB available, ` +
+            `~${Math.ceil(fileStat.size * 2 / (1024 * 1024))}MB needed (2× file size). ` +
+            'Close other applications or split the file.',
+          );
+          return { facts: [], chunks: [], totalMessages: 0, warnings, errors };
+        }
         content = fs.readFileSync(resolvedPath, 'utf-8');
       } catch (e) {
         errors.push(`Failed to read file: ${e instanceof Error ? e.message : 'Unknown error'}`);

--- a/skill/plugin/import-adapters/claude-adapter.ts
+++ b/skill/plugin/import-adapters/claude-adapter.ts
@@ -45,6 +45,24 @@ export class ClaudeAdapter extends BaseImportAdapter {
     } else if (input.file_path) {
       try {
         const resolvedPath = input.file_path.replace(/^~/, os.homedir());
+        const fileStat = fs.statSync(resolvedPath);
+        const fileSizeMB = fileStat.size / (1024 * 1024);
+        if (fileSizeMB > 500) {
+          errors.push(
+            `File is too large to import: ${fileSizeMB.toFixed(1)}MB exceeds the 500MB cap. ` +
+            'Split the file into smaller chunks and import each separately.',
+          );
+          return { facts: [], chunks: [], totalMessages: 0, warnings, errors };
+        }
+        const freeMem = os.freemem();
+        if (freeMem < fileStat.size * 2) {
+          errors.push(
+            `Not enough free memory: ${(freeMem / (1024 * 1024)).toFixed(0)}MB available, ` +
+            `~${Math.ceil(fileStat.size * 2 / (1024 * 1024))}MB needed (2× file size). ` +
+            'Close other applications or split the file.',
+          );
+          return { facts: [], chunks: [], totalMessages: 0, warnings, errors };
+        }
         content = fs.readFileSync(resolvedPath, 'utf-8');
       } catch (e) {
         errors.push(`Failed to read file: ${e instanceof Error ? e.message : 'Unknown error'}`);

--- a/skill/plugin/import-adapters/gemini-adapter.ts
+++ b/skill/plugin/import-adapters/gemini-adapter.ts
@@ -75,6 +75,24 @@ export class GeminiAdapter extends BaseImportAdapter {
     } else if (input.file_path) {
       try {
         const resolved = input.file_path.replace(/^~/, os.homedir());
+        const fileStat = fs.statSync(resolved);
+        const fileSizeMB = fileStat.size / (1024 * 1024);
+        if (fileSizeMB > 500) {
+          errors.push(
+            `File is too large to import: ${fileSizeMB.toFixed(1)}MB exceeds the 500MB cap. ` +
+            'Split the file into smaller chunks and import each separately.',
+          );
+          return { facts: [], chunks: [], totalMessages: 0, warnings, errors };
+        }
+        const freeMem = os.freemem();
+        if (freeMem < fileStat.size * 2) {
+          errors.push(
+            `Not enough free memory: ${(freeMem / (1024 * 1024)).toFixed(0)}MB available, ` +
+            `~${Math.ceil(fileStat.size * 2 / (1024 * 1024))}MB needed (2× file size). ` +
+            'Close other applications or split the file.',
+          );
+          return { facts: [], chunks: [], totalMessages: 0, warnings, errors };
+        }
         content = fs.readFileSync(resolved, 'utf-8');
       } catch (e) {
         errors.push(`Failed to read file: ${e instanceof Error ? e.message : 'Unknown error'}`);

--- a/skill/plugin/import-adapters/import-adapters.test.ts
+++ b/skill/plugin/import-adapters/import-adapters.test.ts
@@ -14,6 +14,7 @@ import { Mem0Adapter } from './mem0-adapter.js';
 import { MCPMemoryAdapter } from './mcp-memory-adapter.js';
 import { ChatGPTAdapter } from './chatgpt-adapter.js';
 import { ClaudeAdapter } from './claude-adapter.js';
+import { GeminiAdapter } from './gemini-adapter.js';
 import { BaseImportAdapter } from './base-adapter.js';
 import { getAdapter } from './index.js';
 import type {
@@ -22,6 +23,8 @@ import type {
   ImportSource,
   ProgressCallback,
 } from './types.js';
+import fs from 'node:fs';
+import os from 'node:os';
 
 // ---------------------------------------------------------------------------
 // TAP Helpers
@@ -1097,6 +1100,82 @@ User prefers TypeScript over JavaScript`;
       assert(msg.includes('mcp-memory'), 'getAdapter error lists "mcp-memory" as valid source');
       assert(msg.includes('chatgpt'), 'getAdapter error lists "chatgpt" as valid source');
       assert(msg.includes('claude'), 'getAdapter error lists "claude" as valid source');
+    }
+  }
+
+  // =========================================================================
+  // File preflight — 500MB cap + RAM check
+  // =========================================================================
+
+  console.log('# File preflight checks');
+
+  // Monkey-patch helpers for statSync / freemem without a mocking framework.
+  async function withFakeStat(fakeSize: number, fn: () => Promise<void>): Promise<void> {
+    const orig = fs.statSync;
+    (fs as any).statSync = (_p: string) => ({ size: fakeSize } as fs.Stats);
+    await fn().finally(() => { (fs as any).statSync = orig; });
+  }
+  async function withFakeFreemem(fakeBytes: number, fn: () => Promise<void>): Promise<void> {
+    const orig = os.freemem;
+    os.freemem = () => fakeBytes;
+    await fn().finally(() => { os.freemem = orig; });
+  }
+
+  // --- 500MB hard cap returns an error with size info (Claude) ---
+  {
+    await withFakeStat(501 * 1024 * 1024, async () => {
+      const result = await new ClaudeAdapter().parse({ file_path: '/tmp/fake-large.txt' });
+      assert(result.errors.length > 0, 'Preflight: Claude oversized file returns error');
+      assert(
+        result.errors[0].includes('501') || result.errors[0].includes('500MB'),
+        `Preflight: Claude error mentions size/cap (got: ${result.errors[0]})`,
+      );
+      assert(result.chunks.length === 0, 'Preflight: no chunks on oversized file');
+    });
+  }
+
+  // --- 500MB hard cap (ChatGPT) ---
+  {
+    await withFakeStat(600 * 1024 * 1024, async () => {
+      const result = await new ChatGPTAdapter().parse({ file_path: '/tmp/fake-large.json' });
+      assert(result.errors.length > 0, 'Preflight: ChatGPT oversized file returns error');
+      assert(result.errors[0].includes('500MB'), 'Preflight: ChatGPT error mentions 500MB cap');
+    });
+  }
+
+  // --- 500MB hard cap (Gemini) ---
+  {
+    await withFakeStat(510 * 1024 * 1024, async () => {
+      const result = await new GeminiAdapter().parse({ file_path: '/tmp/fake-large.html' });
+      assert(result.errors.length > 0, 'Preflight: Gemini oversized file returns error');
+      assert(result.errors[0].includes('500MB'), 'Preflight: Gemini error mentions 500MB cap');
+    });
+  }
+
+  // --- RAM preflight triggers when freemem < 2x file size (Claude) ---
+  {
+    await withFakeFreemem(1 * 1024 * 1024, async () => {  // 1MB free
+      await withFakeStat(10 * 1024 * 1024, async () => {  // 10MB file (passes 500MB check)
+        const result = await new ClaudeAdapter().parse({ file_path: '/tmp/fake-low-mem.txt' });
+        assert(result.errors.length > 0, 'Preflight: low RAM returns error');
+        assert(
+          result.errors[0].toLowerCase().includes('memory'),
+          `Preflight: RAM error mentions memory (got: ${result.errors[0]})`,
+        );
+      });
+    });
+  }
+
+  // --- normal-sized file passes preflight (real temp file) ---
+  {
+    const tmpFile = os.tmpdir() + '/totalreclaw-preflight-test.txt';
+    fs.writeFileSync(tmpFile, 'User prefers dark mode\nUser works remotely\n', 'utf-8');
+    try {
+      const result = await new ClaudeAdapter().parse({ file_path: tmpFile });
+      assert(result.errors.length === 0, 'Preflight: normal file has no errors');
+      assert(result.chunks.length > 0, 'Preflight: normal file produces chunks');
+    } finally {
+      fs.unlinkSync(tmpFile);
     }
   }
 

--- a/skill/plugin/import-adapters/mcp-memory-adapter.ts
+++ b/skill/plugin/import-adapters/mcp-memory-adapter.ts
@@ -64,6 +64,24 @@ export class MCPMemoryAdapter extends BaseImportAdapter {
     } else if (input.file_path) {
       try {
         const resolvedPath = input.file_path.replace(/^~/, os.homedir());
+        const fileStat = fs.statSync(resolvedPath);
+        const fileSizeMB = fileStat.size / (1024 * 1024);
+        if (fileSizeMB > 500) {
+          errors.push(
+            `File is too large to import: ${fileSizeMB.toFixed(1)}MB exceeds the 500MB cap. ` +
+            'Split the file into smaller chunks and import each separately.',
+          );
+          return { facts: [], chunks: [], totalMessages: 0, warnings, errors };
+        }
+        const freeMem = os.freemem();
+        if (freeMem < fileStat.size * 2) {
+          errors.push(
+            `Not enough free memory: ${(freeMem / (1024 * 1024)).toFixed(0)}MB available, ` +
+            `~${Math.ceil(fileStat.size * 2 / (1024 * 1024))}MB needed (2× file size). ` +
+            'Close other applications or split the file.',
+          );
+          return { facts: [], chunks: [], totalMessages: 0, warnings, errors };
+        }
         content = fs.readFileSync(resolvedPath, 'utf-8');
       } catch (e) {
         errors.push(`Failed to read file: ${e instanceof Error ? e.message : 'Unknown error'}`);


### PR DESCRIPTION
🤖 Autonomous implementation — agent/imp-5

## Summary

Implements imp-5 per canonical-roadmap issue p-diogo/totalreclaw-internal#247.

**Risk tier:** L2
**Files changed:** 11
**Net diff:** 428 insertions

## Done criteria (from issue)

- [x] OOM-proof on small VPS hosts
- [x] Helpful error names actual file size + cap

## Changes

All eight file-based import adapters now gate on two checks before calling `readFileSync` / `open()`:

1. **500MB hard cap** — `fs.statSync` / `os.stat` before reading; rejects with a message naming the actual size and the cap. No 500MB file is ever loaded into memory.
2. **RAM preflight** — `os.freemem()` / `psutil.virtual_memory().available` must be ≥ 2× file size; rejects with available + needed MB in the error message.

Adapters covered: TS (claude, chatgpt, gemini, mcp-memory) + Python (claude, chatgpt, gemini, mem0). `psutil>=5.9` added to Python package dependencies.

## Test results

- **TS:** 196/196 pass (11 new preflight tests)
- **Python:** 9/9 new preflight tests pass + 18/18 existing mem0 adapter tests still pass

## RC artifacts

- Plugin: `totalreclaw@3.3.12-rc.7` on ClawHub — `clawhub install totalreclaw --version 3.3.12-rc.7`
- Python: `totalreclaw==2.3.6rc3` on PyPI — `pip install totalreclaw==2.3.6rc3`

Coordinator: please run `qa-totalreclaw` against these RCs.

Closes p-diogo/totalreclaw-internal#247