### PR TITLE
chore(hermes): align SKILL.md frontmatter version to client base (2.4.4)

### DIFF
--- a/python/src/totalreclaw/hermes/SKILL.md
+++ b/python/src/totalreclaw/hermes/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "Encrypted memory for Hermes — remember, recall, forget, pin, re-type / re-scope, check status & quota, upgrade, and import the user's saved memories. Trigger on 'install / set up TotalReclaw', 'restore my recovery phrase', or ANY request to remember, recall, forget, search, manage, or report on the user's memory or quota — not just remember / recall."
-version: 2.5.0
+version: 2.4.4
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz


### PR DESCRIPTION
Cosmetic: #300 bumped SKILL.md frontmatter `version` to `2.5.0`, conflating it with the **core crate** version. But that field tracks the **`totalreclaw` client** version (both were `2.4.4` pre-#300), and the client base stays `2.4.4` (rc6 = `2.4.4rc6`; core `2.5.0` is an independent dep). Re-aligns to `2.4.4`.

Hermes parses SKILL.md frontmatter only for `platforms:` / `required_environment_variables:` — **not** `version` — so this is consistency-only, no functional change. Resolves the §10 version-skew item from the consolidation design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)