### PR TITLE
docs(guide): bump Hermes stable pin to 2.4.4 (post-promote)

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -11,8 +11,8 @@ This document describes how the agent installs and sets up TotalReclaw on Hermes
 
 | Channel | Version | Install command |
 |---|---|---|
-| stable (default) | `2.4.3` | `pip install totalreclaw` |
-| latest RC | `2.4.4rc6` | `pip install --pre --upgrade totalreclaw==2.4.4rc6` |
+| stable (default) | `2.4.4` | `pip install totalreclaw` |
+| latest RC | `2.4.4rc7` | `pip install --pre --upgrade totalreclaw==2.4.4rc7` |
 
 Source of truth for what's currently published: `pip index versions totalreclaw`. The table above is updated on every PyPI release.
 


### PR DESCRIPTION
2.4.4 stable is live on PyPI (promoted run 27059611736). Per the user-guide-pins rule, bump the hermes-setup.md Versions table stable pin 2.4.3→2.4.4 (+ RC pin →2.4.4rc7). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)