### PR TITLE
fix: core 2.5.1 for parse_gemini API (2.5.0 already published without it)

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -30,9 +30,12 @@ dependencies = [
     # >=2.5.0: chain/env-aware DataEdge param on encode_single_call /
     # encode_batch_call (#366). Once the relay reports data_edge_address,
     # the client passes it through and requires the parameterized core API.
-    # Also 2.5.0: import adapters delegate ALL Gemini format parsing to the
+    # >=2.5.1: import adapters delegate ALL Gemini format parsing to the
     # hoisted `totalreclaw_core.parse_gemini` (no Python-side parser fallback).
-    "totalreclaw-core>=2.5.0,<3.0.0",
+    # parse_gemini was ADDED in core 2.5.1 — PyPI core 2.5.0 (published
+    # 2026-06-05 for #366) predates it, so the floor must be 2.5.1 or the
+    # adapter raises AttributeError at runtime against a 2.5.0 wheel.
+    "totalreclaw-core>=2.5.1,<3.0.0",
     "httpx>=0.27",
     "onnxruntime>=1.24",
     "numpy>=1.26",

--- a/rust/totalreclaw-core/Cargo.lock
+++ b/rust/totalreclaw-core/Cargo.lock
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "totalreclaw-core"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/rust/totalreclaw-core/Cargo.toml
+++ b/rust/totalreclaw-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "totalreclaw-core"
-version = "2.5.0"
+version = "2.5.1"
 edition = "2021"
 description = "TotalReclaw core — E2EE crypto, reranker, wallet, UserOp, store/search pipelines. Single source of truth for all clients."
 license = "MIT"

--- a/rust/totalreclaw-core/pyproject.toml
+++ b/rust/totalreclaw-core/pyproject.toml
@@ -4,7 +4,10 @@ build-backend = "maturin"
 
 [project]
 name = "totalreclaw-core"
-version = "2.5.0"
+# Keep in lockstep with Cargo.toml [package].version. maturin uses THIS value
+# for the PyPI wheel version; Cargo.toml drives crates.io + the wasm-pack npm
+# package. Both MUST match or the PyPI wheel ships under the wrong version.
+version = "2.5.1"
 description = "TotalReclaw crypto core — E2EE, LSH, blind indices, protobuf encoding (Rust)"
 requires-python = ">=3.10"
 license = { text = "MIT" }


### PR DESCRIPTION
## Problem

`totalreclaw-core==2.5.0` was published to PyPI/crates on **2026-06-05** for the #366 DataEdge work — **before** the Gemini parsers merged (#324, today). So `parse_gemini` is **not in published core 2.5.0**. The Python Gemini adapter calls it with no fallback → `AttributeError` at runtime against a 2.5.0 wheel. CI didn't catch it because the Python job builds core locally (maturin), not from PyPI.

## Fix

- Bump core `2.5.0 → 2.5.1` (`parse_gemini` is purely additive).
- Bump Python core floor `>=2.5.0 → >=2.5.1`.

Core **2.5.1** then carries both the validated DataEdge API (#366/#299, hermes 2.4.4rc7 GO) and the new parsers, and must be published to npm/PyPI/crates before the next Python/plugin client release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)