### PR TITLE
ci(app): chain QA autopilot after preview deploys

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -90,3 +90,32 @@ jobs:
             } else {
               await github.rest.issues.createComment({ owner, repo, issue_number, body });
             }
+
+      # Fire qa-autopilot on the internal repo against this preview URL. The
+      # phrase + reporting stay private over there. Skipped if the dispatch
+      # PAT isn't configured yet (gate-by-secret-presence in the next step).
+      - name: Check internal-dispatch PAT
+        id: dispatch_gate
+        if: github.event_name == 'pull_request' && steps.deploy.outputs.deployment-url != ''
+        env:
+          PAT: ${{ secrets.INTERNAL_DISPATCH_PAT }}
+        run: |
+          if [ -n "$PAT" ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::INTERNAL_DISPATCH_PAT not set — skipping QA autopilot dispatch"
+          fi
+
+      - name: Trigger QA autopilot on totalreclaw-internal
+        if: steps.dispatch_gate.outputs.ready == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.INTERNAL_DISPATCH_PAT }}
+          PREVIEW_URL: ${{ steps.deploy.outputs.deployment-url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh workflow run qa-autopilot.yml \
+            --repo p-diogo/totalreclaw-internal \
+            --ref main \
+            --field target_url="$PREVIEW_URL" \
+            --field pr_number="$PR_NUMBER"


### PR DESCRIPTION
## Summary

After a successful preview Pages deploy, fire `gh workflow run qa-autopilot.yml` on `p-diogo/totalreclaw-internal` with the preview URL + PR number. The internal workflow runs Playwright against the URL and (on regression) opens an issue back on this repo tagged `qa-autopilot`.

Gated behind `INTERNAL_DISPATCH_PAT` — without that secret the dispatch step short-circuits with a workflow notice, so deploys keep flowing even before the QA wiring is fully provisioned.

## One-time setup (this repo, Settings → Secrets and variables → Actions)

- `INTERNAL_DISPATCH_PAT` — fine-scoped PAT with `actions: write` on **p-diogo/totalreclaw-internal** only. Used by `gh workflow run` to dispatch the QA workflow over there.

The phrase + cross-repo issue PAT live on the internal repo, not here.

## Companion PRs

- p-diogo/totalreclaw#238 — Playwright driver (`tools/qa-vault.mjs`)
- p-diogo/totalreclaw-internal PR `qa/autopilot-workflow` — the QA workflow itself

## Test plan

- [ ] Add `INTERNAL_DISPATCH_PAT` secret on this repo
- [ ] Merge the internal-repo workflow PR + #238
- [ ] Push any commit to a PR with `app/**` changes — deploy completes → QA workflow run appears on totalreclaw-internal
- [ ] Confirm regression-on-purpose triggers a `qa-autopilot` issue on this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)