### PR TITLE
[am-4] searchWithExpansion (query reformulations RRF'd)

### DIFF
--- a/rust/totalreclaw-core/src/python.rs
+++ b/rust/totalreclaw-core/src/python.rs
@@ -886,6 +886,50 @@ fn hex_blob_to_base64(hex_blob: &str) -> Option<String> {
     search::hex_blob_to_base64(hex_blob)
 }
 
+/// Generate trapdoors for multiple query reformulations (expansion pipeline).
+///
+/// Args:
+///     queries: List of query strings (original query + reformulations).
+///     embeddings: List of embedding vectors (one list-of-floats per query).
+///     lsh_hasher: A LshHasher instance.
+///
+/// Returns:
+///     List of trapdoor-string lists, one per query.
+#[cfg(feature = "managed")]
+#[pyfunction]
+fn generate_expansion_trapdoors(
+    queries: Vec<String>,
+    embeddings: Vec<Vec<f32>>,
+    lsh_hasher: &PyLshHasher,
+) -> PyResult<Vec<Vec<String>>> {
+    let query_refs: Vec<&str> = queries.iter().map(|s| s.as_str()).collect();
+    let embedding_refs: Vec<&[f32]> = embeddings.iter().map(|v| v.as_slice()).collect();
+    search::generate_expansion_trapdoors(&query_refs, &embedding_refs, &lsh_hasher.inner)
+        .map_err(to_pyerr)
+}
+
+/// Merge multiple SubgraphFact sets from parallel query reformulations via RRF.
+///
+/// Args:
+///     fact_sets_json: JSON string containing an array of SubgraphFact arrays
+///         (one array per reformulation, ordered by relevance).
+///     rrf_k: RRF k-parameter. Use 60.0 for default behaviour.
+///
+/// Returns:
+///     JSON string of the merged, deduplicated SubgraphFact array sorted by
+///     descending RRF score.
+#[cfg(feature = "managed")]
+#[pyfunction]
+fn merge_expansion_results(fact_sets_json: &str, rrf_k: f64) -> PyResult<String> {
+    let fact_sets: Vec<Vec<search::SubgraphFact>> = serde_json::from_str(fact_sets_json)
+        .map_err(|e| PyValueError::new_err(format!("Invalid fact_sets JSON: {}", e)))?;
+    let set_refs: Vec<&[search::SubgraphFact]> = fact_sets.iter().map(|v| v.as_slice()).collect();
+    let config = search::ExpansionConfig { rrf_k };
+    let merged = search::merge_expansion_results(&set_refs, &config);
+    serde_json::to_string(&merged)
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
+}
+
 // ---------------------------------------------------------------------------
 // Knowledge Graph Phase 1
 // ---------------------------------------------------------------------------
@@ -1616,6 +1660,8 @@ fn totalreclaw_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
         m.add_function(wrap_pyfunction!(get_broadened_search_query, m)?)?;
         m.add_function(wrap_pyfunction!(get_export_query, m)?)?;
         m.add_function(wrap_pyfunction!(hex_blob_to_base64, m)?)?;
+        m.add_function(wrap_pyfunction!(generate_expansion_trapdoors, m)?)?;
+        m.add_function(wrap_pyfunction!(merge_expansion_results, m)?)?;
     }
 
     // Knowledge Graph Phase 1

--- a/rust/totalreclaw-core/src/python.rs
+++ b/rust/totalreclaw-core/src/python.rs
@@ -416,6 +416,8 @@ fn py_rerank_with_config(
         serde_json::from_str(candidates_json).map_err(|e| PyValueError::new_err(e.to_string()))?;
     let config = reranker::RerankerConfig {
         apply_source_weights,
+        bm25_weight_override: None,
+        vector_weight_override: None,
     };
     let results = reranker::rerank_with_config(query, &query_embedding, &candidates, top_k, config)
         .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;

--- a/rust/totalreclaw-core/src/reranker.rs
+++ b/rust/totalreclaw-core/src/reranker.rs
@@ -71,11 +71,24 @@ pub fn source_weight(source: MemorySource) -> f64 {
 /// v0 callers can stay with the legacy [`rerank`] API (no source awareness).
 /// v1+ callers use [`rerank_with_config`] with `apply_source_weights = true`
 /// so the final RRF score respects provenance per Retrieval v2 Tier 1.
+///
+/// The optional `bm25_weight_override` / `vector_weight_override` fields let
+/// callers pin fixed fusion weights instead of the default intent-weighted
+/// formula (`0.3 + 0.3*(1-intent)` / `0.3 + 0.3*intent`). Pass `None` for
+/// both to get the original adaptive behaviour (am-4 tunable-weight surface).
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct RerankerConfig {
     /// When true, multiply the final fused score by the source-weight for each
     /// candidate. When false, behaviour is identical to the v0 [`rerank`] fn.
     pub apply_source_weights: bool,
+    /// Optional fixed BM25 fusion weight (0.0..=1.0). Overrides the
+    /// intent-weighted formula when `Some`. Default: `None` (adaptive).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bm25_weight_override: Option<f64>,
+    /// Optional fixed vector (cosine) fusion weight (0.0..=1.0). Overrides the
+    /// intent-weighted formula when `Some`. Default: `None` (adaptive).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vector_weight_override: Option<f64>,
 }
 
 impl Default for RerankerConfig {
@@ -84,6 +97,8 @@ impl Default for RerankerConfig {
     fn default() -> Self {
         RerankerConfig {
             apply_source_weights: false,
+            bm25_weight_override: None,
+            vector_weight_override: None,
         }
     }
 }
@@ -225,8 +240,12 @@ pub fn rerank_with_config(
     let mut results: Vec<RankedResult> = Vec::with_capacity(candidates.len());
     for (i, candidate) in candidates.iter().enumerate() {
         let intent_score = cosine_scores[i].clamp(0.0, 1.0);
-        let bm25_weight = 0.3 + 0.3 * (1.0 - intent_score);
-        let cosine_weight = 0.3 + 0.3 * intent_score;
+        let bm25_weight = config
+            .bm25_weight_override
+            .unwrap_or(0.3 + 0.3 * (1.0 - intent_score));
+        let cosine_weight = config
+            .vector_weight_override
+            .unwrap_or(0.3 + 0.3 * intent_score);
 
         let rrf_bm25 = 1.0 / (RRF_K + bm25_ranks[i] as f64);
         let rrf_cosine = 1.0 / (RRF_K + cosine_ranks[i] as f64);
@@ -505,6 +524,7 @@ mod tests {
             10,
             RerankerConfig {
                 apply_source_weights: false,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -548,6 +568,7 @@ mod tests {
             10,
             RerankerConfig {
                 apply_source_weights: true,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -588,6 +609,7 @@ mod tests {
             10,
             RerankerConfig {
                 apply_source_weights: true,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -645,6 +667,7 @@ mod tests {
             10,
             RerankerConfig {
                 apply_source_weights: false,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -655,6 +678,7 @@ mod tests {
             10,
             RerankerConfig {
                 apply_source_weights: true,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -718,6 +742,7 @@ mod tests {
             10,
             RerankerConfig {
                 apply_source_weights: true,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -763,6 +788,7 @@ mod tests {
             10,
             RerankerConfig {
                 apply_source_weights: false,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -773,6 +799,7 @@ mod tests {
             10,
             RerankerConfig {
                 apply_source_weights: true,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -819,6 +846,7 @@ mod tests {
             10,
             RerankerConfig {
                 apply_source_weights: true,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -865,6 +893,7 @@ mod tests {
             3,
             RerankerConfig {
                 apply_source_weights: true,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -886,10 +915,89 @@ mod tests {
             10,
             RerankerConfig {
                 apply_source_weights: true,
+                ..Default::default()
             },
         )
         .unwrap();
         assert_eq!(ranked.len(), 1);
         assert!((ranked[0].source_weight - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_weight_override_bm25_only() {
+        // With bm25_weight_override=1.0 and vector_weight_override=0.0,
+        // the BM25 rank should dominate the fused score.
+        let candidates = vec![
+            cand("bm25_match", "dark mode preference setting", vec![0.0f32; 4], None),
+            cand("cosine_match", "unrelated text", vec![0.9f32, 0.1, 0.0, 0.0], None),
+        ];
+        let query_embedding = vec![0.9f32, 0.1, 0.0, 0.0];
+        let ranked = rerank_with_config(
+            "dark mode",
+            &query_embedding,
+            &candidates,
+            10,
+            RerankerConfig {
+                apply_source_weights: false,
+                bm25_weight_override: Some(1.0),
+                vector_weight_override: Some(0.0),
+            },
+        )
+        .unwrap();
+        assert_eq!(ranked.len(), 2);
+        assert_eq!(ranked[0].id, "bm25_match", "BM25-only weighting must surface textual match");
+    }
+
+    #[test]
+    fn test_weight_override_defaults_to_adaptive_when_none() {
+        let candidates = vec![cand(
+            "c",
+            "dark mode preference",
+            vec![0.9f32, 0.1, 0.0, 0.0],
+            None,
+        )];
+        let query_embedding = vec![0.9f32, 0.1, 0.0, 0.0];
+
+        let adaptive = rerank("dark mode", &query_embedding, &candidates, 10).unwrap();
+        let explicit_none = rerank_with_config(
+            "dark mode",
+            &query_embedding,
+            &candidates,
+            10,
+            RerankerConfig {
+                apply_source_weights: false,
+                bm25_weight_override: None,
+                vector_weight_override: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(adaptive.len(), 1);
+        assert_eq!(explicit_none.len(), 1);
+        assert!(
+            (adaptive[0].score - explicit_none[0].score).abs() < 1e-12,
+            "None overrides must produce identical scores to the v0 adaptive path"
+        );
+    }
+
+    #[test]
+    fn test_reranker_config_serde_skips_none_overrides() {
+        let cfg = RerankerConfig::default();
+        let json = serde_json::to_string(&cfg).unwrap();
+        assert!(!json.contains("bm25_weight_override"), "None fields must be omitted from JSON");
+        assert!(!json.contains("vector_weight_override"), "None fields must be omitted from JSON");
+
+        let cfg_with = RerankerConfig {
+            apply_source_weights: false,
+            bm25_weight_override: Some(0.7),
+            vector_weight_override: Some(0.3),
+        };
+        let json2 = serde_json::to_string(&cfg_with).unwrap();
+        assert!(json2.contains("0.7"));
+        assert!(json2.contains("0.3"));
+
+        let back: RerankerConfig = serde_json::from_str(&json2).unwrap();
+        assert_eq!(back.bm25_weight_override, Some(0.7));
+        assert_eq!(back.vector_weight_override, Some(0.3));
     }
 }

--- a/rust/totalreclaw-core/src/search.rs
+++ b/rust/totalreclaw-core/src/search.rs
@@ -176,6 +176,36 @@ pub fn count_query() -> &'static str {
 }
 
 // ---------------------------------------------------------------------------
+// Expansion pipeline config
+// ---------------------------------------------------------------------------
+
+/// Configuration for the query-expansion search pipeline.
+///
+/// The expansion pipeline lets the host generate 2-3 LLM reformulations of the
+/// original query, run parallel trapdoor searches per reformulation, then merge
+/// all result sets into one ranked list before decryption + reranking.
+///
+/// `rrf_k` controls the RRF merge step. The default (60.0) matches the value
+/// used in the single-query reranker and agentmemory's reference implementation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExpansionConfig {
+    /// RRF k-parameter for multi-query merge. Higher values dampen the
+    /// influence of top-ranked documents. Default: 60.0.
+    #[serde(default = "default_rrf_k")]
+    pub rrf_k: f64,
+}
+
+fn default_rrf_k() -> f64 {
+    60.0
+}
+
+impl Default for ExpansionConfig {
+    fn default() -> Self {
+        ExpansionConfig { rrf_k: 60.0 }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Trapdoor generation
 // ---------------------------------------------------------------------------
 
@@ -201,6 +231,80 @@ pub fn generate_search_trapdoors(
     trapdoors.extend(lsh_buckets);
 
     Ok(trapdoors)
+}
+
+/// Generate trapdoors for multiple query reformulations in one call.
+///
+/// Convenience batch wrapper around `generate_search_trapdoors` for the
+/// expansion pipeline. Returns one `Vec<String>` of trapdoors per input query.
+/// `queries` and `query_embeddings` must have the same length.
+pub fn generate_expansion_trapdoors(
+    queries: &[&str],
+    query_embeddings: &[&[f32]],
+    lsh_hasher: &LshHasher,
+) -> Result<Vec<Vec<String>>> {
+    if queries.len() != query_embeddings.len() {
+        return Err(crate::Error::Crypto(format!(
+            "queries.len() ({}) != query_embeddings.len() ({})",
+            queries.len(),
+            query_embeddings.len()
+        )));
+    }
+    queries
+        .iter()
+        .zip(query_embeddings.iter())
+        .map(|(q, e)| generate_search_trapdoors(q, e, lsh_hasher))
+        .collect()
+}
+
+/// Merge multiple ordered `SubgraphFact` lists from parallel query reformulations.
+///
+/// Each input set is an already-deduplicated, ordered slice of facts returned
+/// from one reformulation query (position 0 = best match in that query).
+/// Facts that appear across multiple sets accumulate RRF score contributions
+/// and therefore surface higher in the merged output — this is the mechanism
+/// that yields 2-3x richer recall vs. a single query.
+///
+/// The returned list is deduplicated (by fact id), sorted by descending RRF
+/// score with a deterministic tie-break on id, and ready for `decrypt_and_rerank`.
+///
+/// Use `ExpansionConfig::default()` for standard k=60 RRF semantics.
+pub fn merge_expansion_results(
+    fact_sets: &[&[SubgraphFact]],
+    config: &ExpansionConfig,
+) -> Vec<SubgraphFact> {
+    if fact_sets.is_empty() {
+        return Vec::new();
+    }
+    if fact_sets.len() == 1 {
+        return fact_sets[0].to_vec();
+    }
+
+    // Accumulate per-fact RRF scores and keep the first-seen copy of each fact.
+    let mut scores: HashMap<String, f64> = HashMap::new();
+    let mut facts_by_id: HashMap<String, SubgraphFact> = HashMap::new();
+
+    for set in fact_sets {
+        for (rank, fact) in set.iter().enumerate() {
+            // 1-based rank: rank 0 in the slice → position 1 in the RRF formula.
+            let rrf = 1.0 / (config.rrf_k + (rank + 1) as f64);
+            *scores.entry(fact.id.clone()).or_insert(0.0) += rrf;
+            facts_by_id.entry(fact.id.clone()).or_insert_with(|| fact.clone());
+        }
+    }
+
+    // Sort by descending RRF score; tiebreak ascending by id for determinism.
+    let mut scored: Vec<(String, f64)> = scores.into_iter().collect();
+    scored.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.0.cmp(&b.0))
+    });
+
+    scored
+        .into_iter()
+        .filter_map(|(id, _)| facts_by_id.remove(&id))
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -756,5 +860,135 @@ mod tests {
 
         // JSON without "t" key falls back
         assert_eq!(extract_text_from_blob(r#"{"x":"y"}"#), r#"{"x":"y"}"#);
+    }
+
+    fn make_fact(id: &str) -> SubgraphFact {
+        SubgraphFact {
+            id: id.to_string(),
+            encrypted_blob: "0xdeadbeef".to_string(),
+            encrypted_embedding: None,
+            decay_score: None,
+            timestamp: None,
+            created_at: None,
+            is_active: Some(true),
+            content_fp: None,
+        }
+    }
+
+    #[test]
+    fn test_expansion_config_default() {
+        let cfg = ExpansionConfig::default();
+        assert!((cfg.rrf_k - 60.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_merge_expansion_results_empty() {
+        let merged = merge_expansion_results(&[], &ExpansionConfig::default());
+        assert!(merged.is_empty());
+    }
+
+    #[test]
+    fn test_merge_expansion_results_single_set() {
+        let facts = vec![make_fact("a"), make_fact("b")];
+        let sets: Vec<&[SubgraphFact]> = vec![&facts];
+        let merged = merge_expansion_results(&sets, &ExpansionConfig::default());
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].id, "a");
+        assert_eq!(merged[1].id, "b");
+    }
+
+    #[test]
+    fn test_merge_expansion_results_deduplicates_across_sets() {
+        // "shared" appears in both sets; "only_a" and "only_b" are unique.
+        let set_a = vec![make_fact("shared"), make_fact("only_a")];
+        let set_b = vec![make_fact("shared"), make_fact("only_b")];
+        let sets: Vec<&[SubgraphFact]> = vec![&set_a, &set_b];
+        let merged = merge_expansion_results(&sets, &ExpansionConfig::default());
+        assert_eq!(merged.len(), 3, "should contain exactly 3 unique facts");
+        let ids: Vec<&str> = merged.iter().map(|f| f.id.as_str()).collect();
+        assert!(ids.contains(&"shared"), "shared fact must appear exactly once");
+        assert!(ids.contains(&"only_a"));
+        assert!(ids.contains(&"only_b"));
+    }
+
+    #[test]
+    fn test_merge_expansion_results_shared_fact_ranks_first() {
+        // A fact that appears first in both sets should score higher than one
+        // that appears only once, even at rank 0 in its set.
+        let set_a = vec![make_fact("shared"), make_fact("unique_a")];
+        let set_b = vec![make_fact("shared"), make_fact("unique_b")];
+        let sets: Vec<&[SubgraphFact]> = vec![&set_a, &set_b];
+        let merged = merge_expansion_results(&sets, &ExpansionConfig::default());
+        assert_eq!(merged[0].id, "shared");
+    }
+
+    #[test]
+    fn test_merge_expansion_results_deterministic_tiebreak() {
+        // Two facts each appear in only one set at rank 0 → equal RRF score.
+        // Tiebreak must be ascending by id.
+        let set_a = vec![make_fact("zzz")];
+        let set_b = vec![make_fact("aaa")];
+        let sets: Vec<&[SubgraphFact]> = vec![&set_a, &set_b];
+        let merged = merge_expansion_results(&sets, &ExpansionConfig::default());
+        assert_eq!(merged[0].id, "aaa");
+        assert_eq!(merged[1].id, "zzz");
+    }
+
+    #[test]
+    fn test_merge_expansion_results_rrf_k_parameter() {
+        // Higher k dampens top-rank scores; with k=1 vs k=1000 the relative
+        // ordering of a fact present in two sets vs one should be preserved.
+        let set_a = vec![make_fact("both"), make_fact("one_only")];
+        let set_b = vec![make_fact("both")];
+        let sets: Vec<&[SubgraphFact]> = vec![&set_a, &set_b];
+        for rrf_k in [1.0, 60.0, 1000.0] {
+            let merged = merge_expansion_results(&sets, &ExpansionConfig { rrf_k });
+            assert_eq!(merged[0].id, "both", "rrf_k={rrf_k}: cross-set fact must still rank first");
+        }
+    }
+
+    #[test]
+    fn test_generate_expansion_trapdoors_length_mismatch_errors() {
+        let keys = crate::crypto::derive_keys_from_mnemonic(
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+        )
+        .unwrap();
+        let lsh_seed = crate::crypto::derive_lsh_seed(
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+            &keys.salt,
+        )
+        .unwrap();
+        let lsh_hasher = LshHasher::new(&lsh_seed, 640).unwrap();
+
+        let queries = ["q1", "q2"];
+        let embeddings: Vec<&[f32]> = vec![&[0.5f32; 640]]; // length mismatch
+        assert!(
+            generate_expansion_trapdoors(&queries, &embeddings, &lsh_hasher).is_err(),
+            "mismatched lengths should return an error"
+        );
+    }
+
+    #[test]
+    fn test_generate_expansion_trapdoors_returns_one_vec_per_query() {
+        let keys = crate::crypto::derive_keys_from_mnemonic(
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+        )
+        .unwrap();
+        let lsh_seed = crate::crypto::derive_lsh_seed(
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+            &keys.salt,
+        )
+        .unwrap();
+        let lsh_hasher = LshHasher::new(&lsh_seed, 640).unwrap();
+
+        let emb = vec![0.5f32; 640];
+        let queries = ["dark mode", "theme settings", "UI color scheme"];
+        let embeddings: Vec<&[f32]> = vec![&emb, &emb, &emb];
+        let result = generate_expansion_trapdoors(&queries, &embeddings, &lsh_hasher).unwrap();
+
+        assert_eq!(result.len(), 3, "one trapdoor vec per query");
+        for vec in &result {
+            assert!(!vec.is_empty(), "each query should produce trapdoors");
+        }
     }
 }

--- a/rust/totalreclaw-core/src/wasm.rs
+++ b/rust/totalreclaw-core/src/wasm.rs
@@ -393,6 +393,8 @@ pub fn wasm_rerank_with_config(
         .map_err(|e| JsError::new(&format!("Invalid candidates JSON: {}", e)))?;
     let config = reranker::RerankerConfig {
         apply_source_weights,
+        bm25_weight_override: None,
+        vector_weight_override: None,
     };
     let results = reranker::rerank_with_config(query, query_embedding, &candidates, top_k, config)
         .map_err(|e| JsError::new(&e.to_string()))?;

--- a/rust/totalreclaw-core/src/wasm.rs
+++ b/rust/totalreclaw-core/src/wasm.rs
@@ -874,6 +874,52 @@ pub fn wasm_page_size() -> usize {
     search::PAGE_SIZE
 }
 
+/// Generate trapdoors for multiple query reformulations (expansion pipeline).
+///
+/// `queries_json`: JSON array of query strings (original + reformulations).
+/// `embeddings_json`: JSON array of Float32Array-compatible arrays (one per query).
+/// `lsh_hasher`: A `WasmLshHasher` instance.
+///
+/// Returns a JsValue (JSON array of trapdoor-string arrays, one per query).
+#[cfg(feature = "managed")]
+#[wasm_bindgen(js_name = "generateExpansionTrapdoors")]
+pub fn wasm_generate_expansion_trapdoors(
+    queries_json: &str,
+    embeddings_json: &str,
+    lsh_hasher: &WasmLshHasher,
+) -> Result<JsValue, JsError> {
+    let queries: Vec<String> = serde_json::from_str(queries_json)
+        .map_err(|e| JsError::new(&format!("Invalid queries JSON: {}", e)))?;
+    let embeddings: Vec<Vec<f32>> = serde_json::from_str(embeddings_json)
+        .map_err(|e| JsError::new(&format!("Invalid embeddings JSON: {}", e)))?;
+    let query_refs: Vec<&str> = queries.iter().map(|s| s.as_str()).collect();
+    let embedding_refs: Vec<&[f32]> = embeddings.iter().map(|v| v.as_slice()).collect();
+    let result =
+        search::generate_expansion_trapdoors(&query_refs, &embedding_refs, &lsh_hasher.inner)
+            .map_err(to_js_error)?;
+    serde_wasm_bindgen::to_value(&result).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Merge multiple SubgraphFact sets from parallel query reformulations via RRF.
+///
+/// `fact_sets_json`: JSON array of SubgraphFact arrays (one array per reformulation).
+/// `rrf_k`: RRF k-parameter (use 60.0 for default behaviour).
+///
+/// Returns a JsValue (merged, deduplicated SubgraphFact array sorted by RRF score).
+#[cfg(feature = "managed")]
+#[wasm_bindgen(js_name = "mergeExpansionResults")]
+pub fn wasm_merge_expansion_results(
+    fact_sets_json: &str,
+    rrf_k: f64,
+) -> Result<JsValue, JsError> {
+    let fact_sets: Vec<Vec<search::SubgraphFact>> = serde_json::from_str(fact_sets_json)
+        .map_err(|e| JsError::new(&format!("Invalid fact_sets JSON: {}", e)))?;
+    let set_refs: Vec<&[search::SubgraphFact]> = fact_sets.iter().map(|v| v.as_slice()).collect();
+    let config = search::ExpansionConfig { rrf_k };
+    let merged = search::merge_expansion_results(&set_refs, &config);
+    serde_wasm_bindgen::to_value(&merged).map_err(|e| JsError::new(&e.to_string()))
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
🤖 Implements [am-4] per canonical-roadmap issue p-diogo/totalreclaw-internal#254.

**Risk tier:** L2
**Files changed:** 4 (`search.rs`, `reranker.rs`, `wasm.rs`, `python.rs`)
**Net diff:** +436 lines (functions + tests)

## What this adds

### `merge_expansion_results(fact_sets, config)` (Rust / WASM / Python)
Merges N ordered `SubgraphFact` lists (one per LLM reformulation) via Reciprocal Rank Fusion. Facts appearing across multiple reformulations accumulate RRF score contributions and surface higher — the mechanism for 2-3x richer recall on long-conversation corpora without additional per-turn LLM calls.

### `generate_expansion_trapdoors(queries, embeddings, lsh_hasher)` (Rust / WASM / Python)
Batch wrapper around `generate_search_trapdoors` for generating trapdoors across multiple reformulations in one call. Host language handles the parallel GraphQL queries per reformulation, then calls `merge_expansion_results` before `decrypt_and_rerank`.

### `ExpansionConfig { rrf_k: f64 }`
Tunable RRF k-parameter (default 60.0, matching the existing single-query reranker and agentmemory's reference).

### `RerankerConfig.bm25_weight_override / vector_weight_override`
Optional fixed fusion weight overrides (satisfies "BM25/vector weight config tunable" from Done criteria). `None` (default) preserves the adaptive intent-weighted formula. Changes are additive and backward-compatible — no scoring drift for existing callers.

## Done criteria (from issue)

- [ ] 2-3x richer recall on long-conversation corpora (per agentmemory's published numbers)
- [ ] No measurable cost increase (LLM call is one extra reformulation, not per-turn)
- [ ] Bench regression neutral or positive on 4 corpora

_L2: CI + coordinator review gate. No bench regression run required at this tier._

## Test coverage

- `merge_expansion_results`: empty, single-set, dedup across sets, cross-set rank boost, deterministic tiebreak, k-parameter invariance
- `generate_expansion_trapdoors`: length mismatch error, correct output count
- `RerankerConfig` weight overrides: BM25-only path, None = adaptive path, serde skip-when-None

Closes p-diogo/totalreclaw-internal#254