### PR TITLE
ci(publish): auto-bump 'latest RC' marker in hermes-setup.md on each RC cut

### DIFF
--- a/.github/workflows/publish-python-client.yml
+++ b/.github/workflows/publish-python-client.yml
@@ -276,3 +276,66 @@ jobs:
         with:
           verbose: true
           attestations: false
+
+  # After a successful RC publish, bump the human-readable "Most recent RC"
+  # marker in the Hermes setup guide. The install commands are version-agnostic
+  # (self-resolving), so this is display-only — but it keeps the doc the agent
+  # fetches honest about what the newest cut is, with zero manual upkeep.
+  bump-rc-doc:
+    name: Bump latest-RC marker in hermes-setup.md
+    needs: [publish]
+    if: ${{ inputs.release-type == 'rc' && inputs.dry-run == false }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Compute target RC version
+        id: ver
+        run: |
+          BASE_VERSION=$(grep '^version' python/pyproject.toml | sed -E 's/version *= *"([^"]+)"/\1/')
+          BASE_NO_RC=$(echo "$BASE_VERSION" | sed -E 's/rc[0-9]+$//')
+          echo "v=${BASE_NO_RC}rc${{ inputs.rc-number }}" >> "$GITHUB_OUTPUT"
+
+      - name: Update the LATEST_RC marker
+        run: |
+          python - "${{ steps.ver.outputs.v }}" <<'PY'
+          import sys, re, pathlib
+          v = sys.argv[1]
+          p = pathlib.Path("docs/guides/hermes-setup.md")
+          s = p.read_text()
+          repl = f"<!-- LATEST_RC -->_Most recent RC published: `{v}`._<!-- /LATEST_RC -->"
+          s2, n = re.subn(r"<!-- LATEST_RC -->.*?<!-- /LATEST_RC -->", repl, s, flags=re.S)
+          if n == 0:
+              raise SystemExit("LATEST_RC marker not found in hermes-setup.md — was it removed?")
+          p.write_text(s2)
+          print(f"hermes-setup.md latest-RC marker -> {v}")
+          PY
+
+      - name: Open / update the marker PR
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: ci/latest-rc-marker
+          base: main
+          commit-message: "docs(hermes-setup): latest RC = ${{ steps.ver.outputs.v }}"
+          title: "docs(hermes-setup): latest RC = ${{ steps.ver.outputs.v }}"
+          body: |
+            Auto-bump of the display-only "Most recent RC published" marker after the **${{ steps.ver.outputs.v }}** PyPI publish, by `publish-python-client.yml`.
+
+            The install commands in the guide are version-agnostic (`pip install --pre --upgrade totalreclaw`), so this number never affects an install — it just keeps the doc the Hermes agent fetches honest about the newest cut.
+
+            🤖 Generated with [Claude Code](https://claude.com/claude-code)
+          delete-branch: true
+          add-paths: |
+            docs/guides/hermes-setup.md
+
+      - name: Enable auto-merge (best-effort)
+        if: steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge --squash --auto "${{ steps.cpr.outputs.pull-request-number }}" \
+            || echo "auto-merge not enabled — marker PR #${{ steps.cpr.outputs.pull-request-number }} left for review/auto-merge-l1."

--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -14,6 +14,8 @@ This document describes how the agent installs and sets up TotalReclaw on Hermes
 | stable (default) | newest final | `pip install totalreclaw` |
 | latest RC | newest pre-release | `pip install --pre --upgrade totalreclaw` |
 
+<!-- LATEST_RC -->_Most recent RC published: `2.4.4rc9`._<!-- /LATEST_RC --> <sub>(display only — auto-bumped by `publish-python-client.yml` on each RC cut; the install commands above are version-agnostic, so this number never affects an install.)</sub>
+
 **Both rows are version-agnostic by design — neither pins a number, so this table never goes stale when an RC is cut.** `pip install totalreclaw` always lands the newest *final*; `pip install --pre --upgrade totalreclaw` always lands the newest *pre-release*. To install a SPECIFIC version, pin it: `pip install --pre totalreclaw==<version>`. `pip index versions totalreclaw` shows exactly what's live on PyPI.
 
 ---


### PR DESCRIPTION
You asked for a live, human-readable 'current RC = X' in the setup guide that stays current automatically.

- Adds a display-only `<!-- LATEST_RC -->` marker to `docs/guides/hermes-setup.md` (seeded at `2.4.4rc9`).
- Adds a `bump-rc-doc` job to `publish-python-client.yml`: after a successful RC publish it rewrites the marker to the published version and opens an **auto-merge PR** (mirrors the `changelog.yml` peter-evans pattern). Best-effort auto-merge; falls back to a review PR if auto-merge isn't enabled.

The install commands stay version-agnostic, so the number is purely informational — but it'll never go stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)