### PR TITLE
fix(hermes): 2.3.7rc2 — break plugin-load fork-bomb in built-in memory check

### DIFF
--- a/python/src/totalreclaw/hermes/__init__.py
+++ b/python/src/totalreclaw/hermes/__init__.py
@@ -269,6 +269,9 @@ def register(ctx):
     logger.info("TotalReclaw plugin registered (14+ tools, 6 hooks)")
 
 
+_RECURSION_GUARD_ENV = "_TOTALRECLAW_SKIP_BUILTIN_MEMORY_CHECK"
+
+
 def _warn_if_built_in_memory_enabled() -> None:
     """Check whether Hermes' built-in `memory` tool is currently enabled.
 
@@ -283,13 +286,35 @@ def _warn_if_built_in_memory_enabled() -> None:
     for "remember X" / "recall X" intents during natural conversation.
     The install flow disables the built-in via SKILL.md step 3, but
     this WARN catches users who re-enabled it manually.
+
+    Recursion guard (2.3.7rc2): this function shells out to
+    ``hermes tools list``. That subprocess is ALSO ``hermes`` — it
+    boots the gateway, discovers this plugin, calls ``register()``,
+    which calls this function, which spawns another ``hermes tools
+    list``... fork bomb. The 5s timeout per call does not help, since
+    each call forks multiple children before its own timeout fires.
+    We set a sentinel env var before spawning the subprocess so the
+    child plugin-load short-circuits and the recursion terminates at
+    depth 1.
     """
+    import os
     import shutil
     import subprocess
+
+    # Recursion guard: if we're loading inside the subprocess we
+    # spawned for the check itself, short-circuit.
+    if os.environ.get(_RECURSION_GUARD_ENV) == "1":
+        logger.debug(
+            "built-in memory check skipped — running inside the "
+            "spawned `hermes tools list` subprocess (recursion guard)"
+        )
+        return
 
     if shutil.which("hermes") is None:
         logger.debug("hermes CLI not found on PATH; skipping built-in memory check")
         return
+
+    child_env = {**os.environ, _RECURSION_GUARD_ENV: "1"}
 
     try:
         proc = subprocess.run(
@@ -298,6 +323,7 @@ def _warn_if_built_in_memory_enabled() -> None:
             text=True,
             timeout=5,
             check=False,
+            env=child_env,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError, PermissionError):
         logger.debug("hermes tools list failed; skipping built-in memory check", exc_info=True)

--- a/python/tests/test_warn_log_on_built_in_memory_enabled.py
+++ b/python/tests/test_warn_log_on_built_in_memory_enabled.py
@@ -19,16 +19,29 @@ must be best-effort — must NOT crash plugin load if the CLI is
 absent or returns garbage.
 
 Implementation lives in ``totalreclaw.hermes.__init__:_warn_if_built_in_memory_enabled``.
+
+Recursion-guard tests (2.3.7rc2)
+--------------------------------
+
+The 2.3.7rc2 hotfix adds a sentinel env var so the spawned
+``hermes tools list`` subprocess short-circuits its own plugin-load
+check (which would otherwise fork-bomb the host). Tests below
+verify: (a) the function early-returns when the sentinel is set,
+(b) the subprocess is invoked with the sentinel set in its env.
 """
 from __future__ import annotations
 
 import logging
+import os
 import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from totalreclaw.hermes import _warn_if_built_in_memory_enabled
+from totalreclaw.hermes import (
+    _RECURSION_GUARD_ENV,
+    _warn_if_built_in_memory_enabled,
+)
 
 
 def _make_proc(stdout: str = "", returncode: int = 0) -> MagicMock:
@@ -141,3 +154,93 @@ class TestWarnIfBuiltInMemoryEnabled:
                 _warn_if_built_in_memory_enabled()
             except Exception as exc:  # pragma: no cover
                 pytest.fail(f"_warn_if_built_in_memory_enabled raised: {exc!r}")
+
+
+class TestRecursionGuard:
+    """2.3.7rc2 hotfix: prevent fork-bomb from the
+    ``hermes tools list`` subprocess re-loading this plugin → calling
+    ``_warn_if_built_in_memory_enabled`` recursively → spawning
+    another ``hermes tools list``…
+
+    On pop-os 2026-05-14 this storm pinned a 4-core box (load avg 4.04,
+    7+ concurrent ``hermes tools list`` processes per container, dozens
+    of ``[hermes] <defunct>`` zombies). 5s timeout per call did NOT
+    help — each call forks many children before its own timeout fires.
+    """
+
+    def test_sentinel_env_var_short_circuits(self, caplog, monkeypatch):
+        """When ``_TOTALRECLAW_SKIP_BUILTIN_MEMORY_CHECK=1`` is set in
+        the parent env, the function MUST return immediately without
+        invoking ``shutil.which`` or ``subprocess.run`` — otherwise the
+        recursion can't terminate."""
+        monkeypatch.setenv(_RECURSION_GUARD_ENV, "1")
+        with patch("shutil.which") as mock_which, patch(
+            "subprocess.run"
+        ) as mock_run:
+            _warn_if_built_in_memory_enabled()
+        mock_which.assert_not_called()
+        mock_run.assert_not_called()
+
+    def test_sentinel_set_to_other_value_does_not_short_circuit(
+        self, monkeypatch
+    ):
+        """Only exact ``1`` triggers the short-circuit. Other values
+        (e.g. ``0``, ``false``, empty) must NOT short-circuit — this
+        keeps the guard predictable + minimises confusion if the env
+        leaks from an unrelated source."""
+        monkeypatch.setenv(_RECURSION_GUARD_ENV, "0")
+        with patch("shutil.which", return_value="/usr/bin/hermes"), patch(
+            "subprocess.run", return_value=_make_proc("foo  disabled\n")
+        ) as mock_run:
+            _warn_if_built_in_memory_enabled()
+        mock_run.assert_called_once()
+
+    def test_subprocess_invoked_with_sentinel_in_child_env(self, monkeypatch):
+        """The subprocess MUST be spawned with
+        ``_TOTALRECLAW_SKIP_BUILTIN_MEMORY_CHECK=1`` in its env.
+        Without this, the child plugin-load recurses → fork bomb."""
+        # Strip any pre-existing sentinel from the parent so the spawn
+        # path is exercised (not the early-return path).
+        monkeypatch.delenv(_RECURSION_GUARD_ENV, raising=False)
+        with patch("shutil.which", return_value="/usr/bin/hermes"), patch(
+            "subprocess.run", return_value=_make_proc("memory  disabled\n")
+        ) as mock_run:
+            _warn_if_built_in_memory_enabled()
+        mock_run.assert_called_once()
+        call = mock_run.call_args
+        passed_env = call.kwargs.get("env")
+        assert passed_env is not None, (
+            "subprocess.run MUST be called with an explicit env= so the "
+            "recursion-guard sentinel is set. Inheriting the parent env "
+            "won't work — the parent's env may not contain the sentinel."
+        )
+        assert passed_env.get(_RECURSION_GUARD_ENV) == "1", (
+            f"subprocess.run env MUST contain "
+            f"{_RECURSION_GUARD_ENV}=1 so the recursive plugin load "
+            f"short-circuits. Got: {passed_env.get(_RECURSION_GUARD_ENV)!r}"
+        )
+
+    def test_subprocess_env_preserves_parent_environment(self, monkeypatch):
+        """The child env MUST inherit the parent env (PATH, HOME,
+        TOTALRECLAW_* etc.) plus the sentinel — not be a stripped
+        env with only the sentinel. Otherwise the spawned ``hermes``
+        won't find its dependencies."""
+        monkeypatch.delenv(_RECURSION_GUARD_ENV, raising=False)
+        monkeypatch.setenv("TOTALRECLAW_TEST_MARKER", "preserved")
+        with patch("shutil.which", return_value="/usr/bin/hermes"), patch(
+            "subprocess.run", return_value=_make_proc("")
+        ) as mock_run:
+            _warn_if_built_in_memory_enabled()
+        passed_env = mock_run.call_args.kwargs["env"]
+        assert passed_env.get("TOTALRECLAW_TEST_MARKER") == "preserved", (
+            "Child env must inherit parent env vars; the sentinel is "
+            "an addition, not a replacement."
+        )
+
+    def test_recursion_guard_env_name_is_stable(self):
+        """The sentinel env var name is part of the contract between
+        parent + child processes. Pin it so a rename doesn't break the
+        guard for users on older deployed versions of the plugin (the
+        parent process may be running a newer version while a stale
+        subprocess from a transition window runs an older version)."""
+        assert _RECURSION_GUARD_ENV == "_TOTALRECLAW_SKIP_BUILTIN_MEMORY_CHECK"


### PR DESCRIPTION
## Summary

- `_warn_if_built_in_memory_enabled()` in `python/src/totalreclaw/hermes/__init__.py` shells out to `hermes tools list` on every plugin load. That subprocess IS `hermes` — boots gateway → discovers plugin → calls `register()` → which calls this function → spawns another `hermes tools list` → **recursive fork bomb**.
- The 5s per-call timeout does not help: each call forks many children before its own timeout fires.
- Fix: sentinel env var `_TOTALRECLAW_SKIP_BUILTIN_MEMORY_CHECK=1` is set in `subprocess.run(... env=child_env)`. The spawned `hermes`'s plugin-load reads the sentinel and short-circuits this function, terminating recursion at depth 1.

## Reproduction (pop-os 2026-05-14)

4-core box, 7.7G RAM, single `tr-hermes` container running 2.3.7rc1:

```
load average: 4.04, 2.63, 1.74
Mem: 5.3Gi used / 7.7Gi total, 3.5Gi swap thrashing
docker stats: tr-hermes 100% CPU, tr-hermes-import-test 211% CPU (just spawned)
ps tree of `hermes gateway run`: 30+ `hermes tools list` children, dozens of [hermes] <defunct> zombies
```

Killing one container (the just-spawned import-test) cut storm by half but tr-hermes still pinned. Same code path = same storm.

## Recursion chain

```
hermes gateway run
  → loads totalreclaw plugin → register() → _warn_if_built_in_memory_enabled()
    → subprocess.run(["hermes", "tools", "list"])
      → that process is ALSO `hermes` → loads gateway-init → discovers totalreclaw plugin
        → register() → _warn_if_built_in_memory_enabled()
          → subprocess.run(["hermes", "tools", "list"])
            → … recursion (5s timeout but forks before timeout)
```

Confirmed by:
- `agent.log` showing `TotalReclaw plugin registered` twice within 2 seconds (recursion in flight).
- `pstree -p` showing N-deep `hermes → hermes → hermes` chains.
- cgroup mapping: 4/5 storm PIDs live in tr-hermes-import-test cgroup, 1/5 in tr-hermes — same bug, both containers.

## Patch design

Minimal env-var sentinel:

```python
_RECURSION_GUARD_ENV = "_TOTALRECLAW_SKIP_BUILTIN_MEMORY_CHECK"

def _warn_if_built_in_memory_enabled() -> None:
    if os.environ.get(_RECURSION_GUARD_ENV) == "1":
        return  # we're inside the spawned subprocess — short-circuit
    ...
    child_env = {**os.environ, _RECURSION_GUARD_ENV: "1"}
    subprocess.run([...], env=child_env, ...)
```

Alternatives rejected:
- Don't shell out at all (query in-process registry): bigger surgery, requires gateway-internal API access from plugin.
- Module-level `_already_ran = True` flag: doesn't help — each spawned subprocess is a fresh Python interpreter with fresh module state.
- Detect-by-PPID: brittle (PPID can be re-parented to init under some signal handlers).

## Tests

5 new tests in `TestRecursionGuard`:
1. `test_sentinel_env_var_short_circuits` — when sentinel set, neither `shutil.which` nor `subprocess.run` is invoked
2. `test_sentinel_set_to_other_value_does_not_short_circuit` — only exact `"1"` triggers short-circuit
3. `test_subprocess_invoked_with_sentinel_in_child_env` — `subprocess.run(env=...)` MUST contain the sentinel
4. `test_subprocess_env_preserves_parent_environment` — parent env vars are preserved alongside sentinel
5. `test_recursion_guard_env_name_is_stable` — pins the cross-version env-name contract

All 13 tests in `test_warn_log_on_built_in_memory_enabled.py` pass (8 pre-existing + 5 new).

## Affected versions

- `0e9d2ee` (2026-04-26, rc.26 series) introduced the unguarded shell-out.
- Affects 2.3.6 stable + 2.3.7rc1 currently on PyPI.
- Stable users likely silently affected; QA on pop-os surfaced it during the 2.3.7rc1 retest.

## Test plan

- [x] Unit tests pass locally (13/13)
- [ ] CI green
- [ ] Merge → dispatch `publish-python-client.yml release-type=rc rc-number=2`
- [ ] Wait for `totalreclaw==2.3.7rc2` on PyPI
- [ ] Install on fresh `tr-hermes-import-test` (CLI-only, no Telegram bot conflict) on pop-os
- [ ] Confirm `pgrep -f 'hermes tools list' | wc -l` returns 0 (or ≤1 momentarily) instead of double-digit
- [ ] Confirm `docker stats` for the test container settles to <10% CPU at steady state
- [ ] Pair via `mode=either`, verify pair completes without storm
- [ ] Memory store + recall test
- [ ] If GO: promote to stable 2.3.7 (replaces silently-broken 2.3.6 stable on PyPI dist-tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)