### PR TITLE
docs(claude): mandate release-pipeline tracker update on release events + fix prod subgraph endpoint vars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -427,8 +427,16 @@ Full CI/CD pipeline documented in `totalreclaw-internal/docs/ci-cd-pipeline.md`.
 4. **Subgraph deploys to staging first.** Verify indexing before deploying to production subgraph.
 5. **After every subgraph deploy, immediately update the relay's `SUBGRAPH_ENDPOINT` env var on Railway.** The relay queries the subgraph via this URL — a stale version means the relay reads from an outdated schema. Update both services:
    - **Staging**: `railway variables set "SUBGRAPH_ENDPOINT=https://api.studio.thegraph.com/query/41768/total-reclaw-gnosis/<new-version>" -s totalreclaw`
-   - **Production**: `railway variables set "SUBGRAPH_ENDPOINT=https://api.studio.thegraph.com/query/41768/total-reclaw-gnosis/<new-version>" -s totalreclaw-production`
-   Setting env vars triggers an automatic Railway redeploy. Verify the relay restarts cleanly by checking `/health`.
+   - **Production** (production runs TWO endpoint vars — free `SUBGRAPH_ENDPOINT` + `PRO_SUBGRAPH_ENDPOINT` — update BOTH): `railway variables --set "SUBGRAPH_ENDPOINT=https://api.studio.thegraph.com/query/41768/total-reclaw-gnosis/<new-version>" --set "PRO_SUBGRAPH_ENDPOINT=https://api.studio.thegraph.com/query/41768/total-reclaw-gnosis/<new-version>" -s totalreclaw-production`
+   Setting env vars triggers an automatic Railway redeploy. Verify the relay restarts cleanly by checking `/health`. NOTE: `railway variables --set` may time out on the response yet still apply — re-read with `railway variables -s <svc> --json` to confirm before retrying. Also: deploy the prod subgraph from `subgraph/subgraph-gnosis-mainnet.yaml` (the default `subgraph.yaml` is a stale base-sepolia manifest — a bare `graph deploy` targets the wrong chain).
+
+6. **After every release event, update the release pipeline tracker (MANDATORY).** The single source of truth for "what's live / next RC / what's been QA'd" is **`totalreclaw-internal/docs/release-pipeline.md`**. The session that runs the event updates it **the same session** — never defer to a follow-up:
+   - **RC publish** (workflow success) → update Latest RC + Status + history.
+   - **Stable promote** (you dispatched `release-type=stable`) → swap the new version into Production, set Status `promoted`, append history.
+   - **Prod infra change** (subgraph redeploy, relay endpoint repoint, chain flip) → note it under the affected integration.
+   - **QA verdict** (GO / NO-GO) → update Status + blocker.
+
+   This rule is canonical in `totalreclaw-internal/CLAUDE.md` (§"Release pipeline tracker") but is repeated HERE because release events are dispatched from THIS (public) repo — an agent operating only in the public repo otherwise never loads the rule and the tracker silently rots. (Added 2026-06-06 after a 2.4.4 stable promote shipped without a tracker update; the tracker had gone a month stale.)
 
 For deployment procedures, follow the canonical runbook **[`docs/guides/deployment.md`](docs/guides/deployment.md)** (version-controlled source of truth — verified service↔env↔domain map, TS-relay `/health` contract, deploy-SHA sentinel, SHA hard-gate, subgraph + rollback). The machine-local `deploy-totalreclaw` skill mirrors it; if they disagree, the doc wins.
 


### PR DESCRIPTION
## Why
The release-pipeline tracker (`totalreclaw-internal/docs/release-pipeline.md`) is the MANDATORY single source of truth for "what's live / next RC / what's QA'd" (internal CLAUDE.md §"Release pipeline tracker"). It went **a month stale** — the 2.4.4 stable promote shipped without updating it. Root cause: the rule lived **only** in the *internal* CLAUDE.md; agents operating in the *public* repo (where publish/promote workflows run) never load it.

## Changes (CLAUDE.md)
1. **New CI/CD rule 6** — repeats the tracker-update mandate in the public CLAUDE.md, with the concrete triggers (RC publish / stable promote / prod infra change / QA verdict) and a note on *why* it's duplicated here.
2. **Fix CI/CD rule 5** — production runs **two** subgraph endpoint vars (`SUBGRAPH_ENDPOINT` + `PRO_SUBGRAPH_ENDPOINT`); both must be repointed. Adds the `railway variables --set` timeout-but-applied gotcha + the `subgraph-gnosis-mainnet.yaml` manifest note (the default `subgraph.yaml` is a stale base-sepolia manifest — a bare `graph deploy` targets the wrong chain).

Companion: the internal tracker itself is being updated to reflect 2.4.4 stable + the prod subgraph forget-fix (separate internal-repo change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)