### PR TITLE
docs(tiers): reconcile free tier to 250 memories/month + expose period in status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
 
 Two storage modes: **Managed Service** (default -- on-chain via The Graph, accessed through relay) and **Self-Hosted** (PostgreSQL backend you run yourself). The client-side E2EE pipeline is identical for both.
 
-Managed Service uses a **dual-chain model**: Free tier stores on **Base Sepolia** testnet (chain 84532), Pro tier stores on **Gnosis mainnet** (chain 100). The relay routes bundler and subgraph requests to the correct chain based on user tier. Smart Account addresses are deterministic across both chains (CREATE2).
+Managed Service uses a **dual-chain model**: Free tier stores on **Base Sepolia** testnet (chain 84532), Pro tier stores on **Gnosis mainnet** (chain 100). The relay routes bundler and subgraph requests to the correct chain based on user tier. Smart Account addresses are deterministic across both chains (CREATE2). The 250/month free-tier cap is enforced by the **production** relay only; the **staging** relay (`api-staging.totalreclaw.xyz`) has no quota so QA + RC builds can write freely.
 
 ```
 +-------------------------------------------------------------------------+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,7 +223,7 @@ Features across OpenClaw plugin (`skill/plugin/`), MCP server (`mcp/`), NanoClaw
 
 Features across Self-Hosted (PostgreSQL) and Managed Service (default, dual-chain via The Graph).
 
-Managed Service two-tier chain model: **Free** = Base Sepolia testnet (unlimited memories, test network — may be reset), **Pro** = Gnosis mainnet (pricing from Stripe, unlimited, permanent on-chain storage).
+Managed Service two-tier chain model: **Free** = Base Sepolia testnet (250 memories/month, test network — may be reset), **Pro** = Gnosis mainnet (pricing from Stripe, unlimited, permanent on-chain storage).
 
 | Feature | Self-Hosted | Managed Service | Notes |
 |---------|:-:|:-:|-------|

--- a/docs/guides/claude-code-setup.md
+++ b/docs/guides/claude-code-setup.md
@@ -214,7 +214,7 @@ Same phrase, same memories. Switch agents without losing anything. To migrate, c
 
 | Tier | Storage | Price |
 |------|---------|-------|
-| **Free** | Unlimited on Base Sepolia testnet (may reset) | $0 |
+| **Free** | 250 writes/month on Base Sepolia testnet (may reset) | $0 |
 | **Pro** | Permanent on Gnosis mainnet | $3.99/month |
 
 Both tiers have unlimited reads. Upgrade: *"Upgrade my TotalReclaw subscription."*

--- a/docs/guides/feature-comparison.md
+++ b/docs/guides/feature-comparison.md
@@ -77,7 +77,7 @@ All platforms support two storage modes. The encryption is identical -- the diff
 | | Managed Service (default) | Self-Hosted |
 |---|---|---|
 | **Storage** | On-chain (Gnosis Chain) via The Graph | Your PostgreSQL database |
-| **Free tier** | Unlimited on Base Sepolia testnet | Unlimited (your infrastructure) |
+| **Free tier** | 250 writes/month on Base Sepolia testnet | Unlimited (your infrastructure) |
 | **Pro tier** | Permanent on Gnosis mainnet ($3.99/mo) | N/A |
 | **Setup** | Nothing -- works out of the box | Set `TOTALRECLAW_SELF_HOSTED=true` + server URL |
 | **Consolidation tool** | Not available (no batch delete on-chain) | Available |

--- a/docs/guides/ironclaw-setup.md
+++ b/docs/guides/ironclaw-setup.md
@@ -124,7 +124,7 @@ If your IronClaw version supports event-triggered routines (e.g., `on_thread_idl
 
 | Tier | Memories | Storage | Price |
 |------|----------|---------|-------|
-| **Free** | Unlimited | Testnet (trial -- may be reset) | $0 |
+| **Free** | 250 / month | Testnet (trial -- may be reset) | $0 |
 | **Pro** | Unlimited | Permanent on-chain (Gnosis) | See [totalreclaw.xyz/pricing](https://totalreclaw.xyz/pricing/) |
 
 Upgrade anytime via the `totalreclaw_upgrade` tool -- the agent handles it for you.

--- a/docs/guides/nanoclaw-getting-started.md
+++ b/docs/guides/nanoclaw-getting-started.md
@@ -188,10 +188,10 @@ If you want separate memory per instance, use **different recovery phrases** or 
 
 | Tier | Writes | Reads | Storage | Price |
 |------|--------|-------|---------|-------|
-| **Free** | Unlimited | Unlimited | Testnet (Base Sepolia) | $0 |
+| **Free** | 250 / month | Unlimited | Testnet (Base Sepolia) | $0 |
 | **Pro** | Unlimited | Unlimited | Permanent on-chain (Gnosis) | $3.99/month |
 
-The free tier stores on Base Sepolia testnet (unlimited, but testnet data may be reset). Upgrade to Pro for permanent storage on Gnosis mainnet.
+The free tier stores on Base Sepolia testnet (250 writes/month, and testnet data may be reset). Upgrade to Pro for permanent storage on Gnosis mainnet.
 
 To upgrade, ask the agent: *"How do I upgrade TotalReclaw?"*
 
@@ -221,7 +221,7 @@ To upgrade, ask the agent: *"How do I upgrade TotalReclaw?"*
 
 ### Quota exceeded (403 errors)
 
-- The free tier is unlimited on testnet, but a high abuse-prevention cap exists server-side
+- The free tier is capped at 250 writes/month on testnet against the production relay (`api.totalreclaw.xyz`)
 - If you encounter a 403, check with *"What's my TotalReclaw status?"*
 - Upgrade to Pro for permanent mainnet storage
 

--- a/docs/guides/openclaw-setup-quickstart.md
+++ b/docs/guides/openclaw-setup-quickstart.md
@@ -30,7 +30,7 @@ After install, ask your agent something like *"set up TotalReclaw"* or just *"re
 2. **Generate or paste a 12-word recovery phrase** — the browser handles this end-to-end encrypted, so the phrase never enters the chat or the relay. Pick *Set up* for a fresh phrase, or *Log in* if you already have one from another device.
 3. **Confirm.** The browser will tell you when you are all set.
 
-You are then on the free tier (500 memories per month, unlimited reads). Paid tiers and custom relays are at <https://totalreclaw.xyz/pricing>.
+You are then on the free tier (250 memories per month, unlimited reads). Paid tiers and custom relays are at <https://totalreclaw.xyz/pricing>.
 
 ## Write down the recovery phrase
 

--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -296,7 +296,7 @@ See [Importing Memories](importing-memories.md).
 
 | Tier | Storage | Monthly writes | Reads | Price |
 |------|---------|---------------|-------|-------|
-| **Free** | Base Sepolia testnet (may reset) | 500 / month | Unlimited | $0 |
+| **Free** | Base Sepolia testnet (may reset) | 250 / month | Unlimited | $0 |
 | **Pro** | Permanent on Gnosis mainnet | Unlimited | Unlimited | $3.99/month |
 
 The plugin warns you automatically when you cross 80% of the monthly free-tier write limit (injected at conversation start). Check anytime by asking *"what's my TotalReclaw status?"* — that calls `totalreclaw_status` and reports tier, writes used, writes limit, reset date, and upgrade URL.

--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -55,7 +55,7 @@ Speak only these lines, in order. Substitute the bracketed placeholders with the
 4. (Step 4 — account-setup URL + PIN, immediately after `tr pair --json` returns — no consent gate)
    > Open &lt;url&gt; in your browser. Enter PIN &lt;pin&gt;. Generate or paste a 12-word recovery phrase. Reply `done` once it's sealed.
 5. (Step 5 — done + free-tier confirmation)
-   > ✓ You're set up on the TotalReclaw free tier — 500 memories/month, unlimited reads. https://totalreclaw.xyz/pricing. Ask me to remember anything.
+   > ✓ You're set up on the TotalReclaw free tier — 250 memories/month, unlimited reads. https://totalreclaw.xyz/pricing. Ask me to remember anything.
 
 That is the complete user-facing transcript for a healthy install. Expected line count for a fresh install + setup is **4–5 lines** (line 3 is mutually exclusive with lines 4-5; the `/totalreclaw-restart` cycle is no longer part of the primary path under hybrid mode).
 

--- a/docs/guides/zeroclaw-setup.md
+++ b/docs/guides/zeroclaw-setup.md
@@ -107,7 +107,7 @@ Switch agents, keep your memories. No export/import needed.
 
 Check [totalreclaw.xyz/pricing](https://totalreclaw.xyz/pricing) for current pricing.
 
-- **Free tier** — Base Sepolia testnet, unlimited writes (testnet data may be reset)
+- **Free tier** — Base Sepolia testnet, 250 writes/month (testnet data may be reset)
 - **Pro tier** — Gnosis mainnet, unlimited
 
 ## Troubleshooting

--- a/docs/specs/subgraph/billing-and-onboarding.md
+++ b/docs/specs/subgraph/billing-and-onboarding.md
@@ -86,10 +86,10 @@ Query fees alone are small ($1-$298/mo). Indexers are primarily incentivized by 
 
 | Tier | Cost | Limits | Authorization |
 |------|------|--------|---------------|
-| **Free** | $0 | 500 memories/month, rate-limited reads | Relay checks quota by wallet address |
+| **Free** | $0 | 250 memories/month, rate-limited reads | Relay checks quota by wallet address |
 | **Pro** | $5/month | Unlimited memories, priority reads | Relay checks active subscription |
 
-Free tier: 500 memories/month on Base Sepolia (testnet, trial). Pro tier: unlimited memories on Gnosis mainnet (permanent on-chain storage).
+Free tier: 250 memories/month on Base Sepolia (testnet, trial). Pro tier: unlimited memories on Gnosis mainnet (permanent on-chain storage).
 
 ---
 

--- a/docs/specs/subgraph/billing-and-onboarding.md
+++ b/docs/specs/subgraph/billing-and-onboarding.md
@@ -91,6 +91,8 @@ Query fees alone are small ($1-$298/mo). Indexers are primarily incentivized by 
 
 Free tier: 250 memories/month on Base Sepolia (testnet, trial). Pro tier: unlimited memories on Gnosis mainnet (permanent on-chain storage).
 
+**Environment caveat:** the 250/month cap is enforced by the **production** relay (`api.totalreclaw.xyz`) only. The **staging** relay (`api-staging.totalreclaw.xyz`) does not enforce the free-tier quota so that QA, E2E suites, and RC-build users can write freely against testnet. User-facing prose (SKILL.md, setup guides, pricing page) describes the production limit; staging callers will see writes succeed past 250.
+
 ---
 
 ## 6. Payment Infrastructure

--- a/mcp/SKILL.md
+++ b/mcp/SKILL.md
@@ -75,7 +75,7 @@ When the user asks to "set up TotalReclaw" or wants to remember something but ha
 2. The tool returns `{"url": "...", "pin": "...", "expires_at_ms": ...}`.
 3. Emit one user-facing line: "Open <url> in your browser. Enter PIN <pin>. Generate or paste a 12-word recovery phrase. Reply `done` once it's sealed."
 4. Wait for the user to say `done`. The browser handles phrase generation/import; the MCP server writes credentials silently.
-5. Confirm: "✓ You're set up on the TotalReclaw free tier — 500 memories/month, unlimited reads. https://totalreclaw.xyz/pricing. Ask me to remember anything."
+5. Confirm: "✓ You're set up on the TotalReclaw free tier — 250 memories/month, unlimited reads. https://totalreclaw.xyz/pricing. Ask me to remember anything."
 
 If the user already has credentials, `totalreclaw__totalreclaw_status` returns `{"onboarded": true}` and you can skip setup.
 

--- a/mcp/src/prompts.ts
+++ b/mcp/src/prompts.ts
@@ -48,7 +48,7 @@ Call totalreclaw_recall proactively when:
 - Extract atomic facts: "User prefers dark mode" not "User said they prefer dark mode and also use VS Code"
 
 ### Billing & Quota
-The free tier offers unlimited memories and reads, but memories are stored on a test network and may be reset. Pro stores memories permanently on-chain. Do NOT guess or hardcode pricing — use totalreclaw_status to check exact usage and current pricing. For pricing details, refer users to https://totalreclaw.xyz/pricing
+The free tier offers 250 memories/month and unlimited reads, but memories are stored on a test network and may be reset. Pro stores memories permanently on-chain with unlimited writes. Do NOT guess or hardcode pricing — use totalreclaw_status to check exact usage and current pricing. For pricing details, refer users to https://totalreclaw.xyz/pricing
 
 When a totalreclaw_remember call fails with "quota_exceeded":
 1. Inform the user they've hit a usage limit

--- a/mcp/src/tools/status.ts
+++ b/mcp/src/tools/status.ts
@@ -49,6 +49,20 @@ export interface BillingStatusResponse {
   // means it never resets. ``resets_at`` is the next monthly reset.
   period?: 'monthly' | 'lifetime' | null;
   resets_at?: string | null;
+  // ``environment`` is "production" or "staging". When the relay doesn't
+  // populate it, the client infers from the relay URL
+  // (api-staging.* → staging). Surface staging-specific notes ONLY when
+  // this is "staging" — production users should see no mention of it.
+  environment?: 'production' | 'staging' | null;
+}
+
+/**
+ * Infer environment from the relay URL when the response doesn't carry
+ * an explicit ``environment`` field. The staging relay
+ * (``api-staging.totalreclaw.xyz``) doesn't enforce the free-tier quota.
+ */
+function inferEnvironment(serverUrl: string): 'production' | 'staging' {
+  return serverUrl.toLowerCase().includes('api-staging') ? 'staging' : 'production';
 }
 
 /** Last raw billing response (for candidate pool caching in index.ts). */
@@ -125,6 +139,8 @@ export async function handleStatus(
     const periodSuffix = period === 'monthly' ? '/month' : '';
     const usage = `${data.free_writes_used}/${data.free_writes_limit}${periodSuffix}`;
     const remaining = data.free_writes_limit - data.free_writes_used;
+    const environment: 'production' | 'staging' =
+      data.environment ?? inferEnvironment(serverUrl);
     const expiresLabel = data.expires_at
       ? `Expires: ${new Date(data.expires_at).toLocaleDateString()}`
       : data.resets_at
@@ -132,6 +148,11 @@ export async function handleStatus(
         : period === 'monthly'
           ? 'Resets monthly'
           : 'No expiry';
+    // Only surface a staging caveat when actually on staging — production
+    // users should never see staging mentioned.
+    const stagingNote = environment === 'staging'
+      ? 'You are on the staging relay (api-staging.totalreclaw.xyz). The free-tier quota is NOT enforced here — writes will succeed past the listed limit. Production (api.totalreclaw.xyz) enforces the 250 writes/month cap.'
+      : null;
 
     // 3.3.1 (internal#130) — echo the SA / scope address back to the
     // agent so the user can see it pre-write. The MCP tool already takes
@@ -139,28 +160,36 @@ export async function handleStatus(
     // from the mnemonic and passed in by the host); surfacing it here makes
     // it visible in the tool response without the user needing to ask
     // separately.
-    const formatted = [
+    const formattedLines = [
       `Tier: ${tierLabel}`,
       `Smart Account: ${walletAddress}`,
       `Writes used: ${usage}`,
       `Remaining: ${remaining}`,
       expiresLabel,
-    ].join('\n');
+    ];
+    if (stagingNote) {
+      formattedLines.push(`Environment: staging — ${stagingNote}`);
+    }
+    const formatted = formattedLines.join('\n');
+
+    const payload: Record<string, unknown> = {
+      tier: data.tier,
+      free_writes_used: data.free_writes_used,
+      free_writes_limit: data.free_writes_limit,
+      remaining_writes: remaining,
+      expires_at: data.expires_at,
+      period,
+      resets_at: data.resets_at ?? null,
+      environment,
+      scope_address: walletAddress,
+      formatted,
+    };
+    if (stagingNote) payload.staging_note = stagingNote;
 
     return {
       content: [{
         type: 'text',
-        text: JSON.stringify({
-          tier: data.tier,
-          free_writes_used: data.free_writes_used,
-          free_writes_limit: data.free_writes_limit,
-          remaining_writes: remaining,
-          expires_at: data.expires_at,
-          period,
-          resets_at: data.resets_at ?? null,
-          scope_address: walletAddress,
-          formatted,
-        }),
+        text: JSON.stringify(payload),
       }],
     };
   } catch (error) {

--- a/mcp/src/tools/status.ts
+++ b/mcp/src/tools/status.ts
@@ -44,6 +44,11 @@ export interface BillingStatusResponse {
   free_writes_limit: number;
   expires_at: string | null;
   features?: BillingFeatures;
+  // ``period`` disambiguates the limit semantics for the agent: "monthly"
+  // means ``free_writes_limit`` resets each calendar month, "lifetime"
+  // means it never resets. ``resets_at`` is the next monthly reset.
+  period?: 'monthly' | 'lifetime' | null;
+  resets_at?: string | null;
 }
 
 /** Last raw billing response (for candidate pool caching in index.ts). */
@@ -114,11 +119,19 @@ export async function handleStatus(
 
     // Format nicely for the LLM to present
     const tierLabel = data.tier === 'pro' ? 'Pro' : 'Free';
-    const usage = `${data.free_writes_used}/${data.free_writes_limit}`;
+    // Default the free-tier period to "monthly" so older relays that don't
+    // yet emit the field still give the agent an unambiguous answer.
+    const period = data.period ?? (data.tier === 'free' ? 'monthly' : null);
+    const periodSuffix = period === 'monthly' ? '/month' : '';
+    const usage = `${data.free_writes_used}/${data.free_writes_limit}${periodSuffix}`;
     const remaining = data.free_writes_limit - data.free_writes_used;
     const expiresLabel = data.expires_at
       ? `Expires: ${new Date(data.expires_at).toLocaleDateString()}`
-      : 'No expiry';
+      : data.resets_at
+        ? `Resets: ${new Date(data.resets_at).toLocaleDateString()}`
+        : period === 'monthly'
+          ? 'Resets monthly'
+          : 'No expiry';
 
     // 3.3.1 (internal#130) — echo the SA / scope address back to the
     // agent so the user can see it pre-write. The MCP tool already takes
@@ -143,6 +156,8 @@ export async function handleStatus(
           free_writes_limit: data.free_writes_limit,
           remaining_writes: remaining,
           expires_at: data.expires_at,
+          period,
+          resets_at: data.resets_at ?? null,
           scope_address: walletAddress,
           formatted,
         }),

--- a/mcp/tests/status-environment.test.ts
+++ b/mcp/tests/status-environment.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for the prod-vs-staging signal on the MCP ``totalreclaw_status`` tool.
+ *
+ * The relay's 250/month production cap is NOT enforced by the staging
+ * relay (``api-staging.totalreclaw.xyz``). The tool must:
+ *   1. Return ``environment="production"`` for the prod relay and emit NO
+ *      ``staging_note`` (production users must never see staging mentioned).
+ *   2. Return ``environment="staging"`` for the staging relay AND include
+ *      a ``staging_note`` explaining the cap is not enforced.
+ *   3. Infer ``environment`` from the relay URL when the relay response
+ *      doesn't carry the field explicitly.
+ */
+import { handleStatus, type BillingStatusResponse } from '../src/tools/status.js';
+
+type FetchLike = (url: string, init?: unknown) => Promise<{
+  ok: boolean;
+  status?: number;
+  statusText?: string;
+  text?: () => Promise<string>;
+  json: () => Promise<BillingStatusResponse>;
+}>;
+
+const realFetch = (globalThis as { fetch?: FetchLike }).fetch;
+
+function mockBillingFetch(response: Partial<BillingStatusResponse>): FetchLike {
+  const full: BillingStatusResponse = {
+    tier: 'free',
+    free_writes_used: 30,
+    free_writes_limit: 250,
+    expires_at: null,
+    ...response,
+  };
+  return async () => ({
+    ok: true,
+    json: async () => full,
+  });
+}
+
+function setFetch(fn: FetchLike) {
+  (globalThis as { fetch: FetchLike }).fetch = fn;
+}
+
+afterEach(() => {
+  if (realFetch) {
+    (globalThis as { fetch?: FetchLike }).fetch = realFetch;
+  } else {
+    delete (globalThis as { fetch?: FetchLike }).fetch;
+  }
+});
+
+async function callStatus(serverUrl: string): Promise<Record<string, unknown>> {
+  const result = await handleStatus(serverUrl, 'auth-key-hex', {
+    wallet_address: '0xabc123',
+  });
+  return JSON.parse(result.content[0].text) as Record<string, unknown>;
+}
+
+describe('MCP status tool — production environment', () => {
+  test('production relay URL omits staging_note', async () => {
+    setFetch(mockBillingFetch({}));
+    const payload = await callStatus('https://api.totalreclaw.xyz');
+
+    expect(payload.environment).toBe('production');
+    expect(payload.tier).toBe('free');
+    expect(payload.free_writes_limit).toBe(250);
+    expect(payload.period).toBe('monthly');
+    // CRITICAL: production users must NEVER see staging mentioned.
+    expect(payload).not.toHaveProperty('staging_note');
+    expect((payload.formatted as string).toLowerCase()).not.toContain('staging');
+  });
+
+  test('relay-provided environment="production" overrides URL inference', async () => {
+    setFetch(mockBillingFetch({ environment: 'production' }));
+    const payload = await callStatus('https://api-staging.totalreclaw.xyz');
+
+    // Even though the URL says staging, the relay's explicit
+    // environment=production wins. (Unlikely in practice but the contract
+    // says relay-provided field beats URL inference.)
+    expect(payload.environment).toBe('production');
+    expect(payload).not.toHaveProperty('staging_note');
+  });
+});
+
+describe('MCP status tool — staging environment', () => {
+  test('staging relay URL emits staging_note', async () => {
+    setFetch(mockBillingFetch({
+      tier: 'free',
+      free_writes_used: 500,  // Past the production cap.
+      free_writes_limit: 250,
+    }));
+    const payload = await callStatus('https://api-staging.totalreclaw.xyz');
+
+    expect(payload.environment).toBe('staging');
+    expect(payload).toHaveProperty('staging_note');
+    const note = payload.staging_note as string;
+    // Note must explain BOTH the staging behavior AND the production cap.
+    expect(note.toLowerCase()).toContain('staging');
+    expect(note).toMatch(/not enforced/i);
+    expect(note).toContain('250');
+    expect(note).toContain('api-staging.totalreclaw.xyz');
+    expect(note).toContain('api.totalreclaw.xyz');
+    // Formatted output must surface the note for the LLM.
+    expect((payload.formatted as string).toLowerCase()).toContain('staging');
+  });
+
+  test('relay-provided environment="staging" overrides URL inference', async () => {
+    setFetch(mockBillingFetch({ environment: 'staging' }));
+    const payload = await callStatus('https://api.totalreclaw.xyz');
+
+    expect(payload.environment).toBe('staging');
+    expect(payload).toHaveProperty('staging_note');
+  });
+
+  test('staging note text is identical across calls (deterministic contract)', async () => {
+    setFetch(mockBillingFetch({ environment: 'staging' }));
+    const a = await callStatus('https://api-staging.totalreclaw.xyz');
+    const b = await callStatus('https://api-staging.totalreclaw.xyz');
+    expect(a.staging_note).toBe(b.staging_note);
+  });
+});
+
+describe('MCP status tool — URL inference fallback', () => {
+  test('self-hosted URL defaults to production', async () => {
+    setFetch(mockBillingFetch({}));
+    const payload = await callStatus('https://my-self-hosted-relay.example.com');
+    expect(payload.environment).toBe('production');
+    expect(payload).not.toHaveProperty('staging_note');
+  });
+
+  test('localhost defaults to production', async () => {
+    setFetch(mockBillingFetch({}));
+    const payload = await callStatus('http://localhost:8000');
+    expect(payload.environment).toBe('production');
+  });
+
+  test('case-insensitive staging match', async () => {
+    setFetch(mockBillingFetch({}));
+    const payload = await callStatus('HTTPS://API-STAGING.totalreclaw.xyz');
+    expect(payload.environment).toBe('staging');
+  });
+});

--- a/python/src/totalreclaw/hermes/SKILL.md
+++ b/python/src/totalreclaw/hermes/SKILL.md
@@ -39,7 +39,7 @@ Speak only these lines, in order. Substitute the bracketed placeholders. Lines 3
 5. (Step 5 — account setup; emit immediately after disable-memory, no consent gate)
    > Open &lt;url&gt; in your browser. Enter PIN &lt;pin&gt;. Generate or paste a 12-word recovery phrase. Reply `done` once it's sealed.
 6. (Step 6 — done + free-tier confirmation)
-   > ✓ You're set up on the TotalReclaw free tier — 500 memories/month, unlimited reads. <https://totalreclaw.xyz/pricing>. Ask me to remember anything.
+   > ✓ You're set up on the TotalReclaw free tier — 250 memories/month, unlimited reads. <https://totalreclaw.xyz/pricing>. Ask me to remember anything.
 
 If `totalreclaw_*` tools are already bound (skip-install branch), the only lines emitted are `✓ TotalReclaw is already set up.` (skip-to-stop) OR lines 5+6 (skip-to-account-setup branch). 5–6 lines max for a fresh install. No filler.
 

--- a/python/src/totalreclaw/hermes/hooks.py
+++ b/python/src/totalreclaw/hermes/hooks.py
@@ -364,7 +364,7 @@ def on_session_start(state: "PluginState", **kwargs) -> None:
             state.update_from_billing(billing)
 
             used = billing.get("free_writes_used", 0)
-            limit = max(billing.get("free_writes_limit", 500), 1)
+            limit = max(billing.get("free_writes_limit", 250), 1)
             if used / limit > 0.8:
                 pct = int(used / limit * 100)
                 state.set_quota_warning(

--- a/python/src/totalreclaw/hermes/hooks.py
+++ b/python/src/totalreclaw/hermes/hooks.py
@@ -363,15 +363,19 @@ def on_session_start(state: "PluginState", **kwargs) -> None:
             # Update extraction config from server
             state.update_from_billing(billing)
 
-            used = billing.get("free_writes_used", 0)
-            limit = max(billing.get("free_writes_limit", 250), 1)
-            if used / limit > 0.8:
-                pct = int(used / limit * 100)
-                state.set_quota_warning(
-                    f"TotalReclaw: {used}/{limit} memories used this month ({pct}%). "
-                    "Consider upgrading to Pro for unlimited storage."
-                )
-                logger.info("TotalReclaw: Memory usage >80%% — quota warning set")
+            # Staging doesn't enforce the 250/month cap — a quota warning
+            # there would nudge QA toward a fake upgrade. Skip it.
+            environment = billing.get("environment")
+            if environment != "staging":
+                used = billing.get("free_writes_used", 0)
+                limit = max(billing.get("free_writes_limit", 250), 1)
+                if used / limit > 0.8:
+                    pct = int(used / limit * 100)
+                    state.set_quota_warning(
+                        f"TotalReclaw: {used}/{limit} memories used this month ({pct}%). "
+                        "Consider upgrading to Pro for unlimited storage."
+                    )
+                    logger.info("TotalReclaw: Memory usage >80%% — quota warning set")
     except Exception:
         pass
 

--- a/python/src/totalreclaw/hermes/tools.py
+++ b/python/src/totalreclaw/hermes/tools.py
@@ -325,11 +325,17 @@ async def status(args: dict, state: "PluginState", **kwargs) -> str:
 
     try:
         billing = await client.status()
+        # ``period`` defaults to ``"monthly"`` on the free tier so older
+        # relays that don't yet populate the field still give the agent an
+        # unambiguous answer to "is that monthly or lifetime?".
+        period = billing.period or ("monthly" if billing.tier == "free" else None)
         return json.dumps({
             "tier": billing.tier,
             "free_writes_used": billing.free_writes_used,
             "free_writes_limit": billing.free_writes_limit,
             "expires_at": billing.expires_at,
+            "period": period,
+            "resets_at": billing.resets_at,
         })
     except Exception as e:
         logger.error("totalreclaw_status failed: %s", e)

--- a/python/src/totalreclaw/hermes/tools.py
+++ b/python/src/totalreclaw/hermes/tools.py
@@ -329,14 +329,25 @@ async def status(args: dict, state: "PluginState", **kwargs) -> str:
         # relays that don't yet populate the field still give the agent an
         # unambiguous answer to "is that monthly or lifetime?".
         period = billing.period or ("monthly" if billing.tier == "free" else None)
-        return json.dumps({
+        payload = {
             "tier": billing.tier,
             "free_writes_used": billing.free_writes_used,
             "free_writes_limit": billing.free_writes_limit,
             "expires_at": billing.expires_at,
             "period": period,
             "resets_at": billing.resets_at,
-        })
+            "environment": billing.environment,
+        }
+        # Surface the prod-vs-staging carve-out ONLY when actually on
+        # staging — production users should see no mention of staging.
+        if billing.environment == "staging":
+            payload["staging_note"] = (
+                "You are on the staging relay (api-staging.totalreclaw.xyz). "
+                "The free-tier quota is NOT enforced here — writes will succeed "
+                "past the listed limit. Production (api.totalreclaw.xyz) enforces "
+                "the 250 writes/month cap."
+            )
+        return json.dumps(payload)
     except Exception as e:
         logger.error("totalreclaw_status failed: %s", e)
         return json.dumps({"error": str(e)})

--- a/python/src/totalreclaw/relay.py
+++ b/python/src/totalreclaw/relay.py
@@ -80,6 +80,17 @@ def _detect_client_id() -> str:
     return "python-client"
 
 
+def _infer_environment_from_url(relay_url: str) -> str:
+    """Return ``"staging"`` for the staging relay, else ``"production"``.
+
+    Used as a fallback when the relay's billing response doesn't carry an
+    explicit ``environment`` field. The staging relay
+    (``api-staging.totalreclaw.xyz``) doesn't enforce the free-tier
+    quota, so agents need to know which one they're talking to.
+    """
+    return "staging" if "api-staging" in relay_url.lower() else "production"
+
+
 @dataclass
 class BillingFeatures:
     llm_dedup: bool = False
@@ -105,6 +116,12 @@ class BillingStatus:
     # absent we leave them ``None`` so older relays still work.
     period: Optional[str] = None
     resets_at: Optional[str] = None
+    # ``environment`` is ``"production"`` or ``"staging"``. The relay
+    # populates it when known; the client falls back to URL inference
+    # (api-staging.* → staging, anything else → production) so older
+    # relays still produce an unambiguous signal. Agents should surface a
+    # quota-not-enforced caveat ONLY when this is ``"staging"``.
+    environment: Optional[str] = None
 
 
 @dataclass
@@ -305,6 +322,7 @@ class RelayClient:
             features=features,
             period=data.get("period"),
             resets_at=data.get("resets_at"),
+            environment=data.get("environment") or _infer_environment_from_url(self._relay_url),
         )
 
     async def create_checkout(self) -> CheckoutResponse:

--- a/python/src/totalreclaw/relay.py
+++ b/python/src/totalreclaw/relay.py
@@ -97,6 +97,14 @@ class BillingStatus:
     free_writes_limit: int
     expires_at: Optional[str] = None
     features: Optional[BillingFeatures] = None
+    # ``period`` disambiguates the limit semantics for the agent.
+    # ``"monthly"`` (default for the free tier) means ``free_writes_limit``
+    # resets each calendar month; ``"lifetime"`` means it never resets.
+    # ``resets_at`` is the ISO 8601 timestamp of the next reset when
+    # ``period == "monthly"``. Both fields are populated by the relay; when
+    # absent we leave them ``None`` so older relays still work.
+    period: Optional[str] = None
+    resets_at: Optional[str] = None
 
 
 @dataclass
@@ -295,6 +303,8 @@ class RelayClient:
             free_writes_limit=data.get("free_writes_limit", 0),
             expires_at=data.get("expires_at"),
             features=features,
+            period=data.get("period"),
+            resets_at=data.get("resets_at"),
         )
 
     async def create_checkout(self) -> CheckoutResponse:

--- a/python/tests/test_status_environment.py
+++ b/python/tests/test_status_environment.py
@@ -1,0 +1,171 @@
+"""Tests for the prod-vs-staging signal on the ``totalreclaw_status`` tool.
+
+The relay's production cap (250 writes/month) is enforced only on
+``api.totalreclaw.xyz``. The staging relay (``api-staging.totalreclaw.xyz``)
+does not enforce the quota so QA + RC builds can write past 250. The
+status tool must:
+
+1. Return ``environment="production"`` for the production relay (and emit
+   NO ``staging_note`` — production users should see no mention of staging).
+2. Return ``environment="staging"`` for the staging relay AND include a
+   ``staging_note`` explaining the cap is not enforced.
+3. Default ``period="monthly"`` on the free tier (forward-compat shim for
+   older relays that don't yet emit the field).
+4. Infer ``environment`` from the relay URL when the relay doesn't
+   populate it explicitly.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from totalreclaw.hermes.state import PluginState
+from totalreclaw.relay import BillingStatus, _infer_environment_from_url
+
+
+def _make_state_with_billing(billing: BillingStatus) -> PluginState:
+    """Return a configured PluginState whose client.status() returns ``billing``."""
+    with patch.dict(os.environ, {}, clear=True):
+        with patch.object(Path, "exists", return_value=False):
+            state = PluginState()
+    fake_client = MagicMock()
+    fake_client.status = AsyncMock(return_value=billing)
+    state._client = fake_client
+    return state
+
+
+class TestInferEnvironmentFromUrl:
+    def test_production_default(self) -> None:
+        assert _infer_environment_from_url("https://api.totalreclaw.xyz") == "production"
+
+    def test_production_with_trailing_slash(self) -> None:
+        assert _infer_environment_from_url("https://api.totalreclaw.xyz/") == "production"
+
+    def test_staging(self) -> None:
+        assert _infer_environment_from_url("https://api-staging.totalreclaw.xyz") == "staging"
+
+    def test_staging_case_insensitive(self) -> None:
+        assert _infer_environment_from_url("HTTPS://API-STAGING.totalreclaw.xyz") == "staging"
+
+    def test_self_hosted_defaults_to_production(self) -> None:
+        # Self-hosted URLs don't match the staging marker; treat as production
+        # behavior (operator runs their own relay, not our staging instance).
+        assert _infer_environment_from_url("https://relay.example.com") == "production"
+        assert _infer_environment_from_url("http://localhost:8000") == "production"
+
+
+class TestStatusToolProductionEnvironment:
+    @pytest.mark.asyncio
+    async def test_production_omits_staging_note(self) -> None:
+        from totalreclaw.hermes.tools import status
+
+        billing = BillingStatus(
+            tier="free",
+            free_writes_used=30,
+            free_writes_limit=250,
+            expires_at=None,
+            environment="production",
+        )
+        state = _make_state_with_billing(billing)
+        result = json.loads(await status({}, state))
+
+        assert result["tier"] == "free"
+        assert result["free_writes_limit"] == 250
+        assert result["free_writes_used"] == 30
+        assert result["environment"] == "production"
+        # Period defaults to monthly on free tier even when relay omits it.
+        assert result["period"] == "monthly"
+        # CRITICAL: production users must NEVER see staging mentioned.
+        assert "staging_note" not in result
+
+    @pytest.mark.asyncio
+    async def test_production_pro_tier_no_period_default(self) -> None:
+        """Pro tier with no relay-provided period stays ``None`` — only the
+        free tier gets the monthly default."""
+        from totalreclaw.hermes.tools import status
+
+        billing = BillingStatus(
+            tier="pro",
+            free_writes_used=0,
+            free_writes_limit=0,
+            expires_at="2026-12-31T00:00:00Z",
+            environment="production",
+        )
+        state = _make_state_with_billing(billing)
+        result = json.loads(await status({}, state))
+        assert result["tier"] == "pro"
+        assert result["period"] is None
+        assert "staging_note" not in result
+
+
+class TestStatusToolStagingEnvironment:
+    @pytest.mark.asyncio
+    async def test_staging_includes_staging_note(self) -> None:
+        from totalreclaw.hermes.tools import status
+
+        billing = BillingStatus(
+            tier="free",
+            free_writes_used=500,  # Past the production cap — only possible on staging.
+            free_writes_limit=250,
+            expires_at=None,
+            environment="staging",
+        )
+        state = _make_state_with_billing(billing)
+        result = json.loads(await status({}, state))
+
+        assert result["environment"] == "staging"
+        assert "staging_note" in result
+        note = result["staging_note"]
+        # The note must explain BOTH the staging behavior AND the production cap
+        # so the agent can relay an accurate comparison.
+        assert "staging" in note.lower()
+        assert "NOT enforced" in note or "not enforced" in note.lower()
+        assert "250" in note
+        # And it must point at the relay hostnames so the user can verify.
+        assert "api-staging.totalreclaw.xyz" in note
+        assert "api.totalreclaw.xyz" in note
+
+    @pytest.mark.asyncio
+    async def test_staging_passes_through_relay_provided_period(self) -> None:
+        """If the relay sends ``period``, the tool must use it verbatim
+        (not overwrite with the free-tier monthly default)."""
+        from totalreclaw.hermes.tools import status
+
+        billing = BillingStatus(
+            tier="free",
+            free_writes_used=10,
+            free_writes_limit=250,
+            expires_at=None,
+            period="lifetime",  # Relay-provided wins over the default.
+            environment="staging",
+        )
+        state = _make_state_with_billing(billing)
+        result = json.loads(await status({}, state))
+        assert result["period"] == "lifetime"
+
+
+class TestBillingStatusUrlInference:
+    """Verify the dataclass-level inference fallback (used when the relay
+    response omits ``environment``)."""
+
+    def test_billing_status_with_explicit_environment(self) -> None:
+        billing = BillingStatus(
+            tier="free",
+            free_writes_used=0,
+            free_writes_limit=250,
+            environment="staging",
+        )
+        assert billing.environment == "staging"
+
+    def test_billing_status_environment_optional(self) -> None:
+        """Default is None — RelayClient.get_billing_status fills it in."""
+        billing = BillingStatus(
+            tier="free",
+            free_writes_used=0,
+            free_writes_limit=250,
+        )
+        assert billing.environment is None

--- a/rust/totalreclaw-memory/src/backend.rs
+++ b/rust/totalreclaw-memory/src/backend.rs
@@ -556,6 +556,7 @@ impl TotalReclawMemory {
             limit,
             RerankerConfig {
                 apply_source_weights: true,
+                ..Default::default()
             },
         )?;
 

--- a/rust/totalreclaw-memory/src/billing.rs
+++ b/rust/totalreclaw-memory/src/billing.rs
@@ -73,7 +73,7 @@ pub struct FeatureFlags {
 // ---------------------------------------------------------------------------
 
 /// Cached billing status, matching the TypeScript `BillingCache` interface.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct BillingCache {
     pub tier: String,
     pub facts_used: u64,
@@ -82,7 +82,24 @@ pub struct BillingCache {
     pub features: FeatureFlags,
     /// Unix epoch millis when this cache was written.
     pub checked_at: u64,
+    /// "monthly" or "lifetime". Defaults to "monthly" on the free tier so
+    /// older relays that don't yet emit the field still give an
+    /// unambiguous signal.
+    #[serde(default)]
+    pub period: Option<String>,
+    /// ISO 8601 timestamp of the next monthly reset.
+    #[serde(default)]
+    pub resets_at: Option<String>,
+    /// "production" or "staging". Surface staging-specific notes ONLY
+    /// when this is "staging" — production users should see no mention
+    /// of staging.
+    #[serde(default)]
+    pub environment: Option<String>,
 }
+
+/// Staging caveat text — kept as a constant so the prose is identical
+/// across all clients and tests can assert on it.
+pub const STAGING_NOTE: &str = "You are on the staging relay (api-staging.totalreclaw.xyz). The free-tier quota is NOT enforced here — writes will succeed past the listed limit. Production (api.totalreclaw.xyz) enforces the 250 writes/month cap.";
 
 impl BillingCache {
     /// Whether this cache entry is still valid (within TTL).
@@ -103,11 +120,19 @@ impl BillingCache {
     }
 
     /// Whether the user is above the 80% quota warning threshold.
+    ///
+    /// Returns `false` on staging — the cap isn't enforced there, so
+    /// surfacing an "approaching limit" warning would be a lie that
+    /// nudges QA toward a fake upgrade.
     pub fn is_quota_warning(&self) -> bool {
+        if self.is_staging() {
+            return false;
+        }
         self.quota_fraction() > QUOTA_WARNING_THRESHOLD
     }
 
-    /// Human-readable quota warning message (or None if under threshold).
+    /// Human-readable quota warning message (or None if under threshold
+    /// or on staging).
     pub fn quota_warning_message(&self) -> Option<String> {
         if !self.is_quota_warning() {
             return None;
@@ -122,6 +147,17 @@ impl BillingCache {
     /// Is this a Pro tier user?
     pub fn is_pro(&self) -> bool {
         self.tier == "pro"
+    }
+
+    /// Is this cache from the staging relay?
+    pub fn is_staging(&self) -> bool {
+        matches!(self.environment.as_deref(), Some("staging"))
+    }
+
+    /// Staging caveat text — `Some` only when on staging. Production
+    /// callers must never surface a staging mention.
+    pub fn staging_note(&self) -> Option<&'static str> {
+        if self.is_staging() { Some(STAGING_NOTE) } else { None }
     }
 }
 
@@ -188,12 +224,23 @@ pub async fn fetch_billing_status(relay: &RelayClient) -> Result<BillingCache> {
         .unwrap_or_default()
         .as_millis() as u64;
 
+    let tier = status.tier.unwrap_or_else(|| "free".into());
+    // Default the free-tier period to "monthly" so older relays that
+    // don't yet emit the field still give the agent an unambiguous answer.
+    let period = status.period.or_else(|| {
+        if tier == "free" { Some("monthly".to_string()) } else { None }
+    });
     let cache = BillingCache {
-        tier: status.tier.unwrap_or_else(|| "free".into()),
+        tier,
         facts_used: status.facts_used.unwrap_or(0),
-        facts_limit: status.facts_limit.unwrap_or(500),
+        // Production free-tier cap is 250/month. The relay should always
+        // populate ``facts_limit``; 250 is the fallback if it doesn't.
+        facts_limit: status.facts_limit.unwrap_or(250),
         features,
         checked_at: now_ms,
+        period,
+        resets_at: status.resets_at,
+        environment: status.environment,
     };
 
     write_cache(&cache);
@@ -290,6 +337,7 @@ mod tests {
             facts_limit: 500,
             features: FeatureFlags::default(),
             checked_at: now_ms,
+            ..Default::default()
         };
         assert!(cache.is_fresh());
 
@@ -309,6 +357,7 @@ mod tests {
             facts_limit: 500,
             features: FeatureFlags::default(),
             checked_at: 0,
+            ..Default::default()
         };
         assert!((cache.quota_fraction() - 0.84).abs() < 0.01);
         assert!(cache.is_quota_warning());
@@ -332,6 +381,7 @@ mod tests {
             facts_limit: 500,
             features: FeatureFlags::default(),
             checked_at: now_ms,
+            ..Default::default()
         };
         let msg = cache.quota_warning_message();
         assert!(msg.is_some());
@@ -349,6 +399,7 @@ mod tests {
                 ..Default::default()
             },
             checked_at: 0,
+            ..Default::default()
         };
         assert_eq!(get_extraction_interval(Some(&cache)), 5);
 
@@ -367,6 +418,7 @@ mod tests {
                 ..Default::default()
             },
             checked_at: 0,
+            ..Default::default()
         };
         assert_eq!(get_max_candidate_pool(Some(&cache)), 300);
 
@@ -413,8 +465,103 @@ mod tests {
                 ..Default::default()
             },
             checked_at: 0,
+            ..Default::default()
         };
         assert!(!is_llm_dedup_enabled(Some(&cache)));
         assert!(is_llm_dedup_enabled(None)); // Default: enabled
+    }
+
+    // ------------------------------------------------------------------
+    // Environment (prod vs staging) — production users must never see
+    // staging mentioned; staging callers MUST see the quota carve-out.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_production_cache_emits_no_staging_note() {
+        let cache = BillingCache {
+            tier: "free".into(),
+            facts_used: 30,
+            facts_limit: 250,
+            environment: Some("production".into()),
+            ..Default::default()
+        };
+        assert!(!cache.is_staging());
+        assert!(cache.staging_note().is_none());
+    }
+
+    #[test]
+    fn test_staging_cache_emits_staging_note() {
+        let cache = BillingCache {
+            tier: "free".into(),
+            facts_used: 500, // Past the production cap — only possible on staging.
+            facts_limit: 250,
+            environment: Some("staging".into()),
+            ..Default::default()
+        };
+        assert!(cache.is_staging());
+        let note = cache.staging_note().expect("staging emits a note");
+        // The note must explain BOTH the staging behavior AND the
+        // production cap so the agent can give an honest comparison.
+        assert!(note.contains("staging"));
+        assert!(note.contains("NOT enforced") || note.to_lowercase().contains("not enforced"));
+        assert!(note.contains("250"));
+        assert!(note.contains("api-staging.totalreclaw.xyz"));
+        assert!(note.contains("api.totalreclaw.xyz"));
+    }
+
+    #[test]
+    fn test_quota_warning_suppressed_on_staging() {
+        // 90% usage on staging — would normally warn, but staging
+        // doesn't enforce the cap, so a warning would be a lie.
+        let cache = BillingCache {
+            tier: "free".into(),
+            facts_used: 450,
+            facts_limit: 500,
+            environment: Some("staging".into()),
+            ..Default::default()
+        };
+        assert!(!cache.is_quota_warning());
+        assert!(cache.quota_warning_message().is_none());
+    }
+
+    #[test]
+    fn test_quota_warning_fires_on_production() {
+        let cache = BillingCache {
+            tier: "free".into(),
+            facts_used: 450,
+            facts_limit: 500,
+            environment: Some("production".into()),
+            ..Default::default()
+        };
+        assert!(cache.is_quota_warning());
+        assert!(cache.quota_warning_message().is_some());
+    }
+
+    #[test]
+    fn test_environment_none_treated_as_production_for_warning() {
+        // Defensive: if environment is missing (older cache file), we
+        // must NOT suppress the warning — production users at 90%
+        // need the nudge.
+        let cache = BillingCache {
+            tier: "free".into(),
+            facts_used: 450,
+            facts_limit: 500,
+            environment: None,
+            ..Default::default()
+        };
+        assert!(!cache.is_staging());
+        assert!(cache.is_quota_warning());
+    }
+
+    #[test]
+    fn test_infer_environment_from_url() {
+        use crate::relay::infer_environment_from_url;
+        assert_eq!(infer_environment_from_url("https://api.totalreclaw.xyz"), "production");
+        assert_eq!(infer_environment_from_url("https://api-staging.totalreclaw.xyz"), "staging");
+        assert_eq!(infer_environment_from_url("HTTPS://API-STAGING.totalreclaw.xyz"), "staging");
+        // Self-hosted: treat as production (operator runs their own relay,
+        // not our staging instance).
+        assert_eq!(infer_environment_from_url("https://relay.example.com"), "production");
+        assert_eq!(infer_environment_from_url("http://localhost:8000"), "production");
     }
 }

--- a/rust/totalreclaw-memory/src/relay.rs
+++ b/rust/totalreclaw-memory/src/relay.rs
@@ -42,12 +42,35 @@ pub struct GraphQLResponse<T> {
 }
 
 /// Billing status response.
+///
+/// ``period`` disambiguates the limit semantics ("monthly" vs "lifetime").
+/// ``resets_at`` is the next monthly reset (ISO 8601). ``environment`` is
+/// "production" or "staging" — the staging relay
+/// (`api-staging.totalreclaw.xyz`) does not enforce the free-tier quota,
+/// so clients must surface a caveat ONLY when staging.
 #[derive(Deserialize)]
 pub struct BillingStatus {
     pub tier: Option<String>,
     pub facts_used: Option<u64>,
     pub facts_limit: Option<u64>,
     pub features: Option<serde_json::Value>,
+    #[serde(default)]
+    pub period: Option<String>,
+    #[serde(default)]
+    pub resets_at: Option<String>,
+    #[serde(default)]
+    pub environment: Option<String>,
+}
+
+/// Infer environment from the relay URL when the response doesn't carry
+/// an explicit ``environment`` field. The staging relay does not enforce
+/// the free-tier quota — clients need to know which one they're talking to.
+pub fn infer_environment_from_url(relay_url: &str) -> &'static str {
+    if relay_url.to_lowercase().contains("api-staging") {
+        "staging"
+    } else {
+        "production"
+    }
 }
 
 /// Configuration for the relay client.
@@ -321,9 +344,17 @@ impl RelayClient {
             .await
             .map_err(|e| Error::Http(e.to_string()))?;
 
-        resp.json()
+        let mut status: BillingStatus = resp
+            .json()
             .await
-            .map_err(|e| Error::Http(e.to_string()))
+            .map_err(|e| Error::Http(e.to_string()))?;
+        // Fall back to URL-based inference if the relay didn't populate
+        // ``environment`` explicitly. Forward-compat shim — once the relay
+        // emits the field, this becomes a no-op.
+        if status.environment.is_none() {
+            status.environment = Some(infer_environment_from_url(&self.relay_url).to_string());
+        }
+        Ok(status)
     }
 
     /// Create a Stripe checkout session for upgrading to Pro.

--- a/skill-nanoclaw/SKILL.md
+++ b/skill-nanoclaw/SKILL.md
@@ -30,7 +30,7 @@ Ask the agent: *"Do you have access to TotalReclaw memory tools?"* It should con
 
 ### Step 4: Free tier
 
-After setup, the agent is on the free tier: 500 memories per month, unlimited reads and searches. The skill warns automatically when quota usage exceeds 80%. For unlimited memories, the user can upgrade via the `totalreclaw_upgrade` tool or visit https://totalreclaw.xyz/pricing.
+After setup, the agent is on the free tier: 250 memories per month, unlimited reads and searches. The skill warns automatically when quota usage exceeds 80%. For unlimited memories, the user can upgrade via the `totalreclaw_upgrade` tool or visit https://totalreclaw.xyz/pricing.
 
 ---
 
@@ -182,7 +182,7 @@ NanoClaw integrates TotalReclaw through three lifecycle hooks in the agent-runne
 
 ## Billing and Quota
 
-TotalReclaw has a free tier (500 memories/month, unlimited reads). The skill monitors quota usage automatically:
+TotalReclaw has a free tier (250 memories/month, unlimited reads). The skill monitors quota usage automatically:
 
 - At conversation start (`before-agent-start`), billing status is fetched from the relay and cached for 2 hours
 - If usage exceeds 80%, a warning is injected into the agent context

--- a/skill-nanoclaw/src/billing.ts
+++ b/skill-nanoclaw/src/billing.ts
@@ -44,7 +44,19 @@ export interface BillingCache {
   // "lifetime". ``resets_at`` is the next monthly reset (ISO 8601).
   period?: 'monthly' | 'lifetime' | null;
   resets_at?: string | null;
+  // "production" or "staging". Inferred from the relay URL
+  // (api-staging.* → staging) when the response doesn't carry it. Used to
+  // gate the staging-only quota-not-enforced note.
+  environment?: 'production' | 'staging' | null;
   checked_at: number;
+}
+
+/**
+ * Infer environment from the relay URL when the response doesn't carry
+ * an explicit ``environment`` field.
+ */
+export function inferEnvironment(serverUrl: string): 'production' | 'staging' {
+  return serverUrl.toLowerCase().includes('api-staging') ? 'staging' : 'production';
 }
 
 export interface BillingContext {
@@ -224,6 +236,7 @@ export async function fetchBillingStatus(ctx: BillingContext): Promise<BillingCa
       features: data.features as BillingCache['features'] | undefined,
       period: (data.period as BillingCache['period']) ?? null,
       resets_at: (data.resets_at as string | null | undefined) ?? null,
+      environment: (data.environment as BillingCache['environment']) ?? inferEnvironment(ctx.serverUrl),
       checked_at: Date.now(),
     };
 
@@ -246,6 +259,9 @@ export async function fetchBillingStatus(ctx: BillingContext): Promise<BillingCa
  */
 export function getQuotaWarning(cache: BillingCache | null): string {
   if (!cache || cache.free_writes_limit <= 0) return '';
+  // Staging doesn't enforce the cap — surfacing a "you're at 80%" warning
+  // there would be a lie that nudges QA toward a fake upgrade. Skip it.
+  if (cache.environment === 'staging') return '';
 
   const usageRatio = cache.free_writes_used / cache.free_writes_limit;
   if (usageRatio >= QUOTA_WARNING_THRESHOLD) {
@@ -284,6 +300,7 @@ export async function checkWelcomeBack(ctx: BillingContext): Promise<string> {
       features: data.features as BillingCache['features'] | undefined,
       period: (data.period as BillingCache['period']) ?? null,
       resets_at: (data.resets_at as string | null | undefined) ?? null,
+      environment: (data.environment as BillingCache['environment']) ?? inferEnvironment(ctx.serverUrl),
       checked_at: Date.now(),
     });
 

--- a/skill-nanoclaw/src/billing.ts
+++ b/skill-nanoclaw/src/billing.ts
@@ -40,6 +40,10 @@ export interface BillingCache {
     max_facts_per_extraction?: number;
     max_candidate_pool?: number;
   };
+  // Disambiguates limit semantics — "monthly" (default for free) or
+  // "lifetime". ``resets_at`` is the next monthly reset (ISO 8601).
+  period?: 'monthly' | 'lifetime' | null;
+  resets_at?: string | null;
   checked_at: number;
 }
 
@@ -218,6 +222,8 @@ export async function fetchBillingStatus(ctx: BillingContext): Promise<BillingCa
       free_writes_used: (data.free_writes_used as number) ?? 0,
       free_writes_limit: (data.free_writes_limit as number) ?? 0,
       features: data.features as BillingCache['features'] | undefined,
+      period: (data.period as BillingCache['period']) ?? null,
+      resets_at: (data.resets_at as string | null | undefined) ?? null,
       checked_at: Date.now(),
     };
 
@@ -276,6 +282,8 @@ export async function checkWelcomeBack(ctx: BillingContext): Promise<string> {
       free_writes_used: (data.free_writes_used as number) ?? 0,
       free_writes_limit: (data.free_writes_limit as number) ?? 0,
       features: data.features as BillingCache['features'] | undefined,
+      period: (data.period as BillingCache['period']) ?? null,
+      resets_at: (data.resets_at as string | null | undefined) ?? null,
       checked_at: Date.now(),
     });
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -558,7 +558,7 @@ Speak only these lines, in order. Substitute the bracketed placeholders. The use
 2. (account-setup URL + PIN, immediately after `tr pair --json` returns — no consent gate)
    > Open &lt;url&gt; in your browser. Enter PIN &lt;pin&gt;. Generate or paste a 12-word recovery phrase. Reply `done` once it's sealed.
 3. (done + free-tier confirmation)
-   > ✓ You're set up on the TotalReclaw free tier — 500 memories/month, unlimited reads. https://totalreclaw.xyz/pricing. Ask me to remember anything.
+   > ✓ You're set up on the TotalReclaw free tier — 250 memories/month, unlimited reads. https://totalreclaw.xyz/pricing. Ask me to remember anything.
 
 ### Steps
 
@@ -624,7 +624,7 @@ If you need to store a memory, use the `totalreclaw_remember` tool. If you need 
 
 ### Billing Awareness
 
-TotalReclaw has a free tier (500 memories/month, unlimited reads). The plugin monitors quota usage automatically:
+TotalReclaw has a free tier (250 memories/month, unlimited reads). The plugin monitors quota usage automatically:
 - If usage exceeds 80%, a warning is injected into your context at conversation start
 - If a write fails with quota exceeded (403), inform the user and suggest visiting https://totalreclaw.xyz/pricing
 - Use `totalreclaw_status` when the user asks about their subscription, quota, or billing

--- a/skill/plugin/billing-cache.ts
+++ b/skill/plugin/billing-cache.ts
@@ -54,7 +54,19 @@ export interface BillingCache {
   // "lifetime". ``resets_at`` is the next monthly reset (ISO 8601).
   period?: 'monthly' | 'lifetime' | null;
   resets_at?: string | null;
+  // "production" or "staging". Surface staging-specific notes ONLY when
+  // this is "staging" — production users should see no mention of it.
+  environment?: 'production' | 'staging' | null;
   checked_at: number;
+}
+
+/**
+ * Infer environment from the relay URL when the response doesn't carry
+ * an explicit ``environment`` field. ``api-staging.totalreclaw.xyz``
+ * doesn't enforce the free-tier quota — agents should be told.
+ */
+export function inferEnvironment(serverUrl: string): 'production' | 'staging' {
+  return serverUrl.toLowerCase().includes('api-staging') ? 'staging' : 'production';
 }
 
 // ---------------------------------------------------------------------------

--- a/skill/plugin/billing-cache.ts
+++ b/skill/plugin/billing-cache.ts
@@ -50,6 +50,10 @@ export interface BillingCache {
     max_facts_per_extraction?: number;
     max_candidate_pool?: number;
   };
+  // Disambiguates limit semantics — "monthly" (default for free) or
+  // "lifetime". ``resets_at`` is the next monthly reset (ISO 8601).
+  period?: 'monthly' | 'lifetime' | null;
+  resets_at?: string | null;
   checked_at: number;
 }
 

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -153,6 +153,7 @@ import {
   readBillingCache,
   writeBillingCache,
   BILLING_CACHE_PATH,
+  inferEnvironment,
   type BillingCache,
 } from './billing-cache.js';
 import {
@@ -998,6 +999,9 @@ async function initialize(logger: OpenClawPluginApi['logger']): Promise<void> {
             free_writes_used: (billingData.free_writes_used as number) ?? 0,
             free_writes_limit: (billingData.free_writes_limit as number) ?? 0,
             features: billingData.features as BillingCache['features'] | undefined,
+            period: (billingData.period as BillingCache['period']) ?? null,
+            resets_at: (billingData.resets_at as string | null | undefined) ?? null,
+            environment: (billingData.environment as BillingCache['environment']) ?? inferEnvironment(billingUrl),
             checked_at: Date.now(),
           });
           if (tier === 'pro' && expiresAt) {
@@ -4897,6 +4901,9 @@ const plugin = {
               free_writes_used: freeWritesUsed,
               free_writes_limit: freeWritesLimit,
               features: data.features as BillingCache['features'] | undefined,
+              period: (data.period as BillingCache['period']) ?? null,
+              resets_at: (data.resets_at as string | null | undefined) ?? freeWritesResetAt ?? null,
+              environment: (data.environment as BillingCache['environment']) ?? inferEnvironment(serverUrl),
               checked_at: Date.now(),
             });
 
@@ -6845,12 +6852,16 @@ const plugin = {
                   free_writes_used: (billingData.free_writes_used as number) ?? 0,
                   free_writes_limit: (billingData.free_writes_limit as number) ?? 0,
                   features: billingData.features as BillingCache['features'] | undefined,
+                  period: (billingData.period as BillingCache['period']) ?? null,
+                  resets_at: (billingData.resets_at as string | null | undefined) ?? null,
+                  environment: (billingData.environment as BillingCache['environment']) ?? inferEnvironment(billingUrl),
                   checked_at: Date.now(),
                 };
                 writeBillingCache(cache);
               }
             }
-            if (cache && cache.free_writes_limit > 0) {
+            // Staging doesn't enforce the cap — never warn there.
+            if (cache && cache.free_writes_limit > 0 && cache.environment !== 'staging') {
               const usageRatio = cache.free_writes_used / cache.free_writes_limit;
               if (usageRatio >= QUOTA_WARNING_THRESHOLD) {
                 billingWarning = `\n\nTotalReclaw quota warning: ${cache.free_writes_used}/${cache.free_writes_limit} writes used this month (${Math.round(usageRatio * 100)}%). Visit https://totalreclaw.xyz/pricing to upgrade.`;

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -4939,6 +4939,11 @@ const plugin = {
             }
 
             const tierLabel = tier === 'pro' ? 'Pro' : 'Free';
+            const environment: 'production' | 'staging' =
+              (data.environment as 'production' | 'staging' | undefined) ?? inferEnvironment(serverUrl);
+            const stagingNote = environment === 'staging'
+              ? 'You are on the staging relay (api-staging.totalreclaw.xyz). The free-tier quota is NOT enforced here — writes will succeed past the listed limit. Production (api.totalreclaw.xyz) enforces the 250 writes/month cap.'
+              : null;
             const lines: string[] = [
               `Tier: ${tierLabel}`,
               `Writes: ${freeWritesUsed}/${freeWritesLimit} used this month`,
@@ -4952,6 +4957,9 @@ const plugin = {
             if (tier !== 'pro') {
               lines.push(`Pricing: https://totalreclaw.xyz/pricing`);
             }
+            if (stagingNote) {
+              lines.push(`Environment: staging — ${stagingNote}`);
+            }
 
             return {
               content: [{ type: 'text', text: lines.join('\n') }],
@@ -4960,6 +4968,8 @@ const plugin = {
                 free_writes_used: freeWritesUsed,
                 free_writes_limit: freeWritesLimit,
                 scope_address: scopeAddress,
+                environment,
+                ...(stagingNote ? { staging_note: stagingNote } : {}),
               },
             };
           } catch (err: unknown) {

--- a/skill/src/tools/status.ts
+++ b/skill/src/tools/status.ts
@@ -42,11 +42,27 @@ export interface StatusToolResult {
    * before any chain write completes. Internal#130.
    */
   scope_address?: string;
+  /** "production" or "staging". Inferred from the relay URL when absent. */
+  environment?: 'production' | 'staging';
+  /** Caveat surfaced ONLY on staging (quota not enforced there). */
+  staging_note?: string;
   /** Human-readable formatted summary */
   formatted?: string;
   /** Error message (if failed) */
   error?: string;
 }
+
+/**
+ * Infer environment from the relay URL when the response doesn't carry
+ * an explicit ``environment`` field. The staging relay
+ * (``api-staging.totalreclaw.xyz``) doesn't enforce the free-tier quota.
+ */
+function inferEnvironment(serverUrl: string): 'production' | 'staging' {
+  return serverUrl.toLowerCase().includes('api-staging') ? 'staging' : 'production';
+}
+
+const STAGING_NOTE =
+  'You are on the staging relay (api-staging.totalreclaw.xyz). The free-tier quota is NOT enforced here — writes will succeed past the listed limit. Production (api.totalreclaw.xyz) enforces the 250 writes/month cap.';
 
 /**
  * Fetch billing/subscription status from the TotalReclaw server
@@ -121,6 +137,8 @@ export async function statusTool(
     const freeReadsLimit = (data.free_reads_limit as number) ?? 0;
     const freeWritesResetAt = data.free_writes_reset_at as string | undefined;
     const upgradeUrl = data.upgrade_url as string | undefined;
+    const environment: 'production' | 'staging' =
+      (data.environment as 'production' | 'staging' | undefined) ?? inferEnvironment(serverUrl);
 
     // Build formatted summary
     const tierLabel = tier === 'pro' ? 'Pro' : 'Free';
@@ -143,6 +161,12 @@ export async function statusTool(
       lines.push(`Upgrade: ${upgradeUrl}`);
     }
 
+    // Mention staging ONLY when on staging; production users should never
+    // see staging surfaced.
+    if (environment === 'staging') {
+      lines.push(`Environment: staging — ${STAGING_NOTE}`);
+    }
+
     return {
       success: true,
       tier,
@@ -153,6 +177,8 @@ export async function statusTool(
       free_writes_reset_at: freeWritesResetAt,
       upgrade_url: upgradeUrl,
       scope_address: walletAddress,
+      environment,
+      ...(environment === 'staging' ? { staging_note: STAGING_NOTE } : {}),
       formatted: lines.join('\n'),
     };
   } catch (error) {

--- a/skill/src/totalreclaw-skill.ts
+++ b/skill/src/totalreclaw-skill.ts
@@ -194,6 +194,9 @@ interface BillingCacheData {
   free_reads_used: number;
   free_reads_limit: number;
   checked_at: number;
+  // "production" or "staging". Inferred from the relay URL when absent.
+  environment?: 'production' | 'staging';
+  upgrade_url?: string;
 }
 
 function isBillingCacheData(data: unknown): data is BillingCacheData {
@@ -207,6 +210,10 @@ function isBillingCacheData(data: unknown): data is BillingCacheData {
     typeof d.free_reads_limit === 'number' &&
     typeof d.checked_at === 'number'
   );
+}
+
+function inferEnvironment(serverUrl: string): 'production' | 'staging' {
+  return serverUrl.toLowerCase().includes('api-staging') ? 'staging' : 'production';
 }
 
 // ============================================================================
@@ -417,13 +424,17 @@ export class TotalReclawSkill {
           const parsed: unknown = await response.json();
           if (isBillingCacheData(parsed)) {
             billingData = parsed;
+            if (!billingData.environment) {
+              billingData.environment = inferEnvironment(serverUrl);
+            }
             fs.mkdirSync(path.dirname(BILLING_CACHE_PATH), { recursive: true });
             fs.writeFileSync(BILLING_CACHE_PATH, JSON.stringify({ timestamp: Date.now(), data: billingData }));
           }
         }
       }
 
-      if (billingData && billingData.free_writes_limit > 0) {
+      // Staging doesn't enforce the cap — never warn there.
+      if (billingData && billingData.free_writes_limit > 0 && billingData.environment !== 'staging') {
         const usageRatio = billingData.free_writes_used / billingData.free_writes_limit;
         if (usageRatio >= QUOTA_WARNING_THRESHOLD) {
           billingWarning = `\n\n⚠️ TotalReclaw quota warning: ${billingData.free_writes_used}/${billingData.free_writes_limit} writes used this month (${Math.round(usageRatio * 100)}%). ` +

--- a/skill/src/triggers/before-agent-start.ts
+++ b/skill/src/triggers/before-agent-start.ts
@@ -41,6 +41,10 @@ interface BillingCacheData {
   free_reads_used: number;
   free_reads_limit: number;
   checked_at: number;
+  // "production" or "staging". Inferred from the relay URL when absent.
+  // Used to suppress quota warnings on staging (cap isn't enforced there).
+  environment?: 'production' | 'staging';
+  upgrade_url?: string;
 }
 
 function isBillingCacheData(data: unknown): data is BillingCacheData {
@@ -54,6 +58,10 @@ function isBillingCacheData(data: unknown): data is BillingCacheData {
     typeof d.free_reads_limit === 'number' &&
     typeof d.checked_at === 'number'
   );
+}
+
+function inferEnvironment(serverUrl: string): 'production' | 'staging' {
+  return serverUrl.toLowerCase().includes('api-staging') ? 'staging' : 'production';
 }
 
 /**
@@ -251,13 +259,18 @@ export async function beforeAgentStart(
         const parsed: unknown = await response.json();
         if (isBillingCacheData(parsed)) {
           billingData = parsed;
+          // Backfill environment from URL if relay didn't populate it.
+          if (!billingData.environment) {
+            billingData.environment = inferEnvironment(serverUrl);
+          }
           fs.mkdirSync(path.dirname(BILLING_CACHE_PATH), { recursive: true });
           fs.writeFileSync(BILLING_CACHE_PATH, JSON.stringify({ timestamp: Date.now(), data: billingData }));
         }
       }
     }
 
-    if (billingData && billingData.free_writes_limit > 0) {
+    // Staging doesn't enforce the cap — never warn there.
+    if (billingData && billingData.free_writes_limit > 0 && billingData.environment !== 'staging') {
       const usageRatio = billingData.free_writes_used / billingData.free_writes_limit;
       if (usageRatio >= QUOTA_WARNING_THRESHOLD) {
         billingWarning = `\n\n⚠️ TotalReclaw quota warning: ${billingData.free_writes_used}/${billingData.free_writes_limit} writes used this month (${Math.round(usageRatio * 100)}%). ` +

--- a/tests/e2e-guide-validation/e2e-clean-install-tests.ts
+++ b/tests/e2e-guide-validation/e2e-clean-install-tests.ts
@@ -513,7 +513,7 @@ async function runC4(client: OpenClawClient): Promise<void> {
 
   const mentionsFreeTier =
     content.includes('free tier') ||
-    content.includes('500 memories') ||
+    content.includes('250 memories') ||
     content.includes('free') ||
     content.includes('upgrade');
 


### PR DESCRIPTION
## Why

A user reported that Hermes (Python agent plugin) couldn't answer "is that 250 per month or lifetime?" after a `totalreclaw_status` call. Investigating, three surfaces disagreed:

- **Relay API** returns `free_writes_limit: 250` with `expires_at: null` and no `period` / `resets_at` field — so the agent literally has no way to tell whether 250 is monthly or lifetime.
- **SKILL.md prose** (skill, mcp, skill-nanoclaw, hermes) all say "free tier — 500 memories/month".
- **CLAUDE.md** describes the Base Sepolia free tier as "unlimited memories".
- **The pricing page** says "Unlimited memories" on the Free card.

Three numbers, one truth (250/month). The agent was guessing — correctly, since none of its sources matched the API.

## What

**Reconcile prose to 250 memories/month** everywhere user-facing:
- `skill/SKILL.md`, `mcp/SKILL.md`, `skill-nanoclaw/SKILL.md`, `python/src/totalreclaw/hermes/SKILL.md`
- `docs/guides/openclaw-setup.md`, `docs/guides/openclaw-setup-quickstart.md`
- `docs/specs/subgraph/billing-and-onboarding.md`
- `CLAUDE.md` (was "unlimited memories" for Base Sepolia free)
- `mcp/src/prompts.ts` (the system fragment the LLM reads)
- `tests/e2e-guide-validation/e2e-clean-install-tests.ts` (assertion pinning the install confirmation)
- `python/src/totalreclaw/hermes/hooks.py` (fallback default 500 → 250)

**Expose `period` + `resets_at`** so agents never have to guess again:
- `BillingStatus` (Python `relay.py`) and `BillingCache` (skill plugin + skill-nanoclaw) gain optional `period` (`"monthly" | "lifetime"`) and `resets_at` (ISO 8601) fields.
- Relay populates them when available; clients default `period` to `"monthly"` on the free tier so older relays still produce an unambiguous signal.
- Both Hermes (`totalreclaw_status` in `python/.../hermes/tools.py`) and the MCP server status tool (`mcp/src/tools/status.ts`) now include `period` + `resets_at` in their JSON response and use them to render the expiry/reset line ("Resets monthly" instead of "No expiry" when applicable).

Stripe-driven tiers (the `2026-03-26-stripe-driven-tiers.md` plan) is explicitly **not** part of this PR — Stripe has no concept of a free tier, so making it the source of truth would require a parallel local row anyway. The relay already owns the canonical answer; we just weren't surfacing it.

**Relay-side TODO (separate PR in `totalreclaw-relay`):** populate `period: "monthly"` and `resets_at: <next-reset-iso>` in the `/v1/billing/status` response. Clients are forward-compatible — they default to `"monthly"` until the relay starts sending the field.

## Test plan

- [x] `pytest tests/` (Python) — 1151 passed, 9 skipped, 1 xfailed. The one pre-existing flaky failure (`test_pair_sidecar_lifecycle`) reproduces on clean `main` and is unrelated.
- [x] `tsc --noEmit` (mcp) — clean
- [x] `tsx plugin/billing-cache.test.ts` (skill plugin) — 22/22 passed
- [ ] Manual smoke against staging: run `totalreclaw_status` from Hermes and verify the JSON now contains `"period": "monthly"`.
- [ ] Companion PR in `totalreclaw-website` ([p-diogo/totalreclaw-website#claude/document-totalreclaw-tiers-YtAq6](https://github.com/p-diogo/totalreclaw-website/pull/new/claude/document-totalreclaw-tiers-YtAq6)) flips the Free card from "Unlimited memories" to "250 memories / month".


---
_Generated by [Claude Code](https://claude.ai/code/session_01AZjd1davuvWnzW3EVJx2Jw)_