### PR TITLE
[cred-6] feat(contracts): per-inner-call executeBatch scope validation

### DIFF
--- a/contracts/contracts/SessionKeyModule.sol
+++ b/contracts/contracts/SessionKeyModule.sol
@@ -21,11 +21,12 @@ interface IAccountWithOwner {
 
 /**
  * @title SessionKeyModule
- * @notice cred-5 stage 2 — real validator body. Per
+ * @notice cred-5 stage 2 + cred-6 — real validator body with per-inner-call
+ *         executeBatch scope validation. Per
  *         `docs/specs/cred/session-key-delegation.md` §4.2.
  *
  * STAGES SHIPPED IN THIS FILE
- * - validateSessionKeyUserOp (single-call path; executeBatch defers to cred-6)
+ * - validateSessionKeyUserOp (single-call path AND executeBatch per-inner)
  * - revokeSessionKey (caller == account, idempotent)
  * - isSessionKeyActive / getSessionKeyGrant (read-side)
  * - lazy install on first UserOp via `abi.encode(PermissionGrant, ecdsaSig)`
@@ -33,9 +34,6 @@ interface IAccountWithOwner {
  * - replay protection via monotonic per-(account, signer) nonce
  *
  * STILL PENDING (separate work-leafs)
- * - cred-6: `executeBatch` per-inner-call scope validation. Stage 2 SAFE-defaults
- *           to SIG_VALIDATION_FAILED on any executeBatch callData so batched
- *           UserOps cannot bypass scope until cred-6 lands.
  * - cred-7: Pimlico CREATE2 cross-chain deploy + kernel v3 wiring.
  * - cred-8: subgraph indexing of SessionKeyInstalled / SessionKeyRevoked
  *           (out of scope for the validator itself).
@@ -48,9 +46,12 @@ interface IAccountWithOwner {
  *      Grants are valid until explicit revoke (PRD-01 §9 Q2).
  *   3. `valueMax` is enforced to be exactly 0 on the inner `execute` call —
  *      session keys cannot move ETH from the Smart Account.
- *   4. Per-inner-call scope validation under `executeBatch` ships in cred-6.
- *      Stage 2 rejects all executeBatch UserOps; this is intentional and
- *      documented in the cred spec (§4.2 "module-implementation note").
+ *   4. Per-inner-call scope validation under `executeBatch` (cred-6): every
+ *      inner call's target, value-zero, and selector are individually checked
+ *      against the grant; a single out-of-scope inner fails the whole batch.
+ *      No "outer-selector-passes" shortcut, no first-inner sampling, no
+ *      partial-execution. The same pattern MUST be applied to any future
+ *      call-aggregator (`multicall`, etc.) per spec §4.2.
  */
 contract SessionKeyModule is ISessionKeyModule {
     // -------------------------------------------------------------------------
@@ -348,13 +349,15 @@ contract SessionKeyModule is ISessionKeyModule {
         }
     }
 
-    /// @dev Single-call scope validation. Cred-6 wires the per-inner-call
-    ///      branch for executeBatch; stage 2 rejects all batches.
+    /// @dev Scope validation for both `execute` and `executeBatch` outer calls.
+    ///      Marked `view` (not `pure`) because the `executeBatch` branch uses
+    ///      a self-external try/catch around `abi.decode` so malformed batch
+    ///      payloads return false instead of reverting validateUserOp.
     function _isCallDataInScope(
         bytes calldata callData,
         address grantTarget,
         bytes4[] memory allowedSelectors
-    ) internal pure returns (bool) {
+    ) internal view returns (bool) {
         if (callData.length < 4) return false;
         bytes4 outerSel = bytes4(callData[:4]);
 
@@ -372,12 +375,73 @@ contract SessionKeyModule is ISessionKeyModule {
         }
 
         if (outerSel == EXECUTE_BATCH_SELECTOR) {
-            // STAGE 2 — cred-6 lands per-inner-call validation. Reject for
-            // now so batched UserOps cannot bypass scope until cred-6 ships.
-            return false;
+            // executeBatch(address[] targets, uint256[] values, bytes[] datas).
+            // Per spec §4.2 cross-spec invariant + #281 OQ-A: every inner call
+            // is individually validated. First non-match → false; no partial
+            // execution semantics.
+            try this._decodeExecuteBatch(callData[4:]) returns (
+                address[] memory targets,
+                uint256[] memory values,
+                bytes[] memory datas
+            ) {
+                return _isBatchInScope(targets, values, datas, grantTarget, allowedSelectors);
+            } catch {
+                return false;
+            }
         }
 
         return false;
+    }
+
+    /// @dev Public-but-only-self entry for the try/catch decode of the
+    ///      executeBatch payload. External so revert-on-malformed surfaces
+    ///      cleanly in the catch — mirrors the `_decodeInstallSig` pattern.
+    function _decodeExecuteBatch(
+        bytes calldata payload
+    )
+        external
+        pure
+        returns (address[] memory targets, uint256[] memory values, bytes[] memory datas)
+    {
+        (targets, values, datas) = abi.decode(payload, (address[], uint256[], bytes[]));
+    }
+
+    /// @dev Per-inner-call scope assertion. Reject on:
+    ///      - empty batch (no useful work; defensive — spec is silent but
+    ///        nothing else in the pipeline currently emits zero-inner batches)
+    ///      - mismatched array lengths (defensive — abi.decode does not check)
+    ///      - any inner with wrong target, non-zero value, missing selector,
+    ///        or selector not in the grant's allowlist
+    ///      Returns true only when EVERY inner passes.
+    function _isBatchInScope(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory datas,
+        address grantTarget,
+        bytes4[] memory allowedSelectors
+    ) internal pure returns (bool) {
+        uint256 n = targets.length;
+        if (n == 0) return false;
+        if (values.length != n || datas.length != n) return false;
+
+        for (uint256 i = 0; i < n; i++) {
+            if (targets[i] != grantTarget) return false;
+            if (values[i] != 0) return false;
+
+            bytes memory inner = datas[i];
+            if (inner.length < 4) return false;
+
+            // First 4 bytes of `inner` — the in-memory layout is
+            // (length: 32 bytes)(data...), so mload at offset 0x20 yields
+            // a word whose top 4 bytes are the selector.
+            bytes4 innerSel;
+            // solhint-disable-next-line no-inline-assembly
+            assembly {
+                innerSel := mload(add(inner, 0x20))
+            }
+            if (!_inSelectors(innerSel, allowedSelectors)) return false;
+        }
+        return true;
     }
 
     function _inSelectors(bytes4 needle, bytes4[] memory hay) internal pure returns (bool) {

--- a/contracts/test/SessionKeyModule.t.sol
+++ b/contracts/test/SessionKeyModule.t.sol
@@ -334,29 +334,177 @@ contract SessionKeyModuleTest is Test {
 
     // ============================================================
     // Spec §4.2 cross-spec invariant — per-inner-call validation
-    // under executeBatch. Lands in cred-6. Stage 2 SAFE-defaults
-    // to SIG_VALIDATION_FAILED for any executeBatch UserOp.
+    // under executeBatch (cred-6). Every inner is validated against
+    // grant.target, value==0, and selector ∈ grant.selectors.
     // ============================================================
 
-    function test_executeBatch_rejected_until_cred6() public {
+    function test_malformed_executeBatch_calldata_rejected() public {
         _installGrant(1);
 
-        // Even with executeBatch in the grant's allowlist, stage 2 rejects.
-        bytes32 hash2 = keccak256("batch-attempt");
+        // Outer selector is executeBatch (in the allowlist) but the payload
+        // is too short to abi.decode into (address[], uint256[], bytes[]).
+        // The validator's self-external try/catch must surface the decode
+        // revert as SIG_VALIDATION_FAILED, not bubble it up.
+        bytes32 hash2 = keccak256("malformed-batch");
         bytes memory ecdsaSig = _signWithKey(signerPriv, hash2);
         bytes memory batchCallData = abi.encodePacked(EXECUTE_BATCH_SEL, hex"00");
         PackedUserOperation memory op = _makePackedOp(batchCallData, ecdsaSig);
 
         uint256 vd = account.callValidator(module, op, hash2);
-        assertEq(vd, 1, "stage 2 must reject all executeBatch - wait for cred-6");
+        assertEq(vd, 1, "malformed executeBatch payload must SIG_VALIDATION_FAILED");
     }
 
     function test_session_key_rejects_batch_with_out_of_scope_inner_call() public {
-        vm.skip(true); // cred-6
+        _installGrant(1);
+
+        // 3-inner batch: first two in-scope, third targets a different
+        // address. Per spec §4.2 step 4 ("Return SIG_VALIDATION_FAILED on
+        // the first non-matching inner"), this rejects.
+        address[] memory targets = new address[](3);
+        uint256[] memory values = new uint256[](3);
+        bytes[] memory datas = new bytes[](3);
+
+        targets[0] = DATA_EDGE;
+        targets[1] = DATA_EDGE;
+        targets[2] = address(0xBADC0DE); // out-of-scope target
+        for (uint256 i = 0; i < 3; i++) {
+            values[i] = 0;
+            datas[i] = abi.encodePacked(EXECUTE_SEL, uint256(i)); // selector ∈ allowlist
+        }
+
+        bytes32 h = keccak256("out-of-scope-inner");
+        bytes memory sig = _signWithKey(signerPriv, h);
+        bytes memory cd = abi.encodePacked(EXECUTE_BATCH_SEL, abi.encode(targets, values, datas));
+        PackedUserOperation memory op = _makePackedOp(cd, sig);
+
+        uint256 vd = account.callValidator(module, op, h);
+        assertEq(vd, 1, "single out-of-scope inner must fail the whole batch");
     }
 
     function test_session_key_accepts_batch_with_all_in_scope_inner_calls() public {
-        vm.skip(true); // cred-6
+        _installGrant(1);
+
+        // 3-inner batch: every inner targets DATA_EDGE with value=0 and an
+        // allowed selector. Validator must return SIG_VALIDATION_SUCCESS.
+        bytes memory cd = _inScopeBatchCallData(3);
+
+        bytes32 h = keccak256("all-in-scope-3");
+        bytes memory sig = _signWithKey(signerPriv, h);
+        PackedUserOperation memory op = _makePackedOp(cd, sig);
+
+        uint256 vd = account.callValidator(module, op, h);
+        assertEq(vd, 0, "all-in-scope batch must SIG_VALIDATION_SUCCESS");
+    }
+
+    function test_session_key_rejects_batch_with_nonzero_value_inner() public {
+        _installGrant(1);
+
+        // Session keys cannot move ETH (spec §4.2 + invariant 3). Any
+        // values[i] != 0 → reject.
+        address[] memory targets = new address[](2);
+        uint256[] memory values = new uint256[](2);
+        bytes[] memory datas = new bytes[](2);
+        targets[0] = DATA_EDGE;
+        targets[1] = DATA_EDGE;
+        values[0] = 0;
+        values[1] = 1 wei;
+        datas[0] = abi.encodePacked(EXECUTE_SEL, uint256(0));
+        datas[1] = abi.encodePacked(EXECUTE_SEL, uint256(1));
+
+        bytes32 h = keccak256("nonzero-value-inner");
+        bytes memory sig = _signWithKey(signerPriv, h);
+        bytes memory cd = abi.encodePacked(EXECUTE_BATCH_SEL, abi.encode(targets, values, datas));
+        PackedUserOperation memory op = _makePackedOp(cd, sig);
+
+        uint256 vd = account.callValidator(module, op, h);
+        assertEq(vd, 1, "any nonzero value in batch must SIG_VALIDATION_FAILED");
+    }
+
+    function test_session_key_rejects_batch_with_out_of_scope_inner_selector() public {
+        // Install grant with ONLY execute in the allowlist (no executeBatch
+        // as inner selector). Then batch with an inner whose selector is
+        // not in the grant — reject.
+        bytes4[] memory onlyExec = new bytes4[](1);
+        onlyExec[0] = EXECUTE_BATCH_SEL; // outer must be in grant for the batch path to be reachable
+
+        SessionKeyModule.PermissionGrant memory grant = _buildGrant(
+            address(account),
+            signer,
+            DATA_EDGE,
+            onlyExec,
+            1
+        );
+        bytes32 installH = keccak256("install-batch-only");
+        // Install batch: outer = executeBatch (in grant), inner = executeBatch (in grant).
+        bytes memory installCd = _batchWithSingleInner(EXECUTE_BATCH_SEL);
+        bytes memory installSig = abi.encode(grant, _signWithKey(signerPriv, installH));
+        PackedUserOperation memory installOp = _makePackedOp(installCd, installSig);
+        assertEq(
+            account.callValidator(module, installOp, installH),
+            0,
+            "install must succeed with all-in-scope inner"
+        );
+
+        // Now build a batch whose inner uses EXECUTE_SEL — NOT in grant.
+        bytes memory cd = _batchWithSingleInner(EXECUTE_SEL);
+        bytes32 h = keccak256("inner-sel-bad");
+        bytes memory sig = _signWithKey(signerPriv, h);
+        PackedUserOperation memory op = _makePackedOp(cd, sig);
+
+        uint256 vd = account.callValidator(module, op, h);
+        assertEq(vd, 1, "inner selector not in grant must SIG_VALIDATION_FAILED");
+    }
+
+    function test_session_key_rejects_empty_batch() public {
+        _installGrant(1);
+
+        // Empty batch is defensively rejected — there is no positive
+        // proof of in-scope work being performed.
+        address[] memory targets = new address[](0);
+        uint256[] memory values = new uint256[](0);
+        bytes[] memory datas = new bytes[](0);
+
+        bytes32 h = keccak256("empty-batch");
+        bytes memory sig = _signWithKey(signerPriv, h);
+        bytes memory cd = abi.encodePacked(EXECUTE_BATCH_SEL, abi.encode(targets, values, datas));
+        PackedUserOperation memory op = _makePackedOp(cd, sig);
+
+        uint256 vd = account.callValidator(module, op, h);
+        assertEq(vd, 1, "empty executeBatch must SIG_VALIDATION_FAILED");
+    }
+
+    /// @dev Gas-budget assertion: per-inner-call validator overhead must be
+    ///      under the 5K-gas budget set by the cred-6 issue acceptance
+    ///      criteria. Compares the gas of a 2-inner batch and a 6-inner
+    ///      batch; the delta divided by 4 is the per-inner cost.
+    function test_session_key_batch_per_inner_gas_under_5k_budget() public {
+        _installGrant(1);
+
+        bytes memory cd2 = _inScopeBatchCallData(2);
+        bytes memory cd6 = _inScopeBatchCallData(6);
+
+        bytes32 h2 = keccak256("batch-gas-2");
+        bytes32 h6 = keccak256("batch-gas-6");
+        bytes memory sig2 = _signWithKey(signerPriv, h2);
+        bytes memory sig6 = _signWithKey(signerPriv, h6);
+
+        PackedUserOperation memory op2 = _makePackedOp(cd2, sig2);
+        PackedUserOperation memory op6 = _makePackedOp(cd6, sig6);
+
+        uint256 g0 = gasleft();
+        uint256 vd2 = account.callValidator(module, op2, h2);
+        uint256 gas2 = g0 - gasleft();
+        assertEq(vd2, 0, "2-inner in-scope batch must succeed");
+
+        uint256 g1 = gasleft();
+        uint256 vd6 = account.callValidator(module, op6, h6);
+        uint256 gas6 = g1 - gasleft();
+        assertEq(vd6, 0, "6-inner in-scope batch must succeed");
+
+        // (gas6 - gas2) isolates the cost of the 4 additional inner calls.
+        uint256 perInner = (gas6 - gas2) / 4;
+        emit log_named_uint("per-inner validator gas", perInner);
+        assertLt(perInner, 5000, "per-inner-call overhead must be under 5K gas");
     }
 
     // ============================================================
@@ -459,6 +607,33 @@ contract SessionKeyModuleTest is Test {
         bytes memory data
     ) internal pure returns (bytes memory) {
         return abi.encodePacked(EXECUTE_SEL, abi.encode(tgt, value, data));
+    }
+
+    /// @dev Build an `executeBatch(...)` call whose inners all target
+    ///      DATA_EDGE with value=0 and use EXECUTE_SEL as the inner selector
+    ///      (which is in the default `_twoSelectors()` grant allowlist).
+    function _inScopeBatchCallData(uint256 n) internal pure returns (bytes memory) {
+        address[] memory targets = new address[](n);
+        uint256[] memory values = new uint256[](n);
+        bytes[] memory datas = new bytes[](n);
+        for (uint256 i = 0; i < n; i++) {
+            targets[i] = DATA_EDGE;
+            values[i] = 0;
+            datas[i] = abi.encodePacked(EXECUTE_SEL, uint256(i));
+        }
+        return abi.encodePacked(EXECUTE_BATCH_SEL, abi.encode(targets, values, datas));
+    }
+
+    /// @dev Build a single-inner `executeBatch(...)` call with the given
+    ///      inner selector. Used to test inner-selector allowlist checks.
+    function _batchWithSingleInner(bytes4 innerSel) internal pure returns (bytes memory) {
+        address[] memory targets = new address[](1);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory datas = new bytes[](1);
+        targets[0] = DATA_EDGE;
+        values[0] = 0;
+        datas[0] = abi.encodePacked(innerSel, uint256(0));
+        return abi.encodePacked(EXECUTE_BATCH_SEL, abi.encode(targets, values, datas));
     }
 
     function _makePackedOp(


### PR DESCRIPTION
## Summary

Implements **cred-6 — Per-inner-call executeBatch scope validation** per canonical-roadmap issue [p-diogo/totalreclaw-internal#332](https://github.com/p-diogo/totalreclaw-internal/issues/332) and spec [`docs/specs/cred/session-key-delegation.md`](docs/specs/cred/session-key-delegation.md) §4.2.

- **Risk tier:** L3 (ERC-4337 + EIP-712 validator surface — `phrase-safety:exempt` granted on issue per PRD-01 + session-key-delegation spec, mirroring #320 cred-5 carve-out)
- **Net diff:** 261 insertions / 22 deletions across 2 files
- **Files changed:** `contracts/contracts/SessionKeyModule.sol`, `contracts/test/SessionKeyModule.t.sol`
- **Depends on:** cred-5 stage 2 ([#272](https://github.com/p-diogo/totalreclaw/pull/272)) — MERGED ✅

## What changed

Replaces the cred-5 stage 2 SAFE-default (`executeBatch → SIG_VALIDATION_FAILED`) with the real per-inner-call validator:

1. **Detect** `executeBatch(address[], uint256[], bytes[])` outer selector (`0x47e1da2a`).
2. **ABI-decode** `(targets, values, datas)` via a self-external `try`/`catch` (mirrors the `_decodeInstallSig` pattern). Malformed payload → `SIG_VALIDATION_FAILED` rather than reverting `validateUserOp`.
3. **For each inner `i`**:
   - `targets[i] == grant.target` (else fail)
   - `values[i] == 0` (session keys cannot move ETH — invariant 3)
   - `datas[i].length >= 4` and `bytes4(datas[i][:4]) ∈ grant.selectors`
4. **First non-matching inner → return false** (spec §4.2 step 4 — no partial-execution semantics).
5. Defensive rejects on empty batch and mismatched-array-length payloads.

`_isCallDataInScope` is promoted from `pure` to `view` because the executeBatch branch uses a self-external call for try/catch.

## Done criteria (from issue #332)

- [x] `test_session_key_rejects_batch_with_out_of_scope_inner_call` un-skipped + implemented + **PASS**
- [x] `test_session_key_accepts_batch_with_all_in_scope_inner_calls` un-skipped + implemented + **PASS**
- [x] `forge snapshot` per-inner-call overhead < 5K gas — **3,291 gas** measured (asserted in `test_session_key_batch_per_inner_gas_under_5k_budget`)
- [x] No regression in existing 14 cred-5 stage 2 tests — all 14 still PASS

## Additional tests added (defensive)

- `test_session_key_rejects_batch_with_nonzero_value_inner` — enforces invariant 3
- `test_session_key_rejects_batch_with_out_of_scope_inner_selector` — distinguishes outer-vs-inner selector allowlist
- `test_session_key_rejects_empty_batch` — defensive
- `test_session_key_batch_per_inner_gas_under_5k_budget` — direct gas-budget assertion (measures 2-inner vs 6-inner delta)
- `test_executeBatch_rejected_until_cred6` renamed → `test_malformed_executeBatch_calldata_rejected` (still passes; same body, accurate name for post-cred-6 world)

## Test results

```
Ran 1 test suite: 20 passed; 0 failed; 1 skipped (21 total tests)
  per-inner validator gas: 3291  ← budget 5000
```

The 1 skip (`test_create2_address_unchanged_after_module_install`) is intentionally deferred to cred-7 (requires kernel-v3 wiring).

## RC artifact

N/A — `contracts/` is a Solidity package with no npm/PyPI/crate artifact. Validator change is observable only after on-chain deploy + module install (cred-7 path). Coordinator review can verify by:
1. Reading the diff in `SessionKeyModule.sol::_isCallDataInScope` / `_isBatchInScope`.
2. Running `forge test --match-path test/SessionKeyModule.t.sol -vv` locally.

## Cross-spec invariants honored

- ✅ Per-inner-call assertion (§4.2 cross-spec invariant + #281 OQ-A): rejects on first non-matching inner; no outer-selector-passes shortcut; no first-inner sampling.
- ✅ Same recursive pattern documented for future call-aggregators (`multicall`, etc.) in the contract NatSpec.
- ✅ CREATE2 byte-equality invariant (1): no storage layout changes — only added internal helpers.
- ✅ No-TTL invariant (2): unchanged.
- ✅ `valueMax == 0` invariant (3): applied per-inner (`values[i] == 0`).

## Notes for coordinator review

- The repo has **no CI workflow that runs `forge test` yet** (verified across `.github/workflows/`). The cred-5 stage 2 PR (#272) shipped `foundry.toml` + `foundry.lock` but did not wire CI. This PR inherits that gap. Suggest filing a separate hygiene task to add a `forge-test.yml` workflow before cred-6 hits stable promote.
- `forge install foundry-rs/forge-std@v1.16.1` is required locally to run the tests; the install adds `.gitmodules` + `contracts/lib/forge-std` which are intentionally NOT committed (mirrors cred-5 stage 2 — main has no `.gitmodules` either).
- No `.gas-snapshot` committed; the in-test gas-budget assertion (`assertLt(perInner, 5000)`) is the load-bearing budget check.

Closes p-diogo/totalreclaw-internal#332

🤖 Generated with [Claude Code](https://claude.com/claude-code) (`tr-implement-task` skill)