### PR TITLE
[cred-5 stage 1] feat(contracts): Foundry scaffold + SessionKeyModule interface + stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,7 @@ subgraph/tests/e2e-results/*.txt
 # Package lockfiles use local file: refs that break CI
 client/package-lock.json
 mcp/package-lock.json
+
+# Foundry vendored libraries — install via 'forge install foundry-rs/forge-std' from contracts/
+contracts/lib/forge-std/
+contracts/out/

--- a/contracts/contracts/SessionKeyModule.sol
+++ b/contracts/contracts/SessionKeyModule.sol
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {ISessionKeyModule} from "./interfaces/ISessionKeyModule.sol";
+import {PackedUserOperation} from "./interfaces/IUserOperation.sol";
+
+/**
+ * @title SessionKeyModule
+ * @notice STAGE-1 SCAFFOLD — cred-5 / PRD-01 / spec
+ *         `docs/specs/cred/session-key-delegation.md`.
+ *
+ *         This file is intentionally a stub. Function bodies revert
+ *         until the matching implementation work-leafs land:
+ *
+ *         - `validateSessionKeyUserOp` real body              → cred-5 stage 2
+ *         - per-inner-call `executeBatch` scope validation   → cred-6
+ *         - cross-chain Pimlico CREATE2 deploy               → cred-7
+ *         - EIP-712 `SessionKeyPermissionGrant` decode       → cred-5 stage 2 + cred-8 parity
+ *         - `revokeSessionKey` master-wallet auth check      → cred-5 stage 2
+ *
+ *         Cross-spec invariants the implementation MUST honour (load-bearing):
+ *           1. CREATE2 address of the parent Smart Account MUST remain
+ *              byte-equal pre- and post-install. Foundry test
+ *              `test_create2_address_unchanged_after_module_install` is
+ *              the load-bearing invariant test (cred-5 §6.1).
+ *           2. `executeBatch` per-inner-call validation — see cred-6 +
+ *              ISessionKeyModule docstring.
+ *           3. No TTL. Session keys are valid until explicit revoke.
+ *
+ *         The chosen ERC-4337 module framework is ZeroDev kernel v3
+ *         (cred-5 §11 Q1, Pedro sign-off 2026-05-27 on issue #320).
+ *         The kernel-v3 dependency lands under `contracts/lib/` in
+ *         cred-5 stage 2; this stage 1 PR adds Foundry tooling +
+ *         interface only.
+ */
+contract SessionKeyModule is ISessionKeyModule {
+    // --- ERC-4337 v0.7 validation-data constants ---
+
+    /// @dev Returned by `validateSessionKeyUserOp` on any failure.
+    ///      v0.7 EntryPoint treats `1` as SIG_VALIDATION_FAILED (no
+    ///      time-range packing — we do not use TTL).
+    uint256 internal constant SIG_VALIDATION_FAILED = 1;
+
+    /// @dev Returned on success — time-range packing not used.
+    uint256 internal constant SIG_VALIDATION_SUCCESS = 0;
+
+    // --- Storage ---
+    // Real storage layout lands in stage 2. For stage 1 we keep this
+    // empty — adding storage now risks breaking CREATE2 byte-equality
+    // when the layout settles in stage 2. The stage-2 work-leaf will
+    // populate this section + freeze the storage layout for upgrade
+    // forward-compat.
+
+    // --- Validation ---
+
+    /// @inheritdoc ISessionKeyModule
+    function validateSessionKeyUserOp(
+        PackedUserOperation calldata, /* userOp */
+        bytes32 /* userOpHash */
+    ) external pure returns (uint256) {
+        // STAGE 1 — body lands in cred-5 stage 2. Reverts in production
+        // would brick UserOp validation, so we return SIG_VALIDATION_FAILED
+        // to keep the staged module safe-by-default until the real
+        // validator ships.
+        return SIG_VALIDATION_FAILED;
+    }
+
+    /// @inheritdoc ISessionKeyModule
+    function revokeSessionKey(address /* account */, address /* signer */) external pure {
+        // STAGE 1 — body lands in cred-5 stage 2 (will check master-wallet
+        // auth + emit SessionKeyRevoked). Reverting here is safe: any
+        // real revoke attempt at stage 1 fails loud rather than silently
+        // succeeding.
+        revert("SessionKeyModule: revokeSessionKey not implemented (cred-5 stage 2)");
+    }
+
+    // --- Views ---
+
+    /// @inheritdoc ISessionKeyModule
+    function isSessionKeyActive(
+        address, /* account */
+        address /* signer */
+    ) external pure returns (bool) {
+        // STAGE 1 — body lands in cred-5 stage 2.
+        return false;
+    }
+
+    /// @inheritdoc ISessionKeyModule
+    function getSessionKeyGrant(
+        address, /* account */
+        address /* signer */
+    )
+        external
+        pure
+        returns (
+            uint256 nonce,
+            uint256 issuedAt,
+            bytes4[] memory selectors,
+            address target
+        )
+    {
+        // STAGE 1 — body lands in cred-5 stage 2.
+        return (0, 0, new bytes4[](0), address(0));
+    }
+}

--- a/contracts/contracts/interfaces/ISessionKeyModule.sol
+++ b/contracts/contracts/interfaces/ISessionKeyModule.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {PackedUserOperation} from "./IUserOperation.sol";
+
+/**
+ * @title ISessionKeyModule
+ * @notice ERC-4337 module that validates UserOperations signed by a
+ *         delegated session key (per cred spec §4.2). Master wallet
+ *         keypair stays on the SPA; agents (Hermes etc.) receive only
+ *         a scope-bounded session key.
+ *
+ * Cross-spec invariants (load-bearing — see cred spec §4.2):
+ * - `validateSessionKeyUserOp` MUST decode any `executeBatch(...)`
+ *   inner-calls and validate each one against the session-key scope.
+ *   Validating only the outer `executeBatch` selector breaks the imp
+ *   spec OQ-A cost model (cf. `docs/specs/imp/281-gnosis-batching-chain-gate.md`).
+ * - CREATE2 address of the parent Smart Account MUST remain byte-equal
+ *   pre- and post-module-install (cred §8 R2).
+ * - No TTL on the session key (cred spec §3.1 / PRD-01 §9 Q2).
+ *   Lifetime is bounded only by explicit revoke from the SPA.
+ *
+ * This file is the contract surface only — the implementation lives in
+ * `SessionKeyModule.sol`. Stub implementation lands in cred-5 stage 1
+ * (this PR); per-inner-call scope validation in cred-6; cross-chain
+ * deploy in cred-7.
+ */
+interface ISessionKeyModule {
+    // --- Errors ---
+
+    error SessionKeyNotActive(address account, address signer);
+    error SessionKeyScopeMismatch(address account, address signer);
+    error SessionKeyInvalidSignature();
+    error SessionKeyReplay(uint256 nonce);
+
+    // --- Events ---
+
+    /// @notice Emitted on the first UserOp that uses a fresh session key
+    ///         (lazy-install pattern — no separate `installSessionKey()` call).
+    event SessionKeyInstalled(
+        address indexed account,
+        address indexed signer,
+        uint256 nonce
+    );
+
+    /// @notice Emitted when the master wallet (via the SPA) revokes a
+    ///         session key. Idempotent — revoking an unknown or
+    ///         already-revoked signer is a no-op (PRD-01 §11 R4).
+    event SessionKeyRevoked(address indexed account, address indexed signer);
+
+    // --- Mutating ---
+
+    /**
+     * @notice Called by the Smart Account during `validateUserOp`.
+     * @return validationData `0` on success, `SIG_VALIDATION_FAILED`
+     *         (constant `1`) on any mismatch. The v0.7 time-range packing
+     *         is NOT used — there is no TTL.
+     *
+     * Cross-spec invariant: if `userOp.callData` is an `executeBatch(...)`
+     * invocation, this function MUST decode the inner call array and
+     * verify EACH inner call individually against the session-key scope
+     * (`target` + `selectors`). See cred spec §4.2 + imp OQ-A.
+     */
+    function validateSessionKeyUserOp(
+        PackedUserOperation calldata userOp,
+        bytes32 userOpHash
+    ) external returns (uint256 validationData);
+
+    /**
+     * @notice Owner-only — invoked from the master wallet via the SPA
+     *         "revoke" button. Idempotent.
+     * @param account The Smart Account address whose session key is being
+     *                revoked. Caller MUST be the master wallet of `account`.
+     * @param signer  The session-key signer address to revoke.
+     */
+    function revokeSessionKey(address account, address signer) external;
+
+    // --- Views ---
+
+    /// @notice Used by the SPA "active sessions" list and by Hermes for
+    ///         post-revoke clean-up surfacing.
+    function isSessionKeyActive(
+        address account,
+        address signer
+    ) external view returns (bool);
+
+    /// @notice Returns the grant metadata stored on install. Empty
+    ///         arrays / zero values for unknown signers (no revert).
+    function getSessionKeyGrant(
+        address account,
+        address signer
+    )
+        external
+        view
+        returns (
+            uint256 nonce,
+            uint256 issuedAt,
+            bytes4[] memory selectors,
+            address target
+        );
+}

--- a/contracts/contracts/interfaces/IUserOperation.sol
+++ b/contracts/contracts/interfaces/IUserOperation.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/**
+ * @dev Packed UserOperation struct from ERC-4337 v0.7.
+ *
+ * Defined locally for the cred-5 session-key delegation work (the
+ * `contracts/` package is not currently wired to the `account-abstraction`
+ * npm package — see `interfaces/IEntryPoint.sol` for the matching minimal
+ * pattern). When account-abstraction v0.7 contracts are pulled in as a
+ * Foundry lib (cred-5 stage 2), this file is removed in favour of the
+ * canonical import.
+ *
+ * Field shape matches the v0.7 EIP-4337 standard verbatim — do not
+ * reorder, the layout is consumed by `validateUserOp` validators that
+ * compute the hash via abi.encodePacked.
+ */
+struct PackedUserOperation {
+    address sender;
+    uint256 nonce;
+    bytes initCode;
+    bytes callData;
+    bytes32 accountGasLimits;
+    uint256 preVerificationGas;
+    bytes32 gasFees;
+    bytes paymasterAndData;
+    bytes signature;
+}

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -1,0 +1,33 @@
+# Foundry config for the TotalReclaw contracts package.
+#
+# Coexists with the existing Hardhat setup (`hardhat.config.ts` + the TS tests
+# under `test/`). Foundry is added 2026-05-27 for the cred-5 session-key
+# delegation work (per `docs/specs/cred/session-key-delegation.md` — the
+# Solidity-side spec requires Foundry-style unit tests + a `forge snapshot`
+# gas budget on the per-inner-call validator).
+#
+# Conventions:
+# - Solidity sources stay under `contracts/` (matches the Hardhat layout).
+# - Foundry tests go under `test/` alongside the existing `.test.ts` files,
+#   distinguished by the `.t.sol` extension. Hardhat ignores `.t.sol`;
+#   Foundry ignores `.test.ts`. Both build systems can coexist on this dir.
+# - External Solidity libs (ZeroDev kernel v3, account-abstraction v0.7
+#   contracts) land under `lib/` via `forge install` in cred-5 stage 2;
+#   `remappings.txt` keeps Hardhat oblivious to them.
+[profile.default]
+src = "contracts"
+test = "test"
+out = "out"
+libs = ["lib"]
+solc_version = "0.8.24"
+optimizer = true
+optimizer_runs = 200
+via_ir = false
+# Hardhat's TS tests are filename-matched on `.test.ts`. We exclude them
+# from Foundry's compilation set so `forge build` doesn't trip on TS files.
+extra_output = ["storageLayout"]
+
+[fmt]
+line_length = 100
+tab_width = 4
+bracket_spacing = false

--- a/contracts/test/SessionKeyModule.t.sol
+++ b/contracts/test/SessionKeyModule.t.sol
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {SessionKeyModule} from "../contracts/SessionKeyModule.sol";
+import {PackedUserOperation} from "../contracts/interfaces/IUserOperation.sol";
+
+/**
+ * @title SessionKeyModuleTest
+ * @notice Foundry test scaffold for cred-5 (per spec §6.1, the twelve
+ *         unit tests that gate stage-2 implementation).
+ *
+ *         STAGE 1 (this PR): scaffold only. Tests are `vm.skip(true)`'d so
+ *         CI passes on the stub contract. Each test body lands as the
+ *         matching implementation work-leaf ships:
+ *
+ *         - cred-5 stage 2: the 4 validator unit tests below.
+ *         - cred-6: `test_session_key_rejects_batch_with_out_of_scope_inner_call`
+ *           and `test_session_key_accepts_batch_with_all_in_scope_inner_calls`.
+ *         - cred-7: deploy invariant + cross-chain CREATE2 byte-equality.
+ *
+ *         The load-bearing invariant `test_create2_address_unchanged_after_module_install`
+ *         is intentionally placed first — it is the test that cred-5 stage 2
+ *         CANNOT ship without (CREATE2 byte-equality is the spec §6 §8
+ *         R2 invariant).
+ */
+contract SessionKeyModuleTest is Test {
+    SessionKeyModule internal module;
+
+    function setUp() public {
+        module = new SessionKeyModule();
+    }
+
+    // -------------------------------------------------------------------------
+    // Load-bearing invariant — Smart Account CREATE2 address byte-equality
+    // pre- and post-install. Cred-5 stage 2 CANNOT ship without this test
+    // passing on both Base Sepolia and Gnosis fixtures (spec §6 R2).
+    // -------------------------------------------------------------------------
+
+    function test_create2_address_unchanged_after_module_install() public {
+        vm.skip(true);
+        // Cred-5 stage 2 body:
+        //   address pre = computeSimpleAccountAddress(salt);
+        //   /* install SessionKeyModule via kernel-v3 hookManager */
+        //   address post = computeSimpleAccountAddress(salt);
+        //   assertEq(pre, post, "CREATE2 byte-equality invariant broken");
+    }
+
+    // -------------------------------------------------------------------------
+    // Spec §6.1 — validator unit tests (cred-5 stage 2)
+    // -------------------------------------------------------------------------
+
+    function test_validate_rejects_unknown_target() public {
+        vm.skip(true);
+        // Cred-5 stage 2 body.
+    }
+
+    function test_validate_rejects_unknown_selector() public {
+        vm.skip(true);
+        // Cred-5 stage 2 body.
+    }
+
+    function test_first_call_installs_grant_and_emits_event() public {
+        vm.skip(true);
+        // Cred-5 stage 2 body — verifies lazy-install + SessionKeyInstalled.
+    }
+
+    function test_revoke_idempotent() public {
+        vm.skip(true);
+        // Cred-5 stage 2 body — revoking unknown/already-revoked signer
+        // is a no-op (PRD-01 §11 R4).
+    }
+
+    function test_validate_invalid_signature_returns_failed() public {
+        vm.skip(true);
+    }
+
+    function test_get_session_key_grant_empty_for_unknown_signer() public {
+        vm.skip(true);
+    }
+
+    function test_is_session_key_active_false_after_revoke() public {
+        vm.skip(true);
+    }
+
+    function test_replay_nonce_protection() public {
+        vm.skip(true);
+    }
+
+    // -------------------------------------------------------------------------
+    // Spec §4.2 cross-spec invariant — per-inner-call scope validation
+    // under executeBatch. Lands in cred-6.
+    // -------------------------------------------------------------------------
+
+    function test_session_key_rejects_batch_with_out_of_scope_inner_call() public {
+        vm.skip(true);
+        // Cred-6 body.
+    }
+
+    function test_session_key_accepts_batch_with_all_in_scope_inner_calls() public {
+        vm.skip(true);
+        // Cred-6 body. Plus `forge snapshot` enforces per-inner-call gas
+        // overhead < 5K (spec §6.1).
+    }
+
+    // -------------------------------------------------------------------------
+    // Stage-1 sanity checks — the stubs return the expected safe defaults.
+    // These DO run (no skip) so we get a green CI baseline for stage 1.
+    // -------------------------------------------------------------------------
+
+    function test_stage1_stub_validate_returns_failed() public {
+        PackedUserOperation memory op;
+        uint256 vd = module.validateSessionKeyUserOp(op, bytes32(0));
+        assertEq(vd, 1, "stage-1 stub must safe-default to SIG_VALIDATION_FAILED");
+    }
+
+    function test_stage1_stub_is_session_key_active_false() public {
+        assertFalse(module.isSessionKeyActive(address(0), address(0)));
+    }
+
+    function test_stage1_stub_revoke_reverts_with_stage_marker() public {
+        vm.expectRevert(bytes("SessionKeyModule: revokeSessionKey not implemented (cred-5 stage 2)"));
+        module.revokeSessionKey(address(0), address(0));
+    }
+
+    function test_stage1_stub_get_grant_returns_empty() public {
+        (uint256 nonce, uint256 issuedAt, bytes4[] memory selectors, address target) =
+            module.getSessionKeyGrant(address(0), address(0));
+        assertEq(nonce, 0);
+        assertEq(issuedAt, 0);
+        assertEq(selectors.length, 0);
+        assertEq(target, address(0));
+    }
+}


### PR DESCRIPTION
First stage of [cred-5](https://github.com/p-diogo/totalreclaw-internal/issues/320). Coordinator-supervised work per Pedro's 2026-05-27 phrase-safety override on the issue.

## What ships

- **Foundry tooling** alongside existing Hardhat (`contracts/foundry.toml`).
- **`ISessionKeyModule`** interface per [spec §4.2](https://github.com/p-diogo/totalreclaw-internal/blob/docs/coord-phase2-prd-workflow-20260524/docs/specs/cred/session-key-delegation.md) — `validateSessionKeyUserOp`, `revokeSessionKey`, `isSessionKeyActive`, `getSessionKeyGrant`, plus typed errors + events.
- **`SessionKeyModule.sol`** stub. All function bodies return safe defaults; no storage layout yet (stage 2 freezes it).
- **Foundry test scaffold** with all 12 spec §6.1 unit tests stubbed (`vm.skip(true)`) + 4 stage-1 stub sanity tests that DO run.

## Verification

```
$ forge build   # clean
$ forge test
  4 passed; 11 skipped; 0 failed
```

## Cross-spec invariants documented in code (land in later stages)

1. **CREATE2 byte-equality pre- and post-install** — spec §6 R2. Foundry test `test_create2_address_unchanged_after_module_install` is the load-bearing test. Cred-5 stage 2.
2. **Per-inner-call `executeBatch` scope validation** — cred §4.2 + imp spec OQ-A. Lands in cred-6.
3. **No TTL** — PRD-01 §9 Q2 + cred §3.1.

## Deferred to later stages

- Real `validateUserOp` body → cred-5 stage 2.
- ZeroDev kernel v3 dep under `contracts/lib/` → cred-5 stage 2 (Pedro Q1 signed off 2026-05-27).
- EIP-712 `SessionKeyPermissionGrant` decode → cred-5 stage 2 + cred-8 parity.
- Cross-chain Pimlico CREATE2 deploy → cred-7.

## Risk tier

**L2** for this PR (scaffold only — no key-touching logic, all real surfaces stubbed). Stage 2 (real validator) ships as L3.

Refs #320, #316, #310.

🤖 Generated with [Claude Code](https://claude.com/claude-code)