### PR TITLE
docs(guide): bump Hermes latest-RC pin to 2.4.4rc5

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -12,7 +12,7 @@ This document describes how the agent installs and sets up TotalReclaw on Hermes
 | Channel | Version | Install command |
 |---|---|---|
 | stable (default) | `2.4.3` | `pip install totalreclaw` |
-| latest RC | `2.4.0rc2` | `pip install --pre --upgrade totalreclaw==2.4.0rc2` |
+| latest RC | `2.4.4rc5` | `pip install --pre --upgrade totalreclaw==2.4.4rc5` |
 
 Source of truth for what's currently published: `pip index versions totalreclaw`. The table above is updated on every PyPI release.
 


### PR DESCRIPTION
Per user-guide-pins rule. Pin was stale at `2.4.0rc2`. Bumps to `2.4.4rc5` (full 2.4.4 candidate: F6+F7 + chain-aware #293). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)