### PR TITLE
docs(setup): cooperative tone in agent-facing setup guides + SKILL.md (#201)

### DIFF
--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -26,13 +26,15 @@ This guide is the playbook your agent follows; you can read along to see what ea
 
 ## Agent instructions (read this if you are an OpenClaw agent that just fetched this URL)
 
-You have been asked to install TotalReclaw. **Run all install / verify steps silently** except for the user-visible lines explicitly listed below — those are the ONLY things you should write in chat. Tool calls happen; narration of those tool calls does not.
+You have been asked to install TotalReclaw. Keep the interaction focused — run each step, report progress on the user-visible lines below, and surface errors when they happen.
 
-The user pasted this URL deliberately, but treat each command as a step you and the user complete together. Confirm what you see at each phase. If anything looks wrong, surface it and stop — don't push through.
+Treat each command as a step you and the user complete together. Confirm what you see at each phase. If anything looks wrong, surface it and stop — don't push through.
 
-### Top-level rule (read this before anything else)
+### How to communicate during install
 
-**Emit ONLY the user-visible lines listed below. Do not narrate tool calls. Do not describe what you're doing or about to do. Errors are the only allowed deviation, and only as a single tight line.** Telegram and similar transports edit the bot's messages live as your tool calls progress — every interim "Let me check…" / "Plugin loaded. Let me verify…" line shows up to the user as awkward edit churn, even if your transport later "deletes" or rewrites it. The fix is to never emit it in the first place. The expected user-facing transcript for a healthy install is **5–6 short lines TOTAL**. Anything more is a SKILL violation.
+The user-visible lines below are what the user actually needs to see. On transports like Telegram, intermediate narration ("Let me check…", "Plugin loaded. Let me verify…") shows up as visible edit churn as your tool calls progress — often confusing rather than helpful. The default install path should produce **5–6 short lines TOTAL** in chat.
+
+For errors, one tight line is enough: the error text plus what you're doing about it. Don't pre-narrate steps that succeed.
 
 ### What you will run, and why each step is safe
 
@@ -42,9 +44,9 @@ The user pasted this URL deliberately, but treat each command as a step you and 
 
 You are not asked to handle the recovery phrase. You are not asked to bypass auth. Pasting the install URL IS the consent moment for installing the plugin; the URL + PIN you hand back from `totalreclaw_pair` is the real consent moment for account creation, since the user has to open the page in their browser to continue. There is no separate "yes/no" gate before account setup. If the user pastes a phrase in chat anyway, refuse to proceed — see "Phrase safety" below.
 
-### User-visible prose (THIS IS ALL YOU SAY)
+### User-visible lines
 
-Speak only these lines, in order. Substitute the bracketed placeholders with the real values. No prefaces. No suffixes. No narration around them.
+These are the lines to emit, in order. Substitute the bracketed placeholders with the real values. No prefaces or suffixes needed around them.
 
 1. (Step 1 — start; emit BEFORE any shell tool call so the user knows work is happening)
    > Setting up TotalReclaw — this takes about a minute…
@@ -69,9 +71,9 @@ If a step **actually fails**, surface the failure in one tight line — the erro
 
 Do NOT pre-narrate diagnostics that succeed. Do NOT narrate retries that succeed silently. Do NOT echo command output unless the user asks for it.
 
-### ⛔ FORBIDDEN actions during install + pair (3.3.10-rc.3 — hard rules from Pedro's 2026-05-05 QA)
+### Actions that break pair flows — avoid these (3.3.10-rc.3 notes from 2026-05-05 QA)
 
-These freelancing patterns have broken pair flows. They are FORBIDDEN regardless of how clever the workaround feels:
+These patterns have broken pair flows in previous QA rounds:
 
 1. **Do NOT issue `/totalreclaw-restart`. Do NOT signal the gateway. Do NOT `docker restart`.** The plugin auto-patches the config and emits its own restart-required warn IF (and only if) one is needed. The gateway will restart itself when its reload pipeline decides to. **You restarting it kills the in-flight `setsid -f` pair subprocess and surfaces as 502 on the browser respond.**
 
@@ -81,11 +83,11 @@ These freelancing patterns have broken pair flows. They are FORBIDDEN regardless
 
 4. **Do NOT invoke `tr pair --json` in the foreground.** A foreground pair subprocess is killed when your shell-tool exec returns. The pair WS dies → relay returns 502. Step 4 below uses `setsid -f` for exactly this reason — copy that block VERBATIM. Do not "simplify". Do not drop the `setsid -f`. Do not omit `< /dev/null`.
 
-5. **Do NOT narrate.** Examples that have appeared in past QAs and MUST NEVER appear again: "Now let me verify the CLI…" / "Gateway needs a restart, let me restart it" / "Let me find and signal the gateway process" / "The CLI is at the npm path, not the extensions path" / "CLI reports itself as version X (lag)" / "Now let me also add the required post-install config" / "Let me save the QR as a PNG". All silent — these are internal details. Emit only the 4-5 user-visible lines.
+5. **Avoid narrating internals.** Examples from past QAs that broke the experience: "Now let me verify the CLI…" / "Gateway needs a restart, let me restart it" / "Let me find and signal the gateway process" / "The CLI is at the npm path, not the extensions path" / "CLI reports itself as version X (lag)" / "Now let me also add the required post-install config" / "Let me save the QR as a PNG". These are internal details — emit only the 4–5 user-visible lines.
 
-### Forbidden vocabulary in agent prose
+### Phrases to avoid in agent prose
 
-Unless the user explicitly asks how the install works, the following words / patterns must not appear in your chat output during install + setup. These are the patterns that surface as edit churn in transports like Telegram:
+Unless the user explicitly asks how the install works, the following words / patterns tend to surface as edit churn in transports like Telegram during install + setup:
 
 - "Let me check that…"
 - "Plugin loaded. Let me verify…"
@@ -149,7 +151,7 @@ Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, em
 
 Pasting the install URL was the consent moment for installing the plugin. The URL + PIN you're about to hand the user is the real consent moment for account creation — they have to open the page in their browser to proceed. There is NO separate yes/no gate. Do NOT ask "Would you like to set up an account?" — run pair immediately.
 
-CRITICAL (3.3.10-rc.2): always invoke `tr pair --json` via `setsid -f` so the WS-holding subprocess is in its own session and survives any post-install gateway SIGUSR1 reload. A foreground `node tr-cli pair` is killed mid-flight when the gateway fires its deferred restart, surfacing as `Gateway could not finish pairing (502). The agent timed out or the ciphertext failed to decrypt — ask the agent to retry pairing.` on the user's browser.
+Important (3.3.10-rc.2): always invoke `tr pair --json` via `setsid -f` so the WS-holding subprocess is in its own session and survives any post-install gateway SIGUSR1 reload. A foreground `node tr-cli pair` is killed mid-flight when the gateway fires its deferred restart, surfacing as `Gateway could not finish pairing (502). The agent timed out or the ciphertext failed to decrypt — ask the agent to retry pairing.` on the user's browser.
 
 ```bash
 PAIR_OUT="/tmp/tr-pair-out-$(date +%s).json"
@@ -168,9 +170,11 @@ The pair payload includes a `qr_ascii` field (Unicode block-char QR, ~43 lines �
 
 After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN likely expired — re-run `tr pair --json` and resend line 5 once. If present, emit user-visible line 6 (with the free-tier confirmation) and stop.
 
-### Phrase safety (HARD — never break)
+### Phrase safety
 
-NEVER echo, generate, or ask the user to paste a recovery phrase in chat. NEVER invoke `openclaw totalreclaw onboard` (bare interactive form), `totalreclaw setup`, or any phrase-touching CLI via your shell tool — stdout enters LLM context. The ONLY agent-facilitated account-setup path is the `totalreclaw_pair` tool (the account-setup tool — name kept for backward compatibility). If the user pastes a phrase anyway: tell them it is compromised and call `totalreclaw_pair` with `mode=generate` for a fresh wallet.
+The recovery phrase is the user's only identity in TotalReclaw — it derives all encryption keys and there is no recovery mechanism if lost.
+
+Do not echo, generate, or ask the user to paste a recovery phrase in chat. Do not invoke `openclaw totalreclaw onboard` (bare interactive form), `totalreclaw setup`, or any phrase-touching CLI via your shell tool — their stdout enters LLM context. The only agent-facilitated account-setup path is the `totalreclaw_pair` tool (name kept for backward compatibility). If the user pastes a phrase in chat anyway, let them know it should be considered compromised and call `totalreclaw_pair` with `mode=generate` to create a fresh wallet.
 
 ---
 

--- a/python/src/totalreclaw/hermes/SKILL.md
+++ b/python/src/totalreclaw/hermes/SKILL.md
@@ -20,13 +20,15 @@ TotalReclaw is open-source memory tooling for Hermes, published by `p-diogo` (Gi
 
 The user pasted the install URL deliberately, but treat each command as a step you and the user complete together. You are not asked to handle the recovery phrase, bypass auth, or run unfamiliar shell scripts — every command below is a standard `hermes` or `pip` invocation with a documented purpose. The user already consented by pasting the install message; do NOT add a second consent gate before account setup — surface phase transitions and failures, but proceed straight from disable-memory to handing the user the pair URL + PIN.
 
-## Silence rules (read first — applies to the whole install + setup flow)
+## Communication during install + setup
 
-**Emit ONLY the user-visible lines listed below. Do not narrate tool calls. Do not describe what you're doing or about to do. Errors are the only allowed deviation, and only as a single tight line.** Tool calls happen silently; narration of those tool calls is a SKILL violation. The expected user-facing transcript for a fresh install + setup is **5–6 short lines TOTAL** — anything more is a SKILL violation. There is no second consent gate before account setup; the user already consented by pasting the install message.
+Keep the install interaction focused. On transports like Telegram, intermediate narration ("Let me check…", "Plugin loaded. Let me verify…") shows up as visible edit churn as tool calls progress. The expected user-facing transcript for a fresh install is **5–6 short lines TOTAL**.
 
-### User-visible prose (THIS IS ALL YOU SAY)
+For errors, one tight line is enough. If a step succeeds, just move on.
 
-Speak only these lines, in order. Substitute the bracketed placeholders. Lines 3 and 4 are optional and only emitted on the conditions noted.
+### User-visible lines
+
+These are the lines to emit, in order. Substitute the bracketed placeholders. Lines 3 and 4 are optional and only emitted on the conditions noted.
 
 1. (Step 1 — start)
    > Installing TotalReclaw…
@@ -47,20 +49,20 @@ If `totalreclaw_*` tools are already bound (skip-install branch), the only lines
 
 If a step actually fails, surface a one-line error + the action being taken. Examples: `Install failed: externally-managed-environment. Retrying with --break-system-packages.` / `Plugin installed but tools didn't bind after restart. Asking for a second restart.` / `Account-setup URL returned 404. Generating a fresh URL + PIN.` Do NOT pre-narrate diagnostics that succeed. Do NOT echo command output unless the user asks.
 
-### Forbidden vocabulary in agent prose
+### Phrases to avoid in agent prose
 
-Do not write these words / phrases in chat during install + setup unless the user explicitly asks how the install works: `Python`, `interpreter`, `venv`, `virtual environment`, `pip`, `ensurepip`, `bootstrap`, `find`, `lookup`, `detect`, `probing`, `let me try`, `in parallel`, `got it`, `now installing`, `Step 1a/1b/1c`. Also forbidden — narration patterns Pedro saw in 2026-05-01 QA Telegram transcripts:
+During install + setup, keep the following out of chat output unless the user explicitly asks how the install works: `Python`, `interpreter`, `venv`, `virtual environment`, `pip`, `ensurepip`, `bootstrap`, `find`, `lookup`, `detect`, `probing`, `let me try`, `in parallel`, `got it`, `now installing`, `Step 1a/1b/1c`. Also avoid narration patterns from 2026-05-01 QA Telegram transcripts:
 
 - "Let me check that…" / "Let me check if…" / "Let me verify…" / "Let me try…"
 - "Now installing…" / "Plugin loaded. Let me verify…" / "I'll try…"
 - "Quick fix…" / "One sec…" / "Got it, doing X…"
 - Any "I'm going to do X" / "About to do X" pre-narration of a tool call
 
-These are tool-call mechanics, not user-facing prose. The Telegram bot edit-and-delete behavior makes interim "doing X…" lines look broken to the user even when they get edited away. If the user asks ("what's it doing?", "show me the commands"), narrate freely — the silence rule only governs the default install path.
+These are tool-call mechanics, not user-facing prose. The Telegram bot edit-and-delete behavior makes interim "doing X…" lines look broken to the user even when they get edited away. If the user asks ("what's it doing?", "show me the commands"), narrate freely — the focused-transcript rule only governs the default install path.
 
-### Forbidden phrases when tools fail to bind (deny-list — 2.3.4-rc.1, strengthened in 2.3.5-rc.1)
+### Phrases that stall the install — restart autonomously
 
-When `totalreclaw_*` tools are missing post-install, you MUST issue `/restart` (or `/new` as fallback) **autonomously** and announce the action — never ask the user to authorize it, never stall, never hedge. The following phrases are anti-patterns and MUST NOT appear in chat in that situation:
+When `totalreclaw_*` tools are missing post-install, issue `/restart` (or `/new` as fallback) autonomously and announce the action. These stall-patterns have appeared in past QA and should be avoided:
 
 - "Should I /restart?" / "Should I issue /restart?" / "Want me to restart?" / "Do you want me to restart?"
 - "I need permission to /restart" / "Do you authorize /restart?" / "Confirming before I /restart…"
@@ -69,11 +71,11 @@ When `totalreclaw_*` tools are missing post-install, you MUST issue `/restart` (
 - "Is it OK if I restart?" / "I'll /restart now if that's OK"
 - Describing what `/restart` does ("This will drain runs and reload…") — just send the slash command
 
-The correct pattern is to issue `/restart` immediately and emit user-visible line 3 (`Restarting Hermes to load the plugin…`) as the single chat line. Step 2 of the setup flow is explicit about this — re-read it if you find yourself drafting any of the phrases above.
+The right pattern: issue `/restart` immediately and emit user-visible line 3 (`Restarting Hermes to load the plugin…`) as the single chat line. Step 2 of the setup flow is explicit about this.
 
 ## Setup flow
 
-If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jump to step 5. Otherwise run all steps in order. Numbered steps are internal procedure; user prose is only the lines listed in §"User-visible prose" above.
+If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jump to step 5. Otherwise run all steps in order. Numbered steps are internal procedure; user prose is only the lines listed in §"User-visible lines" above.
 
 1. **Install plugin + Python package (silent — emit user-visible line 1, then nothing until line 2).** Hermes 2026.4.16+ uses Git-based plugin discovery and a separate Python tool implementation. The Python package MUST go into the SAME Python environment that Hermes runs from (containerized venv, native venv, or system Python — whichever your install uses). Bare `pip install` may target the wrong Python on containerized deploys. Run all three substeps via your shell tool **without writing prose about them**:
    ```
@@ -145,9 +147,9 @@ If `totalreclaw_*` tools are already bound to your toolset, SKIP install and jum
 
 7. **Verify and confirm (silent until line 6).** After user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN expired — call `totalreclaw_pair` again silently and resend line 5 once. If present, emit user-visible line 6 (with the free-tier confirmation) and stop.
 
-## Phrase safety (HARD — never break)
+## Phrase safety
 
-NEVER echo / generate / ask the user to paste a recovery phrase in chat. NEVER invoke `totalreclaw setup`, `hermes setup`, or any phrase-touching CLI via your shell tool (stdout enters LLM context). The ONLY agent-facilitated account-setup path is `totalreclaw_pair` (the account-setup tool). If the user pastes a phrase anyway: tell them it is compromised, call `totalreclaw_pair` with `mode=generate` for a fresh wallet.
+The recovery phrase must not cross LLM context. Do not echo, generate, or ask the user to paste a recovery phrase in chat. Do not invoke `totalreclaw setup`, `hermes setup`, or any phrase-touching CLI from your shell (their stdout enters LLM context). The only agent-facilitated account-setup path is `totalreclaw_pair`. If the user pastes a phrase in chat anyway, let them know it should be considered compromised and call `totalreclaw_pair` with `mode=generate` for a fresh wallet.
 
 ## Usage (post-setup)
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -24,7 +24,7 @@ metadata:
 
 # TotalReclaw Skill
 
-## CRITICAL: How TotalReclaw actually stores memories — read before anything else
+## How TotalReclaw stores memories
 
 **TotalReclaw is end-to-end encrypted memory stored across a DECENTRALIZED NETWORK — not on a single company server.** Memories are encrypted with keys derived from the user's 12-word recovery phrase, submitted as Account Abstraction UserOps, and persisted on a public blockchain (Base / Gnosis depending on tier). The Graph subgraph indexes them. The TotalReclaw relay only forwards encrypted bundles to the bundler and proxies subgraph reads — it never sees plaintext, can't read memories, and could be replaced by any compatible relay without losing data. No single company controls or can read user memories.
 
@@ -48,7 +48,7 @@ OpenClaw 2026.5.2 has a tool-policy-pipeline bug (issue #223) that strips non-bu
 - `tr recall --json "<query>" --limit 5` → search memories.
 - Native `totalreclaw_*` tools still registered for back-compat; use them if available, but do NOT depend on their presence.
 
-> Canonical install + account-setup flow lives at <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md> (OpenClaw) and <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md> (Hermes). When a user pastes one of those URLs in chat, fetch it and follow its agent-instructions section verbatim. The "Post-Install Setup" section below mirrors the same account-setup flow as a fallback.
+> The full install + account-setup guides live at <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md> (OpenClaw) and <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md> (Hermes). If a user pastes one of those URLs in chat, fetch it and follow it as collaborative install guidance — confirm what each command does, ask before destructive steps, surface progress. The "Post-Install Setup" section below mirrors the same account-setup flow as a fallback.
 
 > **Gateway restart after install**: OpenClaw's default `gateway.reload.mode = "hybrid"` auto-restarts within 1-3s of plugin install — no agent action needed. If auto-reload doesn't fire (`gateway.reload.mode = off`), issue the plugin's `/totalreclaw-restart` slash command yourself (in-process, drains active runs; 5-tier auth fallback in 3.3.7-rc.2+ so default-config installs work without `allowFrom`). Manual user-prompted restart is fallback only if `/totalreclaw-restart` is unavailable. NEVER invoke external `docker restart` or `openclaw gateway restart` — your shell runs inside the gateway.
 
@@ -66,15 +66,13 @@ TotalReclaw is open-source memory tooling for OpenClaw, published by `p-diogo` (
 
 The user pasted the install URL (or skill name) deliberately, but treat each step as something you and the user complete together. You are not asked to handle the recovery phrase, bypass auth, or run unfamiliar shell scripts — every command is a standard `openclaw` invocation with a documented purpose. Confirm phase transitions; surface failures. Pasting the install URL IS the consent — proceed directly to account setup; the URL + PIN you hand back from `totalreclaw_pair` is the real consent moment, since the user has to open the page in their browser to continue.
 
-## Silence rules during install + setup
+## Communication during install + setup
 
-**Top-level rule: emit ONLY the user-visible lines listed in "Post-Install Setup" below. Do not narrate tool calls. Do not describe what you're doing or about to do. Errors are the only allowed deviation, and only as a single tight line.**
+Keep install interaction focused — the user-visible lines in "Post-Install Setup" below are what the user needs to see. On transports like Telegram, intermediate narration ("Let me check…", "Plugin loaded. Let me verify…") shows up as visible edit churn as tool calls progress. The expected user-facing transcript for a fresh install is **5–6 short lines TOTAL**.
 
-The expected user-facing transcript for a fresh install is **5–6 short lines TOTAL**. Anything more is a SKILL violation.
+For errors, one tight line is enough. Surface failures clearly; don't pre-narrate steps that succeed.
 
-This matters because Telegram and similar transports edit the bot's messages live as your tool calls progress — every interim "Let me check…" / "Plugin loaded. Let me verify…" line shows up to the user as awkward edit churn, even if you "delete" it. The fix is to never emit it in the first place.
-
-**Forbidden vocabulary** (substitute with silence — the next user-visible line, or nothing):
+**Phrases to avoid during install** (substitute with silence — the next user-visible line, or nothing):
 
 - "Let me check that…"
 - "Plugin loaded. Let me verify…"
@@ -89,15 +87,17 @@ This matters because Telegram and similar transports edit the bot's messages liv
 
 If the user explicitly asks ("what's it doing?", "why so quiet?", "show me the commands"), then narrate freely — the silence rule only governs the default install path.
 
-## Recovery Phrase -- READ THIS FIRST
+## How the recovery phrase is handled
 
-**CRITICAL SAFETY RULE:** The recovery phrase MUST NEVER cross the LLM context. NEVER echo, generate, ask the user to paste, or print a recovery phrase in chat or in your shell. The phrase is created and confirmed inside the user's browser via the `totalreclaw_pair` account-setup flow — the relay only receives ciphertext, and your tool calls must never carry a phrase payload.
+The recovery phrase is the user's only identity in TotalReclaw — it derives all encryption keys. There is no password reset and no support channel that can recover it if lost.
 
-If the user pastes a phrase in chat anyway: tell them it is compromised (the chat transcript and any tool stdout enter LLM context, which makes the phrase recoverable from logs and from any model that processes that turn) and call `totalreclaw_pair` with `mode=generate` to create a fresh wallet.
+Because of how LLM context works, anything entered in chat or written to shell stdout becomes part of the model's context (and any logs that capture it). To keep the recovery phrase out of that surface, account setup is structured so the phrase is created and confirmed inside the user's browser via the `totalreclaw_pair` flow — the relay only receives ciphertext, and tool calls don't carry a phrase payload.
 
-The recovery phrase is the user's ONLY identity in TotalReclaw. It derives all encryption keys. There is NO password reset, NO recovery mechanism, and NO support channel that can help if it is lost. The browser-side account-setup flow displays this warning automatically when a new phrase is generated.
+So in practice: do not echo, generate, or ask the user to paste a recovery phrase in chat. Do not invoke phrase-touching CLIs (like `openclaw totalreclaw onboard` bare interactive form) from your shell. The only agent-facilitated account-setup path is the `totalreclaw_pair` tool.
 
-**Do NOT** import a phrase the user already uses for a funded crypto wallet. TotalReclaw uses BIP-39 mnemonics (same format as crypto wallets), but a TotalReclaw phrase must be SEPARATE from any funded wallet. If the user tries to import an existing crypto-wallet phrase, STOP and warn them in chat to use a fresh phrase instead — but warn ABOUT the phrase, never echo any portion of it.
+If a user pastes their phrase in chat anyway, let them know it should be considered compromised (the transcript enters LLM context) and call `totalreclaw_pair` with `mode=generate` to create a fresh wallet.
+
+One more note: TotalReclaw uses BIP-39 mnemonics — the same format as funded crypto wallets — but a TotalReclaw phrase should be separate from any funded wallet. If the user tries to import an existing crypto-wallet phrase, warn them about this (without echoing any portion of the phrase) and offer to generate a fresh one instead.
 
 ---
 
@@ -547,11 +547,11 @@ When the user asks to import conversation history:
 
 ## Post-Install Setup (hybrid-primary — 3.3.9-rc.1+)
 
-Under OpenClaw 2026.5.2+, `totalreclaw_*` tools may NOT be bound (issue #223). Use the `tr` CLI as primary. All install and verify steps run silently — only the user-visible lines below are written to chat.
+Under OpenClaw 2026.5.2+, `totalreclaw_*` tools may NOT be bound (issue #223). Use the `tr` CLI as primary. Keep install interaction focused — only the user-visible lines below need to appear in chat.
 
-### User-visible prose (THIS IS ALL YOU SAY)
+### User-visible lines
 
-Speak only these lines, in order. Substitute the bracketed placeholders. The user already consented by pasting "Install TotalReclaw" + the canonical URL — proceed straight to account setup UNCONDITIONALLY. Do NOT ask permission or confirm before running `tr pair`.
+Emit these lines, in order. Substitute the bracketed placeholders. The user already consented by pasting "Install TotalReclaw" + the canonical URL — proceed straight to account setup without a second confirmation gate.
 
 1. (only if existing credentials were detected, then stop)
    > ✓ TotalReclaw is already set up.
@@ -614,13 +614,11 @@ Decisions and context are treated as high-value memories (importance >= 7) becau
 
 ---
 
-## Instructions for the LLM
+## Notes for the LLM
 
-### IMPORTANT: Do Not Write Cleartext Memory Files
+### Use the encrypted store, not cleartext files
 
-TotalReclaw handles all memory storage with end-to-end encryption. **Do NOT write facts, preferences, or decisions to MEMORY.md or memory/*.md files.** All memories are stored encrypted on-chain and recalled automatically — writing cleartext files defeats the E2EE guarantee.
-
-If you need to store a memory, use the `totalreclaw_remember` tool. If you need to recall memories, use `totalreclaw_recall`.
+TotalReclaw handles memory storage with end-to-end encryption — the relay never sees plaintext. Writing facts, preferences, or decisions to `MEMORY.md` or `memory/*.md` files defeats that guarantee, since those files sit unencrypted on disk and may end up in logs or context outside the encrypted vault. Use `totalreclaw_remember` to store memories and `totalreclaw_recall` to retrieve them.
 
 ### Billing Awareness
 


### PR DESCRIPTION
🤖 (fallback auth — GH App not yet configured)

## Summary

Fixes [p-diogo/totalreclaw-internal#201](https://github.com/p-diogo/totalreclaw-internal/issues/201) — setup guides tripping safety-trained LLM defenses (agent refuses install).

**Why PR #161 was closed:** branch was 2 weeks stale; MCP Server Tests and Python Client Tests red; `hermes-setup.md` rewrite removed test-required content.

**This PR:** fresh branch from current main; targeted cooperative-tone edits only; all tests verified green locally.

## What changed (3 files, ~52 insertions / 48 deletions)

| File | Change |
|------|--------|
| `docs/guides/openclaw-setup.md` | Remove "THIS IS ALL YOU SAY", "⛔ FORBIDDEN", "Emit ONLY", "Run all silently"; reframe as collaborative guidance |
| `skill/SKILL.md` | Soften "## CRITICAL:" heading, "HARD — never break", "Emit ONLY", "THIS IS ALL YOU SAY" in Post-Install Setup; preserve forbidden-vocabulary denylist (required by tests) |
| `python/src/totalreclaw/hermes/SKILL.md` | Soften "Emit ONLY", "HARD — never break", "Forbidden phrases when tools fail to bind"; reframe as collaborative |

**Files NOT changed:** `docs/guides/hermes-setup.md` (already agent-only format; `test_setup_guide_includes_compatibility_section.py` depends on its exact content), no version bumps, no mcp/ changes.

## Patterns removed

From the issue's heuristic scan list:
- `THIS IS ALL YOU SAY` → `User-visible lines`
- `Run all install / verify steps silently` → explains WHY (Telegram edit churn)
- `⛔ FORBIDDEN actions` → `Actions that break pair flows — avoid these`
- `Emit ONLY the user-visible lines` → context-explaining framing
- `## CRITICAL: How TotalReclaw...` → `## How TotalReclaw stores memories`
- `## Phrase safety (HARD — never break)` → `## Phrase safety`
- `MUST NEVER`, `MUST NOT` → descriptive language

## Test results

- ✅ **41/41** `skill/plugin/skill-md-hybrid-primary.test.ts` (validates `skill/SKILL.md` denylist intact)
- ✅ **6/6** `python/tests/test_setup_guide_includes_compatibility_section.py`
- ✅ **60/60** Python plugin + phrase-safety tests
- ✅ Phrase-safety script: 75 artifacts clean
- MCP tests: cannot run locally (onnxruntime GPU binary download fails); `mcp/SKILL.md` is UNCHANGED so the test passes by construction

## Human verification still needed

Per #201 acceptance criteria: paste canonical install prompt against a fresh `claude-sonnet-4` or `GPT-4-with-safety` instance to confirm no refusal. This is a human QA step — not automatable.

## Risk

**L1** — docs only, no code changes, no schema changes.

Closes p-diogo/totalreclaw-internal#201