### PR TITLE
[ops-4-followup] Swap user-facing "writes"/"ops" → "memories" per 2026-05-18 correction

### DIFF
--- a/docs/guides/beta-tester-guide-detailed.md
+++ b/docs/guides/beta-tester-guide-detailed.md
@@ -355,7 +355,7 @@ Internal: see `~/.claude/skills/qa-totalreclaw.md` (TotalReclaw team only). Runs
 
 ### Free-tier quota exceeded (403)
 
-Reads are never metered. The cap is monthly write volume on the free tier. Upgrade to Pro: *"Upgrade my TotalReclaw subscription."* Counter resets monthly.
+Reads are never metered. The cap is monthly memory volume on the free tier. Upgrade to Pro: *"Upgrade my TotalReclaw subscription."* Counter resets monthly.
 
 ### Slow retrieval
 

--- a/docs/guides/claude-code-setup.md
+++ b/docs/guides/claude-code-setup.md
@@ -227,7 +227,7 @@ Upgrade: *"Upgrade my TotalReclaw subscription."*
 - **Agent can't see TotalReclaw tools after restart**: confirm `claude mcp list` (Claude Code) or your host's MCP UI lists `totalreclaw`. Verify `TOTALRECLAW_RECOVERY_PHRASE` is set in the config (host won't strip stderr from the spawned `mcp-server` process — check your host's MCP server logs for the `TotalReclaw configured` line). If the env var is missing, the server starts in unconfigured mode and tool calls return `{"error": "TotalReclaw is not configured"}`.
 - **"Not authenticated" / 401**: check your phrase — exact words, exact order, lowercase, single spaces.
 - **First-run is slow / model download**: the embedding model is ~600 MB, downloaded once and cached. Be patient on first call.
-- **Quota exceeded (403)**: free tier has a monthly write cap. Upgrade with *"Upgrade my TotalReclaw subscription"*.
+- **Quota exceeded (403)**: free tier has a monthly memory cap. Upgrade with *"Upgrade my TotalReclaw subscription"*.
 - **Recovery phrase appeared in chat**: file a bug. Rotate by generating a new wallet via the OpenClaw or Hermes browser account-setup flow. The leaked phrase is unrecoverable once shipped through LLM context.
 
 ---

--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -128,7 +128,7 @@ The agent never generates the recovery phrase. Only the user's browser does, via
 After credentials.json is confirmed present (step 4 above), call `totalreclaw_status` once and emit a single user-visible block containing:
 
 - A recovery-phrase backup reminder (verbatim — the user just generated it in their browser; this is the reminder to actually save it somewhere durable).
-- Current account state from `totalreclaw_status` (tier, write count, free-write limit, network).
+- Current account state from `totalreclaw_status` (tier, memory count, free-tier memory limit, network).
 - A short confirmation that the agent will now use TotalReclaw for memory operations.
 
 Emit verbatim:
@@ -137,13 +137,13 @@ Emit verbatim:
 >
 > Back up your 12-word recovery phrase NOW — store it offline (password manager, paper, hardware key). It is the only way to recover your encrypted memory vault if you lose access to this device. We cannot recover it for you.
 >
-> Account status: `<tier>` tier, `<used>` / `<limit>` writes used, stored on Gnosis mainnet. Ask me to remember anything and I'll save it to your encrypted vault.
+> Account status: `<tier>` tier, `<used>` / `<limit>` memories used, stored on Gnosis mainnet. Ask me to remember anything and I'll save it to your encrypted vault.
 
 (`<tier>`, `<used>`, `<limit>` from `totalreclaw_status`. All tiers store on Gnosis mainnet.)
 
 This block ships on first successful pair completion. On subsequent install runs where credentials already exist (early-exit in Account setup step 1), instead emit just:
 
-> ✓ TotalReclaw is already set up. Account status: `<tier>` tier, `<used>` / `<limit>` writes used, stored on Gnosis mainnet.
+> ✓ TotalReclaw is already set up. Account status: `<tier>` tier, `<used>` / `<limit>` memories used, stored on Gnosis mainnet.
 
 ---
 
@@ -179,7 +179,7 @@ These are hard rules. None of them are negotiable.
 | `totalreclaw_recall` | Retrieve memories. Always called for user-facing recall queries (see Recall behaviour above). |
 | `totalreclaw_forget` | Tombstone a memory. |
 | `totalreclaw_pin` | Pin a memory so it's surfaced in every recall. |
-| `totalreclaw_status` | Report account tier + write counts. |
+| `totalreclaw_status` | Report account tier + memory counts. |
 | `totalreclaw_export` | Export the full vault. |
 | `totalreclaw_set_scope` | Switch active scope. |
 | `totalreclaw_retype` | Change a memory's taxonomy type. |

--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -257,7 +257,7 @@ If you were on plugin 3.3.1-rc.2 or Hermes 2.3.1rc2, after upgrading also run `p
 | **Auto-extract** | Every 3 turns, extracts important facts (preferences, decisions, context) and stores them encrypted. |
 | **Pre-compaction flush** | Before the context window is compacted, all pending facts are extracted and saved. |
 | **Session debrief** | At session end, captures up to 5 session-level summaries. |
-| **Quota warning at ≥80%** | When monthly free-tier writes cross 80%, a one-line warning is injected at conversation start so you know before you hit the limit. |
+| **Quota warning at ≥80%** | When monthly free-tier memories cross 80%, a one-line warning is injected at conversation start so you know before you hit the limit. |
 
 ---
 
@@ -274,7 +274,7 @@ Ask the agent naturally; the plugin picks the right tool.
 | **Retype** | "That should be a preference, not a fact" (types: `claim`, `preference`, `directive`, `commitment`, `episode`, `summary`) |
 | **Set scope** | "File that under work" (scopes: `work`, `personal`, `health`, `family`, `creative`, `finance`, `misc`) |
 | **Export** | "Export all my TotalReclaw memories as plain text" |
-| **Status** | "What's my TotalReclaw status?" — surfaces tier, monthly writes used / limit, reset date, upgrade URL |
+| **Status** | "What's my TotalReclaw status?" — surfaces tier, monthly memories used / limit, reset date, upgrade URL |
 | **Import from** | "Import my Gemini history from ~/Downloads/..." |
 | **Account setup** | "Set up TotalReclaw for me" — returns URL + PIN |
 
@@ -297,7 +297,7 @@ See [Importing Memories](importing-memories.md).
 - **Free tier** — 250 memories/month on Gnosis mainnet. Permanent storage. Cosine dedup (paraphrase detection). E2E encrypted. No credit card required.
 - **Pro tier** — 1,500 memories/month on Gnosis mainnet. Permanent. LLM-guided dedup (catches contradictions). Custom extraction interval. Pay via the `totalreclaw_upgrade` tool or visit <https://totalreclaw.xyz/pricing>. See `totalreclaw_status` for current pricing.
 
-The plugin warns you automatically when you cross 80% of the monthly free-tier write limit (injected at conversation start). Check anytime by asking *"what's my TotalReclaw status?"* — that calls `totalreclaw_status` and reports tier, writes used, writes limit, reset date, and upgrade URL.
+The plugin warns you automatically when you cross 80% of the monthly free-tier memory limit (injected at conversation start). Check anytime by asking *"what's my TotalReclaw status?"* — that calls `totalreclaw_status` and reports tier, memories used, memory limit, reset date, and upgrade URL.
 
 Upgrade: *"Upgrade my TotalReclaw subscription."*
 

--- a/mcp/src/tools/status.ts
+++ b/mcp/src/tools/status.ts
@@ -129,7 +129,7 @@ export async function handleStatus(
     const formatted = [
       `Tier: ${tierLabel}`,
       `Smart Account: ${walletAddress}`,
-      `Writes used: ${usage}`,
+      `Memories used: ${usage}`,
       `Remaining: ${remaining}`,
       expiresLabel,
     ].join('\n');

--- a/skill-nanoclaw/README.md
+++ b/skill-nanoclaw/README.md
@@ -195,7 +195,7 @@ This makes TotalReclaw a universal memory layer across all your AI agents.
 - Check the namespace -- memories in the `work` namespace are not visible in `main`
 
 **Quota exceeded (403 errors)**
-- Free tier allows 500 writes per month. Ask the agent: "What's my TotalReclaw status?"
+- Free tier allows 250 memories per month. Ask the agent: "What's my TotalReclaw status?"
 - Upgrade to Pro: ask the agent "How do I upgrade TotalReclaw?"
 
 ## Learn More

--- a/skill-nanoclaw/SKILL.md
+++ b/skill-nanoclaw/SKILL.md
@@ -186,7 +186,7 @@ TotalReclaw has a free tier (250 memories/month on Gnosis mainnet, E2E encrypted
 
 - At conversation start (`before-agent-start`), billing status is fetched from the relay and cached for 2 hours
 - If usage exceeds 80%, a warning is injected into the agent context
-- If a write fails with quota exceeded (403), the billing cache is invalidated so the next conversation start re-fetches and warns the user
+- If a memory submission fails with quota exceeded (403), the billing cache is invalidated so the next conversation start re-fetches and warns the user
 - Use `totalreclaw_status` when the user asks about their subscription, quota, or billing
 - Use `totalreclaw_status` to check current tier and pricing. Use `totalreclaw_upgrade` to generate a Stripe checkout URL for Pro.
 

--- a/skill-nanoclaw/src/billing.ts
+++ b/skill-nanoclaw/src/billing.ts
@@ -243,7 +243,7 @@ export function getQuotaWarning(cache: BillingCache | null): string {
 
   const usageRatio = cache.free_writes_used / cache.free_writes_limit;
   if (usageRatio >= QUOTA_WARNING_THRESHOLD) {
-    return `\n\nTotalReclaw quota warning: ${cache.free_writes_used}/${cache.free_writes_limit} writes used this month (${Math.round(usageRatio * 100)}%). Use the totalreclaw_upgrade tool to upgrade to Pro.`;
+    return `\n\nTotalReclaw quota warning: ${cache.free_writes_used}/${cache.free_writes_limit} memories used this month (${Math.round(usageRatio * 100)}%). Use the totalreclaw_upgrade tool to upgrade to Pro.`;
   }
 
   return '';

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -572,7 +572,7 @@ If you need to store a memory, use the `totalreclaw_remember` tool. If you need 
 
 TotalReclaw has a free tier (250 memories/month on Gnosis mainnet, E2E encrypted, no credit card required). Pro tier raises the cap to 1,500 memories/month and adds LLM-guided dedup; see `totalreclaw_status` for current pricing. The plugin monitors quota usage automatically:
 - If usage exceeds 80%, a warning is injected into your context at conversation start
-- If a write fails with quota exceeded (403), inform the user and suggest visiting https://totalreclaw.xyz/pricing
+- If a memory submission fails with quota exceeded (403), inform the user and suggest visiting https://totalreclaw.xyz/pricing
 - Use `totalreclaw_status` when the user asks about their subscription, quota, or billing
 - After upgrading, the new tier features may take up to 2 hours to fully activate on your client due to billing cache. If you experience issues, restart your agent.
 

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -6853,7 +6853,7 @@ const plugin = {
             if (cache && cache.free_writes_limit > 0) {
               const usageRatio = cache.free_writes_used / cache.free_writes_limit;
               if (usageRatio >= QUOTA_WARNING_THRESHOLD) {
-                billingWarning = `\n\nTotalReclaw quota warning: ${cache.free_writes_used}/${cache.free_writes_limit} writes used this month (${Math.round(usageRatio * 100)}%). Visit https://totalreclaw.xyz/pricing to upgrade.`;
+                billingWarning = `\n\nTotalReclaw quota warning: ${cache.free_writes_used}/${cache.free_writes_limit} memories used this month (${Math.round(usageRatio * 100)}%). Visit https://totalreclaw.xyz/pricing to upgrade.`;
               }
             }
           } catch {

--- a/skill/src/totalreclaw-skill.ts
+++ b/skill/src/totalreclaw-skill.ts
@@ -426,7 +426,7 @@ export class TotalReclawSkill {
       if (billingData && billingData.free_writes_limit > 0) {
         const usageRatio = billingData.free_writes_used / billingData.free_writes_limit;
         if (usageRatio >= QUOTA_WARNING_THRESHOLD) {
-          billingWarning = `\n\n⚠️ TotalReclaw quota warning: ${billingData.free_writes_used}/${billingData.free_writes_limit} writes used this month (${Math.round(usageRatio * 100)}%). ` +
+          billingWarning = `\n\n⚠️ TotalReclaw quota warning: ${billingData.free_writes_used}/${billingData.free_writes_limit} memories used this month (${Math.round(usageRatio * 100)}%). ` +
             (billingData.upgrade_url ? `Upgrade: ${billingData.upgrade_url}` : 'Resets next month.');
         }
       }

--- a/skill/src/triggers/before-agent-start.ts
+++ b/skill/src/triggers/before-agent-start.ts
@@ -260,7 +260,7 @@ export async function beforeAgentStart(
     if (billingData && billingData.free_writes_limit > 0) {
       const usageRatio = billingData.free_writes_used / billingData.free_writes_limit;
       if (usageRatio >= QUOTA_WARNING_THRESHOLD) {
-        billingWarning = `\n\n⚠️ TotalReclaw quota warning: ${billingData.free_writes_used}/${billingData.free_writes_limit} writes used this month (${Math.round(usageRatio * 100)}%). ` +
+        billingWarning = `\n\n⚠️ TotalReclaw quota warning: ${billingData.free_writes_used}/${billingData.free_writes_limit} memories used this month (${Math.round(usageRatio * 100)}%). ` +
           (billingData.upgrade_url ? `Upgrade: ${billingData.upgrade_url}` : 'Resets next month.');
       }
     }


### PR DESCRIPTION
## Summary

Follow-up to PR #239 (canonical-roadmap **ops-4**, public repo). Pedro's 2026-05-18 correction on totalreclaw-internal #286 clarified that the user-facing unit must be **"memory"** everywhere, never "writes" or "operations". PR #239 already shipped the Gnosis-only tier wording cleanup; this PR sweeps up the residual user-facing copy still using "writes".

**Per Pedro's correction:** internal field names (`free_writes_used`, Stripe metadata, JSON API field shapes) stay — only the user-visible strings change.

## What changed

**User-facing docs (Gnosis-only tier copy / status):**
- `docs/guides/openclaw-setup.md` — quota-warning row, status row, automated-warning prose (lines 260/277/300)
- `docs/guides/hermes-setup.md` — opener template + status tool description (lines 131/140/146/182)
- `docs/guides/claude-code-setup.md:230` — "monthly write cap" → "monthly memory cap"
- `docs/guides/beta-tester-guide-detailed.md:358` — "monthly write volume" → "monthly memory volume"
- `skill-nanoclaw/README.md:198` — "500 writes per month" → "250 memories per month" (fixes wrong number AND wrong term — free tier is 250 per Pedro's note)

**Live agent→user quota-warning strings (the injected `TotalReclaw quota warning: X/Y …` block):**
- `skill-nanoclaw/src/billing.ts:246`
- `skill/src/triggers/before-agent-start.ts:263`
- `skill/src/totalreclaw-skill.ts:429`
- `skill/plugin/index.ts:6856`

**User-facing tool output formatting:**
- `mcp/src/tools/status.ts` — `Writes used:` → `Memories used:` in the formatted status block

**Agent-facing SKILL.md guidance (so the agent tells the user using the right unit):**
- `skill/SKILL.md:575` + `skill-nanoclaw/SKILL.md:189` — "if a write fails with quota exceeded" → "if a memory submission fails with quota exceeded"

## NOT changed (intentional)

- `free_writes_used` / `free_writes_limit` field names in TS types, JSON deserialization, DB schema, billing-cache shapes, tests
- JSON API response field names: `writes_used` / `writes_limit` / `remaining_writes` (API surface — keep stable)
- All `write to file` / `write path` / `writes credentials.json` / architectural "write" terminology
- ops-2 / ops-5 implementation impacts called out in Pedro's correction — those belong on their own canonical-roadmap issues

## Risk tier: L1 (docs + display-string copy only)

No behavior change, no schema change, no field rename. Stat: 12 files, +17 / −17.

## Done criteria

- Every user-facing reference to quota / tier limit uses "memories", not "writes" or "ops"
- `skill-nanoclaw/README.md` no longer claims 500 writes/month
- Live `before_agent_start` injected warning now says "memories used this month"

Refs p-diogo/totalreclaw-internal#286