### PR TITLE
fix(python): P0 phrase-safety gate — totalreclaw setup refuses agent shell

### DIFF
--- a/python/src/totalreclaw/cli.py
+++ b/python/src/totalreclaw/cli.py
@@ -93,6 +93,7 @@ def _info(text: str) -> str:
 def run_setup(
     credentials_path: Optional[Path] = None,
     emit_phrase: bool = False,
+    allow_non_tty: bool = False,
 ) -> int:
     """Run the interactive setup wizard.
 
@@ -101,13 +102,23 @@ def run_setup(
     ``_try_eager_resolve_scope_address`` in ``hermes/cli.py``). This
     keeps behaviour identical across ``hermes setup`` and
     ``totalreclaw setup``.
+
+    2.3.3 P0: the ``allow_non_tty`` flag propagates through to the
+    shared wizard's agent-runtime gate. Default False — refuses to run
+    from non-TTY stdin or known agent-runtime env. See the docstring
+    in ``totalreclaw.hermes.cli._is_agent_runtime`` for the full
+    phrase-safety rationale.
     """
     # Delay import so `totalreclaw doctor` on a setup-less box doesn't pay
     # for eth_account's import cost.
     from totalreclaw.hermes.cli import run_setup as _hermes_run_setup
 
     path = credentials_path if credentials_path is not None else CANONICAL_CREDENTIALS_PATH
-    return _hermes_run_setup(credentials_path=path, emit_phrase=emit_phrase)
+    return _hermes_run_setup(
+        credentials_path=path,
+        emit_phrase=emit_phrase,
+        allow_non_tty=allow_non_tty,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -391,6 +402,18 @@ def main(argv: Optional[list[str]] = None) -> int:
             "(stderr). Default: silent-save."
         ),
     )
+    sp_setup.add_argument(
+        "--allow-non-tty",
+        action="store_true",
+        default=False,
+        help=(
+            "2.3.3 — override the agent-runtime safety gate. Required for piped or "
+            "scripted invocation from a private user terminal (no agent involved). "
+            "Default: refuse to run when stdin is non-TTY OR when agent-runtime env "
+            "markers are present. NEVER use from an agent shell — use the "
+            "totalreclaw_pair tool instead."
+        ),
+    )
 
     sp_doctor = sub.add_parser(
         "doctor",
@@ -419,6 +442,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         return run_setup(
             credentials_path=args.credentials_path,
             emit_phrase=getattr(args, "emit_phrase", False),
+            allow_non_tty=getattr(args, "allow_non_tty", False),
         )
     if args.command == "doctor":
         return run_doctor(

--- a/python/src/totalreclaw/hermes/cli.py
+++ b/python/src/totalreclaw/hermes/cli.py
@@ -434,10 +434,100 @@ def _run_generate(io: _IO, credentials_path: Path, emit_phrase: bool = False) ->
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Agent-runtime detection gate (2.3.3 — P0 phrase-safety hardening)
+# ---------------------------------------------------------------------------
+
+_AGENT_RUNTIME_ENV_MARKERS = (
+    # Hermes Agent framework markers
+    "HERMES_AGENT_RUN",
+    "HERMES_GATEWAY_RUN",
+    "HERMES_GATEWAY_ALLOW_ALL_USERS",
+    # OpenClaw markers (cross-runtime; we ship as plugin there too)
+    "OPENCLAW_AGENT",
+    "OPENCLAW_AGENT_RUN",
+    # MCP transport (Claude Desktop, Cursor, Windsurf consume our MCP server)
+    "MCP_TRANSPORT",
+    # Explicit opt-in marker callers can set to assert "agent context, never run setup"
+    "TOTALRECLAW_AGENT_CONTEXT",
+)
+
+
+def _is_agent_runtime() -> bool:
+    """Best-effort detect whether ``totalreclaw setup`` is being invoked
+    by an AI-agent's shell-exec tool rather than by a user in a real
+    terminal.
+
+    Why this gate exists (2.3.3, P0 phrase-safety):
+
+    On 2026-05-11 a Hermes chat agent invoked ``totalreclaw setup`` via
+    its shell tool. The default wizard does silent-save (does NOT print
+    the recovery phrase since 2.3.1rc2), so the phrase did not directly
+    cross LLM context in that specific run — but the wallet was created
+    via the local CLI wizard rather than via the architecturally-correct
+    browser-pair flow (``totalreclaw_pair`` tool). That bypass means:
+
+    1. The phrase sits in plaintext at ``~/.totalreclaw/credentials.json``
+       accessible to any subsequent agent shell command. A future agent
+       turn that runs ``cat ~/.totalreclaw/credentials.json`` immediately
+       leaks the phrase into LLM context.
+    2. The user never SEES the phrase in their browser (the browser-pair
+       flow's user-confirmed transcription step is skipped), so backup
+       depends on the agent / user remembering to ``cat`` the file later.
+    3. The phrase-safety architectural invariant — "recovery phrase
+       generated browser-side, never reaches the gateway or the agent in
+       plaintext" — is silently violated even if no single tool result
+       carries the phrase in this run.
+
+    Detection:
+    1. ``sys.stdin.isatty() == False`` — piped / no controlling terminal.
+       Standard signal that no user is typing into the wizard. Catches the
+       observed failure mode ``echo "generate" | totalreclaw setup``.
+    2. Specific env markers set by agent runtimes when they spawn
+       subprocesses. Set listed in ``_AGENT_RUNTIME_ENV_MARKERS``. Tested
+       env vars come from real Hermes / OpenClaw / MCP-host deployments.
+
+    Override:
+    Legitimate user automation (scripted installs in a private terminal,
+    CI bootstrap, etc.) can bypass this gate via the
+    ``--allow-non-tty`` CLI flag — see ``run_setup(allow_non_tty=...)``.
+    Documented loudly; the flag's help text says NEVER from agent.
+
+    Returns
+    -------
+    bool
+        True iff at least one agent-runtime signal fires.
+    """
+    if not sys.stdin.isatty():
+        return True
+    for marker in _AGENT_RUNTIME_ENV_MARKERS:
+        if os.environ.get(marker):
+            return True
+    return False
+
+
+_AGENT_GATE_REFUSAL = """
+❌ totalreclaw setup detected non-TTY stdin or an agent-runtime environment.
+
+You are an AI agent — do not run this CLI. The wizard writes the
+recovery phrase to a file that your subsequent shell tool calls can
+read into your LLM context, defeating the phrase-safety guarantee.
+
+Use the `totalreclaw_pair` tool instead. It returns {url, pin, expires_at_ms}.
+Surface the URL and PIN to the user verbatim — do not invent or modify
+the values. The user opens the URL in their browser, enters the PIN,
+and the browser generates the recovery phrase locally. The phrase
+never crosses your context.
+
+Procedure: https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md
+"""
+
+
 def run_setup(
     credentials_path: Optional[Path] = None,
     io: Optional[_IO] = None,
     emit_phrase: bool = False,
+    allow_non_tty: bool = False,
 ) -> int:
     """Run the interactive setup wizard. Returns exit code.
 
@@ -452,7 +542,21 @@ def run_setup(
         the phrase is displayed on stderr (rc.1 behaviour). Default
         False in 2.3.1rc2 — the phrase is never shown and the user is
         pointed at credentials.json instead.
+    allow_non_tty : bool
+        2.3.3 P0 hardening. When False (default), refuses to run if
+        ``_is_agent_runtime()`` fires (non-TTY OR agent env markers).
+        Pass True for legitimate user-side automation (private terminals,
+        CI bootstrap). NEVER pass True from agent shells — defeats the
+        phrase-safety guarantee. See ``_is_agent_runtime`` docstring for
+        the full rationale.
     """
+    # 2.3.3 — agent-runtime gate. Refuse to run if invoked from a
+    # non-TTY stdin or any known agent-runtime environment, unless the
+    # caller has opted out explicitly via allow_non_tty.
+    if not allow_non_tty and _is_agent_runtime():
+        sys.stderr.write(_AGENT_GATE_REFUSAL)
+        return 3
+
     path = credentials_path if credentials_path is not None else CANONICAL_CREDENTIALS_PATH
     wizard_io = io if io is not None else _IO()
 
@@ -519,6 +623,19 @@ def main(argv: Optional[list[str]] = None) -> int:
             "or shared screens."
         ),
     )
+    sp_setup.add_argument(
+        "--allow-non-tty",
+        action="store_true",
+        default=False,
+        help=(
+            "2.3.3 — override the agent-runtime safety gate. Required for piped or "
+            "scripted invocation from a private user terminal (no agent involved). "
+            "Default: refuse to run when stdin is non-TTY OR when agent-runtime env "
+            "markers are present, since wizard output flows back into the agent's LLM "
+            "context. NEVER use from an agent shell — use the totalreclaw_pair tool "
+            "instead. See the guide for details."
+        ),
+    )
 
     args = parser.parse_args(argv)
 
@@ -526,6 +643,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         return run_setup(
             credentials_path=args.credentials_path,
             emit_phrase=getattr(args, "emit_phrase", False),
+            allow_non_tty=getattr(args, "allow_non_tty", False),
         )
 
     parser.print_help()

--- a/python/tests/test_hermes_setup_cli.py
+++ b/python/tests/test_hermes_setup_cli.py
@@ -58,7 +58,7 @@ class TestRestoreFlow:
         stdin_text = f"restore\n{VALID_MNEMONIC}\n"
         io, stdout, stderr = _make_io(stdin_text)
 
-        rc = hermes_cli.run_setup(credentials_path=creds, io=io)
+        rc = hermes_cli.run_setup(credentials_path=creds, io=io, allow_non_tty=True)
 
         assert rc == 0, stderr.getvalue()
         assert creds.exists()
@@ -76,7 +76,7 @@ class TestRestoreFlow:
         stdin_text = f"restore\n{words_per_line}\n"
         io, stdout, _stderr = _make_io(stdin_text)
 
-        rc = hermes_cli.run_setup(credentials_path=creds, io=io)
+        rc = hermes_cli.run_setup(credentials_path=creds, io=io, allow_non_tty=True)
 
         assert rc == 0
         saved = json.loads(creds.read_text())
@@ -89,7 +89,7 @@ class TestRestoreFlow:
         stdin_text = f"restore\n{short}\n"
         io, _stdout, stderr = _make_io(stdin_text)
 
-        rc = hermes_cli.run_setup(credentials_path=creds, io=io)
+        rc = hermes_cli.run_setup(credentials_path=creds, io=io, allow_non_tty=True)
 
         assert rc != 0
         assert not creds.exists()
@@ -107,7 +107,7 @@ class TestRestoreFlow:
         stdin_text = f"restore\n{bad.strip()}\n"
         io, _stdout, stderr = _make_io(stdin_text)
 
-        rc = hermes_cli.run_setup(credentials_path=creds, io=io)
+        rc = hermes_cli.run_setup(credentials_path=creds, io=io, allow_non_tty=True)
 
         assert rc != 0
         assert not creds.exists()
@@ -119,7 +119,7 @@ class TestRestoreFlow:
         stdin_text = f"restore\n{VALID_MNEMONIC}\n"
         io, _stdout, stderr = _make_io(stdin_text, is_tty=False)
 
-        rc = hermes_cli.run_setup(credentials_path=creds, io=io)
+        rc = hermes_cli.run_setup(credentials_path=creds, io=io, allow_non_tty=True)
         assert rc == 0
         assert creds.exists()
         # Warning about visible input.
@@ -142,7 +142,7 @@ class TestGenerateFlow:
         io, stdout, stderr = _make_io(stdin_text)
 
         with patch.object(hermes_cli, "_generate_mnemonic", return_value=fake_mnem):
-            rc = hermes_cli.run_setup(credentials_path=creds, io=io)
+            rc = hermes_cli.run_setup(credentials_path=creds, io=io, allow_non_tty=True)
 
         assert rc == 0, stderr.getvalue()
         assert creds.exists()
@@ -178,7 +178,7 @@ class TestGenerateFlow:
         io, stdout, stderr = _make_io(stdin_text)
 
         with patch.object(hermes_cli, "_generate_mnemonic", return_value=fake_mnem):
-            rc = hermes_cli.run_setup(credentials_path=creds, io=io, emit_phrase=True)
+            rc = hermes_cli.run_setup(credentials_path=creds, io=io, emit_phrase=True, allow_non_tty=True)
 
         assert rc == 0, stderr.getvalue()
         assert creds.exists()
@@ -209,7 +209,7 @@ class TestGenerateFlow:
         io, stdout, stderr = _make_io(stdin_text)
 
         with patch.object(hermes_cli, "_generate_mnemonic", return_value=fake_mnem):
-            rc = hermes_cli.run_setup(credentials_path=creds, io=io, emit_phrase=True)
+            rc = hermes_cli.run_setup(credentials_path=creds, io=io, emit_phrase=True, allow_non_tty=True)
 
         assert rc != 0
         assert not creds.exists()
@@ -227,7 +227,7 @@ class TestGenerateFlow:
         io, _stdout, _stderr = _make_io(stdin_text, is_tty=False)
 
         with patch.object(hermes_cli, "_generate_mnemonic", return_value=fake_mnem):
-            rc = hermes_cli.run_setup(credentials_path=creds, io=io)
+            rc = hermes_cli.run_setup(credentials_path=creds, io=io, allow_non_tty=True)
 
         assert rc == 0
         assert creds.exists()
@@ -251,7 +251,7 @@ class TestOverwriteConfirmation:
         stdin_text = "n\n"
         io, stdout, _stderr = _make_io(stdin_text)
 
-        rc = hermes_cli.run_setup(credentials_path=creds, io=io)
+        rc = hermes_cli.run_setup(credentials_path=creds, io=io, allow_non_tty=True)
 
         assert rc == 0
         # File is untouched.
@@ -269,7 +269,7 @@ class TestOverwriteConfirmation:
         stdin_text = f"y\nrestore\n{VALID_MNEMONIC}\n"
         io, _stdout, stderr = _make_io(stdin_text)
 
-        rc = hermes_cli.run_setup(credentials_path=creds, io=io)
+        rc = hermes_cli.run_setup(credentials_path=creds, io=io, allow_non_tty=True)
 
         assert rc == 0, stderr.getvalue()
         saved = json.loads(creds.read_text())
@@ -294,7 +294,10 @@ class TestMainEntry:
         with patch.object(hermes_cli, "run_setup", return_value=0) as m:
             rc = hermes_cli.main(["setup", "--credentials-path", str(creds)])
         assert rc == 0
-        m.assert_called_once_with(credentials_path=creds, emit_phrase=False)
+        # 2.3.6rc4 P0: allow_non_tty=False is now part of the default call.
+        m.assert_called_once_with(
+            credentials_path=creds, emit_phrase=False, allow_non_tty=False
+        )
 
     def test_main_setup_emit_phrase_forwarded(self, tmp_path: Path) -> None:
         """`hermes setup --emit-phrase` forwards the flag to run_setup."""
@@ -302,4 +305,7 @@ class TestMainEntry:
         with patch.object(hermes_cli, "run_setup", return_value=0) as m:
             rc = hermes_cli.main(["setup", "--credentials-path", str(creds), "--emit-phrase"])
         assert rc == 0
-        m.assert_called_once_with(credentials_path=creds, emit_phrase=True)
+        # 2.3.6rc4 P0: allow_non_tty=False default carried alongside emit_phrase.
+        m.assert_called_once_with(
+            credentials_path=creds, emit_phrase=True, allow_non_tty=False
+        )

--- a/python/tests/test_setup_agent_gate.py
+++ b/python/tests/test_setup_agent_gate.py
@@ -1,0 +1,227 @@
+"""P0 phrase-safety gate on `totalreclaw setup` / `hermes setup`
+(added 2.3.6rc4 after the 2.3.2 stable QA on Pop-OS Hermes container —
+docs/notes/2026-05-11-hermes-rc3-failure-plan.md).
+
+Verifies the gate added in ``totalreclaw.hermes.cli`` refuses to run the
+wizard when invoked from an agent shell (non-TTY stdin or known agent
+env markers) UNLESS the explicit ``allow_non_tty=True`` opt-out is set.
+
+Why this test exists:
+On 2026-05-11 a Hermes chat agent invoked ``totalreclaw setup`` via its
+shell tool. The wizard's default (silent-save since 2.3.1rc2) did NOT
+print the recovery phrase, but the wallet was generated locally via the
+CLI rather than via the architecturally-correct browser-pair flow
+(``totalreclaw_pair`` tool). The phrase then sits in plaintext at
+``~/.totalreclaw/credentials.json`` accessible to any subsequent agent
+shell command — a future agent turn that runs
+``cat ~/.totalreclaw/credentials.json`` immediately leaks the phrase
+into LLM context. P0 fix: refuse to run the wizard at all when an agent
+shell is detected.
+
+Test matrix:
+* Non-TTY stdin (the actual observed failure mode, ``echo ... | totalreclaw setup``) → refused
+* Each agent-runtime env marker present → refused
+* TTY + no markers → passes the gate (wizard proceeds; we mock
+  downstream so we don't actually run the wizard, just verify the gate
+  doesn't fire)
+* ``allow_non_tty=True`` override → bypasses the gate even on non-TTY
+* Refusal message contains the redirect to ``totalreclaw_pair``
+* Refusal exit code is non-zero (specifically 3, to distinguish from
+  exit 0 success, exit 1 wizard error, exit 2 file-write error)
+"""
+
+from __future__ import annotations
+
+import os
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from totalreclaw.hermes import cli as hermes_cli
+
+
+# ---------------------------------------------------------------------------
+# _is_agent_runtime — the detection function itself
+# ---------------------------------------------------------------------------
+
+
+class TestIsAgentRuntime:
+    """Direct unit tests for ``_is_agent_runtime`` (the detection oracle)."""
+
+    def test_non_tty_stdin_fires(self) -> None:
+        """``sys.stdin.isatty() == False`` (piped / no controlling terminal)
+        is the canonical agent-shell signal."""
+        with patch("sys.stdin.isatty", return_value=False):
+            with patch.dict(os.environ, {}, clear=False):
+                # Ensure no env markers are set during this test
+                for marker in hermes_cli._AGENT_RUNTIME_ENV_MARKERS:
+                    os.environ.pop(marker, None)
+                assert hermes_cli._is_agent_runtime() is True
+
+    def test_tty_stdin_with_no_env_passes(self) -> None:
+        """Real user terminal: TTY stdin + no agent env markers → not
+        agent-runtime."""
+        with patch("sys.stdin.isatty", return_value=True):
+            with patch.dict(os.environ, {}, clear=False):
+                for marker in hermes_cli._AGENT_RUNTIME_ENV_MARKERS:
+                    os.environ.pop(marker, None)
+                assert hermes_cli._is_agent_runtime() is False
+
+    @pytest.mark.parametrize("marker", hermes_cli._AGENT_RUNTIME_ENV_MARKERS)
+    def test_each_env_marker_fires(self, marker: str) -> None:
+        """Each documented agent-runtime env marker, when set to any
+        truthy value, must trigger the gate even on a TTY stdin."""
+        with patch("sys.stdin.isatty", return_value=True):
+            with patch.dict(os.environ, {marker: "1"}, clear=False):
+                assert hermes_cli._is_agent_runtime() is True
+
+    def test_empty_env_marker_value_does_not_fire(self) -> None:
+        """An env var set to the empty string should not fire the gate
+        (the dict iteration uses ``os.environ.get`` which returns "" as
+        falsy here — confirms our truthy semantics)."""
+        with patch("sys.stdin.isatty", return_value=True):
+            with patch.dict(
+                os.environ, {"HERMES_AGENT_RUN": ""}, clear=False
+            ):
+                # Empty string env var is falsy → gate must not fire
+                # off only this marker
+                assert hermes_cli._is_agent_runtime() is False
+
+    def test_unknown_env_marker_does_not_fire(self) -> None:
+        """Random env vars must NOT trigger the gate — only the
+        whitelist in ``_AGENT_RUNTIME_ENV_MARKERS``."""
+        with patch("sys.stdin.isatty", return_value=True):
+            with patch.dict(
+                os.environ, {"RANDOM_UNRELATED_VAR": "1"}, clear=False
+            ):
+                for marker in hermes_cli._AGENT_RUNTIME_ENV_MARKERS:
+                    os.environ.pop(marker, None)
+                assert hermes_cli._is_agent_runtime() is False
+
+
+# ---------------------------------------------------------------------------
+# run_setup — the gate's effect on the wizard entry point
+# ---------------------------------------------------------------------------
+
+
+class TestRunSetupGate:
+    """Integration tests verifying that ``run_setup`` actually refuses
+    when ``_is_agent_runtime()`` fires + a useful error message is
+    written to stderr."""
+
+    def test_refuses_when_agent_runtime_detected(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Default ``allow_non_tty=False`` + non-TTY stdin → refusal
+        with exit code 3."""
+        creds = tmp_path / "creds.json"
+        with patch.object(hermes_cli, "_is_agent_runtime", return_value=True):
+            rc = hermes_cli.run_setup(credentials_path=creds)
+        assert rc == 3, (
+            f"expected exit 3 from agent-gate refusal, got {rc}"
+        )
+        # Refusal message went to stderr
+        captured = capsys.readouterr()
+        assert "totalreclaw_pair" in captured.err, (
+            "refusal message must redirect agents to totalreclaw_pair tool"
+        )
+        assert "non-TTY" in captured.err or "agent-runtime" in captured.err, (
+            "refusal message must explain what triggered the gate"
+        )
+        # No credentials file written on refusal
+        assert not creds.exists(), (
+            "refusal path must not touch the credentials file"
+        )
+
+    def test_allow_non_tty_bypasses_gate(self, tmp_path: Path) -> None:
+        """``allow_non_tty=True`` opt-out → wizard proceeds even when
+        ``_is_agent_runtime()`` would fire."""
+        creds = tmp_path / "creds.json"
+        # Mock the gate to fire AND mock downstream wizard to short-circuit
+        # without actually running the full interactive flow.
+        with patch.object(hermes_cli, "_is_agent_runtime", return_value=True):
+            with patch.object(
+                hermes_cli, "_ask_branch", return_value=None
+            ) as ask:
+                # Stub detect_first_run + io machinery so the wizard reaches
+                # _ask_branch without hitting real stdin.
+                with patch.object(
+                    hermes_cli, "detect_first_run", return_value=True
+                ):
+                    rc = hermes_cli.run_setup(
+                        credentials_path=creds,
+                        allow_non_tty=True,
+                    )
+        # _ask_branch was reached → gate was bypassed
+        assert ask.called, (
+            "with allow_non_tty=True, gate must not fire and wizard "
+            "must proceed past the gate to the branch prompt"
+        )
+        # _ask_branch returned None → wizard hit the unknown-choice
+        # exit path (rc=1). The exact exit code isn't the point —
+        # the point is that _ask_branch was reached at all.
+        assert rc in (0, 1, 2), (
+            f"after bypass, wizard runs normally; got unexpected rc={rc}"
+        )
+
+    def test_user_terminal_passes_gate(self, tmp_path: Path) -> None:
+        """TTY stdin + no env markers → gate doesn't fire; wizard
+        proceeds. Same scaffolding as the allow_non_tty test but with
+        ``_is_agent_runtime()`` returning False naturally."""
+        creds = tmp_path / "creds.json"
+        with patch.object(hermes_cli, "_is_agent_runtime", return_value=False):
+            with patch.object(
+                hermes_cli, "_ask_branch", return_value=None
+            ) as ask:
+                with patch.object(
+                    hermes_cli, "detect_first_run", return_value=True
+                ):
+                    rc = hermes_cli.run_setup(credentials_path=creds)
+        assert ask.called, (
+            "on a real user terminal, the gate must not fire and the "
+            "wizard must proceed past the gate"
+        )
+
+    def test_refusal_message_points_to_guide(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """The refusal message must include the hermes-setup.md guide
+        URL so the agent can resolve confusion immediately."""
+        creds = tmp_path / "creds.json"
+        with patch.object(hermes_cli, "_is_agent_runtime", return_value=True):
+            hermes_cli.run_setup(credentials_path=creds)
+        captured = capsys.readouterr()
+        assert "hermes-setup.md" in captured.err, (
+            "refusal message must reference the user guide for further "
+            "context"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI argparse plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestArgparseAllowNonTtyPropagation:
+    """``hermes setup --allow-non-tty`` must propagate through to
+    ``run_setup(allow_non_tty=True)``."""
+
+    def test_flag_propagates(self) -> None:
+        with patch.object(hermes_cli, "run_setup", return_value=0) as m:
+            hermes_cli.main(["setup", "--allow-non-tty"])
+        m.assert_called_once()
+        call_kwargs = m.call_args.kwargs
+        assert call_kwargs.get("allow_non_tty") is True, (
+            f"--allow-non-tty must propagate; got {call_kwargs}"
+        )
+
+    def test_flag_default_is_false(self) -> None:
+        with patch.object(hermes_cli, "run_setup", return_value=0) as m:
+            hermes_cli.main(["setup"])
+        m.assert_called_once()
+        call_kwargs = m.call_args.kwargs
+        assert call_kwargs.get("allow_non_tty") is False, (
+            f"default must be False; got {call_kwargs}"
+        )


### PR DESCRIPTION
## Summary

Closes the phrase-safety vulnerability surfaced by 2026-05-11 Hermes 2.3.2 stable QA on Pop-OS: chat agent invoked `totalreclaw setup` via shell tool, wizard generated wallet locally, recovery phrase sat in plaintext at `~/.totalreclaw/credentials.json` accessible to any subsequent agent shell call. The architectural invariant ("recovery phrase generated browser-side, never reaches gateway or agent in plaintext") was silently violated.

## Change

New agent-runtime detection gate at the top of `run_setup` in both `hermes/cli.py` and `cli.py` (the two binary entry points share the wizard):

- Detects non-TTY stdin OR specific agent-runtime env markers
- Refuses to run; exits code 3; writes a tight, action-directive refusal to stderr pointing at the `totalreclaw_pair` tool + hermes-setup.md guide
- Does NOT touch the credentials file on refusal
- New `--allow-non-tty` flag bypasses for legitimate user-side automation

Refusal message dropped the multi-runtime list per Pedro's feedback (hallucination guard). Single clear redirect to `totalreclaw_pair`.

## Tests

- New `tests/test_setup_agent_gate.py` — 17 tests covering each env marker, non-TTY stdin, refusal exit code, refusal message content, credentials file untouched on refusal, bypass via `--allow-non-tty`, argparse propagation
- Existing test files updated: 11 wizard-internal callsites now pass `allow_non_tty=True` (bypass for test-internals), 2 argparse-passthrough assertions updated

40/40 tests pass.

## Version

pyproject.toml stays at `2.3.6` (workflow appends rc suffix). Next RC publish = `totalreclaw==2.3.6rc4` on PyPI.

## Test plan post-merge

- [ ] Dispatch `publish-python-client.yml` with `release-type=rc rc-number=4` → publishes `totalreclaw==2.3.6rc4`
- [ ] Wipe `~/.totalreclaw/credentials.json` on Pop-OS `tr-hermes` container
- [ ] Pedro re-tests via Hermes Telegram bot with prompt:
  ```
  Install TotalReclaw. See https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md — pin: pip install --pre --upgrade totalreclaw==2.3.6rc4
  ```
- [ ] Verify: agent attempts `totalreclaw setup` → CLI refuses with the new message → agent reads stderr, redirects to `totalreclaw_pair` tool → browser pair flow runs → phrase generated browser-side → never crosses LLM context
- [ ] Verify on-chain account + recall

## NOT in this patch (future work)

- P4: plugin-driven auto-pair-on-load (port OpenClaw rc.7 architecture to Python plugin)
- P3: first-class `totalreclaw` skill in Python package (overrides Hermes Agent's auto-learned wrong skill)

Refs `docs/notes/2026-05-11-hermes-rc3-failure-plan.md` for the full failure analysis + remaining work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)