### PR TITLE
[imp-17] docs(claude.md): Hermes batching gap RESOLVED + chain-aware note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,7 +206,7 @@ Features across OpenClaw plugin (`skill/plugin/`), MCP server (`mcp/`), NanoClaw
 | Max facts per extraction | Yes | -- | Yes | Yes | -- | Yes | Server-tunable via relay config (default 15) |
 | Chain ID (Gnosis-only) | Yes | Yes | Yes | -- | -- | Yes | All tiers route to Gnosis mainnet (chain 100); no per-tier chain switching |
 | **Batching** | | | | | | |
-| Client batching (multi-call UserOps) | Yes | Yes | Yes (via MCP) | -- | Yes (via MCP) | Hermes stores facts one-by-one (no ERC-4337 batch support in Python) |
+| Client batching (multi-call UserOps) | Yes | Yes | Yes (via MCP) | Yes (Gnosis Pro) | Yes (via MCP) | Yes | Hermes batches on Gnosis Pro (chain 100) via `client.remember_batch()` shipped in PyPI 2.0.0+; Base Sepolia free-tier (chain 84532) writes one fact per UserOp pending Path A gas-estimation diagnosis |
 | **Billing** | | | | | | |
 | Quota warnings (>80%) | Yes | -- | Yes | Yes | -- | Yes | Injected via on_session_start hook; ZeroClaw via quota_warning() method |
 | 403 handling + cache invalidation | Yes | Yes | Yes | -- | Yes (via MCP) | Yes | ZeroClaw invalidates billing cache on 403, returns QuotaExceeded error |
@@ -251,7 +251,8 @@ Managed Service single-chain tier model: **Free** = 250 memories/month on Gnosis
 | Crypto payments removed | LOW | Coinbase Commerce sunset March 31, 2026. Removed from relay, tools, and website. Stripe (fiat) is the sole payment method. |
 | Hermes not on PyPI (hermes-agent) | RESOLVED | `totalreclaw` 1.2.0 on PyPI includes generic agent layer (no hermes-agent dependency). OPENAI_BASE_URL fix + model detection included. |
 | Hermes no import/migrate/consolidate | MEDIUM | Python client does not yet implement import adapters, migrate tool, or consolidation. Core remember/recall/forget/export/status work. |
-| Hermes no client batching | LOW | Python client submits facts one-by-one (no ERC-4337 executeBatch). Acceptable for extraction volumes (max 15 facts). |
+| Hermes no client batching | RESOLVED | Python batch path shipped in PyPI 2.0.0+ (`client.remember_batch()`), now chain-aware after imp-10: Gnosis Pro (chain 100) batches up to 15 facts per UserOp; Base Sepolia free-tier (chain 84532) still single-fact pending Path A gas-estimation diagnosis (tracked separately). |
+| Free-tier (Base Sepolia) batch UserOps | LOW | Free-tier (Base Sepolia) writes one fact per UserOp pending Path A gas-estimation diagnosis. Gnosis Pro tier batches normally via `executeBatch`. |
 | Hermes no store-time dedup | RESOLVED | Generic agent layer now performs cosine-based near-duplicate detection (>= 0.85) before storing. |
 | Hermes heuristic extraction only | LOW | Generic agent layer tries LLM extraction first, falls back to heuristic regex. LLM path requires compatible provider (OpenAI-compatible endpoint). |
 | ZeroClaw no import/migrate | LOW | Rust crate implements core Memory trait + status + export + upgrade (Stripe checkout) but not import adapters or migrate tool. |


### PR DESCRIPTION
## Summary

Implements [imp-17] per canonical-roadmap issue [p-diogo/totalreclaw-internal#330](https://github.com/p-diogo/totalreclaw-internal/issues/330).

**Risk tier:** L1 (docs-only)
**Files changed:** 1 (`CLAUDE.md`)
**Net diff:** +3 / -2 lines

## What changed

Per imp-17 / spec 281-gnosis-batching scope:

1. **Known Gaps row** "Hermes no client batching" flipped from `LOW` → `RESOLVED`. Python batch path shipped in PyPI 2.0.0+ via `client.remember_batch()`; chain-aware after imp-10.
2. **New Known Gaps row** added: "Free-tier (Base Sepolia) batch UserOps" (LOW) documenting single-fact-per-UserOp behavior pending Path A gas-estimation diagnosis.
3. **Feature matrix row** "Client batching (multi-call UserOps)" updated:
   - Hermes column flipped `--` → `Yes (Gnosis Pro)`
   - Notes updated to describe chain-conditional behavior
   - **Also fixes a missing ZeroClaw cell** in this row (it had 6 data cells instead of 7 — adjacent rows like "Content fingerprint" have 7). ZeroClaw cell now `Yes`, consistent with line 258 "ZeroClaw no client batching | RESOLVED".

## Done criteria (from issue)

- [x] CLAUDE.md edits land.
- [x] Gap table accurately reflects post-spec reality (Gnosis Pro batched, Sepolia free-tier still single-fact).

## ⚠️ Coordinator review — flag

The task body references "Free-tier (Base Sepolia, chain 84532)" wording (consistent with spec [#317](https://github.com/p-diogo/totalreclaw-internal/issues/317)). However, current `main` already moved to a **Gnosis-only single-chain policy**:

- Line 207: `Chain ID (Gnosis-only) | ... All tiers route to Gnosis mainnet (chain 100); no per-tier chain switching`
- Line 261: `Hermes chain ID default | RESOLVED | All tiers use Gnosis mainnet (chain 100); per-tier chain switching removed.`
- Line ~244 (`Storage Mode Support` blurb): `Managed Service single-chain tier model: Free = 250 memories/month on Gnosis ...`

This means the new entries I added (referencing "Base Sepolia free-tier") are **internally inconsistent** with the rest of the doc unless the PRD-IMP work is reintroducing dual-chain.

Two valid coord responses:
- **(a) approve as-is** if PRD-IMP is in fact reintroducing Base Sepolia for free-tier (then line 207/261 should be revisited as a follow-up).
- **(b) request changes** to drop the "Base Sepolia" qualifier and reword as "free-tier on Gnosis still writes one fact per UserOp pending Path A diagnosis" — keeping doc coherent with the Gnosis-only policy already on main.

I applied the literal task wording. Coord-review owns this decision.

## Test results

_L1 docs-only: no test/CI changes. Visual diff review only._

Closes p-diogo/totalreclaw-internal#330