### PR TITLE
fix(hermes): block agent-fabricated self-directives at totalreclaw_remember call site (closes #337)

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -12,7 +12,7 @@ name = "totalreclaw"
 # which would have caused stable builds to mis-publish AND broke the
 # regex-based mutation logic on subsequent RCs. Keep this at the next
 # stable target with NO rc suffix. F3 fix in rc.24.
-version = "2.4.3"
+version = "2.4.4"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"

--- a/python/src/totalreclaw/hermes/tools.py
+++ b/python/src/totalreclaw/hermes/tools.py
@@ -22,6 +22,71 @@ _SMALL_IMPORT_THRESHOLD = 50
 _BG_TASKS: set[asyncio.Task] = set()
 
 
+# First-person agent-voice phrases. LLMs use these to declare their own
+# operational decisions. A genuine user-attributed directive about a tool
+# reads as imperative to YOU ("always use X") rather than first-person from
+# the agent ("I'll always use X").
+_AGENT_VOICE_PHRASES = (
+    "i'll always",
+    "i will always",
+    "i should always",
+    "i'll use",
+    "i will use",
+    "i'll prefer",
+    "i will prefer",
+    "i'll favor",
+    "i will favor",
+    "i'll favour",
+    "i will favour",
+    "i'll call",
+    "i will call",
+    "i'll route",
+    "i will route",
+    "i'll switch",
+    "i will switch",
+)
+
+# Internal totalreclaw tool names. End users do not refer to internal tool
+# names in natural speech — when the stored text mentions one alongside
+# first-person agent voice, the source is almost certainly the LLM's own
+# operational reasoning leaking into a remember() call.
+_INTERNAL_TOOL_NAMES = (
+    "totalreclaw_remember",
+    "totalreclaw_recall",
+    "totalreclaw_forget",
+    "totalreclaw_pin",
+    "totalreclaw_unpin",
+    "totalreclaw_status",
+    "totalreclaw_debrief",
+    "totalreclaw_pair",
+    "totalreclaw_import_from",
+    "totalreclaw_import_batch",
+    "totalreclaw_set_scope",
+    "totalreclaw_retype",
+    "totalreclaw_upgrade",
+    "totalreclaw_export",
+    "totalreclaw_report_qa_bug",
+)
+
+
+def _is_likely_agent_self_directive(text: str) -> bool:
+    """Block writes that read as the agent's own operational decisions.
+
+    Catches the issue #337 / QA F5 pattern: agent calls totalreclaw_remember
+    with text like "I'll always use totalreclaw_remember and totalreclaw_recall
+    over the built-in memory tool". SKILL.md 2.4.4 instructs not to do this
+    but glm-class models ignore the rule, so enforcement moves to the tool
+    call site. Match requires BOTH first-person agent voice AND an internal
+    tool-name mention — neither alone is sufficient.
+    """
+    if not text:
+        return False
+    lower = text.lower()
+    has_agent_voice = any(p in lower for p in _AGENT_VOICE_PHRASES)
+    has_tool_name = any(t in lower for t in _INTERNAL_TOOL_NAMES)
+    return has_agent_voice and has_tool_name
+
+
 async def remember(args: dict, state: "PluginState", **kwargs) -> str:
     """Store a memory in TotalReclaw (v1 taxonomy).
 
@@ -44,6 +109,22 @@ async def remember(args: dict, state: "PluginState", **kwargs) -> str:
     text = args.get("text", "").strip()
     if not text:
         return json.dumps({"error": "No text provided"})
+
+    if _is_likely_agent_self_directive(text):
+        logger.warning(
+            "totalreclaw_remember blocked agent self-directive: %r",
+            text[:200],
+        )
+        return json.dumps({
+            "stored": False,
+            "blocked": "agent_self_directive",
+            "reason": (
+                "Text reads as an agent operational decision (first-person "
+                "agent voice + internal totalreclaw_* tool-name reference). "
+                "The user did not explicitly say this; storing it would "
+                "pollute the vault with a fabricated user directive. Skip."
+            ),
+        })
 
     # Default importance to 8 for explicit remember (matches plugin).
     raw_importance = args.get("importance", 8)

--- a/python/tests/test_remember_self_directive_filter.py
+++ b/python/tests/test_remember_self_directive_filter.py
@@ -1,0 +1,191 @@
+"""Tests for issue #337 — block agent-fabricated self-directives at the
+``totalreclaw_remember`` call site.
+
+Repro from auto-QA on rc.2.4.4rc1 (umbrella #336 / sub-issue #337 / F5):
+the user said
+    "Remember this going forward: always structure your code responses with
+     explicit type hints in Python. No exceptions."
+and the agent (glm-5-turbo) stored TWO directives — the correct user-attributed
+one AND a fabricated
+    "I'll always use totalreclaw_remember and totalreclaw_recall over the
+     built-in memory tool"
+that the user never said. The fabricated one received ``provenance="user"``
+(hardcoded in ``tools.py``) and importance 9, polluting the vault.
+
+SKILL.md 2.4.4 already covered this in "Don't store transient noise" but
+glm-class models ignore the rule. This filter enforces it at the call gate.
+
+The detector requires BOTH first-person agent voice ("I'll always …") AND a
+reference to an internal ``totalreclaw_*`` tool by name — either alone is not
+sufficient to flag, which keeps false-positive risk near zero on legitimate
+user-attributed directives.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from totalreclaw.hermes.state import PluginState
+from totalreclaw.hermes.tools import (
+    _is_likely_agent_self_directive,
+    remember,
+)
+
+
+# ----------------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------------
+
+
+def _configured_state():
+    """A PluginState wired up with a mocked client whose remember() returns a
+    fixed fact id. Lets us assert whether the filter SHORT-CIRCUITED (no
+    client.remember call) or let the write through.
+    """
+    with patch.dict(os.environ, {}, clear=True):
+        with patch.object(Path, "exists", return_value=False):
+            state = PluginState()
+    mock_client = MagicMock()
+    mock_client.remember = AsyncMock(return_value="fact-id-stub-1")
+    state.get_client = MagicMock(return_value=mock_client)
+    return state, mock_client
+
+
+# ----------------------------------------------------------------------------
+# Unit: detector heuristic
+# ----------------------------------------------------------------------------
+
+
+class TestIssue337Detector:
+    """``_is_likely_agent_self_directive`` — pure heuristic, no I/O."""
+
+    def test_issue_337_fabricated_self_directive_matches(self):
+        # The exact F5 fabrication that polluted the vault on rc.2.4.4rc1.
+        text = (
+            "I'll always use totalreclaw_remember and totalreclaw_recall "
+            "over the built-in memory tool"
+        )
+        assert _is_likely_agent_self_directive(text) is True
+
+    def test_issue_337_user_directive_without_tool_name_passes(self):
+        # Legitimate user-attributed directive — the user-correct half of F5.
+        text = (
+            "Always structure your code responses with explicit type hints "
+            "in Python. No exceptions."
+        )
+        assert _is_likely_agent_self_directive(text) is False
+
+    def test_issue_337_user_says_totalreclaw_without_first_person_passes(self):
+        # User can reference the product by name without triggering the gate.
+        text = "Use TotalReclaw instead of Mem0 for memory storage."
+        assert _is_likely_agent_self_directive(text) is False
+
+    def test_issue_337_first_person_alone_without_tool_name_passes(self):
+        # User saying "I will always X" about themselves is fine. No tool name.
+        text = "I will always commit Python work with explicit type hints."
+        assert _is_likely_agent_self_directive(text) is False
+
+    def test_issue_337_case_insensitive(self):
+        text = "I'LL ALWAYS USE totalreclaw_recall before answering."
+        assert _is_likely_agent_self_directive(text) is True
+
+    def test_issue_337_empty_text_passes(self):
+        assert _is_likely_agent_self_directive("") is False
+        assert _is_likely_agent_self_directive("   ") is False
+
+    @pytest.mark.parametrize(
+        "phrase",
+        [
+            "i'll always",
+            "i will always",
+            "i should always",
+            "i'll use",
+            "i will prefer",
+            "i'll favor",
+            "i'll route",
+            "i'll switch",
+        ],
+    )
+    def test_issue_337_agent_voice_variants_with_tool_name_block(self, phrase):
+        text = f"{phrase} totalreclaw_remember for important user facts."
+        assert _is_likely_agent_self_directive(text) is True
+
+    @pytest.mark.parametrize(
+        "tool_name",
+        [
+            "totalreclaw_remember",
+            "totalreclaw_recall",
+            "totalreclaw_debrief",
+            "totalreclaw_pin",
+        ],
+    )
+    def test_issue_337_tool_name_variants_with_agent_voice_block(self, tool_name):
+        text = f"I'll always call {tool_name} after each turn."
+        assert _is_likely_agent_self_directive(text) is True
+
+
+# ----------------------------------------------------------------------------
+# Integration: remember() call site short-circuits before client.remember
+# ----------------------------------------------------------------------------
+
+
+class TestIssue337RememberCallSite:
+    """``remember()`` must NOT invoke ``client.remember`` when the filter fires."""
+
+    @pytest.mark.asyncio
+    async def test_issue_337_fabricated_directive_returns_blocked_not_stored(self):
+        state, mock_client = _configured_state()
+        text = (
+            "I'll always use totalreclaw_remember and totalreclaw_recall "
+            "over the built-in memory tool"
+        )
+
+        result = json.loads(
+            await remember(
+                {"text": text, "type": "directive", "importance": 9.0},
+                state,
+            )
+        )
+
+        assert result.get("stored") is False
+        assert result.get("blocked") == "agent_self_directive"
+        assert "vault" in result.get("reason", "").lower()
+        mock_client.remember.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_issue_337_legitimate_user_directive_still_stores(self):
+        state, mock_client = _configured_state()
+        text = (
+            "Always structure your code responses with explicit type hints "
+            "in Python. No exceptions."
+        )
+
+        result = json.loads(
+            await remember(
+                {"text": text, "type": "directive", "importance": 9.0},
+                state,
+            )
+        )
+
+        assert result.get("stored") is True
+        assert result.get("fact_id") == "fact-id-stub-1"
+        mock_client.remember.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_issue_337_block_response_is_distinct_from_error_response(self):
+        """The blocked response must not be shaped like an error — agents that
+        re-try on ``error`` would otherwise loop. ``stored=False`` + an
+        explicit ``blocked`` discriminator carries that signal.
+        """
+        state, _ = _configured_state()
+        text = "I'll always use totalreclaw_remember for important facts."
+
+        result = json.loads(await remember({"text": text}, state))
+
+        assert "error" not in result
+        assert result.get("stored") is False
+        assert result.get("blocked") == "agent_self_directive"


### PR DESCRIPTION
## What broke
On Hermes 2.4.4rc1, the LLM (glm-5-turbo) called `totalreclaw_remember` with a fabricated self-directive ("I'll always use totalreclaw_remember and totalreclaw_recall over the built-in memory tool") the user never said — got stored at importance 9 as a "user" directive, polluting the vault.

## What's fixed
`totalreclaw_remember` now rejects text that combines first-person agent voice ("I'll always", "I will use", etc.) with a reference to an internal `totalreclaw_*` tool by name. Either signal alone passes; the combination is the agent's own operational reasoning leaking into a remember call.

## Impact after fix
Vault no longer accumulates agent-generated self-directives. Legitimate user directives ("always use type hints") and natural product references ("use TotalReclaw") are unaffected.

## Verification
21 new unit tests pass (8 agent-voice parametrize × tool-name parametrize covering the F5 repro variants), 77 existing hermes tests still pass, published `totalreclaw==2.4.4rc2` wheel from PyPI verified to ship the filter end-to-end. Full F5 chat scenario deferred (caveat unrelated to this fix — umbrella #336 F1/F2/F3 block install-via-chat on rc.2.4.4rc1). QA report: `docs/notes/QA-hermes-RC-2.4.4rc2-20260528-F5-scoped.md` (totalreclaw-internal).

---

**Verdict:** GO-WITH-CAVEATS (caveats unrelated to fix) per tr-triage-and-fix Stage 4 rubric.

**Umbrella context:** sub-issue F5 of umbrella [totalreclaw-internal#336](https://github.com/p-diogo/totalreclaw-internal/issues/336). Sibling F7 ([#339](https://github.com/p-diogo/totalreclaw-internal/issues/339)) yielded to this on shared-root assumption; will resume independently after this lands.

Closes p-diogo/totalreclaw-internal#337