### PR TITLE
test(import): stub embedding in batching tests — fix python-tests timeout flake

### DIFF
--- a/python/tests/test_import_engine_batching.py
+++ b/python/tests/test_import_engine_batching.py
@@ -25,6 +25,24 @@ from totalreclaw.import_engine import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _stub_embedding(monkeypatch):
+    """Stub the embedding model for this module.
+
+    These tests assert *batching* behaviour (one ``remember_batch`` per
+    ≤15-fact group), not embedding correctness. ``_store_facts_chunked`` calls
+    ``_prepare_fact_payload`` → real ``get_embedding`` (the 344 MB Harrier ONNX
+    model) for every fact, which costs ~23 s/fact on CI — so the 14- and
+    15-fact cases ran ~5-6 min EACH and blew the python-tests ``timeout-minutes``
+    (the operation-cancelled failure on doc-only PR #302). The payload attaches
+    the embedding best-effort and the assertions never inspect the vector, so a
+    constant stub is sound and keeps the batching logic running in milliseconds.
+    """
+    import totalreclaw.embedding as _emb
+
+    monkeypatch.setattr(_emb, "get_embedding", lambda _text: [0.0] * 640)
+
+
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
`test_import_engine_batching` 14/15-fact cases call `_store_facts_chunked` → `_prepare_fact_payload` → **real `get_embedding`** (344 MB Harrier ONNX) per fact. At **~23 s/fact** on CI, the two tests ran **323 s + 347 s** ≈ 11 of the suite's ~13 min → blew `timeout-minutes` (`The operation was canceled` at 30%). This is what red-flagged the docs-only PR #302 — **not a rate-limit, not the change under test.**

## Root cause (verified)
Per-test timings from the full CI log: 23 s/fact × fact-count matched 323/347 s exactly. The model is module-cached (not reloaded), so it's pure CI-CPU inference cost.

## Fix
Autouse fixture stubs `get_embedding` to a constant vector. These tests assert *batching* (one `remember_batch` per ≤15 facts), never the embedding vector; `_prepare_fact_payload` attaches it best-effort + swallows exceptions. Batching logic now runs in ms.

**Verification:** python-tests wall time should drop from ~13 min (timeout) to ~2 min, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)