### PR TITLE
[imp-8] Guides refresh — import LLM extraction docs + standalone Gemini guide

### DIFF
--- a/docs/guides/importing-from-chatgpt.md
+++ b/docs/guides/importing-from-chatgpt.md
@@ -11,7 +11,7 @@ ChatGPT stores your data in two places. You can import from either or both.
 | Method | What it contains | Best for |
 |--------|-----------------|----------|
 | **ChatGPT Memories** (recommended) | Pre-curated facts ChatGPT saved about you | Quick import, high-quality facts |
-| **conversations.json** | Full conversation export with all messages | Comprehensive extraction (slower) |
+| **conversations.json** | Full conversation export with all messages | Comprehensive extraction (slower, LLM-driven) |
 
 ---
 
@@ -37,17 +37,17 @@ Then paste the copied text when asked. Or provide it directly:
 
 > "Import these ChatGPT memories: [paste text]"
 
-The agent calls `totalreclaw_import_from` with `source: "chatgpt"` and your pasted content. Each line becomes an encrypted memory in your TotalReclaw vault.
+The agent calls `totalreclaw_import_from` with `source: "chatgpt"` and your pasted content. Each line is run through an LLM extraction pass that classifies it and normalises it into an atomic fact, then encrypted into your TotalReclaw vault.
 
 ### What to expect
 
-ChatGPT memories are already curated facts (e.g., "User prefers dark mode", "User works at Acme Corp"), so they import cleanly with minimal noise. A typical import of 50-100 memories takes a few seconds.
+ChatGPT memories are already curated facts (e.g., "User prefers dark mode", "User works at Acme Corp"), so they import cleanly with minimal noise. A typical import of 50-100 memories takes 1-2 minutes — the bottleneck is the LLM extraction pass, not network or storage.
 
 ---
 
 ## Method 2: Import conversations.json
 
-The full data export contains every conversation you have had with ChatGPT. TotalReclaw scans the user messages for fact-like statements using pattern matching (no LLM required).
+The full data export contains every conversation you have had with ChatGPT. TotalReclaw uses **LLM extraction** to identify facts, preferences, decisions, and other personal context from your conversations.
 
 ### Step 1: Export your ChatGPT data
 
@@ -65,30 +65,35 @@ Tell your agent:
 
 > "Import my ChatGPT conversations from /path/to/conversations.json"
 
-Or paste the JSON content directly. For large exports, providing the file path is recommended.
+Or paste the JSON content directly. For large exports, providing the file path is recommended (drag-and-drop is the preferred path on OpenClaw + Hermes).
 
 The agent calls `totalreclaw_import_from` with `source: "chatgpt"` and the file path or content.
 
 ### How extraction works
 
-TotalReclaw scans your user messages (not assistant responses) for fact-like statements:
+TotalReclaw uses **LLM extraction** (not pattern matching) to identify facts from your conversation history. The pipeline is:
 
-- **Personal info**: "I am...", "I work at...", "I live in...", "My name is..."
-- **Preferences**: "I like...", "I prefer...", "I don't like...", "My favorite..."
-- **Decisions**: "I decided...", "I chose...", "We agreed..."
-- **Goals**: "I want to...", "I plan to...", "I'm working on..."
-
-Messages that are purely questions, greetings, or very short responses are skipped.
+1. **Parse**: walk the `conversations.json` mapping tree and pull user + assistant messages in chronological order. Both roles are included because the assistant's response often clarifies what the user meant.
+2. **Chunk**: split each conversation into batches of ~20 messages (`CHUNK_SIZE`). Large conversations become multiple chunks (`part 1/N`, `part 2/N`, ...).
+3. **Extract**: each chunk is run through an LLM (the host's LLM on MCP integrations; your gateway's LLM on OpenClaw; Hermes' configured LLM otherwise). The LLM identifies facts, preferences, decisions, goals, and context.
+4. **Triage + profile**: extracted facts are deduplicated and merged into a coherent profile via the smart-import pipeline (see [`rust/totalreclaw-core/src/smart_import.rs`](https://github.com/p-diogo/totalreclaw/blob/main/rust/totalreclaw-core/src/smart_import.rs) for the schema).
+5. **Encrypt + store**: each surviving fact is encrypted with your TotalReclaw key (XChaCha20-Poly1305), fingerprinted for dedup, and stored.
 
 ### What to expect
 
-The extraction is deliberately conservative -- it uses pattern matching, not an LLM, to keep things fast and deterministic. For a typical export with thousands of conversations, expect:
+Because extraction is LLM-driven and runs per-chunk, processing time scales with the number of conversations:
 
-- **Processing time**: A few seconds (all local, no API calls)
-- **Extraction rate**: Roughly 1-5% of user messages contain extractable facts
-- **Quality**: Good for personal info and preferences; may miss subtle or implicit facts
+- **Small exports** (<50 chunks, ~1000 messages): ~30 seconds
+- **Typical exports** (a few hundred conversations): 5-15 minutes
+- **Large exports** (3,000+ conversations): 10-60+ minutes depending on your LLM provider and rate limits
 
-If you want higher-quality extraction, use Method 1 (ChatGPT memories) instead -- ChatGPT has already done the hard work of identifying what matters.
+The import runs in the **background** on OpenClaw + Hermes — you can keep chatting with your agent during the import. Ask "how's the import?" anytime to see progress. On MCP integrations (Claude Desktop, Claude Code, Cursor, Windsurf), the host's LLM drives the extraction loop one chunk per turn, so you'll see chunks process in the foreground.
+
+### Privacy disclosure
+
+LLM extraction sends your conversation content **in cleartext** to your LLM provider. Before the import starts, your agent will show an explicit privacy disclosure naming the provider (e.g., "Anthropic via Claude on Hermes", "OpenAI via your OpenClaw gateway") and ask for explicit confirmation. TotalReclaw itself never sees plaintext — but the LLM doing the extraction does.
+
+If you don't want to expose conversation content to your LLM, use **Method 1 (ChatGPT memories)** — the memories are already pre-curated short facts, and while they still go through LLM normalisation, the surface area is far smaller than full conversations.
 
 ---
 
@@ -98,7 +103,22 @@ Always preview before importing:
 
 > "Import my ChatGPT memories with dry run first"
 
-This parses your data and shows a preview of the first 10 facts without storing anything. Review and confirm before running the actual import.
+This parses your data and shows an estimate: `total_chunks`, `est_facts`, `est_minutes`, `est_completion_iso`, and the projected LLM cost. Review and confirm before running the actual import.
+
+---
+
+## File size limits
+
+- **Hard cap**: 500 MB per import file. Larger files are rejected up-front with guidance to split.
+- **RAM pre-flight**: imports require ~10× the file size in free RAM (JSON parse peak overhead). The tool checks available memory before loading and aborts with a clear error if the gateway / host doesn't have enough headroom. Workarounds: split the export, or upgrade your VPS.
+- **Streaming parser**: not yet — phase 2 follow-up.
+
+---
+
+## Tier gating
+
+- **Free tier**: one import lifetime (across all sources). Subsequent attempts are blocked with an upgrade prompt.
+- **Pro tier** ($3.99/mo): unlimited imports. The pre-flight projects the LLM cost vs your subscription; soft warning if the projection exceeds $1.00, hard block above $5.00 (you can override with a flag).
 
 ---
 
@@ -109,13 +129,20 @@ Imported memories behave identically to natively stored ones:
 - **Searchable immediately** via `totalreclaw_recall`
 - **Encrypted** with your recovery phrase (XChaCha20-Poly1305)
 - **Tagged** with `import_source:chatgpt` for filtering
-- **Deduplicated** -- re-importing the same data skips duplicates automatically
+- **Deduplicated** -- re-importing the same data skips duplicates automatically (content fingerprint)
+
+---
+
+## Abort + resume
+
+- **Abort**: say "stop the import" — the background loop exits at the next chunk boundary. Already-stored facts stay (dedup makes resume idempotent).
+- **Resume**: re-run the import with the same file. State persists in `~/.totalreclaw/import-state/<import_id>.json`; the loop picks up from the last completed chunk. On OpenClaw + Hermes, restarts auto-resume if the previous run was less than 1 hour ago.
 
 ---
 
 ## Tips
 
-- **Start with memories, not conversations.** ChatGPT memories are pre-curated and import cleanly. The full conversation export is noisier.
+- **Start with memories, not conversations.** ChatGPT memories are pre-curated and import cleanly with minimal LLM cost. The full conversation export is noisier and costs more LLM tokens.
 - **Review after import.** Run `totalreclaw_recall` with a few queries to verify the imported facts make sense.
 - **Use consolidate after large imports.** If you import from both methods, run `totalreclaw_consolidate` with `dry_run=true` to find and merge near-duplicates.
 - **Curate manually if needed.** Use `totalreclaw_forget` to remove any imported facts that are outdated or incorrect.

--- a/docs/guides/importing-from-gemini.md
+++ b/docs/guides/importing-from-gemini.md
@@ -1,0 +1,119 @@
+# Importing from Gemini
+
+TotalReclaw can import your Gemini conversation history, so the personal facts, preferences, and decisions Google's AI has learned about you are encrypted and portable across any AI agent.
+
+Google doesn't have a dedicated "memory" feature like ChatGPT or Claude, but your Gemini conversation history contains the same kind of personal context. TotalReclaw extracts it from the Google Takeout export.
+
+---
+
+## Step 1: Export from Google Takeout
+
+1. Go to [takeout.google.com](https://takeout.google.com)
+2. Click **Deselect all**
+3. Scroll down and select **Gemini Apps** only
+4. Click **Next step** -> **Create export**
+5. Wait for the email with the download link (usually 1-5 minutes; can be longer for very active accounts)
+6. Download and unzip the archive
+7. Find the file at: `Takeout/My Activity/Gemini Apps/My Activity.html`
+
+---
+
+## Step 2: Import into TotalReclaw
+
+Ask your agent:
+
+> "Import my Gemini conversation history from ~/Downloads/Takeout/My Activity/Gemini Apps/My Activity.html"
+
+Or, on OpenClaw + Hermes, just drag the HTML file into the chat — drag-and-drop is the preferred input path.
+
+The agent calls `totalreclaw_import_from` with `source: "gemini"` and the file path.
+
+The flow:
+
+1. **Dry run first**: the tool returns an estimate — `conversations_found`, `estimated_facts`, `estimated_minutes`, projected LLM cost.
+2. **Privacy disclosure**: the agent shows what will be sent to your LLM provider for extraction (see [Privacy disclosure](#privacy-disclosure) below) and asks for explicit confirmation.
+3. **Background execution** (OpenClaw + Hermes): the actual extraction runs out-of-band. You can keep chatting with your agent and ask "how's the import?" any time.
+4. **Foreground execution** (MCP hosts — Claude Desktop, Claude Code, Cursor, Windsurf): your host's LLM drives the extraction loop one chunk per turn.
+5. **Completion notification**: when the import finishes, your agent injects a system message on your next turn — e.g., *"Import done. 234 memories stored, 18 dups skipped."*
+
+---
+
+## How extraction works
+
+TotalReclaw uses **LLM extraction** to identify facts from your Gemini conversations:
+
+1. **Parse**: read the Takeout HTML and pull out individual Gemini turns (user prompt + Gemini response) with their timestamps. Timestamps come from Google's `D MMM YYYY, HH:MM:SS TZ` format (e.g., `1 Apr 2026, 18:39:35 WEST`) and are normalised to ISO 8601.
+2. **Sessionise**: group consecutive turns into pseudo-sessions, splitting whenever the gap between turns exceeds 30 minutes. This recovers a conversation structure Takeout doesn't preserve directly.
+3. **Chunk**: split each session into batches of ~20 messages (`CHUNK_SIZE`).
+4. **Extract**: each chunk is run through an LLM (the host's LLM on MCP integrations; your gateway's LLM on OpenClaw; Hermes' configured LLM otherwise). The LLM identifies facts, preferences, decisions, goals, and context. Generic Q&A turns (recipe lookups, product searches, weather) typically produce zero facts — only personal, long-term-valuable information is extracted.
+5. **Triage + profile**: extracted facts are deduplicated and merged into a coherent profile via the smart-import pipeline.
+6. **Encrypt + store**: each surviving fact is encrypted with your TotalReclaw key (XChaCha20-Poly1305), fingerprinted for dedup, and stored.
+
+---
+
+## Privacy disclosure
+
+LLM extraction sends your Gemini conversation content **in cleartext** to your LLM provider. Before the import starts, your agent will show an explicit privacy disclosure naming the provider (e.g., "Anthropic via Claude on Hermes", "OpenAI via your OpenClaw gateway") and ask for explicit confirmation. TotalReclaw itself never sees plaintext — but the LLM doing the extraction does.
+
+This is the same trade-off that applies to the `conversations.json` path for ChatGPT and is documented up-front. Inline "memory" sources like ChatGPT Memories or Claude memories have a smaller surface area because the data is already pre-curated short facts; full conversation imports (Gemini Takeout, ChatGPT conversations.json) involve the entire chat history.
+
+---
+
+## What gets imported
+
+- ✅ Text conversations from Gemini Apps (web + mobile)
+- ✅ Timestamps + session boundaries (30-minute gap heuristic)
+- ❌ Attachments — images, PDFs, audio in the Gemini export are not imported. Only text turns.
+- ❌ Gemini-in-Workspace activity that doesn't land in My Activity (e.g., Smart Reply suggestions)
+
+---
+
+## File size + RAM limits
+
+- **Hard cap**: 500 MB per import file. Larger exports are rejected up-front with guidance to split.
+- **RAM pre-flight**: imports require ~10× the file size in free RAM. The tool checks available memory before loading and aborts with a clear error if the gateway / host doesn't have enough headroom.
+- **Large exports** (3,000+ conversations): expect 10-60+ minutes depending on your LLM provider and rate limits. Background execution on OpenClaw + Hermes means you can keep using your agent during the import.
+
+---
+
+## Tier gating
+
+- **Free tier**: one import lifetime (across all sources — Gemini, ChatGPT, Claude, Mem0, MCP-Memory). Subsequent attempts are blocked with an upgrade prompt.
+- **Pro tier** ($3.99/mo): unlimited imports. The pre-flight projects the LLM cost vs your subscription; soft warning if the projection exceeds $1.00, hard block above $5.00 (you can override with a flag).
+
+---
+
+## Dry Run First
+
+Always preview before importing:
+
+> "Import my Gemini history with dry run first"
+
+This parses the HTML and shows the estimate (sessions found, chunks, estimated facts, time, projected LLM cost) without storing anything. Review and confirm before running the actual import.
+
+---
+
+## Abort + resume
+
+- **Abort**: say "stop the import" — the background loop exits at the next chunk boundary. Already-stored facts stay (dedup makes resume idempotent).
+- **Resume**: re-run the import with the same file. State persists in `~/.totalreclaw/import-state/<import_id>.json`; the loop picks up from the last completed chunk. On OpenClaw + Hermes, restarts auto-resume if the previous run was less than 1 hour ago.
+
+---
+
+## After Import
+
+Imported memories behave identically to natively stored ones:
+
+- **Searchable immediately** via `totalreclaw_recall`
+- **Encrypted** with your recovery phrase (XChaCha20-Poly1305)
+- **Tagged** with `import_source:gemini` for filtering
+- **Deduplicated** -- re-importing the same export skips duplicates automatically (content fingerprint)
+
+---
+
+## Tips
+
+- **Run consolidate after large imports.** Gemini conversations often re-surface the same fact multiple times. After importing, run `totalreclaw_consolidate` with `dry_run=true` to find and merge near-duplicates.
+- **Spot-check after import.** Run `totalreclaw_recall` with a few topic queries to verify the imported facts make sense.
+- **Combine with ChatGPT + Claude imports.** Dedup is automatic — facts already stored from another source won't be duplicated.
+- **Curate manually if needed.** Use `totalreclaw_forget` to remove any imported facts that are outdated or incorrect.

--- a/docs/guides/importing-memories.md
+++ b/docs/guides/importing-memories.md
@@ -185,45 +185,9 @@ Copy your memories from Claude: Settings -> Memory -> select all and copy.
 
 ## Importing from Gemini
 
-Google does not have a dedicated "memory" feature like ChatGPT or Claude, but your Gemini conversation history contains the same kind of personal facts, preferences, and decisions. TotalReclaw extracts these from the Google Takeout export.
+See the dedicated guide: **[Importing from Gemini](importing-from-gemini.md)**
 
-### Step 1: Export from Google Takeout
-
-1. Go to [takeout.google.com](https://takeout.google.com)
-2. Click "Deselect all"
-3. Scroll down and select **"Gemini Apps"** only
-4. Click "Next step" -> "Create export"
-5. Wait for the email with the download link (usually 1-5 minutes)
-6. Download and unzip the archive
-7. Find the file at: `Takeout/My Activity/Gemini Apps/My Activity.html`
-
-### Step 2: Import into TotalReclaw
-
-Ask your agent:
-
-> "Import my Gemini conversation history from ~/Downloads/Takeout/My Activity/Gemini Apps/My Activity.html"
-
-Or more explicitly:
-
-> "Use totalreclaw_import_from with source=gemini and file_path=~/Downloads/Takeout/My Activity/Gemini Apps/My Activity.html"
-
-The agent will:
-
-1. Run a dry-run first showing the estimate (conversations found, estimated facts, time)
-2. Ask for your confirmation
-3. For small exports: process everything at once
-4. For large exports (3,000+ conversations): process in batches with progress updates
-
-### What gets imported
-
-The tool parses your Gemini conversations, groups them into sessions (conversations within 30 minutes of each other), then uses LLM extraction to identify important facts, preferences, decisions, and context. Generic Q&A conversations (recipes, product lookups) may not produce facts -- only personal, long-term-valuable information is extracted.
-
-### Important notes
-
-- The HTML file is processed entirely on your device -- never sent to any server unencrypted
-- Large exports (3,000+ conversations) may take 10-30 minutes depending on your LLM provider
-- Attachments (images, PDFs, audio) in the Gemini export are not imported -- only text conversations
-- The import is idempotent: re-running it won't create duplicates
+Export from [takeout.google.com](https://takeout.google.com) (select **Gemini Apps**), then import the `My Activity.html` file from the unzipped archive. Uses LLM extraction with a privacy disclosure before extraction starts.
 
 ---
 


### PR DESCRIPTION
## Summary

Implements **[imp-8] Guides refresh** per canonical-roadmap issue p-diogo/totalreclaw-internal#250.

**Risk tier:** L1 (docs only)

## What changed

- **`docs/guides/importing-from-chatgpt.md`** — rewrote the "How extraction works" + "What to expect" sections. The ChatGPT adapter switched to LLM extraction a while back (chunked via `CHUNK_SIZE=20` per `python/src/totalreclaw/import_adapters/chatgpt_adapter.py`), but the guide still described pattern matching with "no LLM required" / "few seconds" / "1-5% extraction rate". Updated to document the actual pipeline:
  - Chunked LLM extraction via host (MCP) / gateway (OpenClaw) / configured (Hermes) LLM
  - Smart-import triage + profile per `rust/totalreclaw-core/src/smart_import.rs`
  - Mandatory privacy disclosure before extraction starts (cleartext to LLM provider)
  - Background execution on OpenClaw + Hermes; foreground on MCP hosts
  - 500 MB hard cap + 10× free-RAM pre-flight
  - Free-tier 1-import-lifetime gating; $3.99/mo Pro projection with $1 soft-warn / $5 hard-block
  - Time scales: 30s small → 60+min large, instead of "few seconds"
- **`docs/guides/importing-from-gemini.md`** — new standalone guide, parallel to `importing-from-{chatgpt,claude}.md`. Covers Takeout export, LLM extraction with 30-min session-gap heuristic, privacy disclosure, RAM/file caps, tier gating, abort/resume, after-import behavior.
- **`docs/guides/importing-memories.md`** — replaced the 43-line inline Gemini section with a 5-line pointer matching the existing ChatGPT/Claude cross-ref pattern (lines 168-184). No ROADMAP.md references found anywhere in the file (verified clean — done criterion 2 already met).

## Done criteria

- [x] Public docs match shipped feature (LLM extraction, privacy disclosure, background exec, tier gating)
- [x] No stale ROADMAP.md references
- [x] `importing-from-gemini.md` exists + matches actual flow (Takeout HTML, 30-min sessions, LLM chunks, privacy disclosure)

## Test results

L1 docs-only: no test suites apply. Verified internally:
- Cross-links resolve: `importing-from-chatgpt.md`, `importing-from-claude.md`, `importing-from-gemini.md` all referenced from `importing-memories.md` line 170/180/188.
- `grep -niE 'ROADMAP\.md' docs/guides/importing-*.md` → no hits.
- All new factual claims (CHUNK_SIZE=20, SESSION_GAP_MINUTES=30, $3.99 Pro, $1 soft / $5 hard, 500 MB cap, 10× RAM) cross-checked against `python/src/totalreclaw/import_adapters/{chatgpt,gemini}_adapter.py` + `docs/plans/2026-05-04-import-feature-design.md`.

## RC artifact

_(L1: no RC publish — docs-only)_

## Ship-gate note

Per Pedro's 2026-05-19 comment on p-diogo/totalreclaw-internal#250: stable promote of imp-1..imp-4 (which this docs refresh documents) is gated on p-diogo/totalreclaw-internal#281 (P0 batched UserOp restore). This PR documents the shipped feature and can merge ahead of stable promote — the dependency is on shipping the cost fix, not on writing the docs.

Closes p-diogo/totalreclaw-internal#250