### PR TITLE
chore: bump plugin to 3.3.12-rc.9 (skip rc.8; ClawHub reconcile)

### DIFF
--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -114,12 +114,14 @@ openclaw skills install totalreclaw
 
 **No extra config steps needed.** As of 3.3.9-rc.2 the plugin's `register()` auto-patches `~/.openclaw/openclaw.json` with the keys OpenClaw 2026.5.x looks for (`plugins.slots.memory`, `plugins.entries.totalreclaw.hooks.allowConversationAccess`, `channels.telegram.streaming.mode`, `plugins.bundledDiscovery`, `plugins.allow`, `plugins.installs.totalreclaw`). As of 3.3.12-rc.6 the plugin auto-fires SIGUSR1 to its own PID after the patch, so the gateway in-process restart picks up the new keys without any manual `/totalreclaw-restart` from the user — hooks register cleanly on the first session post-install.
 
+> **Setup is plugin-driven as of 3.3.12-rc.7.** When the plugin loads with no `~/.totalreclaw/credentials.json`, it autonomously opens a relay pair session and writes `{url, pin, sid, expires_at_ms}` to `~/.totalreclaw/.pair-pending.json`. A `before_agent_start` hook then injects the URL+PIN into the agent's context block on every turn. The agent's only job is to read those values from the injected context and surface them verbatim to you — it does NOT need to know how `tr pair --json` works or run any pair CLI itself. This eliminates the "agent hallucinates a pair URL" failure mode seen in rc.6 QA.
+
 > **Auto-extraction safety net (3.3.11-rc.1).** Even when the `agent_end` hook is gated by an upstream policy, the plugin runs a filesystem-polling backup that watches `~/.openclaw/agents/<agent>/sessions/*.trajectory.jsonl` every 60 s and runs the same extraction pipeline (NOT a hook event, so it's never gated). On 3.3.12-rc.6+ the hook fires alongside the poller; offset-based dedup prevents double-extraction.
 
 > **Plugin status caveat — OpenClaw 2026.5.7.** On the freshest OpenClaw releases the install path can occasionally land the plugin as `Status: disabled` after restart (upstream config-strip-on-restart). If `openclaw plugins list` shows totalreclaw as disabled, run `openclaw plugins enable totalreclaw` once and continue. The plugin remains on disk; only the registry flag needs flipping.
 
 Notes:
-- For an RC build, replace the first command with `openclaw plugins install @totalreclaw/totalreclaw@rc` (latest release candidate) or pin a version like `openclaw plugins install @totalreclaw/totalreclaw@3.3.12-rc.6`.
+- For an RC build, replace the first command with `openclaw plugins install @totalreclaw/totalreclaw@rc` (latest release candidate) or pin a version like `openclaw plugins install @totalreclaw/totalreclaw@3.3.12-rc.9`.
 - If install reports `already exists` or non-zero on a re-run (the plugin is already on disk from a previous attempt), add `--force`: `openclaw plugins install @totalreclaw/totalreclaw@rc --force` and `openclaw skills install totalreclaw --force`.
 - If either command fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment), STOP and tell the user verbatim: *"Your environment doesn't expose the OpenClaw CLI to me. Please install `totalreclaw` from your service's plugins / skills UI, then reply `done`."* Wait for `done` before continuing to Step 2.
 
@@ -225,7 +227,7 @@ The plugin self-restarts the gateway via SIGUSR1 when needed. You should not nee
 
 Then in chat: *"Set up TotalReclaw"* — the agent will call `totalreclaw_pair` and hand you the URL + PIN. Open the URL in your browser to enter or generate your phrase.
 
-> Pin a specific RC with `openclaw plugins install @totalreclaw/totalreclaw@3.3.12-rc.6`. Check what each tag resolves to: `npm view @totalreclaw/totalreclaw dist-tags`. Keep skill and plugin on the same version family (both stable or both RC).
+> Pin a specific RC with `openclaw plugins install @totalreclaw/totalreclaw@3.3.12-rc.9`. Check what each tag resolves to: `npm view @totalreclaw/totalreclaw dist-tags`. Keep skill and plugin on the same version family (both stable or both RC).
 
 <details>
 <summary>From-source install (for plugin development — self-host only)</summary>

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "End-to-end encrypted, decentralized memory for OpenClaw. Set up an account once, then call totalreclaw_remember / totalreclaw_recall (or the tr CLI under hybrid-primary) instead of writing to MEMORY.md / USER.md / local files. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', any remember / recall request, AND any user statement that contains a preference / fact / decision / commitment about themselves."
-version: 3.3.12-rc.7
+version: 3.3.12-rc.9
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.12-rc.7",
+  "version": "3.3.12-rc.9",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "3.3.12-rc.7",
+  "version": "3.3.12-rc.9",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",

--- a/skill/plugin/tr-cli.ts
+++ b/skill/plugin/tr-cli.ts
@@ -72,7 +72,7 @@ const STATE_PATH = CONFIG.onboardingStatePath;
 // Auto-synced by skill/scripts/sync-version.mjs from skill/plugin/package.json::version.
 // Do not edit by hand — running tests will catch drift but the publish workflow
 // rewrites this constant at the start of every npm/ClawHub publish.
-const PLUGIN_VERSION = '3.3.12-rc.7';
+const PLUGIN_VERSION = '3.3.12-rc.9';
 
 function die(msg: string, code = 1): never {
   process.stderr.write(`tr: ${msg}\n`);


### PR DESCRIPTION
## Summary

Version-only bump 3.3.12-rc.7 → 3.3.12-rc.9. Skips rc.8 (published to ClawHub on 2026-05-10 by an auto-triage agent before the rc.7 SKILL.md collapse + auto-pair runtime merged to main; that rc.8 tarball is stale).

Once merged, dispatch BOTH `npm-publish.yml` (rc-number=9, package=plugin) AND `publish-clawhub.yml` (rc-number=9) to re-establish version monotony across both registries.

## What's in rc.9

Same as rc.7 (no code change):
- Plugin auto-pair-on-load + `before_agent_start` hook context injection
- `.pair-pending.json` sentinel + cleanup
- SKILL.md collapsed to 76 lines
- Consumes `@totalreclaw/client@^1.3.0` (pure-JS argon2id)

Plus version sync + guide pin bump.

## Verified

- [x] `check-scanner` — 137 files, 0 flags
- [x] `check-version-drift` — all sites = 3.3.12-rc.9
- [x] `check-url-binding --release-type=rc` — 7 prod hits, 0 staging-default
- [x] Build clean

## Out of scope (followup)

- Full install-guide collapse alongside SKILL.md collapse — agent-imperative tone in rest of guide is now stale (rc.10 candidate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)