### PR TITLE
[ops-5 script-stage] feat(contracts): isolated staging DataEdge CREATE2 deploy script (no broadcast)

### DIFF
--- a/contracts/deployed-addresses.json
+++ b/contracts/deployed-addresses.json
@@ -6,5 +6,16 @@
   "totalReclawPaymaster": "0xd10Be4669c739C3315616f7E6a2D7Dbd7033e7aD",
   "deployedAt": "2026-03-20T12:55:55.353Z",
   "deployer": "0x5C6A2E495F032E31Fc4c042085Bea0006B9C7A06",
-  "blockNumber": 39121533
+  "blockNumber": 39121533,
+  "stagingGnosis": {
+    "network": "gnosis",
+    "chainId": 100,
+    "eventfulDataEdge": "0xE7a4D2677B686e13775Ba9092631089e35F0BB91",
+    "status": "PREDICTED (not yet broadcast)",
+    "create2Factory": "0x4e59b44847b379578588920cA78FbF26c0B4956C",
+    "create2Salt": "keccak256(\"totalreclaw.EventfulDataEdge.staging.v1\")",
+    "purpose": "Isolated staging DataEdge on Gnosis — distinct address from prod 0xC445 (ops-5, staging-chain-isolation spec). Broadcast via script/DeployDataEdgeStaging.s.sol --broadcast when funded.",
+    "deployedAt": null,
+    "blockNumber": null
+  }
 }

--- a/contracts/script/DeployDataEdgeStaging.s.sol
+++ b/contracts/script/DeployDataEdgeStaging.s.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {EventfulDataEdge} from "../contracts/EventfulDataEdge.sol";
+
+/**
+ * @title DeployDataEdgeStaging
+ * @notice ops-5 (script-stage) — CREATE2 deploy script for an ISOLATED
+ *         staging instance of EventfulDataEdge on Gnosis mainnet.
+ *         NO BROADCAST in this stage. Computes + logs the predicted CREATE2
+ *         address so ops-6 (staging subgraph) can be pre-configured and
+ *         ops-7/8 (relay env) know the target before the funded broadcast.
+ *
+ *         Per the staging-chain-isolation spec
+ *         (`totalreclaw-internal/docs/specs/ops/staging-chain-isolation.md`):
+ *         staging runs on Gnosis (chain 100) — same chain as production —
+ *         but writes to a DIFFERENT DataEdge address so staging on-chain
+ *         activity is isolated from production's `0xC445…c36f`.
+ *
+ *         The isolation comes purely from a DIFFERENT CREATE2 SALT:
+ *           - prod salt → `0xC445af1D4EB9fce4e1E61fE96ea7B8feBF03c5ca`
+ *           - staging salt (this script) → a distinct address.
+ *
+ *         EventfulDataEdge has a PARAM-LESS constructor (`owner = msg.sender`),
+ *         so its init code is deterministic → the CREATE2 address depends
+ *         only on (factory, salt, initCodeHash) and is byte-equal on every
+ *         chain. Under the Arachnid factory, `msg.sender` in the constructor
+ *         resolves to the factory itself, so `owner` = factory — irrelevant,
+ *         because EventfulDataEdge is a permissionless `fallback()`-only
+ *         emitter with no owner-gated write path (same as prod, see CLAUDE.md
+ *         "DataEdge: permissionless").
+ *
+ * Usage (script-stage — predicted address only):
+ *   forge script script/DeployDataEdgeStaging.s.sol --rpc-url $GNOSIS_RPC_URL
+ *
+ * Usage (broadcast-stage — separate Pedro-supervised step, funded deployer):
+ *   forge script script/DeployDataEdgeStaging.s.sol \
+ *       --rpc-url $GNOSIS_RPC_URL \
+ *       --private-key $DEPLOYER_PRIVATE_KEY \
+ *       --broadcast --verify
+ *   Then: record the address in `contracts/deployed-addresses.json` under a
+ *   `stagingGnosis` key + set the staging relay's DATA_EDGE_ADDRESS /
+ *   PRO_DATA_EDGE_ADDRESS to it (ops-7/8).
+ */
+contract DeployDataEdgeStaging is Script {
+    // forge-std exposes Arachnid's deterministic deployment proxy as
+    // `Base.CREATE2_FACTORY` (0x4e59b44847b379578588920cA78FbF26c0B4956C),
+    // inherited via Script. Do NOT redeclare.
+
+    /// @dev Staging-specific salt — DISTINCT from production's DataEdge salt,
+    ///      which is what yields a different address on the same chain. Bump
+    ///      the version suffix only for an intentional staging re-deploy.
+    bytes32 internal constant DATA_EDGE_STAGING_SALT =
+        keccak256("totalreclaw.EventfulDataEdge.staging.v1");
+
+    function run() external view {
+        bytes memory initCode = abi.encodePacked(type(EventfulDataEdge).creationCode);
+        bytes32 initCodeHash = keccak256(initCode);
+
+        address predicted = address(
+            uint160(
+                uint256(
+                    keccak256(
+                        abi.encodePacked(
+                            bytes1(0xff),
+                            CREATE2_FACTORY,
+                            DATA_EDGE_STAGING_SALT,
+                            initCodeHash
+                        )
+                    )
+                )
+            )
+        );
+
+        console2.log("=== Staging EventfulDataEdge CREATE2 deployment ===");
+        console2.log("Chain id:        ", block.chainid);
+        console2.log("Factory:         ", CREATE2_FACTORY);
+        console2.log("Salt:            ");
+        console2.logBytes32(DATA_EDGE_STAGING_SALT);
+        console2.log("Init code hash:  ");
+        console2.logBytes32(initCodeHash);
+        console2.log("Predicted addr:  ", predicted);
+        console2.log("Prod DataEdge:   0xC445af1D4EB9fce4e1E61fE96ea7B8feBF03c5ca");
+        console2.log("Isolated?:       ", predicted != 0xC445af1D4EB9fce4e1E61fE96ea7B8feBF03c5ca);
+
+        if (predicted.code.length > 0) {
+            console2.log("Already deployed at predicted address. Skipping.");
+            return;
+        }
+        console2.log("Script-stage: predicted address only - no broadcast.");
+    }
+}

--- a/contracts/test/DataEdgeStagingCreate2.t.sol
+++ b/contracts/test/DataEdgeStagingCreate2.t.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {EventfulDataEdge} from "../contracts/EventfulDataEdge.sol";
+
+/**
+ * @title DataEdgeStagingCreate2Test
+ * @notice ops-5 — locks two invariants for the isolated staging DataEdge:
+ *   1. ISOLATION: the staging CREATE2 address differs from production's
+ *      `0xC445…c36f`, purely because of a different salt.
+ *   2. DETERMINISM: the staging address is byte-equal across chains
+ *      (Gnosis 100 vs the local default), so a future broadcast lands at
+ *      the same address regardless of chain — the property that lets ops-1
+ *      reuse the staging config shape on prod.
+ */
+contract DataEdgeStagingCreate2Test is Test {
+    // forge-std Base.CREATE2_FACTORY = 0x4e59b44847b379578588920cA78FbF26c0B4956C
+
+    /// @dev Must match `DeployDataEdgeStaging.DATA_EDGE_STAGING_SALT`.
+    bytes32 internal constant DATA_EDGE_STAGING_SALT =
+        keccak256("totalreclaw.EventfulDataEdge.staging.v1");
+
+    address internal constant PROD_DATA_EDGE =
+        0xC445af1D4EB9fce4e1E61fE96ea7B8feBF03c5ca;
+
+    function _predict(bytes32 salt) internal pure returns (address) {
+        bytes32 initCodeHash = keccak256(
+            abi.encodePacked(type(EventfulDataEdge).creationCode)
+        );
+        return address(
+            uint160(
+                uint256(
+                    keccak256(
+                        abi.encodePacked(
+                            bytes1(0xff),
+                            CREATE2_FACTORY,
+                            salt,
+                            initCodeHash
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    function test_staging_address_isolated_from_production() public pure {
+        address staging = _predict(DATA_EDGE_STAGING_SALT);
+        assertTrue(
+            staging != PROD_DATA_EDGE,
+            "staging DataEdge must NOT collide with prod 0xC445"
+        );
+    }
+
+    function test_staging_address_byte_equal_across_chains() public {
+        uint256 original = block.chainid;
+        vm.chainId(100); // Gnosis
+        address onGnosis = _predict(DATA_EDGE_STAGING_SALT);
+        vm.chainId(84532); // Base Sepolia (for contrast)
+        address onSepolia = _predict(DATA_EDGE_STAGING_SALT);
+        vm.chainId(original);
+        assertEq(
+            onGnosis,
+            onSepolia,
+            "CREATE2 address must be chain-independent"
+        );
+    }
+
+    function test_pinned_predicted_address() public pure {
+        // Pin the computed address so an accidental salt/bytecode change
+        // surfaces as a failing test (the staging subgraph + relay env are
+        // configured against this exact address).
+        assertEq(
+            _predict(DATA_EDGE_STAGING_SALT),
+            0xE7a4D2677B686e13775Ba9092631089e35F0BB91,
+            "staging DataEdge predicted address drifted - update subgraph/relay config if intentional"
+        );
+    }
+}


### PR DESCRIPTION
First leaf of the staging-chain-isolation epic (`totalreclaw-internal#363`). Script-stage only — **no broadcast.**

## What ships

| File | Purpose |
|---|---|
| `contracts/script/DeployDataEdgeStaging.s.sol` | CREATE2 deploy script for an isolated staging `EventfulDataEdge` on Gnosis. Predicted-addr only; broadcast block documented + commented. |
| `contracts/test/DataEdgeStagingCreate2.t.sol` | 3 tests — isolation (≠ prod `0xC445`), determinism (byte-equal across chains), pinned-address drift guard. |
| `contracts/deployed-addresses.json` | `stagingGnosis` entry, status `PREDICTED`. |

## Predicted staging address

```
Salt:    keccak256("totalreclaw.EventfulDataEdge.staging.v1")
Addr:    0xE7a4D2677B686e13775Ba9092631089e35F0BB91
Prod:    0xC445af1D4EB9fce4e1E61fE96ea7B8feBF03c5ca   (isolated ✓)
```

Staging runs on **Gnosis (chain 100, same as prod)** but a **different DataEdge address** — isolation comes purely from a different CREATE2 salt (per Pedro's req 2026-05-30). `EventfulDataEdge` has a param-less constructor → deterministic init code → address depends only on (factory, salt, bytecode), byte-equal on every chain.

## Why (primary driver)

Single-chain (free + pro both on Gnosis) fixes the **live data-loss-on-upgrade bug**: today Stripe upgrade is a bare `tier='pro'` flip with no data migration, so a free user's Base Sepolia vault is stranded on free→pro upgrade. Staging-on-isolated-Gnosis is the dry-run that de-risks the prod single-chain flip (ops-1). See `totalreclaw-internal/docs/specs/ops/staging-chain-isolation.md`.

## Next (broadcast-stage, separate Pedro-supervised PR)

`forge script ... --broadcast --verify` with a funded Gnosis deployer → fill `deployedAt`/`blockNumber` → point staging relay `DATA_EDGE_ADDRESS` + `PRO_DATA_EDGE_ADDRESS` at it (ops-7/8).

## Tests

```
forge test --match-contract DataEdgeStagingCreate2 → 3 pass
```

`Forge Test` CI (#281) exercises this on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)