### PR TITLE
fix(hermes): install_memory_provider regex no longer eats trailing newline (#351)

### DIFF
--- a/python/src/totalreclaw/hermes/install_memory_provider.py
+++ b/python/src/totalreclaw/hermes/install_memory_provider.py
@@ -137,7 +137,11 @@ def uninstall_sidecar(hermes_home: Optional[Path] = None) -> bool:
     return True
 
 
-_PROVIDER_LINE_RE = re.compile(r"^(\s*)provider\s*:\s*(\S+)\s*$", re.MULTILINE)
+# Trailing `[ \t]*$` (horizontal whitespace only) is load-bearing: `\s*$`
+# would let the engine consume the line-terminating `\n` (since `\s` matches
+# newlines and `$` matches end-of-string), so the replacement would smash the
+# value into the next top-level key. See test_issue_351_*.
+_PROVIDER_LINE_RE = re.compile(r"^(\s*)provider\s*:\s*(\S+)[ \t]*$", re.MULTILINE)
 _MEMORY_BLOCK_RE = re.compile(
     r"^(memory:\s*\n(?:[ \t]+.*\n?)*)",
     re.MULTILINE,

--- a/python/tests/test_memory_provider.py
+++ b/python/tests/test_memory_provider.py
@@ -538,6 +538,48 @@ class TestInstallMemoryProvider:
         assert "other: keep_me" in body
         assert "flag: true" in body
 
+    def test_issue_351_provider_last_in_block_preserves_yaml(self, tmp_path: Path):
+        # Pre-state: 'provider:' is the LAST line of the memory block and a
+        # top-level key (delegation:) follows on the next line. Pre-fix, the
+        # provider-line regex's trailing \s*$ consumed the line-terminating
+        # newline and the replacement smashed `delegation:` onto the same
+        # line as the new provider value, producing invalid YAML.
+        import yaml as _yaml
+        cfg = imp.config_path(tmp_path)
+        cfg.parent.mkdir(parents=True, exist_ok=True)
+        cfg.write_text(
+            "memory:\n"
+            "  memory_enabled: true\n"
+            "  provider: none\n"
+            "delegation:\n"
+            "  enabled: false\n",
+            encoding="utf-8",
+        )
+        imp.set_active_provider("totalreclaw", hermes_home=tmp_path)
+        body = cfg.read_text(encoding="utf-8")
+        assert "totalreclawdelegation" not in body
+        assert "provider: totalreclaw\ndelegation:" in body
+        parsed = _yaml.safe_load(body)
+        assert parsed["memory"]["provider"] == "totalreclaw"
+        assert parsed["memory"]["memory_enabled"] is True
+        assert "delegation" in parsed
+
+    def test_issue_351_provider_at_eof_preserves_yaml(self, tmp_path: Path):
+        import yaml as _yaml
+        cfg = imp.config_path(tmp_path)
+        cfg.parent.mkdir(parents=True, exist_ok=True)
+        cfg.write_text(
+            "other: keep_me\n"
+            "memory:\n"
+            "  provider: none\n",
+            encoding="utf-8",
+        )
+        imp.set_active_provider("totalreclaw", hermes_home=tmp_path)
+        body = cfg.read_text(encoding="utf-8")
+        parsed = _yaml.safe_load(body)
+        assert parsed["other"] == "keep_me"
+        assert parsed["memory"]["provider"] == "totalreclaw"
+
     def test_install_and_activate_combines_steps(self, tmp_path: Path):
         result = imp.install_and_activate(hermes_home=tmp_path, activate=True)
 


### PR DESCRIPTION
## What broke
On Hermes fresh install, `set_active_provider('totalreclaw')` corrupted `~/.hermes/config.yaml` — the file ended up with `provider: totalreclawdelegation:` on one line, breaking every subsequent `hermes` command with `mapping values are not allowed here`.

## What's fixed
Tightened the trailing match of `_PROVIDER_LINE_RE` from `\s*$` to `[ \t]*$` so the regex no longer greedy-consumes the line-terminating `\n`. The previous form let `\s*` swallow the newline (since `\s` includes `\n` and `$` matches end-of-string), and the substitution then smashed the new value into the next top-level YAML key.

## Impact after fix
Hermes install on a default config (memory block immediately followed by `delegation:`) writes valid YAML. PyYAML `safe_load` round-trips cleanly. All other YAML keys preserved.

## Verification
- Unit: 2 new tests in `test_memory_provider.py` (`test_issue_351_provider_last_in_block_preserves_yaml`, `test_issue_351_provider_at_eof_preserves_yaml`) — both PASS post-patch, the bug-shape one FAILS pre-patch. 50/50 in module pass.
- E2E: local reproduction against the same config shape from QA report `QA-hermes-RC-2.4.4rc2-20260528.md` — pre-write config corrupted, post-patch write is valid YAML.

## Bundling
No version bump / no rc3 publish in this PR. F1 fix ships bundled with the rest of umbrella #348 work (#352 split-brain memory, #349 F6, #350 F7, #353 stale hooks.py) when those land — per the umbrella tradeoff. RC3 will get cut once F6+F7 are implemented.

Closes #351