### PR TITLE
feat(hermes-import): Pro-only tier gate + proactive completion notification

### DIFF
--- a/python/src/totalreclaw/hermes/hooks.py
+++ b/python/src/totalreclaw/hermes/hooks.py
@@ -622,6 +622,29 @@ def pre_llm_call(state: "PluginState", **kwargs) -> Optional[dict]:
         context_parts.append(quota_warning)
         state.clear_quota_warning()
 
+    # Proactive import-completion notice (PRD-IMP OQ-5) — one-shot per
+    # completed import. The background import task only writes
+    # status=completed; this surfaces it on the next turn so the agent tells
+    # the user the import finished WITHOUT being asked (pull -> push).
+    try:
+        from totalreclaw.import_state import (
+            read_completed_unannounced_imports,
+            mark_import_announced,
+        )
+        for done in read_completed_unannounced_imports():
+            dups = (
+                f", {done.dups_skipped} duplicate(s) skipped"
+                if done.dups_skipped else ""
+            )
+            context_parts.append(
+                f"[totalreclaw] The background import from {done.source} just "
+                f"finished: {done.facts_stored} memories stored{dups}. Proactively "
+                "tell the user the import is done and briefly what was imported."
+            )
+            mark_import_announced(done.import_id)
+    except Exception as e:  # never let notification break the turn
+        logger.debug("import-completion injection skipped: %s", e)
+
     if is_first_turn and user_message:
         # Auto-recall relevant memories for the first turn
         try:

--- a/python/src/totalreclaw/hermes/tools.py
+++ b/python/src/totalreclaw/hermes/tools.py
@@ -769,6 +769,38 @@ async def import_from(args: dict, state: "PluginState", **kwargs) -> str:
         estimate = engine.estimate(source=source, file_path=file_path, content=content)
         total_items = estimate.get("total_chunks") or estimate.get("total_facts") or 0
 
+        # ── Tier gate (PRD-IMP §6: import is a Pro-only feature) ───────────
+        # Interim client-side UX gate: a free-tier user hits the upgrade wall
+        # BEFORE any LLM extraction or on-chain write, so they aren't charged
+        # cost/quota by surprise. The relay still enforces the real write
+        # quota server-side. Full "free gets 1 lifetime trial" enforcement is
+        # pending the relay `import_count_lifetime` field (imp-3); until then
+        # this is strict Pro-only. Fails OPEN if billing is unreachable
+        # (self-hosted / offline) so those flows are not blocked.
+        try:
+            billing = await client.status()
+            tier = (getattr(billing, "tier", "") or "").strip().lower()
+        except Exception:
+            tier = ""
+        if tier and tier != "pro":
+            return json.dumps({
+                "blocked": True,
+                "reason": "import_is_pro_only",
+                "tier": tier,
+                "import_id": import_id,
+                "estimated_facts": estimate.get("estimated_facts"),
+                "estimated_minutes": estimate.get("estimated_minutes"),
+                "message": (
+                    "Importing your AI memory history is a Pro feature. Your "
+                    f"archive looks like ~{estimate.get('estimated_facts', '?')} "
+                    "memories (~"
+                    f"{estimate.get('estimated_minutes', '?')} min to import). "
+                    "Upgrade to Pro ($3.99/mo) to run it — call "
+                    "totalreclaw_upgrade for a checkout link. Nothing was "
+                    "extracted or stored."
+                ),
+            })
+
         if total_items <= _SMALL_IMPORT_THRESHOLD:
             # Small import: process synchronously but still write state for tracking.
             now = datetime.now(timezone.utc).isoformat()

--- a/python/src/totalreclaw/import_state.py
+++ b/python/src/totalreclaw/import_state.py
@@ -37,6 +37,16 @@ class ImportState:
     estimated_minutes: int = 0
     estimated_completion_iso: str = ""
     disclosure_confirmed: bool = False
+    #: Set True once the agent has proactively told the user this import
+    #: finished (the completion-notification one-shot). Prevents re-announcing
+    #: the same completed import on every subsequent turn.
+    announced: bool = False
+
+
+def _coerce_state(data: dict) -> "ImportState":
+    """Build ImportState from a dict, tolerating unknown/legacy keys."""
+    allowed = {f.name for f in __import__("dataclasses").fields(ImportState)}
+    return ImportState(**{k: v for k, v in data.items() if k in allowed})
 
 
 def _state_path(import_id: str) -> Path:
@@ -53,7 +63,7 @@ def write_import_state(state: ImportState) -> None:
 def read_import_state(import_id: str) -> Optional[ImportState]:
     try:
         data = json.loads(_state_path(import_id).read_text(encoding="utf-8"))
-        return ImportState(**data)
+        return _coerce_state(data)
     except Exception:
         return None
 
@@ -75,7 +85,7 @@ def read_most_recent_active_import() -> Optional[ImportState]:
         for p in IMPORT_STATE_DIR.glob("*.json"):
             try:
                 data = json.loads(p.read_text(encoding="utf-8"))
-                state = ImportState(**data)
+                state = _coerce_state(data)
                 if state.status in ("running", "pending"):
                     candidates.append(state)
             except Exception:
@@ -85,3 +95,31 @@ def read_most_recent_active_import() -> Optional[ImportState]:
         return max(candidates, key=lambda s: s.started_at)
     except Exception:
         return None
+
+
+def read_completed_unannounced_imports() -> List[ImportState]:
+    """Return completed imports the agent has not yet proactively reported.
+
+    Used by the Hermes ``pre_llm_call`` hook to inject a one-shot
+    "import finished" note so the agent tells the user without being asked.
+    """
+    out: List[ImportState] = []
+    try:
+        for p in IMPORT_STATE_DIR.glob("*.json"):
+            try:
+                state = _coerce_state(json.loads(p.read_text(encoding="utf-8")))
+                if state.status == "completed" and not state.announced:
+                    out.append(state)
+            except Exception:
+                pass
+    except Exception:
+        pass
+    return sorted(out, key=lambda s: s.last_updated)
+
+
+def mark_import_announced(import_id: str) -> None:
+    """Latch a completed import as announced so it is not reported twice."""
+    state = read_import_state(import_id)
+    if state is not None and not state.announced:
+        state.announced = True
+        write_import_state(state)

--- a/python/tests/test_import_quota_gate_and_notify.py
+++ b/python/tests/test_import_quota_gate_and_notify.py
@@ -1,0 +1,182 @@
+"""Tests for the rc9 import additions:
+
+#1 — Pro-only tier gate in ``totalreclaw_import_from`` (free tier hits the
+     upgrade wall before any extraction; fails open if billing is unreachable).
+#2 — Proactive import-completion notification (one-shot context injection in
+     ``pre_llm_call`` so the agent tells the user the import finished).
+
+All pure/unit: no network, no LLM, no on-chain writes. The import-state dir is
+redirected to a tmp dir so the real ``~/.totalreclaw`` is never touched.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import totalreclaw.import_state as ist
+from totalreclaw.import_state import (
+    ImportState,
+    write_import_state,
+    read_import_state,
+    read_completed_unannounced_imports,
+    mark_import_announced,
+    _coerce_state,
+)
+
+
+def _redirect_state_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(ist, "IMPORT_STATE_DIR", tmp_path / "import-state")
+
+
+# ---------------------------------------------------------------------------
+# import_state helpers (#2 backbone)
+# ---------------------------------------------------------------------------
+
+def test_coerce_tolerates_legacy_and_unknown_keys():
+    s = _coerce_state({
+        "import_id": "a", "source": "gemini", "status": "completed",
+        "started_at": "t", "last_updated": "t",
+        "some_future_field": 123,  # must not blow up
+    })
+    assert s.import_id == "a"
+    assert s.announced is False  # defaulted
+
+
+def test_completed_unannounced_then_marked(tmp_path, monkeypatch):
+    _redirect_state_dir(tmp_path, monkeypatch)
+    write_import_state(ImportState(
+        import_id="i1", source="gemini", status="completed",
+        started_at="2026-06-07T00:00:00+00:00", last_updated="x",
+        facts_stored=7, dups_skipped=2,
+    ))
+    pending = read_completed_unannounced_imports()
+    assert [s.import_id for s in pending] == ["i1"]
+    assert pending[0].facts_stored == 7
+
+    mark_import_announced("i1")
+    assert read_completed_unannounced_imports() == []
+    assert read_import_state("i1").announced is True
+
+
+def test_running_import_is_not_reported_as_complete(tmp_path, monkeypatch):
+    _redirect_state_dir(tmp_path, monkeypatch)
+    write_import_state(ImportState(
+        import_id="r", source="chatgpt", status="running",
+        started_at="t", last_updated="t",
+    ))
+    assert read_completed_unannounced_imports() == []
+
+
+# ---------------------------------------------------------------------------
+# #2 — pre_llm_call proactive completion injection
+# ---------------------------------------------------------------------------
+
+def _configured_state(monkeypatch):
+    from totalreclaw.hermes.state import PluginState
+    state = PluginState()
+    monkeypatch.setattr(state, "is_configured", lambda: True)
+    return state
+
+
+def test_pre_llm_call_injects_completion_once(tmp_path, monkeypatch):
+    _redirect_state_dir(tmp_path, monkeypatch)
+    from totalreclaw.hermes import hooks
+
+    write_import_state(ImportState(
+        import_id="done1", source="gemini", status="completed",
+        started_at="t", last_updated="t", facts_stored=5, dups_skipped=1,
+    ))
+
+    state = _configured_state(monkeypatch)
+    out = hooks.pre_llm_call(state, user_message="hello", is_first_turn=False)
+    assert out and "context" in out
+    ctx = out["context"]
+    assert "finished" in ctx and "5 memories" in ctx and "gemini" in ctx
+
+    # Latched — a second turn must NOT re-announce the same import.
+    out2 = hooks.pre_llm_call(state, user_message="hello", is_first_turn=False)
+    ctx2 = (out2 or {}).get("context", "") if out2 else ""
+    assert "finished" not in ctx2
+    assert read_import_state("done1").announced is True
+
+
+# ---------------------------------------------------------------------------
+# #1 — Pro-only tier gate in import_from
+# ---------------------------------------------------------------------------
+
+def _state_with_tier(tier, *, status_raises=False):
+    from totalreclaw.hermes.state import PluginState
+    state = PluginState()
+    client = MagicMock()
+    if status_raises:
+        client.status = AsyncMock(side_effect=RuntimeError("billing down"))
+    else:
+        client.status = AsyncMock(return_value=MagicMock(tier=tier))
+    state._client = client
+    return state, client
+
+
+def _patch_engine(monkeypatch, *, process=None):
+    import totalreclaw.import_engine as ie
+    monkeypatch.setattr(
+        ie.ImportEngine, "estimate",
+        lambda self, **k: {
+            "total_chunks": 2, "estimated_facts": 50,
+            "estimated_minutes": 3, "num_batches": 1, "batch_size": 25,
+        },
+    )
+    if process is not None:
+        monkeypatch.setattr(ie.ImportEngine, "process_batch", process)
+
+
+@pytest.mark.asyncio
+async def test_free_tier_is_blocked_with_upgrade_message(monkeypatch):
+    from totalreclaw.hermes import tools
+    _patch_engine(monkeypatch)
+    state, client = _state_with_tier("free")
+
+    res = json.loads(await tools.import_from(
+        {"source": "gemini", "content": "irrelevant — estimate is patched"}, state,
+    ))
+    assert res.get("blocked") is True
+    assert res["tier"] == "free"
+    assert "Pro" in res["message"]
+    client.status.assert_awaited()  # tier WAS checked
+
+
+@pytest.mark.asyncio
+async def test_pro_tier_is_not_blocked(tmp_path, monkeypatch):
+    _redirect_state_dir(tmp_path, monkeypatch)
+    from totalreclaw.hermes import tools
+    called = AsyncMock(return_value=MagicMock(
+        facts_stored=3, facts_extracted=3, is_complete=True,
+    ))
+    # process_batch returns a stub so we don't run real extraction.
+    _patch_engine(monkeypatch, process=lambda self, **k: called(**k))
+    state, _client = _state_with_tier("pro")
+
+    res = json.loads(await tools.import_from(
+        {"source": "gemini", "content": "x"}, state,
+    ))
+    assert res.get("blocked") is not True
+    assert called.await_count >= 1  # import actually proceeded
+
+
+@pytest.mark.asyncio
+async def test_billing_unreachable_fails_open(tmp_path, monkeypatch):
+    _redirect_state_dir(tmp_path, monkeypatch)
+    from totalreclaw.hermes import tools
+    called = AsyncMock(return_value=MagicMock(
+        facts_stored=1, facts_extracted=1, is_complete=True,
+    ))
+    _patch_engine(monkeypatch, process=lambda self, **k: called(**k))
+    state, _client = _state_with_tier("free", status_raises=True)
+
+    res = json.loads(await tools.import_from(
+        {"source": "gemini", "content": "x"}, state,
+    ))
+    # Billing down -> do NOT block (self-hosted / offline must still import).
+    assert res.get("blocked") is not True
+    assert called.await_count >= 1


### PR DESCRIPTION
Adds the two import-UX pieces flagged as missing during QA prep, for rc9:

**#1 — Pro-only tier gate** (`import_from`): checks billing tier before any LLM extraction / on-chain write. Free → upgrade wall (+ estimate + `totalreclaw_upgrade` hint); Pro → proceeds; billing unreachable → **fails open** (self-hosted/offline still import). Interim client-side gate — full *free-1-lifetime-trial* enforcement is still pending the relay `import_count_lifetime` field (PRD-IMP imp-3).

**#2 — Proactive completion notification** (`pre_llm_call`): was pull-only (user had to ask "how's the import?"). Now a one-shot context note ("import finished: N stored") is injected on the next turn, latched via a new `ImportState.announced` flag, so the agent tells the user without being asked. Closes PRD-IMP OQ-5 for Hermes.

7 new unit tests; no network/LLM/chain; import-state redirected to tmp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)