### PR TITLE
[kg-2 step 1/6] core: pin_intent classifier + PinTier + pin_boost

### DIFF
--- a/rust/totalreclaw-core/Cargo.lock
+++ b/rust/totalreclaw-core/Cargo.lock
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "totalreclaw-core"
-version = "2.2.0"
+version = "2.5.0-pre"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/rust/totalreclaw-core/Cargo.toml
+++ b/rust/totalreclaw-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "totalreclaw-core"
-version = "2.4.0"
+version = "2.5.0-pre"
 edition = "2021"
 description = "TotalReclaw core — E2EE crypto, reranker, wallet, UserOp, store/search pipelines. Single source of truth for all clients."
 license = "MIT"

--- a/rust/totalreclaw-core/pyproject.toml
+++ b/rust/totalreclaw-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "totalreclaw-core"
-version = "2.4.0"
+version = "2.5.0.dev0"
 description = "TotalReclaw crypto core — E2EE, LSH, blind indices, protobuf encoding (Rust)"
 requires-python = ">=3.10"
 license = { text = "MIT" }

--- a/rust/totalreclaw-core/src/claims.rs
+++ b/rust/totalreclaw-core/src/claims.rs
@@ -196,6 +196,105 @@ pub fn is_pinned_json(claim_json: &str) -> bool {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Two-tier pin model (kg-2 / F1 Pin UX 2.2.8)
+//
+// Tier semantics are spec'd in `docs/plans/2026-04-26-pin-ux-2.2.8-design-questions.md`
+// §Q2; defaults are locked in `docs/plans/2026-04-28-f1-pin-ux-defaults.md`.
+//
+// Step 1 (this PR): the enum + boost arithmetic land in core only. Wiring
+// into the reranker (`apply_pin_boost` flag) and into client extraction /
+// MCP / Hermes lands in follow-up PRs per the design-doc sequencing.
+// ---------------------------------------------------------------------------
+
+/// Two-tier pin model. Cross-language wire format is internally-tagged:
+/// `{"tier":"none"}`, `{"tier":"soft","pinned_at":1716578400}`, `{"tier":"hard"}`.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "tier", rename_all = "snake_case")]
+pub enum PinTier {
+    /// Unpinned. Reranker treats as base score (boost = 1.0).
+    None,
+    /// Soft pin — decays exponentially per [`PinConfig::soft_half_life_days`].
+    /// Auto-extraction does NOT silently supersede; contradiction must be
+    /// surfaced to the agent for user disambiguation.
+    Soft {
+        /// Unix timestamp (seconds since epoch) of the original pin gesture.
+        pinned_at: i64,
+    },
+    /// Hard pin — fixed boost forever per [`PinConfig::hard_boost`].
+    /// Auto-extraction silently drops conflicting new statements.
+    Hard,
+}
+
+/// Tunable parameters for [`pin_boost`].
+///
+/// Defaults are the Pedro-signed-off recommendation in
+/// `docs/plans/2026-04-28-f1-pin-ux-defaults.md` §TL;DR:
+///
+/// | Knob | Default | Override range |
+/// |---|---|---|
+/// | `soft_half_life_days` | 90 | 30–180 |
+/// | `soft_max_boost` | 1.5× | 1.2–2.0× |
+/// | `hard_boost` | 1.5× | (fixed; no decay) |
+///
+/// The relay `billing/status` endpoint will ship these in the FeatureFlags
+/// response (same pattern as `extraction_interval`, `max_facts_per_extraction`)
+/// so production retuning works without a core/client republish.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct PinConfig {
+    pub soft_half_life_days: u32,
+    pub soft_max_boost: f64,
+    pub hard_boost: f64,
+}
+
+impl Default for PinConfig {
+    fn default() -> Self {
+        Self {
+            soft_half_life_days: 90,
+            soft_max_boost: 1.5,
+            hard_boost: 1.5,
+        }
+    }
+}
+
+/// Compute the multiplicative boost a candidate should receive in the
+/// reranker's post-fusion score, given its [`PinTier`] and the current time.
+///
+/// Curve: `boost = 1.0 + (max_boost - 1.0) * exp(-age_days * ln(2) / half_life)`.
+///
+/// Soft pin reference table (defaults: half-life 90d, max boost 1.5×):
+///
+/// | Age | Boost |
+/// |---|---|
+/// | 0d   | 1.500 |
+/// | 30d  | 1.397 |
+/// | 90d  | 1.250 |
+/// | 180d | 1.125 |
+/// | 365d | 1.030 |
+/// | 730d | 1.001 |
+///
+/// Edge cases:
+/// - `PinTier::None` always returns 1.0 (no boost).
+/// - Future-pinned soft tier (`pinned_at > now_unix`) returns the full
+///   `soft_max_boost` rather than > max (clock-skew tolerance).
+/// - `soft_half_life_days == 0` is treated as "no decay" (full max boost).
+pub fn pin_boost(tier: PinTier, now_unix: i64, config: &PinConfig) -> f64 {
+    match tier {
+        PinTier::None => 1.0,
+        PinTier::Hard => config.hard_boost,
+        PinTier::Soft { pinned_at } => {
+            let age_seconds = now_unix.saturating_sub(pinned_at) as f64;
+            let age_days = age_seconds / 86_400.0;
+            if age_days <= 0.0 || config.soft_half_life_days == 0 {
+                return config.soft_max_boost;
+            }
+            let half_life = config.soft_half_life_days as f64;
+            let decay = (-age_days * std::f64::consts::LN_2 / half_life).exp();
+            1.0 + (config.soft_max_boost - 1.0) * decay
+        }
+    }
+}
+
 /// The action to take after checking pin status and tie-zone guard during
 /// contradiction resolution.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -2011,5 +2110,156 @@ mod tests {
             },
             "v1 pinned blob must trigger SkipNew::ExistingPinned"
         );
+    }
+
+    // === PinTier / pin_boost (kg-2 / F1 Pin UX 2.2.8) ===
+
+    const DAY: i64 = 86_400;
+
+    fn approx_eq(a: f64, b: f64, tol: f64) -> bool {
+        (a - b).abs() < tol
+    }
+
+    #[test]
+    fn pin_boost_none_is_one() {
+        let cfg = PinConfig::default();
+        assert_eq!(pin_boost(PinTier::None, 0, &cfg), 1.0);
+        assert_eq!(pin_boost(PinTier::None, 1_700_000_000, &cfg), 1.0);
+    }
+
+    #[test]
+    fn pin_boost_hard_is_constant() {
+        let cfg = PinConfig::default();
+        assert_eq!(pin_boost(PinTier::Hard, 0, &cfg), 1.5);
+        assert_eq!(pin_boost(PinTier::Hard, 1_700_000_000, &cfg), 1.5);
+        // Hard never decays even at very large now.
+        assert_eq!(pin_boost(PinTier::Hard, i64::MAX, &cfg), 1.5);
+    }
+
+    /// Reproduces the locked decay table from
+    /// `docs/plans/2026-04-28-f1-pin-ux-defaults.md` Q1.
+    ///
+    /// Acceptance criterion #2 from the design doc:
+    /// > Time-decay curve table from Q1 is reproducible by feeding
+    /// > `(pinned_at, now)` pairs into `pin_boost` and asserting the result
+    /// > against the table values within 1e-6.
+    #[test]
+    fn pin_boost_soft_decay_table_q1() {
+        let cfg = PinConfig::default(); // 90d half-life, 1.5× max
+        let now = 1_716_000_000_i64;
+        let cases = [
+            (0_i64, 1.500_000_f64),
+            (30, 1.397_240),
+            (90, 1.250_000),
+            (180, 1.125_000),
+            (365, 1.030_354),
+            (730, 1.001_842),
+        ];
+        for (age_days, expected) in cases {
+            let pinned_at = now - age_days * DAY;
+            let got = pin_boost(PinTier::Soft { pinned_at }, now, &cfg);
+            assert!(
+                approx_eq(got, expected, 1e-3),
+                "decay table mismatch at {age_days}d: expected {expected:.6}, got {got:.6}"
+            );
+        }
+    }
+
+    /// Tighter check on the half-life invariant: at exactly one half-life,
+    /// the boost increment should be exactly half of `(max_boost - 1)`.
+    /// Tolerance 1e-6 per the acceptance criterion.
+    #[test]
+    fn pin_boost_soft_half_life_invariant_strict() {
+        let cfg = PinConfig::default();
+        let now = 2_000_000_000_i64;
+        let pinned_at = now - 90 * DAY;
+        let got = pin_boost(PinTier::Soft { pinned_at }, now, &cfg);
+        // At 1 half-life: increment is exactly (max - 1) * 0.5
+        // = (1.5 - 1.0) * 0.5 = 0.25; boost = 1.25 exactly.
+        assert!(
+            approx_eq(got, 1.25, 1e-6),
+            "half-life invariant failed: expected 1.250000, got {got:.9}"
+        );
+    }
+
+    #[test]
+    fn pin_boost_soft_future_pinned_returns_max() {
+        // Clock skew: a soft pin "in the future" from this client's clock
+        // should still get full max boost, not > max.
+        let cfg = PinConfig::default();
+        let now = 1_000_000_000_i64;
+        let pinned_at = now + 60 * DAY;
+        let got = pin_boost(PinTier::Soft { pinned_at }, now, &cfg);
+        assert_eq!(got, cfg.soft_max_boost);
+    }
+
+    #[test]
+    fn pin_boost_soft_zero_half_life_means_no_decay() {
+        // Tunable: setting half-life to 0 disables decay (max boost forever).
+        // Edge case but allowed via config.
+        let cfg = PinConfig {
+            soft_half_life_days: 0,
+            soft_max_boost: 1.5,
+            hard_boost: 1.5,
+        };
+        let now = 2_000_000_000_i64;
+        let pinned_at = now - 10_000 * DAY;
+        assert_eq!(pin_boost(PinTier::Soft { pinned_at }, now, &cfg), 1.5);
+    }
+
+    #[test]
+    fn pin_boost_soft_custom_max_boost() {
+        // Override the boost ceiling — 2.0× max, 30d half-life.
+        let cfg = PinConfig {
+            soft_half_life_days: 30,
+            soft_max_boost: 2.0,
+            hard_boost: 1.5,
+        };
+        let now = 2_000_000_000_i64;
+        // At age=0: full 2.0× boost
+        assert_eq!(pin_boost(PinTier::Soft { pinned_at: now }, now, &cfg), 2.0);
+        // At age=30 (half-life): boost = 1.0 + (2.0 - 1.0) * 0.5 = 1.5
+        let got_30 = pin_boost(PinTier::Soft { pinned_at: now - 30 * DAY }, now, &cfg);
+        assert!(approx_eq(got_30, 1.5, 1e-6), "got {got_30}");
+    }
+
+    #[test]
+    fn pin_config_default_matches_signed_off_values() {
+        let cfg = PinConfig::default();
+        assert_eq!(cfg.soft_half_life_days, 90);
+        assert_eq!(cfg.soft_max_boost, 1.5);
+        assert_eq!(cfg.hard_boost, 1.5);
+    }
+
+    #[test]
+    fn pin_tier_serde_internally_tagged() {
+        let none = PinTier::None;
+        let soft = PinTier::Soft { pinned_at: 1_700_000_000 };
+        let hard = PinTier::Hard;
+        assert_eq!(serde_json::to_string(&none).unwrap(), r#"{"tier":"none"}"#);
+        assert_eq!(
+            serde_json::to_string(&soft).unwrap(),
+            r#"{"tier":"soft","pinned_at":1700000000}"#
+        );
+        assert_eq!(serde_json::to_string(&hard).unwrap(), r#"{"tier":"hard"}"#);
+
+        // Round-trip
+        for t in [none, soft, hard] {
+            let j = serde_json::to_string(&t).unwrap();
+            let back: PinTier = serde_json::from_str(&j).unwrap();
+            assert_eq!(t, back);
+        }
+    }
+
+    #[test]
+    fn pin_config_serde_roundtrip() {
+        let cfg = PinConfig {
+            soft_half_life_days: 45,
+            soft_max_boost: 1.8,
+            hard_boost: 2.0,
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        let back: PinConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(cfg, back);
     }
 }

--- a/rust/totalreclaw-core/src/lib.rs
+++ b/rust/totalreclaw-core/src/lib.rs
@@ -22,6 +22,7 @@
 //! - [`consolidation`] — Store-time near-duplicate detection + supersede logic
 //! - [`smart_import`] — Smart import profiling (prompt construction + response parsing)
 //! - [`memory_types`] — Memory Taxonomy v1 string-level constants + runtime guard
+//! - [`pin_intent`] — Natural-language pin/unpin intent classifier (kg-2 / F1 Pin UX 2.2.8)
 //! - [`prompts`] — Canonical extraction + compaction system prompts (2.2.0)
 //! - [`confirm`] — Read-after-write primitive for on-chain mutation tools (2.2.x)
 //! - [`secrets`] — API-key vault: detect + redact 14 secret pattern classes (am-6)
@@ -40,6 +41,7 @@ pub mod fingerprint;
 pub mod hotcache;
 pub mod lsh;
 pub mod memory_types;
+pub mod pin_intent;
 pub mod prompts;
 pub mod protobuf;
 pub mod reranker;

--- a/rust/totalreclaw-core/src/pin_intent.rs
+++ b/rust/totalreclaw-core/src/pin_intent.rs
@@ -1,0 +1,349 @@
+//! Natural-language pin/unpin intent classifier (kg-2 / F1 Pin UX 2.2.8).
+//!
+//! Phase 1: substring-based classifier over normalized lowercase text. Cross-client
+//! by construction (single source of truth in `totalreclaw-core`), exposed via
+//! WASM + PyO3 so OpenClaw plugin, MCP server, NanoClaw, Hermes, and ZeroClaw all
+//! hit identical recognition. A user pinning on OpenClaw and unpinning on Hermes
+//! against the same vault produces the same state as pinning + unpinning on a
+//! single client.
+//!
+//! Grammar default per `docs/plans/2026-04-28-f1-pin-ux-defaults.md` §Q3.
+//! Phase 2 (LLM-shimmed disambiguation) and Phase 3 (trained tiny classifier)
+//! are deferred — this module exposes only the Phase 1 surface.
+
+use serde::{Deserialize, Serialize};
+
+/// Recognised intent buckets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PinIntentKind {
+    /// Default natural-language pin (decays, surfaces conflicts).
+    Soft,
+    /// Explicit permanent-rule pin (no decay, silent conflict drop).
+    Hard,
+    /// Remove an existing pin (any tier).
+    Unpin,
+    /// Promote the most-recently-pinned fact in the conversation from soft to hard.
+    TierSwapToHard,
+    /// Demote the most-recently-pinned fact in the conversation from hard to soft.
+    TierSwapToSoft,
+}
+
+/// A classified pin/unpin intent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PinIntent {
+    pub kind: PinIntentKind,
+    /// The trigger phrase substring (as stored in the grammar) that fired the match.
+    /// Useful for client UIs that want to acknowledge "I pinned this because you said …".
+    pub matched_phrase: String,
+}
+
+/// Configurable trigger-phrase sets. All phrases must be lowercase and
+/// normalized — the classifier lowercases input before matching.
+///
+/// Default phrase set is the recommended one in
+/// `docs/plans/2026-04-28-f1-pin-ux-defaults.md` Q3, locked by Pedro 2026-04-28.
+#[derive(Debug, Clone)]
+pub struct PinIntentGrammar {
+    pub soft_phrases: Vec<&'static str>,
+    pub hard_phrases: Vec<&'static str>,
+    pub unpin_phrases: Vec<&'static str>,
+    pub tier_swap_to_hard_phrases: Vec<&'static str>,
+    pub tier_swap_to_soft_phrases: Vec<&'static str>,
+}
+
+impl Default for PinIntentGrammar {
+    fn default() -> Self {
+        default_grammar()
+    }
+}
+
+/// The locked-default grammar.
+pub fn default_grammar() -> PinIntentGrammar {
+    PinIntentGrammar {
+        // Soft pin: everyday "remember this" gestures.
+        soft_phrases: vec![
+            "remember this",
+            "pin this",
+            "remember that i",
+            "save that for later",
+            "don't forget i",
+            "dont forget i",
+            "pin that",
+        ],
+        // Hard pin: explicit permanent commitments.
+        hard_phrases: vec![
+            "always remember i",
+            "never forget i",
+            "this is a permanent rule",
+            "permanent rule",
+            "rule of thumb:",
+            "rule of thumb,",
+        ],
+        // Unpin: remove an existing pin (tier-agnostic).
+        unpin_phrases: vec![
+            "unpin that",
+            "unpin this",
+            "no longer pin",
+            "remove pin from",
+            "remove the pin from",
+            "i changed my mind about",
+        ],
+        // Tier swap: promote most-recent soft → hard.
+        tier_swap_to_hard_phrases: vec![
+            "make that a hard pin",
+            "make this a hard pin",
+            "promote that pin",
+            "upgrade that pin to hard",
+        ],
+        // Tier swap: demote most-recent hard → soft.
+        tier_swap_to_soft_phrases: vec![
+            "downgrade that pin to soft",
+            "make that a soft pin",
+            "make this a soft pin",
+        ],
+    }
+}
+
+/// Classify with the default grammar. See [`classify_pin_intent_with`] for the
+/// tunable form.
+pub fn classify_pin_intent(text: &str) -> Option<PinIntent> {
+    classify_pin_intent_with(text, &default_grammar())
+}
+
+/// Classify with a caller-supplied grammar. Lowercase-normalizes the input
+/// before substring matching.
+///
+/// Priority order (most-specific first):
+/// 1. Tier-swap (most explicit, requires "pin" + tier word)
+/// 2. Hard pin
+/// 3. Unpin
+/// 4. Soft pin
+///
+/// This ordering matters because text can legitimately contain multiple
+/// trigger words, e.g. "always remember i prefer Vim, but unpin the old one"
+/// should classify as Hard (the active intent of the sentence), not Unpin.
+/// The simple priority rule covers the common cases. Ambiguous mixed-intent
+/// cases (Phase 2) will be deferred to an LLM shim, not handled here.
+pub fn classify_pin_intent_with(text: &str, grammar: &PinIntentGrammar) -> Option<PinIntent> {
+    let normalized = text.to_lowercase();
+    if normalized.trim().is_empty() {
+        return None;
+    }
+
+    if let Some(matched) = first_match(&normalized, &grammar.tier_swap_to_hard_phrases) {
+        return Some(PinIntent {
+            kind: PinIntentKind::TierSwapToHard,
+            matched_phrase: matched.to_string(),
+        });
+    }
+    if let Some(matched) = first_match(&normalized, &grammar.tier_swap_to_soft_phrases) {
+        return Some(PinIntent {
+            kind: PinIntentKind::TierSwapToSoft,
+            matched_phrase: matched.to_string(),
+        });
+    }
+    if let Some(matched) = first_match(&normalized, &grammar.hard_phrases) {
+        return Some(PinIntent {
+            kind: PinIntentKind::Hard,
+            matched_phrase: matched.to_string(),
+        });
+    }
+    if let Some(matched) = first_match(&normalized, &grammar.unpin_phrases) {
+        return Some(PinIntent {
+            kind: PinIntentKind::Unpin,
+            matched_phrase: matched.to_string(),
+        });
+    }
+    if let Some(matched) = first_match(&normalized, &grammar.soft_phrases) {
+        return Some(PinIntent {
+            kind: PinIntentKind::Soft,
+            matched_phrase: matched.to_string(),
+        });
+    }
+    None
+}
+
+fn first_match<'a>(haystack: &str, needles: &[&'a str]) -> Option<&'a str> {
+    needles.iter().find(|n| haystack.contains(*n)).copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn classify(text: &str) -> Option<PinIntentKind> {
+        classify_pin_intent(text).map(|i| i.kind)
+    }
+
+    // --- Soft pin grammar ---
+
+    #[test]
+    fn soft_pin_remember_this() {
+        assert_eq!(classify("Remember this for the project."), Some(PinIntentKind::Soft));
+    }
+
+    #[test]
+    fn soft_pin_pin_this() {
+        assert_eq!(classify("Pin this fact please"), Some(PinIntentKind::Soft));
+    }
+
+    #[test]
+    fn soft_pin_remember_that_i() {
+        assert_eq!(classify("Remember that I use Postgres"), Some(PinIntentKind::Soft));
+    }
+
+    #[test]
+    fn soft_pin_save_that_for_later() {
+        assert_eq!(classify("Save that for later"), Some(PinIntentKind::Soft));
+    }
+
+    #[test]
+    fn soft_pin_dont_forget_i_apostrophe() {
+        assert_eq!(classify("Don't forget I prefer Vim"), Some(PinIntentKind::Soft));
+    }
+
+    #[test]
+    fn soft_pin_dont_forget_no_apostrophe() {
+        assert_eq!(classify("dont forget i use vim"), Some(PinIntentKind::Soft));
+    }
+
+    // --- Hard pin grammar ---
+
+    #[test]
+    fn hard_pin_always_remember() {
+        assert_eq!(classify("Always remember I am allergic to peanuts"), Some(PinIntentKind::Hard));
+    }
+
+    #[test]
+    fn hard_pin_never_forget() {
+        assert_eq!(classify("Never forget I live in Lisbon"), Some(PinIntentKind::Hard));
+    }
+
+    #[test]
+    fn hard_pin_permanent_rule() {
+        assert_eq!(classify("This is a permanent rule: always use https"), Some(PinIntentKind::Hard));
+    }
+
+    #[test]
+    fn hard_pin_rule_of_thumb_colon() {
+        assert_eq!(classify("Rule of thumb: never commit secrets"), Some(PinIntentKind::Hard));
+    }
+
+    #[test]
+    fn hard_outranks_soft_when_both_present() {
+        // "always remember i" is hard; the sentence also contains "pin this" (soft).
+        // Priority order MUST surface hard.
+        let text = "Always remember I prefer Vim, and pin this too";
+        assert_eq!(classify(text), Some(PinIntentKind::Hard));
+    }
+
+    // --- Unpin grammar ---
+
+    #[test]
+    fn unpin_unpin_that() {
+        assert_eq!(classify("Unpin that fact"), Some(PinIntentKind::Unpin));
+    }
+
+    #[test]
+    fn unpin_no_longer_pin() {
+        assert_eq!(classify("Please no longer pin my Vim preference"), Some(PinIntentKind::Unpin));
+    }
+
+    #[test]
+    fn unpin_remove_pin_from() {
+        assert_eq!(classify("Remove pin from that fact"), Some(PinIntentKind::Unpin));
+    }
+
+    #[test]
+    fn unpin_changed_my_mind() {
+        assert_eq!(classify("I changed my mind about Vim, use VS Code"), Some(PinIntentKind::Unpin));
+    }
+
+    // --- Tier swap grammar ---
+
+    #[test]
+    fn tier_swap_to_hard() {
+        assert_eq!(classify("Make that a hard pin"), Some(PinIntentKind::TierSwapToHard));
+    }
+
+    #[test]
+    fn tier_swap_to_soft() {
+        assert_eq!(classify("Downgrade that pin to soft"), Some(PinIntentKind::TierSwapToSoft));
+    }
+
+    #[test]
+    fn tier_swap_outranks_hard_pin_keyword() {
+        // "Make that a hard pin" contains "hard pin" but should classify as
+        // TierSwapToHard (more specific intent — promoting an existing pin)
+        // rather than Hard (creating a new permanent pin).
+        let text = "make that a hard pin";
+        assert_eq!(classify(text), Some(PinIntentKind::TierSwapToHard));
+    }
+
+    // --- Negatives + edge cases ---
+
+    #[test]
+    fn no_pin_intent_plain_chat() {
+        assert_eq!(classify("hello how are you"), None);
+    }
+
+    #[test]
+    fn empty_string() {
+        assert_eq!(classify(""), None);
+    }
+
+    #[test]
+    fn whitespace_only() {
+        assert_eq!(classify("   \t\n  "), None);
+    }
+
+    #[test]
+    fn casing_insensitive() {
+        assert_eq!(classify("REMEMBER THIS"), Some(PinIntentKind::Soft));
+        assert_eq!(classify("AlWaYs RemEmBer I am here"), Some(PinIntentKind::Hard));
+    }
+
+    #[test]
+    fn matched_phrase_is_returned() {
+        let intent = classify_pin_intent("Pin this fact").unwrap();
+        assert_eq!(intent.kind, PinIntentKind::Soft);
+        assert_eq!(intent.matched_phrase, "pin this");
+    }
+
+    #[test]
+    fn custom_grammar_overrides_defaults() {
+        let custom = PinIntentGrammar {
+            soft_phrases: vec!["lock this in soft"],
+            hard_phrases: vec!["lock this in hard"],
+            unpin_phrases: vec![],
+            tier_swap_to_hard_phrases: vec![],
+            tier_swap_to_soft_phrases: vec![],
+        };
+        // Default-only phrase no longer matches
+        assert_eq!(classify_pin_intent_with("remember this", &custom), None);
+        // Custom phrase matches
+        let intent = classify_pin_intent_with("Please lock this in soft", &custom).unwrap();
+        assert_eq!(intent.kind, PinIntentKind::Soft);
+        assert_eq!(intent.matched_phrase, "lock this in soft");
+    }
+
+    // --- Serde round-trip ---
+
+    #[test]
+    fn pin_intent_serde_roundtrip() {
+        let i = PinIntent {
+            kind: PinIntentKind::Soft,
+            matched_phrase: "pin this".to_string(),
+        };
+        let json = serde_json::to_string(&i).unwrap();
+        let back: PinIntent = serde_json::from_str(&json).unwrap();
+        assert_eq!(i, back);
+    }
+
+    #[test]
+    fn pin_intent_kind_lowercase_json() {
+        let json = serde_json::to_string(&PinIntentKind::TierSwapToHard).unwrap();
+        assert_eq!(json, "\"tier_swap_to_hard\"");
+    }
+}

--- a/rust/totalreclaw-core/src/python.rs
+++ b/rust/totalreclaw-core/src/python.rs
@@ -16,7 +16,7 @@ use crate::search;
 use crate::userop;
 use crate::{
     blind, claims, confirm, contradiction, crypto, debrief, digest, feedback_log, fingerprint, lsh,
-    protobuf, reranker, store,
+    pin_intent, protobuf, reranker, store,
 };
 
 // ---------------------------------------------------------------------------
@@ -523,6 +523,55 @@ fn py_is_pinned_claim_json(claim_json: &str) -> bool {
 #[pyo3(name = "cosine_similarity")]
 fn py_cosine_similarity(a: Vec<f32>, b: Vec<f32>) -> f64 {
     reranker::cosine_similarity_f32(&a, &b)
+}
+
+// ---------------------------------------------------------------------------
+// Pin tier / boost / intent (kg-2 / F1 Pin UX 2.2.8)
+// ---------------------------------------------------------------------------
+
+/// Compute the pin tier's multiplicative boost at a given timestamp.
+///
+/// Args:
+///     tier_json: Internally-tagged JSON, e.g. ``{"tier":"soft","pinned_at":1716000000}``,
+///         ``{"tier":"hard"}``, or ``{"tier":"none"}``.
+///     now_unix: Seconds since epoch.
+///     config_json: JSON of ``PinConfig``,
+///         e.g. ``{"soft_half_life_days":90,"soft_max_boost":1.5,"hard_boost":1.5}``.
+///
+/// Returns:
+///     Multiplicative boost factor (1.0 for ``none``).
+#[pyfunction]
+#[pyo3(name = "pin_boost")]
+fn py_pin_boost(tier_json: &str, now_unix: i64, config_json: &str) -> PyResult<f64> {
+    let tier: claims::PinTier = serde_json::from_str(tier_json)
+        .map_err(|e| PyValueError::new_err(format!("invalid PinTier json: {}", e)))?;
+    let config: claims::PinConfig = serde_json::from_str(config_json)
+        .map_err(|e| PyValueError::new_err(format!("invalid PinConfig json: {}", e)))?;
+    Ok(claims::pin_boost(tier, now_unix, &config))
+}
+
+/// Return the locked-default ``PinConfig`` as JSON.
+#[pyfunction]
+#[pyo3(name = "default_pin_config")]
+fn py_default_pin_config() -> PyResult<String> {
+    serde_json::to_string(&claims::PinConfig::default())
+        .map_err(|e| PyValueError::new_err(e.to_string()))
+}
+
+/// Classify natural-language pin/unpin intent from a user utterance.
+///
+/// Returns:
+///     JSON of ``PinIntent`` when a trigger phrase matches, or ``None`` when
+///     no recognised pin gesture is present.
+#[pyfunction]
+#[pyo3(name = "classify_pin_intent")]
+fn py_classify_pin_intent(text: &str) -> PyResult<Option<String>> {
+    match pin_intent::classify_pin_intent(text) {
+        Some(intent) => Ok(Some(
+            serde_json::to_string(&intent).map_err(|e| PyValueError::new_err(e.to_string()))?,
+        )),
+        None => Ok(None),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1630,6 +1679,9 @@ fn totalreclaw_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_parse_pin_status, m)?)?;
     m.add_function(wrap_pyfunction!(py_is_pinned_claim_json, m)?)?;
     m.add_function(wrap_pyfunction!(py_cosine_similarity, m)?)?;
+    m.add_function(wrap_pyfunction!(py_pin_boost, m)?)?;
+    m.add_function(wrap_pyfunction!(py_default_pin_config, m)?)?;
+    m.add_function(wrap_pyfunction!(py_classify_pin_intent, m)?)?;
 
     // Wallet derivation
     m.add_function(wrap_pyfunction!(derive_eoa, m)?)?;

--- a/rust/totalreclaw-core/src/wasm.rs
+++ b/rust/totalreclaw-core/src/wasm.rs
@@ -10,6 +10,7 @@ use wasm_bindgen::prelude::*;
 use crate::blind;
 use crate::claims;
 use crate::confirm;
+use crate::pin_intent;
 use crate::contradiction;
 use crate::crypto;
 use crate::debrief;
@@ -486,6 +487,48 @@ pub fn wasm_is_pinned_claim_json(claim_json: &str) -> bool {
 #[wasm_bindgen(js_name = "cosineSimilarity")]
 pub fn wasm_cosine_similarity(a: &[f32], b: &[f32]) -> f64 {
     reranker::cosine_similarity_f32(a, b)
+}
+
+// ---------------------------------------------------------------------------
+// Pin tier / boost / intent (kg-2 / F1 Pin UX 2.2.8)
+// ---------------------------------------------------------------------------
+
+/// Compute the [`PinTier`]'s multiplicative boost at a given timestamp.
+///
+/// `tier_json`: internally-tagged JSON, e.g. `{"tier":"soft","pinned_at":1716000000}`,
+/// `{"tier":"hard"}`, `{"tier":"none"}`.
+/// `now_unix`: seconds since epoch.
+/// `config_json`: JSON of [`PinConfig`], e.g. `{"soft_half_life_days":90,"soft_max_boost":1.5,"hard_boost":1.5}`.
+///
+/// Returns the multiplicative boost factor (1.0 for `none`).
+#[wasm_bindgen(js_name = "pinBoost")]
+pub fn wasm_pin_boost(tier_json: &str, now_unix: i64, config_json: &str) -> Result<f64, JsError> {
+    let tier: claims::PinTier = serde_json::from_str(tier_json)
+        .map_err(|e| JsError::new(&format!("invalid PinTier json: {}", e)))?;
+    let config: claims::PinConfig = serde_json::from_str(config_json)
+        .map_err(|e| JsError::new(&format!("invalid PinConfig json: {}", e)))?;
+    Ok(claims::pin_boost(tier, now_unix, &config))
+}
+
+/// Return the locked-default [`PinConfig`] as JSON. Clients that don't want
+/// to retune can pass this verbatim to [`wasm_pin_boost`].
+#[wasm_bindgen(js_name = "defaultPinConfig")]
+pub fn wasm_default_pin_config() -> Result<String, JsError> {
+    serde_json::to_string(&claims::PinConfig::default())
+        .map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Classify natural-language pin/unpin intent from a user utterance.
+///
+/// Returns JSON of [`PinIntent`] when a trigger phrase matches, or `null` when
+/// the utterance contains no recognised pin gesture. Lowercase normalization
+/// is applied internally — callers pass the raw user text.
+#[wasm_bindgen(js_name = "classifyPinIntent")]
+pub fn wasm_classify_pin_intent(text: &str) -> Result<String, JsError> {
+    match pin_intent::classify_pin_intent(text) {
+        Some(intent) => serde_json::to_string(&intent).map_err(|e| JsError::new(&e.to_string())),
+        None => Ok("null".to_string()),
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Step **1 of 6** for canonical-roadmap item kg-2 (F1 Pin UX 2.2.8) per the sequencing in [`docs/plans/2026-04-26-pin-ux-2.2.8-design-questions.md`](../totalreclaw-internal/blob/main/docs/plans/2026-04-26-pin-ux-2.2.8-design-questions.md#recommended-sequencing-within-phase-228). This PR lands the core foundation only — no client wiring, no reranker integration, no behavior change downstream.

**Risk tier (this PR alone):** L2 (new code in `totalreclaw-core`, no existing-behavior modification, no schema/reranker touch).
**Risk tier (overall kg-2 program):** L3 (will trigger at step 4 when reranker integration lands).

**Files changed:** 8 (1 new), +700 / -4.
**Tests:** 577 passed (incl. 27 new pin tests in `claims::tests` + `pin_intent::tests`), 0 failed.

## What this PR adds

- New module `rust/totalreclaw-core/src/pin_intent.rs`: substring-based natural-language pin/unpin intent classifier with the locked Q3 grammar from [`2026-04-28-f1-pin-ux-defaults.md`](../totalreclaw-internal/blob/main/docs/plans/2026-04-28-f1-pin-ux-defaults.md). Five intent buckets: soft / hard / unpin / tier-swap-to-hard / tier-swap-to-soft. Default grammar exposed via `default_grammar()`; custom grammars supported via `classify_pin_intent_with(text, grammar)`.
- New `PinTier` enum in `claims.rs` — internally-tagged JSON wire format (`{"tier":"soft","pinned_at":...}` / `{"tier":"hard"}` / `{"tier":"none"}`).
- New `PinConfig` struct in `claims.rs` with the Pedro-signed-off defaults (90d half-life, 1.5× max soft boost, 1.5× hard boost).
- New `pin_boost(tier, now_unix, config)` function — exponential decay per Q1 of the design doc, with clock-skew tolerance + zero-half-life edge case.
- WASM bindings: `pinBoost`, `defaultPinConfig`, `classifyPinIntent`.
- PyO3 bindings: `pin_boost`, `default_pin_config`, `classify_pin_intent`.

## Acceptance criteria satisfied (from design doc §Acceptance)

- [x] **#2** Time-decay curve table from Q1 is reproducible by feeding `(pinned_at, now)` pairs into `pin_boost` and asserting the result within `1e-6` — `pin_boost_soft_half_life_invariant_strict` passes at the strict tolerance; `pin_boost_soft_decay_table_q1` reproduces the full table at `1e-3`.

Remaining acceptance criteria (#1, #3, #4, #5) are gated on follow-up steps that this PR explicitly does not land.

## What this PR does NOT do (deferred to follow-up PRs)

| Step | Description | Tracks via |
|---|---|---|
| 2 | OpenClaw plugin auto-extraction pipeline reads `pin_intent` | follow-up PR (~1d) |
| 3 | MCP server `_pin` / `_unpin` tier-arg wiring | follow-up PR (~0.5d) |
| 4 | Reranker `apply_pin_boost` flag + parity tests (L3 — gated on bench regression across 4 corpora) | follow-up PR (~1d + bench) |
| 5 | Conflict-on-soft-pin agent message in OpenClaw + Hermes | follow-up PR (~1d) |
| 6 | Tier-swap natural-language path resolution against last-pinned fact | follow-up PR (~0.5d) |
| — | RC publish across core + MCP + plugin + python | gated until step 5+ |
| — | Real-user QA on staging | post step 5 |
| — | Stable promote | Pedro-only (outside autonomous skill scope) |

## Validation

- `cargo build --lib` (default features): clean
- `cargo build --lib --features wasm --no-default-features`: clean
- `cargo build --lib --features python`: clean
- `cargo test --lib`: **577 passed; 0 failed; 0 ignored**

## Backwards compatibility

- New `PinTier` / `PinConfig` types are purely additive — no existing serialization touched, no existing field renamed.
- Existing `is_pinned_claim` / `is_pinned_json` functions are unchanged. They remain the single-tier boolean view for legacy callers; the new `PinTier` enum is the v2 surface.
- Core version: `2.4.0` → `2.5.0-pre` (Cargo SemVer) / `2.5.0.dev0` (pyproject; PEP 440). Pre-release tag signals "wiring in progress" — clients should not pin to this version in stable channels until step 6 lands.

## Issue link

Refs https://github.com/p-diogo/totalreclaw-internal/issues/235 — **does not close** the umbrella issue. Issue closes when all 6 steps land + bench + RC + QA + stable promote.