### PR TITLE
docs(hermes-setup): bump latest RC to 2.4.4rc6 (#369)

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -12,7 +12,7 @@ This document describes how the agent installs and sets up TotalReclaw on Hermes
 | Channel | Version | Install command |
 |---|---|---|
 | stable (default) | `2.4.3` | `pip install totalreclaw` |
-| latest RC | `2.4.4rc5` | `pip install --pre --upgrade totalreclaw==2.4.4rc5` |
+| latest RC | `2.4.4rc6` | `pip install --pre --upgrade totalreclaw==2.4.4rc6` |
 
 Source of truth for what's currently published: `pip index versions totalreclaw`. The table above is updated on every PyPI release.
 


### PR DESCRIPTION
## What broke
The `Versions` table in `docs/guides/hermes-setup.md` still pinned latest-RC at `2.4.4rc5` after `2.4.4rc6` was published to PyPI — a user pasting the RC install prompt would get an older RC.

## What's fixed
Bumped the latest-RC row from `2.4.4rc5` → `2.4.4rc6` (one-line table update). Stable row stays at `2.4.3` because umbrella verdict on 2.4.4rc6 is NO-GO and the 2.4.4 stable promote is blocked.

## Impact after fix
Pasting the RC install prompt now resolves to the actual latest-RC on PyPI (`2.4.4rc6`). No behavior change for the stable install prompt.

## Verification
`pip index versions totalreclaw --pre` shows `2.4.4rc6` as the latest pre-release (confirmed during triage). Table now matches.

Closes p-diogo/totalreclaw-internal#369

Sub-issue F1 of umbrella p-diogo/totalreclaw-internal#368. Filed by Phase 3 auto-triage pipeline.