### PR TITLE
chore(ops-5): record deployed staging DataEdge + set subgraph startBlock

### DIFF
--- a/contracts/deployed-addresses.json
+++ b/contracts/deployed-addresses.json
@@ -11,11 +11,12 @@
     "network": "gnosis",
     "chainId": 100,
     "eventfulDataEdge": "0xE7a4D2677B686e13775Ba9092631089e35F0BB91",
-    "status": "PREDICTED (not yet broadcast)",
+    "status": "DEPLOYED",
     "create2Factory": "0x4e59b44847b379578588920cA78FbF26c0B4956C",
     "create2Salt": "keccak256(\"totalreclaw.EventfulDataEdge.staging.v1\")",
-    "purpose": "Isolated staging DataEdge on Gnosis — distinct address from prod 0xC445 (ops-5, staging-chain-isolation spec). Broadcast via script/DeployDataEdgeStaging.s.sol --broadcast when funded.",
-    "deployedAt": null,
-    "blockNumber": null
+    "purpose": "Isolated staging DataEdge on Gnosis — distinct address from prod 0xC445 (ops-5, staging-chain-isolation spec).",
+    "deployedAt": "2026-06-01",
+    "deployTx": "0x94f08afe7f26ed9d660d4181ca562d991cc14f408900a9c45a727226b8f87be6",
+    "blockNumber": 46464196
   }
 }

--- a/subgraph/subgraph-gnosis-staging.yaml
+++ b/subgraph/subgraph-gnosis-staging.yaml
@@ -13,13 +13,9 @@ dataSources:
       # Verified against contracts/deployed-addresses.json → stagingGnosis.eventfulDataEdge.
       address: "0xE7a4D2677B686e13775Ba9092631089e35F0BB91"
       abi: EventfulDataEdge
-      # TODO(ops-5 broadcast): set to the staging DataEdge deploy block.
-      # Until the contract is broadcast on Gnosis this value is a placeholder.
-      # On broadcast, read the deploy-tx block from the forge broadcast receipt
-      # (or contracts/deployed-addresses.json → stagingGnosis.blockNumber) and
-      # set it here BEFORE `graph deploy` — a too-low startBlock makes indexing
-      # crawl from that block forward (slow); a too-high one misses early facts.
-      startBlock: 45217698
+      # Staging DataEdge deploy block on Gnosis (ops-5 broadcast 2026-06-01,
+      # tx 0x94f08afe…7be6). The contract emits no events before this block.
+      startBlock: 46464196
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7


### PR DESCRIPTION
Staging DataEdge **deployed on Gnosis** 2026-06-01 (ops-5 broadcast done).

- address: `0xE7a4D2677B686e13775Ba9092631089e35F0BB91` (== predicted; verified on-chain, 524 bytes code)
- tx: `0x94f08afe7f26ed9d660d4181ca562d991cc14f408900a9c45a727226b8f87be6`
- block: `46464196`

Updates:
- `deployed-addresses.json` → `stagingGnosis`: status `DEPLOYED` + deployTx + blockNumber
- `subgraph-gnosis-staging.yaml` → `startBlock: 46464196` (was placeholder) → ops-6 `npm run deploy:staging` is now ready

Next: ops-6 (subgraph deploy) → ops-7/8 (relay env). Refs `totalreclaw-internal#363`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)