### PR TITLE
feat(client): consume authoritative chain_id from billing (root fix #364) [DRAFT — phrase-safety review]

### DIFF
--- a/python/src/totalreclaw/client.py
+++ b/python/src/totalreclaw/client.py
@@ -61,6 +61,34 @@ DEFAULT_CHAIN_ID_PRO: int = 100
 CHAIN_ID_AUTODETECT_TIMEOUT_SECONDS: float = 5.0
 
 
+def _chain_id_from_billing(payload: object) -> int:
+    """Resolve the target chain id from a ``/v1/billing/status`` payload.
+
+    Precedence (root fix #364 / totalreclaw-relay#21):
+
+    1. **Authoritative ``chain_id`` field** — consumed verbatim when the relay
+       emits a positive integer. The relay sources it from its own
+       ``getChainConfigForTier(tier)``, so after the ops-1 single-chain Gnosis
+       cutover a free user's chain flips to 100 with **zero client release** —
+       the relay env change propagates automatically.
+    2. **Legacy tier->chain map** — graceful fallback for an older relay that
+       does not yet emit the field (the field is additive / non-breaking):
+       ``tier == 'pro'`` -> Gnosis (100), otherwise Base Sepolia (84532).
+
+    A malformed ``chain_id`` (missing, null, string, float, bool, ``<= 0``)
+    is ignored and falls through to the tier map rather than signing a UserOp
+    for a garbage chain.
+    """
+    if isinstance(payload, dict):
+        raw = payload.get("chain_id")
+        # ``bool`` is a subclass of ``int`` — exclude True/False explicitly.
+        if isinstance(raw, int) and not isinstance(raw, bool) and raw > 0:
+            return raw
+        if payload.get("tier") == "pro":
+            return DEFAULT_CHAIN_ID_PRO
+    return DEFAULT_CHAIN_ID_FREE
+
+
 def _get_eoa_account(mnemonic: str):
     """Derive the EOA (externally-owned account) from a BIP-39 mnemonic.
 
@@ -256,24 +284,30 @@ class TotalReclaw:
             pass
 
     async def resolve_chain_id(self) -> int:
-        """Auto-detect target chain ID from billing tier.
+        """Auto-detect the target chain ID from ``/v1/billing/status``.
 
-        Mirrors the MCP behavior (``mcp/src/index.ts`` ~346). Makes a
-        best-effort ``GET /v1/billing/status?wallet_address=<sa>`` call and
-        returns:
+        Makes a best-effort ``GET /v1/billing/status?wallet_address=<sa>``
+        call and resolves the chain via :func:`_chain_id_from_billing`:
 
-        * :data:`DEFAULT_CHAIN_ID_PRO` (100, Gnosis mainnet) if the
-          response's ``tier == "pro"``.
-        * :data:`DEFAULT_CHAIN_ID_FREE` (84532, Base Sepolia) otherwise.
+        * **Authoritative ``chain_id``** from the relay is consumed verbatim
+          when present (root fix #364 / totalreclaw-relay#21). This decouples
+          chain selection from a hardcoded tier map, so the ops-1 single-chain
+          Gnosis cutover flips free users to chain 100 with **no client
+          release** — the relay env change propagates automatically.
+        * **Tier-map fallback** for an older relay that does not yet emit the
+          field: ``tier == "pro"`` -> 100 (Gnosis), otherwise 84532 (Base
+          Sepolia). Mirrors the MCP behavior (``mcp/src/index.ts`` ~346);
+          the MCP/TS client needs an equivalent ``chain_id`` upgrade.
 
         Errors from the billing endpoint (network, auth, malformed JSON)
         are swallowed — we fall back to the free-tier chain so the client
         is usable offline. The result is cached on the client for the
         lifetime of the instance.
 
-        Without this, Pro users' Python writes were signed for Base
-        Sepolia but the relay routed them to Gnosis, producing silent AA23
-        failures (QA-V1CLEAN-VPS-20260418 Bug #11).
+        Without authoritative resolution, Pro users' Python writes were
+        signed for Base Sepolia but the relay routed them to Gnosis,
+        producing silent AA23 failures (QA-V1CLEAN-VPS-20260418 Bug #11);
+        post-ops-1 the same failure would hit free users.
         """
         if self._chain_id_resolved:
             return self._chain_id
@@ -303,11 +337,7 @@ class TotalReclaw:
                     headers=headers,
                 )
             if resp.status_code == 200:
-                payload = resp.json()
-                if isinstance(payload, dict) and payload.get("tier") == "pro":
-                    self._chain_id = DEFAULT_CHAIN_ID_PRO
-                else:
-                    self._chain_id = DEFAULT_CHAIN_ID_FREE
+                self._chain_id = _chain_id_from_billing(resp.json())
             else:
                 self._chain_id = DEFAULT_CHAIN_ID_FREE
         except Exception:

--- a/python/tests/test_chain_id_autodetect.py
+++ b/python/tests/test_chain_id_autodetect.py
@@ -229,3 +229,80 @@ async def test_legacy_chain_id_env_is_ignored() -> None:
         with billing_patch:
             chain_id = await client.resolve_chain_id()
     assert chain_id == 84532  # free-tier default, NOT 9999
+
+
+# ---------------------------------------------------------------------------
+# Root fix (#364 / relay #21): consume the relay's AUTHORITATIVE chain_id.
+#
+# After ops-1 (single-chain Gnosis), the relay's GET /v1/billing/status
+# returns an explicit ``chain_id`` sourced from getChainConfigForTier(tier).
+# The client MUST consume it verbatim and stop deriving the chain from the
+# hardcoded tier->chain map. This lets a free user be flipped to Gnosis with
+# ZERO client release — the relay env change propagates automatically.
+#
+# The local tier->chain map is retained ONLY as a graceful fallback for an
+# old relay that doesn't yet emit the field (additive/non-breaking rollout).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_authoritative_chain_id_overrides_free_tier_map() -> None:
+    """THE migration scenario: free tier but relay says chain_id=100.
+
+    Post ops-1 the relay reports a free user's authoritative chain as Gnosis.
+    The client must sign for 100 even though the legacy tier-map would say
+    84532 for ``tier == 'free'``.
+    """
+    client = _make_client()
+    patch_ctx, _ = _patch_billing({"tier": "free", "chain_id": 100})
+    with patch_ctx:
+        chain_id = await client.resolve_chain_id()
+    assert chain_id == 100
+
+
+@pytest.mark.asyncio
+async def test_authoritative_chain_id_overrides_pro_tier_map() -> None:
+    """Authoritative field wins in BOTH directions — pro reported on 84532."""
+    client = _make_client()
+    patch_ctx, _ = _patch_billing({"tier": "pro", "chain_id": 84532})
+    with patch_ctx:
+        chain_id = await client.resolve_chain_id()
+    assert chain_id == 84532
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_tier_map_when_chain_id_field_absent() -> None:
+    """Old relay (no chain_id field) -> graceful fallback to the tier-map."""
+    client = _make_client()
+    patch_ctx, _ = _patch_billing({"tier": "pro"})  # no chain_id key
+    with patch_ctx:
+        chain_id = await client.resolve_chain_id()
+    assert chain_id == 100  # tier-map fallback still works
+
+
+@pytest.mark.asyncio
+async def test_invalid_chain_id_field_falls_back_to_tier_map() -> None:
+    """A malformed chain_id (non-int / null / zero) is ignored — fall back
+    to the tier-map rather than signing for a garbage chain."""
+    for bad in ("not-a-number", None, 0, -1, 1.5):
+        client = _make_client()
+        patch_ctx, _ = _patch_billing({"tier": "free", "chain_id": bad})
+        with patch_ctx:
+            chain_id = await client.resolve_chain_id()
+        assert chain_id == 84532, f"bad chain_id {bad!r} should fall back to tier-map"
+
+
+@pytest.mark.asyncio
+async def test_remember_signs_for_authoritative_chain_id() -> None:
+    """End-to-end: a free user whose relay reports chain_id=100 must have
+    ``remember`` sign the UserOp for Gnosis (100), not Base Sepolia."""
+    client = _make_client()
+    billing_patch, _ = _patch_billing({"tier": "free", "chain_id": 100})
+    mock_userop = AsyncMock(return_value="0xabc123")
+
+    with billing_patch, patch(
+        "totalreclaw.operations.build_and_send_userop", new=mock_userop,
+    ):
+        await client.remember("Free user migrated to Gnosis")
+
+    assert mock_userop.await_args.kwargs["chain_id"] == 100


### PR DESCRIPTION
## ⚠️ DRAFT — DO NOT MERGE without Pedro's review

Touches ERC-4337 chain routing (phrase-safety hard rail). Tracking: [totalreclaw-internal#364](https://github.com/p-diogo/totalreclaw-internal/issues/364). Gated on the ops-1 single-chain migration sequencing — see **Sequencing** below.

## What

The client half of the tier→chain root fix. `resolve_chain_id()` now consumes the relay's **authoritative `chain_id`** from `GET /v1/billing/status` (added relay-side in [`totalreclaw-relay#21`](https://github.com/p-diogo/totalreclaw-relay/pull/21)) instead of deriving the chain from a hardcoded tier→chain map.

Result: after the ops-1 single-chain Gnosis cutover, a **free user flips to chain 100 with zero client release** — the relay env change propagates automatically. The hardcoded map is retained ONLY as a graceful fallback for an older relay that doesn't yet emit the field (additive / non-breaking rollout).

## Why this is required (not optional)

Before this, `resolve_chain_id()` mapped `tier=free → 84532 (Base Sepolia)` locally. When ops-1 flips free→Gnosis, a free user still reports `tier=free`, so an unchanged client signs UserOps for Sepolia → the Gnosis bundler rejects them (AA23). The infra agent will **not** flip free→Gnosis on any env until a chain-aware client exists. So this PR is the long pole unblocking the migration.

## Safety — phrase-safety surface is minimal

- **No Smart Account / key material touch.** The only change is reading which `chain_id` to route to from an authoritative source. `_derive_smart_account_address` is **untouched** — it runs before chain resolution (chicken-egg) and is provably address-neutral:
- **Verified empirically:** `SimpleAccountFactory.getAddress(owner, 0)` returns the **identical** SA address from both chains (`0x4e6d7733…2c68` via Base Sepolia RPC == via Gnosis RPC) because the factory is deployed at the same address (`0x91E60e…`) on both. An RPC swap could never move a user's account — so no swap was needed.
- Malformed `chain_id` (missing / null / string / float / bool / `<= 0`) is ignored → falls through to the tier map rather than signing for a garbage chain.
- The recovery phrase never enters this code path; no new logging of key material.

## Tests (TDD: RED → GREEN → REFACTOR)

5 new tests in `test_chain_id_autodetect.py`:
- authoritative `chain_id` overrides the free-tier map (THE migration scenario: free + `chain_id=100` → 100)
- authoritative overrides the pro-tier map too (`chain_id=84532` wins)
- graceful fallback when the field is absent (old relay)
- malformed `chain_id` ignored → tier-map fallback
- end-to-end: `remember` signs the UserOp for the authoritative chain

`78 passed` across `test_chain_id_autodetect` + `test_client` + `test_retype_setscope` + `test_operations`. Existing tests unchanged (fallback preserves prior behavior).

## Sequencing (do not merge out of order)

1. Relay [#21](https://github.com/p-diogo/totalreclaw-relay/pull/21) (authoritative `chain_id`) merges + deploys.
2. This PR merges (Pedro phrase-safety review) → cut an RC.
3. Infra points staging at the RC + flips staging free→Gnosis (ops-8).
4. I run **free-tier write+recall QA on single-chain Gnosis** (this change's own QA — rc4's F6/F7 GO does NOT cover it).
5. Infra does prod ops-1 + closes #283 → trigger to cut 2.4.4 stable (bundled with #286 F6+F7).

## Coordination notes for the infra agent

- **`client_upgrade_required` gate version cutoff:** this artifact (the first 2.4.4 RC containing this commit) is the first chain-aware Python client. Key the relay's old-client write-rejection on `X-TotalReclaw-Client` >= that version.
- **MCP/TS client needs the equivalent.** `mcp/src/index.ts` (~346) has the same hardcoded tier→chain map. The OpenClaw plugin's free users break at cutover unless it also consumes the authoritative `chain_id`. Follow-up issue to file.
- **`retype_setscope.py` direct-caller defaults** (`chain_id=84532`) are dead via the client (it always passes its resolved chain) but remain Sepolia-hardcoded for external direct callers — minor follow-up.

No version bump in this PR — folds into the 2.4.4 RC line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
