### PR TITLE
ci(npm-publish): migrate publish-core to tokenless OIDC

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -97,25 +97,36 @@ jobs:
           console.log('RC version:', p.version);
           "
 
+      - name: Upgrade npm to latest (required for tokenless OIDC publish)
+        if: inputs.dry-run == false
+        # npm 10.x (Node 22) signs provenance with OIDC but still PUTs with a
+        # legacy token → E404 after NPM_TOKEN expired (the 2026-06-07 core run).
+        # Tokenless OIDC (the OIDC token IS the auth) needs npm >= 11.5.1.
+        run: |
+          npm install -g npm@latest
+          npm --version
+
       - name: Publish
         if: inputs.dry-run == false
+        # OIDC trusted publishing — mirrors the migrated publish-mcp-server job.
+        # Requires a Trusted Publisher config for @totalreclaw/core on npmjs.com
+        # pointing at this workflow file. NO `NODE_AUTH_TOKEN` env — setting it
+        # short-circuits OIDC back to the expired secret-token path (E404).
         run: |
           cd rust/totalreclaw-core/pkg
           TAG="latest"
           if [ "${{ inputs.release-type }}" = "rc" ]; then
             TAG="rc"
           fi
-          echo "Publishing with dist-tag: $TAG"
-          npm publish --access public --tag "$TAG" 2>&1 || {
-            # Tolerate "already published" (403/409) — version already exists on registry
+          echo "Publishing with dist-tag: $TAG (OIDC trusted publishing)"
+          npm publish --access public --tag "$TAG" --provenance 2>&1 || {
+            # Tolerate "already published" — version already exists on registry
             if npm view @totalreclaw/core@$(node -e "console.log(require('./package.json').version)") version 2>/dev/null; then
               echo "Version already published, continuing"
             else
               exit 1
             fi
           }
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Report version
         run: |


### PR DESCRIPTION
Core npm publish still used the expired `NPM_TOKEN` → E404 on the core 2.5.1 run (2026-06-07). Mirrors the already-migrated `publish-mcp-server` job: npm upgrade + drop `NODE_AUTH_TOKEN` + `--provenance`.

**Requires** a Trusted Publisher config for `@totalreclaw/core` on npmjs.com pointing at `npm-publish.yml` (same setup mcp-server has). Until that's configured, OIDC publish will still fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)