### PR TITLE
feat(reranker): promote v2-lenient source weights to default (core 2.4.0)

### DIFF
--- a/docs/specs/totalreclaw/retrieval-v2.md
+++ b/docs/specs/totalreclaw/retrieval-v2.md
@@ -68,30 +68,34 @@ top N (default 8)
 
 **Change:**
 
-Add a multiplier to the final RRF score based on source:
+Add a multiplier to the final RRF score based on source. The values below
+(v2-lenient) shipped in `@totalreclaw/core@2.4.0` per the kg-1 promote
+([`docs/plans/2026-04-28-v2-lenient-promotion-proposal.md`](../../plans/2026-04-28-v2-lenient-promotion-proposal.md)).
+For the historical v1 weight matrix that shipped 2.0.0–2.2.0, see
+[Tier 1 v1 (deprecated)](#tier-1-v1-deprecated) below.
 
 ```rust
-// rust/totalreclaw-core/src/reranker.rs
+// rust/totalreclaw-core/src/reranker.rs (v2-lenient, core 2.4.0+)
 
-const SOURCE_WEIGHT: [(MemorySource, f64); 5] = [
+pub const SOURCE_WEIGHTS: &[(MemorySource, f64)] = &[
     (MemorySource::User,          1.00),  // user explicitly said it
-    (MemorySource::UserInferred,  0.90),  // extractor inferred from user signals
-    (MemorySource::Derived,       0.70),  // digest, summary, consolidation
-    (MemorySource::External,      0.70),  // imported from another system
-    (MemorySource::Assistant,     0.55),  // assistant-authored (heavy penalty)
+    (MemorySource::UserInferred,  0.95),  // extractor inferred from user signals
+    (MemorySource::Derived,       0.85),  // digest, summary, consolidation
+    (MemorySource::External,      0.85),  // imported from another system
+    (MemorySource::Assistant,     0.85),  // assistant-authored (mild penalty)
 ];
 
-fn source_weight(source: &MemorySource) -> f64 {
-    SOURCE_WEIGHT.iter()
-        .find(|(s, _)| s == source)
+pub fn source_weight(source: MemorySource) -> f64 {
+    SOURCE_WEIGHTS.iter()
+        .find(|(s, _)| *s == source)
         .map(|(_, w)| *w)
-        .unwrap_or(0.85) // unknown source = moderate penalty
+        .unwrap_or(LEGACY_CLAIM_FALLBACK_WEIGHT) // 0.85, for missing-source candidates
 }
 
 pub fn rerank(candidates: &[Candidate], query: &Query) -> Vec<ScoredCandidate> {
     // ... existing BM25 + cosine + RRF ...
     for scored in &mut scored_candidates {
-        scored.final_score *= source_weight(&scored.claim.source);
+        scored.final_score *= source_weight(scored.claim.source);
     }
     scored_candidates.sort_by(|a, b| b.final_score.partial_cmp(&a.final_score).unwrap());
     scored_candidates.truncate(query.top_k);
@@ -99,9 +103,12 @@ pub fn rerank(candidates: &[Candidate], query: &Query) -> Vec<ScoredCandidate> {
 }
 ```
 
-**Weight calibration:**
+**Weight calibration (v2-lenient):**
 
-Exact values TBD during E13 retrieval benchmark. Above defaults are starting guess.
+Bench-validated across 3+ corpora (LongMemEval-500 big-vault, Gemini big-vault,
+ChatGPT-export big-vault) per the v2-lenient promotion proposal. Net effect
+when paired with B1 entity-trapdoors: +3 pp accuracy overall, +50 pp on
+assistant-sourced recall, no measured loss on any corpus.
 
 Constraints:
 - `user` = 1.0 (anchor — never penalize explicit user statements)
@@ -109,6 +116,31 @@ Constraints:
 - Never drop to zero — all facts remain eligible for top-k
 
 **Effort:** ~20 lines + 10 tests. 1 day including calibration on benchmark data.
+
+### Tier 1 v1 (deprecated)
+
+Shipped in `@totalreclaw/core@2.0.0` through `2.2.0`. Replaced by v2-lenient
+in core 2.4.0. The legacy weight matrix is preserved as
+`SOURCE_WEIGHTS_V1_LEGACY` in `rust/totalreclaw-core/src/reranker.rs` for
+back-compat / benchmark spike work; production callers MUST consume the
+default `SOURCE_WEIGHTS` (v2-lenient) above.
+
+```rust
+// v1 (pre-2.4.0). Retained as SOURCE_WEIGHTS_V1_LEGACY.
+pub const SOURCE_WEIGHTS_V1_LEGACY: &[(MemorySource, f64)] = &[
+    (MemorySource::User,          1.00),
+    (MemorySource::UserInferred,  0.90),
+    (MemorySource::Derived,       0.70),
+    (MemorySource::External,      0.70),
+    (MemorySource::Assistant,     0.55),  // heavy penalty (v1)
+];
+```
+
+Why v1 was replaced: the heavy penalty on assistant-sourced facts (0.55)
+disproportionately penalized recalled facts that were extracted from
+assistant turns, even when the underlying content was user-confirmed. v2-lenient
+compresses the gap, retaining provenance ordering but letting strong-signal
+assistant-source facts surface when the user query targets them.
 
 **Test vectors:**
 - Query "Bangkok hotel" against Pipeline F vault. Expected top-1: `source:assistant` claim "Sheraton Grande Sukhumvit" beats user turn "I want to go to Bangkok" (because former has high cosine + specific entity).
@@ -252,7 +284,7 @@ All 5 clients share `@totalreclaw/core` reranker. Change once, ships everywhere.
 ## Testing strategy
 
 **Unit tests (Tier 1, MUST):**
-- Weight application correctness (user score unchanged, assistant score ×0.55, etc.)
+- Weight application correctness (user score unchanged, assistant score ×0.85 v2-lenient / ×0.55 v1, etc.)
 - Total ordering preservation (no equal-score instability)
 - Edge case: missing source field defaults to moderate penalty
 - Edge case: all candidates source=assistant → ordering still reflects base score
@@ -270,7 +302,7 @@ All 5 clients share `@totalreclaw/core` reranker. Change once, ships everywhere.
 ## Open items
 
 1. **Source weight calibration** — values above are starting guess. Tune during E13 or via A/B against small beta cohort.
-2. **Tier boundary: where does `derived` sit?** Digests/summaries are authoritative reductions of user facts, not noise. Current draft = 0.70 (below user-inferred). Alternative: equal to user (1.0) since derived items are computed from user content. Decide with concrete examples during implementation.
+2. **Tier boundary: where does `derived` sit?** Digests/summaries are authoritative reductions of user facts, not noise. v1 draft = 0.70 (below user-inferred); v2-lenient bumped this to 0.85 (equal to assistant + external) based on bench data — the heavy v1 penalty on derived content was empirically over-aggressive. Alternative still open: equal to user (1.0) since derived items are computed from user content. Decide with concrete bench data when next E13 calibration runs.
 3. **Handling legacy vaults post-v1** — users who stored under v0 (no source field) get `source: user-inferred` by default at normalization? Or fail-safe to `assistant` (most penalized)? Need backward-compat decision at migration.
 4. **Intent extractor LLM vs regex** — Tier 2-4 can use either. LLM = more accurate but +1 call per query. Regex = free but brittle. Start regex.
 5. **Source weight user override** — should users be able to re-weight globally ("I want assistant-authored facts to rank as high as user")? Probably no in v1. Reopen if demand.

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -39,7 +39,7 @@
     "@noble/hashes": "^2.0.1",
     "@scure/bip39": "^2.0.1",
     "@totalreclaw/client": "^1.3.0",
-    "@totalreclaw/core": "^2.0.0",
+    "@totalreclaw/core": "2.4.0-rc.1",
     "permissionless": "^0.3.4",
     "porter-stemmer": "^0.9.1",
     "tslib": "^2.8.1",

--- a/mcp/tests/recall-source-weight.test.ts
+++ b/mcp/tests/recall-source-weight.test.ts
@@ -66,7 +66,8 @@ describe('handleRecall — Retrieval v2 Tier 1 source weighting', () => {
     const body = JSON.parse(out.content[0].text);
     expect(body.memories).toHaveLength(2);
 
-    // User claim must rank first because sourceWeight(user)=1.0, sourceWeight(assistant)=0.55.
+    // User claim must rank first because sourceWeight(user)=1.0,
+    // sourceWeight(assistant)=0.85 (v2-lenient, core 2.4.0+).
     expect(body.memories[0].fact_id).toBe('user-fact-id');
     expect(body.memories[0].source).toBe('user');
     expect(body.memories[1].fact_id).toBe('assistant-fact-id');
@@ -75,7 +76,7 @@ describe('handleRecall — Retrieval v2 Tier 1 source weighting', () => {
     // Weighted scores reflect the multiplier.
     expect(body.memories[0].score).toBeGreaterThan(body.memories[1].score);
     expect(body.memories[0].source_weight).toBe(1.0);
-    expect(body.memories[1].source_weight).toBe(0.55);
+    expect(body.memories[1].source_weight).toBe(0.85);
   });
 
   test('unspecified / missing source falls back to legacy fallback weight', async () => {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     # Upper bound stays at <3.0.0 to match the TypeScript clients'
     # `^2.0.0` semver semantics — a future core@3 will be a breaking
     # change and must bump this constraint in lockstep.
-    "totalreclaw-core>=2.2.0,<3.0.0",
+    "totalreclaw-core==2.4.0rc1",
     "httpx>=0.27",
     "onnxruntime>=1.24",
     "numpy>=1.26",

--- a/python/tests/test_reranker.py
+++ b/python/tests/test_reranker.py
@@ -63,18 +63,19 @@ class TestCosineSimilarity:
 
 
 class TestSourceWeight:
+    # v2-lenient (core 2.4.0+) — per docs/specs/totalreclaw/retrieval-v2.md §Tier 1.
     def test_user_is_one(self) -> None:
         assert source_weight("user") == 1.0
 
     def test_user_inferred(self) -> None:
-        assert source_weight("user-inferred") == pytest.approx(0.9, abs=1e-3)
+        assert source_weight("user-inferred") == pytest.approx(0.95, abs=1e-3)
 
     def test_derived_and_external(self) -> None:
-        assert source_weight("derived") == pytest.approx(0.7, abs=1e-3)
-        assert source_weight("external") == pytest.approx(0.7, abs=1e-3)
+        assert source_weight("derived") == pytest.approx(0.85, abs=1e-3)
+        assert source_weight("external") == pytest.approx(0.85, abs=1e-3)
 
     def test_assistant(self) -> None:
-        assert source_weight("assistant") == pytest.approx(0.55, abs=1e-3)
+        assert source_weight("assistant") == pytest.approx(0.85, abs=1e-3)
 
     def test_none_falls_back_to_legacy(self) -> None:
         assert source_weight(None) == LEGACY_CLAIM_FALLBACK_WEIGHT
@@ -173,7 +174,8 @@ class TestRerank:
                          apply_source_weights=True)
         assert results[0].id == "user"
         assert results[0].source_weight == pytest.approx(1.0, abs=1e-3)
-        assert results[1].source_weight == pytest.approx(0.55, abs=1e-3)
+        # v2-lenient (core 2.4.0+): assistant=0.85, not v1's 0.55.
+        assert results[1].source_weight == pytest.approx(0.85, abs=1e-3)
 
     def test_apply_source_weights_false_leaves_weight_none(self) -> None:
         emb = [1.0, 0.0]

--- a/python/tests/test_v1_parity.py
+++ b/python/tests/test_v1_parity.py
@@ -145,11 +145,12 @@ def test_core_parse_memory_type_v1_passthrough(v1_type: str) -> None:
 @pytest.mark.parametrize(
     "source,expected",
     [
+        # v2-lenient (core 2.4.0+) — per docs/specs/totalreclaw/retrieval-v2.md §Tier 1.
         ("user", 1.0),
-        ("user-inferred", 0.9),
-        ("external", 0.7),
-        ("derived", 0.7),
-        ("assistant", 0.55),
+        ("user-inferred", 0.95),
+        ("external", 0.85),
+        ("derived", 0.85),
+        ("assistant", 0.85),
     ],
 )
 def test_python_source_weight_matches_core(source: str, expected: float) -> None:

--- a/python/tests/test_v1_taxonomy.py
+++ b/python/tests/test_v1_taxonomy.py
@@ -407,12 +407,13 @@ def test_parse_facts_response_for_compaction_floor_5() -> None:
 # ---------------------------------------------------------------------------
 
 
+# v2-lenient (core 2.4.0+) — per docs/specs/totalreclaw/retrieval-v2.md §Tier 1.
 def test_source_weight_user_is_1() -> None:
     assert source_weight("user") == 1.0
 
 
-def test_source_weight_assistant_is_0_55() -> None:
-    assert source_weight("assistant") == pytest.approx(0.55, abs=0.001)
+def test_source_weight_assistant_is_0_85_v2_lenient() -> None:
+    assert source_weight("assistant") == pytest.approx(0.85, abs=0.001)
 
 
 def test_source_weight_legacy_none_fallback() -> None:
@@ -420,8 +421,8 @@ def test_source_weight_legacy_none_fallback() -> None:
     assert LEGACY_CLAIM_FALLBACK_WEIGHT == 0.85
 
 
-def test_source_weight_user_inferred_is_0_9() -> None:
-    assert source_weight("user-inferred") == pytest.approx(0.9, abs=0.001)
+def test_source_weight_user_inferred_is_0_95_v2_lenient() -> None:
+    assert source_weight("user-inferred") == pytest.approx(0.95, abs=0.001)
 
 
 def test_rerank_with_source_weights_promotes_user_over_assistant() -> None:
@@ -458,7 +459,8 @@ def test_rerank_with_source_weights_promotes_user_over_assistant() -> None:
     assert results[0].source == "user"
     assert results[0].source_weight == 1.0
     assert results[1].source == "assistant"
-    assert results[1].source_weight == pytest.approx(0.55, abs=0.001)
+    # v2-lenient (core 2.4.0+): assistant=0.85, not v1's 0.55.
+    assert results[1].source_weight == pytest.approx(0.85, abs=0.001)
 
 
 def test_rerank_without_source_weights_omits_weight_field() -> None:

--- a/rust/totalreclaw-core/Cargo.toml
+++ b/rust/totalreclaw-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "totalreclaw-core"
-version = "2.2.0"
+version = "2.4.0"
 edition = "2021"
 description = "TotalReclaw core — E2EE crypto, reranker, wallet, UserOp, store/search pipelines. Single source of truth for all clients."
 license = "MIT"

--- a/rust/totalreclaw-core/pyproject.toml
+++ b/rust/totalreclaw-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "totalreclaw-core"
-version = "2.2.0"
+version = "2.4.0"
 description = "TotalReclaw crypto core — E2EE, LSH, blind indices, protobuf encoding (Rust)"
 requires-python = ">=3.10"
 license = { text = "MIT" }

--- a/rust/totalreclaw-core/src/python.rs
+++ b/rust/totalreclaw-core/src/python.rs
@@ -2172,22 +2172,23 @@ mod tests {
 
     #[test]
     fn py_source_weight_known_values() {
+        // v2-lenient (core 2.4.0+) — per docs/specs/totalreclaw/retrieval-v2.md §Tier 1.
         // Direct call — no GIL needed because py_source_weight returns f64.
         assert_eq!(py_source_weight("user"), 1.00);
-        assert_eq!(py_source_weight("user-inferred"), 0.90);
-        assert_eq!(py_source_weight("derived"), 0.70);
-        assert_eq!(py_source_weight("external"), 0.70);
-        assert_eq!(py_source_weight("assistant"), 0.55);
+        assert_eq!(py_source_weight("user-inferred"), 0.95);
+        assert_eq!(py_source_weight("derived"), 0.85);
+        assert_eq!(py_source_weight("external"), 0.85);
+        assert_eq!(py_source_weight("assistant"), 0.85);
     }
 
     #[test]
     fn py_source_weight_unknown_returns_fallback() {
-        // Policy: unknown source string -> user-inferred (0.90), not 0.85.
-        // 0.85 is ONLY the fallback for missing-source candidates in the
-        // reranker. The binding here maps string -> MemorySource -> weight,
+        // Policy: unknown source string -> user-inferred (v2-lenient 0.95),
+        // not 0.85. The 0.85 fallback is ONLY for missing-source candidates in
+        // the reranker. The binding here maps string -> MemorySource -> weight,
         // and from_str_lossy routes unknowns to UserInferred.
-        assert_eq!(py_source_weight("bot"), 0.90);
-        assert_eq!(py_source_weight(""), 0.90);
+        assert_eq!(py_source_weight("bot"), 0.95);
+        assert_eq!(py_source_weight(""), 0.95);
     }
 
     #[test]

--- a/rust/totalreclaw-core/src/reranker.rs
+++ b/rust/totalreclaw-core/src/reranker.rs
@@ -36,10 +36,30 @@ const RRF_K: f64 = 60.0;
 /// Source-weight multipliers applied to the final fused score when
 /// [`RerankerConfig::apply_source_weights`] is enabled.
 ///
+/// **v2-lenient (core 2.4.0+, default):** bench-validated across 3+ corpora
+/// per `docs/plans/2026-04-28-v2-lenient-promotion-proposal.md`. Net effect:
+/// strictly improves on v1 when B1 entity-trapdoors are on (+3pp acc, +50pp
+/// on assistant-source recall) and matches v1 when B1 is off — no loss on
+/// any corpus measured (LongMemEval-500, Gemini, ChatGPT-export big-vault).
+///
 /// Values sourced from `docs/specs/totalreclaw/retrieval-v2.md` §Tier 1. The
 /// array is sorted highest-to-lowest trust; values MUST NOT be edited without
 /// updating the spec + recalibrating via the E13 retrieval benchmark.
 pub const SOURCE_WEIGHTS: &[(MemorySource, f64)] = &[
+    (MemorySource::User, 1.00),
+    (MemorySource::UserInferred, 0.95),
+    (MemorySource::Derived, 0.85),
+    (MemorySource::External, 0.85),
+    (MemorySource::Assistant, 0.85),
+];
+
+/// Legacy v1 source-weight multipliers retained for back-compat / spike work.
+///
+/// Pre-2.4.0 default. Kept exported so callers that want to compare v1 vs
+/// v2-lenient ranking (e.g. the retrieval-benchmark harness) can opt in
+/// without re-implementing the table. Production callers MUST use
+/// [`SOURCE_WEIGHTS`] (v2-lenient).
+pub const SOURCE_WEIGHTS_V1_LEGACY: &[(MemorySource, f64)] = &[
     (MemorySource::User, 1.00),
     (MemorySource::UserInferred, 0.90),
     (MemorySource::Derived, 0.70),
@@ -50,8 +70,12 @@ pub const SOURCE_WEIGHTS: &[(MemorySource, f64)] = &[
 /// Fallback weight applied to candidates that have no `source` field.
 ///
 /// Used for legacy v0 claims written before Memory Taxonomy v1 introduced
-/// the `source` axis. Value (0.85) sits between `user-inferred` (0.90) and
-/// `derived` / `external` (0.70) — mild penalty without erasing legacy data.
+/// the `source` axis. Value (0.85) sits below `user` (1.00) /
+/// `user-inferred` (0.95) and equals the v2-lenient floor for
+/// derived / external / assistant — mild penalty for unknown provenance
+/// without erasing legacy data. (Under the prior v1 weight matrix, 0.85
+/// sat between `user-inferred` 0.90 and `derived`/`external` 0.70; same
+/// numeric value, slightly different relative position post-v2-lenient.)
 pub const LEGACY_CLAIM_FALLBACK_WEIGHT: f64 = 0.85;
 
 /// Return the source-weight multiplier for a known [`MemorySource`].
@@ -486,11 +510,25 @@ mod tests {
 
     #[test]
     fn test_source_weight_table_matches_spec() {
+        // v2-lenient (core 2.4.0+) — per docs/specs/totalreclaw/retrieval-v2.md §Tier 1.
         assert_eq!(source_weight(MemorySource::User), 1.00);
-        assert_eq!(source_weight(MemorySource::UserInferred), 0.90);
-        assert_eq!(source_weight(MemorySource::Derived), 0.70);
-        assert_eq!(source_weight(MemorySource::External), 0.70);
-        assert_eq!(source_weight(MemorySource::Assistant), 0.55);
+        assert_eq!(source_weight(MemorySource::UserInferred), 0.95);
+        assert_eq!(source_weight(MemorySource::Derived), 0.85);
+        assert_eq!(source_weight(MemorySource::External), 0.85);
+        assert_eq!(source_weight(MemorySource::Assistant), 0.85);
+    }
+
+    #[test]
+    fn test_source_weights_v1_legacy_preserved() {
+        // Legacy v1 const kept exported for back-compat / benchmark spike work.
+        // Production callers must not consume this — use [`SOURCE_WEIGHTS`].
+        let v1: std::collections::HashMap<_, _> =
+            SOURCE_WEIGHTS_V1_LEGACY.iter().copied().collect();
+        assert_eq!(v1[&MemorySource::User], 1.00);
+        assert_eq!(v1[&MemorySource::UserInferred], 0.90);
+        assert_eq!(v1[&MemorySource::Derived], 0.70);
+        assert_eq!(v1[&MemorySource::External], 0.70);
+        assert_eq!(v1[&MemorySource::Assistant], 0.55);
     }
 
     #[test]
@@ -579,14 +617,14 @@ mod tests {
             "user source must outrank assistant on base-score tie"
         );
         assert_eq!(ranked[1].id, "a");
-        // Sanity-check the per-result source_weight field.
+        // Sanity-check the per-result source_weight field (v2-lenient).
         assert!((ranked[0].source_weight - 1.00).abs() < 1e-12);
-        assert!((ranked[1].source_weight - 0.55).abs() < 1e-12);
-        // Assistant score must be ~55% of user score on tie.
+        assert!((ranked[1].source_weight - 0.85).abs() < 1e-12);
+        // Assistant score must be ~85% of user score on tie (v2-lenient ratio).
         let ratio = ranked[1].score / ranked[0].score;
         assert!(
-            (ratio - 0.55).abs() < 1e-6,
-            "assistant/user ratio should equal 0.55, got {}",
+            (ratio - 0.85).abs() < 1e-6,
+            "assistant/user ratio should equal 0.85 (v2-lenient), got {}",
             ratio
         );
     }
@@ -618,7 +656,7 @@ mod tests {
             ranked[0].score > 0.0,
             "assistant score must not drop to zero"
         );
-        assert!((ranked[0].source_weight - 0.55).abs() < 1e-12);
+        assert!((ranked[0].source_weight - 0.85).abs() < 1e-12);
     }
 
     #[test]
@@ -699,16 +737,24 @@ mod tests {
             );
         }
 
-        // And the canonical ordering: user (1.00) > inferred (0.90) > ext/derived
-        // (0.70) > assistant (0.55). All base scores are equal, so source
-        // weight is the only discriminator.
+        // v2-lenient canonical ordering: user (1.00) > inferred (0.95) >
+        // derived / ext / assistant (all 0.85). All base scores are equal, so
+        // source weight is the only discriminator. Three-way 0.85 tie resolves
+        // via stable input-order tie-break — assistant entered as "asst"
+        // candidate first in the vec above, before derived + ext.
         let ids: Vec<_> = on.iter().map(|r| r.id.as_str()).collect();
         assert_eq!(ids[0], "user");
         assert_eq!(ids[1], "inferred");
-        // derived and ext both at 0.70 — deterministic tie-break on id.
-        assert_eq!(ids[2], "derived");
-        assert_eq!(ids[3], "ext");
-        assert_eq!(ids[4], "asst");
+        // Three-way 0.85 tie (asst / derived / ext) — order is
+        // implementation-defined but stable. Assert membership of the tail
+        // rather than a specific permutation.
+        let tail: std::collections::HashSet<&str> = ids[2..5].iter().copied().collect();
+        let expected_tail: std::collections::HashSet<&str> =
+            ["asst", "derived", "ext"].iter().copied().collect();
+        assert_eq!(
+            tail, expected_tail,
+            "v2-lenient: asst/derived/ext tie at 0.85 — all three must occupy the tail"
+        );
     }
 
     #[test]
@@ -747,12 +793,26 @@ mod tests {
         )
         .unwrap();
 
-        // On a three-way tie the legacy fallback (0.85) sits between assistant (0.55)
-        // and user (1.00) — so the ordering MUST be user > legacy > assistant.
+        // v2-lenient: legacy fallback (0.85) ties with assistant (0.85), both
+        // ranked under user (1.00). User must come first; legacy + assistant
+        // tie at second/third on stable tie-break.
         assert_eq!(ranked[0].id, "user");
-        assert_eq!(ranked[1].id, "legacy");
-        assert_eq!(ranked[2].id, "asst");
-        assert!((ranked[1].source_weight - LEGACY_CLAIM_FALLBACK_WEIGHT).abs() < 1e-12);
+        let tail: std::collections::HashSet<&str> =
+            [ranked[1].id.as_str(), ranked[2].id.as_str()].into_iter().collect();
+        let expected_tail: std::collections::HashSet<&str> =
+            ["legacy", "asst"].into_iter().collect();
+        assert_eq!(
+            tail, expected_tail,
+            "v2-lenient: legacy + assistant tie at 0.85 — both must occupy the tail"
+        );
+        // Whichever of legacy/asst placed second must carry the correct weight.
+        for r in &ranked[1..=2] {
+            if r.id == "legacy" {
+                assert!((r.source_weight - LEGACY_CLAIM_FALLBACK_WEIGHT).abs() < 1e-12);
+            } else {
+                assert!((r.source_weight - 0.85).abs() < 1e-12);
+            }
+        }
     }
 
     #[test]
@@ -812,10 +872,11 @@ mod tests {
             "uniform source must not change relative ordering"
         );
 
-        // And every score in the weighted run must equal the unweighted score times 0.55.
+        // And every score in the weighted run must equal the unweighted score times 0.85
+        // (v2-lenient assistant weight).
         for (w, u) in on.iter().zip(off.iter()) {
-            assert!((w.score - u.score * 0.55).abs() < 1e-12);
-            assert!((w.source_weight - 0.55).abs() < 1e-12);
+            assert!((w.score - u.score * 0.85).abs() < 1e-12);
+            assert!((w.source_weight - 0.85).abs() < 1e-12);
         }
     }
 

--- a/rust/totalreclaw-core/src/wasm.rs
+++ b/rust/totalreclaw-core/src/wasm.rs
@@ -406,8 +406,8 @@ pub fn wasm_rerank_with_config(
 /// Accepted values: "user" | "user-inferred" | "assistant" | "external" | "derived".
 ///
 /// Unknown input is routed through `MemorySource::from_str_lossy` which
-/// falls back to `user-inferred` (weight 0.90). Callers who need the
-/// "no source field at all" fallback (weight 0.85) should call
+/// falls back to `user-inferred` (v2-lenient weight 0.95). Callers who need
+/// the "no source field at all" fallback (weight 0.85) should call
 /// `legacyClaimFallbackWeight()` instead.
 #[wasm_bindgen(js_name = "sourceWeight")]
 pub fn wasm_source_weight(source: &str) -> f64 {

--- a/skill/plugin/package-lock.json
+++ b/skill/plugin/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.12-rc.1",
+  "version": "3.3.12-rc.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/totalreclaw",
-      "version": "3.3.12-rc.1",
+      "version": "3.3.12-rc.10",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@scure/bip39": "^2.2.0",
-        "@totalreclaw/client": "^1.2.0",
-        "@totalreclaw/core": "^2.1.1",
+        "@totalreclaw/client": "^1.3.0",
+        "@totalreclaw/core": "2.4.0-rc.1",
         "@types/qrcode": "^1.5.6",
         "@types/ws": "^8.5.12",
         "qrcode": "^1.5.4",
@@ -615,26 +616,6 @@
         "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/@mapbox/node-pre-gyp": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
-      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "make-dir": "^3.1.0",
-        "node-fetch": "^2.6.7",
-        "nopt": "^5.0.0",
-        "npmlog": "^5.0.1",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "tar": "^6.1.11"
-      },
-      "bin": {
-        "node-pre-gyp": "bin/node-pre-gyp"
-      }
-    },
     "node_modules/@noble/ciphers": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
@@ -684,15 +665,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@phc/format": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
-      "integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -817,16 +789,16 @@
       }
     },
     "node_modules/@totalreclaw/client": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@totalreclaw/client/-/client-1.2.0.tgz",
-      "integrity": "sha512-aH6XjksnPYIwmqcWslNK+YwlqG5S9TGv1Bzq4yiZZHgfZ1UBd/hUVd6rwrd2ToGIWFM7y0KCjIV0OrU4BMHjJQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@totalreclaw/client/-/client-1.3.0.tgz",
+      "integrity": "sha512-nFCk3eNKuJp5h74zFkkTjpExBnlkUSuyNbUoo3dVAxVskvtQIxhTVNkDEFVgeImqZR6klh64YRbJ+nhjgp9iDQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.0.1",
+        "@noble/hashes": "^2.0.1",
         "@scure/bip39": "^2.0.1",
         "@totalreclaw/core": "^1.1.0",
-        "argon2": "^0.31.0",
         "permissionless": "^0.3.4",
         "protobufjs": "^7.2.5",
         "viem": "^2.46.3"
@@ -845,9 +817,9 @@
       "license": "MIT"
     },
     "node_modules/@totalreclaw/core": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@totalreclaw/core/-/core-2.2.0.tgz",
-      "integrity": "sha512-r3rUJGk0HJpOKyxXmswhoepJGko23qPibkYHeL66x1RBPMBmClFme8bjW7G/pEuoRvwjgYRJbwRA1Z/OhgXaYg==",
+      "version": "2.4.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@totalreclaw/core/-/core-2.4.0-rc.1.tgz",
+      "integrity": "sha512-QYxt7wwNoZtR0gn6H0MK77nRFrhmDFU6WPde5d2wx84CMqs06OGT5yPwrtB7PSdytpg6Pf2Dql6p/C3s59Hpww==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -876,12 +848,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "license": "ISC"
     },
     "node_modules/abitype": {
       "version": "1.2.3",
@@ -913,18 +879,6 @@
         "node": ">=12.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -948,47 +902,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/aproba": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
-      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
-      "license": "ISC"
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
-      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/argon2": {
-      "version": "0.31.2",
-      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.31.2.tgz",
-      "integrity": "sha512-QSnJ8By5Mth60IEte45w9Y7v6bWcQw3YhRtJKKN8oNCxnTLDiv/AXXkDPf2srTMfxFVn3QJdVv2nhXESsUa+Yg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.11",
-        "@phc/format": "^1.0.0",
-        "node-addon-api": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1030,16 +943,6 @@
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT"
     },
-    "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -1074,15 +977,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/cliui": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -1111,44 +1005,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
-    },
-    "node_modules/color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "license": "ISC",
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "license": "MIT"
-    },
-    "node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-      "license": "ISC"
-    },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
     },
     "node_modules/decamelize": {
       "version": "1.2.0",
@@ -1218,12 +1074,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1340,57 +1190,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "license": "ISC"
-    },
-    "node_modules/gauge": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
-      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.2",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.1",
-        "object-assign": "^4.1.1",
-        "signal-exit": "^3.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -1406,27 +1205,6 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/global-agent": {
       "version": "4.1.3",
@@ -1490,25 +1268,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "license": "ISC"
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -1530,22 +1289,12 @@
       "license": "BSD-3-Clause",
       "optional": true
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -1621,30 +1370,6 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
-    "node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/matcher": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-4.0.0.tgz",
@@ -1674,18 +1399,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -1696,64 +1409,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
@@ -1775,69 +1436,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "license": "MIT"
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/nopt": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/npmlog": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
-      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "dependencies": {
-        "are-we-there-yet": "^2.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^3.0.0",
-        "set-blocking": "^2.0.0"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -1852,6 +1450,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -2010,15 +1609,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/permissionless": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/permissionless/-/permissionless-0.3.5.tgz",
@@ -2158,6 +1748,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -2181,22 +1772,6 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "license": "ISC"
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/roarr": {
       "version": "2.15.4",
@@ -2233,7 +1808,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -2319,12 +1895,6 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
-    },
     "node_modules/simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
@@ -2383,6 +1953,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -2423,24 +1994,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -2477,12 +2030,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -2521,7 +2068,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -2541,7 +2088,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/viem": {
       "version": "2.48.8",
@@ -2628,36 +2176,11 @@
         }
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/which-module": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "license": "ISC"
-    },
-    "node_modules/wide-align": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
     },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",
@@ -2677,7 +2200,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/ws": {
       "version": "8.20.0",
@@ -2704,12 +2228,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "license": "ISC"
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
     },
     "node_modules/yargs": {

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@scure/bip39": "^2.2.0",
     "@totalreclaw/client": "^1.3.0",
-    "@totalreclaw/core": "^2.1.1",
+    "@totalreclaw/core": "2.4.0-rc.1",
     "@types/qrcode": "^1.5.6",
     "@types/ws": "^8.5.12",
     "qrcode": "^1.5.4",

--- a/skill/plugin/reranker.test.ts
+++ b/skill/plugin/reranker.test.ts
@@ -68,11 +68,12 @@ console.log('# cosineSimilarity');
 console.log('# getSourceWeight');
 
 {
+  // v2-lenient (core 2.4.0+) — per docs/specs/totalreclaw/retrieval-v2.md §Tier 1.
   assert(getSourceWeight('user') === 1.0, 'sourceWeight: user = 1.0');
-  assert(getSourceWeight('user-inferred') === 0.9, 'sourceWeight: user-inferred = 0.9');
-  assert(getSourceWeight('derived') === 0.7, 'sourceWeight: derived = 0.7');
-  assert(getSourceWeight('external') === 0.7, 'sourceWeight: external = 0.7');
-  assert(getSourceWeight('assistant') === 0.55, 'sourceWeight: assistant = 0.55');
+  assert(getSourceWeight('user-inferred') === 0.95, 'sourceWeight: user-inferred = 0.95');
+  assert(getSourceWeight('derived') === 0.85, 'sourceWeight: derived = 0.85');
+  assert(getSourceWeight('external') === 0.85, 'sourceWeight: external = 0.85');
+  assert(getSourceWeight('assistant') === 0.85, 'sourceWeight: assistant = 0.85');
   assert(getSourceWeight(undefined) === 0.85, 'sourceWeight: undefined -> 0.85 (legacy fallback)');
 }
 
@@ -138,7 +139,7 @@ console.log('# rerank (core delegation)');
 }
 
 {
-  // applySourceWeights=true: user (1.0) beats assistant (0.55) on tied content
+  // applySourceWeights=true: user (1.0) beats assistant (0.85, v2-lenient) on tied content
   const embedding = new Array(8).fill(0).map((_, i) => (i % 3) * 0.1);
   const candidates: RerankerCandidate[] = [
     { id: 'asst', text: 'prefers PostgreSQL for analytics', embedding, source: 'assistant' },
@@ -147,7 +148,7 @@ console.log('# rerank (core delegation)');
   const ranked = rerank('PostgreSQL analytics', embedding, candidates, 2, undefined, true);
   assert(ranked[0].id === 'user', 'rerank: user > assistant w/ source weights');
   assertClose(ranked[0].sourceWeight ?? 0, 1.0, 1e-6, 'rerank: user weight = 1.0');
-  assertClose(ranked[1].sourceWeight ?? 0, 0.55, 1e-6, 'rerank: assistant weight = 0.55');
+  assertClose(ranked[1].sourceWeight ?? 0, 0.85, 1e-6, 'rerank: assistant weight = 0.85 (v2-lenient)');
 }
 
 {

--- a/skill/plugin/reranker.ts
+++ b/skill/plugin/reranker.ts
@@ -286,12 +286,16 @@ export interface RerankerResult extends RerankerCandidate {
 // of truth and will be used directly by MCP/Python adapters.
 // ---------------------------------------------------------------------------
 
+// v2-lenient (core 2.4.0+, default). Bench-validated across 3+ corpora per
+// docs/plans/2026-04-28-v2-lenient-promotion-proposal.md. Mirrors
+// `SOURCE_WEIGHTS` in rust/totalreclaw-core/src/reranker.rs — values MUST
+// stay in lockstep or the cross-runtime parity test fails.
 const SOURCE_WEIGHTS: Record<string, number> = {
   'user': 1.0,
-  'user-inferred': 0.9,
-  'derived': 0.7,
-  'external': 0.7,
-  'assistant': 0.55,
+  'user-inferred': 0.95,
+  'derived': 0.85,
+  'external': 0.85,
+  'assistant': 0.85,
 };
 
 const LEGACY_FALLBACK_WEIGHT = 0.85;
@@ -383,9 +387,10 @@ export function applyMMR(
  *
  * When `applySourceWeights` is true, the final RRF score for each candidate
  * is multiplied by a Retrieval v2 Tier 1 source weight based on the
- * candidate's `source` field (user=1.0, user-inferred=0.9, derived/external=0.7,
- * assistant=0.55). Candidates without a `source` field use the legacy
- * fallback weight (0.85). This is the flag equivalent of core
+ * candidate's `source` field. v2-lenient (core 2.4.0+, default):
+ * user=1.0, user-inferred=0.95, derived/external/assistant=0.85.
+ * Candidates without a `source` field use the legacy fallback weight (0.85).
+ * This is the flag equivalent of core
  * `rerankWithConfig(.., apply_source_weights=true)`.
  */
 export function rerank(
@@ -494,7 +499,7 @@ export function rerank(
   }
 
   // When source weights are applied the RRF-scaled scores may no longer be in
-  // descending order (weighted=0.55 assistant could slip below a weighted=1.0
+  // descending order (weighted=0.85 assistant could slip below a weighted=1.0
   // user fact that was originally ranked lower). Re-sort so the top-K picked
   // by MMR is meaningful.
   if (applySourceWeights) {

--- a/skill/plugin/v1-taxonomy.test.ts
+++ b/skill/plugin/v1-taxonomy.test.ts
@@ -459,13 +459,14 @@ assertEq(
 // getSourceWeight — Retrieval v2 Tier 1 table
 // ---------------------------------------------------------------------------
 
+// v2-lenient (core 2.4.0+) — per docs/specs/totalreclaw/retrieval-v2.md §Tier 1.
 assertEq(getSourceWeight('user'), 1.0, 'sourceWeight: user = 1.0');
-assertEq(getSourceWeight('user-inferred'), 0.9, 'sourceWeight: user-inferred = 0.9');
-assertEq(getSourceWeight('derived'), 0.7, 'sourceWeight: derived = 0.7');
-assertEq(getSourceWeight('external'), 0.7, 'sourceWeight: external = 0.7');
-assertEq(getSourceWeight('assistant'), 0.55, 'sourceWeight: assistant = 0.55');
+assertEq(getSourceWeight('user-inferred'), 0.95, 'sourceWeight: user-inferred = 0.95');
+assertEq(getSourceWeight('derived'), 0.85, 'sourceWeight: derived = 0.85');
+assertEq(getSourceWeight('external'), 0.85, 'sourceWeight: external = 0.85');
+assertEq(getSourceWeight('assistant'), 0.85, 'sourceWeight: assistant = 0.85');
 assertEq(getSourceWeight(undefined), 0.85, 'sourceWeight: missing = 0.85 (legacy fallback)');
-assertEq(getSourceWeight('unknown'), 0.9, 'sourceWeight: unknown = 0.9 (core falls back to user-inferred via from_str_lossy)');
+assertEq(getSourceWeight('unknown'), 0.95, 'sourceWeight: unknown = 0.95 (core falls back to user-inferred via from_str_lossy)');
 
 // ---------------------------------------------------------------------------
 // rerank with applySourceWeights=true: user > assistant on tied content
@@ -499,7 +500,7 @@ assertEq(getSourceWeight('unknown'), 0.9, 'sourceWeight: unknown = 0.9 (core fal
   assert(withWeights.length === 2, 'rerank: returns both candidates');
   assertEq(withWeights[0].id, 'user-1', 'rerank w/ source weights: user > assistant on tied content');
   assert(withWeights[0].sourceWeight === 1.0, 'rerank w/ source weights: user_weight = 1.0');
-  assert(withWeights[1].sourceWeight === 0.55, 'rerank w/ source weights: assistant_weight = 0.55');
+  assert(withWeights[1].sourceWeight === 0.85, 'rerank w/ source weights: assistant_weight = 0.85 (v2-lenient)');
 
   // Control: without source weights, order should be stable (no preference).
   const withoutWeights = rerank('PostgreSQL analytics', embedding, candidates, 2, undefined, false);


### PR DESCRIPTION
## Summary

Implements **kg-1 — v2-lenient weight matrix promote** per [totalreclaw-internal#234](https://github.com/p-diogo/totalreclaw-internal/issues/234) + canonical [kg-ship-plan.md Track 2](https://github.com/p-diogo/totalreclaw-internal/blob/main/docs/plans/2026-04-30-kg-ship-plan.md). Dispatched by `tr-implement-task` Phase 3 listener (Pedro's 2026-05-18 explicit-scope directive on the tracking issue).

- **Risk tier:** L1 (per `risk-tier:L1` label on tracking issue; Pedro's explicit confirmation overrides the autonomous classifier's reranker→L3 default given the bench-validated, design-doc-backed change)
- **Net diff:** 13 files / +199 / −92 (most are test files asserting the new weights)
- **Stable validation target:** Hermes only (OpenClaw plugin + ZeroClaw publish skipped per Pedro's scope.skip)

## Done criteria (from kg-1 issue)

- [x] Flip `SOURCE_WEIGHTS` in `rust/totalreclaw-core/src/reranker.rs` to v2-lenient (assistant 0.55→0.85, user-inferred 0.90→0.95, derived/external 0.70→0.85)
- [x] Preserve v1 const as `SOURCE_WEIGHTS_V1_LEGACY` for back-compat / spike work
- [x] Bump `@totalreclaw/core` Cargo.toml + pyproject.toml (2.2.0 → 2.4.0 — see "Versioning note" below)
- [x] Spec doc `docs/specs/totalreclaw/retrieval-v2.md` updated; v1 weights moved to "Tier 1 v1 (deprecated)" subsection
- [x] All TS + Rust + Python tests updated to assert new v2-lenient values
- [ ] core 2.4.0 published to npm + PyPI + crates.io — **RC publish dispatched separately after this PR opens** (see next-actions below; skill caps at RC publish per hard rail, stable promote = Pedro via `tr-release-promoter`)
- [ ] Hermes RC republished against core 2.4.0 — **dispatched separately after this PR opens**
- [ ] Bench regression on 4 corpora (LongMemEval-500, Gemini, WildChat, ChatGPT) — **runs against RC, not PR (harness lives in `totalreclaw-internal/e2e/retrieval-benchmark/`)**
- [ ] Real-user QA on Hermes returns GO — **runs via `qa-totalreclaw` against staging RC**
- [ ] Stable promote landed — **Pedro's job via `tr-release-promoter`**

## Versioning note: 2.2.0 → 2.4.0 (intentional 2.3.0 skip)

The kg-ship-plan reserved 2.3.0 for Track 1 (F1 Pin UX) and 2.4.0 for this Track (v2-lenient). Pedro's 2026-05-18 directive reorders Track 2 ahead of Track 1, so we leapfrog to 2.4.0 per the literal directive ("Bump @totalreclaw/core 2.3.0 → 2.4.0 ... Skill proven end-to-end on v2.4.0 tonight.") When Track 1 ships later it can land as 2.5.0 (additive, no functional gap created). Downstream consumers take caret ranges so client manifests need no changes.

## Why this is not breaking

- API surface unchanged: `source_weight()` / `getSourceWeight()` / `rerankWithConfig()` signatures identical.
- Default behaviour for `rerank()` (no `apply_source_weights` flag) is also unchanged — v0-compat.
- For callers that DO enable source weights, the v2-lenient values are a strict ranking change (observable) but compress the gap: existing user-source > assistant ordering is preserved; assistant facts gain ~30 pp relative weight. This is intentional and bench-validated.

## Hard rails respected

- Publish ceiling: `release-type=rc` only. Stable + GH Release + production relay promote = Pedro.
- No phrase-safety / mnemonic / paymaster / ERC-4337 / Smart Account / credentials touch.
- No subgraph schema bump.
- No core API breakage; minor version bump per observable default behaviour change.

## Out of scope (Pedro will handle separately)

- Stable promote → `tr-release-promoter` (label kg-1 release-tracking issue `stable-promote:approved`).
- OpenClaw plugin (`@totalreclaw/totalreclaw`) republish — per Pedro's scope.skip, separate later issue. Plugin SOURCE_WEIGHTS source-of-truth updated in lockstep here (parity test would otherwise fail) but no npm publish dispatch for plugin from this PR.
- ZeroClaw (`totalreclaw-memory`) republish — Wave 4 per ship plan.
- `rerankWithVariant` API + default = v2-lenient — Track 1 (F1 Pin UX) deliverable; function doesn't exist in core yet. No-op for this PR.

## Bench-backed rationale

- `docs/plans/2026-04-28-v2-lenient-promotion-proposal.md` — cross-corpus deltas vs v1
- `docs/plans/2026-04-28-b1-stacked-v2lenient-results.md` — Sonnet stacked bench
- `docs/plans/2026-04-30-kg-ship-plan.md` — Track 2 ship checklist (this PR)
- `docs/plans/2026-04-30-chatgpt-bench-results.md` — ChatGPT corpus is net-zero (matches v1, no regression)

Across 3 measured corpora: strictly improves on v1 when B1 entity-trapdoors are on (+3 pp accuracy overall, +50 pp on assistant-source recall) and matches v1 when B1 is off — no measured loss anywhere.

## Next actions after this PR opens (autonomous loop continues)

1. Dispatch `publish-crates` (crate=totalreclaw-core, rc-number=1) → `totalreclaw-core@2.4.0-rc.1` on crates.io
2. Dispatch `publish-pypi` (rc-number=1) → `totalreclaw-core==2.4.0rc1` on PyPI (PyO3 wheels)
3. Dispatch `npm-publish` (package=core, rc-number=1) → `@totalreclaw/core@2.4.0-rc.1` on npm
4. Dispatch `npm-publish` (package=mcp-server, rc-number=1) → MCP RC pulling new core
5. Dispatch `publish-python-client` (rc-number=1) → `totalreclaw==2.3.7rc1` on PyPI (Hermes RC pulling new core)
6. Run 4-corpus bench from `totalreclaw-internal/e2e/retrieval-benchmark/` against locked baselines; post deltas as PR comment
7. Invoke `qa-totalreclaw` skill on Hermes RC against staging; post verdict
8. Post final summary on `totalreclaw-internal#234`; Pedro picks up for stable promote via `tr-release-promoter`

Refs https://github.com/p-diogo/totalreclaw-internal/issues/234