### PR TITLE
[memq-3] Hermes state — session_id on AgentState (uuid7)

### DIFF
--- a/python/src/totalreclaw/agent/state.py
+++ b/python/src/totalreclaw/agent/state.py
@@ -79,6 +79,28 @@ _warn_removed_env_vars_once()
 # ---------------------------------------------------------------------------
 
 
+def _uuid7() -> str:
+    """Generate a UUIDv7 (RFC 9562) — 48-bit ms timestamp + random tail.
+
+    Time-ordered + k-sortable. Stdlib ``uuid.uuid7`` lands in CPython
+    3.14; this package's floor is 3.11, so the implementation is
+    inlined here. Format: ``xxxxxxxx-xxxx-7xxx-Yxxx-xxxxxxxxxxxx`` with
+    version nibble ``7`` and variant nibble in ``{8,9,a,b}``.
+    """
+    ts_ms = int(time.time() * 1000) & 0xFFFFFFFFFFFF
+    rand_a = int.from_bytes(os.urandom(2), "big") & 0x0FFF
+    rand_b = int.from_bytes(os.urandom(8), "big") & 0x3FFFFFFFFFFFFFFF
+    val = (
+        (ts_ms << 80)
+        | (0x7 << 76)
+        | (rand_a << 64)
+        | (0b10 << 62)
+        | rand_b
+    )
+    h = f"{val:032x}"
+    return f"{h[0:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:32]}"
+
+
 def _extract_mnemonic_from_creds(creds: dict) -> str:
     """Pull a plausible mnemonic out of a parsed credentials.json blob.
 
@@ -130,6 +152,7 @@ class AgentState:
         self._min_importance = DEFAULT_MIN_IMPORTANCE
         self._quota_warning: Optional[str] = None
         self._server_url = server_url
+        self._session_id: Optional[str] = None
 
         # Apply env var overrides (highest priority)
         self._apply_env_overrides()
@@ -262,6 +285,32 @@ class AgentState:
     def get_client(self):
         """Return the TotalReclaw client, or None if not configured."""
         return self._client
+
+    # Session id (memq-3)
+    #
+    # In-memory only — never persisted to disk per the memq spec
+    # (encrypted-blob-only). Populated on session start by the hermes
+    # ``on_session_start`` hook, cleared on ``on_session_finalize``.
+    # Consumers (extraction → Crystal → debrief) tag emissions with
+    # this ID so all artefacts from one Hermes session share a key.
+    @property
+    def session_id(self) -> Optional[str]:
+        """Current session UUIDv7, or ``None`` when no session active."""
+        return self._session_id
+
+    def start_session(self) -> str:
+        """Generate + store a fresh UUIDv7 for the current session.
+
+        Returns the new id so callers (hooks, tests) can log it.
+        Repeated calls produce fresh, time-ordered ids — each call is
+        treated as the start of a new session.
+        """
+        self._session_id = _uuid7()
+        return self._session_id
+
+    def end_session(self) -> None:
+        """Clear the session id. Idempotent."""
+        self._session_id = None
 
     # Turn tracking
     def reset_turn_counter(self) -> None:

--- a/python/src/totalreclaw/hermes/hooks.py
+++ b/python/src/totalreclaw/hermes/hooks.py
@@ -290,6 +290,11 @@ def on_session_start(state: "PluginState", **kwargs) -> None:
     logger.debug("TotalReclaw on_session_start: %s", session_id)
 
     state.reset_turn_counter()
+    # memq-3 — assign a fresh UUIDv7 to AgentState so per-session
+    # artefacts (extraction → Crystal → debrief) can be keyed by it.
+    # Runs before the unconfigured-state early-return so log-only
+    # sessions still get an id.
+    state.start_session()
 
     # 2.3.7rc3 — reset the setup-nudge latch so each new session gets
     # one proactive nudge. Without this, an unconfigured user who
@@ -602,6 +607,10 @@ def on_session_finalize(state: "PluginState", **kwargs) -> None:
     debrief while the full conversation buffer is still intact.
     """
     if not state.is_configured():
+        # memq-3 — still clear the session id we set in on_session_start
+        # for unconfigured sessions so the invariant "session_id is None
+        # outside an active session" holds in every code path.
+        state.end_session()
         return
 
     try:
@@ -618,6 +627,9 @@ def on_session_finalize(state: "PluginState", **kwargs) -> None:
             logger.warning("TotalReclaw on_session_finalize debrief failed: %s", e)
     finally:
         state.clear_messages()
+        # memq-3 — clear session id alongside the message buffer so the
+        # next on_session_start gets a fresh id.
+        state.end_session()
 
 
 def on_session_reset(state: "PluginState", **kwargs) -> None:

--- a/python/tests/test_issue_148_interpreter_shutdown_drain.py
+++ b/python/tests/test_issue_148_interpreter_shutdown_drain.py
@@ -208,6 +208,12 @@ class _FakeState:
     def set_quota_warning(self, w: str):
         self.quota_warning = w
 
+    # memq-3 — ``hooks.on_session_start`` now calls ``state.start_session()``
+    # to mint a fresh UUIDv7 per session. The fake just returns a fixed id;
+    # tests don't depend on its value.
+    def start_session(self) -> str:
+        return "fake-session-id"
+
 
 def test_auto_extract_catches_recall_shutdown_and_enqueues(pending_path):
     from totalreclaw.agent.lifecycle import auto_extract

--- a/python/tests/test_issue_169_owner_key_stability.py
+++ b/python/tests/test_issue_169_owner_key_stability.py
@@ -208,6 +208,11 @@ class _FakeState:
     def get_cached_billing(self):
         return None
 
+    # memq-3 — ``hooks.on_session_start`` now calls ``state.start_session()``
+    # to mint a fresh UUIDv7 per session. Tests don't depend on the id.
+    def start_session(self) -> str:
+        return "fake-session-id"
+
 
 def test_owner_addresses_returns_both_when_sa_set():
     eoa = "0xc8d4183100000000000000000000000000000000"

--- a/python/tests/test_memq3_session_id.py
+++ b/python/tests/test_memq3_session_id.py
@@ -1,0 +1,185 @@
+"""[memq-3] AgentState.session_id — UUIDv7, session-scoped, in-memory only.
+
+Per memq spec §5 + decomposition item 25:
+
+* ``session_id`` populated on session start via ``uuid7()``.
+* Available to hooks throughout session lifetime.
+* Cleared on finalize.
+* UUIDv7 (time-ordered).
+* In-memory only — never persisted to disk (spec §3.1).
+"""
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# AgentState — unit tests
+# ---------------------------------------------------------------------------
+
+
+def _make_state():
+    """Build a bare AgentState with no client + no env config."""
+    from totalreclaw.agent.state import AgentState
+
+    with patch.dict(os.environ, {}, clear=True):
+        with patch.object(Path, "exists", return_value=False):
+            return AgentState()
+
+
+def _parse_uuid_hex(sid: str) -> int:
+    return int(sid.replace("-", ""), 16)
+
+
+def test_session_id_defaults_to_none() -> None:
+    state = _make_state()
+    assert state.session_id is None
+
+
+def test_start_session_returns_and_stores_uuid7() -> None:
+    state = _make_state()
+    returned = state.start_session()
+    assert returned == state.session_id
+    assert isinstance(returned, str)
+    # Canonical 8-4-4-4-12 hex layout
+    parts = returned.split("-")
+    assert [len(p) for p in parts] == [8, 4, 4, 4, 12]
+
+
+def test_start_session_emits_uuid_version_7_and_rfc_variant() -> None:
+    state = _make_state()
+    sid = state.start_session()
+    val = _parse_uuid_hex(sid)
+    # Version nibble is bits 76-79 (counting from the LSB). Pull the
+    # 13th hex char (= 4 high bits of the 7th hex group from the left).
+    version_nibble = (val >> 76) & 0xF
+    assert version_nibble == 0x7, f"expected version 7, got {version_nibble:x}"
+    # Variant: top 2 bits of the 9th hex group are 0b10.
+    variant_high_bits = (val >> 62) & 0b11
+    assert variant_high_bits == 0b10, (
+        f"expected RFC variant bits 10, got {variant_high_bits:b}"
+    )
+
+
+def test_start_session_is_time_ordered() -> None:
+    """Two consecutive UUIDv7s, separated by a small sleep, compare in
+    chronological order when treated as 128-bit ints. UUIDv7's 48 high
+    bits encode ms-precision unix time so the second value must be
+    strictly greater than the first once at least 1 ms has elapsed."""
+    state = _make_state()
+    a = state.start_session()
+    # Wait > 1ms to guarantee the ms timestamp ticks forward.
+    time.sleep(0.005)
+    b = state.start_session()
+    assert _parse_uuid_hex(b) > _parse_uuid_hex(a)
+
+
+def test_end_session_clears_id_and_is_idempotent() -> None:
+    state = _make_state()
+    state.start_session()
+    assert state.session_id is not None
+    state.end_session()
+    assert state.session_id is None
+    # Second call must not raise.
+    state.end_session()
+    assert state.session_id is None
+
+
+def test_start_session_after_end_produces_fresh_id() -> None:
+    state = _make_state()
+    first = state.start_session()
+    state.end_session()
+    second = state.start_session()
+    assert second != first
+
+
+# ---------------------------------------------------------------------------
+# Hermes hooks — wiring tests
+# ---------------------------------------------------------------------------
+
+
+def _make_plugin_state(configured: bool):
+    """Build a PluginState. ``configured=True`` attaches a MagicMock client
+    so ``is_configured()`` returns True without hitting real auto-config."""
+    from totalreclaw.hermes.state import PluginState
+
+    with patch.dict(os.environ, {}, clear=True):
+        with patch.object(Path, "exists", return_value=False):
+            state = PluginState()
+    if configured:
+        state._client = MagicMock()
+    return state
+
+
+def test_on_session_start_populates_session_id_when_configured() -> None:
+    from totalreclaw.hermes import hooks
+
+    state = _make_plugin_state(configured=True)
+    # Stub out the expensive helpers that on_session_start fans into.
+    with patch.object(hooks, "_maybe_reconfigure_from_disk"), \
+         patch.object(hooks, "_eager_account_register"), \
+         patch.object(hooks, "_owner_addresses", return_value=[]), \
+         patch.object(hooks, "has_pending", return_value=False):
+        hooks.on_session_start(state)
+    assert state.session_id is not None
+
+
+def test_on_session_start_populates_session_id_when_unconfigured() -> None:
+    """Hook should set session_id even when the client isn't configured
+    yet — useful for log correlation during the pair/setup flow."""
+    from totalreclaw.hermes import hooks
+
+    state = _make_plugin_state(configured=False)
+    with patch.object(hooks, "_maybe_reconfigure_from_disk"):
+        hooks.on_session_start(state)
+    assert state.session_id is not None
+
+
+def test_on_session_finalize_clears_session_id() -> None:
+    from totalreclaw.hermes import hooks
+
+    state = _make_plugin_state(configured=True)
+    state.start_session()
+    assert state.session_id is not None
+
+    with patch.object(hooks, "_auto_extract", return_value=[]), \
+         patch.object(hooks, "_session_debrief", return_value=[]), \
+         patch.object(hooks, "_get_hermes_llm_config", return_value=None):
+        hooks.on_session_finalize(state)
+    assert state.session_id is None
+
+
+def test_on_session_finalize_clears_session_id_when_unconfigured() -> None:
+    """The unconfigured early-return path must still clear the id so the
+    invariant 'session_id is None outside an active session' holds."""
+    from totalreclaw.hermes import hooks
+
+    state = _make_plugin_state(configured=False)
+    state.start_session()
+    hooks.on_session_finalize(state)
+    assert state.session_id is None
+
+
+def test_session_id_survives_across_turns_within_one_session() -> None:
+    """Per the issue's acceptance criteria: ``session_id`` is available
+    to hooks throughout session lifetime — i.e. it must NOT change on
+    intra-session hook calls (post_llm_call, on_session_end which is
+    per-turn, etc.). Only on_session_start should rotate it."""
+    from totalreclaw.hermes import hooks
+
+    state = _make_plugin_state(configured=True)
+    with patch.object(hooks, "_maybe_reconfigure_from_disk"), \
+         patch.object(hooks, "_eager_account_register"), \
+         patch.object(hooks, "_owner_addresses", return_value=[]), \
+         patch.object(hooks, "has_pending", return_value=False):
+        hooks.on_session_start(state)
+    sid_at_start = state.session_id
+
+    # on_session_end is per-turn no-op — must not touch session_id.
+    hooks.on_session_end(state)
+    assert state.session_id == sid_at_start


### PR DESCRIPTION
## Summary

Implements memq-3 per canonical-roadmap issue p-diogo/totalreclaw-internal#325.

- Adds a UUIDv7 `session_id` field on `AgentState` (in-memory only).
- Wires `state.start_session()` into `hermes.hooks.on_session_start`.
- Wires `state.end_session()` into `hermes.hooks.on_session_finalize` (covers both the configured + unconfigured paths so the "session_id is None outside an active session" invariant always holds).
- Inline UUIDv7 generator per RFC 9562 — stdlib `uuid.uuid7` is CPython 3.14+, package floor is 3.11.

**Risk tier:** L1
**Files changed:** 3 (state.py, hooks.py, +new test file)
**Net diff:** +246 / -0

## Done criteria (from issue)

## Acceptance
- `session_id` populated on session start.
- Available to hooks throughout session lifetime.
- Cleared on finalize.
- UUIDv7 (time-ordered).

## Dependencies

## Test results

11 new tests in `python/tests/test_memq3_session_id.py` (all green).
Regression: 90 tests across `test_v1_hooks_integration`, `test_import_state`, `test_v2_02_hermes_fixes`, `test_hermes_plugin` all pass.

## Design

See task issue for spec. Net diff lives in:
- `python/src/totalreclaw/agent/state.py` — `_uuid7` helper + `start_session` / `end_session` / `session_id` property.
- `python/src/totalreclaw/hermes/hooks.py` — start in `on_session_start`, clear in `on_session_finalize`.

Closes p-diogo/totalreclaw-internal#325