### PR TITLE
[cred-3 stage 2] feat(python): credential-provider abstraction (Hermes mirror)

### DIFF
--- a/python/src/totalreclaw/credential_provider.py
+++ b/python/src/totalreclaw/credential_provider.py
@@ -1,0 +1,360 @@
+"""credential_provider — credential source abstraction (cred-3 stage 2).
+
+Python mirror of `skill/plugin/credential-provider.ts` (cred-3 stage 1,
+merged in p-diogo/totalreclaw#271). Same shape: a small abstraction over
+where Hermes reads / writes `credentials.json` from, so the daemon can be
+run against either:
+
+  1. ``file`` — read/write ``~/.totalreclaw/credentials.json`` directly
+     (legacy behavior; default; what every existing call site does today).
+
+  2. ``external`` — read from a secret manager via one of two transports:
+
+     - **Inline JSON** (``TOTALRECLAW_EXTERNAL_CREDENTIALS_JSON``) — the raw
+       credentials JSON injected as an env var at process start. Most
+       ergonomic for managed platforms exposing secrets as env vars
+       (Railway secrets, K8s ``envFrom``, Docker ``--env-file``).
+
+     - **File mount** (``TOTALRECLAW_EXTERNAL_CREDENTIALS_PATH``) — a path
+       to a JSON file the secret manager mounts. Works with Docker Compose
+       ``secrets:`` blocks, K8s secret ``volumeMount``\\s, and tmpfs paths
+       populated by an ops wrapper that pulls the payload from a vault
+       (AWS Secrets Manager, HashiCorp Vault, etc.) before Hermes start.
+
+Stage 2 introduces the module + unit tests. Call sites in
+``hermes/cli.py``, ``hermes/pair_tool_completion.py``, ``agent/state.py``,
+``pair/http_server.py``, etc. are **not yet rewired** to go through this
+abstraction — that's stage 3. The default ``file`` mode is byte-identical
+to today's direct ``json.dumps`` / ``read_text`` calls.
+
+Phrase-safety:
+  - Credential payloads are never logged from this module.
+  - File writes preserve mode ``0o600`` (best-effort on Windows / read-only
+    filesystems, matching the existing ``hermes/cli.py`` pattern).
+  - ``external`` mode is read-only by design — the secret manager owns
+    the source of truth and writing back from Hermes would split it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, Optional, Protocol
+
+logger = logging.getLogger(__name__)
+
+ProviderMode = Literal["file", "external"]
+
+
+# ---------------------------------------------------------------------------
+# CredentialsDict — the shape that lives in credentials.json
+# ---------------------------------------------------------------------------
+
+# We keep this as a plain ``dict[str, Any]`` (rather than ``TypedDict``)
+# for two reasons:
+#
+# 1. The existing Python call sites in ``hermes/cli.py`` already do
+#    ``json.dumps({"mnemonic": ..., "scope_address": ...})`` with a
+#    free-form dict; introducing a strict TypedDict would force a
+#    cascade of touch-ups across cli.py, pair_tool_completion.py,
+#    onboarding.py, etc. That work belongs in cred-3 stage 3.
+#
+# 2. The v1 schema (legacy: ``{mnemonic}``) and v2 schema (post-spec:
+#    ``{version, schema, session_signer, smart_account, ...}``) coexist
+#    during the migration window. A plain dict accommodates both
+#    without us reaching for a discriminated union.
+
+CredentialsDict = dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# Provider protocol
+# ---------------------------------------------------------------------------
+
+
+class CredentialProvider(Protocol):
+    """Three-method protocol covering the credential lifecycle.
+
+    Mirrors the TS interface — see ``skill/plugin/credential-provider.ts``
+    in cred-3 stage 1 for the canonical contract.
+    """
+
+    @property
+    def mode(self) -> ProviderMode:
+        """``"file"`` or ``"external"`` — exposed so callers can branch
+        on UI / warning behaviour (e.g. skip the first-run nudge in
+        ``external`` mode because the mnemonic was authored elsewhere).
+        """
+        ...
+
+    def load(self) -> Optional[CredentialsDict]:
+        """Return parsed credentials, or ``None`` when the source has
+        none usable.
+
+        ``None`` covers every "no credentials available" path —
+        file-not-found, empty payload, malformed JSON, env var unset.
+        Never raises; the caller decides how to surface a missing
+        credential (typically: log + fall through to a fresh-generate
+        bootstrap, same shape as today's first-run detection).
+        """
+        ...
+
+    def save(self, creds: CredentialsDict) -> bool:
+        """Persist freshly-generated or updated credentials.
+
+        Returns ``True`` on success, ``False`` on failure (the caller
+        decides whether to retry or escalate). Read-only providers
+        (``external``) always return ``False`` — the caller should log a
+        warning that the write didn't propagate to the secret manager.
+        """
+        ...
+
+    def clear(self) -> bool:
+        """Delete the credentials (used by re-pairing flows).
+
+        Returns ``True`` on success, ``False`` for read-only providers
+        or filesystem errors.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# FileCredentialProvider — default; reads / writes credentials.json
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FileCredentialProvider:
+    """Default provider — reads + writes ``credentials.json`` on disk.
+
+    Behaviour matches the existing inline ``path.read_text()`` /
+    ``path.write_text(json.dumps(...))`` pattern in ``hermes/cli.py``
+    et al., so wiring a call site through this provider in ``file`` mode
+    produces zero behaviour delta.
+    """
+
+    credentials_path: Path
+
+    @property
+    def mode(self) -> ProviderMode:
+        return "file"
+
+    def load(self) -> Optional[CredentialsDict]:
+        try:
+            if not self.credentials_path.exists():
+                return None
+        except OSError:
+            return None
+
+        try:
+            raw = self.credentials_path.read_text()
+        except OSError:
+            return None
+
+        if not raw.strip():
+            return None
+
+        try:
+            parsed = json.loads(raw)
+        except (ValueError, json.JSONDecodeError):
+            return None
+
+        if not isinstance(parsed, dict):
+            return None
+
+        return parsed
+
+    def save(self, creds: CredentialsDict) -> bool:
+        try:
+            self.credentials_path.parent.mkdir(parents=True, exist_ok=True)
+            self.credentials_path.write_text(json.dumps(creds, indent=2))
+        except OSError:
+            logger.warning(
+                "FileCredentialProvider.save: failed to write %s",
+                self.credentials_path,
+                exc_info=True,
+            )
+            return False
+
+        # Best-effort mode 0o600 — matches the inline pattern in
+        # hermes/cli.py (Windows / read-only FS may reject; we accept that
+        # rather than block save). Never log the payload.
+        try:
+            self.credentials_path.chmod(0o600)
+        except OSError:
+            logger.debug(
+                "FileCredentialProvider.save: chmod 0600 failed on %s",
+                self.credentials_path,
+                exc_info=True,
+            )
+
+        return True
+
+    def clear(self) -> bool:
+        try:
+            self.credentials_path.unlink(missing_ok=True)
+            return True
+        except OSError:
+            logger.warning(
+                "FileCredentialProvider.clear: failed to unlink %s",
+                self.credentials_path,
+                exc_info=True,
+            )
+            return False
+
+
+# ---------------------------------------------------------------------------
+# ExternalCredentialProvider — read-only secret-manager wrapper
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ExternalCredentialProvider:
+    """Read-only secret-manager wrapper.
+
+    Two transports — env-injected JSON (``inline_json``) wins if both are
+    set. Both are read-only: ``save()`` and ``clear()`` always return
+    ``False``. The secret manager owns the canonical state; writing back
+    would create two competing sources of truth.
+    """
+
+    inline_json: Optional[str]
+    file_path: Optional[Path]
+
+    @property
+    def mode(self) -> ProviderMode:
+        return "external"
+
+    def load(self) -> Optional[CredentialsDict]:
+        raw = self._read_raw()
+        if raw is None:
+            return None
+
+        try:
+            parsed = json.loads(raw)
+        except (ValueError, json.JSONDecodeError):
+            # Parse error — return None so the bootstrap path can decide
+            # how to surface (typically: log + fall through to fresh
+            # bootstrap, same as a corrupt credentials.json on disk).
+            # Deliberately do not echo the payload here on parse failure.
+            logger.warning(
+                "ExternalCredentialProvider.load: payload did not parse as JSON"
+            )
+            return None
+
+        if not isinstance(parsed, dict):
+            logger.warning(
+                "ExternalCredentialProvider.load: payload was not a JSON object "
+                "(type=%s)",
+                type(parsed).__name__,
+            )
+            return None
+
+        return parsed
+
+    def save(self, _creds: CredentialsDict) -> bool:
+        # Read-only.
+        return False
+
+    def clear(self) -> bool:
+        # Read-only.
+        return False
+
+    def _read_raw(self) -> Optional[str]:
+        if self.inline_json is not None:
+            return self.inline_json
+
+        if self.file_path is not None:
+            try:
+                if not self.file_path.exists():
+                    return None
+                return self.file_path.read_text()
+            except OSError:
+                return None
+
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Config + factory
+# ---------------------------------------------------------------------------
+
+# Env-var names — kept identical to the TS side (cred-3 stage 1) so
+# operators configure the same way regardless of which client (plugin
+# or Hermes) consumes the secret.
+
+ENV_PROVIDER = "TOTALRECLAW_CREDENTIALS_PROVIDER"
+ENV_EXTERNAL_JSON = "TOTALRECLAW_EXTERNAL_CREDENTIALS_JSON"
+ENV_EXTERNAL_PATH = "TOTALRECLAW_EXTERNAL_CREDENTIALS_PATH"
+ENV_CREDENTIALS_PATH = "TOTALRECLAW_CREDENTIALS_PATH"
+
+
+def _resolve_credentials_path() -> Path:
+    """Default credentials path — matches ``onboarding.CANONICAL_CREDENTIALS_PATH``.
+
+    Honours ``TOTALRECLAW_CREDENTIALS_PATH`` env override (used by the
+    pair-tool integration tests + by operators who relocate the dotfile).
+    """
+    override = os.environ.get(ENV_CREDENTIALS_PATH)
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".totalreclaw" / "credentials.json"
+
+
+def _resolve_provider_mode() -> ProviderMode:
+    raw = os.environ.get(ENV_PROVIDER, "file").strip().lower()
+    if raw == "external":
+        return "external"
+    # Anything else (unset, empty, "file", typo) → file mode. Symmetric
+    # with the TS side which also defaults to file. We do not silently
+    # honour unknown modes — that would mask a deploy-time mistake.
+    return "file"
+
+
+def get_credential_provider(
+    *,
+    credentials_path: Optional[Path] = None,
+    provider_mode: Optional[ProviderMode] = None,
+    inline_json: Optional[str] = None,
+    external_file_path: Optional[Path] = None,
+) -> CredentialProvider:
+    """Factory — pick the configured provider.
+
+    All parameters are optional; unset values fall back to env vars (so
+    production callers can call with zero args and tests can override by
+    passing explicit values).
+
+    In ``external`` mode with neither transport set, we still return an
+    ``ExternalCredentialProvider`` so the caller observes the configured
+    mode + sees ``None`` from ``load()``. Mirroring the TS stage-1
+    behaviour: we do NOT silently fall back to ``file`` mode (that would
+    mask a deploy-time mistake by reading a stale credentials.json left
+    on disk).
+    """
+    mode: ProviderMode = (
+        provider_mode if provider_mode is not None else _resolve_provider_mode()
+    )
+
+    if mode == "external":
+        resolved_inline = (
+            inline_json if inline_json is not None else os.environ.get(ENV_EXTERNAL_JSON)
+        )
+        resolved_path: Optional[Path]
+        if external_file_path is not None:
+            resolved_path = external_file_path
+        else:
+            env_path = os.environ.get(ENV_EXTERNAL_PATH)
+            resolved_path = Path(env_path).expanduser() if env_path else None
+
+        return ExternalCredentialProvider(
+            inline_json=resolved_inline,
+            file_path=resolved_path,
+        )
+
+    resolved_credentials_path = (
+        credentials_path if credentials_path is not None else _resolve_credentials_path()
+    )
+    return FileCredentialProvider(credentials_path=resolved_credentials_path)

--- a/python/tests/test_credential_provider.py
+++ b/python/tests/test_credential_provider.py
@@ -1,0 +1,320 @@
+"""Unit tests for ``totalreclaw.credential_provider`` (cred-3 stage 2).
+
+Mirrors the test surface of ``skill/plugin/credential-provider.test.ts``
+(cred-3 stage 1, merged in p-diogo/totalreclaw#271) so the Python and TS
+sides have matching coverage. Tests cover:
+
+  - file-mode round-trip + 0o600 preservation
+  - external-mode boot load via inline JSON
+  - external-mode boot load via mounted JSON file
+  - inline JSON wins when both transports set
+  - read-only enforcement on external mode
+  - corrupt / missing / unset → ``None``
+  - factory mode switch
+  - factory honours explicit args over env vars
+
+The "external secret provider loads credentials at boot" done criterion
+from cred-3 #263 is the load-mode tests below.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from totalreclaw.credential_provider import (
+    ENV_CREDENTIALS_PATH,
+    ENV_EXTERNAL_JSON,
+    ENV_EXTERNAL_PATH,
+    ENV_PROVIDER,
+    ExternalCredentialProvider,
+    FileCredentialProvider,
+    get_credential_provider,
+)
+
+
+# ---------------------------------------------------------------------------
+# FileCredentialProvider — round trip + edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_file_provider_save_then_load_round_trip(tmp_path: Path) -> None:
+    p = tmp_path / "credentials.json"
+    provider = FileCredentialProvider(credentials_path=p)
+
+    creds = {"mnemonic": "abandon " * 11 + "about", "scope_address": "0xabc"}
+    assert provider.save(creds) is True
+
+    loaded = provider.load()
+    assert loaded == creds
+
+
+def test_file_provider_save_creates_parent_dir(tmp_path: Path) -> None:
+    p = tmp_path / "nested" / "deep" / "credentials.json"
+    provider = FileCredentialProvider(credentials_path=p)
+
+    assert provider.save({"mnemonic": "x"}) is True
+    assert p.exists()
+
+
+def test_file_provider_save_preserves_0o600_mode(tmp_path: Path) -> None:
+    if os.name != "posix":
+        pytest.skip("chmod 0o600 is best-effort on Windows")
+
+    p = tmp_path / "credentials.json"
+    provider = FileCredentialProvider(credentials_path=p)
+    assert provider.save({"mnemonic": "x"}) is True
+
+    mode = stat.S_IMODE(p.stat().st_mode)
+    assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
+
+
+def test_file_provider_load_missing_file_returns_none(tmp_path: Path) -> None:
+    p = tmp_path / "nope.json"
+    provider = FileCredentialProvider(credentials_path=p)
+    assert provider.load() is None
+
+
+def test_file_provider_load_empty_file_returns_none(tmp_path: Path) -> None:
+    p = tmp_path / "credentials.json"
+    p.write_text("")
+    provider = FileCredentialProvider(credentials_path=p)
+    assert provider.load() is None
+
+
+def test_file_provider_load_malformed_json_returns_none(tmp_path: Path) -> None:
+    p = tmp_path / "credentials.json"
+    p.write_text("{not valid json")
+    provider = FileCredentialProvider(credentials_path=p)
+    assert provider.load() is None
+
+
+def test_file_provider_load_non_object_returns_none(tmp_path: Path) -> None:
+    p = tmp_path / "credentials.json"
+    p.write_text(json.dumps(["a", "b"]))
+    provider = FileCredentialProvider(credentials_path=p)
+    assert provider.load() is None
+
+
+def test_file_provider_mode_is_file(tmp_path: Path) -> None:
+    provider = FileCredentialProvider(credentials_path=tmp_path / "x.json")
+    assert provider.mode == "file"
+
+
+def test_file_provider_clear_removes_file(tmp_path: Path) -> None:
+    p = tmp_path / "credentials.json"
+    p.write_text(json.dumps({"mnemonic": "x"}))
+    provider = FileCredentialProvider(credentials_path=p)
+
+    assert provider.clear() is True
+    assert not p.exists()
+
+
+def test_file_provider_clear_missing_file_succeeds(tmp_path: Path) -> None:
+    p = tmp_path / "never-existed.json"
+    provider = FileCredentialProvider(credentials_path=p)
+    # Path.unlink(missing_ok=True) keeps this a no-op success.
+    assert provider.clear() is True
+
+
+# ---------------------------------------------------------------------------
+# ExternalCredentialProvider — read paths
+# ---------------------------------------------------------------------------
+
+
+def test_external_provider_load_via_inline_json() -> None:
+    creds = {"mnemonic": "x" * 12, "smart_account": "0xabc"}
+    provider = ExternalCredentialProvider(
+        inline_json=json.dumps(creds), file_path=None
+    )
+
+    loaded = provider.load()
+    assert loaded == creds
+
+
+def test_external_provider_load_via_file_mount(tmp_path: Path) -> None:
+    creds = {"mnemonic": "y" * 12, "schema": "session-key-v1"}
+    p = tmp_path / "mounted-secret.json"
+    p.write_text(json.dumps(creds))
+
+    provider = ExternalCredentialProvider(inline_json=None, file_path=p)
+
+    loaded = provider.load()
+    assert loaded == creds
+
+
+def test_external_provider_inline_json_wins_over_file_path(tmp_path: Path) -> None:
+    inline = {"source": "inline"}
+    on_disk = {"source": "file"}
+    p = tmp_path / "mounted-secret.json"
+    p.write_text(json.dumps(on_disk))
+
+    provider = ExternalCredentialProvider(
+        inline_json=json.dumps(inline), file_path=p
+    )
+
+    loaded = provider.load()
+    assert loaded == inline
+
+
+def test_external_provider_neither_transport_set_returns_none() -> None:
+    provider = ExternalCredentialProvider(inline_json=None, file_path=None)
+    assert provider.load() is None
+
+
+def test_external_provider_missing_file_path_returns_none(tmp_path: Path) -> None:
+    p = tmp_path / "does-not-exist.json"
+    provider = ExternalCredentialProvider(inline_json=None, file_path=p)
+    assert provider.load() is None
+
+
+def test_external_provider_malformed_inline_json_returns_none() -> None:
+    provider = ExternalCredentialProvider(
+        inline_json="{not valid", file_path=None
+    )
+    assert provider.load() is None
+
+
+def test_external_provider_non_object_inline_json_returns_none() -> None:
+    provider = ExternalCredentialProvider(
+        inline_json=json.dumps([1, 2, 3]), file_path=None
+    )
+    assert provider.load() is None
+
+
+# ---------------------------------------------------------------------------
+# ExternalCredentialProvider — read-only enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_external_provider_save_returns_false() -> None:
+    provider = ExternalCredentialProvider(
+        inline_json=json.dumps({"mnemonic": "x"}), file_path=None
+    )
+    assert provider.save({"mnemonic": "y"}) is False
+
+
+def test_external_provider_clear_returns_false() -> None:
+    provider = ExternalCredentialProvider(
+        inline_json=json.dumps({"mnemonic": "x"}), file_path=None
+    )
+    assert provider.clear() is False
+
+
+def test_external_provider_mode_is_external() -> None:
+    provider = ExternalCredentialProvider(inline_json=None, file_path=None)
+    assert provider.mode == "external"
+
+
+# ---------------------------------------------------------------------------
+# get_credential_provider factory
+# ---------------------------------------------------------------------------
+
+
+def test_factory_default_returns_file_provider(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv(ENV_PROVIDER, raising=False)
+    monkeypatch.setenv(ENV_CREDENTIALS_PATH, str(tmp_path / "credentials.json"))
+
+    provider = get_credential_provider()
+    assert isinstance(provider, FileCredentialProvider)
+    assert provider.credentials_path == tmp_path / "credentials.json"
+
+
+def test_factory_unknown_mode_falls_back_to_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(ENV_PROVIDER, "made-up-mode")
+
+    provider = get_credential_provider()
+    assert isinstance(provider, FileCredentialProvider)
+
+
+def test_factory_external_mode_with_inline_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    creds = {"mnemonic": "x" * 12}
+    monkeypatch.setenv(ENV_PROVIDER, "external")
+    monkeypatch.setenv(ENV_EXTERNAL_JSON, json.dumps(creds))
+    monkeypatch.delenv(ENV_EXTERNAL_PATH, raising=False)
+
+    provider = get_credential_provider()
+    assert isinstance(provider, ExternalCredentialProvider)
+    assert provider.load() == creds
+
+
+def test_factory_external_mode_with_file_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    creds = {"mnemonic": "y" * 12}
+    p = tmp_path / "vault-mount.json"
+    p.write_text(json.dumps(creds))
+
+    monkeypatch.setenv(ENV_PROVIDER, "external")
+    monkeypatch.delenv(ENV_EXTERNAL_JSON, raising=False)
+    monkeypatch.setenv(ENV_EXTERNAL_PATH, str(p))
+
+    provider = get_credential_provider()
+    assert isinstance(provider, ExternalCredentialProvider)
+    assert provider.load() == creds
+
+
+def test_factory_external_mode_neither_transport_returns_provider_with_none_load(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(ENV_PROVIDER, "external")
+    monkeypatch.delenv(ENV_EXTERNAL_JSON, raising=False)
+    monkeypatch.delenv(ENV_EXTERNAL_PATH, raising=False)
+
+    provider = get_credential_provider()
+    # We DO NOT silently fall back to file mode — caller must observe
+    # the misconfiguration (matches TS stage-1 behaviour).
+    assert isinstance(provider, ExternalCredentialProvider)
+    assert provider.load() is None
+
+
+def test_factory_explicit_args_override_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv(ENV_PROVIDER, "external")
+    monkeypatch.setenv(ENV_EXTERNAL_JSON, json.dumps({"source": "env"}))
+
+    explicit_creds = {"source": "explicit-arg"}
+    provider = get_credential_provider(
+        provider_mode="external",
+        inline_json=json.dumps(explicit_creds),
+    )
+
+    assert isinstance(provider, ExternalCredentialProvider)
+    assert provider.load() == explicit_creds
+
+
+def test_factory_explicit_file_path_override(tmp_path: Path) -> None:
+    explicit_path = tmp_path / "custom-credentials.json"
+    explicit_path.write_text(json.dumps({"mnemonic": "z"}))
+
+    provider = get_credential_provider(
+        provider_mode="file", credentials_path=explicit_path
+    )
+
+    assert isinstance(provider, FileCredentialProvider)
+    assert provider.load() == {"mnemonic": "z"}
+
+
+def test_factory_file_mode_default_path_expands_home(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.delenv(ENV_CREDENTIALS_PATH, raising=False)
+    monkeypatch.delenv(ENV_PROVIDER, raising=False)
+
+    provider = get_credential_provider()
+    assert isinstance(provider, FileCredentialProvider)
+    assert provider.credentials_path == fake_home / ".totalreclaw" / "credentials.json"


### PR DESCRIPTION
Second stage of [cred-3](https://github.com/p-diogo/totalreclaw-internal/issues/263). Coordinator-supervised work on Mac per Pedro's 2026-05-27 phrase-safety override on the parent issue.

Python mirror of the TS \`credential-provider\` that shipped in cred-3 stage 1 ([#271](https://github.com/p-diogo/totalreclaw/pull/271)). Same shape, same env-var names, same read-only semantics on external mode — so an operator configures Hermes + plugin identically.

## What ships

- **\`python/src/totalreclaw/credential_provider.py\`** — new module:
  - \`CredentialProvider\` protocol — \`load() / save() / clear()\` + \`mode\` property
  - \`FileCredentialProvider\` — reads/writes \`~/.totalreclaw/credentials.json\`. Behaviour byte-identical to today's inline \`path.write_text(json.dumps(...))\` + \`path.read_text()\` pattern in \`hermes/cli.py\`, \`agent/state.py\`, \`hermes/pair_tool_completion.py\`. Preserves \`0o600\` mode best-effort.
  - \`ExternalCredentialProvider\` — read-only secret-manager wrapper:
    - Inline-JSON transport (\`TOTALRECLAW_EXTERNAL_CREDENTIALS_JSON\`) — wins if both set.
    - File-mount transport (\`TOTALRECLAW_EXTERNAL_CREDENTIALS_PATH\`) — Docker Compose \`secrets:\` / K8s \`volumeMount\` / tmpfs paths.
  - \`get_credential_provider()\` factory — picks based on \`TOTALRECLAW_CREDENTIALS_PROVIDER\` env var (default \`file\`). Explicit args override env (for tests + advanced callers).
- **\`python/tests/test_credential_provider.py\`** — 28 unit tests, mirror of the TS surface:
  - file-mode round-trip + \`0o600\` preservation + missing/empty/malformed/non-object → \`None\`
  - external-mode inline JSON + file-mount transports + which wins + neither transport set
  - read-only enforcement (\`save()\` / \`clear()\` both \`False\`)
  - factory mode switch + unknown-mode fallback + explicit-args override

## What's intentionally NOT in this PR (stage 3)

Call sites in \`hermes/cli.py\`, \`hermes/pair_tool_completion.py\`, \`agent/state.py\`, \`pair/http_server.py\`, \`pair/remote_client.py\` are **not yet rewired**. Default \`file\` mode is byte-identical to today, so this is a pure-additive change.

Stage 3 rewires the call sites + adds an integration test booting Hermes against an \`external\`-mode credentials source end-to-end. Per the cred spec §5 row \"Python — keychain wrap call\", the rewire couples with cred-2's \`keychain_wrap.wrap_blob\` / \`unwrap_blob\` once that lands.

## Phrase-safety

Stage 2 is additive — no existing credential read/write path changes. Module never logs payloads. \`ExternalCredentialProvider\` is read-only by design. Parent issue [#263](https://github.com/p-diogo/totalreclaw-internal/issues/263) carries \`phrase-safety:exempt\` (Pedro 2026-05-27); coord-review will escalate to Pedro per the autonomous-merge rule's phrase-safety carve-out.

## Tests

\`\`\`
cd python && pytest tests/test_credential_provider.py -q
............................                                             [100%]
28 passed
\`\`\`

Refs #263, #316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)