### PR TITLE
ci(npm-publish): switch mcp-server job to OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -244,16 +244,20 @@ jobs:
 
       - name: Publish
         if: inputs.dry-run == false
+        # OIDC trusted publishing — npm trusts this workflow file
+        # (`npm-publish.yml`) per the @totalreclaw/mcp-server package's
+        # Trusted Publisher config on npmjs.com. NO `NODE_AUTH_TOKEN` env —
+        # setting it would short-circuit OIDC and force npm to use the
+        # secret-token path (which caused the 2026-05-19 / 2026-05-24 E404
+        # failures after `NPM_TOKEN` expired).
         run: |
           cd mcp
           TAG="latest"
           if [ "${{ inputs.release-type }}" = "rc" ]; then
             TAG="rc"
           fi
-          echo "Publishing with dist-tag: $TAG"
-          npm publish --access public --tag "$TAG"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          echo "Publishing with dist-tag: $TAG (OIDC trusted publishing)"
+          npm publish --access public --tag "$TAG" --provenance
 
       - name: Report version
         run: |


### PR DESCRIPTION
## Summary

- Fixes the recurring **E404** failure on `@totalreclaw/mcp-server@3.3.0` publish (2026-05-19 + 2026-05-24).
- Root cause: `NODE_AUTH_TOKEN` env on the publish step short-circuits OIDC; npm CLI falls back to `NPM_TOKEN` secret which expired between 3.2.1 (2026-05-10, worked) and 3.3.0 attempts.
- The Trusted Publisher on npmjs.com is already correctly configured for `@totalreclaw/mcp-server` — workflow file `npm-publish.yml`, org `p-diogo`, repo `totalreclaw`, action `npm publish`, no env constraint. It was just being bypassed.

## Change scope

**Only the `publish-mcp-server` job is modified.** Other jobs (`publish-core`, `publish-client`, `publish-nanoclaw`, `publish-plugin`) keep the existing `NODE_AUTH_TOKEN` pattern until their Trusted Publishers are set up on npmjs.com. Once configured, the same pattern can be applied to each.

## Test plan

- [ ] Merge.
- [ ] Re-trigger `Publish npm packages` workflow → `package=mcp-server`, `release-type=stable`, `dry-run=false`.
- [ ] Verify `@totalreclaw/mcp-server@3.3.0` appears on npm with a provenance badge.
- [ ] Confirm `npm view @totalreclaw/mcp-server version` returns `3.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)