### PR TITLE
ci: automated changelog via git-cliff (opens reviewable PR)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,178 @@
+name: Changelog (git-cliff)
+
+# Generate a changelog section from Conventional Commits and open a reviewable
+# PR. DECOUPLED from the release-critical publish workflows by design: a
+# changelog failure can never block a release, and every generated entry is
+# reviewed in a normal PR before it lands.
+#
+# Why this exists: the python client CHANGELOG.md was hand-assembled per
+# release. This automates the mechanical part (the bullet list of what changed)
+# while keeping the curated preamble and prior entries intact.
+#
+# See docs/guides/release-process.md -> "Changelog automation (git-cliff)".
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'New version the entry documents (no v prefix), e.g. 2.4.5'
+        required: true
+        type: string
+      from_ref:
+        description: 'Lower bound of the commit range (tag or SHA). Blank = auto-detect the last python-v* tag. REQUIRED on the first run, before any python-v* tag exists.'
+        required: false
+        type: string
+        default: ''
+      package_glob:
+        description: 'Path filter — only commits touching this glob are included'
+        required: false
+        type: string
+        default: 'python/**'
+      changelog_file:
+        description: 'Changelog file to insert the new section into'
+        required: false
+        type: string
+        default: 'python/CHANGELOG.md'
+      tag_namespace:
+        description: 'Tag pattern that bounds this package version line (git glob == git-cliff regex for these names)'
+        required: false
+        type: string
+        default: 'python-v[0-9]*'
+      dry_run:
+        description: 'Render to the job summary only — no file edit, no PR'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  changelog:
+    name: Generate + open PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # full history + tags for range detection
+
+      - name: Resolve commit range
+        id: range
+        env:
+          FROM_REF: ${{ inputs.from_ref }}
+          TAG_NS: ${{ inputs.tag_namespace }}
+        run: |
+          set -euo pipefail
+          if [ -n "${FROM_REF}" ]; then
+            if ! git rev-parse --verify "${FROM_REF}^{commit}" >/dev/null 2>&1; then
+              echo "::error::from_ref '${FROM_REF}' is not a valid commit/tag."
+              exit 1
+            fi
+            echo "range=${FROM_REF}..HEAD" >> "$GITHUB_OUTPUT"
+            echo "unreleased=" >> "$GITHUB_OUTPUT"
+            echo "Resolved explicit range: ${FROM_REF}..HEAD"
+          else
+            LAST_TAG="$(git tag --list "${TAG_NS}" --sort=-creatordate | head -n1 || true)"
+            if [ -z "${LAST_TAG}" ]; then
+              echo "::error::No tag matches '${TAG_NS}' yet and no from_ref was given."
+              echo "::error::First-run bootstrap: pass from_ref=<sha-or-tag of the previous stable release> so the range has a lower bound. Once a stable publish tags python-v<version>, future runs auto-detect and from_ref can be left blank."
+              exit 1
+            fi
+            echo "range=" >> "$GITHUB_OUTPUT"
+            echo "unreleased=--unreleased" >> "$GITHUB_OUTPUT"
+            echo "Auto-detected last tag: ${LAST_TAG} (using --unreleased)"
+          fi
+
+      - name: Install git-cliff
+        uses: taiki-e/install-action@v2
+        with:
+          # Pin the exact version the config + template were validated against.
+          tool: git-cliff@2.13.1
+
+      - name: Run git-cliff
+        env:
+          RANGE: ${{ steps.range.outputs.range }}
+          UNRELEASED: ${{ steps.range.outputs.unreleased }}
+          VERSION: ${{ inputs.version }}
+          TAG_NS: ${{ inputs.tag_namespace }}
+          GLOB: ${{ inputs.package_glob }}
+          OUT: ${{ runner.temp }}/fragment.md
+        run: |
+          set -euo pipefail
+          # Globby vars are double-quoted so the shell can't expand them; the
+          # range/unreleased flags are plain (a 'sha..HEAD' string or a flag).
+          # This is the exact invocation validated locally against git-cliff 2.13.1.
+          git-cliff --config cliff.toml \
+            ${RANGE:-} ${UNRELEASED:-} \
+            --tag "${VERSION}" \
+            --tag-pattern "${TAG_NS}" \
+            --include-path "${GLOB}" \
+            > "${OUT}"
+          echo "Wrote fragment to ${OUT}"
+
+      - name: Publish fragment to job summary
+        run: |
+          {
+            echo "### Generated changelog fragment — v${{ inputs.version }}"
+            echo ''
+            echo '```markdown'
+            cat "${{ runner.temp }}/fragment.md"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Insert fragment below preamble
+        if: ${{ inputs.dry_run != true }}
+        env:
+          FILE: ${{ inputs.changelog_file }}
+          FRAG: ${{ runner.temp }}/fragment.md
+        run: |
+          # Splice the new section immediately above the first existing
+          # '## [' version heading — i.e. after the Keep-a-Changelog preamble.
+          # This preserves the curated header AND every prior entry, unlike a
+          # naive prepend (which lands the section above the file title).
+          # Done in python so blank-line normalization is deterministic: the
+          # git-cliff fragment carries a leading blank and no trailing blank
+          # (trim=true), so we strip surrounding blanks and rejoin with exactly
+          # one blank line on each side regardless of git-cliff's whitespace.
+          python3 - <<'PY'
+          import os, sys, pathlib
+          file = pathlib.Path(os.environ["FILE"])
+          frag = pathlib.Path(os.environ["FRAG"]).read_text().strip("\n")
+          if not frag.strip():
+              print("::warning::git-cliff produced an empty fragment (no matching commits in range). Nothing to insert.")
+              sys.exit(0)
+          text = file.read_text()
+          lines = text.splitlines(keepends=True)
+          idx = next((i for i, l in enumerate(lines) if l.startswith("## [")), None)
+          if idx is None:
+              new = text.rstrip("\n") + "\n\n" + frag + "\n"
+          else:
+              preamble = "".join(lines[:idx]).rstrip("\n")
+              rest = "".join(lines[idx:])
+              new = preamble + "\n\n" + frag + "\n\n" + rest
+          file.write_text(new)
+          print(f"Inserted section into {file}.")
+          PY
+
+      - name: Open changelog PR
+        if: ${{ inputs.dry_run != true }}
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: ci/changelog-${{ inputs.version }}
+          base: main
+          commit-message: "docs(changelog): python client ${{ inputs.version }}"
+          title: "docs(changelog): python client ${{ inputs.version }}"
+          body: |
+            Auto-generated changelog section for **python client `${{ inputs.version }}`**, produced by `.github/workflows/changelog.yml` (git-cliff) from Conventional Commits.
+
+            - **Range:** `${{ steps.range.outputs.range || format('last {0} tag .. HEAD', inputs.tag_namespace) }}`
+            - **Path filter:** `${{ inputs.package_glob }}`
+            - **File:** `${{ inputs.changelog_file }}`
+
+            **Review before merge.** git-cliff renders one bullet per commit subject — enrich prose, regroup, or trim noise as needed. The Keep-a-Changelog preamble and all prior entries are preserved.
+
+            🤖 Generated with [Claude Code](https://claude.com/claude-code)
+          delete-branch: true
+          add-paths: |
+            ${{ inputs.changelog_file }}

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,72 @@
+# git-cliff configuration — automated changelog from Conventional Commits.
+# Drives `.github/workflows/changelog.yml`.
+#
+# MONOREPO SCOPING. This repo ships several independently-versioned packages
+# (python client 2.4.x, plugin/ClawHub 3.3.x, core 2.x, ...) from one git
+# history with a SHARED tag namespace. A naive `tag_pattern = "v[0-9]*"` would
+# scope the python changelog against the most recent *plugin* tag (e.g.
+# `v3.3.12-rc.11`), producing a wrong commit range. Two guards keep runs honest:
+#   1. Per-package tag namespace: stable python releases are tagged
+#      `python-v<version>`; `tag_pattern` below only matches those.
+#   2. Per-run path filter: the workflow passes `--include-path "python/**"` so
+#      only commits that touched the python tree appear.
+# Other packages reuse this same config and override the namespace on the CLI
+# with `--tag-pattern "<pkg>-v[0-9]*"` + their own `--include-path`.
+# Docs: https://git-cliff.org/docs/configuration
+
+[changelog]
+# Prepend mode: the workflow runs `--unreleased --prepend <FILE>`, so this body
+# renders ONLY the new version's section and prepends it above existing,
+# hand-curated history. The file header already exists in CHANGELOG.md.
+header = ""
+body = """
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] — {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}\
+- {{ commit.message | split(pat="\n") | first | upper_first }}
+{% endfor %}\
+{% endfor %}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+# Drop anything that isn't a conventional commit (merge commits, raw subjects).
+filter_unconventional = true
+split_commits = false
+# Map commit type -> changelog group. Order here = render order.
+commit_parsers = [
+    { message = "^feat", group = "Added" },
+    { message = "^fix", group = "Fixed" },
+    { message = "^perf", group = "Changed" },
+    { message = "^refactor", group = "Changed" },
+    { message = "^docs", group = "Documentation" },
+    # Noise: never appears in a user-facing changelog.
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^chore: bump", skip = true },
+    { message = "^chore", skip = true },
+    { message = "^test", skip = true },
+    { message = "^ci", skip = true },
+    { message = "^style", skip = true },
+    { message = "^build", skip = true },
+    { message = "^Merge", skip = true },
+    # Anything else conventional but unmapped -> Changed (don't silently drop).
+    { message = ".*", group = "Changed" },
+]
+protect_breaking_commits = true
+filter_commits = false
+# Per-package namespace (see MONOREPO SCOPING header). Only python release tags
+# match — the plugin's shared `v3.3.x` tags are deliberately excluded so the
+# python changelog range is never bounded by an unrelated package's release.
+# The workflow may override this on the CLI with `--tag-pattern` for other
+# packages. Note: this same string doubles as the git glob the workflow feeds
+# to `git tag --list` when auto-detecting the previous tag — for these tag
+# names the glob and regex interpretations select the identical set.
+tag_pattern = "python-v[0-9]*"
+topo_order = false
+sort_commits = "oldest"

--- a/docs/guides/release-process.md
+++ b/docs/guides/release-process.md
@@ -155,7 +155,51 @@ differ. Ship with the table below in front of you.
    # (stable-version auto-derived to 2.1.0)
    ```
 
-6. **Announce.** GitHub release, Telegram notification, website update.
+6. **Generate the changelog.** Dispatch `changelog.yml` for the stable
+   version (see "Changelog automation" below). It opens a reviewable PR
+   with the auto-generated section; review and merge it.
+
+7. **Announce.** GitHub release, Telegram notification, website update.
+
+## Changelog automation (git-cliff)
+
+`python/CHANGELOG.md` entries are generated from
+[Conventional Commits](https://www.conventionalcommits.org/) by
+`.github/workflows/changelog.yml` (driven by `cliff.toml`). This replaces
+hand-assembling the "what changed" bullet list each release.
+
+**Design — decoupled on purpose.** The workflow is standalone and never runs
+inside the publish workflows. A changelog failure can't block a release, and
+every generated section lands as a normal, reviewable PR. git-cliff renders one
+bullet per commit subject; enrich the prose before merging if you like — the
+Keep-a-Changelog preamble and all prior entries are preserved (the new section
+is spliced in above the first `## [` heading, not blindly prepended).
+
+**Dispatch it after a stable publish:**
+
+```bash
+# Normal run (a python-v<prev> tag already exists -> range auto-detected):
+gh workflow run changelog.yml -f version=2.4.5
+
+# First run / bootstrap (no python-v* tag exists yet) -> give the lower bound
+# explicitly: the tag or SHA where the PREVIOUS stable shipped.
+gh workflow run changelog.yml -f version=2.4.5 -f from_ref=<prev-stable-sha>
+
+# Preview only — render to the run's job summary, no file edit, no PR:
+gh workflow run changelog.yml -f version=2.4.5 -f from_ref=<sha> -f dry_run=true
+```
+
+**Monorepo scoping.** This repo ships several independently-versioned packages
+from one history with a shared tag namespace. Two guards keep the python range
+honest: a per-package tag namespace (`python-v[0-9]*`, so the plugin's
+`v3.3.x` tags can't bound the range) and a path filter (`--include-path
+"python/**"`). Other packages reuse the same `cliff.toml` and override both on
+the CLI (`-f tag_namespace=...`, `-f package_glob=...`).
+
+**Bootstrap note.** Until a stable publish creates the first `python-v<version>`
+tag, `from_ref` is REQUIRED (the workflow fails loud rather than dumping the
+whole history). A planned fast-follow tags `python-v<version>` automatically on
+stable publish, after which `from_ref` can be omitted.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## What

Automates the mechanical part of writing `python/CHANGELOG.md` — the bullet list of *what changed* — from [Conventional Commits](https://www.conventionalcommits.org/), so we stop hand-assembling it per release (the pain point behind #315).

Three files, **purely additive — zero changes to any release-critical publish workflow**:

| File | Role |
|------|------|
| `cliff.toml` | git-cliff config: commit-type → group mapping, per-line bullet template, monorepo tag scoping |
| `.github/workflows/changelog.yml` | `workflow_dispatch` job: render section → splice into CHANGELOG → open a reviewable PR |
| `docs/guides/release-process.md` | "Changelog automation (git-cliff)" section + step 6 pointer |

## Design

- **Decoupled by design.** Standalone `workflow_dispatch`; it never runs inside the publish workflows. A changelog failure can't block a release, and every generated section lands as a normal, reviewable PR.
- **Splices, doesn't clobber.** The new section is inserted immediately above the first `## [` heading, so the Keep-a-Changelog preamble and every prior hand-curated entry are preserved. Blank-line normalization is done in python (deterministic regardless of git-cliff's `trim` whitespace).
- **Monorepo-scoped.** This repo ships several independently-versioned packages from one history with a *shared* tag namespace — the latest `v*` tag is currently a **plugin** tag (`v3.3.12-rc.11`), which would wrongly bound a python range. Two guards: a per-package tag namespace (`python-v[0-9]*`) and a path filter (`--include-path "python/**"`). Other packages reuse the same config and override both on the CLI.
- **Pinned + reproducible.** Installs the exact git-cliff version validated here (2.13.1) and runs the byte-identical command — CI executes precisely what was tested.

## Validation (local, git-cliff 2.13.1)

Ran the real command against `release-v2.4.0..HEAD` and spliced into a copy of `python/CHANGELOG.md`:

- ✅ Conventional prefix stripped (`feat(core): …` → `Promote v2-lenient …`), `(#PR)` refs preserved
- ✅ Correct grouping (Added / Changed / Documentation / Fixed), one bullet per line
- ✅ Non-conventional/merge commits dropped (`filter_unconventional`)
- ✅ Curated preamble + all prior entries intact; exactly one blank line on each side of the splice

## Usage

```bash
# Normal (a python-v<prev> tag exists → range auto-detected)
gh workflow run changelog.yml -f version=2.4.5

# First run / bootstrap (no python-v* tag yet → pass the lower bound)
gh workflow run changelog.yml -f version=2.4.5 -f from_ref=<prev-stable-sha>

# Preview only (job summary, no file edit, no PR)
gh workflow run changelog.yml -f version=2.4.5 -f from_ref=<sha> -f dry_run=true
```

## Follow-ups (intentionally NOT in this PR)

1. **Seed `python-v*` tags** — a focused, separate change to `publish-python-client.yml` (the release-critical path) to tag `python-v<version>` on stable publish, after which `from_ref` can be omitted. Kept out of this PR so the sensitive workflow is reviewed in isolation.
2. **Post-merge E2E** — `workflow_dispatch` workflows can only be dispatched once on the default branch; after merge, run with `-f dry_run=true -f from_ref=release-v2.4.0` to confirm the CI action wiring renders the same fragment validated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)