### PR TITLE
fix(subgraph): default manifest → Gnosis prod + add prod build/deploy scripts

### DIFF
--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -10,6 +10,8 @@
     "create:local": "graph create --node http://localhost:8020/ totalreclaw/subgraph",
     "build:staging": "graph build subgraph-gnosis-staging.yaml",
     "deploy:staging": "graph deploy --studio total-reclaw-gnosis-staging subgraph-gnosis-staging.yaml",
+    "build:prod": "graph build subgraph-gnosis-mainnet.yaml",
+    "deploy:prod": "graph deploy --studio total-reclaw-gnosis subgraph-gnosis-mainnet.yaml",
     "test:gas": "tsx --tsconfig tsconfig.node.json tests/gas-measurement.ts",
     "test:e2e": "tsx --tsconfig tsconfig.node.json tests/e2e-ombh-validation.ts",
     "test:scaling": "tsx --tsconfig tsconfig.node.json tests/scaling-analysis.ts"

--- a/subgraph/subgraph-gnosis-mainnet.yaml
+++ b/subgraph/subgraph-gnosis-mainnet.yaml
@@ -1,3 +1,4 @@
+# PROD — Gnosis mainnet (chain 100). Deploy via `npm run deploy:prod`.
 specVersion: 0.0.5
 description: TotalReclaw — End-to-end encrypted memory vault subgraph (Gnosis mainnet, test instance)
 repository: https://github.com/p-diogo/totalreclaw

--- a/subgraph/subgraph-gnosis-staging.yaml
+++ b/subgraph/subgraph-gnosis-staging.yaml
@@ -1,3 +1,4 @@
+# STAGING — Gnosis (isolated DataEdge). Deploy via `npm run deploy:staging`.
 specVersion: 0.0.5
 description: TotalReclaw — STAGING subgraph (Gnosis mainnet, isolated DataEdge). Indexes the staging-only EventfulDataEdge so staging on-chain activity is isolated from the production subgraph. Part of ops-6 (totalreclaw-internal#363 staging-chain-isolation).
 repository: https://github.com/p-diogo/totalreclaw

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -1,3 +1,6 @@
+# DEFAULT — mirrors PROD (Gnosis mainnet). A bare `graph deploy`/`graph build`
+# (no manifest arg) targets production. Per-target manifests:
+# subgraph-gnosis-mainnet.yaml (prod) / subgraph-gnosis-staging.yaml (staging).
 specVersion: 0.0.5
 description: TotalReclaw — End-to-end encrypted memory vault subgraph
 repository: https://github.com/p-diogo/totalreclaw
@@ -6,13 +9,14 @@ schema:
 dataSources:
   - kind: ethereum
     name: EventfulDataEdge
-    # Local dev: hardhat | Production: gnosis | Testnet: gnosis-chiado
-    # deploy-contracts.sh updates address + startBlock for localhost deploys
-    network: base-sepolia
+    # PROD config (Gnosis mainnet, chain 100). Kept in sync with
+    # subgraph-gnosis-mainnet.yaml so a manifest-less deploy hits prod.
+    # deploy-contracts.sh updates address + startBlock for localhost deploys.
+    network: gnosis
     source:
       address: "0xC445af1D4EB9fce4e1E61fE96ea7B8feBF03c5ca"
       abi: EventfulDataEdge
-      startBlock: 39870000
+      startBlock: 45217698
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7


### PR DESCRIPTION
## Problem

The **default** `subgraph/subgraph.yaml` still targeted `network: base-sepolia` with `startBlock: 39870000` — a **retired testnet** from before the single-chain Gnosis migration (chain 100). The real deploys use per-target manifests:

- `subgraph-gnosis-mainnet.yaml` — PROD (network `gnosis`, DataEdge `0xC445af1D4EB9fce4e1E61fE96ea7B8feBF03c5ca`, startBlock 45217698)
- `subgraph-gnosis-staging.yaml` — staging (isolated DataEdge)

A bare `graph deploy` / `graph build` (no manifest arg) silently used the stale default → targeted the **wrong chain**. This **nearly caused a bad prod deploy on 2026-06-06**.

Additionally, `subgraph/package.json` had `build:staging` + `deploy:staging` scripts but **no prod equivalents** — so prod deploys were manual and error-prone.

## Fix

1. **`subgraph.yaml` now mirrors Gnosis PROD** — `network: base-sepolia → gnosis`, `startBlock: 39870000 → 45217698`. The `source.address` was already the prod DataEdge (`0xC445…c36f`); mappings / ABIs / entities are shared with the per-target manifests and unchanged. A manifest-less `graph deploy`/`graph build` now targets prod correctly.
2. **Added `build:prod` + `deploy:prod` npm scripts** to `package.json`, mirroring the staging pair but pointing at `subgraph-gnosis-mainnet.yaml` (`graph deploy --studio total-reclaw-gnosis subgraph-gnosis-mainnet.yaml`).
3. **Header comments** on all three manifests naming their target (`# DEFAULT — mirrors PROD …`, `# PROD — Gnosis mainnet …`, `# STAGING — Gnosis …`).

Per-target manifests are otherwise unchanged. No `graph deploy` was run — config + scripts only.

## Verification

```
$ npm install && npx graph codegen && npx graph build
Types generated successfully
Build completed: build/subgraph.yaml          # codegen + default build PASS (exit 0)

$ npx graph build subgraph-gnosis-mainnet.yaml
Build completed: build/subgraph.yaml          # mainnet build PASS (exit 0)
```

(The `INFO AS210: Expression is never 'null'` lines from `src/mapping.ts` are pre-existing AssemblyScript info-level notes, not errors.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)