### PR TITLE
feat(hermes): 2.3.7rc3 — proactive setup nudge on first turn of every unconfigured session

### DIFF
--- a/python/src/totalreclaw/hermes/hooks.py
+++ b/python/src/totalreclaw/hermes/hooks.py
@@ -63,19 +63,38 @@ def _rc_staging_banner_active() -> bool:
         return False
     return True
 
-#: Bug #6: when the user hasn't run ``totalreclaw_setup`` yet but is
-#: asking a natural memory-related question, inject a one-time context
-#: nudge telling the agent to offer setup. Otherwise Hermes's built-in
-#: ``memory`` tool absorbs the request and the user never discovers
-#: TotalReclaw is installed.
+#: Bug #6 + 2.3.7rc3: when the plugin is installed + enabled but the
+#: user hasn't completed pairing (no ``credentials.json`` on disk),
+#: inject a one-time-per-session context nudge telling the agent to
+#: PROACTIVELY ask whether the user wants to create a new account or
+#: restore an existing one — before answering whatever else they
+#: said. Catches the "abandoned mid-setup" case after a gateway
+#: ``/restart`` (or docker restart) wiped chat history: the agent
+#: would otherwise forget it was supposed to continue with
+#: ``totalreclaw_pair`` and silently treat the user's latest message
+#: as a fresh request.
+#:
+#: rc.26 → rc3 copy update: drop the implicit "user is asking about
+#: memory" framing — the nudge now fires on ANY first turn while
+#: unconfigured, so the copy must be unconditional + decision-focused.
 _SETUP_NUDGE = (
-    "## TotalReclaw setup nudge (one-time)\n"
-    "TotalReclaw is installed but not yet configured. If the user is "
-    "asking about remembering things across sessions, encrypted memory, "
-    "or cross-agent persistence, call `totalreclaw_setup` to generate a "
-    "BIP-39 recovery phrase and enable the vault. After that, use "
-    "`totalreclaw_remember` / `totalreclaw_recall` — they outrank any "
-    "built-in 'memory' tool for durability + encryption."
+    "## TotalReclaw setup not complete\n"
+    "The TotalReclaw plugin is installed and enabled, but the user "
+    "hasn't finished pairing (no credentials on disk yet). They may "
+    "have started setup in a previous session and lost chat history "
+    "from a gateway /restart — they probably don't realise setup is "
+    "incomplete.\n\n"
+    "Before answering the user's current message, proactively ask "
+    "something like: \"I notice you haven't finished setting up "
+    "TotalReclaw. Would you like to create a new account, or restore "
+    "an existing one with your 12-word recovery phrase?\"\n\n"
+    "Once they pick a path: if they want to create a new account, "
+    "call `totalreclaw_pair` with `mode=generate` (or no mode arg — "
+    "the default `mode=either` lets them choose on the browser page). "
+    "If they want to restore, call `totalreclaw_pair` with "
+    "`mode=import`. After pairing completes, use `totalreclaw_remember` "
+    "/ `totalreclaw_recall` for end-to-end encrypted memory — they "
+    "outrank any built-in `memory` tool for durability + encryption."
 )
 
 #: F4 (issue #167): for configured users, schema-level "prefer this tool"
@@ -272,6 +291,15 @@ def on_session_start(state: "PluginState", **kwargs) -> None:
 
     state.reset_turn_counter()
 
+    # 2.3.7rc3 — reset the setup-nudge latch so each new session gets
+    # one proactive nudge. Without this, an unconfigured user who
+    # closed session A (nudge consumed) and opens session B inside the
+    # SAME daemon process never re-surfaces the nudge — silently
+    # stuck mid-setup. The latch deliberately persists across turns
+    # within a single session so the agent doesn't spam the prompt.
+    if hasattr(state, "_totalreclaw_setup_nudge_shown"):
+        state._totalreclaw_setup_nudge_shown = False
+
     # 2.3.3-rc.1 (PR #165) — emit the RC/staging banner exactly once per
     # session when the wheel is RC AND the user hasn't overridden the
     # server URL. Surfaced via the existing ``quota_warning`` channel so
@@ -416,15 +444,26 @@ def pre_llm_call(state: "PluginState", **kwargs) -> Optional[dict]:
         # register so #192 stays fixed for the mid-session pair path.
         _eager_account_register(state)
 
-    # Bug #6 — unconfigured: one-time setup nudge, fires only when the
-    # user message looks like a memory intent. We never return None here
-    # so the Hermes agent sees the nudge as soon as memory semantics hit.
-    # The "shown once" flag lives as an ad-hoc attribute on the state
-    # instance — ``AgentState`` itself is owned by Phase 1's surface and
-    # we don't want to add state-management methods there from the plugin.
+    # Bug #6 + 2.3.7rc3 — unconfigured: one-time-per-session setup
+    # nudge. The original rc.26 implementation gated the nudge on
+    # ``_looks_like_memory_intent(user_message)`` — i.e. the nudge only
+    # surfaced if the user asked something memory-related on their very
+    # first turn. That worked for users who paired uninterrupted from
+    # the first prompt, but Pedro's 2.3.7rc2 QA (2026-05-14) hit the
+    # "abandoned mid-setup" path: the agent had asked the user to
+    # ``/restart``, the restart killed the daemon and wiped chat
+    # history, the user reopened chat and typed something unrelated
+    # (a greeting / unrelated question) → no memory intent → no nudge,
+    # so the agent silently moved on without resuming pairing.
+    #
+    # rc3 drops the memory-intent gate. If the plugin is loaded and
+    # creds.json is absent, fire the nudge on the FIRST TURN of EVERY
+    # session. The latch is reset in ``on_session_start`` (see below)
+    # so a user who closed session A unconfigured + opens session B
+    # gets a fresh nudge.
     if not state.is_configured():
         shown = getattr(state, "_totalreclaw_setup_nudge_shown", False)
-        if not shown and _looks_like_memory_intent(user_message):
+        if not shown:
             state._totalreclaw_setup_nudge_shown = True
             return {"context": _SETUP_NUDGE}
         return None

--- a/python/tests/test_hermes_plugin.py
+++ b/python/tests/test_hermes_plugin.py
@@ -295,10 +295,44 @@ class TestHooks:
         assert state.get_quota_warning() is None
 
     def test_pre_llm_call_not_configured(self):
+        """2.3.7rc3 contract change: when the plugin is not configured,
+        pre_llm_call now SURFACES the setup nudge on first turn
+        regardless of message content (was: returned None unless the
+        message looked like a memory intent). The nudge must contain
+        the rc3 contract markers: ``totalreclaw_pair`` tool name +
+        ``create a new account`` / ``restore an existing one`` decision
+        copy. See ``TestRc3SetupNudgeFirstTurn`` in
+        ``test_v2_02_hermes_fixes.py`` for the rationale (abandoned-
+        mid-setup path after a /restart wipes chat history).
+
+        Note: ``_maybe_reconfigure_from_disk`` runs at the head of
+        ``pre_llm_call`` and re-stats ``credentials.json``, so dev
+        machines with a real ``~/.totalreclaw/credentials.json``
+        would silently flip the state to configured during the call
+        (test passed pre-rc3 by luck — returning None matched). Mock
+        ``Path.exists`` through the call so the test is deterministic.
+        """
         from totalreclaw.hermes.hooks import pre_llm_call
         state = _make_state()
-        result = pre_llm_call(state, is_first_turn=True, user_message="hello")
-        assert result is None
+        with patch.object(Path, "exists", return_value=False):
+            result = pre_llm_call(state, is_first_turn=True, user_message="hello")
+        assert result is not None, (
+            "rc3 expected the setup nudge on first turn of an "
+            "unconfigured session. Got None."
+        )
+        ctx = result.get("context", "").lower()
+        assert "totalreclaw_pair" in ctx
+        assert "create a new account" in ctx
+        assert "restore" in ctx
+
+        # rc3 latch contract — second call within the same session must
+        # NOT re-fire the nudge.
+        with patch.object(Path, "exists", return_value=False):
+            result2 = pre_llm_call(state, is_first_turn=False, user_message="more")
+        if result2 is not None:
+            ctx2 = result2.get("context", "").lower()
+            assert "totalreclaw_pair" not in ctx2
+            assert "create a new account" not in ctx2
 
     def test_pre_llm_call_injects_quota_warning(self):
         """pre_llm_call should inject and clear quota warning."""

--- a/python/tests/test_v2_02_hermes_fixes.py
+++ b/python/tests/test_v2_02_hermes_fixes.py
@@ -374,13 +374,22 @@ class TestBug6FirstRunNudge:
                     user_message="Can you remember that I prefer dark mode?",
                 )
 
-        # Should return a context nudge mentioning setup.
+        # Should return a context nudge offering setup.
         assert result is not None, "expected setup nudge on first turn"
-        ctx = result.get("context", "")
-        assert "totalreclaw_setup" in ctx.lower() or "set up" in ctx.lower()
+        ctx = result.get("context", "").lower()
+        # rc3 — copy now talks about pairing + new-vs-restore choice
+        # rather than the legacy ``totalreclaw_setup`` tool name. Accept
+        # either the legacy term or the rc3 contract markers.
+        assert (
+            "totalreclaw_pair" in ctx
+            or "create a new account" in ctx
+            or "totalreclaw_setup" in ctx
+        )
 
-    def test_pre_llm_call_nudge_only_fires_once(self):
-        """Second invocation should NOT re-inject the nudge."""
+    def test_pre_llm_call_nudge_only_fires_once_per_session(self):
+        """Second invocation in the same session should NOT re-inject
+        the nudge. The latch resets on ``on_session_start`` (see the
+        TestRc3SetupNudgeFirstTurn class)."""
         from totalreclaw.hermes.hooks import pre_llm_call
         from totalreclaw.hermes.state import PluginState
 
@@ -399,10 +408,11 @@ class TestBug6FirstRunNudge:
                     user_message="Can you remember another thing for me?",
                 )
         assert first is not None
-        # Second call: nudge should not re-fire (no "totalreclaw_setup" in ctx).
+        # Second call: nudge should not re-fire.
         if second is not None:
             ctx = second.get("context", "").lower()
-            assert "totalreclaw_setup" not in ctx
+            assert "totalreclaw_pair" not in ctx
+            assert "create a new account" not in ctx
 
     def test_pre_llm_call_configured_user_no_nudge(self):
         """Configured users don't see the setup nudge."""
@@ -423,7 +433,146 @@ class TestBug6FirstRunNudge:
         # No nudge when configured.
         if result is not None:
             ctx = result.get("context", "").lower()
-            assert "totalreclaw_setup" not in ctx
+            assert "totalreclaw_pair" not in ctx
+            assert "create a new account" not in ctx
+
+
+class TestRc3SetupNudgeFirstTurn:
+    """2.3.7rc3 — drop the memory-intent gate on the setup nudge.
+
+    rc.26 implementation only surfaced the nudge if the FIRST user
+    message looked like a memory intent (``remember X``, ``what do you
+    know about Y``, etc.). That worked for users who paired in one
+    uninterrupted conversation, but broke the "abandoned mid-setup"
+    path:
+
+      1. Agent installs the plugin, asks the user to ``/restart``.
+      2. ``/restart`` (or a docker restart of the gateway container)
+         kills the daemon and wipes chat history.
+      3. User reopens chat, types something unrelated (a greeting or
+         unrelated question).
+      4. No memory intent → no nudge → agent silently treats the
+         message as a fresh request, never resuming pairing.
+
+    Pedro hit this 2026-05-14 during 2.3.7rc2 QA. rc3 fix: fire the
+    nudge on EVERY first turn while unconfigured, regardless of
+    message content. Latch is reset in ``on_session_start`` so each
+    new session gets one nudge chance.
+    """
+
+    @staticmethod
+    def _make_unconfigured_state():
+        from totalreclaw.hermes.state import PluginState
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(Path, "exists", return_value=False):
+                state = PluginState()
+        assert not state.is_configured()
+        return state
+
+    def test_nudge_fires_on_first_turn_even_without_memory_intent(self):
+        """rc3 contract: a bare greeting on the first turn of an
+        unconfigured session MUST still produce the setup nudge.
+        rc.26 would have returned None here."""
+        from totalreclaw.hermes.hooks import pre_llm_call
+
+        state = self._make_unconfigured_state()
+        with patch.object(Path, "exists", return_value=False):
+            result = pre_llm_call(
+                state, is_first_turn=True, user_message="hello",
+            )
+        assert result is not None, (
+            "rc3 expected a nudge on a non-memory-intent first turn "
+            "(the 'abandoned mid-setup' path). Got None."
+        )
+        ctx = result.get("context", "").lower()
+        # rc3 contract markers — the nudge must surface the choice +
+        # the canonical pair-tool name.
+        assert "create a new account" in ctx, (
+            "rc3 nudge copy must include 'create a new account' so the "
+            "agent surfaces the new-vs-restore decision verbatim."
+        )
+        assert "restore" in ctx, (
+            "rc3 nudge copy must mention restore so the agent surfaces "
+            "the import path explicitly."
+        )
+        assert "totalreclaw_pair" in ctx, (
+            "rc3 nudge must point at the canonical pair-tool name."
+        )
+
+    def test_nudge_fires_on_first_turn_with_unrelated_question(self):
+        """Same as above but with a generic question (not a greeting).
+        Both shapes must trigger the nudge under rc3."""
+        from totalreclaw.hermes.hooks import pre_llm_call
+
+        state = self._make_unconfigured_state()
+        with patch.object(Path, "exists", return_value=False):
+            result = pre_llm_call(
+                state, is_first_turn=True,
+                user_message="What's 2+2?",
+            )
+        assert result is not None
+        ctx = result.get("context", "").lower()
+        assert "create a new account" in ctx
+        assert "totalreclaw_pair" in ctx
+
+    def test_nudge_latch_resets_on_session_start(self):
+        """Each new session must get one nudge chance. Without the
+        reset, a user who consumed the nudge in session A and opened
+        session B inside the same daemon process never re-surfaces the
+        nudge — silently stuck mid-setup."""
+        from totalreclaw.hermes.hooks import pre_llm_call, on_session_start
+
+        state = self._make_unconfigured_state()
+
+        # Session A: nudge fires, latch flips True.
+        with patch.object(Path, "exists", return_value=False):
+            first = pre_llm_call(
+                state, is_first_turn=True, user_message="hi",
+            )
+            assert first is not None
+            assert getattr(state, "_totalreclaw_setup_nudge_shown", False) is True
+
+            # Session A continues — second turn must not re-fire.
+            second = pre_llm_call(
+                state, is_first_turn=False, user_message="more",
+            )
+            if second is not None:
+                assert "create a new account" not in second.get("context", "").lower()
+
+            # NEW SESSION — on_session_start must reset the latch.
+            on_session_start(state, session_id="session-B")
+            assert state._totalreclaw_setup_nudge_shown is False, (
+                "on_session_start must reset the nudge latch so a new "
+                "session gets a fresh nudge."
+            )
+
+            # Session B first turn — nudge fires again.
+            third = pre_llm_call(
+                state, is_first_turn=True, user_message="hello again",
+            )
+            assert third is not None
+            assert "create a new account" in third.get("context", "").lower()
+
+    def test_nudge_does_not_fire_when_configured(self):
+        """Configured users must NEVER see the setup nudge, even on
+        first turn (regression guard — the rc3 ungating must not leak
+        into the configured path)."""
+        from totalreclaw.hermes.hooks import pre_llm_call
+
+        state = self._make_unconfigured_state()
+        state._client = MagicMock()  # Forge configured.
+
+        with patch("totalreclaw.hermes.hooks.auto_recall", return_value=None):
+            with patch.object(Path, "exists", return_value=False):
+                result = pre_llm_call(
+                    state, is_first_turn=True, user_message="hello",
+                )
+        if result is not None:
+            ctx = result.get("context", "").lower()
+            assert "create a new account" not in ctx, (
+                "Configured users must not see the setup nudge."
+            )
+            assert "totalreclaw_pair" not in ctx
 
 
 class TestIssue167ToolPriorityNudge:


### PR DESCRIPTION
## Summary

- Drop the memory-intent gate on the setup nudge. If the plugin is loaded and `credentials.json` is absent, fire the nudge on the FIRST TURN of every session, regardless of user-message content.
- Reset the nudge latch in `on_session_start` so each new session gets one nudge chance.
- Rewrite the nudge copy to surface the new-vs-restore decision verbatim and point at `totalreclaw_pair` (replaces the legacy `totalreclaw_setup` tool name).

## UX feedback that triggered this fix

Pedro 2026-05-14, mid-2.3.7rc2 QA on pop-os:

> Once I restarted the gateway, it was an abrupt container restart which led hermes to lose history. When I picked up the chat, it didn't know it had to continue with the setup by calling the pairing tool. I had to explicitly say "please continue setting up totalreclaw". To avoid this (we can't control if users will gracefully restart hermes), can we have a check on whether the plugin is installed AND enabled BUT NOT configured (credentials and others)? If that checks out, the agent should say "you haven't finished configuring totalreclaw. would you like to create a new account or restore an existing one".

## The bug path

rc.26 nudge fires only when `_looks_like_memory_intent(user_message)`. Covered the happy path but broke the abandoned-mid-setup path:

1. Agent installs the plugin, asks user to `/restart`.
2. `/restart` kills the daemon and wipes chat history.
3. User reopens chat, types something unrelated (greeting / random question) — no memory intent.
4. No nudge → agent silently moves on, never resumes pairing.

## Tests (101 hermes tests pass)

- 4 new tests in `TestRc3SetupNudgeFirstTurn`:
  1. Nudge fires on a bare "hello" first turn (rc.26 would have returned None).
  2. Nudge fires on a generic non-memory question.
  3. `on_session_start` resets latch so session-A→session-B re-fires the nudge.
  4. Regression guard: configured users still see no nudge.
- 3 existing tests updated to accept rc3 markers (`create a new account` / `totalreclaw_pair`) alongside the legacy `totalreclaw_setup` tool name.

## Test plan

- [x] 101/101 hermes tests pass locally
- [ ] CI green on PR
- [ ] Merge + dispatch `publish-python-client.yml release-type=rc rc-number=3`
- [ ] Wait for `totalreclaw==2.3.7rc3` on PyPI
- [ ] Install on `tr-hermes-import-test` (CLI-only fresh container) → repro the abandoned-mid-setup path: install, `/restart` (docker restart), reopen chat with bare "hello" → agent must proactively ask new-vs-restore.
- [ ] Pedro full natural-flow QA on tr-hermes (or fresh container) for the rc3 build.
- [ ] If GO: promote `2.3.7` to stable, replacing silently-broken `2.3.6` (still contains the fork-bomb bug from rc2 fix + the missing rc3 nudge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)