### PR TITLE
feat(app): rewire vault SPA for managed-mode reads via relay subgraph proxy

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -106,7 +106,6 @@ const PAGE_QUERY = `
       timestamp
       createdAt
       version
-      source
       isActive
     }
   }
@@ -170,7 +169,10 @@ function subgraphFactToRawFact(sf: SubgraphFact): RawFact {
     blind_indices: [], // subgraph carries blind indices separately; not needed for read path
     decay_score: Number(sf.decayScore),
     version: sf.version,
-    source: sf.source,
+    // `source` was removed from the subgraph Fact entity in v0.6.0. The
+    // decrypted MemoryClaim carries its own `source` field (taxonomy v1),
+    // so this stub is only used to keep the RawFact shape stable.
+    source: "",
     created_at: iso,
     updated_at: iso,
     encrypted_embedding: sf.encryptedEmbedding?.replace(/^0x/, "") || undefined,

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -1,23 +1,30 @@
 import {
-  ExportResponse,
-  AccountInfo,
+  BillingStatus,
   RawFact,
   VaultItem,
   MemoryClaimV1,
   MemoryTypeV1,
   MEMORY_TYPES_V1,
+  SubgraphFact,
 } from "./types";
-import { decryptBlob, encryptBlob } from "./crypto";
+import { decryptBlob } from "./crypto";
 import { SessionKeys } from "./types";
 
 const SERVER_URL =
-  import.meta.env.VITE_SERVER_URL?.replace(/\/$/, "") ?? "https://relay.totalreclaw.xyz";
+  import.meta.env.VITE_SERVER_URL?.replace(/\/$/, "") ??
+  "https://api.totalreclaw.xyz";
+
+export function getServerUrl(): string {
+  return SERVER_URL;
+}
 
 function authHeaders(keys: SessionKeys): HeadersInit {
   return {
     Authorization: `Bearer ${keys.authKeyHex}`,
     "Content-Type": "application/json",
     Accept: "application/json",
+    "X-Wallet-Address": keys.walletAddress,
+    "X-TotalReclaw-Client": "ts-spa-vault",
   };
 }
 
@@ -40,36 +47,134 @@ async function apiFetch<T>(
   return res.json() as Promise<T>;
 }
 
-export async function getAccount(keys: SessionKeys): Promise<AccountInfo> {
-  return apiFetch<AccountInfo>("/v1/account", keys);
+/**
+ * Idempotent vault registration. Required before any authenticated relay call
+ * succeeds — the relay looks up the user by sha256(authKey), and 401s if no
+ * row exists. Re-registering is a no-op.
+ */
+export async function registerSession(keys: SessionKeys): Promise<void> {
+  const authKeyHashHex = await sha256Hex(keys.authKey);
+  // salt is the first 32 bytes of the BIP-39 seed, but the SPA already exposes
+  // a stable salt via the relay's persisted record. Per the auth design,
+  // re-registering with the same auth_key_hash is idempotent regardless of
+  // salt — relay does an existsByAuthHash short-circuit. We send a 32-byte
+  // dummy salt that's deterministic from authKey so the relay never sees a
+  // changing value across logins from the same SPA session.
+  const saltHex = await sha256Hex(
+    concat(new TextEncoder().encode("totalreclaw-spa-salt-v1"), keys.authKey),
+  );
+  const res = await fetch(`${SERVER_URL}/v1/register`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-TotalReclaw-Client": "ts-spa-vault",
+    },
+    body: JSON.stringify({
+      auth_key_hash: authKeyHashHex,
+      salt: saltHex,
+    }),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`register → ${res.status}: ${body}`);
+  }
 }
 
-/** Fetch all facts via cursor-paginated export. Returns raw encrypted facts. */
+export async function getAccount(keys: SessionKeys): Promise<BillingStatus> {
+  const path = `/v1/billing/status?wallet_address=${keys.walletAddress}`;
+  return apiFetch<BillingStatus>(path, keys);
+}
+
+interface SubgraphResponse<T> {
+  data?: T;
+  errors?: Array<{ message: string }>;
+}
+
+const PAGE_QUERY = `
+  query VaultExport($owner: Bytes!, $first: Int!, $skip: Int!) {
+    facts(
+      where: { owner: $owner, isActive: true }
+      first: $first
+      skip: $skip
+      orderBy: createdAt
+      orderDirection: desc
+    ) {
+      id
+      encryptedBlob
+      encryptedEmbedding
+      decayScore
+      timestamp
+      createdAt
+      version
+      source
+      isActive
+    }
+  }
+`;
+
+const PAGE_SIZE = 1000; // Graph Studio caps `first` at 1000
+
+/**
+ * Fetch all active facts owned by the Smart Account via the relay's
+ * subgraph proxy. Pagination via skip (deterministic ordering on createdAt).
+ */
 export async function exportAllFacts(
   keys: SessionKeys,
   onProgress?: (loaded: number, total: number | undefined) => void,
 ): Promise<RawFact[]> {
   const all: RawFact[] = [];
-  let cursor: string | undefined;
-  let total: number | undefined;
+  let skip = 0;
 
-  do {
-    const params = new URLSearchParams({ limit: "1000" });
-    if (cursor) params.set("cursor", cursor);
-    const page = await apiFetch<ExportResponse>(
-      `/v1/export?${params}`,
+  for (;;) {
+    const res = await apiFetch<SubgraphResponse<{ facts: SubgraphFact[] }>>(
+      "/v1/subgraph",
       keys,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          query: PAGE_QUERY,
+          variables: {
+            owner: keys.walletAddress,
+            first: PAGE_SIZE,
+            skip,
+          },
+        }),
+      },
     );
-    if (!page.success) {
-      throw new Error(page.error_message ?? "Export failed");
+
+    if (res.errors?.length) {
+      throw new Error(`subgraph: ${res.errors.map((e) => e.message).join("; ")}`);
     }
-    all.push(...page.facts);
-    total = page.total_count;
-    cursor = page.has_more ? page.cursor : undefined;
-    onProgress?.(all.length, total);
-  } while (cursor);
+
+    const page = res.data?.facts ?? [];
+    for (const fact of page) {
+      all.push(subgraphFactToRawFact(fact));
+    }
+    onProgress?.(all.length, undefined);
+
+    if (page.length < PAGE_SIZE) break;
+    skip += PAGE_SIZE;
+  }
 
   return all;
+}
+
+function subgraphFactToRawFact(sf: SubgraphFact): RawFact {
+  const createdAtMs = Number(sf.createdAt || sf.timestamp) * 1000;
+  const iso = Number.isFinite(createdAtMs)
+    ? new Date(createdAtMs).toISOString()
+    : new Date().toISOString();
+  return {
+    id: sf.id,
+    encrypted_blob: sf.encryptedBlob.replace(/^0x/, ""),
+    blind_indices: [], // subgraph carries blind indices separately; not needed for read path
+    decay_score: Number(sf.decayScore),
+    version: sf.version,
+    source: sf.source,
+    created_at: iso,
+    updated_at: iso,
+    encrypted_embedding: sf.encryptedEmbedding?.replace(/^0x/, "") || undefined,
+  };
 }
 
 function resolveType(claim: MemoryClaimV1, tags: string[]): MemoryTypeV1 | string {
@@ -108,54 +213,52 @@ export function decryptFacts(
   return items;
 }
 
+// ---------------------------------------------------------------------------
+// Write path — Phase 2 (managed-mode UserOp construction not yet implemented).
+// These stubs preserve the hook surface so the UI compiles + renders. Calls
+// that hit the write path will surface a clear error to the user.
+// ---------------------------------------------------------------------------
+
+const WRITES_NOT_IMPLEMENTED =
+  "Vault writes are not yet available in the web app. Use a TotalReclaw agent (Claude Desktop, OpenClaw, etc.) to modify your vault.";
+
 export async function deleteFact(
-  factId: string,
-  keys: SessionKeys,
+  _factId: string,
+  _keys: SessionKeys,
 ): Promise<void> {
-  await apiFetch<unknown>(`/v1/facts/${factId}`, keys, { method: "DELETE" });
+  throw new Error(WRITES_NOT_IMPLEMENTED);
 }
 
 export async function batchDeleteFacts(
-  factIds: string[],
-  keys: SessionKeys,
+  _factIds: string[],
+  _keys: SessionKeys,
 ): Promise<void> {
-  if (factIds.length === 0) return;
-  // Server supports up to 500 per batch
-  for (let i = 0; i < factIds.length; i += 500) {
-    const batch = factIds.slice(i, i + 500);
-    await apiFetch<unknown>("/v1/facts/batch-delete", keys, {
-      method: "POST",
-      body: JSON.stringify({ fact_ids: batch }),
-    });
-  }
+  throw new Error(WRITES_NOT_IMPLEMENTED);
 }
 
-/** Re-store a modified claim (retype or pin update). Reuses existing blind indices. */
 export async function updateClaim(
-  item: VaultItem,
-  updatedClaim: MemoryClaimV1,
-  keys: SessionKeys,
+  _item: VaultItem,
+  _updatedClaim: MemoryClaimV1,
+  _keys: SessionKeys,
 ): Promise<void> {
-  const newBlob = encryptBlob(
-    JSON.stringify(updatedClaim),
-    keys.encryptionKey,
-  );
+  throw new Error(WRITES_NOT_IMPLEMENTED);
+}
 
-  // First delete the old fact, then store the new one
-  // (server /v1/store is append-only; deletion is the update mechanism)
-  await apiFetch<unknown>(`/v1/facts/${item.id}`, keys, { method: "DELETE" });
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
 
-  await apiFetch<unknown>("/v1/store", keys, {
-    method: "POST",
-    body: JSON.stringify({
-      facts: [
-        {
-          id: item.id,
-          encrypted_blob: newBlob,
-          blind_indices: item.blindIndices,
-          decay_score: item.decayScore,
-        },
-      ],
-    }),
-  });
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const hash = await crypto.subtle.digest("SHA-256", bytes as unknown as ArrayBuffer);
+  const arr = new Uint8Array(hash);
+  return Array.from(arr)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function concat(a: Uint8Array, b: Uint8Array): Uint8Array {
+  const out = new Uint8Array(a.length + b.length);
+  out.set(a, 0);
+  out.set(b, a.length);
+  return out;
 }

--- a/app/src/lib/crypto.test.ts
+++ b/app/src/lib/crypto.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from "vitest";
-import { deriveSessionKeys, encryptBlob, decryptBlob, isMnemonicValid } from "./crypto";
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+  deriveSessionKeys,
+  encryptBlob,
+  decryptBlob,
+  isMnemonicValid,
+} from "./crypto";
 
 // BIP-39 test mnemonic (all-zeros entropy, BIP-39 spec vector)
 const TEST_MNEMONIC =
@@ -14,6 +19,12 @@ const GOLDEN_AUTH_KEY_HEX =
 const GOLDEN_ENC_KEY_HEX =
   "a58fdc56e1d768461d95cd46b49e03727b2eb342ac558b9f3ebf1255b871f703";
 
+// EOA for TEST_MNEMONIC at BIP-32 m/44'/60'/0'/0/0 — well-known test vector.
+const GOLDEN_EOA = "0x9858effd232b4033e47d90003d41ec34ecaeda94";
+
+const SERVER_URL = "https://relay.test";
+const MOCK_SMART_ACCOUNT = "0xcafef00dcafef00dcafef00dcafef00dcafef00d";
+
 // Fixture ciphertext: encryptBlob('{"test":"golden"}', GOLDEN_ENC_KEY, nonce=zeros[24])
 // wire format: nonce[24] || tag[16] || ciphertext
 const FIXTURE_CIPHERTEXT_HEX =
@@ -27,56 +38,101 @@ function hexToBytes(hex: string): Uint8Array {
   return out;
 }
 
+beforeEach(() => {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes("/v1/smart-account")) {
+      return new Response(
+        JSON.stringify({ smart_account: MOCK_SMART_ACCOUNT, chain_id: 84532 }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    return new Response("not mocked: " + url, { status: 404 });
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe("deriveSessionKeys", () => {
   it("produces canonical authKey for known mnemonic (golden vector)", async () => {
-    const keys = await deriveSessionKeys(TEST_MNEMONIC);
+    const keys = await deriveSessionKeys(TEST_MNEMONIC, SERVER_URL);
     expect(keys.authKeyHex).toBe(GOLDEN_AUTH_KEY_HEX);
   });
 
   it("produces canonical encryptionKey for known mnemonic (golden vector)", async () => {
-    const keys = await deriveSessionKeys(TEST_MNEMONIC);
+    const keys = await deriveSessionKeys(TEST_MNEMONIC, SERVER_URL);
     const encHex = Array.from(keys.encryptionKey)
       .map((b) => b.toString(16).padStart(2, "0"))
       .join("");
     expect(encHex).toBe(GOLDEN_ENC_KEY_HEX);
   });
 
+  it("derives canonical EOA for TEST_MNEMONIC", async () => {
+    const keys = await deriveSessionKeys(TEST_MNEMONIC, SERVER_URL);
+    expect(keys.eoaAddress).toBe(GOLDEN_EOA);
+  });
+
+  it("fetches walletAddress from /v1/smart-account using the EOA", async () => {
+    const keys = await deriveSessionKeys(TEST_MNEMONIC, SERVER_URL);
+    expect(keys.walletAddress).toBe(MOCK_SMART_ACCOUNT);
+
+    const fetchMock = vi.mocked(fetch);
+    const calledUrl = String(fetchMock.mock.calls[0][0]);
+    expect(calledUrl).toContain("/v1/smart-account");
+    expect(calledUrl).toContain(`eoa=${GOLDEN_EOA}`);
+    expect(calledUrl).toContain("chain=84532");
+  });
+
   it("authKey and encryptionKey are distinct", async () => {
-    const keys = await deriveSessionKeys(TEST_MNEMONIC);
+    const keys = await deriveSessionKeys(TEST_MNEMONIC, SERVER_URL);
     expect(keys.authKeyHex).not.toBe(GOLDEN_ENC_KEY_HEX);
   });
 
   it("is deterministic", async () => {
-    const k1 = await deriveSessionKeys(TEST_MNEMONIC);
-    const k2 = await deriveSessionKeys(TEST_MNEMONIC);
+    const k1 = await deriveSessionKeys(TEST_MNEMONIC, SERVER_URL);
+    const k2 = await deriveSessionKeys(TEST_MNEMONIC, SERVER_URL);
     expect(k1.authKeyHex).toBe(k2.authKeyHex);
-    expect(
-      Array.from(k1.encryptionKey).join(","),
-    ).toBe(Array.from(k2.encryptionKey).join(","));
+    expect(Array.from(k1.encryptionKey).join(",")).toBe(
+      Array.from(k2.encryptionKey).join(","),
+    );
+    expect(k1.eoaAddress).toBe(k2.eoaAddress);
   });
 
   it("produces different keys for different mnemonics", async () => {
-    const k1 = await deriveSessionKeys(TEST_MNEMONIC);
+    const k1 = await deriveSessionKeys(TEST_MNEMONIC, SERVER_URL);
     const k2 = await deriveSessionKeys(
-      "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
+      "legal winner thank year wave sausage worth useful legal winner thank yellow",
+      SERVER_URL,
     );
     expect(k1.authKeyHex).not.toBe(
       Array.from(k2.authKey)
         .map((b) => b.toString(16).padStart(2, "0"))
         .join(""),
     );
+    expect(k1.eoaAddress).not.toBe(k2.eoaAddress);
   });
 
   it("rejects invalid mnemonic", async () => {
-    await expect(deriveSessionKeys("not valid mnemonic")).rejects.toThrow(
-      "Invalid 12-word recovery phrase",
+    await expect(
+      deriveSessionKeys("not valid mnemonic", SERVER_URL),
+    ).rejects.toThrow("Invalid 12-word recovery phrase");
+  });
+
+  it("surfaces relay errors with status code", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response("rate-limited", { status: 429 }),
     );
+    await expect(
+      deriveSessionKeys(TEST_MNEMONIC, SERVER_URL),
+    ).rejects.toThrow(/smart-account derivation failed \(429\)/);
   });
 });
 
 describe("encryptBlob / decryptBlob round-trip", () => {
   it("encrypt then decrypt returns original plaintext", async () => {
-    const { encryptionKey } = await deriveSessionKeys(TEST_MNEMONIC);
+    const { encryptionKey } = await deriveSessionKeys(TEST_MNEMONIC, SERVER_URL);
     const original = JSON.stringify({ type: "fact", content: "hello world" });
     const hex = encryptBlob(original, encryptionKey);
     const decrypted = decryptBlob(hex, encryptionKey);
@@ -90,7 +146,7 @@ describe("encryptBlob / decryptBlob round-trip", () => {
   });
 
   it("decryptBlob rejects tampered ciphertext", async () => {
-    const { encryptionKey } = await deriveSessionKeys(TEST_MNEMONIC);
+    const { encryptionKey } = await deriveSessionKeys(TEST_MNEMONIC, SERVER_URL);
     const hex = encryptBlob("secret", encryptionKey);
     // Flip last byte
     const tampered =

--- a/app/src/lib/crypto.ts
+++ b/app/src/lib/crypto.ts
@@ -8,8 +8,14 @@
 
 import { validateMnemonic, mnemonicToSeed } from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english";
+import { HDKey } from "@scure/bip32";
+import { secp256k1 } from "@noble/curves/secp256k1";
+import { keccak_256 } from "@noble/hashes/sha3";
 import { xchacha20poly1305 } from "@noble/ciphers/chacha";
 import { SessionKeys } from "./types";
+
+const BIP44_PATH = "m/44'/60'/0'/0/0";
+const DEFAULT_CHAIN_ID = 84532; // Base Sepolia (free tier)
 
 // HKDF-SHA256 via WebCrypto SubtleCrypto
 async function hkdf(
@@ -65,17 +71,73 @@ export function isMnemonicValid(phrase: string): boolean {
 }
 
 /**
- * Derive session keys from a 12-word BIP-39 mnemonic.
+ * Derive the EOA Ethereum address that owns the ERC-4337 Smart Account.
  *
- * Matches client/src/crypto/seed.ts deriveKeysFromMnemonic() + mcp/src/subgraph/crypto.ts:
- *   seed = BIP-39 PBKDF2(mnemonic, "mnemonic", 2048, SHA-512, 64 bytes)
- *   salt = seed[0:32]
- *   authKey = HKDF-SHA256(seed, salt, "totalreclaw-auth-key-v1",       32)
- *   encKey  = HKDF-SHA256(seed, salt, "totalreclaw-encryption-key-v1", 32)
+ * Mirrors the canonical client/src/crypto/seed.ts derivation:
+ *   - BIP-32 HD key at m/44'/60'/0'/0/0
+ *   - secp256k1 uncompressed public key (65 bytes, leading 0x04)
+ *   - EOA = keccak256(pubkey[1:65])[12:32] (last 20 bytes)
  *
- * BIP-32 derivation is NOT used for session keys (only needed for UserOp signing).
+ * Returns lowercase 0x-prefixed hex (not EIP-55 checksummed).
  */
-export async function deriveSessionKeys(mnemonic: string): Promise<SessionKeys> {
+function deriveEoaFromSeed(seed: Uint8Array): string {
+  const hdKey = HDKey.fromMasterSeed(seed);
+  const child = hdKey.derive(BIP44_PATH);
+  if (!child.privateKey) {
+    throw new Error("BIP-32 derivation failed");
+  }
+  const pubUncompressed = secp256k1.getPublicKey(child.privateKey, false); // 65 bytes
+  const hash = keccak_256(pubUncompressed.slice(1));
+  const addr = hash.slice(-20);
+  return "0x" + bytesToHex(addr);
+}
+
+/**
+ * Fetch the deterministic Smart Account address from the relay.
+ *
+ * The relay calls `SimpleAccountFactory.getAddress(eoa, 0)` via a public RPC
+ * (CREATE2 view function). Same answer on every chain where the factory is
+ * deployed — but we still pass chainId so the relay routes to the correct
+ * RPC endpoint.
+ */
+async function fetchSmartAccountAddress(
+  serverUrl: string,
+  eoa: string,
+  chainId: number,
+): Promise<string> {
+  const url = `${serverUrl.replace(/\/$/, "")}/v1/smart-account?eoa=${eoa}&chain=${chainId}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`smart-account derivation failed (${res.status}): ${body}`);
+  }
+  const json = (await res.json()) as { smart_account?: string };
+  if (!json.smart_account || !/^0x[0-9a-fA-F]{40}$/.test(json.smart_account)) {
+    throw new Error("smart-account response missing valid address");
+  }
+  return json.smart_account.toLowerCase();
+}
+
+/**
+ * Derive session keys + Smart Account address from a 12-word BIP-39 mnemonic.
+ *
+ * Mirrors client/src/crypto/seed.ts deriveKeysFromMnemonic() + the Smart
+ * Account derivation flow used by every other client. The Smart Account
+ * address is fetched from the relay (browser can't easily call the factory
+ * view function without bundle-heavy deps).
+ *
+ *   seed     = BIP-39 PBKDF2(mnemonic, "mnemonic", 2048, SHA-512, 64 bytes)
+ *   salt     = seed[0:32]
+ *   authKey  = HKDF-SHA256(seed, salt, "totalreclaw-auth-key-v1",       32)
+ *   encKey   = HKDF-SHA256(seed, salt, "totalreclaw-encryption-key-v1", 32)
+ *   eoa      = keccak256(secp256k1_pubkey(BIP32(m/44'/60'/0'/0/0)))[-20:]
+ *   wallet   = SimpleAccountFactory.getAddress(eoa, 0) [via relay]
+ */
+export async function deriveSessionKeys(
+  mnemonic: string,
+  serverUrl: string,
+  chainId: number = DEFAULT_CHAIN_ID,
+): Promise<SessionKeys> {
   const normalized = mnemonic.trim().toLowerCase();
   if (!isMnemonicValid(normalized)) {
     throw new Error("Invalid 12-word recovery phrase");
@@ -83,14 +145,26 @@ export async function deriveSessionKeys(mnemonic: string): Promise<SessionKeys> 
 
   const seed = await mnemonicToSeed(normalized); // 512-bit BIP-39 seed
   const salt = seed.slice(0, 32);
-  const authKey = await hkdf(seed, salt, "totalreclaw-auth-key-v1", 32);
-  const encryptionKey = await hkdf(seed, salt, "totalreclaw-encryption-key-v1", 32);
+  const [authKey, encryptionKey, eoaAddress] = await Promise.all([
+    hkdf(seed, salt, "totalreclaw-auth-key-v1", 32),
+    hkdf(seed, salt, "totalreclaw-encryption-key-v1", 32),
+    Promise.resolve(deriveEoaFromSeed(seed)),
+  ]);
+
+  const walletAddress = await fetchSmartAccountAddress(
+    serverUrl,
+    eoaAddress,
+    chainId,
+  );
 
   return {
     mnemonic: normalized,
     authKey,
     encryptionKey,
     authKeyHex: bytesToHex(authKey),
+    eoaAddress,
+    walletAddress,
+    chainId,
   };
 }
 

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -90,7 +90,8 @@ export interface BillingStatus {
   max_candidate_pool?: number;
 }
 
-/** Subgraph GraphQL response — `facts` entity per docs/specs/subgraph/seed-to-subgraph.md */
+/** Subgraph GraphQL response — `facts` entity per docs/specs/subgraph/seed-to-subgraph.md.
+ *  Note: `source` was removed from the schema in v0.6.0 (Session 53). */
 export interface SubgraphFact {
   id: string;
   encryptedBlob: string;
@@ -99,7 +100,6 @@ export interface SubgraphFact {
   timestamp: string;
   createdAt: string;
   version: number;
-  source: string;
   isActive: boolean;
 }
 

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -43,17 +43,8 @@ export interface VaultItem {
   decayScore: number;
 }
 
-/** Paginated response from GET /v1/export */
-export interface ExportResponse {
-  success: boolean;
-  error_code?: string;
-  error_message?: string;
-  facts: RawFact[];
-  cursor?: string;
-  has_more: boolean;
-  total_count?: number;
-}
-
+/** Raw fact shape consumed by the SPA's decrypt path. Normalized from the
+ *  subgraph GraphQL response, which uses camelCase + hex strings. */
 export interface RawFact {
   id: string;
   encrypted_blob: string;
@@ -61,24 +52,55 @@ export interface RawFact {
   decay_score: number;
   version: number;
   source: string;
+  /** ISO-8601 — derived from the subgraph's `createdAt` Unix timestamp */
   created_at: string;
   updated_at: string;
   encrypted_embedding?: string;
 }
 
-/** Keys derived from the 12-word mnemonic — held in CryptoContext only */
+/** Keys derived from the 12-word mnemonic — held in CryptoContext only.
+ *  walletAddress is the deterministic ERC-4337 Smart Account address that owns
+ *  the on-chain vault (returned by the relay's /v1/smart-account endpoint). */
 export interface SessionKeys {
   mnemonic: string;
   authKey: Uint8Array;
   encryptionKey: Uint8Array;
   authKeyHex: string;
+  /** EOA derived from BIP-32 m/44'/60'/0'/0/0 — owns the Smart Account */
+  eoaAddress: string;
+  /** Smart Account address — the `owner` field used to query the subgraph */
+  walletAddress: string;
+  /** Chain ID for subgraph routing (84532 free / 100 pro). Pro detection
+   *  happens after billing/status returns — defaults to free at derivation. */
+  chainId: number;
 }
 
-/** Response from GET /v1/account */
-export interface AccountInfo {
-  user_id: string;
-  created_at: string;
-  fact_count: number;
+/** Response from GET /v1/billing/status?wallet_address=... */
+export interface BillingStatus {
+  wallet_address: string;
+  tier: "free" | "pro";
+  writes_used?: number;
+  writes_limit?: number;
+  reads_used?: number;
+  reads_limit?: number;
+  features?: Record<string, unknown>;
+  /** Server-computed extraction tuning knobs (not relevant for read-only SPA) */
+  extraction_interval?: number;
+  max_facts_per_extraction?: number;
+  max_candidate_pool?: number;
+}
+
+/** Subgraph GraphQL response — `facts` entity per docs/specs/subgraph/seed-to-subgraph.md */
+export interface SubgraphFact {
+  id: string;
+  encryptedBlob: string;
+  encryptedEmbedding?: string;
+  decayScore: string;
+  timestamp: string;
+  createdAt: string;
+  version: number;
+  source: string;
+  isActive: boolean;
 }
 
 export const TYPE_COLORS: Record<string, string> = {

--- a/app/src/pages/PairPage.tsx
+++ b/app/src/pages/PairPage.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useCallback, FormEvent } from "react";
 import { useNavigate } from "react-router-dom";
 import { clsx } from "clsx";
 import { isMnemonicValid, deriveSessionKeys } from "../lib/crypto";
+import { getServerUrl, registerSession } from "../lib/api";
 import { useCrypto } from "../contexts/CryptoContext";
 
 const WORD_COUNT = 12;
@@ -67,7 +68,8 @@ export function PairPage() {
 
       setLoading(true);
       try {
-        const keys = await deriveSessionKeys(phrase);
+        const keys = await deriveSessionKeys(phrase, getServerUrl());
+        await registerSession(keys);
         setKeys(keys);
         navigate("/vault", { replace: true });
       } catch (err) {


### PR DESCRIPTION
## Summary

The vault SPA was written against the self-hosted Python server's REST surface (`/v1/export`, `/v1/account`, `/v1/store`, `/v1/facts/*`). Pointing it at the managed-mode relay returned `Cannot GET /v1/export` — the relay only exposes proxy + billing routes. This PR moves the SPA's **read path** to the managed-mode architecture (subgraph via relay).

* **Reads via relay-proxied subgraph.** `exportAllFacts` now does paginated GraphQL `facts(where: { owner, isActive: true })` through `POST /v1/subgraph` — relay routes by user tier (free→Base Sepolia, pro→Gnosis), Graph Studio API keys stay server-side. SPA never touches a subgraph URL.
* **Smart Account derivation via relay.** New `deriveSessionKeys(mnemonic, serverUrl)` derives the EOA in-browser (BIP32 → secp256k1 → keccak via `@noble`), then fetches the deterministic ERC-4337 Smart Account address from the new relay `GET /v1/smart-account` endpoint. Keeps the SPA bundle viem-free (322 KB → 109 KB gzipped).
* **Session register.** `registerSession` runs once at phrase entry. Idempotent — relay short-circuits on existing `auth_key_hash`.
* **Write path stubbed.** `deleteFact` / `batchDeleteFacts` / `updateClaim` throw a clear "writes coming in Phase 2 — use an agent for now" error. UI surface preserved (ClaimPage still compiles + renders). Phase 2 will add client-side ERC-4337 UserOp construction + signing.

## Companion relay changes (private repo)

Already deployed to staging (Railway `totalreclaw` @ `39e3d1f`):

* `feat(cors)`: leftmost-subdomain wildcard support in `CORS_ORIGINS` for CF Pages branch previews
* `feat(smart-account)`: `GET /v1/smart-account?eoa=&chain=` — raw `eth_call` to `SimpleAccountFactory.getAddress(eoa, 0)` against a public RPC (Pimlico v2 bundler rejects `eth_call` with `-32601`, so the route uses `BASE_SEPOLIA_RPC_URL` / `GNOSIS_RPC_URL` env vars with public defaults)

`CORS_ORIGINS` env var on both Railway services now allows `https://totalreclaw.xyz, https://app.totalreclaw.xyz, https://totalreclaw-app.pages.dev, https://*.totalreclaw-app.pages.dev`.

## Test plan

- [x] `vitest run src/lib/crypto.test.ts` — 14/14 (BIP-39 golden vectors, EOA golden vector, fetch-mocked smart-account, deterministic + distinct + invalid)
- [x] `npm run build` — green (322 KB bundle, 109 KB gzipped, no viem)
- [x] End-to-end relay probe — `eoa=0x9858effd232b4033e47d90003d41ec34ecaeda94` → `smart_account=0x2c0CF74B2b76110708CA431796367779e3738250` (matches the canonical test Smart Account in CLAUDE.md)
- [x] Deploy `app/dist` to Cloudflare Pages, walk a real recovery phrase through the flow
- [x] Verify decrypted vault list renders for a populated account on staging

## Known caveats

* SPA defaults derivation to `chain=84532` (free / Base Sepolia). Smart Account addresses are deterministic across chains, so this is fine for Pro users — relay's `/v1/subgraph` still routes them to Gnosis based on `getEffectiveTier`.
* SPA-issued register sends a deterministic per-authKey salt rather than the BIP-39 seed salt. Benign — relay does idempotent lookup by `auth_key_hash` only.
* `BASE_SEPOLIA_RPC_URL` / `GNOSIS_RPC_URL` not yet set on Railway → relay falls back to public defaults (`sepolia.base.org`, `rpc.gnosischain.com`). Override later if rate-limited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)