### PR TITLE
[imp-11] Python import-engine chunked batch helper

### DIFF
--- a/python/src/totalreclaw/import_engine.py
+++ b/python/src/totalreclaw/import_engine.py
@@ -52,6 +52,18 @@ DEFAULT_BATCH_SIZE = 25    # Chunks per batch
 CHUNK_SIZE = 20            # Messages per conversation chunk (matches adapters)
 INTER_CHUNK_DELAY = 2.0    # Seconds between LLM extraction calls (rate-limit mitigation)
 
+# Maximum facts per batched UserOperation. Mirrors userop.MAX_BATCH_SIZE; kept
+# local to avoid importing from userop here (consistent with lifecycle.py's
+# _LIFECYCLE_MAX_BATCH). If the userop constant changes, update both.
+IMPORT_MAX_BATCH_SIZE = 15
+
+# Gnosis mainnet chain ID — the Pro-tier chain where batched UserOps are
+# economically meaningful. Free-tier (Base Sepolia, 84532) falls back to
+# per-fact submission per the spec §5 chain-gate. Per PRD-IMP, imports run
+# Pro-only, so this gate evaluates true in practice; the explicit check keeps
+# the cost claim self-verifying and tolerates future free-tier import flows.
+_GNOSIS_CHAIN_ID = 100
+
 
 class ImportEngine:
     """Agent-agnostic batch import engine.
@@ -228,11 +240,15 @@ class ImportEngine:
             )
 
         facts_extracted = 0
-        facts_stored = 0
         errors: list[str] = []
         chunks_with_no_facts = 0
         extraction_failures = 0
+        all_extracted: list[dict] = []
 
+        # Extraction phase: collect facts from every chunk in the batch so the
+        # subsequent store phase can chunk across chunks into Gnosis-batched
+        # UserOps (spec §5). Per-chunk granularity is preserved for extraction
+        # errors and "no facts produced" warnings.
         for i, chunk in enumerate(batch):
             # Rate-limit: add delay between LLM calls (skip before the first one)
             if i > 0:
@@ -243,27 +259,19 @@ class ImportEngine:
                 if not extracted:
                     chunks_with_no_facts += 1
                 facts_extracted += len(extracted)
-
-                for fact in extracted:
-                    try:
-                        await self._store_fact(fact)
-                        facts_stored += 1
-                    except Exception as e:
-                        msg = str(e)
-                        # Content fingerprint dedup (409) is expected
-                        if '409' in msg or 'duplicate' in msg or 'fingerprint' in msg:
-                            logger.debug("Skipped duplicate: %s", fact.get('text', '')[:60])
-                        else:
-                            errors.append(f"Store failed: {msg}")
-                            if len(errors) >= 20:
-                                errors.append("Error limit reached (20). Remaining facts in this batch skipped.")
-                                break
+                all_extracted.extend(extracted)
             except Exception as e:
                 extraction_failures += 1
                 errors.append(f"Extraction failed for chunk '{chunk.title}': {repr(e)}")
 
             if len(errors) >= 20:
                 break
+
+        # Store phase: one batched UserOp per ≤15-fact chunk on Gnosis, or a
+        # per-fact remember() loop on free-tier / unresolvable chain.
+        facts_stored, store_errors = await self._store_facts_chunked(all_extracted)
+        if store_errors:
+            errors.extend(store_errors)
 
         # Surface extraction problems as warnings so the user gets feedback
         if extraction_failures > 0:
@@ -321,27 +329,19 @@ class ImportEngine:
                 duration_ms=_now_ms() - start_ms,
             )
 
-        facts_stored = 0
-        errors: list[str] = []
-
-        for fact in batch:
-            try:
-                fact_dict = {
-                    'text': fact.text,
-                    'type': fact.type,
-                    'importance': fact.importance,
-                }
-                await self._store_fact(fact_dict)
-                facts_stored += 1
-            except Exception as e:
-                msg = str(e)
-                if '409' in msg or 'duplicate' in msg or 'fingerprint' in msg:
-                    logger.debug("Skipped duplicate: %s", fact.text[:60])
-                else:
-                    errors.append(f"Store failed for '{fact.text[:60]}': {msg}")
-                    if len(errors) >= 20:
-                        errors.append("Error limit reached (20). Remaining facts skipped.")
-                        break
+        # Convert NormalizedFact dataclass instances to the dict shape the
+        # store helper expects. Routes through the chunked-batch helper:
+        # one ≤15-fact remember_batch UserOp on Gnosis, per-fact remember()
+        # everywhere else (spec §5).
+        fact_dicts = [
+            {
+                'text': fact.text,
+                'type': fact.type,
+                'importance': fact.importance,
+            }
+            for fact in batch
+        ]
+        facts_stored, errors = await self._store_facts_chunked(fact_dicts)
 
         return BatchImportResult(
             success=facts_stored > 0 or not errors,
@@ -406,17 +406,18 @@ class ImportEngine:
 
         return valid
 
-    async def _store_fact(self, fact: dict) -> str:
-        """Embed and store a single fact via the client.
+    @staticmethod
+    def _prepare_fact_payload(fact: dict) -> dict:
+        """Build the per-fact payload shape shared by ``client.remember`` and
+        ``client.remember_batch``.
 
-        Returns the stored fact ID.
+        Normalises importance from the 1-10 input scale to the 0.0-1.0 scale
+        the client expects, and best-effort attaches an embedding.
         """
         text = fact["text"]
         importance = fact.get("importance", 5)
-        # Normalize importance from 1-10 to 0.0-1.0
         importance_normalized = max(0.0, min(1.0, importance / 10.0))
 
-        # Try to generate embedding (optional -- client works without it)
         embedding = None
         try:
             from totalreclaw.embedding import get_embedding
@@ -424,12 +425,113 @@ class ImportEngine:
         except Exception:
             pass
 
+        return {
+            "text": text,
+            "importance": importance_normalized,
+            "embedding": embedding,
+        }
+
+    async def _store_fact(self, fact: dict) -> str:
+        """Embed and store a single fact via the client.
+
+        Returns the stored fact ID.
+        """
+        payload = self._prepare_fact_payload(fact)
         return await self._client.remember(
-            text,
-            embedding=embedding,
-            importance=importance_normalized,
+            payload["text"],
+            embedding=payload["embedding"],
+            importance=payload["importance"],
             source="import",
         )
+
+    async def _resolve_chain_id_safely(self) -> Optional[int]:
+        """Resolve ``client.chain_id`` defensively.
+
+        Returns the resolved chain id, or ``None`` if resolution fails (test
+        clients without a real ``_ensure_chain_id`` coroutine, offline runs,
+        etc.). Callers must treat ``None`` as "not Gnosis" and use the
+        per-fact fallback path.
+        """
+        try:
+            return await self._client._ensure_chain_id()
+        except Exception:
+            return None
+
+    async def _store_facts_chunked(
+        self,
+        facts: list[dict],
+    ) -> tuple[int, list[str]]:
+        """Store ``facts`` via chunked batched UserOps when the client is on
+        Gnosis (chain 100); otherwise via per-fact ``client.remember`` calls.
+
+        Per spec ``docs/specs/imp/281-gnosis-batching-chain-gate.md`` §5 +
+        decomposition imp-11: buffer facts into groups of ≤15 and submit one
+        ``client.remember_batch`` per group on chain 100. PRD-IMP's Pro-only
+        import gate guarantees ``chain_id == 100`` on this code path; the
+        explicit check keeps the cost claim self-verifying.
+
+        Returns ``(facts_stored, errors)`` so callers can aggregate into the
+        existing ``BatchImportResult`` shape.
+
+        Dedup (HTTP 409 / fingerprint) is logged at DEBUG and not counted as
+        an error. Other failures are surfaced via the returned error list,
+        capped at 20 entries to match the per-fact loop's contract.
+        """
+        if not facts:
+            return 0, []
+
+        chain_id = await self._resolve_chain_id_safely()
+        errors: list[str] = []
+        facts_stored = 0
+
+        if chain_id == _GNOSIS_CHAIN_ID:
+            for chunk_start in range(0, len(facts), IMPORT_MAX_BATCH_SIZE):
+                chunk = facts[chunk_start:chunk_start + IMPORT_MAX_BATCH_SIZE]
+                payloads = [self._prepare_fact_payload(f) for f in chunk]
+                try:
+                    ids = await self._client.remember_batch(payloads, source="import")
+                    facts_stored += len(ids)
+                    if len(ids) < len(chunk):
+                        logger.debug(
+                            "remember_batch returned %d ids for %d-fact chunk "
+                            "(likely fingerprint dedup of subset)",
+                            len(ids), len(chunk),
+                        )
+                except Exception as e:
+                    msg = str(e)
+                    if '409' in msg or 'duplicate' in msg or 'fingerprint' in msg:
+                        logger.debug(
+                            "Batch of %d facts rejected as duplicate", len(chunk),
+                        )
+                    else:
+                        errors.append(
+                            f"Batch store failed ({len(chunk)} facts): {msg}"
+                        )
+                        if len(errors) >= 20:
+                            errors.append(
+                                "Error limit reached (20). Remaining facts in this batch skipped."
+                            )
+                            break
+            return facts_stored, errors
+
+        # Per-fact fallback: free-tier / non-Gnosis / chain probe failed.
+        for fact in facts:
+            try:
+                await self._store_fact(fact)
+                facts_stored += 1
+            except Exception as e:
+                msg = str(e)
+                if '409' in msg or 'duplicate' in msg or 'fingerprint' in msg:
+                    logger.debug("Skipped duplicate: %s", fact.get('text', '')[:60])
+                else:
+                    errors.append(f"Store failed: {msg}")
+                    if len(errors) >= 20:
+                        errors.append(
+                            "Error limit reached (20). Remaining facts in this batch skipped."
+                        )
+                        break
+
+        return facts_stored, errors
 
 
 def _now_ms() -> int:

--- a/python/tests/test_import_engine_batching.py
+++ b/python/tests/test_import_engine_batching.py
@@ -1,0 +1,288 @@
+"""Tests for the imp-11 import-engine chunked-batch helper.
+
+Acceptance criteria (imp-11 decomposition): the helper must:
+
+* On Gnosis (chain 100), buffer facts into groups of ≤15 and submit each
+  group via ``client.remember_batch`` (one UserOp per group).
+* On free-tier / non-Gnosis chains, fall back to per-fact
+  ``client.remember`` calls (current behaviour).
+* Cover 14-, 15-, and 30-fact cases (exactly the matrix called out by the
+  decomposition's acceptance criteria).
+
+Spec: ``docs/specs/imp/281-gnosis-batching-chain-gate.md`` §5.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from totalreclaw.import_engine import (
+    ImportEngine,
+    IMPORT_MAX_BATCH_SIZE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_facts(n: int) -> list[dict]:
+    """Build ``n`` distinct fact dicts in the engine's internal shape."""
+    return [
+        {
+            "text": f"Fact number {i}: some unique user detail to avoid dedup",
+            "type": "fact",
+            "importance": 7,
+        }
+        for i in range(n)
+    ]
+
+
+def _make_pro_client() -> MagicMock:
+    """Build a fake TotalReclaw client resolved on Gnosis (chain 100).
+
+    ``remember_batch`` returns one UUID-shaped string per fact so the
+    engine's ``len(ids)`` accounting reflects ``len(input)``.
+    ``remember`` is wired but should not be invoked on the batched path.
+    """
+    client = MagicMock()
+
+    async def _ensure_chain_id():
+        return 100
+
+    async def _remember_batch(facts, source="python-client"):
+        return [f"fact-id-{i}" for i in range(len(facts))]
+
+    async def _remember(text, **kwargs):
+        return f"single-{text[:20]}"
+
+    client._ensure_chain_id = AsyncMock(side_effect=_ensure_chain_id)
+    client.remember_batch = AsyncMock(side_effect=_remember_batch)
+    client.remember = AsyncMock(side_effect=_remember)
+    return client
+
+
+def _make_free_client() -> MagicMock:
+    """Build a fake client resolved on free-tier (Base Sepolia, 84532)."""
+    client = MagicMock()
+
+    async def _ensure_chain_id():
+        return 84532
+
+    async def _remember(text, **kwargs):
+        return f"single-{text[:20]}"
+
+    async def _remember_batch(facts, source="python-client"):
+        raise AssertionError("remember_batch must not be called on free-tier chain")
+
+    client._ensure_chain_id = AsyncMock(side_effect=_ensure_chain_id)
+    client.remember = AsyncMock(side_effect=_remember)
+    client.remember_batch = AsyncMock(side_effect=_remember_batch)
+    return client
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Chain-gate predicate
+# ---------------------------------------------------------------------------
+
+
+def test_gnosis_14_facts_submits_one_batch() -> None:
+    """14 facts on Gnosis → 1 remember_batch call of 14, 0 remember calls."""
+    client = _make_pro_client()
+    engine = ImportEngine(client=client, llm_extract=None)
+
+    facts_stored, errors = _run(engine._store_facts_chunked(_make_facts(14)))
+
+    assert errors == []
+    assert facts_stored == 14
+    assert client.remember_batch.await_count == 1
+    submitted = client.remember_batch.await_args_list[0].args[0]
+    assert len(submitted) == 14
+    assert client.remember.await_count == 0
+
+
+def test_gnosis_15_facts_submits_one_batch() -> None:
+    """15 facts on Gnosis → exactly 1 remember_batch call of 15."""
+    client = _make_pro_client()
+    engine = ImportEngine(client=client, llm_extract=None)
+
+    facts_stored, errors = _run(engine._store_facts_chunked(_make_facts(15)))
+
+    assert errors == []
+    assert facts_stored == 15
+    assert client.remember_batch.await_count == 1
+    submitted = client.remember_batch.await_args_list[0].args[0]
+    assert len(submitted) == IMPORT_MAX_BATCH_SIZE == 15
+    assert client.remember.await_count == 0
+
+
+def test_gnosis_30_facts_submits_two_batches() -> None:
+    """30 facts on Gnosis → 2 remember_batch calls of 15 each."""
+    client = _make_pro_client()
+    engine = ImportEngine(client=client, llm_extract=None)
+
+    facts_stored, errors = _run(engine._store_facts_chunked(_make_facts(30)))
+
+    assert errors == []
+    assert facts_stored == 30
+    assert client.remember_batch.await_count == 2
+    sizes = [len(c.args[0]) for c in client.remember_batch.await_args_list]
+    assert sizes == [15, 15]
+    assert client.remember.await_count == 0
+
+
+def test_gnosis_uneven_split_last_chunk_short() -> None:
+    """20 facts on Gnosis → 1 batch of 15 followed by 1 batch of 5."""
+    client = _make_pro_client()
+    engine = ImportEngine(client=client, llm_extract=None)
+
+    facts_stored, errors = _run(engine._store_facts_chunked(_make_facts(20)))
+
+    assert errors == []
+    assert facts_stored == 20
+    sizes = [len(c.args[0]) for c in client.remember_batch.await_args_list]
+    assert sizes == [15, 5]
+
+
+# ---------------------------------------------------------------------------
+# Source tag + payload shape
+# ---------------------------------------------------------------------------
+
+
+def test_gnosis_batch_uses_import_source_tag() -> None:
+    """remember_batch must be called with source="import" to match the
+    pre-batching per-fact behaviour."""
+    client = _make_pro_client()
+    engine = ImportEngine(client=client, llm_extract=None)
+
+    _run(engine._store_facts_chunked(_make_facts(3)))
+
+    call = client.remember_batch.await_args_list[0]
+    assert call.kwargs.get("source") == "import"
+
+
+def test_gnosis_batch_normalises_importance_to_unit_range() -> None:
+    """The 1-10 importance scale must be normalised to 0.0-1.0 before
+    submission, matching the existing _store_fact contract."""
+    client = _make_pro_client()
+    engine = ImportEngine(client=client, llm_extract=None)
+
+    _run(engine._store_facts_chunked([
+        {"text": "max importance fact", "type": "fact", "importance": 10},
+        {"text": "mid importance fact", "type": "fact", "importance": 5},
+    ]))
+
+    submitted = client.remember_batch.await_args_list[0].args[0]
+    assert submitted[0]["importance"] == pytest.approx(1.0)
+    assert submitted[1]["importance"] == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# Free-tier fallback
+# ---------------------------------------------------------------------------
+
+
+def test_free_tier_falls_back_to_per_fact_remember() -> None:
+    """On Base Sepolia (84532) the helper must use per-fact remember() and
+    never call remember_batch — current behaviour is preserved."""
+    client = _make_free_client()
+    engine = ImportEngine(client=client, llm_extract=None)
+
+    facts_stored, errors = _run(engine._store_facts_chunked(_make_facts(15)))
+
+    assert errors == []
+    assert facts_stored == 15
+    assert client.remember.await_count == 15
+    assert client.remember_batch.await_count == 0
+
+
+def test_unresolvable_chain_falls_back_to_per_fact() -> None:
+    """If ``_ensure_chain_id`` raises (e.g. test client without an awaitable
+    stub), the helper must fall back to per-fact remember() rather than
+    crash. This preserves backwards compat with existing tests."""
+    client = MagicMock()
+    # MagicMock auto-creates _ensure_chain_id as a non-awaitable Mock so
+    # ``await self._client._ensure_chain_id()`` raises TypeError.
+    async def _remember(text, **kwargs):
+        return f"single-{text[:20]}"
+    client.remember = AsyncMock(side_effect=_remember)
+    engine = ImportEngine(client=client, llm_extract=None)
+
+    facts_stored, errors = _run(engine._store_facts_chunked(_make_facts(3)))
+
+    assert errors == []
+    assert facts_stored == 3
+    assert client.remember.await_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Error / dedup handling
+# ---------------------------------------------------------------------------
+
+
+def test_gnosis_batch_409_dedup_is_silent() -> None:
+    """A 409/duplicate failure from remember_batch must not surface as an
+    error — matches the per-fact loop's contract."""
+    client = _make_pro_client()
+    client.remember_batch = AsyncMock(
+        side_effect=RuntimeError("409 fingerprint duplicate")
+    )
+    engine = ImportEngine(client=client, llm_extract=None)
+
+    facts_stored, errors = _run(engine._store_facts_chunked(_make_facts(15)))
+
+    assert errors == []
+    assert facts_stored == 0
+
+
+def test_gnosis_batch_partial_id_list_counts_only_returned_ids() -> None:
+    """If remember_batch returns fewer ids than facts submitted (likely
+    fingerprint dedup of a subset), only the returned count is credited."""
+    client = _make_pro_client()
+
+    async def _short_batch(facts, source="python-client"):
+        return [f"id-{i}" for i in range(len(facts) - 2)]
+
+    client.remember_batch = AsyncMock(side_effect=_short_batch)
+    engine = ImportEngine(client=client, llm_extract=None)
+
+    facts_stored, errors = _run(engine._store_facts_chunked(_make_facts(15)))
+
+    assert errors == []
+    assert facts_stored == 13
+
+
+def test_gnosis_batch_non_dedup_error_surfaced() -> None:
+    """Non-409 errors propagate to the returned error list (capped at 20)."""
+    client = _make_pro_client()
+    client.remember_batch = AsyncMock(
+        side_effect=RuntimeError("AA25 nonce zombie")
+    )
+    engine = ImportEngine(client=client, llm_extract=None)
+
+    facts_stored, errors = _run(engine._store_facts_chunked(_make_facts(30)))
+
+    assert facts_stored == 0
+    # Two chunks attempted; two errors collected.
+    assert len(errors) == 2
+    assert all("AA25 nonce zombie" in e for e in errors)
+
+
+def test_empty_input_returns_zero_no_calls() -> None:
+    client = _make_pro_client()
+    engine = ImportEngine(client=client, llm_extract=None)
+
+    facts_stored, errors = _run(engine._store_facts_chunked([]))
+
+    assert facts_stored == 0
+    assert errors == []
+    assert client.remember_batch.await_count == 0
+    assert client.remember.await_count == 0


### PR DESCRIPTION
## Summary

Implements `[imp-11]` (Python import-engine chunked batch helper) per spec `docs/specs/imp/281-gnosis-batching-chain-gate.md` §5 and the work-leaf decomposition in p-diogo/totalreclaw-internal#326.

- **Risk tier:** L2
- **Surface:** `python/src/totalreclaw/import_engine.py` only (1 source file + 1 new test file).
- **Net diff:** +435 / -45 (most of which is the new test file).

## What changed

- New `_store_facts_chunked(facts)` helper. Buffers facts into groups of ≤15. On Gnosis (`client.chain_id == 100`) it submits each group via `client.remember_batch(..., source="import")` — one batched UserOp per group. Off Gnosis / unresolvable chain it falls back to per-fact `client.remember(...)`, preserving today's behaviour.
- Shared `_prepare_fact_payload` extracts the importance-normalisation + embedding-fetch logic used by both `remember` and `remember_batch`.
- `_process_chunk_batch` now accumulates all extracted facts across the conversation chunks in a batch before storing, so cross-chunk batching is reachable (one `process_batch` invocation can produce `ceil(facts/15)` UserOps instead of `facts`).
- `_process_fact_batch` routes through the same helper.
- `_store_fact` is kept for the per-fact fallback (and is now defined in terms of `_prepare_fact_payload`).

PRD-IMP's Pro-only import gate guarantees `chain_id == 100` on this code path in practice. The explicit chain check is defensive and keeps the spec's cost claim ($105 → $7 per 10K-fact import) self-verifying.

## Tests

New `python/tests/test_import_engine_batching.py` covers the acceptance-criteria matrix and edge cases:

| Test | Verifies |
|---|---|
| `test_gnosis_14_facts_submits_one_batch` | 14 facts → 1 `remember_batch` call of 14, 0 `remember` calls |
| `test_gnosis_15_facts_submits_one_batch` | 15 facts → 1 `remember_batch` call of 15 |
| `test_gnosis_30_facts_submits_two_batches` | 30 facts → 2 `remember_batch` calls of 15 each |
| `test_gnosis_uneven_split_last_chunk_short` | 20 facts → `[15, 5]` |
| `test_gnosis_batch_uses_import_source_tag` | `remember_batch` is called with `source="import"` |
| `test_gnosis_batch_normalises_importance_to_unit_range` | 1-10 importance → 0.0-1.0 |
| `test_free_tier_falls_back_to_per_fact_remember` | Base Sepolia → per-fact `remember`, no batch |
| `test_unresolvable_chain_falls_back_to_per_fact` | Test client without awaitable `_ensure_chain_id` still works (backwards-compat with existing `test_mem0_adapter`) |
| `test_gnosis_batch_409_dedup_is_silent` | 409 / `duplicate` / `fingerprint` from `remember_batch` is debug-logged, not surfaced |
| `test_gnosis_batch_partial_id_list_counts_only_returned_ids` | Short id-list from `remember_batch` accounted correctly |
| `test_gnosis_batch_non_dedup_error_surfaced` | Other errors propagate via the `errors` return |
| `test_empty_input_returns_zero_no_calls` | Empty input fast-path |

### Full Python suite

`pytest -x --ignore=tests/cross_client_e2e.py` → **1221 passed, 13 skipped, 1 xfailed**. No regression in the existing import-pipeline tests (`test_mem0_adapter`, `test_import_adapter_preflight`, `test_import_state`).

## Dependencies

The decomposition lists `imp-10` (chain-gate in `agent/lifecycle.py`) as a dependency. The dependency is on the `client.chain_id` surface, which is already in place — see `python/src/totalreclaw/client.py:328-342` and the spec's §5 "No change" row for the client. `imp-10` is a parallel chain-gate at a different call site and does not block this work-leaf.

## RC publish

L2 → no automatic RC publish from this PR. The kill-switch env var (`imp-16`) is the rollout safety net once `imp-9` + `imp-10` land and the spec moves into Phase 1.

Closes p-diogo/totalreclaw-internal#326