### PR TITLE
ci(npm-publish): upgrade npm to latest for tokenless OIDC publish (mcp-server)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -242,6 +242,18 @@ jobs:
           console.log('RC version:', p.version);
           "
 
+      - name: Upgrade npm to latest (required for tokenless OIDC publish)
+        if: inputs.dry-run == false
+        # The npm CLI shipped with Node 22 (npm 10.x) signs provenance with
+        # OIDC but still expects a legacy auth token for the actual PUT.
+        # Tokenless OIDC trusted publishing (where the OIDC token IS the
+        # auth) requires npm >= 11.5.1. Without this upgrade, the workflow
+        # signed sigstore provenance successfully but the PUT 404'd
+        # (2026-05-24 run 26374302750).
+        run: |
+          npm install -g npm@latest
+          npm --version
+
       - name: Publish
         if: inputs.dry-run == false
         # OIDC trusted publishing — npm trusts this workflow file


### PR DESCRIPTION
## Summary

Follow-up to #257. After OIDC switch, `mcp-server` publish signed sigstore provenance successfully but PUT to npm still 404'd. Root cause: npm CLI bundled with Node 22 (npm ~10.5) signs OIDC provenance but still expects an auth token for the actual PUT. **Tokenless** OIDC publishing requires `npm >= 11.5.1`.

Adds `npm install -g npm@latest` step before the publish step, scoped to `publish-mcp-server` only.

## Test plan

- [ ] Merge.
- [ ] Re-trigger `Publish npm packages` workflow → `package=mcp-server`, `release-type=stable`, `dry-run=false`.
- [ ] Verify `@totalreclaw/mcp-server@3.3.0` appears on npm with a provenance badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)