### PR TITLE
ci: auto-merge-l1 ignore Publish workflows

### DIFF
--- a/.github/workflows/auto-merge-l1.yml
+++ b/.github/workflows/auto-merge-l1.yml
@@ -36,7 +36,7 @@ jobs:
           delay: 30
           interval: 30
           # Don't include the auto-merge job's own status in what we wait for.
-          ignore: 'auto-merge'
+          ignore: 'auto-merge,Publish to PyPI,Publish to crates.io,Publish to npm,Publish to ClawHub,publish-pypi,publish-crates,publish-npm,publish-clawhub'
 
       - name: Verify PR is from a coding-agent branch
         env:


### PR DESCRIPTION
Publish workflows fire on PR labels but can't actually publish from PR branches → fail → block auto-merge. Add to ignore list so only required CI gates merging.