### PR TITLE
[cred-3 stage 3] feat(hermes): route AgentState boot through credential-provider

### DIFF
--- a/python/src/totalreclaw/agent/state.py
+++ b/python/src/totalreclaw/agent/state.py
@@ -197,19 +197,22 @@ class AgentState:
             self.configure(mnemonic)
             return
 
-        # Check credentials file — accept both canonical ``mnemonic`` and
-        # legacy ``recovery_phrase`` spellings.
-        creds_path = Path.home() / ".totalreclaw" / "credentials.json"
-        if creds_path.exists():
-            try:
-                creds = json.loads(creds_path.read_text())
-            except Exception:
-                return
-            if not isinstance(creds, dict):
-                return
-            mnemonic = _extract_mnemonic_from_creds(creds)
-            if mnemonic:
-                self.configure(mnemonic)
+        # cred-3 stage 3 — route credential discovery through the
+        # credential-provider abstraction so Hermes can boot against an
+        # env-var (TOTALRECLAW_EXTERNAL_CREDENTIALS_JSON) or mounted file
+        # (TOTALRECLAW_EXTERNAL_CREDENTIALS_PATH) secret manager.
+        # TOTALRECLAW_CREDENTIALS_PROVIDER=external switches transports;
+        # default 'file' mode is byte-identical to the prior path.
+        # Accepts both canonical ``mnemonic`` and legacy ``recovery_phrase``
+        # spellings.
+        from totalreclaw.credential_provider import get_credential_provider
+
+        creds = get_credential_provider().load()
+        if creds is None:
+            return
+        mnemonic = _extract_mnemonic_from_creds(creds)
+        if mnemonic:
+            self.configure(mnemonic)
 
     def configure(self, mnemonic: str) -> None:
         """Configure the TotalReclaw client with a mnemonic.
@@ -233,32 +236,35 @@ class AgentState:
         relay_url = self._server_url or _default_relay_url()
         self._client = TotalReclaw(mnemonic=mnemonic, relay_url=relay_url)
 
-        # Save credentials — preserve legacy shape when present, write
-        # canonical shape otherwise.
-        creds_path = Path.home() / ".totalreclaw" / "credentials.json"
-        creds_path.parent.mkdir(parents=True, exist_ok=True)
+        # cred-3 stage 3 — route the credential write through the
+        # credential-provider abstraction. In default ``file`` mode this is
+        # byte-identical to the prior path. In ``external`` mode the
+        # provider is read-only: secret-manager owns the source of truth,
+        # so ``provider.save()`` returns ``False`` and we skip the write
+        # (the secret already lives in the manager — no point writing to
+        # disk and splitting the source of truth).
+        from totalreclaw.credential_provider import get_credential_provider
+
+        provider = get_credential_provider()
 
         should_preserve_legacy = False
-        if creds_path.exists():
-            try:
-                existing = json.loads(creds_path.read_text())
-                if (
-                    isinstance(existing, dict)
-                    and "mnemonic" not in existing
-                    and isinstance(existing.get("recovery_phrase"), str)
-                    and existing.get("recovery_phrase", "").strip() == mnemonic.strip()
-                ):
-                    should_preserve_legacy = True
-            except Exception:
-                pass
+        if provider.mode == "file":
+            existing = provider.load()
+            if (
+                isinstance(existing, dict)
+                and "mnemonic" not in existing
+                and isinstance(existing.get("recovery_phrase"), str)
+                and existing.get("recovery_phrase", "").strip() == mnemonic.strip()
+            ):
+                # Existing file has legacy ``recovery_phrase`` shape and
+                # matches the configured mnemonic — leave the file
+                # untouched (Bug #7 / Wave 2a write policy).
+                should_preserve_legacy = True
 
-        if should_preserve_legacy:
-            # Leave the file untouched. Same mnemonic, same content —
-            # no reason to rewrite and risk a partial update.
-            pass
-        else:
-            creds_path.write_text(json.dumps({"mnemonic": mnemonic}))
-            creds_path.chmod(0o600)
+        if not should_preserve_legacy:
+            # In ``external`` mode this is a no-op (returns False); the
+            # secret manager already holds the credentials.
+            provider.save({"mnemonic": mnemonic})
 
         # 2.3.2-rc.1 (#192): clear any stale eager-account-register
         # latch attached by ``totalreclaw.hermes.hooks._eager_account_

--- a/python/tests/test_external_credentials_boot.py
+++ b/python/tests/test_external_credentials_boot.py
@@ -1,0 +1,206 @@
+"""Integration test for cred-3 stage 3 external-mode boot.
+
+Validates the cred-3 #263 done criterion: "external secret provider loads
+mnemonic at boot." Hermes's ``AgentState._try_auto_configure`` now routes
+credential discovery through ``get_credential_provider()``, so configuring
+``TOTALRECLAW_CREDENTIALS_PROVIDER=external`` + a transport env var lets
+the daemon boot against env-var- or mounted-file-backed secret managers
+without touching ``~/.totalreclaw/credentials.json`` on disk.
+
+Tests cover:
+  - Inline JSON env var → daemon boots with that mnemonic, never reads disk.
+  - Mounted JSON file → daemon boots with that mnemonic, disk file untouched.
+  - External mode + neither transport set → daemon does NOT silently fall
+    back to disk (per cred-3 stage 1 + 2 spec).
+  - External mode + ``configure()`` is a no-op write (secret manager owns
+    the source of truth).
+  - Legacy file-mode behaviour byte-identical to pre-stage-3.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from totalreclaw.agent.state import AgentState
+from totalreclaw.credential_provider import (
+    ENV_CREDENTIALS_PATH,
+    ENV_EXTERNAL_JSON,
+    ENV_EXTERNAL_PATH,
+    ENV_PROVIDER,
+)
+
+
+# A real BIP-39 24-word phrase isn't required for boot — `AgentState.configure`
+# calls into `TotalReclaw(mnemonic=...)` which only fails on truly malformed
+# input. Using a known-good 12-word test mnemonic.
+TEST_MNEMONIC = (
+    "abandon abandon abandon abandon abandon abandon "
+    "abandon abandon abandon abandon abandon about"
+)
+
+
+@pytest.fixture
+def isolated_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Reroute $HOME so no test contaminates the real ~/.totalreclaw."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.delenv("TOTALRECLAW_RECOVERY_PHRASE", raising=False)
+    monkeypatch.delenv(ENV_CREDENTIALS_PATH, raising=False)
+    return fake_home
+
+
+def test_file_mode_boot_unchanged(
+    isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Default file mode — boots from ~/.totalreclaw/credentials.json
+    exactly like before stage 3."""
+    monkeypatch.delenv(ENV_PROVIDER, raising=False)
+    monkeypatch.delenv(ENV_EXTERNAL_JSON, raising=False)
+    monkeypatch.delenv(ENV_EXTERNAL_PATH, raising=False)
+
+    creds_dir = isolated_home / ".totalreclaw"
+    creds_dir.mkdir()
+    creds_file = creds_dir / "credentials.json"
+    creds_file.write_text(json.dumps({"mnemonic": TEST_MNEMONIC}))
+
+    state = AgentState()
+    state._try_auto_configure()
+
+    assert state.is_configured()
+
+
+def test_external_mode_boot_via_inline_json(
+    isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """External mode + inline JSON — daemon boots with that mnemonic
+    without ever reading disk."""
+    monkeypatch.setenv(ENV_PROVIDER, "external")
+    monkeypatch.setenv(
+        ENV_EXTERNAL_JSON, json.dumps({"mnemonic": TEST_MNEMONIC})
+    )
+    monkeypatch.delenv(ENV_EXTERNAL_PATH, raising=False)
+
+    # Critically: no credentials.json on disk.
+    assert not (isolated_home / ".totalreclaw" / "credentials.json").exists()
+
+    state = AgentState()
+    state._try_auto_configure()
+
+    assert state.is_configured()
+
+
+def test_external_mode_boot_via_mounted_file(
+    isolated_home: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """External mode + file-mount transport — daemon boots from the mount
+    path, ignoring ~/.totalreclaw entirely."""
+    secret_mount = tmp_path / "vault-secret.json"
+    secret_mount.write_text(json.dumps({"mnemonic": TEST_MNEMONIC}))
+
+    monkeypatch.setenv(ENV_PROVIDER, "external")
+    monkeypatch.delenv(ENV_EXTERNAL_JSON, raising=False)
+    monkeypatch.setenv(ENV_EXTERNAL_PATH, str(secret_mount))
+
+    # Critically: no credentials.json on disk.
+    assert not (isolated_home / ".totalreclaw" / "credentials.json").exists()
+
+    state = AgentState()
+    state._try_auto_configure()
+
+    assert state.is_configured()
+
+
+def test_external_mode_neither_transport_does_not_fall_back(
+    isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """External mode with neither transport set — provider returns None,
+    daemon stays unconfigured. We do NOT silently fall back to reading
+    a stale credentials.json off disk (would mask a deploy misconfig)."""
+    monkeypatch.setenv(ENV_PROVIDER, "external")
+    monkeypatch.delenv(ENV_EXTERNAL_JSON, raising=False)
+    monkeypatch.delenv(ENV_EXTERNAL_PATH, raising=False)
+
+    # Put a credentials.json on disk that WOULD work in file mode.
+    creds_dir = isolated_home / ".totalreclaw"
+    creds_dir.mkdir()
+    creds_file = creds_dir / "credentials.json"
+    creds_file.write_text(json.dumps({"mnemonic": TEST_MNEMONIC}))
+
+    state = AgentState()
+    state._try_auto_configure()
+
+    # Stays unconfigured — external mode does not read disk.
+    assert not state.is_configured()
+
+
+def test_external_mode_configure_does_not_write_disk(
+    isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """In external mode, ``state.configure(mnemonic)`` must NOT write to
+    ~/.totalreclaw/credentials.json — the secret manager owns the source
+    of truth. Writing would create two competing truths."""
+    monkeypatch.setenv(ENV_PROVIDER, "external")
+    monkeypatch.setenv(
+        ENV_EXTERNAL_JSON, json.dumps({"mnemonic": TEST_MNEMONIC})
+    )
+    monkeypatch.delenv(ENV_EXTERNAL_PATH, raising=False)
+
+    # Pre-condition: no credentials.json on disk.
+    creds_file = isolated_home / ".totalreclaw" / "credentials.json"
+    assert not creds_file.exists()
+
+    state = AgentState()
+    state.configure(TEST_MNEMONIC)
+
+    # Post-condition: still no credentials.json on disk. configure()
+    # produced no write because provider.save() returns False in
+    # external mode.
+    assert not creds_file.exists()
+
+
+def test_legacy_recovery_phrase_preservation_in_file_mode(
+    isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bug #7 / Wave 2a write policy — if credentials.json has the legacy
+    ``recovery_phrase`` key with the same mnemonic, leave file untouched.
+    Stage 3 must preserve this file-mode behaviour."""
+    monkeypatch.delenv(ENV_PROVIDER, raising=False)
+
+    creds_dir = isolated_home / ".totalreclaw"
+    creds_dir.mkdir()
+    creds_file = creds_dir / "credentials.json"
+    legacy_blob = json.dumps({"recovery_phrase": TEST_MNEMONIC})
+    creds_file.write_text(legacy_blob)
+    original_mtime = creds_file.stat().st_mtime_ns
+
+    state = AgentState()
+    state.configure(TEST_MNEMONIC)
+
+    # File untouched — same content, same mtime within the test window.
+    assert creds_file.read_text() == legacy_blob
+
+
+def test_unknown_provider_mode_falls_back_to_file(
+    isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A typo in TOTALRECLAW_CREDENTIALS_PROVIDER must fall back to file
+    mode (matches the cred-3 stage 1 + 2 factory behaviour). A deploy
+    that intended ``external`` but typo'd ``externl`` reads disk like
+    legacy — louder than silent breakage."""
+    monkeypatch.setenv(ENV_PROVIDER, "made-up-mode")
+
+    creds_dir = isolated_home / ".totalreclaw"
+    creds_dir.mkdir()
+    creds_file = creds_dir / "credentials.json"
+    creds_file.write_text(json.dumps({"mnemonic": TEST_MNEMONIC}))
+
+    state = AgentState()
+    state._try_auto_configure()
+
+    assert state.is_configured()


### PR DESCRIPTION
Third + final stage of [cred-3](https://github.com/p-diogo/totalreclaw-internal/issues/263). Coordinator-supervised on Mac per Pedro's 2026-05-27 phrase-safety override.

Wires `AgentState._try_auto_configure` + `AgentState.configure` through the `get_credential_provider()` factory shipped in cred-3 stage 2 ([#273](https://github.com/p-diogo/totalreclaw/pull/273)). Hermes now boots against `external`-mode secret managers without touching `~/.totalreclaw/credentials.json`.

**Closes the cred-3 done criterion:** "external secret provider loads mnemonic at boot."

## What ships

| File | Change |
|---|---|
| `python/src/totalreclaw/agent/state.py` | `_try_auto_configure` reads via `provider.load()`; `configure` writes via `provider.save()`. Default `file` mode byte-identical to prior path. Legacy `recovery_phrase` preservation (Bug #7 / Wave 2a) intact. |
| `python/tests/test_external_credentials_boot.py` | 7 new integration tests covering file-mode (unchanged), external-mode inline JSON boot, external-mode mounted-file boot, external-mode + neither transport → no silent fallback, external-mode + configure → no disk write, legacy `recovery_phrase` preservation, unknown-mode typo fallback to file. |

## What's intentionally NOT in this PR

- **Interactive setup wizard** in `hermes/cli.py` (`_write_credentials` + `_try_eager_resolve_scope_address`) — fresh-setup-only path; external-mode users don't run the wizard. Follow-up only if needed.
- **Pair-flow writes** in `pair/http_server.py` + `pair/remote_client.py` + `hermes/pair_tool_completion.py` — first-time setup paths. Same reasoning.
- **`agent/llm_client.py:443`** — unrelated `auth_path` read.

Minimum surface that delivers external-mode boot for the running daemon. Setup wizards are out of scope.

## Tests

```
pytest tests/test_credential_provider.py \
       tests/test_external_credentials_boot.py \
       tests/test_wave2a_hermes_fixes.py \
       tests/test_issue_191_192_daemon_pair_lazy_reconfigure.py \
       tests/test_issue_148_interpreter_shutdown_drain.py \
       tests/test_issue_169_owner_key_stability.py
83 passed
```

## Phrase-safety

Reads + writes via the provider abstraction — same surface as cred-3 stage 2 ([#273](https://github.com/p-diogo/totalreclaw/pull/273)). Parent issue #263 carries `phrase-safety:exempt` (Pedro 2026-05-27). Coord-review likely escalates per the credentials.json write-path carve-out.

Refs #263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)