### PR TITLE
[ops-5 broadcast] wire the real CREATE2 deploy into the staging DataEdge script

### DIFF
--- a/contracts/script/DeployDataEdgeStaging.s.sol
+++ b/contracts/script/DeployDataEdgeStaging.s.sol
@@ -34,14 +34,25 @@ import {EventfulDataEdge} from "../contracts/EventfulDataEdge.sol";
  * Usage (script-stage — predicted address only):
  *   forge script script/DeployDataEdgeStaging.s.sol --rpc-url $GNOSIS_RPC_URL
  *
- * Usage (broadcast-stage — separate Pedro-supervised step, funded deployer):
+ * Usage (PREDICT-only — no key, no broadcast; safe to run anywhere):
+ *   forge script script/DeployDataEdgeStaging.s.sol --rpc-url $GNOSIS_RPC_URL
+ *   → logs the predicted address + simulates the deploy; sends NO transaction.
+ *
+ * Usage (BROADCAST — Pedro-supervised, funded deployer on Gnosis):
+ *   # Recommended: encrypted keystore so the key never touches the CLI/history:
+ *   cast wallet import staging-deployer --interactive   # one-time
  *   forge script script/DeployDataEdgeStaging.s.sol \
- *       --rpc-url $GNOSIS_RPC_URL \
- *       --private-key $DEPLOYER_PRIVATE_KEY \
- *       --broadcast --verify
- *   Then: record the address in `contracts/deployed-addresses.json` under a
- *   `stagingGnosis` key + set the staging relay's DATA_EDGE_ADDRESS /
- *   PRO_DATA_EDGE_ADDRESS to it (ops-7/8).
+ *       --rpc-url https://rpc.gnosischain.com \
+ *       --account staging-deployer \
+ *       --broadcast
+ *   # (add --verify only if GNOSISSCAN_API_KEY is set; otherwise verify later)
+ *
+ *   The script ASSERTS the on-chain deployed address == the predicted
+ *   0xE7a4D2677B686e13775Ba9092631089e35F0BB91 and reverts on mismatch, so a
+ *   wrong salt / bytecode drift can't silently deploy to the wrong address.
+ *   After it succeeds: set `stagingGnosis.status` = "DEPLOYED" +
+ *   `deployedAt`/`blockNumber` in contracts/deployed-addresses.json, then
+ *   point the staging relay at it (ops-7/8 — see subgraph/STAGING-DEPLOY.md).
  */
 contract DeployDataEdgeStaging is Script {
     // forge-std exposes Arachnid's deterministic deployment proxy as
@@ -54,7 +65,13 @@ contract DeployDataEdgeStaging is Script {
     bytes32 internal constant DATA_EDGE_STAGING_SALT =
         keccak256("totalreclaw.EventfulDataEdge.staging.v1");
 
-    function run() external view {
+    /// @dev The predicted staging address (chain-independent — depends only on
+    ///      factory + salt + bytecode). Pinned so a bytecode/salt drift makes
+    ///      the broadcast revert instead of deploying somewhere unexpected.
+    address internal constant EXPECTED_STAGING_ADDR =
+        0xE7a4D2677B686e13775Ba9092631089e35F0BB91;
+
+    function run() external {
         bytes memory initCode = abi.encodePacked(type(EventfulDataEdge).creationCode);
         bytes32 initCodeHash = keccak256(initCode);
 
@@ -84,10 +101,40 @@ contract DeployDataEdgeStaging is Script {
         console2.log("Prod DataEdge:   0xC445af1D4EB9fce4e1E61fE96ea7B8feBF03c5ca");
         console2.log("Isolated?:       ", predicted != 0xC445af1D4EB9fce4e1E61fE96ea7B8feBF03c5ca);
 
+        // Safety: the computed address must match the pinned expectation.
+        // A mismatch means the salt or EventfulDataEdge bytecode changed —
+        // abort rather than deploy to an unexpected address (which the
+        // staging subgraph + relay env are NOT configured for).
+        require(
+            predicted == EXPECTED_STAGING_ADDR,
+            "predicted addr != pinned EXPECTED_STAGING_ADDR (salt/bytecode drift)"
+        );
+
+        // Idempotent: if already deployed, do nothing (re-running is safe).
         if (predicted.code.length > 0) {
-            console2.log("Already deployed at predicted address. Skipping.");
+            console2.log("Already deployed at predicted address. Nothing to do.");
             return;
         }
-        console2.log("Script-stage: predicted address only - no broadcast.");
+
+        // Deploy via the Arachnid CREATE2 factory. Under `--broadcast` this
+        // sends a real tx signed by --account/--private-key; without it,
+        // forge simulates (no key, no tx) so the predict path stays keyless.
+        // Factory calldata = salt (32 bytes) ++ creationCode; it returns the
+        // 20-byte deployed address.
+        vm.startBroadcast();
+        (bool ok, bytes memory ret) = CREATE2_FACTORY.call(
+            abi.encodePacked(DATA_EDGE_STAGING_SALT, initCode)
+        );
+        vm.stopBroadcast();
+
+        require(ok, "CREATE2 factory call failed");
+        address deployed = address(bytes20(ret));
+        require(
+            deployed == predicted,
+            "deployed addr != predicted (factory returned unexpected address)"
+        );
+
+        console2.log("Deployed staging EventfulDataEdge at:", deployed);
+        console2.log("Record this in deployed-addresses.json -> stagingGnosis (status=DEPLOYED + block).");
     }
 }


### PR DESCRIPTION
Makes Monday's staging DataEdge deploy a **single command**. Stage 1 (#291) shipped the script as predict-only; this wires the actual broadcast.

## What changed
`run()` (was `view`, now broadcasts):
- **Asserts** `predicted == 0xE7a4D2677B686e13775Ba9092631089e35F0BB91` — a salt/bytecode drift **reverts** instead of deploying to an unexpected address.
- Idempotent (no-op if already deployed).
- `vm.startBroadcast()` → Arachnid CREATE2 factory (`salt ++ creationCode`) → asserts factory-returned addr == predicted.

**Keyless predict path preserved:** without `--broadcast`, forge simulates (no key, no tx).

## Monday (Pedro, funded Gnosis deployer)
```bash
cd contracts
cast wallet import staging-deployer --interactive   # one-time; key stays encrypted, never on CLI/history
forge script script/DeployDataEdgeStaging.s.sol \
  --rpc-url https://rpc.gnosischain.com \
  --account staging-deployer --broadcast
# asserts on-chain addr == 0xE7a4…; then flip deployed-addresses.json
# stagingGnosis.status=DEPLOYED + block, and do ops-7/8 relay env (STAGING-DEPLOY.md)
```
Use a **dedicated/throwaway deployer** (~0.05 xDAI). The DataEdge owner is the CREATE2 factory, so the deployer key has zero ongoing authority — it only pays gas.

## Verified
`forge build` OK · `DataEdgeStagingCreate2` 3/3 pass · predict dry-run prints `0xE7a4…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)