### PR TITLE
feat(llm): empty-content diag surfaces reasoning_content (#376 follow-on)

### DIFF
--- a/python/src/totalreclaw/agent/llm_client.py
+++ b/python/src/totalreclaw/agent/llm_client.py
@@ -1301,7 +1301,8 @@ async def _call_openai(
         resp.raise_for_status()
         data = resp.json()
         choice = (data.get("choices") or [{}])[0]
-        content = choice.get("message", {}).get("content")
+        message = choice.get("message", {}) or {}
+        content = message.get("content")
         if not content:
             # F2 — empty responses must be loud, not silent. Prior to
             # rc.24 this was logged as a generic "returned None/empty"
@@ -1309,10 +1310,19 @@ async def _call_openai(
             # response shape (finish_reason, usage) at WARN here so the
             # operator can correlate empty extraction batches with the
             # provider response without enabling DEBUG.
+            #
+            # #376 follow-on: GLM models on the z.ai Coding endpoint often
+            # return empty ``content`` while putting the text in
+            # ``reasoning_content`` (a "thinking" field). Log its presence +
+            # length and the message keys so the root-cause is visible —
+            # "empty content" alone is misleading when the answer is in
+            # ``reasoning_content``.
+            reasoning = message.get("reasoning_content")
             logger.warning(
                 "LLM returned empty content (provider=%s, model=%s, "
                 "system_chars=%d, user_chars=%d, finish_reason=%s, usage=%s, "
-                "json_response_format=%s)",
+                "json_response_format=%s, message_keys=%s, "
+                "reasoning_content_present=%s, reasoning_content_chars=%d)",
                 config.base_url,
                 config.model,
                 len(system_prompt or ""),
@@ -1320,6 +1330,9 @@ async def _call_openai(
                 choice.get("finish_reason"),
                 data.get("usage"),
                 "response_format" in body,
+                sorted(message.keys()),
+                reasoning is not None,
+                len(reasoning or ""),
             )
         return content
 

--- a/python/src/totalreclaw/agent/llm_client.py
+++ b/python/src/totalreclaw/agent/llm_client.py
@@ -1318,13 +1318,22 @@ async def _call_openai(
             # "empty content" alone is misleading when the answer is in
             # ``reasoning_content``.
             reasoning = message.get("reasoning_content")
+            # Rate-limit / quota headers (z.ai + OpenAI-style) help the
+            # operator distinguish "exhausted key" from "reasoning ate the
+            # token budget". No secrets in response headers.
+            rl_headers = {
+                k: v for k, v in resp.headers.items()
+                if any(t in k.lower() for t in ("ratelimit", "quota", "x-request-id", "retry-after"))
+            }
             logger.warning(
                 "LLM returned empty content (provider=%s, model=%s, "
-                "system_chars=%d, user_chars=%d, finish_reason=%s, usage=%s, "
-                "json_response_format=%s, message_keys=%s, "
-                "reasoning_content_present=%s, reasoning_content_chars=%d)",
+                "http_status=%s, system_chars=%d, user_chars=%d, finish_reason=%s, "
+                "usage=%s, json_response_format=%s, message_keys=%s, "
+                "reasoning_content_present=%s, reasoning_content_chars=%d, "
+                "rl_headers=%s, body_snippet=%r)",
                 config.base_url,
                 config.model,
+                resp.status_code,
                 len(system_prompt or ""),
                 len(user_prompt or ""),
                 choice.get("finish_reason"),
@@ -1333,6 +1342,10 @@ async def _call_openai(
                 sorted(message.keys()),
                 reasoning is not None,
                 len(reasoning or ""),
+                rl_headers,
+                # Truncated raw message — shows where the text actually went
+                # (e.g. reasoning_content) without dumping a huge payload.
+                str(message)[:400],
             )
         return content
 

--- a/python/tests/test_issue_376_empty_content_diag.py
+++ b/python/tests/test_issue_376_empty_content_diag.py
@@ -1,0 +1,88 @@
+"""#376 follow-on — empty-content diagnostic must surface response shape.
+
+The rc7 #376 hunt could not get finish_reason / reasoning_content from the
+logs. GLM models on the z.ai Coding endpoint frequently return empty
+``message.content`` while putting the actual text in
+``message.reasoning_content`` — so "empty content" is misleading. The
+``_call_openai`` empty-content WARN must log: finish_reason, usage,
+message keys, and reasoning_content presence/length, so the operator (and
+the coordinator's z.ai root-cause) can see WHY content was empty.
+"""
+from __future__ import annotations
+
+import logging
+
+import httpx
+import pytest
+
+from totalreclaw.agent import llm_client
+from totalreclaw.agent.llm_client import LLMConfig, _call_openai
+
+
+def _patch_openai_response(monkeypatch, payload: dict):
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=payload)
+
+    transport = httpx.MockTransport(handler)
+
+    class _Patched(httpx.AsyncClient):
+        def __init__(self, *a, **k):
+            k.pop("transport", None)
+            super().__init__(*a, transport=transport, **k)
+
+    monkeypatch.setattr(llm_client.httpx, "AsyncClient", _Patched)
+
+
+_CFG = LLMConfig(
+    api_key="k",
+    base_url="https://api.z.ai/api/coding/paas/v4",
+    model="glm-4.5-flash",
+    api_format="openai",
+)
+
+
+@pytest.mark.asyncio
+async def test_empty_content_diag_surfaces_reasoning_content(monkeypatch, caplog):
+    _patch_openai_response(
+        monkeypatch,
+        {
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "message": {
+                        "content": "",
+                        "reasoning_content": "answer was put here by the model",
+                    },
+                }
+            ],
+            "usage": {"prompt_tokens": 12, "completion_tokens": 0, "total_tokens": 12},
+        },
+    )
+    with caplog.at_level(logging.WARNING, logger="totalreclaw.agent.llm_client"):
+        out = await _call_openai(_CFG, "sys", "usr", 100, 0.0)
+
+    assert not out  # content was empty
+    diag = [r.getMessage() for r in caplog.records if "LLM returned empty content" in r.getMessage()]
+    assert diag, "empty-content diag must fire"
+    msg = diag[0]
+    assert "finish_reason=stop" in msg
+    assert "reasoning_content_present=True" in msg
+    assert "reasoning_content_chars=" in msg
+    assert "message_keys=" in msg
+
+
+@pytest.mark.asyncio
+async def test_diag_reports_no_reasoning_when_truly_empty(monkeypatch, caplog):
+    _patch_openai_response(
+        monkeypatch,
+        {
+            "choices": [{"finish_reason": "length", "message": {"content": ""}}],
+            "usage": {"total_tokens": 5},
+        },
+    )
+    with caplog.at_level(logging.WARNING, logger="totalreclaw.agent.llm_client"):
+        await _call_openai(_CFG, "sys", "usr", 100, 0.0)
+    diag = [r.getMessage() for r in caplog.records if "LLM returned empty content" in r.getMessage()]
+    assert diag
+    assert "reasoning_content_present=False" in diag[0]
+    assert "finish_reason=length" in diag[0]


### PR DESCRIPTION
Unblocks the coordinator's #376 root-cause. **Observability only, non-gating** (post-stable follow-on).

The rc7 #376 hunt couldn't get finish_reason/reasoning_content from the logs. `_call_openai`'s empty-content WARN now also logs `message_keys`, `reasoning_content_present`, `reasoning_content_chars` — alongside the existing finish_reason + usage.

**Likely root cause this exposes:** GLM models on the z.ai Coding endpoint often return empty `message.content` with the actual text in `message.reasoning_content` (a 'thinking' field). The client reads `content` → sees empty → no-op, while the answer sits in `reasoning_content`. This diag will confirm it on the next run / the coordinator's repro.

The **behavior** fix (consume `reasoning_content` when `content` is empty, or a Coding-endpoint config change) is the coordinator's #376 z.ai lane — merge this standalone for the diag, or bundle with that fix. 2 tests + 46/46 llm_client regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)