### PR TITLE
fix(pair): F1 — pair client defaults to prod relay + TOTALRECLAW_SERVER_URL/RELAY_URL cascade

### DIFF
--- a/python/src/totalreclaw/pair/remote_client.py
+++ b/python/src/totalreclaw/pair/remote_client.py
@@ -47,9 +47,19 @@ from .crypto import decrypt_pairing_payload, generate_gateway_keypair, GatewayKe
 logger = logging.getLogger(__name__)
 
 
-# Default relay endpoint. Configurable via TOTALRECLAW_PAIR_RELAY_URL so
-# self-hosters can point at their own relay.
-DEFAULT_RELAY_URL = "wss://api-staging.totalreclaw.xyz"
+# Default relay endpoint. Production by default — both stable AND RC
+# Python clients install + pair against ``api.totalreclaw.xyz`` unless the
+# user opts into staging via env. This mirrors the documented contract in
+# ``docs/guides/hermes-setup.md`` (default = prod; staging = QA-only opt-in
+# via ``TOTALRECLAW_SERVER_URL`` / ``TOTALRECLAW_RELAY_URL`` /
+# ``TOTALRECLAW_PAIR_RELAY_URL``).
+#
+# History: prior to 2.3.6rc5 this constant was hardcoded to the staging
+# relay, which silently routed real-user pair sessions through staging
+# even when no env vars were set. Auto-QA 2026-05-11 (F1 finding) flagged
+# the drift between the guide's documented default and the package
+# behaviour. 2.3.6rc5 aligns them.
+DEFAULT_RELAY_URL = "wss://api.totalreclaw.xyz"
 
 
 @dataclass
@@ -75,11 +85,57 @@ def _default_client_id() -> str:
     return f"gw-{secrets.token_hex(8)}"
 
 
+def _http_to_ws(url: str) -> str:
+    """Convert ``https://`` → ``wss://`` and ``http://`` → ``ws://``.
+
+    The canonical server-URL env vars (``TOTALRECLAW_SERVER_URL``,
+    ``TOTALRECLAW_RELAY_URL``) are documented in ``hermes-setup.md`` with
+    ``https://`` prefixes (matching the relay's HTTP entrypoint), but
+    ``open_remote_pair_session`` needs a WebSocket-shape URL to dial.
+    Strip + replace the scheme so users don't have to remember which
+    env var takes which prefix.
+    """
+    if url.startswith("https://"):
+        return "wss://" + url[len("https://") :]
+    if url.startswith("http://"):
+        return "ws://" + url[len("http://") :]
+    return url  # already wss:// / ws:// or unprefixed
+
+
 def _resolve_relay_url() -> str:
-    """Read ``TOTALRECLAW_PAIR_RELAY_URL`` with a fallback to the staging default."""
+    """Resolve the pair relay URL using a 4-tier env cascade.
+
+    Cascade (highest priority first):
+
+    1. ``TOTALRECLAW_PAIR_RELAY_URL`` — pair-specific override. Used by
+       integration tests + self-hosters pointing the pair flow at a
+       relay distinct from the main TR server.
+    2. ``TOTALRECLAW_SERVER_URL`` — the canonical server URL env the
+       rest of the Python client reads (``relay.py``, ``onboarding.py``,
+       ``hermes/hooks.py``, ``hermes/pair_tool.py``). Honoured here so
+       pair behaviour matches the rest of the client. Auto-converted
+       from ``https://``/``http://`` to ``wss://``/``ws://``.
+    3. ``TOTALRECLAW_RELAY_URL`` — alias documented in
+       ``hermes-setup.md`` for clarity ("relay" vs "server"). Some
+       managed Hermes deployments set this instead of (or in addition
+       to) ``TOTALRECLAW_SERVER_URL``. Auto-scheme-converted.
+    4. ``DEFAULT_RELAY_URL`` — production (``wss://api.totalreclaw.xyz``).
+
+    Why the cascade exists (2.3.6rc5): the F1 finding in auto-QA on
+    2026-05-11 was that this function silently fell through to staging
+    even when the user / guide expected prod. The new cascade honours
+    every relay-URL env the rest of the client honours, in priority
+    order, before falling back to the prod default.
+    """
     v = os.environ.get("TOTALRECLAW_PAIR_RELAY_URL")
     if v:
         return v.rstrip("/")
+    v = os.environ.get("TOTALRECLAW_SERVER_URL")
+    if v:
+        return _http_to_ws(v.rstrip("/"))
+    v = os.environ.get("TOTALRECLAW_RELAY_URL")
+    if v:
+        return _http_to_ws(v.rstrip("/"))
     return DEFAULT_RELAY_URL.rstrip("/")
 
 

--- a/python/tests/test_pair_relay_resolution.py
+++ b/python/tests/test_pair_relay_resolution.py
@@ -1,0 +1,167 @@
+"""F1 fix tests (2.3.6rc5) — pair relay URL cascade.
+
+Before 2.3.6rc5, ``totalreclaw.pair.remote_client._resolve_relay_url``
+returned the hardcoded staging default unless ``TOTALRECLAW_PAIR_RELAY_URL``
+was set. So a real user who set ``TOTALRECLAW_SERVER_URL=https://api-staging...``
+(the canonical server-URL env the rest of the Python client respects)
+still got the pair flow against the hardcoded relay regardless. Auto-QA
+on 2026-05-11 flagged this drift between the documented contract
+("default = prod; staging is QA-only opt-in via env") and the package's
+behaviour (silent default to staging; only one env honoured).
+
+2.3.6rc5 ships:
+
+1. ``DEFAULT_RELAY_URL`` flipped to ``wss://api.totalreclaw.xyz`` (prod)
+2. ``_resolve_relay_url`` now reads a 4-tier env cascade:
+   - ``TOTALRECLAW_PAIR_RELAY_URL`` (most specific)
+   - ``TOTALRECLAW_SERVER_URL``
+   - ``TOTALRECLAW_RELAY_URL``
+   - ``DEFAULT_RELAY_URL``
+3. Auto-converts ``https://`` → ``wss://`` and ``http://`` → ``ws://`` for
+   the SERVER / RELAY envs (they're documented with HTTP prefix).
+
+Why it matters: a real user installing stable from PyPI without any env
+vars set would silently route their pair session through staging,
+landing memories on Base Sepolia (testnet) instead of whichever mainnet
+they intended. The guide promises prod-by-default; this fix aligns the
+package with the guide.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from totalreclaw.pair import remote_client
+
+
+_RELAY_ENV_NAMES = (
+    "TOTALRECLAW_PAIR_RELAY_URL",
+    "TOTALRECLAW_SERVER_URL",
+    "TOTALRECLAW_RELAY_URL",
+)
+
+
+@pytest.fixture
+def clear_relay_env(monkeypatch):
+    """Strip all relay-URL env vars so each test starts from the same
+    baseline (no env override → DEFAULT_RELAY_URL falls through)."""
+    for name in _RELAY_ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# DEFAULT_RELAY_URL — flipped to prod in 2.3.6rc5
+# ---------------------------------------------------------------------------
+
+
+def test_default_relay_is_production() -> None:
+    """Module-level DEFAULT must be the production relay, not staging."""
+    assert remote_client.DEFAULT_RELAY_URL == "wss://api.totalreclaw.xyz", (
+        "DEFAULT_RELAY_URL regressed back to staging or some other URL. "
+        "F1 fix: must be the production relay wss://api.totalreclaw.xyz."
+    )
+
+
+def test_no_env_falls_back_to_production(clear_relay_env) -> None:
+    """A user with no env vars set gets the production relay."""
+    assert remote_client._resolve_relay_url() == "wss://api.totalreclaw.xyz"
+
+
+# ---------------------------------------------------------------------------
+# Cascade priority — TOTALRECLAW_PAIR_RELAY_URL wins
+# ---------------------------------------------------------------------------
+
+
+def test_pair_relay_env_takes_priority_over_server_and_relay(
+    clear_relay_env, monkeypatch
+) -> None:
+    monkeypatch.setenv("TOTALRECLAW_PAIR_RELAY_URL", "wss://pair-override.example")
+    monkeypatch.setenv("TOTALRECLAW_SERVER_URL", "https://server-other.example")
+    monkeypatch.setenv("TOTALRECLAW_RELAY_URL", "https://relay-other.example")
+    assert remote_client._resolve_relay_url() == "wss://pair-override.example"
+
+
+# ---------------------------------------------------------------------------
+# Cascade priority — TOTALRECLAW_SERVER_URL is tier 2
+# ---------------------------------------------------------------------------
+
+
+def test_server_url_used_when_pair_relay_not_set(
+    clear_relay_env, monkeypatch
+) -> None:
+    monkeypatch.setenv("TOTALRECLAW_SERVER_URL", "https://api-staging.totalreclaw.xyz")
+    assert (
+        remote_client._resolve_relay_url() == "wss://api-staging.totalreclaw.xyz"
+    ), "TOTALRECLAW_SERVER_URL must be honoured + scheme-converted to wss://"
+
+
+def test_server_url_https_converted_to_wss(clear_relay_env, monkeypatch) -> None:
+    monkeypatch.setenv("TOTALRECLAW_SERVER_URL", "https://custom.example.com")
+    assert remote_client._resolve_relay_url() == "wss://custom.example.com"
+
+
+def test_server_url_http_converted_to_ws(clear_relay_env, monkeypatch) -> None:
+    monkeypatch.setenv("TOTALRECLAW_SERVER_URL", "http://localhost:18789")
+    assert remote_client._resolve_relay_url() == "ws://localhost:18789"
+
+
+# ---------------------------------------------------------------------------
+# Cascade priority — TOTALRECLAW_RELAY_URL is tier 3
+# ---------------------------------------------------------------------------
+
+
+def test_relay_url_used_when_higher_tiers_not_set(
+    clear_relay_env, monkeypatch
+) -> None:
+    monkeypatch.setenv("TOTALRECLAW_RELAY_URL", "https://api-staging.totalreclaw.xyz")
+    assert (
+        remote_client._resolve_relay_url() == "wss://api-staging.totalreclaw.xyz"
+    )
+
+
+def test_server_url_wins_over_relay_url(clear_relay_env, monkeypatch) -> None:
+    monkeypatch.setenv("TOTALRECLAW_SERVER_URL", "https://server.example")
+    monkeypatch.setenv("TOTALRECLAW_RELAY_URL", "https://relay.example")
+    assert remote_client._resolve_relay_url() == "wss://server.example", (
+        "Cascade priority regressed — TOTALRECLAW_SERVER_URL should win "
+        "over TOTALRECLAW_RELAY_URL."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Trailing-slash normalisation
+# ---------------------------------------------------------------------------
+
+
+def test_trailing_slash_stripped(clear_relay_env, monkeypatch) -> None:
+    monkeypatch.setenv("TOTALRECLAW_SERVER_URL", "https://api.example.com/")
+    assert remote_client._resolve_relay_url() == "wss://api.example.com"
+
+
+# ---------------------------------------------------------------------------
+# _http_to_ws — scheme-conversion helper
+# ---------------------------------------------------------------------------
+
+
+def test_http_to_ws_https_to_wss() -> None:
+    assert remote_client._http_to_ws("https://x.example") == "wss://x.example"
+
+
+def test_http_to_ws_http_to_ws() -> None:
+    assert remote_client._http_to_ws("http://x.example") == "ws://x.example"
+
+
+def test_http_to_ws_passthrough_for_already_ws() -> None:
+    """Values that already start with wss:// or ws:// must pass through."""
+    assert remote_client._http_to_ws("wss://x.example") == "wss://x.example"
+    assert remote_client._http_to_ws("ws://x.example") == "ws://x.example"
+
+
+def test_http_to_ws_passthrough_for_unprefixed() -> None:
+    """Unprefixed bare host:port passes through (caller may rely on this
+    for tests that don't care about scheme)."""
+    assert remote_client._http_to_ws("api.example.com") == "api.example.com"


### PR DESCRIPTION
## Summary

F1 fix from auto-QA finding 2026-05-11. The Python pair client at \`python/src/totalreclaw/pair/remote_client.py\` had \`DEFAULT_RELAY_URL\` hardcoded to staging AND only honoured \`TOTALRECLAW_PAIR_RELAY_URL\`. The rest of the Python client honours \`TOTALRECLAW_SERVER_URL\` (\`relay.py\`, \`onboarding.py\`, \`hermes/hooks.py\`, \`hermes/pair_tool.py\`), and the rewritten Hermes guide promises PROD-by-default. So a fresh user installing 2.3.2 stable and pairing without explicit env vars silently routed through staging.

## Changes

1. \`DEFAULT_RELAY_URL = "wss://api.totalreclaw.xyz"\` (prod).
2. \`_resolve_relay_url\` cascade: \`TOTALRECLAW_PAIR_RELAY_URL\` → \`TOTALRECLAW_SERVER_URL\` → \`TOTALRECLAW_RELAY_URL\` → \`DEFAULT_RELAY_URL\`.
3. \`_http_to_ws\` helper auto-converts https→wss / http→ws for the SERVER/RELAY env values.

## Tests

13 new tests in \`tests/test_pair_relay_resolution.py\`. All existing pair tests + rc4 P0 gate + new guide-compatibility tests still pass. 66/66.

## Test plan post-merge

- [ ] Dispatch \`publish-python-client.yml\` \`release-type=rc rc-number=5\` → publishes \`totalreclaw==2.3.6rc5\`
- [ ] Re-run auto-QA on rc5 — verify pair URL hits PROD by default (no env vars set)
- [ ] Pedro retests on his Pop-OS Telegram bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)