### PR TITLE
fix(extraction): chat-model fallback on empty cheap-model extraction (#376)

### DIFF
--- a/python/src/totalreclaw/agent/extraction.py
+++ b/python/src/totalreclaw/agent/extraction.py
@@ -1048,6 +1048,28 @@ async def extract_facts_llm(
         logger.warning("extract_facts_llm: chat_completion threw: %s", e)
         return []
 
+    if not response and config.model != chat_config.model:
+        # #376: the cheap extraction model returned empty. Retry ONCE with
+        # the user's flagship chat model on the SAME endpoint (Pedro's
+        # 2026-04-26 directive: never flip the endpoint — the API key is
+        # endpoint-scoped). The flagship is more capable and recovers turns
+        # the cheap workhorse silently empties. Same key/auth; only the
+        # model differs from ``config``.
+        logger.warning(
+            "extract_facts_llm: cheap extraction model %r returned empty — "
+            "retrying once with chat model %r (#376 fallback).",
+            config.model, chat_config.model,
+        )
+        try:
+            response = await chat_completion(
+                chat_config, EXTRACTION_SYSTEM_PROMPT, user_prompt
+            )
+        except Exception as e:
+            logger.warning(
+                "extract_facts_llm: #376 fallback chat_completion threw: %s", e
+            )
+            response = None
+
     if not response:
         # F2 (rc.24) — bumped from INFO to WARNING. An empty extraction
         # response is a CORRECTNESS bug, not a routine event: the LLM
@@ -1057,6 +1079,8 @@ async def extract_facts_llm(
         # already logs the underlying request shape (finish_reason,
         # usage, response_format) at WARN; this line tells the operator
         # WHERE the empty bubbled up so they can correlate the two.
+        # Reaching here means BOTH the cheap model and the chat-model
+        # fallback (#376) came back empty.
         logger.warning(
             "extract_facts_llm: chat_completion returned None/empty — "
             "auto-extraction will be a no-op for this turn. "

--- a/python/tests/test_issue_376_extraction_empty_fallback.py
+++ b/python/tests/test_issue_376_extraction_empty_fallback.py
@@ -1,0 +1,108 @@
+"""#376 — auto-extraction falls back to the chat model when the cheap
+extraction model returns empty content.
+
+QA-hermes-prestable-2.4.4rc6 F8: the derived cheap extraction model
+(``glm-4.5-flash`` on z.ai) returned empty content, so that turn's facts
+were silently dropped. rc.24 F2 swaps the flagship chat model down to a
+cheap workhorse for extraction; when even the cheap model empties, retry
+ONCE with the original chat model on the SAME endpoint (Pedro's directive:
+never flip the endpoint — the API key is endpoint-scoped).
+"""
+from __future__ import annotations
+
+import pytest
+
+from totalreclaw.agent import extraction
+from totalreclaw.agent.llm_client import LLMConfig
+
+
+_LONG_MSG = (
+    "Hi, I'm Pedro. I live in Porto and I use PostgreSQL for all my side "
+    "projects — never MySQL. I also prefer Vim over VS Code."
+)
+
+
+@pytest.mark.asyncio
+async def test_empty_cheap_extraction_falls_back_to_chat_model(monkeypatch):
+    chat = LLMConfig(
+        api_key="k",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        model="glm-5.1",
+        api_format="openai",
+    )
+    seen: list[tuple[str, str]] = []
+
+    async def fake_cc(cfg, system, user, *a, **k):
+        seen.append((cfg.model, cfg.base_url))
+        return ""  # both attempts empty -> graceful []
+
+    monkeypatch.setattr(extraction, "chat_completion", fake_cc)
+
+    out = await extraction.extract_facts_llm(
+        [{"role": "user", "content": _LONG_MSG}], llm_config=chat
+    )
+
+    assert out == []
+    models = [m for m, _ in seen]
+    assert models[0] == "glm-4.5-flash", "extraction first tries the cheap model"
+    assert "glm-5.1" in models, "on empty, must fall back to the chat model (#376)"
+    assert len(seen) == 2, "exactly one fallback retry"
+    # Pedro's no-endpoint-flip directive: the fallback stays on the same endpoint.
+    assert seen[1][1] == chat.base_url
+
+
+@pytest.mark.asyncio
+async def test_fallback_succeeds_yields_facts(monkeypatch):
+    """If the chat-model retry returns content, extraction is no longer a
+    no-op for the turn."""
+    chat = LLMConfig(
+        api_key="k",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        model="glm-5.1",
+        api_format="openai",
+    )
+    valid = (
+        '{"topics": ["identity"], "facts": [{"text": "Lives in Porto", '
+        '"type": "claim", "scope": "personal", "importance": 0.6, '
+        '"confidence": 0.9, "provenance": "user"}]}'
+    )
+    calls = {"n": 0}
+
+    async def fake_cc(cfg, system, user, *a, **k):
+        calls["n"] += 1
+        return "" if calls["n"] == 1 else valid  # cheap empty, chat-model OK
+
+    monkeypatch.setattr(extraction, "chat_completion", fake_cc)
+
+    out = await extraction.extract_facts_llm(
+        [{"role": "user", "content": _LONG_MSG}], llm_config=chat
+    )
+    # The fallback fired (2 calls) and the non-empty chat-model response
+    # proceeded PAST the empty-return branch into the parse pipeline (what
+    # the parser ultimately yields is exercised by the parser's own tests).
+    assert calls["n"] == 2
+    assert isinstance(out, list)
+
+
+@pytest.mark.asyncio
+async def test_no_fallback_when_extraction_model_equals_chat_model(monkeypatch):
+    """User already on the cheap model -> no swap -> a single attempt, no
+    pointless duplicate call."""
+    chat = LLMConfig(
+        api_key="k",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        model="glm-4.5-flash",
+        api_format="openai",
+    )
+    n = {"c": 0}
+
+    async def fake_cc(cfg, system, user, *a, **k):
+        n["c"] += 1
+        return ""
+
+    monkeypatch.setattr(extraction, "chat_completion", fake_cc)
+
+    await extraction.extract_facts_llm(
+        [{"role": "user", "content": _LONG_MSG}], llm_config=chat
+    )
+    assert n["c"] == 1, "no fallback when extraction model == chat model"


### PR DESCRIPTION
rc7 client lane — the last client code fix from the rc6 pre-stable NO-GO (umbrella totalreclaw-internal#368).

## #376 — auto-extraction silently dropped on empty cheap-model response
rc.24 F2 swaps the flagship chat model down to a cheap workhorse (`glm-4.5-flash`) for extraction. QA F8: the cheap model itself returned empty on z.ai → that turn's facts dropped. Fix: on empty, retry ONCE with the user's flagship chat model on the **same endpoint** (Pedro's no-endpoint-flip directive — key is endpoint-scoped). Graceful `[]` if both empty; no extra call when the user is already on the cheap model.

3 tests + 130/130 extraction regression.

**Coordinator/config caveat:** the glm-5.1-on-Coding case stays a config dead-end (glm-5.1 not served on Coding; no-flip directive forbids re-routing). Persistent glm-4.5-flash empties on Coding = z.ai endpoint/plan config, not client code.

## #378 — NOT a client bug (determination)
`totalreclaw_status` → `client.status()` → `_relay.get_billing_status()` fetches **fresh** every call (no cache). With a monotonic relay counter, the same wallet can't go 13→6 — that's different wallets / a re-register between the QA's status calls (the deterministic-test-wallet + wipe caveat). No client change.

That closes my four: #372 + #373 (merged in #311), #376 (here), #378/#375/#377 = determinations. Part of coordinated rc7. Refs #368.

🤖 Generated with [Claude Code](https://claude.com/claude-code)