### PR TITLE
docs(hermes-guide): rc5 UX-v2 — proactive pair, honest built-in-memory framing, force totalreclaw_recall

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -12,7 +12,7 @@ This document describes how the agent installs and sets up TotalReclaw on Hermes
 | Channel | Version | Install command |
 |---|---|---|
 | stable (default) | `2.3.2` | `pip install totalreclaw` |
-| latest RC | `2.3.6rc4` | `pip install --pre --upgrade totalreclaw==2.3.6rc4` |
+| latest RC | `2.3.6rc5` | `pip install --pre --upgrade totalreclaw==2.3.6rc5` |
 
 Source of truth for what's currently published: `pip index versions totalreclaw`. The table above is updated on every PyPI release.
 
@@ -36,7 +36,7 @@ The agent installs the stable channel from the table above and proceeds to setup
 Install TotalReclaw RC <version>. See https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md
 ```
 
-`<version>` is a PEP 440 RC string the user picks (e.g. `2.3.6rc4`). When the user omits `<version>` and writes only `Install TotalReclaw RC`, the agent installs `latest RC` from the table.
+`<version>` is a PEP 440 RC string the user picks (e.g. `2.3.6rc5`). When the user omits `<version>` and writes only `Install TotalReclaw RC`, the agent installs `latest RC` from the table.
 
 ### RC against the staging relay (QA only)
 
@@ -44,11 +44,23 @@ Install TotalReclaw RC <version>. See https://github.com/p-diogo/totalreclaw/blo
 Install TotalReclaw RC <version> against the staging relay (TOTALRECLAW_SERVER_URL=https://api-staging.totalreclaw.xyz). See https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md
 ```
 
-The agent exports `TOTALRECLAW_SERVER_URL=https://api-staging.totalreclaw.xyz` and `TOTALRECLAW_RELAY_URL=https://api-staging.totalreclaw.xyz` in the install / setup shell before any TotalReclaw command. Without this env var, both stable AND RC installs default to the production relay `api.totalreclaw.xyz`.
+The agent exports `TOTALRECLAW_SERVER_URL=https://api-staging.totalreclaw.xyz` and `TOTALRECLAW_RELAY_URL=https://api-staging.totalreclaw.xyz` in the install / setup shell before any TotalReclaw command. Without these env vars, both stable AND RC installs default to the production relay `api.totalreclaw.xyz`.
+
+---
+
+## Conversational style
+
+This is not a rule the agent follows perfectly, but the more it can, the better the UX:
+
+- Do not surface tool-call mechanics verbatim to the user. The user does not need to see `🐍 execute_code: "from hermes_tools import terminal..."` or `📚 skill_view: "..."` or `📋 todo: "planning N tasks"`. Run the tools silently and emit only the user-visible lines listed in the procedures below.
+- Use the explicit verbatim emit lines where the procedure provides them. Otherwise keep replies short and to-the-point.
+- Do not narrate "Now I'll do X, then Y, then Z." Do the work.
 
 ---
 
 ## Install procedure
+
+After the procedure completes, **proceed directly to Account setup**. Do not ask the user "is it ready?" — that is the agent's job to know.
 
 1. Resolve the Hermes Python interpreter:
    ```bash
@@ -56,20 +68,14 @@ The agent exports `TOTALRECLAW_SERVER_URL=https://api-staging.totalreclaw.xyz` a
    test -x "$HERMES_PYTHON" || HERMES_PYTHON="$(find / -maxdepth 6 -name hermes -type f -executable 2>/dev/null | head -1 | xargs -I{} head -1 {} | sed 's|^#!||')"
    ```
 2. Install the package using `"$HERMES_PYTHON" -m pip install <pin>`, where `<pin>` is the row from the Versions table chosen by the user's prompt.
-3. **Disable Hermes built-in memory (CRITICAL).** Dual-mode (Hermes built-in memory + TotalReclaw active at the same time) is unsupported and causes split-brain memory state. Run:
-   ```bash
-   hermes tools disable memory
-   ```
-   (Or `"$(dirname "$HERMES_PYTHON")/hermes" tools disable memory` when the resolved Hermes binary isn't on `PATH`.)
-   Emit verbatim to the user once:
-
-   > Installed TotalReclaw. I've disabled Hermes' built-in `memory` tool so TotalReclaw is your primary memory. Re-enabling it (`hermes tools enable memory`) is NOT recommended while TotalReclaw is installed. To wipe orphaned MEMORY.md / USER.md files later: `hermes memory reset`.
-4. Register the plugin manifest:
+3. Register the plugin manifest:
    ```bash
    hermes plugins install p-diogo/totalreclaw-hermes --enable
    ```
    (Or `"$(dirname "$HERMES_PYTHON")/hermes" plugins install p-diogo/totalreclaw-hermes --enable` when `hermes` isn't on `PATH`.)
-5. Issue `/restart` in chat to reload the Hermes gateway with the new plugin tools active.
+4. Issue `/restart` in chat to reload the Hermes gateway with the new plugin tools active.
+
+   **After `/restart` succeeds** (you see `Gateway restarted successfully`), the plugin IS loaded with all its tools. **Do NOT ask the user to restart again. Do NOT re-prompt the restart step. Proceed directly to Account setup.** Hermes's `Plugin discovery complete: 1 found, 1 enabled` is the canonical signal — by the time chat resumes after the restart-success notification, that signal has already fired.
 
 ---
 
@@ -77,18 +83,55 @@ The agent exports `TOTALRECLAW_SERVER_URL=https://api-staging.totalreclaw.xyz` a
 
 The agent never generates the recovery phrase. Only the user's browser does, via the `totalreclaw_pair` tool.
 
+**This section starts AUTOMATICALLY after install procedure step 4 completes.** Do not wait for a user prompt; do not ask "want me to set up your account?". The user already consented by sending the install prompt.
+
 1. Check whether credentials already exist:
    ```bash
    test -s ~/.totalreclaw/credentials.json && echo "already set up"
    ```
-   If present, emit `✓ TotalReclaw is already set up.` and stop.
+   If present, emit `✓ TotalReclaw is already set up.` and skip to the Post-setup section below.
 2. Call the `totalreclaw_pair` tool. Inputs: none required (the tool defaults to `mode=generate`). The tool returns a JSON object: `{url, pin, expires_at_ms}`.
 3. Emit ONE user-visible line containing the URL and PIN verbatim:
-   ```
-   Open <url> in your browser. Enter PIN <pin>. Generate a 12-word recovery phrase. Reply `done` once the page says it's sealed.
-   ```
+
+   > Open `<url>` in your browser. Enter PIN `<pin>`. Generate a 12-word recovery phrase. Reply `done` once the page says it's sealed.
+
    Do not paraphrase the URL or PIN. Do not invent values when the tool fails — surface the failure verbatim and stop.
-4. After the user replies `done`, re-check `~/.totalreclaw/credentials.json`. Present → emit `✓ TotalReclaw set up.` and stop. Absent → the PIN expired; call `totalreclaw_pair` again and resend step 3 once.
+4. After the user replies `done`, re-check `~/.totalreclaw/credentials.json`. Present → continue to Post-setup. Absent → the PIN expired; call `totalreclaw_pair` again and resend step 3 once.
+
+---
+
+## Post-setup
+
+After credentials.json is confirmed present (step 4 above), call `totalreclaw_status` once and emit a single user-visible block containing:
+
+- A recovery-phrase backup reminder (verbatim — the user just generated it in their browser; this is the reminder to actually save it somewhere durable).
+- Current account state from `totalreclaw_status` (tier, write count, free-write limit, network).
+- A short confirmation that the agent will now use TotalReclaw for memory operations.
+
+Emit verbatim:
+
+> ✓ TotalReclaw set up.
+>
+> Back up your 12-word recovery phrase NOW — store it offline (password manager, paper, hardware key). It is the only way to recover your encrypted memory vault if you lose access to this device. We cannot recover it for you.
+>
+> Account status: `<tier>` tier, `<used>` / `<limit>` writes used, stored on `<network>`. Ask me to remember anything and I'll save it to your encrypted vault.
+
+(`<tier>`, `<used>`, `<limit>`, `<network>` from `totalreclaw_status`. `<network>` is `Base Sepolia (testnet)` for free tier, `Gnosis (mainnet)` for Pro.)
+
+This block ships on first successful pair completion. On subsequent install runs where credentials already exist (early-exit in Account setup step 1), instead emit just:
+
+> ✓ TotalReclaw is already set up. Account status: `<tier>` tier, `<used>` / `<limit>` writes used, stored on `<network>`.
+
+---
+
+## Recall behaviour
+
+**For any user query that asks about prior facts about themselves** — "what do you know about me", "what are my preferences for X", "did I tell you about Y", etc. — the agent MUST call `totalreclaw_recall` even if it appears to have the answer in its current context.
+
+Rationale: Hermes's built-in memory layer auto-loads a local `~/.hermes/memories/USER.md` cache into the agent's system context at session start. That cache may contain answers from prior sessions, but it is NOT the canonical cross-session store. TotalReclaw on chain IS. Always querying through `totalreclaw_recall` ensures the integration is exercised + that the on-chain memory is the source the user is recovering against.
+
+If `totalreclaw_recall` returns matching facts: use those as the answer.
+If it returns nothing: say so honestly, do not fabricate from context.
 
 ---
 
@@ -110,7 +153,7 @@ These are hard rules. None of them are negotiable.
 |---|---|
 | `totalreclaw_pair` | Open a browser-side pairing session. Returns `{url, pin, expires_at_ms}`. Sole agent-facilitated path for account setup. |
 | `totalreclaw_remember` | Store a memory. |
-| `totalreclaw_recall` | Retrieve memories. |
+| `totalreclaw_recall` | Retrieve memories. Always called for user-facing recall queries (see Recall behaviour above). |
 | `totalreclaw_forget` | Tombstone a memory. |
 | `totalreclaw_pin` | Pin a memory so it's surfaced in every recall. |
 | `totalreclaw_status` | Report account tier + write counts. |
@@ -122,7 +165,7 @@ These are hard rules. None of them are negotiable.
 
 ## Diagnostics
 
-- Plugin not loaded after `/restart`: `"$(dirname "$HERMES_PYTHON")/hermes" plugins list` should show `totalreclaw` as enabled. If absent, re-run install procedure step 4.
+- Plugin not loaded after `/restart`: `"$(dirname "$HERMES_PYTHON")/hermes" plugins list` should show `totalreclaw` as enabled. If absent, re-run install procedure step 3.
 - `totalreclaw_pair` returns a URL that 404s on the browser: the relay is unreachable — check `TOTALRECLAW_SERVER_URL` env var matches the user's intended channel (prod default, or staging from the QA prompt).
 - `totalreclaw_pair` returns a 5xx: ask the user to retry; report the error code verbatim.
 - Tool not bound after install: `/restart` once. If still missing, the package install hit the wrong Python; re-resolve `HERMES_PYTHON` and re-install.
@@ -132,17 +175,16 @@ These are hard rules. None of them are negotiable.
 
 ## Compatibility with Hermes built-in memory
 
-The install procedure step 3 auto-disables Hermes' built-in `memory` tool. Dual-mode (built-in memory + TotalReclaw active at the same time) is unsupported.
+**Hermes built-in memory (`~/.hermes/memories/USER.md` and `MEMORY.md`) cannot be disabled.** Per Hermes upstream design, the built-in layer is always active — `hermes memory --help` explicitly states "Built-in memory (MEMORY.md/USER.md) is always active." The `hermes tools disable memory` command only blocks AGENTS from calling the `memory` tool; the gateway continues to write USER.md autonomously as part of its session-context management.
 
-DO NOT recommend re-enabling built-in memory while TotalReclaw is installed. Both surfaces writing concurrently produces split-brain state (some memories on disk in MEMORY.md / USER.md, others encrypted in TotalReclaw), and recall queries return inconsistent results.
+This is not a bug we can fix from the TotalReclaw side. We document it honestly:
 
-To switch back to Hermes built-in memory (user-initiated):
+- **TotalReclaw is the canonical cross-session store**, derived from your recovery phrase. Memories persist on chain, recoverable on any device or container by re-importing the phrase via `totalreclaw_pair`.
+- **Hermes's USER.md is a local, per-container context cache.** It is NOT cross-session in the cross-device sense; it lives only inside this Hermes deployment and is wiped on container reset or `hermes memory reset`. Treat it as part of the LLM's working memory, not as a memory store.
+- **For any user-facing recall query, the agent calls `totalreclaw_recall`** even when USER.md may already contain a relevant fact in context (see Recall behaviour). This forces the answer through the canonical TotalReclaw read path.
+- **The agent may run `hermes tools disable memory`** to block the `memory` agent tool (this still has value: prevents the agent from being tempted to call the built-in `memory` tool when TotalReclaw's tools are the right ones). But this command does NOT stop the USER.md / MEMORY.md writes.
 
-1. Optional — tombstone existing TotalReclaw memories: `totalreclaw forget --all` (the user runs this in their own terminal, not the agent).
-2. `pip uninstall totalreclaw`
-3. `hermes tools enable memory`
-
-Flag interest in supported dual-mode at <https://github.com/p-diogo/totalreclaw/issues>. We scope it from demand.
+Flag interest in fully-disable-able built-in memory at <https://github.com/NousResearch/hermes-agent/issues> (Hermes upstream). We track interest at <https://github.com/p-diogo/totalreclaw/issues>.
 
 ---
 

--- a/python/tests/test_setup_guide_includes_compatibility_section.py
+++ b/python/tests/test_setup_guide_includes_compatibility_section.py
@@ -1,25 +1,33 @@
-"""rc.26: ``docs/guides/hermes-setup.md`` must include the disable-memory
-agent-imperative step + a Compatibility section.
+"""2.3.6rc5: ``docs/guides/hermes-setup.md`` Compatibility section
+must honestly document Hermes's non-disable-able built-in memory.
 
-Context — rc.24 NO-GO finding (issue #167)
--------------------------------------------
+Context — rc5 finding (2026-05-12 Pop-OS QA)
+---------------------------------------------
 
-The public guide at ``docs/guides/hermes-setup.md`` is the canonical
-URL the user pastes into Hermes chat. The agent fetches it and follows
-its agent-instructions block. rc.26 ships path A (auto-disable
-built-in memory) and the doc MUST mirror SKILL.md so the agent does
-the same thing whether it loaded the local skill or fetched the URL.
+Pre-rc5: the guide claimed step 3 (``hermes tools disable memory``)
+"disables Hermes built-in memory". Verified false: that command only
+blocks the agent-callable ``memory`` tool. Hermes the gateway STILL
+writes ``~/.hermes/memories/USER.md`` autonomously. Upstream Hermes
+explicitly says built-in is "always active" per ``hermes memory --help``.
 
-What this test enforces
------------------------
+rc5 drops the false promise:
+- ``hermes tools disable memory`` is no longer in the install procedure
+  (kept as an optional aside in the Compatibility section since it
+  still has value blocking the agent-callable tool, but it's NOT
+  framed as a disable for the gateway-side writes).
+- The Compatibility section honestly states USER.md cannot be disabled.
+- A new ``## Recall behaviour`` section requires the agent to call
+  ``totalreclaw_recall`` for user-facing recall queries so the
+  canonical TotalReclaw read path is exercised even though USER.md is
+  also in context.
 
-The shipped ``hermes-setup.md`` MUST contain:
+What this test enforces (rc5 update)
+------------------------------------
 
-1. The ``hermes tools disable memory`` invocation in the agent-imperative
-   block (Step 3 in rc.26).
-2. The user-verbatim warning text mirroring SKILL.md.
-3. A ``## Compatibility with Hermes built-in memory`` section near the
-   bottom that documents dual-mode as unsupported.
+1. Compatibility section exists and honestly documents the non-disable.
+2. Recall-behaviour section exists and tells the agent to call
+   ``totalreclaw_recall`` for recall queries.
+3. Phrase-safety + tool reference still present (preserved invariants).
 """
 from __future__ import annotations
 
@@ -39,88 +47,99 @@ def _read_guide() -> str:
     return GUIDE_MD.read_text(encoding="utf-8")
 
 
-def test_guide_includes_disable_memory_agent_step():
-    """The agent-instructions block must include the disable-memory step."""
+def test_guide_does_not_falsely_claim_to_disable_built_in_memory():
+    """rc5 honesty: the guide must NOT claim that running
+    `hermes tools disable memory` actually disables Hermes built-in
+    memory writes. Upstream-verified false claim from rc.26.
+
+    The phrase "disable Hermes built-in memory" or "auto-disables"
+    must not appear as a claim that the gateway USER.md writes stop.
+    Mentions are allowed only in the Compatibility section's honest
+    framing (which acknowledges the gateway side cannot be disabled)."""
     body = _read_guide()
-    # Step heading + invocation (CRITICAL marker per the rc.26 plan).
-    assert "Disable Hermes built-in memory" in body, (
-        "hermes-setup.md must include a step heading 'Disable Hermes "
-        "built-in memory' in the agent-instructions block."
+    # The false-claim phrases from rc.26 must not appear.
+    assert "I've disabled Hermes' built-in `memory` tool so TotalReclaw is your primary memory" not in body, (
+        "rc5 dropped the false claim that `hermes tools disable memory` "
+        "makes TotalReclaw primary. Hermes built-in is non-disable-able "
+        "per upstream — the gateway writes USER.md regardless."
     )
-    assert "(CRITICAL)" in body, (
-        "Disable-memory step must be marked '(CRITICAL)' so the agent "
-        "treats it as non-optional during install."
-    )
-    assert "hermes tools disable memory" in body, (
-        "Agent-instructions block must invoke `hermes tools disable memory`."
+    assert "(CRITICAL)" not in body, (
+        "rc5 removed the (CRITICAL) marker on the disable-memory step "
+        "since that step was based on a false claim."
     )
 
 
-def test_guide_includes_user_verbatim_warning():
-    """Mirrors SKILL.md user-verbatim text."""
-    body = _read_guide()
-    assert "disabled Hermes' built-in `memory` tool" in body, (
-        "hermes-setup.md must mirror the SKILL.md user-verbatim warning."
-    )
-    assert "hermes tools enable memory" in body, (
-        "User-verbatim warning must include the re-enable command + "
-        "the NOT-recommended caveat."
-    )
-    assert "NOT recommended" in body, (
-        "Re-enable instruction must be explicitly NOT recommended while "
-        "TotalReclaw is installed."
-    )
-    assert "hermes memory reset" in body, (
-        "User-verbatim warning must include the optional `hermes memory "
-        "reset` pointer for wiping orphaned MEMORY.md / USER.md files."
-    )
-
-
-def test_guide_has_compatibility_section():
-    """The bottom-of-doc Compatibility section explains dual-mode."""
+def test_guide_includes_honest_compatibility_section():
+    """rc5: the Compatibility section exists and acknowledges the
+    upstream-verified reality that built-in memory cannot be disabled."""
     body = _read_guide()
     assert "## Compatibility with Hermes built-in memory" in body, (
         "hermes-setup.md must include a `## Compatibility with Hermes "
-        "built-in memory` section near the bottom — this is the durable "
-        "human-reader documentation of why dual-mode is unsupported."
+        "built-in memory` section explaining the dual-mode reality."
     )
-    # Compatibility content must explain the auto-disable + recommend
-    # against re-enabling.
-    assert "auto-disables" in body, (
-        "Compatibility section must state that the install flow "
-        "auto-disables Hermes built-in memory."
+    # Honest framing: built-in cannot be disabled.
+    assert "cannot be disabled" in body, (
+        "Compatibility section must honestly state that Hermes built-in "
+        "memory CANNOT be disabled (upstream design)."
     )
-    assert "DO NOT recommend re-enabling" in body, (
-        "Compatibility section must explicitly say DO NOT recommend "
-        "re-enabling while TotalReclaw is installed."
+    assert "always active" in body, (
+        "Compatibility section must reference the upstream Hermes "
+        "phrase 'always active' that documents the non-disable behaviour."
+    )
+    assert "USER.md" in body, (
+        "Compatibility section must name the actual file Hermes writes "
+        "to (~/.hermes/memories/USER.md) so users / readers can trace it."
     )
 
 
-def test_guide_compatibility_section_documents_switch_back_path():
-    """If the user wants to switch back to Hermes built-in memory,
-    the doc must show the canonical commands (enable + clear + uninstall)."""
+def test_guide_includes_canonical_cross_session_framing():
+    """rc5: the guide must clearly frame TotalReclaw as the canonical
+    cross-session store, with Hermes USER.md framed as a local
+    per-container context cache (not a memory store).
+    """
     body = _read_guide()
-    # Switch-back recipe — the canonical 3-step flow.
-    assert "totalreclaw forget --all" in body, (
-        "Compatibility section must document the optional "
-        "`totalreclaw forget --all` command for users switching back "
-        "to Hermes built-in memory."
+    assert "canonical cross-session store" in body, (
+        "Compatibility section must label TotalReclaw as the canonical "
+        "cross-session store so the dual-mode reality has a clear "
+        "value-prop anchor."
     )
-    assert "pip uninstall totalreclaw" in body, (
-        "Compatibility section must document the optional "
-        "`pip uninstall totalreclaw` command for users switching back."
+    # USER.md is framed as a CACHE / context layer, not a memory store.
+    assert "context cache" in body or "context layer" in body, (
+        "Compatibility section must frame USER.md as a local per-"
+        "container context cache, not a memory store."
     )
 
 
-def test_guide_compatibility_section_points_users_to_issue_tracker():
-    """Users who want dual-mode must be pointed at GitHub issues so we
-    can scope demand without committing to support upfront."""
+def test_guide_requires_totalreclaw_recall_for_recall_queries():
+    """rc5: a new ``## Recall behaviour`` section requires the agent to
+    call ``totalreclaw_recall`` for user-facing recall queries so the
+    canonical read path is exercised even when USER.md has the answer
+    in context."""
     body = _read_guide()
-    # rc.26 plan asked for a link to the GitHub discussion / issue
-    # tracker; we use the issues page.
+    assert "## Recall behaviour" in body, (
+        "hermes-setup.md must include a `## Recall behaviour` section "
+        "telling the agent how to handle user recall queries."
+    )
+    assert "totalreclaw_recall" in body, (
+        "Recall-behaviour section must explicitly direct the agent to "
+        "call the `totalreclaw_recall` tool."
+    )
+
+
+def test_guide_points_users_to_issue_tracker_for_dual_mode_feedback():
+    """rc5: users who want fully-disable-able built-in memory must be
+    pointed at Hermes upstream (since that's where the fix would land)
+    AND our own tracker for scope-of-demand signal."""
+    body = _read_guide()
+    # rc5 points at BOTH the upstream Hermes repo (where the actual fix
+    # would have to land) AND our own tracker.
+    assert "github.com/NousResearch/hermes-agent/issues" in body or "NousResearch/hermes-agent" in body, (
+        "Compatibility section must link to Hermes upstream issue "
+        "tracker since the fix has to land there, not in totalreclaw."
+    )
     assert "github.com/p-diogo/totalreclaw/issues" in body, (
-        "Compatibility section must link to the GitHub issue tracker so "
-        "users wanting dual-mode can flag demand."
+        "Compatibility section must also link to our own tracker so we "
+        "can scope demand independently."
     )
 
 


### PR DESCRIPTION
## Summary

rc5 guide UX-v2. Six changes from Pedro's 2026-05-12 stable QA on Pop-OS + log forensics:

1. **Proactive pair after install** — no "is it ready?" check; agent proceeds directly to Account setup
2. **No second-restart re-prompt** — logs confirm plugin loads after first /restart; guide tells agent to trust the success notification
3. **Proactive post-pair status + recovery-phrase reminder** — new Post-setup section, verbatim template
4. **Honest built-in-memory framing** — drops the false "I've disabled Hermes built-in memory" claim (upstream-verified non-disable-able); new honest Compatibility section
5. **Force `totalreclaw_recall` for recall queries** — new Recall behaviour section; agent must call the tool even when USER.md has the answer in context
6. **Suppress verbose tool-call narration** — new Conversational style section

Plus: Versions table bump rc4 → rc5. Test contract rewritten to enforce rc5 honesty + new sections.

## Tests

73/73 affected tests pass (guide-compat + restart-hardening + agent-gate + hermes-cli + totalreclaw-cli + pair-relay-resolution).

## Test plan post-merge

- [ ] Dispatch \`publish-python-client.yml\` rc-number=5 → publishes \`totalreclaw==2.3.6rc5\`
- [ ] Auto-QA on rc5: install prompt → install → /restart → pair → post-setup status block → simulated recall query → verify totalreclaw_recall called + phrase never crosses LLM
- [ ] Pedro retests on Pop-OS Telegram bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)