### PR TITLE
feat(hermes-guide): 2.3.7rc4 — restart branch table + continuation-phrase reply

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -60,7 +60,7 @@ This is not a rule the agent follows perfectly, but the more it can, the better 
 
 ## Install procedure
 
-After the procedure completes (the user replies `done` to the `/restart` request in step 4), **proceed directly to Account setup**. Do not ask the user "is it ready?" — the user's `done` IS the signal.
+After the procedure completes (the user replies *"Done — continue setting up TotalReclaw"* or equivalent to the restart request in step 4), **proceed directly to Account setup**. Do not ask the user "is it ready?" — the user's reply IS the signal.
 
 1. Resolve the Hermes Python interpreter:
    ```bash
@@ -73,11 +73,32 @@ After the procedure completes (the user replies `done` to the `/restart` request
    hermes plugins install p-diogo/totalreclaw-hermes --enable
    ```
    (Or `"$(dirname "$HERMES_PYTHON")/hermes" plugins install p-diogo/totalreclaw-hermes --enable` when `hermes` isn't on `PATH`.)
-4. **Ask the user to issue `/restart`** so the gateway reloads with the new plugin tools active. The agent does NOT issue `/restart` itself — agents have repeatedly mis-tracked restart state and issued it twice, killing the pair sidecar mid-flight. Emit ONE user-visible line:
+4. **Ask the user to restart the gateway** so the new plugin tools bind. The agent does NOT issue the restart itself — agents have repeatedly mis-tracked restart state and issued it twice, killing the pair sidecar mid-flight.
 
-   > Send `/restart` in chat now. Reply `done` once you see `Gateway restarted successfully`.
+   The restart command depends on which surface the user is chatting through. Hermes only intercepts the `/restart` slash command from messaging-platform adapters (Telegram, Discord, Slack, Matrix, Feishu, WhatsApp); in the CLI/TUI (`hermes chat`) the agent sees `/restart` as ordinary text and cannot execute it, and in docker the gateway has no systemd/launchd supervisor to respawn after a self-exit.
 
-   Wait for the user to reply `done`. Do NOT proceed to Account setup until the user confirms. Do NOT issue `/restart` yourself.
+   Probe the surface before emitting:
+
+   ```bash
+   IN_DOCKER=$(grep -q -E 'docker|containerd' /proc/1/cgroup 2>/dev/null && echo yes || echo no)
+   HAS_MSG_BOT="$(printenv | grep -E '^HERMES_(TELEGRAM|DISCORD|SLACK|MATRIX|FEISHU|WHATSAPP)_(BOT_TOKEN|HOMESERVER|APP_ID|PHONE_NUMBER_ID)=' | head -1)"
+   HAS_SYSTEMCTL=$(command -v systemctl >/dev/null 2>&1 && echo yes || echo no)
+   HAS_LAUNCHCTL=$(command -v launchctl >/dev/null 2>&1 && echo yes || echo no)
+   ```
+
+   Emit ONE user-visible line per the matrix below. **In every case the user is asked to reply with an unambiguous continuation phrase** — bare `done` is insufficient because, after a restart, chat history is gone and the agent needs both a system-injected nudge (rc.27+ ships this automatically when credentials are absent) AND an explicit user message to reliably resume the setup flow.
+
+   | Surface | Detected by | Emit (verbatim) |
+   |---|---|---|
+   | Messaging platform — user is chatting via Telegram / Discord / Slack / Matrix / Feishu / WhatsApp | `HAS_MSG_BOT != ""` | `> Send /restart in chat now. Once you see the gateway-restart confirmation, reply: "Done — continue setting up TotalReclaw".` |
+   | `hermes chat` inside docker | `IN_DOCKER=yes` AND `HAS_MSG_BOT == ""` | `> The /restart slash command is messaging-platform only and won't work from this CLI. Open a host shell (outside the container) and run: docker restart <container-name>. Wait for the container to come back up, reopen hermes chat, and reply: "Done — continue setting up TotalReclaw".` |
+   | `hermes chat` native install with systemd | `IN_DOCKER=no` AND `HAS_SYSTEMCTL=yes` AND `HAS_MSG_BOT == ""` | `> The /restart slash command won't work from this CLI. Open a second terminal and run: hermes gateway restart. When it returns, reply here: "Done — continue setting up TotalReclaw".` |
+   | `hermes chat` native install on macOS / launchd | `IN_DOCKER=no` AND `HAS_LAUNCHCTL=yes` AND `HAS_MSG_BOT == ""` | `> The /restart slash command won't work from this CLI. Open a second terminal and run: hermes gateway restart. When it returns, reply here: "Done — continue setting up TotalReclaw".` |
+   | Detection fails / ambiguous | none of the above match | Ask the user how they're chatting with Hermes (Telegram / Discord / Slack / Matrix / Feishu / WhatsApp / `hermes chat` in docker / `hermes chat` native), then emit the matching line above. |
+
+   Substitute the actual container name in the docker line — usually visible via `docker ps --format '{{.Names}}'`; if the agent runs that probe and finds exactly one container, splice the name in. Fall back to `<container-name>` placeholder otherwise.
+
+   Wait for the user's reply containing "continue" / "set up" / similar resumption language. Do NOT proceed to Account setup until the user confirms. Do NOT issue any restart yourself.
 
 ---
 
@@ -167,11 +188,14 @@ These are hard rules. None of them are negotiable.
 
 ## Diagnostics
 
-- Plugin not loaded after `/restart`: `"$(dirname "$HERMES_PYTHON")/hermes" plugins list` should show `totalreclaw` as enabled. If absent, re-run install procedure step 3.
+- Plugin not loaded after the restart: `"$(dirname "$HERMES_PYTHON")/hermes" plugins list` should show `totalreclaw` as enabled. If absent, re-run install procedure step 3.
 - `totalreclaw_pair` returns a URL that 404s on the browser: the relay is unreachable — check `TOTALRECLAW_SERVER_URL` env var matches the user's intended channel (prod default, or staging from the QA prompt).
 - `totalreclaw_pair` returns a 5xx: ask the user to retry; report the error code verbatim.
-- Tool not bound after install: `/restart` once. If still missing, the package install hit the wrong Python; re-resolve `HERMES_PYTHON` and re-install.
-- `/restart` returns "not authorized" or "command not found" (managed Hermes deployments may gate it behind RBAC): issue `/new` to start a fresh session instead — the plugin manifest is reloaded on session start and the new tools bind without a full gateway restart.
+- Tool not bound after install: restart once per Install procedure step 4. If still missing, the package install hit the wrong Python; re-resolve `HERMES_PYTHON` and re-install.
+- **Agent says `/restart` "can't do that here" / "I'm not able to issue that":** the user is in `hermes chat` (CLI/TUI), where `/restart` reaches the LLM as ordinary text instead of being intercepted. The `/restart` slash command is wired only in messaging-platform adapters (Telegram / Discord / Slack / Matrix / Feishu / WhatsApp). Switch the user to the correct restart command for their surface per the Install procedure step 4 matrix.
+- **`hermes gateway restart` from inside a docker container returns "no running gateway" or fails silently:** the container has no systemd / launchd service supervisor to respawn the gateway after a self-exit. The correct restart for docker is `docker restart <container-name>` from the **host** shell, not from inside the container.
+- **`/restart` returns "not authorized" or "command not found"** (managed Hermes deployments may gate it behind RBAC): issue `/new` to start a fresh session instead — the plugin manifest is reloaded on session start and the new tools bind without a full gateway restart.
+- **After restart, agent doesn't continue setup:** if the user replied only `done` without a continuation phrase, the agent may not infer it should resume. The rc.27+ proactive setup nudge fires on the first turn of every unconfigured session, so re-engaging the conversation with anything (even another bare message) should trigger the new-vs-restore question. If it doesn't, ask the user to type "Continue setting up TotalReclaw" verbatim.
 
 ---
 

--- a/python/tests/test_setup_guide_restart_branch_rc4.py
+++ b/python/tests/test_setup_guide_restart_branch_rc4.py
@@ -1,0 +1,242 @@
+"""2.3.7rc4 — restart-branch table in ``docs/guides/hermes-setup.md``.
+
+Context — Pedro 2026-05-14 QA on 2.3.7rc3
+------------------------------------------
+
+The previous restart instruction (rc.7+) emitted a single line:
+
+    > Send `/restart` in chat now. Reply `done` once you see
+    > `Gateway restarted successfully`.
+
+That works in messaging-platform surfaces (Telegram, Discord, Slack,
+Matrix, Feishu, WhatsApp) where the gateway intercepts the slash
+command BEFORE the agent sees it. It does NOT work in ``hermes
+chat`` (CLI/TUI) — the ``/restart`` string flows through to the LLM
+as plain text, the agent has no tool to execute it, and the chat
+session can't restart the gateway it's living inside. In docker,
+even ``hermes gateway restart`` fails because there's no
+systemd/launchd service supervisor to respawn the process after a
+SIGUSR1 exit.
+
+rc4 fixes the instruction with:
+
+1. A probe + per-surface emit matrix. Messaging adapters → ``/restart``
+   in chat. Docker CLI → ``docker restart <container>`` from host
+   shell. Native CLI → ``hermes gateway restart`` in a second
+   terminal. Detection-fails → ask the user which surface they're on
+   and branch on the answer.
+
+2. Continuation-phrase reply instead of bare ``done``. After a
+   gateway restart the agent's session memory is wiped; the rc3
+   proactive setup nudge fires on the first turn of every
+   unconfigured session, but for belt-and-suspenders the user is
+   asked to reply ``"Done — continue setting up TotalReclaw"`` (or
+   equivalent resumption language) so the agent's next turn has both
+   a system-injected nudge AND an unambiguous user message.
+
+3. Diagnostics entries documenting the failure modes the user might
+   hit if they ignore (or don't read) the per-surface emit.
+
+These tests pin the rc4 contract so a future refactor can't silently
+drop the multi-surface branch.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+GUIDE_MD = _REPO_ROOT / "docs" / "guides" / "hermes-setup.md"
+
+
+def _read_guide() -> str:
+    assert GUIDE_MD.exists(), f"hermes-setup.md not found at {GUIDE_MD}"
+    return GUIDE_MD.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Section 1 — Surface detection probe
+# ---------------------------------------------------------------------------
+
+
+def test_guide_has_surface_detection_probe():
+    """The Install procedure step 4 must include a small shell probe
+    the agent runs to detect the user's surface before emitting the
+    restart instruction. Without the probe the agent emits the
+    messaging-only ``/restart`` line for every user.
+    """
+    body = _read_guide()
+    # Indicators that a detection probe exists.
+    assert "IN_DOCKER=" in body, (
+        "hermes-setup.md must include a docker-cgroup probe so the "
+        "agent can detect when it's running inside a container."
+    )
+    assert "HAS_MSG_BOT" in body or "HAS_TELEGRAM" in body, (
+        "Probe must check for messaging-bot env vars so the agent can "
+        "detect when ``/restart`` would actually be intercepted by a "
+        "gateway adapter."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section 2 — Per-surface emit matrix
+# ---------------------------------------------------------------------------
+
+
+def test_guide_lists_all_messaging_platforms():
+    """rc4 extends the table to every messaging platform Hermes
+    supports. Per ``gateway/platforms/`` in upstream Hermes: Telegram,
+    Discord, Slack, Matrix, Feishu, WhatsApp. All six must appear in
+    the restart-branch table so the agent doesn't gate on a hardcoded
+    Telegram/Discord-only check.
+    """
+    body = _read_guide()
+    for platform in ("Telegram", "Discord", "Slack", "Matrix", "Feishu", "WhatsApp"):
+        assert platform in body, (
+            f"hermes-setup.md restart matrix must list {platform!r} "
+            f"as a messaging platform that intercepts ``/restart``. "
+            f"Without it the agent will emit the wrong restart "
+            f"instruction for {platform} users."
+        )
+
+
+def test_guide_documents_docker_restart_branch():
+    """When the agent detects it's running inside docker AND there's
+    no messaging-bot env, it must emit a ``docker restart
+    <container>`` instruction (run from the host shell, NOT from
+    inside the container) — that's the only restart path that works
+    without a service supervisor inside the container."""
+    body = _read_guide()
+    assert "docker restart" in body, (
+        "hermes-setup.md must reference ``docker restart <container>`` "
+        "as the restart path for docker-CLI users."
+    )
+    # Must explicitly note the command runs from the host (a common
+    # mistake is to run docker restart from inside the container).
+    assert "host shell" in body or "outside the container" in body, (
+        "hermes-setup.md must clarify that ``docker restart`` runs "
+        "from the HOST shell, not from inside the container — "
+        "otherwise users try ``docker restart`` from inside and hit "
+        "permission errors."
+    )
+
+
+def test_guide_documents_native_cli_restart_branch():
+    """When the agent detects native install (no docker, has
+    systemctl/launchctl, no messaging bot), it must emit a
+    ``hermes gateway restart`` instruction in a second terminal."""
+    body = _read_guide()
+    assert "hermes gateway restart" in body, (
+        "hermes-setup.md must reference ``hermes gateway restart`` "
+        "as the restart path for native CLI users (where a "
+        "systemd/launchd supervisor respawns the gateway)."
+    )
+
+
+def test_guide_documents_detection_failure_fallback():
+    """When the detection probe is inconclusive, the agent must ask
+    the user which surface they're on (not silently pick a default,
+    not loop on ``/restart``). The ask must enumerate the same set
+    of surfaces as the matrix."""
+    body = _read_guide()
+    # Existence of an explicit fallback path.
+    assert "Ask the user" in body or "ask the user how" in body, (
+        "hermes-setup.md must instruct the agent to ASK the user "
+        "when surface detection fails — silent default-picking is "
+        "worse than asking."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section 3 — Continuation-phrase reply (replaces bare ``done``)
+# ---------------------------------------------------------------------------
+
+
+def test_guide_uses_continuation_phrase_instead_of_bare_done():
+    """rc4 replaces ``Reply done`` with a continuation-phrase reply
+    (``Done — continue setting up TotalReclaw`` or equivalent
+    resumption language). Combined with the rc3 proactive setup
+    nudge, this maximises the chance that the agent picks up
+    mid-setup after a gateway restart wipes chat history.
+
+    The exact phrase ``Continue setting up TotalReclaw`` (case-
+    insensitive) MUST appear in the user-visible emit so the user
+    has a verbatim suggestion to type."""
+    body = _read_guide().lower()
+    assert "continue setting up totalreclaw" in body, (
+        "hermes-setup.md must include the literal ``Continue setting "
+        "up TotalReclaw`` resumption phrase as the suggested reply "
+        "after restart. Bare ``done`` is insufficient post-restart — "
+        "the agent's session memory is wiped + needs an unambiguous "
+        "trigger to call totalreclaw_pair."
+    )
+
+
+def test_guide_still_references_rc3_nudge_safety_net():
+    """The continuation phrase pairs with the rc3 proactive setup
+    nudge that fires on the first turn of every unconfigured session.
+    The guide must surface this so the agent doesn't panic when the
+    user replies with something other than the verbatim phrase —
+    the nudge will still fire."""
+    body = _read_guide()
+    # Reference to the proactive nudge / unconfigured-session
+    # auto-prompt mechanism.
+    assert "proactive setup nudge" in body or "proactive" in body and "unconfigured" in body, (
+        "hermes-setup.md must mention the rc3 proactive setup nudge "
+        "so the agent (and human readers) know the nudge is the "
+        "primary belt; the continuation phrase is just the secondary "
+        "suspenders."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section 4 — Diagnostics for the failure modes
+# ---------------------------------------------------------------------------
+
+
+def test_diagnostics_documents_cli_cant_do_that_failure():
+    """The Diagnostics section must document the symptom Pedro hit on
+    2026-05-14: agent in ``hermes chat`` (CLI) refuses to execute
+    ``/restart`` because it doesn't have that tool. The fix is to
+    switch to the per-surface restart command from step 4."""
+    body = _read_guide().lower()
+    # Phrase shape — flexible match.
+    assert "can't do that here" in body or "i'm not able to" in body or "cli/tui" in body, (
+        "Diagnostics must document the 'agent says /restart can't do "
+        "that here in CLI/TUI' failure mode that Pedro hit 2026-05-14. "
+        "Without this entry, future users + their agents won't know "
+        "what to do when /restart silently no-ops in hermes chat."
+    )
+
+
+def test_diagnostics_documents_docker_supervisor_failure():
+    """``hermes gateway restart`` from INSIDE a docker container
+    fails because the container has no systemd/launchd service
+    supervisor to respawn the gateway after SIGUSR1 exit. The
+    Diagnostics section must document this so users don't loop on
+    ``hermes gateway restart`` inside docker."""
+    body = _read_guide()
+    # Must reference the supervisor / respawn concept.
+    assert "service supervisor" in body or "systemd" in body or "launchd" in body, (
+        "Diagnostics must explain why ``hermes gateway restart`` "
+        "fails inside docker (no service supervisor to respawn)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section 5 — Backwards-compat: existing rc.7 user-issued model preserved
+# ---------------------------------------------------------------------------
+
+
+def test_guide_still_requires_user_issued_restart_not_agent_issued():
+    """rc.7 invariant — agent does NOT issue ``/restart`` itself.
+    rc4 extends the surface coverage but must preserve the rc.7
+    user-issued model. Otherwise the rc.7 double-restart 502 bug
+    (sidecar killed by overlapping restarts) re-surfaces."""
+    body = _read_guide()
+    assert "agent does NOT issue" in body or "Do NOT issue" in body, (
+        "hermes-setup.md must preserve the rc.7 invariant: agent "
+        "does NOT issue ``/restart`` itself — the user does. rc.7 "
+        "fixed a double-restart-kills-pair-sidecar 502 bug; rc4 "
+        "must not regress that."
+    )


### PR DESCRIPTION
## Summary

- Replace the single-line ``Send /restart in chat now`` instruction with a per-surface emit matrix (Telegram / Discord / Slack / Matrix / Feishu / WhatsApp / docker CLI / native CLI / fallback-ask).
- Replace bare ``Reply done`` with ``Reply 'Done — continue setting up TotalReclaw'`` so the user's resumption message itself is an unambiguous trigger (belt-and-suspenders with the rc3 proactive setup nudge).
- Add Diagnostics entries for the two failure modes Pedro hit: agent says ``/restart`` can't do that here in CLI, and ``hermes gateway restart`` fails inside docker (no supervisor).
- **Guide-only change** — no plugin code touched. rc.7 user-issued restart model preserved.

## UX feedback that triggered this fix

Pedro 2026-05-14, mid-2.3.7rc3 QA on pop-os:

> When using the actual chat TUI interface with a docker exec command, that didn't really work. The agent said I can't do that here. You need to restart the gateway separately because that would basically kill the process itself but it did work when talking to the Telegram bot apparently.

## Root cause

\`/restart\` is wired only in messaging-platform adapters (\`gateway/run.py:_handle_restart_command\` intercepts the message before the LLM sees it). In \`hermes chat\` (CLI/TUI), the string flows through to the agent as plain text — the agent has no tool to execute it and the chat session can't restart the gateway it's living inside. In docker the gateway has no systemd/launchd supervisor to respawn after SIGUSR1 exit, so even \`hermes gateway restart\` fails.

## The fix

Install procedure step 4 now includes a small probe + matrix:

\`\`\`bash
IN_DOCKER=\$(grep -q -E 'docker|containerd' /proc/1/cgroup 2>/dev/null && echo yes || echo no)
HAS_MSG_BOT="\$(printenv | grep -E '^HERMES_(TELEGRAM|DISCORD|SLACK|MATRIX|FEISHU|WHATSAPP)_(BOT_TOKEN|HOMESERVER|APP_ID|PHONE_NUMBER_ID)=' | head -1)"
HAS_SYSTEMCTL=\$(command -v systemctl >/dev/null 2>&1 && echo yes || echo no)
HAS_LAUNCHCTL=\$(command -v launchctl >/dev/null 2>&1 && echo yes || echo no)
\`\`\`

| Surface | Detected by | Emit |
|---|---|---|
| Messaging platform (Telegram/Discord/Slack/Matrix/Feishu/WhatsApp) | \`HAS_MSG_BOT != ""\` | \`Send /restart in chat now. Reply 'Done — continue setting up TotalReclaw'\` |
| \`hermes chat\` inside docker | \`IN_DOCKER=yes\` AND no msg bot | \`Run docker restart <container> from your host shell. Reply 'Done — continue setting up TotalReclaw'\` |
| \`hermes chat\` native (systemd/launchd) | not docker, no msg bot, has systemctl/launchctl | \`Open a second terminal and run hermes gateway restart. Reply 'Done — continue setting up TotalReclaw'\` |
| Detection fails | none match | Ask the user which surface they're on, then emit the matching line |

The ``Continue setting up TotalReclaw`` phrase aligns with the rc3 \`_SETUP_NUDGE\` copy — both surface the new-vs-restore decision, so the agent's next turn has both a system-injected nudge AND an unambiguous user message.

## Tests (10 new, 30 total pass with existing restart-hardening + compatibility suites)

\`test_setup_guide_restart_branch_rc4.py\`:
- Surface detection probe present (IN_DOCKER, HAS_MSG_BOT).
- All 6 messaging platforms in the matrix.
- Docker branch includes ``docker restart`` + ``host shell`` clarification.
- Native branch includes ``hermes gateway restart``.
- Detection-failure fallback asks the user.
- Continuation phrase ``continue setting up TotalReclaw`` appears verbatim.
- rc3 proactive nudge reference preserved as the primary belt.
- Diagnostics entries for CLI ``can't do that here`` + docker supervisor failure.
- rc.7 user-issued model preserved (no agent-issued ``/restart``).

## Test plan

- [x] 30/30 hermes-guide tests pass locally
- [ ] CI green
- [ ] Merge + dispatch \`publish-python-client.yml release-type=rc rc-number=4\`
- [ ] Wait for \`totalreclaw==2.3.7rc4\` on PyPI
- [ ] Install on \`tr-hermes-import-test\` (fresh, CLI-only, prod relay)
- [ ] Repro the Pedro path: fire install + import prompt → confirm agent emits ``docker restart`` instruction (not ``/restart``) because it detects CLI + docker
- [ ] Confirm agent picks up after restart when user replies ``Done — continue setting up TotalReclaw``
- [ ] Pedro full natural-flow QA
- [ ] If GO → promote 2.3.7 stable (replaces silently-broken 2.3.6 which has the fork-bomb)

🤖 Generated with [Claude Code](https://claude.com/claude-code)