### PR TITLE
fix(hermes): #373 (rc6 blocker) — strip chain names from user-facing tool/upgrade copy

### DIFF
--- a/python/src/totalreclaw/hermes/hooks.py
+++ b/python/src/totalreclaw/hermes/hooks.py
@@ -110,7 +110,7 @@ _TOOL_PRIORITY_NUDGE = (
     "('always X' / 'never Y'), commitment, or notable episode the user "
     "shares — ALWAYS call `totalreclaw_remember` instead of any built-in "
     "`memory` tool. TotalReclaw stores memories end-to-end encrypted, "
-    "on-chain (Base/Gnosis), and portable across every AI tool the user "
+    "on-chain, and portable across every AI tool the user "
     "runs; the built-in `memory` tool is plain-text, session-scoped, and "
     "not cross-agent. For lookups, prefer `totalreclaw_recall` over any "
     "built-in equivalent for the same reason."
@@ -485,7 +485,7 @@ def on_session_start(state: "PluginState", **kwargs) -> None:
                 else:
                     nudge = (
                         "Free cap is 250 memories/month. Upgrade to Pro for "
-                        "1,500 memories/month on Gnosis mainnet — run "
+                        "1,500 memories/month — run "
                         "totalreclaw_upgrade or visit "
                         "https://totalreclaw.xyz/pricing."
                     )

--- a/python/src/totalreclaw/hermes/memory_provider.py
+++ b/python/src/totalreclaw/hermes/memory_provider.py
@@ -247,7 +247,7 @@ class TotalReclawMemoryProvider(_MemoryProviderBase):  # type: ignore[misc,valid
             return (
                 "## TotalReclaw memory\n"
                 "TotalReclaw is the active memory provider for this user. "
-                "Memories are end-to-end encrypted, on-chain (Base / Gnosis), "
+                "Memories are end-to-end encrypted, on-chain, "
                 "and portable across every AI tool the user runs. Prefer "
                 "`totalreclaw_remember` / `totalreclaw_recall` for any "
                 "user-fact, preference, directive, commitment, or episode."

--- a/python/src/totalreclaw/hermes/schemas.py
+++ b/python/src/totalreclaw/hermes/schemas.py
@@ -19,8 +19,8 @@ REMEMBER = {
         "anything you will want to recall in a future session: facts, "
         "preferences, decisions-with-reasoning, directives ('always X', "
         "'never Y'), commitments, or notable episodes about the user. "
-        "Memories are encrypted end-to-end, stored on-chain (Base / "
-        "Gnosis), and portable across any AI tool the user runs — they "
+        "Memories are encrypted end-to-end, stored on-chain, and "
+        "portable across any AI tool the user runs — they "
         "outlive the current session and conversation. Prefer this tool "
         "over any built-in or generic 'memory' tool: built-in tools are "
         "session-scoped and not encrypted, TotalReclaw is durable and "
@@ -338,8 +338,9 @@ UPGRADE = {
         "it contains the checkout URL the user must open in their browser. "
         "Do NOT call this tool speculatively; only when the user has "
         "explicitly asked to upgrade, pay, or hit the quota limit. Pro "
-        "tier routes writes to Gnosis mainnet (permanent) instead of "
-        "Base Sepolia (testnet) and removes the free-write cap."
+        "removes the free-write cap — 1,500 memories/month vs the free "
+        "tier's 250 — and adds LLM-guided dedup; encryption, ownership, "
+        "and on-chain durability are identical across tiers."
     ),
     "parameters": {
         "type": "object",

--- a/python/tests/test_tool_schema_no_chain_names.py
+++ b/python/tests/test_tool_schema_no_chain_names.py
@@ -1,0 +1,50 @@
+"""Guard (#373, rc6 pre-stable QA): no user-facing tool-schema description
+names a chain.
+
+Post-ops-1 (single-chain Gnosis, totalreclaw-internal#283 closed) BOTH tiers
+run on Gnosis — the user never needs the chain, and naming it is both noise and
+(in the upgrade copy) factually wrong ("Pro routes to Gnosis instead of Base
+Sepolia" is false now). The 2.4.4rc6 pre-stable QA (#373, blocker) found
+"Gnosis mainnet" + "Base Sepolia" leaking into the ``totalreclaw_upgrade`` and
+``totalreclaw_remember`` descriptions. Pin every schema description clean: cite
+``totalreclaw_status`` for tier/quota, never a chain name.
+"""
+from __future__ import annotations
+
+import re
+
+from totalreclaw.hermes import schemas as _schemas
+
+_CHAIN = re.compile(r"\b(Gnosis|Base\s+Sepolia|mainnet|testnet)\b", re.IGNORECASE)
+
+
+def _iter_schema_dicts():
+    """Yield (var_name, schema_dict) for every tool-schema dict in the module."""
+    for var_name in dir(_schemas):
+        obj = getattr(_schemas, var_name)
+        if isinstance(obj, dict) and "description" in obj and "name" in obj:
+            yield var_name, obj
+
+
+def test_no_tool_description_names_a_chain():
+    offenders = []
+    for var_name, schema in _iter_schema_dicts():
+        desc = schema.get("description", "") or ""
+        m = _CHAIN.search(desc)
+        if m:
+            offenders.append(f"{var_name} ({schema.get('name')}): {m.group()!r}")
+    assert not offenders, (
+        "User-facing tool-schema descriptions must not name a chain "
+        "(post-ops-1 single-chain; cite totalreclaw_status for tier/quota): "
+        + "; ".join(offenders)
+    )
+
+
+def test_guard_actually_inspects_descriptions():
+    """Sanity: the guard sees a non-trivial number of schemas (so a refactor
+    that empties the introspection doesn't make the guard vacuously pass)."""
+    found = list(_iter_schema_dicts())
+    assert len(found) >= 8, (
+        f"Expected to inspect the full tool surface; only found {len(found)} "
+        "schema dicts — did the schemas module move or change shape?"
+    )


### PR DESCRIPTION
**rc6 pre-stable QA blocker #373.** Status/upgrade copy leaked `Gnosis mainnet` + `Base Sepolia` to the user via tool-schema descriptions + nudges. Post-ops-1 single-chain (#283), both tiers are on Gnosis — the user never needs the chain, and the upgrade copy ("Pro routes to Gnosis instead of Base Sepolia") is factually wrong now.

Fixed the 5 user-facing strings (drop chain name, keep `on-chain` benefit framing); rewrote the UPGRADE description to the real Pro delta (1,500 vs 250 + LLM-dedup; encryption/durability identical across tiers). Added `test_tool_schema_no_chain_names.py` — a guard that fails if any schema description names a chain. Internal code/comments + chain-id param docstrings untouched.

**For the rc7 train:** @hermes-agent — fold this into the rc7 client branch (rebase main or cherry-pick `b69e256`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)