### PR TITLE
fix(hermes): sync SKILL.md version field via publish workflow (#352)

### DIFF
--- a/.github/workflows/publish-python-client.yml
+++ b/.github/workflows/publish-python-client.yml
@@ -77,6 +77,39 @@ jobs:
           print('\n'.join(new_text.splitlines()[:10]))
           PY
 
+      # Sync SKILL.md frontmatter `version:` field to the (post-mutation)
+      # pyproject.toml version. Issue #352: rc.2.4.4rc2 shipped with
+      # SKILL.md `version: 2.3.1rc10` because the field was hardcoded in
+      # source and the publish workflow only mutated pyproject.toml.
+      # Agents load SKILL.md from the installed package — a stale version
+      # there causes them to follow an old install script that diverges
+      # from the current setup guide. Mirroring the pyproject mutation
+      # here closes that drift structurally.
+      - name: Sync SKILL.md version field to pyproject.toml version
+        run: |
+          python3 <<'PY'
+          import re, pathlib
+          pyproject = pathlib.Path('python/pyproject.toml').read_text()
+          m = re.search(r'^version\s*=\s*"([^"]+)"', pyproject, flags=re.MULTILINE)
+          if not m:
+              raise SystemExit("pyproject.toml version line not found")
+          target_version = m.group(1)
+          skill = pathlib.Path('python/src/totalreclaw/hermes/SKILL.md')
+          text = skill.read_text()
+          new_text, n = re.subn(
+              r'(^version:\s*).*$',
+              lambda mm: f'{mm.group(1)}{target_version}',
+              text,
+              count=1,
+              flags=re.MULTILINE,
+          )
+          if n != 1:
+              raise SystemExit("SKILL.md frontmatter `version:` line not found")
+          skill.write_text(new_text)
+          print(f"SKILL.md version field synced to {target_version}")
+          print('\n'.join(new_text.splitlines()[:8]))
+          PY
+
       # 2.3.12-rc.1 (F flip): no URL rewrite needed — the source at
       # `_HARDCODED_DEFAULT_URL` already binds to production for both
       # release types.

--- a/python/src/totalreclaw/hermes/SKILL.md
+++ b/python/src/totalreclaw/hermes/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "Install + set up TotalReclaw encrypted memory for Hermes, then use totalreclaw_remember / totalreclaw_recall. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', or any remember / recall request."
-version: 2.3.5rc1
+version: 2.4.4
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz


### PR DESCRIPTION
## What broke
QA on `totalreclaw==2.4.4rc2` saw the installed Hermes SKILL.md frontmatter still at `version: 2.3.1rc10` and missing the `hermes tools disable memory` install step. Agents that load SKILL.md from the package then followed the stale install flow, skipped `hermes tools disable memory`, fell back to a YAML-corrupting alternative, and left `memory_enabled: true` — split-brain memory active.

## What's fixed
- Bump in-source `python/src/totalreclaw/hermes/SKILL.md` frontmatter from `2.3.5rc1` → `2.4.4` so main no longer ships drift on a stable publish.
- Add a `Sync SKILL.md version field to pyproject.toml version` step to `.github/workflows/publish-python-client.yml`. The step runs after the existing RC suffix mutation and mirrors it onto SKILL.md (so an rc publish ships `version: 2.4.4rc<N>` in the frontmatter, and a stable publish ships `version: 2.4.4`). Same regex-replace pattern as the pyproject mutation, with a hard failure if the frontmatter line is missing.

## Impact after fix
- Future publishes ship SKILL.md frontmatter that matches the wheel version. Eliminates the silent divergence that masked `rc.2.4.4rc2` being built from a stale ref (the SKILL.md version field is now load-bearing evidence of which ref produced the artifact).
- Closes umbrella Finding #6 (informational version-field drift) structurally.
- Does NOT directly add `hermes tools disable memory` to SKILL.md — that content fix landed on main on 2026-04-26 (commit 0e9d2ee, ~33 days ago). It was already there at HEAD before this PR. The reason rc2 shipped without it: the publish workflow built from a stale ref. The next rc cut from current main will ship the correct content, and the synced version field will let QA verify that mechanically.

## Verification
- **Stable mode dry-run (local):** with pyproject `version = "2.4.4"`, sync script writes `version: 2.4.4` into SKILL.md. n=1 substitution. ✓
- **RC mode dry-run (local):** apply RC suffix step (rc=3) on pyproject → `version = "2.4.4rc3"`, then sync script writes `version: 2.4.4rc3` into SKILL.md. n=1 substitution. ✓
- **Full end-to-end QA (install rc3, run install flow, confirm `hermes tools disable memory` fires):** NOT runnable in this triage cycle. The next rc3 publish is blocked behind umbrella sibling blockers p-diogo/totalreclaw-internal#349 (F6 not shipped) and p-diogo/totalreclaw-internal#350 (F7 not shipped) which require new feature implementation, not in scope for this auto-triage. Full F2 verification will fall out of the rc3 QA pass once those land.

Resolves p-diogo/totalreclaw-internal#352 (literal manifestation will not recur once rc3 ships from current main; the workflow change ensures the version field on the shipped artifact is no longer hardcoded).

🤖 Generated by tr-triage-and-fix auto-triage pipeline.