### PR TITLE
chore(kg-1): unpin core dep + bump consumers for stable promote

### DIFF
--- a/mcp/SKILL.md
+++ b/mcp/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "End-to-end encrypted, decentralized memory for OpenClaw via the totalreclaw MCP server. Set up an account once, then call totalreclaw__totalreclaw_remember and totalreclaw__totalreclaw_recall instead of writing to MEMORY.md / USER.md / local files. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', or any user statement that contains a preference / fact / decision / commitment about themselves."
-version: 3.3.0-rc.4
+version: 3.3.0
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/mcp-server",
-  "version": "3.3.0-rc.4",
+  "version": "3.3.0",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. MCP server with XChaCha20-Poly1305 E2EE, semantic search, import/export, and on-chain storage",
   "homepage": "https://totalreclaw.xyz",
   "main": "dist/index.js",
@@ -39,7 +39,7 @@
     "@noble/hashes": "^2.0.1",
     "@scure/bip39": "^2.0.1",
     "@totalreclaw/client": "^1.3.0",
-    "@totalreclaw/core": "2.4.0-rc.1",
+    "@totalreclaw/core": "^2.4.0",
     "permissionless": "^0.3.4",
     "porter-stemmer": "^0.9.1",
     "tslib": "^2.8.1",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -12,7 +12,7 @@ name = "totalreclaw"
 # which would have caused stable builds to mis-publish AND broke the
 # regex-based mutation logic on subsequent RCs. Keep this at the next
 # stable target with NO rc suffix. F3 fix in rc.24.
-version = "2.4.2"
+version = "2.4.3"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"
@@ -27,7 +27,7 @@ dependencies = [
     # Upper bound stays at <3.0.0 to match the TypeScript clients'
     # `^2.0.0` semver semantics — a future core@3 will be a breaking
     # change and must bump this constraint in lockstep.
-    "totalreclaw-core==2.4.0rc1",
+    "totalreclaw-core>=2.4.0,<3.0.0",
     "httpx>=0.27",
     "onnxruntime>=1.24",
     "numpy>=1.26",

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@scure/bip39": "^2.2.0",
     "@totalreclaw/client": "^1.3.0",
-    "@totalreclaw/core": "2.4.0-rc.1",
+    "@totalreclaw/core": "^2.4.0",
     "@types/qrcode": "^1.5.6",
     "@types/ws": "^8.5.12",
     "qrcode": "^1.5.4",


### PR DESCRIPTION
Prep PR for the kg-1 stable promote chain. Unpins consumer `@totalreclaw/core` deps from the temporary `2.4.0-rc.1` pin to caret/range, bumps Python to 2.4.3, drops MCP rc.4 → 3.3.0 stable. After this merges, hand-write release-tracking issue + `stable-promote:approved` label triggers `tr-release-promoter` to chain core×3 + python + mcp publishes.

Auto-merge:L1 — pure metadata, no logic.