### PR TITLE
feat: chain/env-aware DataEdge (ops-9 NO-GO root fix) [DRAFT — phrase-safety review, WIP]

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,7 +27,10 @@ dependencies = [
     # Upper bound stays at <3.0.0 to match the TypeScript clients'
     # `^2.0.0` semver semantics — a future core@3 will be a breaking
     # change and must bump this constraint in lockstep.
-    "totalreclaw-core>=2.4.0,<3.0.0",
+    # >=2.5.0: chain/env-aware DataEdge param on encode_single_call /
+    # encode_batch_call (#366). Once the relay reports data_edge_address,
+    # the client passes it through and requires the parameterized core API.
+    "totalreclaw-core>=2.5.0,<3.0.0",
     "httpx>=0.27",
     "onnxruntime>=1.24",
     "numpy>=1.26",

--- a/python/src/totalreclaw/client.py
+++ b/python/src/totalreclaw/client.py
@@ -89,6 +89,29 @@ def _chain_id_from_billing(payload: object) -> int:
     return DEFAULT_CHAIN_ID_FREE
 
 
+def _data_edge_from_billing(payload: object) -> Optional[str]:
+    """Resolve the authoritative DataEdge address from ``/v1/billing/status``.
+
+    The relay reports ``data_edge_address`` for the wallet's environment+chain
+    (root fix #366) — e.g. the isolated staging Gnosis DataEdge differs from
+    prod's. Returns ``None`` when the field is absent or malformed, in which
+    case callers fall back to the core's default DataEdge (correct for prod).
+    Only a syntactically valid ``0x``-prefixed 20-byte hex string is accepted;
+    a bad value is ignored rather than risking writes to a wrong contract.
+    """
+    if isinstance(payload, dict):
+        raw = payload.get("data_edge_address")
+        if isinstance(raw, str):
+            s = raw.strip()
+            if (
+                s.startswith("0x")
+                and len(s) == 42
+                and all(c in "0123456789abcdefABCDEF" for c in s[2:])
+            ):
+                return s
+    return None
+
+
 def _get_eoa_account(mnemonic: str):
     """Derive the EOA (externally-owned account) from a BIP-39 mnemonic.
 
@@ -247,6 +270,11 @@ class TotalReclaw:
         # user override is exposed here.
         self._chain_id: int = DEFAULT_CHAIN_ID_FREE
         self._chain_id_resolved: bool = False
+        # Relay-authoritative DataEdge for this environment (#366), captured
+        # from /v1/billing/status alongside chain_id. None -> the core's
+        # default DataEdge (correct for prod). Set for chain/env-isolated
+        # environments such as the staging Gnosis DataEdge.
+        self._data_edge_address: Optional[str] = None
 
     async def resolve_address(self) -> str:
         """Resolve the CREATE2 Smart Account address via RPC.
@@ -337,7 +365,9 @@ class TotalReclaw:
                     headers=headers,
                 )
             if resp.status_code == 200:
-                self._chain_id = _chain_id_from_billing(resp.json())
+                payload = resp.json()
+                self._chain_id = _chain_id_from_billing(payload)
+                self._data_edge_address = _data_edge_from_billing(payload)
             else:
                 self._chain_id = DEFAULT_CHAIN_ID_FREE
         except Exception:
@@ -515,6 +545,7 @@ class TotalReclaw:
             eoa_address=self._eoa_address,
             sender=self._wallet_address,
             chain_id=chain_id,
+            data_edge_address=self._data_edge_address,
         )
 
     async def remember_batch(
@@ -615,6 +646,7 @@ class TotalReclaw:
             eoa_address=self._eoa_address,
             sender=self._wallet_address,
             chain_id=chain_id,
+            data_edge_address=self._data_edge_address,
             source=source,
         )
 
@@ -653,6 +685,7 @@ class TotalReclaw:
             eoa_address=self._eoa_address,
             sender=self._wallet_address,
             chain_id=chain_id,
+            data_edge_address=self._data_edge_address,
         )
 
     async def pin_fact(self, fact_id: str) -> dict:
@@ -681,6 +714,7 @@ class TotalReclaw:
             eoa_address=self._eoa_address,
             sender=self._wallet_address,
             chain_id=chain_id,
+            data_edge_address=self._data_edge_address,
         )
 
     async def unpin_fact(self, fact_id: str) -> dict:
@@ -701,6 +735,7 @@ class TotalReclaw:
             eoa_address=self._eoa_address,
             sender=self._wallet_address,
             chain_id=chain_id,
+            data_edge_address=self._data_edge_address,
         )
 
     async def retype(self, fact_id: str, new_type: str) -> dict:
@@ -730,6 +765,7 @@ class TotalReclaw:
             eoa_address=self._eoa_address,
             sender=self._wallet_address,
             chain_id=chain_id,
+            data_edge_address=self._data_edge_address,
         )
 
     async def set_scope(self, fact_id: str, new_scope: str) -> dict:
@@ -752,6 +788,7 @@ class TotalReclaw:
             eoa_address=self._eoa_address,
             sender=self._wallet_address,
             chain_id=chain_id,
+            data_edge_address=self._data_edge_address,
         )
 
     async def export_all(self) -> list[dict]:

--- a/python/src/totalreclaw/operations.py
+++ b/python/src/totalreclaw/operations.py
@@ -175,6 +175,7 @@ async def store_fact(
     reasoning: Optional[str] = None,
     volatility: Optional[str] = None,
     extra_metadata: Optional[dict] = None,
+    data_edge_address: Optional[str] = None,
 ) -> str:
     """Encrypt and store a fact on-chain via relay.
 
@@ -284,6 +285,7 @@ async def store_fact(
         chain_id=chain_id,
         client_id=relay._client_id,
         session_id=getattr(relay, "_session_id", None),
+        data_edge_address=data_edge_address,
     )
 
     return fact_id
@@ -306,6 +308,7 @@ async def store_fact_batch(
     chain_id: int = 84532,
     source: str = "python-client",
     agent_id: str = "python-client",
+    data_edge_address: Optional[str] = None,
 ) -> list[str]:
     """Encrypt and store N facts in a single batched on-chain UserOp.
 
@@ -490,6 +493,7 @@ async def store_fact_batch(
         chain_id=chain_id,
         client_id=relay._client_id,
         session_id=getattr(relay, "_session_id", None),
+        data_edge_address=data_edge_address,
     )
 
     return fact_ids
@@ -699,6 +703,7 @@ async def forget_fact(
     eoa_address: Optional[str] = None,
     sender: Optional[str] = None,
     chain_id: int = 84532,
+    data_edge_address: Optional[str] = None,
 ) -> bool:
     """Write a tombstone on-chain to soft-delete a fact.
 
@@ -733,6 +738,7 @@ async def forget_fact(
             chain_id=chain_id,
             client_id=relay._client_id,
             session_id=getattr(relay, "_session_id", None),
+            data_edge_address=data_edge_address,
         )
         # Read-after-write: wait until the subgraph has flipped the fact's
         # isActive bit. Forget keeps its bool return contract — a False here
@@ -1006,6 +1012,7 @@ async def _change_claim_status(
     sender: Optional[str],
     chain_id: int,
     lsh_hasher: Optional[LSHHasher],
+    data_edge_address: Optional[str] = None,
 ) -> dict:
     """Shared implementation for ``pin_fact`` / ``unpin_fact``.
 
@@ -1277,6 +1284,7 @@ async def _change_claim_status(
         chain_id=chain_id,
         client_id=relay._client_id,
         session_id=getattr(relay, "_session_id", None),
+        data_edge_address=data_edge_address,
     )
 
     # Read-after-write: poll the subgraph until the new (pinned/unpinned)
@@ -1310,6 +1318,7 @@ async def pin_fact(
     sender: Optional[str] = None,
     chain_id: int = 84532,
     lsh_hasher: Optional[LSHHasher] = None,
+    data_edge_address: Optional[str] = None,
 ) -> dict:
     """Pin a claim so auto-resolution cannot supersede it.
 
@@ -1363,6 +1372,7 @@ async def pin_fact(
         sender=sender,
         chain_id=chain_id,
         lsh_hasher=lsh_hasher,
+        data_edge_address=data_edge_address,
     )
 
 
@@ -1376,6 +1386,7 @@ async def unpin_fact(
     sender: Optional[str] = None,
     chain_id: int = 84532,
     lsh_hasher: Optional[LSHHasher] = None,
+    data_edge_address: Optional[str] = None,
 ) -> dict:
     """Inverse of :func:`pin_fact` — move a pinned claim back to ``active``.
 
@@ -1394,6 +1405,7 @@ async def unpin_fact(
         sender=sender,
         chain_id=chain_id,
         lsh_hasher=lsh_hasher,
+        data_edge_address=data_edge_address,
     )
 
 

--- a/python/src/totalreclaw/retype_setscope.py
+++ b/python/src/totalreclaw/retype_setscope.py
@@ -298,6 +298,7 @@ async def _rewrite_with_mutation(
     chain_id: int,
     lsh_hasher: Optional[LSHHasher],
     source_tag: str,
+    data_edge_address: Optional[str] = None,
 ) -> dict:
     """Shared write path for retype + set_scope.
 
@@ -481,6 +482,7 @@ async def _rewrite_with_mutation(
             chain_id=chain_id,
             client_id=relay._client_id,
             session_id=getattr(relay, "_session_id", None),
+            data_edge_address=data_edge_address,
         )
     except Exception as exc:
         return {
@@ -530,6 +532,7 @@ async def execute_retype(
     sender: Optional[str] = None,
     chain_id: int = 84532,
     lsh_hasher: Optional[LSHHasher] = None,
+    data_edge_address: Optional[str] = None,
 ) -> dict:
     """Re-type an existing memory.
 
@@ -562,6 +565,7 @@ async def execute_retype(
         sender=sender,
         chain_id=chain_id,
         lsh_hasher=lsh_hasher,
+        data_edge_address=data_edge_address,
         source_tag="python_retype",
     )
 
@@ -577,6 +581,7 @@ async def execute_set_scope(
     sender: Optional[str] = None,
     chain_id: int = 84532,
     lsh_hasher: Optional[LSHHasher] = None,
+    data_edge_address: Optional[str] = None,
 ) -> dict:
     """Re-scope an existing memory.
 
@@ -606,6 +611,7 @@ async def execute_set_scope(
         sender=sender,
         chain_id=chain_id,
         lsh_hasher=lsh_hasher,
+        data_edge_address=data_edge_address,
         source_tag="python_set_scope",
     )
 

--- a/python/src/totalreclaw/userop.py
+++ b/python/src/totalreclaw/userop.py
@@ -123,13 +123,28 @@ def _encode_uint256(value: int) -> str:
     return hex(value)[2:].zfill(64)
 
 
-def encode_execute_calldata_for_data_edge(protobuf_payload: bytes) -> str:
+def encode_execute_calldata_for_data_edge(
+    protobuf_payload: bytes,
+    data_edge_address: str | None = None,
+) -> str:
     """ABI-encode ``SimpleAccount.execute(dataEdge, 0, protobuf)`` calldata.
 
-    Delegates to totalreclaw_core.encode_single_call() which hardcodes the
-    DataEdge address and value=0. Returns 0x-prefixed hex.
+    Delegates to ``totalreclaw_core.encode_single_call()``. When
+    ``data_edge_address`` is provided (the relay's authoritative
+    ``data_edge_address`` from ``/v1/billing/status``, #366) the inner call
+    targets that DataEdge; otherwise the core's default DataEdge is used.
+    Returns 0x-prefixed hex.
+
+    The optional 2nd arg is only passed through when set, so this stays
+    compatible with a ``totalreclaw-core`` older than 2.5.0 (which does not
+    accept it) on the default path.
     """
-    calldata_bytes = totalreclaw_core.encode_single_call(protobuf_payload)
+    if data_edge_address is not None:
+        calldata_bytes = totalreclaw_core.encode_single_call(
+            protobuf_payload, data_edge_address
+        )
+    else:
+        calldata_bytes = totalreclaw_core.encode_single_call(protobuf_payload)
     return "0x" + calldata_bytes.hex()
 
 
@@ -141,11 +156,17 @@ MAX_BATCH_SIZE: int = 15
 
 def encode_execute_batch_calldata_for_data_edge(
     protobuf_payloads: list[bytes],
+    data_edge_address: str | None = None,
 ) -> str:
     """ABI-encode ``SimpleAccount.executeBatch(dests, values, datas)`` calldata.
 
-    Delegates to :func:`totalreclaw_core.encode_batch_call` which hardcodes
-    the DataEdge address (same target for every call) and ``value=0``.
+    Delegates to :func:`totalreclaw_core.encode_batch_call`. When
+    ``data_edge_address`` is provided (relay-authoritative, #366) every inner
+    call targets that DataEdge; otherwise the core's default is used.
+    The Rust core returns ``execute(...)`` calldata (not ``executeBatch``)
+    when ``len(protobuf_payloads) == 1`` so a batch-of-1 is byte-identical
+    to the single-fact fast path — this preserves gas parity with the TS
+    plugin's ``encodeBatchCalls`` helper.
     The Rust core returns ``execute(...)`` calldata (not ``executeBatch``)
     when ``len(protobuf_payloads) == 1`` so a batch-of-1 is byte-identical
     to the single-fact fast path — this preserves gas parity with the TS
@@ -176,7 +197,12 @@ def encode_execute_batch_calldata_for_data_edge(
             f"Batch size {len(protobuf_payloads)} exceeds maximum of "
             f"{MAX_BATCH_SIZE}"
         )
-    calldata_bytes = totalreclaw_core.encode_batch_call(protobuf_payloads)
+    if data_edge_address is not None:
+        calldata_bytes = totalreclaw_core.encode_batch_call(
+            protobuf_payloads, data_edge_address
+        )
+    else:
+        calldata_bytes = totalreclaw_core.encode_batch_call(protobuf_payloads)
     return "0x" + calldata_bytes.hex()
 
 
@@ -329,6 +355,7 @@ async def build_and_send_userop(
     chain_id: int = 84532,
     client_id: str = "python-client",
     session_id: Optional[str] = None,
+    data_edge_address: Optional[str] = None,
 ) -> str:
     """Build, sign, and submit a UserOperation through the relay.
 
@@ -383,8 +410,10 @@ async def build_and_send_userop(
     async with sender_lock, httpx.AsyncClient(timeout=30.0) as http:
         # 1. Encode the execute calldata (idempotent, does not depend on nonce)
         #    SmartAccount.execute(dataEdgeAddress, 0, protobufPayload)
-        #    Delegates to Rust core which hardcodes DataEdge address + value=0
-        call_data = encode_execute_calldata_for_data_edge(protobuf_payload)
+        #    DataEdge target is relay-authoritative (#366) when supplied.
+        call_data = encode_execute_calldata_for_data_edge(
+            protobuf_payload, data_edge_address
+        )
 
         # Retry loop for AA25 nonce conflicts.  When two UserOps race for
         # the same nonce the bundler rejects one with AA25.  Re-fetching
@@ -531,6 +560,7 @@ async def build_and_send_userop_batch(
     chain_id: int = 84532,
     client_id: str = "python-client",
     session_id: Optional[str] = None,
+    data_edge_address: Optional[str] = None,
 ) -> str:
     """Build, sign, and submit a BATCHED UserOperation through the relay.
 
@@ -634,7 +664,7 @@ async def build_and_send_userop_batch(
         #    so we compute it before the retry loop. Delegates to the
         #    Rust core for byte-parity with the TS plugin.
         call_data = encode_execute_batch_calldata_for_data_edge(
-            protobuf_payloads
+            protobuf_payloads, data_edge_address
         )
 
         # Retry loop for AA25 nonce conflicts.  When two UserOps race for

--- a/python/tests/test_chain_id_autodetect.py
+++ b/python/tests/test_chain_id_autodetect.py
@@ -306,3 +306,85 @@ async def test_remember_signs_for_authoritative_chain_id() -> None:
         await client.remember("Free user migrated to Gnosis")
 
     assert mock_userop.await_args.kwargs["chain_id"] == 100
+
+
+# ---------------------------------------------------------------------------
+# Relay-authoritative DataEdge (#366): consume data_edge_address from billing
+# and thread it to the write path. Pairs with the chain_id root fix above —
+# rc5 signed for the right chain but wrote to the wrong (hardcoded) DataEdge,
+# stranding facts on the isolated staging Gnosis DataEdge.
+# ---------------------------------------------------------------------------
+
+STAGING_DATA_EDGE = "0xE7a4D2677B686e13775Ba9092631089e35F0BB91"
+
+
+@pytest.mark.asyncio
+async def test_resolve_captures_authoritative_data_edge_address() -> None:
+    client = _make_client()
+    patch_ctx, _ = _patch_billing(
+        {"tier": "free", "chain_id": 100, "data_edge_address": STAGING_DATA_EDGE}
+    )
+    with patch_ctx:
+        await client.resolve_chain_id()
+    assert client._data_edge_address == STAGING_DATA_EDGE
+
+
+@pytest.mark.asyncio
+async def test_remember_threads_data_edge_address_to_write() -> None:
+    """THE ops-9 fix: a staging free user must write to the relay-reported
+    DataEdge, not the hardcoded default."""
+    client = _make_client()
+    billing_patch, _ = _patch_billing(
+        {"tier": "free", "chain_id": 100, "data_edge_address": STAGING_DATA_EDGE}
+    )
+    mock_userop = AsyncMock(return_value="0xabc123")
+    with billing_patch, patch(
+        "totalreclaw.operations.build_and_send_userop", new=mock_userop,
+    ):
+        await client.remember("Free user on isolated staging Gnosis")
+    assert mock_userop.await_args.kwargs["data_edge_address"] == STAGING_DATA_EDGE
+
+
+@pytest.mark.asyncio
+async def test_data_edge_absent_threads_none() -> None:
+    """Old relay (no data_edge_address) → None → core default (prod-correct)."""
+    client = _make_client()
+    billing_patch, _ = _patch_billing({"tier": "free", "chain_id": 100})
+    mock_userop = AsyncMock(return_value="0xabc123")
+    with billing_patch, patch(
+        "totalreclaw.operations.build_and_send_userop", new=mock_userop,
+    ):
+        await client.remember("No data edge field")
+    assert mock_userop.await_args.kwargs["data_edge_address"] is None
+
+
+@pytest.mark.asyncio
+async def test_malformed_data_edge_address_ignored() -> None:
+    """A non-address value is ignored rather than risking a wrong target."""
+    for bad in ("not-an-address", "0x1234", "0xZZZ", 100, None, ""):
+        client = _make_client()
+        patch_ctx, _ = _patch_billing(
+            {"tier": "free", "chain_id": 100, "data_edge_address": bad}
+        )
+        with patch_ctx:
+            await client.resolve_chain_id()
+        assert client._data_edge_address is None, f"bad data_edge {bad!r} should be ignored"
+
+
+def test_encode_wrapper_passes_data_edge_to_core() -> None:
+    """userop.py wrapper forwards an explicit DataEdge to the core encoder."""
+    from unittest.mock import MagicMock
+    import totalreclaw.userop as uop
+
+    fake_core = MagicMock()
+    fake_core.encode_single_call.return_value = b"\xde\xad"
+    with patch.object(uop, "totalreclaw_core", fake_core):
+        uop.encode_execute_calldata_for_data_edge(b"payload", STAGING_DATA_EDGE)
+    fake_core.encode_single_call.assert_called_once_with(b"payload", STAGING_DATA_EDGE)
+
+    fake_core.reset_mock()
+    fake_core.encode_single_call.return_value = b"\xbe\xef"
+    with patch.object(uop, "totalreclaw_core", fake_core):
+        uop.encode_execute_calldata_for_data_edge(b"payload")  # default path
+    # Default path must NOT pass a 2nd arg (back-compat with pre-2.5.0 core).
+    fake_core.encode_single_call.assert_called_once_with(b"payload")

--- a/rust/totalreclaw-core/Cargo.lock
+++ b/rust/totalreclaw-core/Cargo.lock
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "totalreclaw-core"
-version = "2.5.0-pre"
+version = "2.5.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/rust/totalreclaw-core/Cargo.toml
+++ b/rust/totalreclaw-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "totalreclaw-core"
-version = "2.5.0-pre"
+version = "2.5.0"
 edition = "2021"
 description = "TotalReclaw core — E2EE crypto, reranker, wallet, UserOp, store/search pipelines. Single source of truth for all clients."
 license = "MIT"

--- a/rust/totalreclaw-core/pyproject.toml
+++ b/rust/totalreclaw-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "totalreclaw-core"
-version = "2.5.0.dev0"
+version = "2.5.0"
 description = "TotalReclaw crypto core — E2EE, LSH, blind indices, protobuf encoding (Rust)"
 requires-python = ">=3.10"
 license = { text = "MIT" }

--- a/rust/totalreclaw-core/src/python.rs
+++ b/rust/totalreclaw-core/src/python.rs
@@ -604,31 +604,52 @@ fn derive_eoa_address(mnemonic: &str) -> PyResult<String> {
 ///
 /// Args:
 ///     protobuf_payload: Raw protobuf bytes.
+///     data_edge_address: Optional 0x-prefixed DataEdge address. When omitted
+///         (or None), uses the default DataEdge (prod). Chain/environment-aware
+///         clients pass the authoritative address from the relay's
+///         /v1/billing/status `data_edge_address` field (#366). Raises
+///         ValueError on an unparseable address.
 ///
 /// Returns:
 ///     bytes (ABI-encoded calldata).
 #[cfg(feature = "managed")]
 #[pyfunction]
-fn encode_single_call<'py>(py: Python<'py>, protobuf_payload: &[u8]) -> Bound<'py, PyBytes> {
-    let encoded = userop::encode_single_call(protobuf_payload);
-    PyBytes::new(py, &encoded)
+#[pyo3(signature = (protobuf_payload, data_edge_address=None))]
+fn encode_single_call<'py>(
+    py: Python<'py>,
+    protobuf_payload: &[u8],
+    data_edge_address: Option<&str>,
+) -> PyResult<Bound<'py, PyBytes>> {
+    let encoded = match data_edge_address {
+        Some(addr) => userop::encode_single_call_to(protobuf_payload, addr)
+            .map_err(|e| PyValueError::new_err(e.to_string()))?,
+        None => userop::encode_single_call(protobuf_payload),
+    };
+    Ok(PyBytes::new(py, &encoded))
 }
 
 /// Encode multiple fact submissions as SimpleAccount.executeBatch() calldata.
 ///
 /// Args:
 ///     payloads: List of bytes (raw protobuf payloads).
+///     data_edge_address: Optional 0x-prefixed DataEdge address (see
+///         encode_single_call). Omit / None for the default DataEdge.
 ///
 /// Returns:
 ///     bytes (ABI-encoded calldata).
 #[cfg(feature = "managed")]
 #[pyfunction]
+#[pyo3(signature = (payloads, data_edge_address=None))]
 fn encode_batch_call<'py>(
     py: Python<'py>,
     payloads: Vec<Vec<u8>>,
+    data_edge_address: Option<&str>,
 ) -> PyResult<Bound<'py, PyBytes>> {
-    let encoded =
-        userop::encode_batch_call(&payloads).map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let encoded = match data_edge_address {
+        Some(addr) => userop::encode_batch_call_to(&payloads, addr),
+        None => userop::encode_batch_call(&payloads),
+    }
+    .map_err(|e| PyValueError::new_err(e.to_string()))?;
     Ok(PyBytes::new(py, &encoded))
 }
 

--- a/rust/totalreclaw-core/src/userop.rs
+++ b/rust/totalreclaw-core/src/userop.rs
@@ -17,7 +17,15 @@ use alloy_sol_types::{sol, SolCall};
 
 use crate::{Error, Result};
 
-/// DataEdge contract address (same on all chains).
+/// Default DataEdge contract address (prod Gnosis + Base Sepolia).
+///
+/// Used when a caller does not supply an explicit DataEdge. Chain/environment
+/// isolation (e.g. the staging Gnosis DataEdge, which differs from prod) is
+/// handled by passing an authoritative address to [`encode_single_call_to`] /
+/// [`encode_batch_call_to`] — the relay reports it via `/v1/billing/status`
+/// (`data_edge_address`). Writing to the wrong DataEdge strands facts outside
+/// the indexing subgraph, so the parameterized path errors on a bad address
+/// rather than silently falling back.
 pub const DATA_EDGE_ADDRESS: &str = "0xC445af1D4EB9fce4e1E61fE96ea7B8feBF03c5ca";
 
 /// EntryPoint v0.7 address.
@@ -43,12 +51,27 @@ sol! {
 /// The DataEdge contract has a fallback() that emits Log(bytes),
 /// so the inner calldata IS the raw protobuf payload.
 pub fn encode_single_call(protobuf_payload: &[u8]) -> Vec<u8> {
-    let dest: Address = DATA_EDGE_ADDRESS.parse().unwrap();
+    // Default DataEdge. The hardcoded const is always a valid address.
+    encode_single_call_to(protobuf_payload, DATA_EDGE_ADDRESS)
+        .expect("hardcoded DATA_EDGE_ADDRESS must parse")
+}
+
+/// Like [`encode_single_call`] but targets an explicit DataEdge address.
+///
+/// Chain/environment-aware clients resolve the authoritative DataEdge from the
+/// relay (`/v1/billing/status` → `data_edge_address`) and pass it here — the
+/// isolated staging Gnosis DataEdge differs from prod's, and on the wrong
+/// contract facts land outside the indexing subgraph (silent data loss).
+/// Errors on an unparseable address rather than defaulting.
+pub fn encode_single_call_to(protobuf_payload: &[u8], data_edge: &str) -> Result<Vec<u8>> {
+    let dest: Address = data_edge
+        .parse()
+        .map_err(|_| Error::Crypto(format!("invalid DataEdge address: {data_edge}")))?;
     let value = U256::ZERO;
     let data = Bytes::copy_from_slice(protobuf_payload);
 
     let call = executeCall { dest, value, data };
-    call.abi_encode()
+    Ok(call.abi_encode())
 }
 
 /// Encode multiple fact submissions as SimpleAccount.executeBatch() calldata.
@@ -56,6 +79,16 @@ pub fn encode_single_call(protobuf_payload: &[u8]) -> Vec<u8> {
 /// Each protobuf payload becomes one call to DataEdge's fallback().
 /// All calls have value=0.
 pub fn encode_batch_call(protobuf_payloads: &[Vec<u8>]) -> Result<Vec<u8>> {
+    encode_batch_call_to(protobuf_payloads, DATA_EDGE_ADDRESS)
+}
+
+/// Like [`encode_batch_call`] but targets an explicit DataEdge address.
+///
+/// See [`encode_single_call_to`] for why the DataEdge is now a parameter.
+/// A batch of 1 is byte-identical to the single-fact `execute()` fast path
+/// (gas parity with the TS plugin), so it delegates to
+/// [`encode_single_call_to`] with the same address.
+pub fn encode_batch_call_to(protobuf_payloads: &[Vec<u8>], data_edge: &str) -> Result<Vec<u8>> {
     if protobuf_payloads.is_empty() {
         return Err(Error::Crypto("Batch must contain at least 1 payload".into()));
     }
@@ -69,10 +102,12 @@ pub fn encode_batch_call(protobuf_payloads: &[Vec<u8>]) -> Result<Vec<u8>> {
 
     // Single payload -> use execute() (no batch overhead)
     if protobuf_payloads.len() == 1 {
-        return Ok(encode_single_call(&protobuf_payloads[0]));
+        return encode_single_call_to(&protobuf_payloads[0], data_edge);
     }
 
-    let dest: Address = DATA_EDGE_ADDRESS.parse().unwrap();
+    let dest: Address = data_edge
+        .parse()
+        .map_err(|_| Error::Crypto(format!("invalid DataEdge address: {data_edge}")))?;
     let dests: Vec<Address> = vec![dest; protobuf_payloads.len()];
     let values: Vec<U256> = vec![U256::ZERO; protobuf_payloads.len()];
     let datas: Vec<Bytes> = protobuf_payloads
@@ -355,6 +390,74 @@ mod tests {
         let payloads: Vec<Vec<u8>> = (0..16).map(|i| vec![i as u8]).collect();
         let result = encode_batch_call(&payloads);
         assert!(result.is_err());
+    }
+
+    // ---- chain/env-aware DataEdge (#366) ----
+
+    /// Isolated staging Gnosis DataEdge (differs from the prod default).
+    const STAGING_DATA_EDGE: &str = "0xE7a4D2677B686e13775Ba9092631089e35F0BB91";
+
+    fn contains_address(calldata: &[u8], addr: &str) -> bool {
+        let parsed: Address = addr.parse().unwrap();
+        let needle = parsed.as_slice(); // 20 raw bytes
+        calldata.windows(needle.len()).any(|w| w == needle)
+    }
+
+    #[test]
+    fn test_encode_single_call_to_default_matches_legacy_path() {
+        let payload = b"test protobuf data";
+        assert_eq!(
+            encode_single_call_to(payload, DATA_EDGE_ADDRESS).unwrap(),
+            encode_single_call(payload),
+            "default address must be byte-identical to the legacy hardcoded path"
+        );
+    }
+
+    #[test]
+    fn test_encode_single_call_to_targets_custom_dataedge() {
+        let payload = b"test protobuf data";
+        let default = encode_single_call_to(payload, DATA_EDGE_ADDRESS).unwrap();
+        let staging = encode_single_call_to(payload, STAGING_DATA_EDGE).unwrap();
+        assert_ne!(default, staging, "a different DataEdge must produce different calldata");
+        assert!(
+            contains_address(&staging, STAGING_DATA_EDGE),
+            "calldata must embed the staging DataEdge address"
+        );
+        assert!(!contains_address(&staging, DATA_EDGE_ADDRESS));
+    }
+
+    #[test]
+    fn test_encode_single_call_to_invalid_address_errors() {
+        assert!(encode_single_call_to(b"x", "not-an-address").is_err());
+        assert!(encode_single_call_to(b"x", "0x1234").is_err());
+    }
+
+    #[test]
+    fn test_encode_batch_call_to_threads_custom_dest() {
+        let payloads = vec![b"a".to_vec(), b"b".to_vec()];
+        let default = encode_batch_call_to(&payloads, DATA_EDGE_ADDRESS).unwrap();
+        let staging = encode_batch_call_to(&payloads, STAGING_DATA_EDGE).unwrap();
+        assert_eq!(&staging[..4], &[0x47, 0xe1, 0xda, 0x2a], "executeBatch selector");
+        assert_ne!(default, staging);
+        assert!(contains_address(&staging, STAGING_DATA_EDGE));
+    }
+
+    #[test]
+    fn test_batch_of_one_to_uses_execute_with_custom_dest() {
+        let payloads = vec![b"solo".to_vec()];
+        let batch1 = encode_batch_call_to(&payloads, STAGING_DATA_EDGE).unwrap();
+        assert_eq!(&batch1[..4], &[0xb6, 0x1d, 0x27, 0xf6], "execute() selector for batch-of-1");
+        assert_eq!(
+            batch1,
+            encode_single_call_to(b"solo", STAGING_DATA_EDGE).unwrap(),
+            "batch-of-1 must equal single_call_to with the same DataEdge"
+        );
+    }
+
+    #[test]
+    fn test_encode_batch_call_to_invalid_address_errors() {
+        let payloads = vec![b"a".to_vec(), b"b".to_vec()];
+        assert!(encode_batch_call_to(&payloads, "bad").is_err());
     }
 
     #[test]

--- a/rust/totalreclaw-core/src/wasm.rs
+++ b/rust/totalreclaw-core/src/wasm.rs
@@ -567,6 +567,21 @@ pub fn wasm_encode_single_call(protobuf_payload: &[u8]) -> Vec<u8> {
     userop::encode_single_call(protobuf_payload)
 }
 
+/// Like `encodeSingleCall` but targets an explicit DataEdge address.
+///
+/// Chain/environment-aware clients pass the authoritative address from the
+/// relay's `/v1/billing/status` `data_edge_address` (#366) — the isolated
+/// staging Gnosis DataEdge differs from prod's. Throws on a bad address.
+#[cfg(feature = "managed")]
+#[wasm_bindgen(js_name = "encodeSingleCallTo")]
+pub fn wasm_encode_single_call_to(
+    protobuf_payload: &[u8],
+    data_edge_address: &str,
+) -> Result<Vec<u8>, JsError> {
+    userop::encode_single_call_to(protobuf_payload, data_edge_address)
+        .map_err(|e| JsError::new(&e.to_string()))
+}
+
 /// Encode multiple fact submissions as SimpleAccount.executeBatch() calldata.
 ///
 /// `payloads_json`: JSON array of hex-encoded payload strings (e.g. `["deadbeef", "cafebabe"]`).
@@ -581,6 +596,22 @@ pub fn wasm_encode_batch_call(payloads_json: &str) -> Result<Vec<u8>, JsError> {
         .map(|h| hex::decode(h.trim_start_matches("0x")).unwrap_or_default())
         .collect();
     userop::encode_batch_call(&payloads).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Like `encodeBatchCall` but targets an explicit DataEdge address (#366).
+#[cfg(feature = "managed")]
+#[wasm_bindgen(js_name = "encodeBatchCallTo")]
+pub fn wasm_encode_batch_call_to(
+    payloads_json: &str,
+    data_edge_address: &str,
+) -> Result<Vec<u8>, JsError> {
+    let hex_strings: Vec<String> = serde_json::from_str(payloads_json)
+        .map_err(|e| JsError::new(&format!("Invalid payloads JSON: {}", e)))?;
+    let payloads: Vec<Vec<u8>> = hex_strings
+        .iter()
+        .map(|h| hex::decode(h.trim_start_matches("0x")).unwrap_or_default())
+        .collect();
+    userop::encode_batch_call_to(&payloads, data_edge_address).map_err(|e| JsError::new(&e.to_string()))
 }
 
 /// Compute the ERC-4337 v0.7 UserOp hash for signing.


### PR DESCRIPTION
## ⚠️ DRAFT — DO NOT MERGE. Phrase-safety review (ERC-4337 calldata) + WIP (Stage B pending).

Tracking: totalreclaw-internal#366. Root-causes the ops-9 dry-run NO-GO. Pedro-approved approach: relay-authoritative DataEdge.

## Problem
rc5's #293 chain-aware client works (signs for Gnosis), but the DataEdge contract was hardcoded `0xC445…` in the Rust core — not chain/env-keyed. On the isolated staging Gnosis DataEdge (`0xE7a4…`) writes landed at `0xC445…`, stranded outside the staging subgraph → zero-loss unassertable. (`0xC445…` is correct for prod; only the isolated staging DataEdge mismatched.)

## Two-stage fix
**Stage A — `totalreclaw-core` (THIS COMMIT, done):**
- `userop`: add `encode_single_call_to` / `encode_batch_call_to(payload, data_edge)`; originals delegate with the default const. Invalid address → `Err` (never silently writes to the wrong contract = data loss).
- PyO3: `encode_single_call` / `encode_batch_call` gain optional `data_edge_address` (None → default, back-compat).
- WASM: `encodeSingleCallTo` / `encodeBatchCallTo` for the TS/plugin sibling (#365), shipped in the same core release to avoid a second republish.
- 6 new userop tests (default-parity, custom-dest threading, batch-of-1 fast path, invalid-address errors). **18/18 userop tests pass**; `python` + `wasm` features type-check.

**Stage B — python client (PENDING, same branch):**
- `resolve_chain_id()` also captures `data_edge_address` from `/v1/billing/status` (graceful fallback to default when absent).
- Thread it through `operations.py` → `build_and_send_userop[_batch]` → `encode_execute_*_for_data_edge` → `totalreclaw_core.encode_*(payload, data_edge_address)`, mirroring how `chain_id` already flows.
- Bump `totalreclaw-core>=2.5.0`.

## Release sequencing
1. Pedro phrase-safety review of this PR.
2. Publish `totalreclaw-core` 2.5.0 (PyPI + crates.io) — additive/back-compat.
3. `totalreclaw` rc6 (pins core ≥2.5.0).
4. Re-run ops-9 (needs infra: relay `data_edge_address` field live on staging + the `X-TotalReclaw-Test` pro-fixture fixed).

## Phrase-safety
No phrase / key-material touch. Changes the ERC-4337 calldata *target* (where encrypted facts are written) — flagged L3, your review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)