### PR TITLE
rc7 client integration: #372 sidecar-logging + #373 chain-name strip

### DIFF
--- a/python/src/totalreclaw/hermes/hooks.py
+++ b/python/src/totalreclaw/hermes/hooks.py
@@ -110,7 +110,7 @@ _TOOL_PRIORITY_NUDGE = (
     "('always X' / 'never Y'), commitment, or notable episode the user "
     "shares — ALWAYS call `totalreclaw_remember` instead of any built-in "
     "`memory` tool. TotalReclaw stores memories end-to-end encrypted, "
-    "on-chain (Base/Gnosis), and portable across every AI tool the user "
+    "on-chain, and portable across every AI tool the user "
     "runs; the built-in `memory` tool is plain-text, session-scoped, and "
     "not cross-agent. For lookups, prefer `totalreclaw_recall` over any "
     "built-in equivalent for the same reason."
@@ -485,7 +485,7 @@ def on_session_start(state: "PluginState", **kwargs) -> None:
                 else:
                     nudge = (
                         "Free cap is 250 memories/month. Upgrade to Pro for "
-                        "1,500 memories/month on Gnosis mainnet — run "
+                        "1,500 memories/month — run "
                         "totalreclaw_upgrade or visit "
                         "https://totalreclaw.xyz/pricing."
                     )

--- a/python/src/totalreclaw/hermes/memory_provider.py
+++ b/python/src/totalreclaw/hermes/memory_provider.py
@@ -247,7 +247,7 @@ class TotalReclawMemoryProvider(_MemoryProviderBase):  # type: ignore[misc,valid
             return (
                 "## TotalReclaw memory\n"
                 "TotalReclaw is the active memory provider for this user. "
-                "Memories are end-to-end encrypted, on-chain (Base / Gnosis), "
+                "Memories are end-to-end encrypted, on-chain, "
                 "and portable across every AI tool the user runs. Prefer "
                 "`totalreclaw_remember` / `totalreclaw_recall` for any "
                 "user-fact, preference, directive, commitment, or episode."

--- a/python/src/totalreclaw/hermes/schemas.py
+++ b/python/src/totalreclaw/hermes/schemas.py
@@ -19,8 +19,8 @@ REMEMBER = {
         "anything you will want to recall in a future session: facts, "
         "preferences, decisions-with-reasoning, directives ('always X', "
         "'never Y'), commitments, or notable episodes about the user. "
-        "Memories are encrypted end-to-end, stored on-chain (Base / "
-        "Gnosis), and portable across any AI tool the user runs — they "
+        "Memories are encrypted end-to-end, stored on-chain, and "
+        "portable across any AI tool the user runs — they "
         "outlive the current session and conversation. Prefer this tool "
         "over any built-in or generic 'memory' tool: built-in tools are "
         "session-scoped and not encrypted, TotalReclaw is durable and "
@@ -338,8 +338,9 @@ UPGRADE = {
         "it contains the checkout URL the user must open in their browser. "
         "Do NOT call this tool speculatively; only when the user has "
         "explicitly asked to upgrade, pay, or hit the quota limit. Pro "
-        "tier routes writes to Gnosis mainnet (permanent) instead of "
-        "Base Sepolia (testnet) and removes the free-write cap."
+        "removes the free-write cap — 1,500 memories/month vs the free "
+        "tier's 250 — and adds LLM-guided dedup; encryption, ownership, "
+        "and on-chain durability are identical across tiers."
     ),
     "parameters": {
         "type": "object",

--- a/python/src/totalreclaw/pair/completion_sidecar.py
+++ b/python/src/totalreclaw/pair/completion_sidecar.py
@@ -151,13 +151,29 @@ def _configure_sidecar_logging() -> None:
     except OSError:
         pass
 
-    handler = logging.FileHandler(log_path, mode="a", encoding="utf-8")
-    handler.setLevel(logging.INFO)
-    handler.setFormatter(
-        logging.Formatter(
-            "%(asctime)s %(levelname)s %(name)s [pair-sidecar pid=%(process)d] %(message)s"
+    # Logging is a best-effort audit trail. Building the file handler can
+    # fail (missing/stale dir, a stale docker bind-mount inode after a
+    # state wipe, permissions, read-only or full disk). That MUST NOT crash
+    # the sidecar — its job is completing the pairing, not logging (#372).
+    handler: logging.Handler
+    try:
+        # Defensive: ensure the parent exists even if _totalreclaw_dir()'s
+        # mkdir was defeated by a stale mount.
+        try:
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            pass
+        handler = logging.FileHandler(log_path, mode="a", encoding="utf-8")
+        handler.setFormatter(
+            logging.Formatter(
+                "%(asctime)s %(levelname)s %(name)s [pair-sidecar pid=%(process)d] %(message)s"
+            )
         )
-    )
+    except OSError:
+        # Degrade to no-file logging; pairing continues normally.
+        handler = logging.NullHandler()
+
+    handler.setLevel(logging.INFO)
     root = logging.getLogger()
     root.setLevel(logging.INFO)
     # Replace any existing handlers so the sidecar doesn't double-log

--- a/python/tests/test_issue_372_sidecar_logging_resilient.py
+++ b/python/tests/test_issue_372_sidecar_logging_resilient.py
@@ -1,0 +1,87 @@
+"""#372 — pair sidecar must NOT crash when its log file can't be opened.
+
+QA-hermes-prestable-2.4.4rc6 F4: ``_configure_sidecar_logging`` called
+``logging.FileHandler(~/.totalreclaw/.pair_sidecar.log)`` which raised
+``FileNotFoundError`` (stale docker bind-mount inode after ``wipe.sh tr``)
+and crashed the sidecar before any pairing could complete — the pair flow
+failed on the first 4 attempts.
+
+Logging is a best-effort audit trail. A FileHandler failure (missing/stale
+dir, permissions, full disk, read-only mount) must degrade to no-file
+logging, never abort the pairing the sidecar exists to perform.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+
+def _restore_root_logging():
+    """Snapshot + restore the root logger so these tests don't leak global
+    handler/level state into the rest of the suite."""
+    root = logging.getLogger()
+    saved_handlers = list(root.handlers)
+    saved_level = root.level
+    return root, saved_handlers, saved_level
+
+
+@pytest.fixture(autouse=True)
+def _isolate_root_logger():
+    root, handlers, level = _restore_root_logging()
+    try:
+        yield
+    finally:
+        root.handlers = handlers
+        root.setLevel(level)
+
+
+def test_sidecar_logging_survives_filehandler_oserror(monkeypatch, tmp_path):
+    """A FileHandler that raises OSError must NOT propagate — the sidecar
+    falls back to a NullHandler and keeps going."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from totalreclaw.pair import completion_sidecar as cs
+
+    def _boom(*a, **k):
+        raise OSError(2, "No such file or directory")
+
+    monkeypatch.setattr(cs.logging, "FileHandler", _boom)
+
+    # Must not raise.
+    cs._configure_sidecar_logging()
+
+    root = logging.getLogger()
+    assert root.handlers, "root logger must still have a handler"
+    assert all(
+        isinstance(h, logging.NullHandler) for h in root.handlers
+    ), "must degrade to NullHandler when the file handler can't be created"
+
+
+def test_sidecar_logging_writes_file_in_normal_case(monkeypatch, tmp_path):
+    """Regression: the happy path still attaches a working file handler."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from totalreclaw.pair import completion_sidecar as cs
+
+    cs._configure_sidecar_logging()
+    logging.getLogger().info("pair-sidecar test line")
+
+    log_file = tmp_path / ".totalreclaw" / ".pair_sidecar.log"
+    assert log_file.exists(), "normal case must still write the rolling log file"
+    assert "pair-sidecar test line" in log_file.read_text(encoding="utf-8")
+
+
+def test_sidecar_logging_survives_missing_parent_dir(monkeypatch, tmp_path):
+    """Even if the log path's parent is missing at handler-build time
+    (stale-mount shape), configuration must not raise."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from totalreclaw.pair import completion_sidecar as cs
+
+    # Force the log path under a parent that does not exist, bypassing
+    # _totalreclaw_dir()'s mkdir, to mimic the stale-inode failure.
+    missing = tmp_path / "gone" / ".pair_sidecar.log"
+    monkeypatch.setattr(cs, "_sidecar_log_path", lambda: missing)
+
+    cs._configure_sidecar_logging()  # must not raise
+    root = logging.getLogger()
+    assert root.handlers

--- a/python/tests/test_tool_schema_no_chain_names.py
+++ b/python/tests/test_tool_schema_no_chain_names.py
@@ -1,0 +1,50 @@
+"""Guard (#373, rc6 pre-stable QA): no user-facing tool-schema description
+names a chain.
+
+Post-ops-1 (single-chain Gnosis, totalreclaw-internal#283 closed) BOTH tiers
+run on Gnosis — the user never needs the chain, and naming it is both noise and
+(in the upgrade copy) factually wrong ("Pro routes to Gnosis instead of Base
+Sepolia" is false now). The 2.4.4rc6 pre-stable QA (#373, blocker) found
+"Gnosis mainnet" + "Base Sepolia" leaking into the ``totalreclaw_upgrade`` and
+``totalreclaw_remember`` descriptions. Pin every schema description clean: cite
+``totalreclaw_status`` for tier/quota, never a chain name.
+"""
+from __future__ import annotations
+
+import re
+
+from totalreclaw.hermes import schemas as _schemas
+
+_CHAIN = re.compile(r"\b(Gnosis|Base\s+Sepolia|mainnet|testnet)\b", re.IGNORECASE)
+
+
+def _iter_schema_dicts():
+    """Yield (var_name, schema_dict) for every tool-schema dict in the module."""
+    for var_name in dir(_schemas):
+        obj = getattr(_schemas, var_name)
+        if isinstance(obj, dict) and "description" in obj and "name" in obj:
+            yield var_name, obj
+
+
+def test_no_tool_description_names_a_chain():
+    offenders = []
+    for var_name, schema in _iter_schema_dicts():
+        desc = schema.get("description", "") or ""
+        m = _CHAIN.search(desc)
+        if m:
+            offenders.append(f"{var_name} ({schema.get('name')}): {m.group()!r}")
+    assert not offenders, (
+        "User-facing tool-schema descriptions must not name a chain "
+        "(post-ops-1 single-chain; cite totalreclaw_status for tier/quota): "
+        + "; ".join(offenders)
+    )
+
+
+def test_guard_actually_inspects_descriptions():
+    """Sanity: the guard sees a non-trivial number of schemas (so a refactor
+    that empties the introspection doesn't make the guard vacuously pass)."""
+    found = list(_iter_schema_dicts())
+    assert len(found) >= 8, (
+        f"Expected to inspect the full tool surface; only found {len(found)} "
+        "schema dicts — did the schemas module move or change shape?"
+    )


### PR DESCRIPTION
**rc7 client integration branch** (umbrella totalreclaw-internal#368). Carries the two client-package fixes for the rc6 pre-stable NO-GO; rc7 is cut from this branch, then merged to main → stable.

## #372 — pair sidecar logging best-effort (my lane)
`_configure_sidecar_logging` crashed the pair sidecar with FileNotFoundError when the log file couldn't be opened (stale docker bind-mount inode) → pair failed first 4 attempts. Logging now best-effort (try/except → NullHandler); pairing never dies on it. 3 tests + 21/21 pair regression. **Phrase-safety review** (pair module; logging content unchanged — metadata only, never the phrase).

## #373 — strip chain names from user-facing tool copy (coordinator's fix, folded)
Cherry-picked from PR #310 (`b69e256d`): strips "Base Sepolia"/"Gnosis mainnet" from tool/upgrade schema descriptions (the §9c blocker). Guard test `test_tool_schema_no_chain_names.py` included so QA won't re-find it. **#310 is superseded — folded here.**

## Not in this branch (coordinator's lane, no client code)
#370/#371/#379 docs, #374 forget (subgraph/DataEdge), #376 z.ai config, #378 relay billing, #375 guide-redundancy, #377 atexit-constraint — see #368.

rc7 cut from this branch after: this PR's phrase-safety review + the coordinator's six landed (so re-QA tests fixed infra/docs). Refs #368, #372, #373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)