### PR TITLE
feat(llm): z.ai extraction efficiency + empty-content observability

### DIFF
--- a/python/src/totalreclaw/agent/extraction.py
+++ b/python/src/totalreclaw/agent/extraction.py
@@ -1082,10 +1082,20 @@ async def extract_facts_llm(
         # Reaching here means BOTH the cheap model and the chat-model
         # fallback (#376) came back empty.
         logger.warning(
-            "extract_facts_llm: chat_completion returned None/empty — "
-            "auto-extraction will be a no-op for this turn. "
-            "See preceding 'LLM returned empty content' log for the "
-            "underlying response shape (finish_reason / usage)."
+            "extract_facts_llm: chat_completion returned None/empty for "
+            "BOTH the cheap extraction model (%r) and the chat-model #376 "
+            "fallback (%r) on %s — auto-extraction is a NO-OP for this turn. "
+            "ACTION: set TOTALRECLAW_EXTRACTION_MODEL to a model that returns "
+            "content on your endpoint (for z.ai Coding/Standard, a known-good "
+            "value is 'glm-4.5-flash'; this is already the default, so if it "
+            "is STILL empty your key/plan may not serve it — try your chat "
+            "model name explicitly, e.g. TOTALRECLAW_EXTRACTION_MODEL=%s). "
+            "See the preceding 'LLM returned empty content' log for the "
+            "underlying response shape (finish_reason / usage).",
+            config.model,
+            chat_config.model,
+            config.base_url,
+            chat_config.model,
         )
         return []
 
@@ -1196,10 +1206,19 @@ async def extract_facts_compaction(
         # to capture facts before the conversation is collapsed; a
         # silent empty-response here is a hard data-loss event.
         logger.warning(
-            "extract_facts_compaction: chat_completion returned None/empty — "
-            "compaction extraction will be a no-op for this conversation. "
-            "See preceding 'LLM returned empty content' log for the "
-            "underlying response shape."
+            "extract_facts_compaction: chat_completion returned None/empty "
+            "for the extraction model (%r) on %s — compaction extraction is a "
+            "NO-OP for this conversation (hard data-loss: this is the last "
+            "chance to capture facts before the context is collapsed). "
+            "ACTION: set TOTALRECLAW_EXTRACTION_MODEL to a model that returns "
+            "content on your endpoint (for z.ai a known-good value is "
+            "'glm-4.5-flash'; if that is STILL empty, set it to your chat "
+            "model name, e.g. TOTALRECLAW_EXTRACTION_MODEL=%s). See the "
+            "preceding 'LLM returned empty content' log for the underlying "
+            "response shape.",
+            config.model,
+            config.base_url,
+            chat_config.model,
         )
         return []
 

--- a/python/src/totalreclaw/agent/llm_client.py
+++ b/python/src/totalreclaw/agent/llm_client.py
@@ -1244,6 +1244,21 @@ def _supports_json_object_response_format(base_url: str) -> bool:
     return any(hint in lower for hint in _JSON_OBJECT_PROVIDER_HINTS)
 
 
+def _is_zai_base_url(base_url: str) -> bool:
+    """Return True for either z.ai endpoint (Coding ``/coding/paas/v4`` or
+    Standard ``/paas/v4``).
+
+    Used to gate the ``thinking: {"type": "disabled"}`` request body field
+    (see :func:`_call_openai`). z.ai is the only OpenAI-spec provider in our
+    table whose GLM models default to a server-side *thinking* mode that
+    routes generated text into ``message.reasoning_content`` and can leave
+    ``message.content`` empty — the #376 silent-no-op root cause.
+    """
+    if not base_url:
+        return False
+    return "z.ai" in base_url.lower()
+
+
 async def _call_openai(
     config: LLMConfig,
     system_prompt: str,
@@ -1288,6 +1303,29 @@ async def _call_openai(
         # what flips zai/GLM from empty-content responses to structured
         # output. See F2 in the rc.23 QA report.
         body["response_format"] = {"type": "json_object"}
+    if _is_zai_base_url(config.base_url):
+        # #376 ROOT CAUSE FIX. z.ai's GLM-4.5-series-and-up models
+        # (including the cheap extraction workhorse ``glm-4.5-flash``)
+        # default to ``thinking: {"type": "enabled"}``. With thinking on,
+        # the model spends the generation budget emitting chain-of-thought
+        # into ``message.reasoning_content`` and can return an EMPTY
+        # ``message.content`` — HTTP 200, no error. The extraction parser
+        # only reads ``content``, so the turn silently produces zero facts
+        # (rc7 QA: the #376 fallback fired 12× and STILL extracted nothing,
+        # because the flagship retry hits the SAME thinking-mode default).
+        #
+        # Sending ``thinking: {"type": "disabled"}`` tells GLM to put the
+        # answer in ``content``. This is z.ai's documented parameter
+        # (default "enabled"; allowed "enabled"/"disabled"); it applies to
+        # GLM-4.5 series and higher and is a no-op on providers that ignore
+        # it. SAME provider, SAME endpoint, SAME key — only the request
+        # body changes. We deliberately do NOT flip the endpoint (the
+        # Coding-plan key is endpoint-scoped; flipping 401s).
+        #
+        # Belt-and-suspenders for any provider/version that ignores the
+        # flag: ``_call_openai`` below also falls back to
+        # ``reasoning_content`` when ``content`` is empty.
+        body["thinking"] = {"type": "disabled"}
 
     async with httpx.AsyncClient(timeout=_LLM_TIMEOUT) as client:
         resp = await client.post(
@@ -1301,8 +1339,33 @@ async def _call_openai(
         resp.raise_for_status()
         data = resp.json()
         choice = (data.get("choices") or [{}])[0]
-        content = choice.get("message", {}).get("content")
+        message = choice.get("message", {}) or {}
+        content = message.get("content")
         if not content:
+            # #376 belt-and-suspenders: GLM (and some other reasoning
+            # models, e.g. Gemma on OpenAI-compat endpoints) can leave
+            # ``content`` empty while placing the actual answer in
+            # ``reasoning_content`` whenever thinking mode is active. We
+            # send ``thinking: {"type": "disabled"}`` for z.ai above to
+            # prevent this, but if a provider/version ignores that flag we
+            # still recover the payload here instead of silently dropping
+            # the whole extraction turn. The extraction parser already
+            # strips ``<think>`` wrappers and bracket-scans for the JSON
+            # body, so a reasoning_content blob that wraps the JSON parses
+            # cleanly.
+            reasoning = message.get("reasoning_content")
+            if isinstance(reasoning, str) and reasoning.strip():
+                logger.warning(
+                    "LLM returned empty content but non-empty "
+                    "reasoning_content (provider=%s, model=%s, "
+                    "reasoning_chars=%d) — recovering from reasoning_content. "
+                    "If this recurs on z.ai, ensure the request is not "
+                    "overriding thinking back to enabled.",
+                    config.base_url,
+                    config.model,
+                    len(reasoning),
+                )
+                return reasoning
             # F2 — empty responses must be loud, not silent. Prior to
             # rc.24 this was logged as a generic "returned None/empty"
             # downstream in extraction.py at INFO. Surface the actual

--- a/python/src/totalreclaw/agent/llm_client.py
+++ b/python/src/totalreclaw/agent/llm_client.py
@@ -1249,10 +1249,15 @@ def _is_zai_base_url(base_url: str) -> bool:
     Standard ``/paas/v4``).
 
     Used to gate the ``thinking: {"type": "disabled"}`` request body field
-    (see :func:`_call_openai`). z.ai is the only OpenAI-spec provider in our
-    table whose GLM models default to a server-side *thinking* mode that
-    routes generated text into ``message.reasoning_content`` and can leave
-    ``message.content`` empty — the #376 silent-no-op root cause.
+    (see :func:`_call_openai`). z.ai's GLM models default to a server-side
+    *thinking* mode that spends generation budget emitting chain-of-thought
+    into ``message.reasoning_content``. For cheap, structured extraction
+    calls that reasoning budget is pure waste — disabling it is an
+    efficiency win (faster, fewer completion tokens) and reduces the chance
+    of a content/``reasoning_content`` split. (NB: thinking mode is NOT the
+    root cause of #376 — at a realistic token budget GLM populates
+    ``content`` with thinking on or off; the #376 empties were
+    environmental/quota. See the empty-content recovery + diag below.)
     """
     if not base_url:
         return False
@@ -1304,27 +1309,31 @@ async def _call_openai(
         # output. See F2 in the rc.23 QA report.
         body["response_format"] = {"type": "json_object"}
     if _is_zai_base_url(config.base_url):
-        # #376 ROOT CAUSE FIX. z.ai's GLM-4.5-series-and-up models
-        # (including the cheap extraction workhorse ``glm-4.5-flash``)
-        # default to ``thinking: {"type": "enabled"}``. With thinking on,
-        # the model spends the generation budget emitting chain-of-thought
-        # into ``message.reasoning_content`` and can return an EMPTY
-        # ``message.content`` — HTTP 200, no error. The extraction parser
-        # only reads ``content``, so the turn silently produces zero facts
-        # (rc7 QA: the #376 fallback fired 12× and STILL extracted nothing,
-        # because the flagship retry hits the SAME thinking-mode default).
+        # EFFICIENCY: z.ai's GLM-4.5-series-and-up models (including the
+        # cheap extraction workhorse ``glm-4.5-flash``) default to
+        # ``thinking: {"type": "enabled"}``. With thinking on, the model
+        # spends generation budget emitting chain-of-thought into
+        # ``message.reasoning_content`` before answering. For our cheap,
+        # JSON-shaped extraction prompts that reasoning pass adds latency
+        # and burns completion tokens for no quality gain.
         #
-        # Sending ``thinking: {"type": "disabled"}`` tells GLM to put the
-        # answer in ``content``. This is z.ai's documented parameter
-        # (default "enabled"; allowed "enabled"/"disabled"); it applies to
-        # GLM-4.5 series and higher and is a no-op on providers that ignore
-        # it. SAME provider, SAME endpoint, SAME key — only the request
-        # body changes. We deliberately do NOT flip the endpoint (the
+        # Sending ``thinking: {"type": "disabled"}`` tells GLM to answer
+        # directly in ``content``. z.ai's documented parameter (default
+        # "enabled"; allowed "enabled"/"disabled"); applies to GLM-4.5
+        # series and higher and is a no-op on providers that ignore it.
+        # SAME provider, SAME endpoint, SAME key — only the request body
+        # changes. We deliberately do NOT flip the endpoint (the
         # Coding-plan key is endpoint-scoped; flipping 401s).
         #
-        # Belt-and-suspenders for any provider/version that ignores the
-        # flag: ``_call_openai`` below also falls back to
-        # ``reasoning_content`` when ``content`` is empty.
+        # NOTE: this is NOT the #376 fix. At a realistic max_tokens budget
+        # GLM populates ``content`` regardless of thinking mode; the #376
+        # QA empties were instant 200-empty responses (quota/throttle,
+        # ~14ms), not thinking-mode content/reasoning splits. Disabling
+        # thinking is an efficiency + hardening measure that ALSO removes
+        # one possible empty-content path; the real #376 fix (detect
+        # quota-exhausted instant-empty → surface an actionable error) is
+        # tracked separately. The recovery + rich diag below cover any
+        # residual empty-content case.
         body["thinking"] = {"type": "disabled"}
 
     async with httpx.AsyncClient(timeout=_LLM_TIMEOUT) as client:
@@ -1342,17 +1351,19 @@ async def _call_openai(
         message = choice.get("message", {}) or {}
         content = message.get("content")
         if not content:
-            # #376 belt-and-suspenders: GLM (and some other reasoning
+            # OBSERVABILITY + HARDENING: GLM (and some other reasoning
             # models, e.g. Gemma on OpenAI-compat endpoints) can leave
             # ``content`` empty while placing the actual answer in
-            # ``reasoning_content`` whenever thinking mode is active. We
-            # send ``thinking: {"type": "disabled"}`` for z.ai above to
-            # prevent this, but if a provider/version ignores that flag we
-            # still recover the payload here instead of silently dropping
-            # the whole extraction turn. The extraction parser already
-            # strips ``<think>`` wrappers and bracket-scans for the JSON
-            # body, so a reasoning_content blob that wraps the JSON parses
-            # cleanly.
+            # ``reasoning_content`` when thinking mode is active. We send
+            # ``thinking: {"type": "disabled"}`` for z.ai above so this
+            # path should not trigger there, but if a provider/version
+            # ignores that flag we recover the payload here instead of
+            # silently dropping the extraction turn. The extraction parser
+            # already strips ``<think>`` wrappers and bracket-scans for the
+            # JSON body, so a reasoning_content blob that wraps the JSON
+            # parses cleanly. (Recovery is a safety net, not the #376 fix —
+            # #376's empties were truly empty, no reasoning_content to
+            # recover; those fall through to the rich diag below.)
             reasoning = message.get("reasoning_content")
             if isinstance(reasoning, str) and reasoning.strip():
                 logger.warning(
@@ -1366,23 +1377,36 @@ async def _call_openai(
                     len(reasoning),
                 )
                 return reasoning
-            # F2 — empty responses must be loud, not silent. Prior to
-            # rc.24 this was logged as a generic "returned None/empty"
-            # downstream in extraction.py at INFO. Surface the actual
-            # response shape (finish_reason, usage) at WARN here so the
-            # operator can correlate empty extraction batches with the
-            # provider response without enabling DEBUG.
+            # Truly empty (no content AND no reasoning_content to recover).
+            # Surface the FULL response shape at WARN so the cause is
+            # diagnosable on the next run without DEBUG (#318): raw HTTP
+            # status + rate-limit/quota headers + a body snippet, on top of
+            # finish_reason/usage/message-keys. This is what distinguishes an
+            # exhausted/throttled key (instant 200-empty, rl headers) from a
+            # token-budget or formatting issue (finish_reason=length, usage).
+            rl_headers = {
+                k: v for k, v in resp.headers.items()
+                if any(t in k.lower() for t in ("ratelimit", "quota", "x-request-id", "retry-after"))
+            }
             logger.warning(
                 "LLM returned empty content (provider=%s, model=%s, "
-                "system_chars=%d, user_chars=%d, finish_reason=%s, usage=%s, "
-                "json_response_format=%s)",
+                "http_status=%s, system_chars=%d, user_chars=%d, finish_reason=%s, "
+                "usage=%s, json_response_format=%s, message_keys=%s, "
+                "reasoning_content_present=%s, reasoning_content_chars=%d, "
+                "rl_headers=%s, body_snippet=%r)",
                 config.base_url,
                 config.model,
+                resp.status_code,
                 len(system_prompt or ""),
                 len(user_prompt or ""),
                 choice.get("finish_reason"),
                 data.get("usage"),
                 "response_format" in body,
+                sorted(message.keys()),
+                reasoning is not None,
+                len(reasoning or ""),
+                rl_headers,
+                str(message)[:400],
             )
         return content
 

--- a/python/tests/test_extraction_empty_response_visibility.py
+++ b/python/tests/test_extraction_empty_response_visibility.py
@@ -63,9 +63,14 @@ from totalreclaw.agent.llm_client import (
 class _FakeResp:
     """Stub of ``httpx.Response`` exercising only what _call_openai uses."""
 
-    def __init__(self, payload: dict, status_code: int = 200) -> None:
+    def __init__(
+        self, payload: dict, status_code: int = 200, headers: dict | None = None
+    ) -> None:
         self._payload = payload
         self.status_code = status_code
+        # _call_openai's empty-content diag scans response headers for
+        # rate-limit/quota markers; mirror httpx.Response.headers.
+        self.headers = headers or {}
 
     def json(self) -> dict:
         return self._payload

--- a/python/tests/test_issue_376_zai_thinking_mode.py
+++ b/python/tests/test_issue_376_zai_thinking_mode.py
@@ -1,0 +1,393 @@
+"""#376 ROOT-CAUSE — z.ai GLM ``thinking`` mode empties ``message.content``.
+
+Symptom (rc7 QA, z.ai GLM Coding Plan stack)
+--------------------------------------------
+Hermes auto-extraction was a SILENT no-op on z.ai Coding: the "#376
+fallback" fired 12× and extraction still produced ZERO facts. Other
+providers (Anthropic / OpenAI / Gemini) were unaffected.
+
+Root cause
+----------
+z.ai's GLM-4.5-series-and-up models — INCLUDING the cheap extraction
+workhorse ``glm-4.5-flash`` — default to ``thinking: {"type":
+"enabled"}``. With thinking on, the model emits its chain-of-thought into
+``message.reasoning_content`` and can return an EMPTY ``message.content``
+(HTTP 200, no error). The extraction parser only reads ``content``, so the
+turn silently yields nothing. The #376 chat-model fallback re-issues the
+request on the SAME endpoint with the SAME thinking-mode default, so the
+flagship empties too → silent no-op.
+
+  Evidence:
+    - z.ai docs: ``thinking`` request param, default "enabled", allowed
+      "enabled"/"disabled"; reasoning lands in ``message.reasoning_content``;
+      applies to GLM-4.5 series and higher.
+    - Community reports: Z.AI GLM returns ``{"content":"","reasoning_content":
+      "..."}`` unless thinking is disabled; NousResearch/hermes-agent#16533
+      (z.ai expects ``thinking={"type":"enabled"}``), oh-my-openagent#980,
+      ollama#15288 (same empty-content-into-reasoning pattern).
+
+Fix (this change)
+-----------------
+1. PRIMARY: ``_call_openai`` sends ``thinking: {"type": "disabled"}`` for
+   z.ai endpoints so the answer lands in ``content``. SAME provider, SAME
+   endpoint, SAME key — only the request body changes. NOT sent to
+   non-z.ai providers (would 400 on OpenAI et al.).
+2. BELT-AND-SUSPENDERS: when ``content`` is empty, ``_call_openai`` falls
+   back to ``reasoning_content`` so any provider/version that ignores the
+   flag still yields the payload (the parser strips ``<think>`` and
+   bracket-scans for the JSON body).
+3. SAFETY NET: when the cheap model AND the #376 chat-model fallback both
+   come back empty, the no-op WARNING is now ACTIONABLE — it instructs the
+   operator to set ``TOTALRECLAW_EXTRACTION_MODEL``.
+
+All tests mock ``httpx`` / ``chat_completion`` — NO network, NO real keys.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from totalreclaw.agent import extraction
+from totalreclaw.agent.extraction import extract_facts_llm, extract_facts_compaction
+from totalreclaw.agent.llm_client import (
+    LLMConfig,
+    ZAI_CODING_BASE_URL,
+    ZAI_STANDARD_BASE_URL,
+    _is_zai_base_url,
+    chat_completion,
+    derive_extraction_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — minimal httpx.Response double (mirrors the convention in
+# test_extraction_empty_response_visibility.py).
+# ---------------------------------------------------------------------------
+
+
+class _FakeResp:
+    def __init__(self, payload: dict, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self) -> dict:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            import httpx
+
+            raise httpx.HTTPStatusError(
+                "fake error",
+                request=MagicMock(),
+                response=MagicMock(status_code=self.status_code),
+            )
+
+
+def _post_returning(payload: dict, status_code: int = 200) -> AsyncMock:
+    return AsyncMock(return_value=_FakeResp(payload, status_code=status_code))
+
+
+_LONG_MSG = (
+    "Hi, I'm Pedro. I live in Porto and I use PostgreSQL for all my side "
+    "projects — never MySQL. I also prefer Vim over VS Code."
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. z.ai endpoint detection (gates the thinking-mode fix).
+# ---------------------------------------------------------------------------
+
+
+def test_is_zai_base_url_matches_both_endpoints() -> None:
+    assert _is_zai_base_url(ZAI_CODING_BASE_URL)
+    assert _is_zai_base_url(ZAI_STANDARD_BASE_URL)
+    # Trailing slash / case variations still match (substring on lower()).
+    assert _is_zai_base_url("https://API.Z.AI/api/coding/paas/v4/")
+
+
+def test_is_zai_base_url_rejects_other_providers() -> None:
+    assert not _is_zai_base_url("https://api.openai.com/v1")
+    assert not _is_zai_base_url("https://api.anthropic.com/v1")
+    assert not _is_zai_base_url("https://generativelanguage.googleapis.com/v1beta/openai")
+    assert not _is_zai_base_url("https://my-self-hosted.example.com/v1")
+    assert not _is_zai_base_url("")
+
+
+# ---------------------------------------------------------------------------
+# 2. PRIMARY FIX — thinking:{type:disabled} is sent for z.ai, and ONLY z.ai.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", [ZAI_CODING_BASE_URL, ZAI_STANDARD_BASE_URL])
+async def test_zai_request_disables_thinking(endpoint: str) -> None:
+    """The z.ai request body MUST carry ``thinking: {"type": "disabled"}``.
+
+    This is the #376 root-cause fix: without it, GLM-4.5-flash routes its
+    output into reasoning_content and returns empty ``content``.
+    """
+    cfg = LLMConfig(api_key="k", base_url=endpoint, model="glm-4.5-flash", api_format="openai")
+    fake = _post_returning({"choices": [{"message": {"content": '{"topics":[],"facts":[]}'}}]})
+    with patch("httpx.AsyncClient.post", new=fake):
+        out = await chat_completion(cfg, "system", "user")
+
+    assert out == '{"topics":[],"facts":[]}'
+    body = fake.await_args.kwargs.get("json") or {}
+    assert body.get("thinking") == {"type": "disabled"}, (
+        "z.ai request must disable thinking so the answer lands in content; "
+        f"got body keys {sorted(body.keys())}"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://api.openai.com/v1",
+        "https://api.anthropic.com/v1",  # routed via _call_openai only if api_format=openai; still must not carry thinking
+        "https://my-self-hosted.example.com/v1",
+    ],
+)
+async def test_non_zai_request_omits_thinking(base_url: str) -> None:
+    """``thinking`` is a z.ai-only field. Sending it to OpenAI (and other
+    strict OpenAI-spec providers) risks a 400, so it must be absent for
+    every non-z.ai endpoint."""
+    cfg = LLMConfig(api_key="k", base_url=base_url, model="some-model", api_format="openai")
+    fake = _post_returning({"choices": [{"message": {"content": "ok"}}]})
+    with patch("httpx.AsyncClient.post", new=fake):
+        await chat_completion(cfg, "system", "user")
+    body = fake.await_args.kwargs.get("json") or {}
+    assert "thinking" not in body, f"non-z.ai provider {base_url} must not get a thinking field"
+
+
+# ---------------------------------------------------------------------------
+# 3. BELT-AND-SUSPENDERS — empty content recovers from reasoning_content.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_content_recovers_from_reasoning_content(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """If a provider ignores ``thinking:disabled`` and still returns empty
+    ``content`` with the payload in ``reasoning_content``, ``_call_openai``
+    must recover it instead of dropping the turn."""
+    cfg = LLMConfig(api_key="k", base_url=ZAI_CODING_BASE_URL, model="glm-4.5-flash", api_format="openai")
+    payload = {
+        "choices": [
+            {
+                "message": {
+                    "content": "",
+                    "reasoning_content": '{"topics": ["identity"], "facts": []}',
+                },
+                "finish_reason": "stop",
+            }
+        ]
+    }
+    caplog.set_level(logging.WARNING, logger="totalreclaw.agent.llm_client")
+    with patch("httpx.AsyncClient.post", new=_post_returning(payload)):
+        out = await chat_completion(cfg, "system", "user")
+
+    assert out == '{"topics": ["identity"], "facts": []}', "must recover the reasoning_content payload"
+    # And it should announce the recovery (so operators know thinking mode leaked through).
+    assert any(
+        "recovering from reasoning_content" in r.getMessage()
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+    ), "recovery must be logged at WARNING"
+
+
+@pytest.mark.asyncio
+async def test_empty_content_and_empty_reasoning_warns_and_returns_empty(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When BOTH ``content`` and ``reasoning_content`` are empty, the
+    original loud "LLM returned empty content" WARNING still fires and the
+    call returns empty (no false recovery)."""
+    cfg = LLMConfig(api_key="k", base_url=ZAI_CODING_BASE_URL, model="glm-4.5-flash", api_format="openai")
+    payload = {
+        "choices": [{"message": {"content": "", "reasoning_content": "   "}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 100, "completion_tokens": 0},
+    }
+    caplog.set_level(logging.WARNING, logger="totalreclaw.agent.llm_client")
+    with patch("httpx.AsyncClient.post", new=_post_returning(payload)):
+        out = await chat_completion(cfg, "system", "user")
+
+    assert out in (None, "")
+    assert any(
+        "LLM returned empty content" in r.getMessage()
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+    ), "genuinely-empty response must still WARN with response shape"
+    # Must NOT have claimed a recovery.
+    assert not any(
+        "recovering from reasoning_content" in r.getMessage() for r in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_reasoning_content_ignored_when_content_present() -> None:
+    """``content`` wins when present — reasoning_content is only a fallback."""
+    cfg = LLMConfig(api_key="k", base_url=ZAI_CODING_BASE_URL, model="glm-4.5-flash", api_format="openai")
+    payload = {
+        "choices": [
+            {"message": {"content": "REAL ANSWER", "reasoning_content": "should be ignored"}}
+        ]
+    }
+    with patch("httpx.AsyncClient.post", new=_post_returning(payload)):
+        out = await chat_completion(cfg, "system", "user")
+    assert out == "REAL ANSWER"
+
+
+# ---------------------------------------------------------------------------
+# 4. z.ai model-selection (the derivation feeding the request).
+# ---------------------------------------------------------------------------
+
+
+def test_derive_extraction_config_zai_uses_flash_same_endpoint_same_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The derived extraction config swaps to ``glm-4.5-flash`` while
+    keeping the user's endpoint + key (so the thinking-mode fix above runs
+    against the same Coding/Standard endpoint the user is entitled to)."""
+    monkeypatch.delenv("TOTALRECLAW_EXTRACTION_MODEL", raising=False)
+    monkeypatch.delenv("ZAI_BASE_URL", raising=False)
+    chat = LLMConfig(api_key="sk-coding", base_url=ZAI_CODING_BASE_URL, model="glm-5.1", api_format="openai")
+    ext = derive_extraction_config(chat)
+    assert ext.model == "glm-4.5-flash"
+    assert ext.base_url == ZAI_CODING_BASE_URL, "no endpoint flip — key is endpoint-scoped"
+    assert ext.api_key == "sk-coding"
+    assert ext.api_format == "openai"
+
+
+def test_extraction_model_override_pins_verbatim(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The operator escape hatch named in the actionable warning actually
+    pins the extraction model verbatim (so following the advice works)."""
+    monkeypatch.setenv("TOTALRECLAW_EXTRACTION_MODEL", "glm-5.1")
+    chat = LLMConfig(api_key="sk", base_url=ZAI_CODING_BASE_URL, model="glm-5.1", api_format="openai")
+    ext = derive_extraction_config(chat)
+    assert ext.model == "glm-5.1"
+    assert ext.base_url == ZAI_CODING_BASE_URL
+
+
+# ---------------------------------------------------------------------------
+# 5. Full path: empty -> #376 fallback -> ACTIONABLE warning.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_double_empty_emits_actionable_warning_naming_env_var(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When the cheap model AND the #376 chat-model fallback both empty,
+    the final no-op WARNING must be ACTIONABLE: name
+    ``TOTALRECLAW_EXTRACTION_MODEL`` and a concrete value to try.
+
+    This is the safety net required so the failure is NEVER silent again.
+    """
+    chat = LLMConfig(api_key="k", base_url=ZAI_CODING_BASE_URL, model="glm-5.1", api_format="openai")
+
+    seen: list[str] = []
+
+    async def fake_cc(cfg, system, user, *a, **k):
+        seen.append(cfg.model)
+        return ""  # both attempts empty
+
+    monkeypatch_target = "totalreclaw.agent.extraction.chat_completion"
+    caplog.set_level(logging.WARNING, logger="totalreclaw.agent.extraction")
+    with patch(monkeypatch_target, new=fake_cc):
+        out = await extract_facts_llm([{"role": "user", "content": _LONG_MSG}], llm_config=chat)
+
+    assert out == []
+    # The #376 fallback must have fired: cheap model first, chat model second.
+    assert seen == ["glm-4.5-flash", "glm-5.1"], seen
+
+    final = [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "NO-OP" in r.getMessage()
+    ]
+    assert final, "expected a final NO-OP warning after both attempts emptied"
+    msg = final[-1]
+    assert "TOTALRECLAW_EXTRACTION_MODEL" in msg, "warning must name the override env var (actionable)"
+    assert "glm-4.5-flash" in msg, "warning should name the known-good default to try"
+    # Names the cheap model and the chat-model fallback that were tried.
+    assert "glm-5.1" in msg
+
+
+@pytest.mark.asyncio
+async def test_compaction_double_empty_emits_actionable_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The compaction path's empty-response warning is likewise actionable
+    (compaction is the last-chance capture, so a silent no-op is data loss)."""
+    chat = LLMConfig(api_key="k", base_url=ZAI_CODING_BASE_URL, model="glm-5.1", api_format="openai")
+
+    async def fake_cc(cfg, system, user, *a, **k):
+        return ""
+
+    caplog.set_level(logging.WARNING, logger="totalreclaw.agent.extraction")
+    with patch("totalreclaw.agent.extraction.chat_completion", new=fake_cc):
+        out = await extract_facts_compaction(
+            [{"role": "user", "content": _LONG_MSG}], llm_config=chat
+        )
+
+    assert out == []
+    final = [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "NO-OP" in r.getMessage()
+    ]
+    assert final, "expected a NO-OP warning from compaction"
+    assert "TOTALRECLAW_EXTRACTION_MODEL" in final[-1]
+
+
+@pytest.mark.asyncio
+async def test_thinking_disabled_makes_extraction_produce_facts_end_to_end() -> None:
+    """End-to-end happy path proving the fix RESTORES extraction on z.ai:
+    a mocked z.ai response (as it now behaves with thinking disabled —
+    JSON in ``content``) flows through ``extract_facts_llm`` and yields a
+    fact. Guards against a regression back to the silent no-op.
+    """
+    chat = LLMConfig(api_key="sk-zai", base_url=ZAI_CODING_BASE_URL, model="glm-5.1", api_format="openai")
+    canned = json.dumps(
+        {
+            "topics": ["identity"],
+            "facts": [
+                {
+                    "text": "User lives in Porto and uses PostgreSQL for side projects.",
+                    "type": "claim",
+                    "importance": 8,
+                    "action": "ADD",
+                    "source": "user",
+                    "scope": "personal",
+                    "volatility": "stable",
+                }
+            ],
+        }
+    )
+
+    # Drive at the httpx layer so the real _call_openai (with the thinking
+    # field + content read) is exercised, not just a stubbed chat_completion.
+    captured_bodies: list[dict] = []
+
+    async def fake_post(self, url, **kwargs):
+        captured_bodies.append(kwargs.get("json") or {})
+        return _FakeResp({"choices": [{"message": {"content": canned}}]})
+
+    with patch("httpx.AsyncClient.post", new=fake_post):
+        facts = await extract_facts_llm(
+            [{"role": "user", "content": _LONG_MSG}], mode="turn", llm_config=chat
+        )
+
+    assert len(facts) > 0, "extraction must produce facts on z.ai now that thinking is disabled"
+    assert facts[0].type == "claim"
+    # The extraction request actually disabled thinking + used the cheap model.
+    assert captured_bodies, "no request was issued"
+    first = captured_bodies[0]
+    assert first.get("thinking") == {"type": "disabled"}
+    assert first.get("model") == "glm-4.5-flash"

--- a/python/tests/test_issue_376_zai_thinking_mode.py
+++ b/python/tests/test_issue_376_zai_thinking_mode.py
@@ -1,44 +1,51 @@
-"""#376 ROOT-CAUSE — z.ai GLM ``thinking`` mode empties ``message.content``.
+"""z.ai GLM extraction efficiency + empty-content observability.
 
-Symptom (rc7 QA, z.ai GLM Coding Plan stack)
---------------------------------------------
-Hermes auto-extraction was a SILENT no-op on z.ai Coding: the "#376
-fallback" fired 12× and extraction still produced ZERO facts. Other
-providers (Anthropic / OpenAI / Gemini) were unaffected.
+Scope
+-----
+These tests cover three z.ai-related hardening measures for the extraction
+path. They are EFFICIENCY + OBSERVABILITY, not the #376 fix (see note).
 
-Root cause
-----------
-z.ai's GLM-4.5-series-and-up models — INCLUDING the cheap extraction
-workhorse ``glm-4.5-flash`` — default to ``thinking: {"type":
-"enabled"}``. With thinking on, the model emits its chain-of-thought into
-``message.reasoning_content`` and can return an EMPTY ``message.content``
-(HTTP 200, no error). The extraction parser only reads ``content``, so the
-turn silently yields nothing. The #376 chat-model fallback re-issues the
-request on the SAME endpoint with the SAME thinking-mode default, so the
-flagship empties too → silent no-op.
+z.ai's GLM-4.5-series-and-up models — including the cheap extraction
+workhorse ``glm-4.5-flash`` — default to ``thinking: {"type": "enabled"}``.
+With thinking on, the model spends generation budget emitting
+chain-of-thought into ``message.reasoning_content`` before answering. For
+our cheap, JSON-shaped extraction prompts that reasoning pass adds latency
+and burns completion tokens for no quality gain, and in edge cases (very
+small token budgets) can split the answer across ``reasoning_content`` with
+an empty ``content``.
 
   Evidence:
     - z.ai docs: ``thinking`` request param, default "enabled", allowed
       "enabled"/"disabled"; reasoning lands in ``message.reasoning_content``;
       applies to GLM-4.5 series and higher.
-    - Community reports: Z.AI GLM returns ``{"content":"","reasoning_content":
-      "..."}`` unless thinking is disabled; NousResearch/hermes-agent#16533
-      (z.ai expects ``thinking={"type":"enabled"}``), oh-my-openagent#980,
-      ollama#15288 (same empty-content-into-reasoning pattern).
+    - Community reports of ``{"content":"","reasoning_content":"..."}``
+      content/reasoning splits at tight token budgets.
 
-Fix (this change)
------------------
-1. PRIMARY: ``_call_openai`` sends ``thinking: {"type": "disabled"}`` for
-   z.ai endpoints so the answer lands in ``content``. SAME provider, SAME
-   endpoint, SAME key — only the request body changes. NOT sent to
-   non-z.ai providers (would 400 on OpenAI et al.).
-2. BELT-AND-SUSPENDERS: when ``content`` is empty, ``_call_openai`` falls
-   back to ``reasoning_content`` so any provider/version that ignores the
-   flag still yields the payload (the parser strips ``<think>`` and
+NOTE — NOT the #376 fix
+-----------------------
+Thinking mode is NOT the root cause of #376. At a realistic max_tokens
+budget GLM populates ``content`` with thinking on or off; the #376 QA
+empties were instant 200-empty responses (quota/throttle, ~14ms), with no
+``reasoning_content`` to recover. The real #376 fix — detect
+quota-exhausted instant-empty and surface an actionable "z.ai quota
+exhausted" error — is tracked separately. This change reduces wasted work
+and makes any residual empty-content case loud and diagnosable.
+
+Changes covered
+---------------
+1. EFFICIENCY: ``_call_openai`` sends ``thinking: {"type": "disabled"}`` for
+   z.ai endpoints so the answer lands in ``content`` without a reasoning
+   pass. SAME provider, SAME endpoint, SAME key — only the request body
+   changes. NOT sent to non-z.ai providers (would 400 on OpenAI et al.).
+2. HARDENING: when ``content`` is empty, ``_call_openai`` falls back to
+   ``reasoning_content`` so any provider/version that ignores the flag
+   still yields the payload (the parser strips ``<think>`` and
    bracket-scans for the JSON body).
-3. SAFETY NET: when the cheap model AND the #376 chat-model fallback both
-   come back empty, the no-op WARNING is now ACTIONABLE — it instructs the
-   operator to set ``TOTALRECLAW_EXTRACTION_MODEL``.
+3. OBSERVABILITY: when both ``content`` and ``reasoning_content`` are empty,
+   ``_call_openai`` WARNs with the full response shape (#318 rich diag), and
+   when the cheap model AND the chat-model fallback both empty, the
+   extraction no-op WARNING is ACTIONABLE — it names
+   ``TOTALRECLAW_EXTRACTION_MODEL``.
 
 All tests mock ``httpx`` / ``chat_completion`` — NO network, NO real keys.
 """
@@ -69,9 +76,14 @@ from totalreclaw.agent.llm_client import (
 
 
 class _FakeResp:
-    def __init__(self, payload: dict, status_code: int = 200) -> None:
+    def __init__(
+        self, payload: dict, status_code: int = 200, headers: dict | None = None
+    ) -> None:
         self._payload = payload
         self.status_code = status_code
+        # _call_openai's rich empty-content diag scans response headers for
+        # rate-limit/quota markers; mirror httpx.Response.headers.
+        self.headers = headers or {}
 
     def json(self) -> dict:
         return self._payload
@@ -127,8 +139,9 @@ def test_is_zai_base_url_rejects_other_providers() -> None:
 async def test_zai_request_disables_thinking(endpoint: str) -> None:
     """The z.ai request body MUST carry ``thinking: {"type": "disabled"}``.
 
-    This is the #376 root-cause fix: without it, GLM-4.5-flash routes its
-    output into reasoning_content and returns empty ``content``.
+    Efficiency: disabling thinking skips the chain-of-thought pass on cheap
+    JSON extraction calls (faster, fewer completion tokens) and avoids the
+    content/reasoning_content split at tight token budgets.
     """
     cfg = LLMConfig(api_key="k", base_url=endpoint, model="glm-4.5-flash", api_format="openai")
     fake = _post_returning({"choices": [{"message": {"content": '{"topics":[],"facts":[]}'}}]})
@@ -227,6 +240,44 @@ async def test_empty_content_and_empty_reasoning_warns_and_returns_empty(
     assert not any(
         "recovering from reasoning_content" in r.getMessage() for r in caplog.records
     )
+
+
+@pytest.mark.asyncio
+async def test_truly_empty_diag_surfaces_full_response_shape(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Supersedes PR #318: when ``content`` is empty with NO recoverable
+    ``reasoning_content``, the WARN must carry the FULL response shape so an
+    operator can tell a quota/throttle instant-empty (rl headers, HTTP 200,
+    no reasoning) apart from a token-budget/formatting issue (finish_reason,
+    usage) WITHOUT needing DEBUG. This is the observability guarantee behind
+    the #376 forensics.
+    """
+    cfg = LLMConfig(api_key="k", base_url=ZAI_CODING_BASE_URL, model="glm-4.5-flash", api_format="openai")
+    payload = {
+        "choices": [{"finish_reason": "length", "message": {"content": ""}}],
+        "usage": {"prompt_tokens": 12, "completion_tokens": 0, "total_tokens": 12},
+    }
+    caplog.set_level(logging.WARNING, logger="totalreclaw.agent.llm_client")
+    with patch("httpx.AsyncClient.post", new=_post_returning(payload)):
+        out = await chat_completion(cfg, "system", "user")
+
+    assert out in (None, "")
+    diag = [
+        r.getMessage()
+        for r in caplog.records
+        if "LLM returned empty content" in r.getMessage()
+    ]
+    assert diag, "truly-empty response must emit the rich diag"
+    msg = diag[0]
+    # Field-level guarantees (the #318 contribution over a bare WARN string).
+    assert "finish_reason=length" in msg
+    assert "reasoning_content_present=False" in msg
+    assert "reasoning_content_chars=0" in msg
+    assert "message_keys=" in msg
+    assert "http_status=200" in msg
+    assert "rl_headers=" in msg
+    assert "usage=" in msg
 
 
 @pytest.mark.asyncio
@@ -348,10 +399,11 @@ async def test_compaction_double_empty_emits_actionable_warning(
 
 @pytest.mark.asyncio
 async def test_thinking_disabled_makes_extraction_produce_facts_end_to_end() -> None:
-    """End-to-end happy path proving the fix RESTORES extraction on z.ai:
-    a mocked z.ai response (as it now behaves with thinking disabled —
-    JSON in ``content``) flows through ``extract_facts_llm`` and yields a
-    fact. Guards against a regression back to the silent no-op.
+    """End-to-end happy path on z.ai with thinking disabled: a mocked z.ai
+    response (JSON in ``content``) flows through ``extract_facts_llm`` and
+    yields a fact, while the issued request carries
+    ``thinking: {"type": "disabled"}`` and the cheap model. Guards the
+    efficiency path + request shape against regression.
     """
     chat = LLMConfig(api_key="sk-zai", base_url=ZAI_CODING_BASE_URL, model="glm-5.1", api_format="openai")
     canned = json.dumps(


### PR DESCRIPTION
## What

Two z.ai-related hardening measures for the extraction path, reconciled into **one** PR (supersedes #318, which touched the same files):

1. **Efficiency** — `_call_openai` sends `thinking: {"type": "disabled"}` on z.ai endpoints. GLM-4.5+ defaults thinking ON, burning completion tokens + latency on a chain-of-thought pass that adds nothing to cheap JSON-shaped extraction prompts. Same provider, same endpoint, same key — only the request body changes. Not sent to non-z.ai providers (would 400 on OpenAI et al.).
2. **Hardening** — when `content` is empty, recover from `reasoning_content` (any provider/version that ignores the flag still yields the payload; parser strips `<think>` and bracket-scans for JSON).
3. **Observability (#318)** — when `content` is empty with **no** recoverable `reasoning_content`, WARN with the full response shape: `http_status`, rate-limit/quota headers, `message_keys`, `reasoning_content` presence/chars, `finish_reason`, `usage`, body snippet. Lets an operator distinguish a quota/throttle instant-empty from a token-budget/formatting issue without DEBUG.

## NOT the #376 fix

**Thinking mode is not the root cause of #376.** At a realistic `max_tokens` budget GLM populates `content` with thinking on or off; the #376 QA empties were instant 200-empty responses (quota/throttle, ~14ms) with no `reasoning_content` to recover. The earlier branch comments + the #318 PR framing both asserted thinking-mode-is-root-cause — **corrected here** to efficiency + observability framing (llm_client.py comments + `test_issue_376_zai_thinking_mode.py` module docstring).

The real #376 fix (detect quota-exhausted instant-empty → actionable "z.ai quota exhausted" error) is **tracked separately and intentionally not folded in.**

## Tests

`test_issue_376_zai_thinking_mode.py` (15) + `test_issue_376_extraction_empty_fallback.py` + `test_extraction_empty_response_visibility.py` — added `test_truly_empty_diag_surfaces_full_response_shape` (the #318 field-level guarantee), gave `_FakeResp` doubles a `headers` attr to mirror `httpx.Response`. **232 passed** in the llm/extraction/zai subset (psutil import-adapter tests excluded — unrelated env gap).

Supersedes #318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
