### PR TITLE
[am-1] Crystal-shaped debrief — one structured summary per session

### DIFF
--- a/mcp/src/claims-helper.ts
+++ b/mcp/src/claims-helper.ts
@@ -361,6 +361,11 @@ export interface BuildV1ClaimInput {
    * treat absence as equivalent. Only emitted in the output when provided.
    */
   pinStatus?: PinStatus;
+  /**
+   * am-1: Crystal-shaped debrief structured metadata. Re-attached after
+   * core validation using the same plugin-extra pattern as schema_version.
+   */
+  metadata?: Record<string, unknown>;
 }
 
 /**
@@ -410,6 +415,10 @@ export function buildV1ClaimBlob(input: BuildV1ClaimInput): string {
   const validated = getWasm().validateMemoryClaimV1(JSON.stringify(claim));
   const parsed = JSON.parse(validated) as Record<string, unknown>;
   parsed.schema_version = MEMORY_CLAIM_V1_SCHEMA_VERSION;
+  // am-1: re-attach Crystal metadata after validation (same plugin-extra pattern).
+  if (input.metadata && typeof input.metadata === 'object') {
+    parsed.metadata = input.metadata;
+  }
   return JSON.stringify(parsed);
 }
 

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -978,33 +978,96 @@ async function handleDebriefSubgraph(
   args: unknown,
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   const input = args as Record<string, unknown>;
-  const factsInput = input?.facts;
 
+  // ── Crystal path (am-1, preferred) ──────────────────────────────────────
+  if (input?.crystal !== undefined) {
+    const raw = input.crystal as Record<string, unknown>;
+    const narrative = typeof raw?.narrative === 'string' ? raw.narrative.trim().slice(0, 512) : '';
+    if (narrative.length < 10) {
+      return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: 'crystal.narrative (10+ chars) is required' }) }] };
+    }
+
+    const strList = (key: string): string[] => {
+      const v = (raw as Record<string, unknown>)[key];
+      if (!Array.isArray(v)) return [];
+      return v.map((x) => String(x).trim()).filter((x) => x.length > 0).slice(0, 10);
+    };
+    let importance = typeof raw?.importance === 'number' ? raw.importance : 8;
+    importance = Math.max(1, Math.min(10, Math.round(importance)));
+
+    const crystalMetadata: Record<string, unknown> = {
+      subtype: 'session_crystal',
+      key_outcomes: strList('key_outcomes'),
+      open_threads: strList('open_threads'),
+      lessons: strList('lessons'),
+    };
+    const filesAffected = strList('files_affected');
+    if (filesAffected.length > 0) crystalMetadata.files_affected = filesAffected;
+    if (typeof raw?.session_id === 'string' && raw.session_id) crystalMetadata.session_id = raw.session_id;
+
+    try {
+      const wordIndices = generateBlindIndices(narrative);
+      const embedding = await generateEmbedding(narrative);
+      const lshIndices = state.lshHasher.hash(embedding);
+      const allIndices = [...wordIndices, ...lshIndices];
+
+      const blobPlaintext = buildV1ClaimBlob({
+        text: narrative,
+        type: 'summary',
+        source: 'derived',
+        importance,
+        metadata: crystalMetadata,
+      });
+      const encryptedBlob = encrypt(blobPlaintext, state.encryptionKey);
+      const contentFp = generateContentFingerprint(narrative, state.dedupKey);
+      const encryptedEmb = encryptEmbedding(embedding, state.encryptionKey);
+
+      const factId = crypto.randomUUID();
+      const factPayload: FactPayload = {
+        id: factId,
+        timestamp: new Date().toISOString(),
+        owner: state.smartAccountAddress,
+        encryptedBlob: Buffer.from(encryptedBlob, 'base64').toString('hex'),
+        blindIndices: allIndices,
+        decayScore: importance / 10,
+        source: 'mcp_debrief',
+        contentFp,
+        agentId: 'mcp-server',
+        encryptedEmbedding: encryptedEmb,
+      };
+
+      const batchConfig = getSubgraphConfig({
+        relayUrl: state.serverUrl,
+        mnemonic: state.mnemonic,
+        authKeyHex: Buffer.from(state.authKey).toString('hex'),
+        walletAddress: state.smartAccountAddress,
+      });
+      const batchResult = await submitFactBatchOnChain([encodeFactProtobuf(factPayload)], batchConfig);
+      console.error(`Crystal debrief stored (tx=${batchResult.txHash.slice(0, 10)}...)`);
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ success: batchResult.success, stored: batchResult.success ? 1 : 0, fact_id: factId, tx_hash: batchResult.txHash, crystal: true }) }],
+      };
+    } catch (error) {
+      console.error(`Crystal debrief failed: ${error instanceof Error ? error.message : String(error)}`);
+      return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: String(error) }) }] };
+    }
+  }
+
+  // ── Legacy facts array path (backward compat) ────────────────────────────
+  const factsInput = input?.facts;
   if (!Array.isArray(factsInput) || factsInput.length === 0) {
     return {
       content: [{
         type: 'text',
-        text: JSON.stringify({
-          success: false,
-          error: 'Invalid input: "facts" array is required and must not be empty',
-        }),
+        text: JSON.stringify({ success: false, error: 'Provide either "crystal" (preferred) or "facts" array' }),
       }],
     };
   }
 
-  // Validate through the canonical parser
   const validated = parseDebriefResponse(JSON.stringify(factsInput));
-
   if (validated.length === 0) {
     return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          success: true,
-          stored: 0,
-          message: 'No valid debrief items to store (filtered by validation)',
-        }),
-      }],
+      content: [{ type: 'text', text: JSON.stringify({ success: true, stored: 0, message: 'No valid debrief items to store (filtered by validation)' }) }],
     };
   }
 
@@ -1018,15 +1081,6 @@ async function handleDebriefSubgraph(
       const lshIndices = state.lshHasher.hash(embedding);
       const allIndices = [...wordIndices, ...lshIndices];
 
-      // Memory Taxonomy v1: emit v1 inner blob with `type: 'summary'` (both
-      // tool-level 'summary' and 'context' map here — per spec §type-semantics,
-      // summary absorbs session-level synthesis regardless of whether the tool
-      // called it "summary" or "context"). `source: 'derived'` marks this as a
-      // derived-from-conversation claim (spec requires summary ∈ {derived,
-      // assistant}; derived is the better fit here).
-      //
-      // TOTALRECLAW_CLAIM_FORMAT=legacy was removed in v1; raw-text blobs are
-      // no longer produced on the write path.
       const blobPlaintext = buildV1ClaimBlob({
         text: item.text,
         type: 'summary',
@@ -1070,11 +1124,7 @@ async function handleDebriefSubgraph(
       });
       const batchResult = await submitFactBatchOnChain(pendingPayloads, batchConfig);
       for (const meta of pendingFactMeta) {
-        results.push({
-          success: batchResult.success,
-          fact_id: meta.factId,
-          tx_hash: batchResult.txHash,
-        });
+        results.push({ success: batchResult.success, fact_id: meta.factId, tx_hash: batchResult.txHash });
       }
       console.error(`Debrief: submitted ${batchResult.batchSize} items (tx=${batchResult.txHash.slice(0, 10)}...)`);
     } catch (error) {
@@ -1086,17 +1136,8 @@ async function handleDebriefSubgraph(
   }
 
   const stored = results.filter((r) => r.success).length;
-
   return {
-    content: [{
-      type: 'text',
-      text: JSON.stringify({
-        success: stored > 0,
-        stored,
-        total: validated.length,
-        results,
-      }),
-    }],
+    content: [{ type: 'text', text: JSON.stringify({ success: stored > 0, stored, total: validated.length, results }) }],
   };
 }
 

--- a/mcp/src/tools/debrief.ts
+++ b/mcp/src/tools/debrief.ts
@@ -1,11 +1,12 @@
 /**
- * TotalReclaw MCP Server - Session Debrief Tool
+ * TotalReclaw MCP Server - Session Debrief Tool (Crystal-shaped, am-1)
  *
- * Stores end-of-conversation summaries that capture broader context,
- * outcomes, and conclusions that individual memory storage may have missed.
+ * Stores one Crystal-shaped session summary per session. The Crystal replaces
+ * 5x free-form debrief items with a structured v1 summary that carries
+ * metadata.subtype="session_crystal" for filtered recall.
  *
- * For MCP: the host agent (Claude, Cursor, etc.) provides the facts array
- * directly — the MCP server does NOT make its own LLM calls.
+ * For MCP: the host agent (Claude, Cursor, etc.) provides the crystal directly
+ * — the MCP server does NOT make its own LLM calls.
  */
 
 import { TotalReclaw, FactMetadata } from '@totalreclaw/client';
@@ -18,6 +19,18 @@ export interface DebriefItem {
   text: string;
   type: 'summary' | 'context';
   importance: number;
+}
+
+/** Crystal-shaped session summary provided by the host agent. */
+export interface CrystalInput {
+  narrative: string;
+  key_outcomes?: string[];
+  files_affected?: string[];
+  open_threads?: string[];
+  lessons?: string[];
+  importance?: number;
+  session_id?: string;
+  source_message_ids?: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -54,7 +67,7 @@ Return a JSON array (no markdown, no code fences):
 If the conversation was too short or trivial to warrant a debrief, return: []`;
 
 // ---------------------------------------------------------------------------
-// Parser
+// Parser (legacy free-form path — kept for backward compat)
 // ---------------------------------------------------------------------------
 
 /**
@@ -104,6 +117,34 @@ export function parseDebriefResponse(response: string): DebriefItem[] {
   }
 }
 
+/** Parse and validate a Crystal input from the tool args. */
+function parseCrystalInput(raw: unknown): CrystalInput | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const d = raw as Record<string, unknown>;
+  const narrative = typeof d.narrative === 'string' ? d.narrative.trim() : '';
+  if (narrative.length < 10) return null;
+
+  const strList = (key: string): string[] => {
+    const v = d[key];
+    if (!Array.isArray(v)) return [];
+    return v.map((x) => String(x).trim()).filter((x) => x.length > 0).slice(0, 10);
+  };
+
+  let importance = typeof d.importance === 'number' ? d.importance : 8;
+  importance = Math.max(1, Math.min(10, Math.round(importance)));
+
+  return {
+    narrative: narrative.slice(0, 512),
+    key_outcomes: strList('key_outcomes'),
+    files_affected: strList('files_affected'),
+    open_threads: strList('open_threads'),
+    lessons: strList('lessons'),
+    importance,
+    session_id: typeof d.session_id === 'string' ? d.session_id : undefined,
+    source_message_ids: strList('source_message_ids'),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Tool Definition
 // ---------------------------------------------------------------------------
@@ -111,7 +152,7 @@ export function parseDebriefResponse(response: string): DebriefItem[] {
 export const debriefToolDefinition = {
   name: 'totalreclaw_debrief',
   description:
-    'Capture broader context/outcomes/open threads extraction missed. v1 summary, source=derived.\n' +
+    'Crystal session summary — one structured summary per session.\n' +
     '\nINVOKE WHEN USER SAYS:\n' +
     '- "goodbye" / "bye" / "thanks"\n' +
     '- "that\'s all" / "I\'m done"\n' +
@@ -121,25 +162,50 @@ export const debriefToolDefinition = {
     '- casual chat / Q&A — adds noise\n' +
     '- no prior totalreclaw_remember — no context\n' +
     '- unsure → skip; debriefs rare\n' +
-    '\nMAX 5 (1-3 sentences, importance 7-8). type: summary|context.',
+    '\nProvide a Crystal object. narrative is embedded; all other fields go in metadata.',
   inputSchema: {
     type: 'object',
-    properties: {
-      facts: {
-        type: 'array',
-        description: 'Array of debrief items to store',
-        items: {
-          type: 'object',
-          properties: {
-            text: { type: 'string', description: 'The debrief summary text (1-3 sentences)' },
-            type: { type: 'string', enum: ['summary', 'context'], description: 'summary=conclusion/outcome, context=broader project context' },
-            importance: { type: 'number', description: 'Importance 1-10 (typically 7-8 for debriefs)' },
+    oneOf: [
+      {
+        description: 'Crystal-shaped debrief (preferred, am-1)',
+        properties: {
+          crystal: {
+            type: 'object',
+            description: 'Structured Crystal session summary',
+            properties: {
+              narrative: { type: 'string', description: '1-2 sentence session summary (will be embedded)' },
+              key_outcomes: { type: 'array', items: { type: 'string' }, description: 'Decisions made, bugs fixed, conclusions reached' },
+              files_affected: { type: 'array', items: { type: 'string' }, description: 'File paths worked on (coding sessions)' },
+              open_threads: { type: 'array', items: { type: 'string' }, description: 'Unfinished items needing follow-up' },
+              lessons: { type: 'array', items: { type: 'string' }, description: 'Patterns, gotchas, insights worth remembering' },
+              importance: { type: 'number', description: 'Importance 1-10 (default 8)' },
+              session_id: { type: 'string', description: 'Optional session identifier' },
+            },
+            required: ['narrative'],
           },
-          required: ['text'],
         },
+        required: ['crystal'],
       },
-    },
-    required: ['facts'],
+      {
+        description: 'Legacy free-form debrief items (backward compat)',
+        properties: {
+          facts: {
+            type: 'array',
+            description: 'Array of debrief items to store',
+            items: {
+              type: 'object',
+              properties: {
+                text: { type: 'string', description: 'The debrief summary text (1-3 sentences)' },
+                type: { type: 'string', enum: ['summary', 'context'], description: 'summary=conclusion/outcome, context=broader project context' },
+                importance: { type: 'number', description: 'Importance 1-10 (typically 7-8 for debriefs)' },
+              },
+              required: ['text'],
+            },
+          },
+        },
+        required: ['facts'],
+      },
+    ],
   },
   annotations: {
     readOnlyHint: false,
@@ -154,53 +220,68 @@ export const debriefToolDefinition = {
 
 /**
  * Handle debrief in HTTP/self-hosted mode: validate, store via TotalReclaw client.
+ * Accepts Crystal-shaped input (preferred) or legacy facts array (backward compat).
  */
 export async function handleDebrief(
   client: TotalReclaw,
   args: unknown,
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   const input = args as Record<string, unknown>;
-  const factsInput = input?.facts;
 
+  // Crystal path (preferred)
+  if (input?.crystal !== undefined) {
+    const crystal = parseCrystalInput(input.crystal);
+    if (!crystal) {
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ success: false, error: 'Invalid crystal: narrative (10+ chars) is required' }) }],
+      };
+    }
+
+    try {
+      const metadata: FactMetadata = {
+        importance: crystal.importance! / 10,
+        source: 'mcp_debrief',
+        tags: [
+          'subtype:session_crystal',
+          'source:derived',
+          ...(crystal.files_affected && crystal.files_affected.length > 0 ? ['has:files_affected'] : []),
+        ],
+      };
+      const factId = await client.remember(crystal.narrative, metadata);
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ success: true, stored: 1, fact_id: factId, crystal: true }) }],
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ success: false, error: message }) }],
+      };
+    }
+  }
+
+  // Legacy facts array path
+  const factsInput = input?.facts;
   if (!Array.isArray(factsInput) || factsInput.length === 0) {
     return {
       content: [{
         type: 'text',
-        text: JSON.stringify({
-          success: false,
-          error: 'Invalid input: "facts" array is required and must not be empty',
-        }),
+        text: JSON.stringify({ success: false, error: 'Provide either "crystal" (preferred) or "facts" array' }),
       }],
     };
   }
 
-  // Validate through the parser
   const validated = parseDebriefResponse(JSON.stringify(factsInput));
-
   if (validated.length === 0) {
     return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          success: true,
-          stored: 0,
-          message: 'No valid debrief items to store (filtered by validation)',
-        }),
-      }],
+      content: [{ type: 'text', text: JSON.stringify({ success: true, stored: 0, message: 'No valid debrief items (filtered)' }) }],
     };
   }
 
   let stored = 0;
   const results: Array<{ success: boolean; fact_id: string }> = [];
-
   for (const item of validated) {
     try {
-      const metadata: FactMetadata = {
-        importance: item.importance / 10,
-        source: 'mcp_debrief',
-        tags: [item.type],
-      };
-
+      const metadata: FactMetadata = { importance: item.importance / 10, source: 'mcp_debrief', tags: [item.type] };
       const factId = await client.remember(item.text, metadata);
       results.push({ success: true, fact_id: factId });
       stored++;
@@ -212,15 +293,6 @@ export async function handleDebrief(
   }
 
   return {
-    content: [{
-      type: 'text',
-      text: JSON.stringify({
-        success: stored > 0,
-        stored,
-        total: validated.length,
-        results,
-      }),
-    }],
+    content: [{ type: 'text', text: JSON.stringify({ success: stored > 0, stored, total: validated.length, results }) }],
   };
 }
-

--- a/python/src/totalreclaw/agent/debrief.py
+++ b/python/src/totalreclaw/agent/debrief.py
@@ -14,8 +14,8 @@ from __future__ import annotations
 import json
 import logging
 import re
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
 
 from .llm_client import detect_llm_config, chat_completion
 
@@ -29,6 +29,42 @@ class DebriefItem:
     text: str
     type: str  # summary or context
     importance: int  # 1-10
+
+
+@dataclass
+class Crystal:
+    """Structured session summary replacing 5x free-form debrief items.
+
+    One Crystal per session, stored as v1 summary + metadata.subtype="session_crystal".
+    """
+    narrative: str                           # 1-2 sentence "what happened" (embedded as text)
+    key_outcomes: list[str] = field(default_factory=list)
+    open_threads: list[str] = field(default_factory=list)
+    lessons: list[str] = field(default_factory=list)
+    importance: int = 8
+    session_id: str = ""
+    source_message_ids: list[str] = field(default_factory=list)
+    # Per-host: exactly one of these is populated
+    files_affected: list[str] = field(default_factory=list)    # coding hosts
+    topics_discussed: list[str] = field(default_factory=list)  # chat hosts
+
+    def to_metadata(self) -> Dict[str, Any]:
+        """Produce the metadata dict stored alongside the v1 summary blob."""
+        meta: Dict[str, Any] = {
+            "subtype": "session_crystal",
+            "key_outcomes": self.key_outcomes,
+            "open_threads": self.open_threads,
+            "lessons": self.lessons,
+        }
+        if self.session_id:
+            meta["session_id"] = self.session_id
+        if self.source_message_ids:
+            meta["source_message_ids"] = self.source_message_ids
+        if self.files_affected:
+            meta["files_affected"] = self.files_affected
+        if self.topics_discussed:
+            meta["topics_discussed"] = self.topics_discussed
+        return meta
 
 
 DEBRIEF_SYSTEM_PROMPT = """You are reviewing a conversation that just ended. The following facts were
@@ -173,3 +209,162 @@ async def generate_debrief(
     except Exception as e:
         logger.warning("Debrief generation failed: %s", e)
         return []
+
+
+# ---------------------------------------------------------------------------
+# Crystal-shaped debrief (am-1) — one structured summary per session
+# ---------------------------------------------------------------------------
+
+_CRYSTAL_COMMON_FIELDS = """\
+Return a JSON object (no markdown, no code fences):
+{
+  "narrative": "1-2 sentence summary of what happened this session",
+  "key_outcomes": ["outcome or decision 1", "outcome or decision 2"],
+  "open_threads": ["unfinished item 1", "unfinished item 2"],
+  "lessons": ["lesson or gotcha learned 1"],
+  "importance": 8
+}"""
+
+CRYSTAL_SYSTEM_PROMPT_CHAT = """You are crystallising a finished conversation into one structured session summary.
+
+The following facts were already extracted and stored during this conversation:
+{already_stored_facts}
+
+Write ONE Crystal that captures what turn-by-turn extraction missed. Include:
+- narrative: 1-2 sentences describing the conversation overall
+- key_outcomes: decisions made, problems solved, conclusions reached
+- open_threads: things left unfinished or needing follow-up
+- lessons: patterns, gotchas, or insights worth remembering
+- topics_discussed: the main subjects covered
+- importance: 7-10 (8 default)
+
+Do NOT repeat facts already stored. If the conversation was too short or trivial, return: null
+
+""" + _CRYSTAL_COMMON_FIELDS + """
+
+Also include "topics_discussed": ["topic 1", "topic 2"] in the object.
+Return null (not an object) for trivial or very short conversations."""
+
+CRYSTAL_SYSTEM_PROMPT_CODING = """You are crystallising a finished coding session into one structured session summary.
+
+The following facts were already extracted and stored during this conversation:
+{already_stored_facts}
+
+Write ONE Crystal that captures what turn-by-turn extraction missed. Include:
+- narrative: 1-2 sentences describing the session overall
+- key_outcomes: decisions made, bugs fixed, features built
+- open_threads: things left unfinished or needing follow-up
+- lessons: patterns, gotchas, or insights worth remembering
+- files_affected: file paths mentioned or worked on (extract from assistant messages)
+- importance: 7-10 (8 default)
+
+Do NOT repeat facts already stored. If the session was too short or trivial, return: null
+
+""" + _CRYSTAL_COMMON_FIELDS + """
+
+Also include "files_affected": ["/path/to/file.py", ...] in the object (may be empty []).
+Return null (not an object) for trivial or very short sessions."""
+
+
+def parse_crystal_response(response: str, host_type: str = "chat") -> Optional[Crystal]:
+    """Parse LLM JSON response into a Crystal object.
+
+    Returns None for null/empty/trivial responses or parse failures.
+    """
+    cleaned = response.strip()
+    if cleaned.startswith("```"):
+        cleaned = re.sub(r"^```(?:json)?\n?", "", cleaned)
+        cleaned = re.sub(r"\n?```$", "", cleaned).strip()
+
+    if cleaned.lower() in ("null", "none", ""):
+        return None
+
+    try:
+        parsed = json.loads(cleaned)
+    except json.JSONDecodeError:
+        return None
+
+    if parsed is None:
+        return None
+
+    if not isinstance(parsed, dict):
+        return None
+
+    narrative = str(parsed.get("narrative", "")).strip()
+    if len(narrative) < 10:
+        return None
+
+    def _str_list(key: str) -> list[str]:
+        raw = parsed.get(key, [])
+        if not isinstance(raw, list):
+            return []
+        return [str(x).strip() for x in raw if str(x).strip()]
+
+    importance = parsed.get("importance", 8)
+    try:
+        importance = max(1, min(10, int(importance)))
+    except (ValueError, TypeError):
+        importance = 8
+
+    return Crystal(
+        narrative=narrative[:512],
+        key_outcomes=_str_list("key_outcomes")[:10],
+        open_threads=_str_list("open_threads")[:10],
+        lessons=_str_list("lessons")[:10],
+        importance=importance,
+        files_affected=_str_list("files_affected") if host_type == "coding" else [],
+        topics_discussed=_str_list("topics_discussed") if host_type == "chat" else [],
+    )
+
+
+async def generate_crystal(
+    messages: list[dict],
+    stored_fact_texts: list[str],
+    host_type: str = "chat",
+) -> Optional[Crystal]:
+    """Generate a Crystal session summary using LLM.
+
+    Args:
+        messages: All conversation messages from the session.
+        stored_fact_texts: Texts of facts already stored (for dedup context).
+        host_type: "chat" (Hermes/NanoClaw) or "coding" (OpenClaw/MCP).
+
+    Returns:
+        A Crystal object, or None if LLM unavailable, session too short,
+        or LLM returns null for trivial sessions.
+    """
+    config = detect_llm_config()
+    if not config:
+        return None
+
+    if len(messages) < 8:
+        return None
+
+    conversation_text = _truncate_messages(messages)
+    if len(conversation_text) < 20:
+        return None
+
+    already_stored = (
+        "\n".join(f"- {t}" for t in stored_fact_texts)
+        if stored_fact_texts
+        else "(none)"
+    )
+
+    system_prompt_template = (
+        CRYSTAL_SYSTEM_PROMPT_CODING if host_type == "coding"
+        else CRYSTAL_SYSTEM_PROMPT_CHAT
+    )
+    system_prompt = system_prompt_template.replace("{already_stored_facts}", already_stored)
+
+    try:
+        response = await chat_completion(
+            config,
+            system_prompt,
+            f"Crystallise this session:\n\n{conversation_text}",
+        )
+        if not response:
+            return None
+        return parse_crystal_response(response, host_type=host_type)
+    except Exception as e:
+        logger.warning("Crystal generation failed: %s", e)
+        return None

--- a/python/src/totalreclaw/agent/lifecycle.py
+++ b/python/src/totalreclaw/agent/lifecycle.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 from .extraction import ExtractedFact, extract_facts_llm, extract_facts_heuristic
 from .contradiction import detect_and_resolve_contradictions
-from .debrief import generate_debrief
+from .debrief import generate_crystal
 from .loop_runner import (
     run_sync,
     InterpreterShutdownError,
@@ -446,21 +446,21 @@ def _auto_extract_inner(
 def session_debrief(
     state: "AgentState",
     stored_fact_texts: Optional[list[str]] = None,
+    host_type: str = "chat",
 ) -> list[str]:
-    """Run session debrief: extract broader context and store it.
+    """Run session debrief: generate one Crystal summary and store it.
+
+    Replaces the old 5-item free-form debrief with a single structured
+    Crystal (am-1). The Crystal is stored as v1 ``summary`` type with
+    ``metadata.subtype="session_crystal"`` for filtered recall queries.
 
     Args:
         state: The AgentState instance (must be configured).
         stored_fact_texts: Optional list of already-stored fact texts for dedup.
-            If None, an empty list is used.
+        host_type: "chat" (Hermes/NanoClaw) or "coding" (OpenClaw/MCP).
 
     Returns:
-        List of newly-stored debrief fact ids. Empty on short sessions,
-        unconfigured state, LLM unavailability, or any interior failure.
-        The return type widened from ``None`` in 2.1.0 so the explicit
-        ``totalreclaw_debrief`` tool can surface per-fact ids back to the
-        user. The auto ``on_session_end`` path ignores the return value —
-        behavior-compatible.
+        List containing the Crystal fact id, or empty list on failure.
     """
     if not state.is_configured():
         return []
@@ -478,48 +478,39 @@ def session_debrief(
 
     stored_fact_ids: list[str] = []
     try:
-        debrief_items = run_sync(generate_debrief(all_messages, stored_fact_texts))
-        if debrief_items:
-            for item in debrief_items:
-                try:
-                    # v1 debrief items are summaries with derived
-                    # provenance — the assistant-side debrief pipeline
-                    # synthesized them from the conversation, so the
-                    # v1 source is always "derived" (plugin parity).
-                    fact_id = run_sync(
-                        client.remember(
-                            item.text,
-                            importance=item.importance / 10.0,
-                            source="hermes_debrief",
-                            fact_type="summary",
-                            provenance="derived",
-                            scope="unspecified",
-                        )
+        crystal = run_sync(generate_crystal(all_messages, stored_fact_texts, host_type=host_type))
+        if crystal:
+            try:
+                fact_id = run_sync(
+                    client.remember(
+                        crystal.narrative,
+                        importance=crystal.importance / 10.0,
+                        source="hermes_debrief",
+                        fact_type="summary",
+                        provenance="derived",
+                        scope="unspecified",
+                        extra_metadata=crystal.to_metadata(),
                     )
-                    if fact_id:
-                        stored_fact_ids.append(fact_id)
-                except InterpreterShutdownError:
-                    raise
-                except Exception as e:
-                    if is_interpreter_shutdown_error(e):
-                        raise InterpreterShutdownError(str(e)) from e
-                    logger.warning("Failed to store debrief item: %s", e)
+                )
+                if fact_id:
+                    stored_fact_ids.append(fact_id)
+                    logger.info("Session Crystal stored (id=%s, importance=%d)", fact_id, crystal.importance)
+            except InterpreterShutdownError:
+                raise
+            except Exception as e:
+                if is_interpreter_shutdown_error(e):
+                    raise InterpreterShutdownError(str(e)) from e
+                logger.warning("Failed to store Crystal: %s", e)
     except InterpreterShutdownError:
-        # Debrief lost to interpreter shutdown. The auto-extract path
-        # already enqueued unprocessed messages for next-session drain
-        # (see issue #148 + ``pending_drain``). Debrief is a derived
-        # session summary — re-running on the drained messages would be
-        # pointless without the full session context, so we just log
-        # and return the partial list of debrief facts (if any).
         logger.warning(
-            "TotalReclaw: session debrief deferred — interpreter shutdown race; "
+            "TotalReclaw: session Crystal deferred — interpreter shutdown race; "
             "next session will re-run extract on the drained messages."
         )
     except Exception as e:
         if is_interpreter_shutdown_error(e):
             logger.warning(
-                "TotalReclaw: session debrief deferred — interpreter shutdown race."
+                "TotalReclaw: session Crystal deferred — interpreter shutdown race."
             )
         else:
-            logger.warning("Session debrief failed: %s", e)
+            logger.warning("Session Crystal generation failed: %s", e)
     return stored_fact_ids

--- a/python/src/totalreclaw/claims_helper.py
+++ b/python/src/totalreclaw/claims_helper.py
@@ -166,6 +166,7 @@ def build_canonical_claim_v1(
     expires_at: Optional[str] = None,
     claim_id: Optional[str] = None,
     pin_status: Optional[str] = None,
+    extra_metadata: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Build a v1 ``MemoryClaimV1`` JSON blob.
 
@@ -294,6 +295,11 @@ def build_canonical_claim_v1(
     canonical["schema_version"] = V1_SCHEMA_VERSION
     if volatility and volatility in VALID_MEMORY_VOLATILITIES:
         canonical["volatility"] = volatility
+    # am-1: Crystal-shaped debrief — re-attach structured metadata dict.
+    # Same pattern as schema_version/volatility: passed through unchanged
+    # since the core validator doesn't know about it.
+    if extra_metadata and isinstance(extra_metadata, dict):
+        canonical["metadata"] = extra_metadata
 
     return json.dumps(canonical, ensure_ascii=False, separators=(",", ":"))
 

--- a/python/src/totalreclaw/client.py
+++ b/python/src/totalreclaw/client.py
@@ -420,6 +420,7 @@ class TotalReclaw:
         scope: str = "unspecified",
         reasoning: Optional[str] = None,
         volatility: Optional[str] = None,
+        extra_metadata: Optional[dict] = None,
     ) -> str:
         """Store a fact. Returns the fact ID.
 
@@ -479,6 +480,7 @@ class TotalReclaw:
             scope=scope,
             reasoning=reasoning,
             volatility=volatility,
+            extra_metadata=extra_metadata,
             eoa_private_key=self._eoa_private_key,
             eoa_address=self._eoa_address,
             sender=self._wallet_address,

--- a/python/src/totalreclaw/operations.py
+++ b/python/src/totalreclaw/operations.py
@@ -174,6 +174,7 @@ async def store_fact(
     scope: str = "unspecified",
     reasoning: Optional[str] = None,
     volatility: Optional[str] = None,
+    extra_metadata: Optional[dict] = None,
 ) -> str:
     """Encrypt and store a fact on-chain via relay.
 
@@ -230,6 +231,7 @@ async def store_fact(
         importance=importance_int,
         created_at=extracted_at or timestamp,
         claim_id=fact_id,
+        extra_metadata=extra_metadata,
     )
 
     encrypted_blob = encrypt(blob_plaintext, keys.encryption_key)

--- a/python/tests/test_debrief_tool.py
+++ b/python/tests/test_debrief_tool.py
@@ -14,7 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from totalreclaw.agent.debrief import DebriefItem
+from totalreclaw.agent.debrief import Crystal
 from totalreclaw.hermes import schemas
 from totalreclaw.hermes.state import PluginState
 
@@ -92,10 +92,10 @@ class TestDebriefTool:
     async def test_explicit_invocation_produces_summary_facts(self) -> None:
         """The tool must call the SAME code path as the auto-flow.
 
-        We fake ``generate_debrief`` so the test is LLM-free and assert:
-        1. The stored facts have ``type=summary``, ``provenance=derived``
-           (the v1 contract the auto-flow commits).
-        2. The tool's response surfaces the stored count + fact ids.
+        We fake ``generate_crystal`` so the test is LLM-free and assert:
+        1. The stored fact has ``type=summary``, ``provenance=derived``,
+           ``extra_metadata.subtype="session_crystal"`` (am-1 contract).
+        2. The tool's response surfaces the stored count + fact id.
         """
         from totalreclaw.hermes.tools import debrief
 
@@ -106,35 +106,38 @@ class TestDebriefTool:
             state.add_message("user", f"A meaningful user message about project X turn {i}")
             state.add_message("assistant", f"A long assistant response covering topic Y turn {i}")
 
-        fake_items = [
-            DebriefItem(text="Session concluded refactor of the auth module.", type="summary", importance=8),
-            DebriefItem(text="API migration still pending for billing module.", type="context", importance=7),
-        ]
+        fake_crystal = Crystal(
+            narrative="Refactored the auth module and identified pending API migration.",
+            key_outcomes=["auth module refactored"],
+            open_threads=["API migration still pending"],
+            lessons=["run tests before merging"],
+            importance=8,
+        )
 
         async def fake_generate(*args, **kwargs):
-            return fake_items
+            return fake_crystal
 
-        with patch("totalreclaw.agent.lifecycle.generate_debrief", new=fake_generate):
+        with patch("totalreclaw.agent.lifecycle.generate_crystal", new=fake_generate):
             result = json.loads(await debrief({}, state))
 
         # Verify the v1 contract — parity with ``on_session_end`` hook.
         calls = fake_client.remember.call_args_list
-        assert len(calls) == 2
-        for call in calls:
-            kwargs = call.kwargs
-            assert kwargs["fact_type"] == "summary"
-            assert kwargs["provenance"] == "derived"
-            assert kwargs["scope"] == "unspecified"
+        assert len(calls) == 1
+        kwargs = calls[0].kwargs
+        assert kwargs["fact_type"] == "summary"
+        assert kwargs["provenance"] == "derived"
+        assert kwargs["scope"] == "unspecified"
+        assert kwargs["extra_metadata"]["subtype"] == "session_crystal"
 
-        # Tool response surfaces the count + fact ids for the user.
-        assert result.get("stored") == 2
-        assert result.get("count") == 2
+        # Tool response surfaces the count + fact id for the user.
+        assert result.get("stored") == 1
+        assert result.get("count") == 1
         assert isinstance(result.get("fact_ids"), list)
-        assert len(result["fact_ids"]) == 2
+        assert len(result["fact_ids"]) == 1
 
     @pytest.mark.asyncio
     async def test_debrief_returns_zero_when_llm_yields_empty(self) -> None:
-        """LLM returns no items → tool reports stored=0 without erroring."""
+        """LLM returns None (trivial session) → tool reports stored=0 without erroring."""
         from totalreclaw.hermes.tools import debrief
 
         state, _client = _make_state_with_client()
@@ -143,9 +146,9 @@ class TestDebriefTool:
             state.add_message("assistant", f"reply {i}")
 
         async def fake_generate(*args, **kwargs):
-            return []
+            return None
 
-        with patch("totalreclaw.agent.lifecycle.generate_debrief", new=fake_generate):
+        with patch("totalreclaw.agent.lifecycle.generate_crystal", new=fake_generate):
             result = json.loads(await debrief({}, state))
 
         assert result.get("stored") == 0

--- a/python/tests/test_v1_hooks_integration.py
+++ b/python/tests/test_v1_hooks_integration.py
@@ -126,12 +126,12 @@ def test_post_llm_call_forwards_v1_fields_to_remember_batch() -> None:
 
 
 def test_on_session_end_debrief_emits_v1_summaries() -> None:
-    """Debrief path forwards type='summary' + provenance='derived' to client.remember.
+    """Crystal debrief path stores one summary fact with provenance='derived' + subtype='session_crystal'.
 
     We call ``session_debrief`` directly (the function the hook invokes) so
     the test is independent of the hook's try/except wrapping.
     """
-    from totalreclaw.agent.debrief import DebriefItem
+    from totalreclaw.agent.debrief import Crystal
     from totalreclaw.agent.lifecycle import session_debrief
 
     state, fake_client = _make_state()
@@ -141,28 +141,31 @@ def test_on_session_end_debrief_emits_v1_summaries() -> None:
         state.add_message("user", f"User message {i} with content words here")
         state.add_message("assistant", f"Assistant reply {i} with different content here")
 
-    debrief_items = [
-        DebriefItem(text="Session conclusion summary here", type="summary", importance=8),
-        DebriefItem(text="Project context notes here for future", type="context", importance=7),
-    ]
+    fake_crystal = Crystal(
+        narrative="Session conclusion: refactored auth module and agreed on API migration plan.",
+        key_outcomes=["auth module refactored"],
+        open_threads=["API migration still pending"],
+        lessons=["run tests before merging"],
+        importance=8,
+    )
 
     async def fake_generate(*args, **kwargs):
-        return debrief_items
+        return fake_crystal
 
-    # Patch at the call site — lifecycle.py imports generate_debrief from
-    # totalreclaw.agent.debrief and then calls it locally.
-    with patch("totalreclaw.agent.lifecycle.generate_debrief", new=fake_generate):
+    # Patch at the call site — lifecycle.py imports generate_crystal from
+    # totalreclaw.agent.debrief and calls it locally.
+    with patch("totalreclaw.agent.lifecycle.generate_crystal", new=fake_generate):
         session_debrief(state)
 
-    # Both debrief items should have been stored with v1 provenance.
+    # Crystal produces exactly one remember call (not one per free-form item).
     calls = fake_client.remember.call_args_list
-    assert len(calls) == 2, f"expected 2 remember calls, got {len(calls)}"
+    assert len(calls) == 1, f"expected 1 remember call (Crystal), got {len(calls)}"
 
-    for call in calls:
-        kwargs = call.kwargs
-        assert kwargs["fact_type"] == "summary"
-        assert kwargs["provenance"] == "derived"
-        assert kwargs["scope"] == "unspecified"
+    kwargs = calls[0].kwargs
+    assert kwargs["fact_type"] == "summary"
+    assert kwargs["provenance"] == "derived"
+    assert kwargs["scope"] == "unspecified"
+    assert kwargs["extra_metadata"]["subtype"] == "session_crystal"
 
 
 # ---------------------------------------------------------------------------

--- a/skill-nanoclaw/src/extraction/prompts.ts
+++ b/skill-nanoclaw/src/extraction/prompts.ts
@@ -345,6 +345,87 @@ export function parseDebriefResponse(response: string): DebriefItem[] {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Crystal-shaped debrief (am-1) — one structured summary per session
+// ---------------------------------------------------------------------------
+
+export const CRYSTAL_SYSTEM_PROMPT_CHAT = `You are crystallising a finished conversation into one structured session summary.
+
+The following facts were already extracted and stored during this conversation:
+{already_stored_facts}
+
+Write ONE Crystal that captures what turn-by-turn extraction missed. Include:
+- narrative: 1-2 sentences describing the conversation overall
+- key_outcomes: decisions made, problems solved, conclusions reached
+- open_threads: things left unfinished or needing follow-up
+- lessons: patterns, gotchas, or insights worth remembering
+- topics_discussed: the main subjects covered
+- importance: 7-10 (8 default)
+
+Do NOT repeat facts already stored. Return null for trivial or very short conversations.
+
+Return a JSON object (no markdown, no code fences):
+{
+  "narrative": "1-2 sentence summary of what happened this session",
+  "key_outcomes": ["outcome or decision 1"],
+  "open_threads": ["unfinished item 1"],
+  "lessons": ["lesson 1"],
+  "topics_discussed": ["topic 1"],
+  "importance": 8
+}
+
+Return null (not an object) for trivial or very short conversations.`;
+
+export interface CrystalResult {
+  narrative: string;
+  importance: number;
+  metadata: {
+    subtype: 'session_crystal';
+    key_outcomes: string[];
+    open_threads: string[];
+    lessons: string[];
+    topics_discussed?: string[];
+    files_affected?: string[];
+  };
+}
+
+export function parseCrystalResponse(response: string): CrystalResult | null {
+  let cleaned = response.trim();
+  if (cleaned.startsWith('```')) {
+    cleaned = cleaned.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '').trim();
+  }
+  if (cleaned.toLowerCase() === 'null' || cleaned === '') return null;
+
+  let parsed: unknown;
+  try { parsed = JSON.parse(cleaned); } catch { return null; }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+
+  const d = parsed as Record<string, unknown>;
+  const narrative = typeof d.narrative === 'string' ? d.narrative.trim().slice(0, 512) : '';
+  if (narrative.length < 10) return null;
+
+  const strList = (key: string): string[] => {
+    const v = d[key];
+    if (!Array.isArray(v)) return [];
+    return v.map((x) => String(x).trim()).filter((x) => x.length > 0).slice(0, 10);
+  };
+
+  let importance = typeof d.importance === 'number' ? d.importance : 8;
+  importance = Math.max(1, Math.min(10, Math.round(importance)));
+
+  return {
+    narrative,
+    importance,
+    metadata: {
+      subtype: 'session_crystal',
+      key_outcomes: strList('key_outcomes'),
+      open_threads: strList('open_threads'),
+      lessons: strList('lessons'),
+      topics_discussed: strList('topics_discussed'),
+    },
+  };
+}
+
 export function formatConversationHistory(
   turns: Array<{ role: 'user' | 'assistant'; content: string; timestamp: Date }>
 ): string {

--- a/skill-nanoclaw/src/hooks/pre-compact.ts
+++ b/skill-nanoclaw/src/hooks/pre-compact.ts
@@ -1,12 +1,11 @@
 import type { TotalReclaw, FactMetadata } from '@totalreclaw/client';
 import type { LLMClient } from './agent-end';
-import type { ExtractedFact, MemoryType } from '../extraction/prompts';
+import type { ExtractedFact } from '../extraction/prompts';
 import {
   PRE_COMPACTION_PROMPT,
-  DEBRIEF_SYSTEM_PROMPT,
-  V0_TO_V1_TYPE,
+  CRYSTAL_SYSTEM_PROMPT_CHAT,
   validateExtractionResponse,
-  parseDebriefResponse,
+  parseCrystalResponse,
 } from '../extraction/prompts';
 import { handleQuotaError } from '../billing.js';
 
@@ -110,54 +109,45 @@ export async function preCompact(
       }
     }
 
-    // Session debrief — after regular extraction
+    // Session Crystal (am-1) — one structured summary replaces free-form debrief items.
     let debriefStored = 0;
-    if (llmClient && validation.facts && validation.facts.length > 0) {
+    if (llmClient && validation.facts && validation.facts.length > 0 && !quotaExceeded) {
       try {
-        // NanoClaw 3.1.0: ADD-only alignment — debrief context reflects
-        // only the facts that were actually stored by this hook.
         const storedTexts = validation.facts
           .filter(f => f.action === 'ADD')
           .map(f => f.text);
         const alreadyStored = storedTexts.length > 0
           ? storedTexts.map(t => `- ${t}`).join('\n')
           : '(none)';
-        const debriefSystemPrompt = DEBRIEF_SYSTEM_PROMPT.replace('{already_stored_facts}', alreadyStored);
+        const crystalSystemPrompt = CRYSTAL_SYSTEM_PROMPT_CHAT.replace('{already_stored_facts}', alreadyStored);
 
-        const debriefResponse = await llmClient.generate(
-          debriefSystemPrompt,
-          `Review this conversation and provide a debrief:\n\n${input.transcript}`,
+        const crystalResponse = await llmClient.generate(
+          crystalSystemPrompt,
+          `Crystallise this session:\n\n${input.transcript}`,
         );
 
-        const debriefItems = parseDebriefResponse(debriefResponse);
-        for (const item of debriefItems) {
-          if (quotaExceeded) break;
-          // Coerce legacy "context" to v1 "claim"; "summary" passes through.
-          const v1Type: MemoryType =
-            item.type === 'context' ? V0_TO_V1_TYPE.context : 'summary';
-          const debriefMetadata: FactMetadata = {
-            importance: item.importance / 10,
+        const crystal = parseCrystalResponse(crystalResponse);
+        if (crystal) {
+          const crystalMetadata: FactMetadata = {
+            importance: crystal.importance / 10,
             source: 'nanoclaw_debrief',
             tags: [
               `namespace:${input.groupFolder}`,
-              v1Type,
+              'summary',
               'source:derived',
+              'subtype:session_crystal',
             ],
           };
           try {
-            await client.remember(item.text, debriefMetadata);
+            await client.remember(crystal.narrative, crystalMetadata);
             debriefStored++;
+            console.error('Session Crystal stored');
           } catch (err: unknown) {
-            if (handleQuotaError(err)) {
-              quotaExceeded = true;
-            }
+            if (handleQuotaError(err)) quotaExceeded = true;
           }
         }
-        if (debriefStored > 0) {
-          console.error(`Session debrief: stored ${debriefStored} items`);
-        }
       } catch (debriefErr) {
-        console.error('Pre-compact debrief failed:', debriefErr);
+        console.error('Pre-compact Crystal failed:', debriefErr);
       }
     }
 

--- a/skill/plugin/claims-helper.ts
+++ b/skill/plugin/claims-helper.ts
@@ -281,6 +281,11 @@ export function buildCanonicalClaimV1(input: BuildClaimV1Input): string {
   if (typeof input.embeddingModelId === 'string' && input.embeddingModelId.length > 0) {
     canonical.embedding_model_id = input.embeddingModelId;
   }
+  // am-1: Crystal-shaped debrief structured metadata. Re-attached after
+  // validation using the same plugin-extra pattern as volatility.
+  if (fact.crystalMetadata) {
+    canonical.metadata = fact.crystalMetadata;
+  }
 
   return JSON.stringify(canonical);
 }

--- a/skill/plugin/extractor.ts
+++ b/skill/plugin/extractor.ts
@@ -199,6 +199,24 @@ export interface ExtractedFact {
    * is skipped (facts.length < 5), by the `defaultVolatility` heuristic.
    */
   volatility?: MemoryVolatility;
+  /**
+   * am-1: Crystal-shaped debrief structured metadata. When present,
+   * re-attached as `metadata` on the v1 blob after core validation.
+   * Only set on Crystal debrief facts (type='summary', source='derived').
+   */
+  crystalMetadata?: CrystalMetadata;
+}
+
+/** Structured metadata for a Crystal-shaped session summary (am-1). */
+export interface CrystalMetadata {
+  subtype: 'session_crystal';
+  key_outcomes: string[];
+  open_threads: string[];
+  lessons: string[];
+  session_id?: string;
+  source_message_ids?: string[];
+  files_affected?: string[];    // coding hosts (OpenClaw, MCP)
+  topics_discussed?: string[];  // chat hosts (Hermes, NanoClaw)
 }
 
 const ALLOWED_ENTITY_TYPES: ReadonlySet<EntityType> = new Set([
@@ -922,6 +940,155 @@ export async function extractDebrief(
     return parseDebriefResponse(response);
   } catch {
     return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Crystal-shaped debrief (am-1) — one structured summary per session
+// ---------------------------------------------------------------------------
+
+const _CRYSTAL_COMMON_FIELDS = `Return a JSON object (no markdown, no code fences):
+{
+  "narrative": "1-2 sentence summary of what happened this session",
+  "key_outcomes": ["outcome or decision 1", "outcome or decision 2"],
+  "open_threads": ["unfinished item 1"],
+  "lessons": ["lesson or gotcha 1"],
+  "importance": 8
+}`;
+
+export const CRYSTAL_SYSTEM_PROMPT_CHAT = `You are crystallising a finished conversation into one structured session summary.
+
+The following facts were already extracted and stored during this conversation:
+{already_stored_facts}
+
+Write ONE Crystal that captures what turn-by-turn extraction missed. Include:
+- narrative: 1-2 sentences describing the conversation overall
+- key_outcomes: decisions made, problems solved, conclusions reached
+- open_threads: things left unfinished or needing follow-up
+- lessons: patterns, gotchas, or insights worth remembering
+- topics_discussed: the main subjects covered
+- importance: 7-10 (8 default)
+
+Do NOT repeat facts already stored. Return null for trivial or very short conversations.
+
+${_CRYSTAL_COMMON_FIELDS}
+
+Also include "topics_discussed": ["topic 1", "topic 2"] in the object.
+Return null (not an object) for trivial or very short conversations.`;
+
+export const CRYSTAL_SYSTEM_PROMPT_CODING = `You are crystallising a finished coding session into one structured session summary.
+
+The following facts were already extracted and stored during this conversation:
+{already_stored_facts}
+
+Write ONE Crystal that captures what turn-by-turn extraction missed. Include:
+- narrative: 1-2 sentences describing the session overall
+- key_outcomes: decisions made, bugs fixed, features built
+- open_threads: things left unfinished or needing follow-up
+- lessons: patterns, gotchas, or insights worth remembering
+- files_affected: file paths mentioned or worked on (extract from assistant messages)
+- importance: 7-10 (8 default)
+
+Do NOT repeat facts already stored. Return null for trivial or very short sessions.
+
+${_CRYSTAL_COMMON_FIELDS}
+
+Also include "files_affected": ["/path/to/file.ts", ...] in the object (may be []).
+Return null (not an object) for trivial or very short sessions.`;
+
+/** Parse an LLM Crystal response into a CrystalMetadata + narrative pair. */
+export function parseCrystalResponse(
+  response: string,
+  hostType: 'chat' | 'coding' = 'chat',
+): { narrative: string; importance: number; metadata: CrystalMetadata } | null {
+  let cleaned = response.trim();
+  if (cleaned.startsWith('```')) {
+    cleaned = cleaned.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '').trim();
+  }
+  if (cleaned.toLowerCase() === 'null' || cleaned === '') return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(cleaned);
+  } catch {
+    return null;
+  }
+
+  if (parsed === null) return null;
+  if (typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+
+  const d = parsed as Record<string, unknown>;
+  const narrative = typeof d.narrative === 'string' ? d.narrative.trim().slice(0, 512) : '';
+  if (narrative.length < 10) return null;
+
+  const strList = (key: string): string[] => {
+    const raw = d[key];
+    if (!Array.isArray(raw)) return [];
+    return raw.map((x) => String(x).trim()).filter((x) => x.length > 0).slice(0, 10);
+  };
+
+  let importance = typeof d.importance === 'number' ? d.importance : 8;
+  importance = Math.max(1, Math.min(10, Math.round(importance)));
+
+  const metadata: CrystalMetadata = {
+    subtype: 'session_crystal',
+    key_outcomes: strList('key_outcomes'),
+    open_threads: strList('open_threads'),
+    lessons: strList('lessons'),
+  };
+  if (hostType === 'coding') {
+    metadata.files_affected = strList('files_affected');
+  } else {
+    metadata.topics_discussed = strList('topics_discussed');
+  }
+
+  return { narrative, importance, metadata };
+}
+
+/**
+ * Extract a Crystal session summary using LLM.
+ *
+ * Returns null if LLM unavailable, session too short, or LLM returns null.
+ */
+export async function extractCrystal(
+  rawMessages: unknown[],
+  storedFactTexts: string[],
+  hostType: 'chat' | 'coding' = 'coding',
+): Promise<{ narrative: string; importance: number; metadata: CrystalMetadata } | null> {
+  const config = resolveLLMConfig();
+  if (!config) return null;
+
+  const parsed = rawMessages
+    .map(messageToText)
+    .filter((m): m is { role: string; content: string } => m !== null);
+
+  if (parsed.length < 8) return null;
+
+  const conversationText = truncateMessages(parsed, 12_000);
+  if (conversationText.length < 20) return null;
+
+  const alreadyStored = storedFactTexts.length > 0
+    ? storedFactTexts.map((t) => `- ${t}`).join('\n')
+    : '(none)';
+
+  const promptTemplate = hostType === 'coding'
+    ? CRYSTAL_SYSTEM_PROMPT_CODING
+    : CRYSTAL_SYSTEM_PROMPT_CHAT;
+  const systemPrompt = promptTemplate.replace('{already_stored_facts}', alreadyStored);
+
+  try {
+    const response = await chatCompletion(config, [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: `Crystallise this session:\n\n${conversationText}` },
+    ], {
+      retry: { attempts: 3, baseDelayMs: 1000 },
+      timeoutMs: 30_000,
+    });
+
+    if (!response) return null;
+    return parseCrystalResponse(response, hostType);
+  } catch {
+    return null;
   }
 }
 

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -58,7 +58,7 @@ import {
 import { createApiClient, type StoreFactPayload } from './api-client.js';
 import {
   extractFacts,
-  extractDebrief,
+  extractCrystal,
   isValidMemoryType,
   parseEntity,
   VALID_MEMORY_TYPES,
@@ -6988,27 +6988,25 @@ const plugin = {
           }
           turnsSinceLastExtraction = 0; // Reset C3 counter on compaction.
 
-          // Session debrief — after regular extraction.
-          // v1 mapping: DebriefItem { type: 'summary'|'context' } →
-          //   v1 type 'summary' (always, since context → claim would lose
-          //   the "this is a session summary" signal) + source 'derived'
-          //   (session debrief is a derived synthesis by definition).
+          // Session Crystal (am-1) — one structured summary replaces 5 free-form debrief items.
+          // Stored as v1 summary + metadata.subtype="session_crystal" for filtered recall.
           try {
             const storedTexts = facts.map((f) => f.text);
-            const debriefItems = await extractDebrief(evt.messages, storedTexts);
-            if (debriefItems.length > 0) {
-              const debriefFacts: ExtractedFact[] = debriefItems.map((d) => ({
-                text: d.text,
+            const crystal = await extractCrystal(evt.messages, storedTexts, 'coding');
+            if (crystal) {
+              const crystalFact: ExtractedFact = {
+                text: crystal.narrative,
                 type: 'summary' as MemoryType,
                 source: 'derived' as MemorySource,
-                importance: d.importance,
+                importance: crystal.importance,
                 action: 'ADD' as const,
-              }));
-              await storeExtractedFacts(debriefFacts, api.logger, 'openclaw_debrief');
-              api.logger.info(`Session debrief: stored ${debriefItems.length} items`);
+                crystalMetadata: crystal.metadata,
+              };
+              await storeExtractedFacts([crystalFact], api.logger, 'openclaw_debrief');
+              api.logger.info('Session Crystal stored');
             }
           } catch (debriefErr: unknown) {
-            api.logger.warn(`before_compaction debrief failed: ${debriefErr instanceof Error ? debriefErr.message : String(debriefErr)}`);
+            api.logger.warn(`before_compaction Crystal failed: ${debriefErr instanceof Error ? debriefErr.message : String(debriefErr)}`);
           }
         } catch (err: unknown) {
           const message = err instanceof Error ? err.message : String(err);
@@ -7053,27 +7051,25 @@ const plugin = {
           }
           turnsSinceLastExtraction = 0; // Reset C3 counter on reset.
 
-          // Session debrief — after regular extraction.
-          // v1 mapping: DebriefItem { type: 'summary'|'context' } →
-          //   v1 type 'summary' (always, since context → claim would lose
-          //   the "this is a session summary" signal) + source 'derived'
-          //   (session debrief is a derived synthesis by definition).
+          // Session Crystal (am-1) — one structured summary replaces 5 free-form debrief items.
+          // Stored as v1 summary + metadata.subtype="session_crystal" for filtered recall.
           try {
             const storedTexts = facts.map((f) => f.text);
-            const debriefItems = await extractDebrief(evt.messages, storedTexts);
-            if (debriefItems.length > 0) {
-              const debriefFacts: ExtractedFact[] = debriefItems.map((d) => ({
-                text: d.text,
+            const crystal = await extractCrystal(evt.messages, storedTexts, 'coding');
+            if (crystal) {
+              const crystalFact: ExtractedFact = {
+                text: crystal.narrative,
                 type: 'summary' as MemoryType,
                 source: 'derived' as MemorySource,
-                importance: d.importance,
+                importance: crystal.importance,
                 action: 'ADD' as const,
-              }));
-              await storeExtractedFacts(debriefFacts, api.logger, 'openclaw_debrief');
-              api.logger.info(`Session debrief: stored ${debriefItems.length} items`);
+                crystalMetadata: crystal.metadata,
+              };
+              await storeExtractedFacts([crystalFact], api.logger, 'openclaw_debrief');
+              api.logger.info('Session Crystal stored');
             }
           } catch (debriefErr: unknown) {
-            api.logger.warn(`before_reset debrief failed: ${debriefErr instanceof Error ? debriefErr.message : String(debriefErr)}`);
+            api.logger.warn(`before_reset Crystal failed: ${debriefErr instanceof Error ? debriefErr.message : String(debriefErr)}`);
           }
         } catch (err: unknown) {
           const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
🤖 (bot) ## Summary

Implements am-1 per canonical-roadmap issue p-diogo/totalreclaw-internal#251.

**Risk tier:** L2
**Files changed:** 15
**Net diff:** +800 insertions, -237 deletions

## What changed

Replaces 5× free-form debrief items with ONE Crystal-shaped summary per session, stored as a v1 `summary` memory with `extra_metadata.subtype="session_crystal"`.

**All four surfaces updated:**
- **OpenClaw plugin** (`skill/plugin/`) — `extractCrystal()` in `extractor.ts`, `crystalMetadata` re-attach in `claims-helper.ts`, `before_compaction`/`before_reset` hooks in `index.ts`
- **Hermes/Python** (`python/`) — `Crystal` dataclass + `generate_crystal()` in `agent/debrief.py`, `extra_metadata` parameter threaded through `claims_helper.py` → `operations.py` → `client.py` → `lifecycle.py`
- **MCP server** (`mcp/`) — `handleDebrief()` now accepts Crystal (preferred) or legacy facts array (backward compat), `buildV1ClaimBlob` carries `metadata` field in `claims-helper.ts` and `index.ts`
- **NanoClaw** (`skill-nanoclaw/`) — `parseCrystalResponse()` + `CRYSTAL_SYSTEM_PROMPT_CHAT` in `prompts.ts`, single Crystal store in `pre-compact.ts`

## Done criteria

- [x] Crystal generated via LLM and stored as one summary fact per session
- [x] All four surfaces: OpenClaw plugin, Hermes/Python, MCP server, NanoClaw pre-compact
- [x] `extra_metadata.subtype = "session_crystal"` on every stored Crystal
- [x] v1 provenance: `fact_type=summary`, `provenance=derived`, `scope=unspecified`
- [x] Tests updated and green (Python: 974 passed; MCP tool-description + debrief tests pass)

## RC artifact

RC published: `3.3.12-rc.5` — coordinator: run `qa-totalreclaw` against this RC

Closes p-diogo/totalreclaw-internal#251