### PR TITLE
feat(hermes): surface memory dates in recall + default source-weights off

### DIFF
--- a/python/src/totalreclaw/agent/recall.py
+++ b/python/src/totalreclaw/agent/recall.py
@@ -10,6 +10,7 @@ integration (Hermes, LangChain, CrewAI, or custom agents).
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timezone
 from typing import Optional, TYPE_CHECKING
 
 from .loop_runner import run_sync
@@ -18,6 +19,46 @@ if TYPE_CHECKING:
     from .state import AgentState
 
 logger = logging.getLogger(__name__)
+
+
+def _fmt_date(created_at) -> str:
+    """Format a Unix-seconds timestamp as 'YYYY-MM-DD', or '' if missing/invalid.
+
+    created_at may be a float, int, or None (legacy entries pre-dating the
+    createdAt subgraph field). The empty string signals to the caller to omit
+    the date tag entirely rather than rendering a placeholder.
+    """
+    if not created_at:
+        return ""
+    try:
+        return datetime.fromtimestamp(float(created_at), tz=timezone.utc).strftime("%Y-%m-%d")
+    except Exception:
+        return ""
+
+
+def _format_recall_context(results) -> str:
+    """Format a list of RerankerResult objects as the LLM recall context block.
+
+    Each memory line includes its recorded date when available:
+      - [category] (YYYY-MM-DD) text
+      - [category] text    (when date is absent)
+
+    A current-date + temporal-reasoning header is prepended so the LLM
+    can compute time deltas without guessing the reference point.
+    """
+    def _line(r):
+        d = _fmt_date(getattr(r, "created_at", None))
+        return f"- [{r.category}] ({d}) {r.text}" if d else f"- [{r.category}] {r.text}"
+
+    memories = "\n".join(_line(r) for r in results)
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    header = (
+        f"## Relevant memories from TotalReclaw\n"
+        f"The current date is {today}. Each memory is tagged with the date it was "
+        f"recorded. When the question involves timing or duration, reason carefully "
+        f"about the dates and compute differences precisely.\n"
+    )
+    return f"{header}{memories}"
 
 
 def auto_recall(
@@ -52,8 +93,7 @@ def auto_recall(
         results = run_sync(client.recall(query, top_k=top_k))
 
         if results:
-            memories = "\n".join(f"- [{r.category}] {r.text}" for r in results)
-            return f"## Relevant memories from TotalReclaw\n{memories}"
+            return _format_recall_context(results)
     except Exception as e:
         logger.warning("TotalReclaw auto-recall failed: %s", e)
 
@@ -85,8 +125,7 @@ async def auto_recall_async(
     try:
         results = await client.recall(query, top_k=top_k)
         if results:
-            memories = "\n".join(f"- [{r.category}] {r.text}" for r in results)
-            return f"## Relevant memories from TotalReclaw\n{memories}"
+            return _format_recall_context(results)
     except Exception as e:
         logger.warning("TotalReclaw auto-recall failed: %s", e)
 

--- a/python/src/totalreclaw/hermes/tools.py
+++ b/python/src/totalreclaw/hermes/tools.py
@@ -204,6 +204,8 @@ async def remember(args: dict, state: "PluginState", **kwargs) -> str:
 
 async def recall(args: dict, state: "PluginState", **kwargs) -> str:
     """Search memories in TotalReclaw."""
+    from totalreclaw.agent.recall import _fmt_date
+
     client = state.get_client()
     if not client:
         return json.dumps({"error": "TotalReclaw not configured. Call totalreclaw_pair to set up — browser-side crypto keeps the phrase out of this chat."})
@@ -226,7 +228,13 @@ async def recall(args: dict, state: "PluginState", **kwargs) -> str:
         return json.dumps({
             "count": len(results),
             "memories": [
-                {"id": r.id, "text": r.text, "type": r.category, "score": round(r.rrf_score, 4)}
+                {
+                    "id": r.id,
+                    "text": r.text,
+                    "type": r.category,
+                    "date": _fmt_date(getattr(r, "created_at", None)),
+                    "score": round(r.rrf_score, 4),
+                }
                 for r in results
             ],
         })

--- a/python/src/totalreclaw/operations.py
+++ b/python/src/totalreclaw/operations.py
@@ -13,6 +13,12 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+# Retrieval v2 Tier 1 source-weighting default. OFF as of 2026-06-08: the
+# agent-experienced benchmark (core 2.4.0) showed it tie-or-worse on the shipped
+# retrieval path (recall is already saturated, so provenance reweighting only
+# reorders). See totalreclaw-internal docs/benchmarks/2026-06-07-agent-experienced-baseline.md.
+APPLY_SOURCE_WEIGHTS_DEFAULT = False
+
 import json as _json
 
 import totalreclaw_core as _core
@@ -690,9 +696,9 @@ async def search_facts(
     if not candidates:
         return []
 
-    # Retrieval v2 Tier 1: source-weighted reranking is always ON as of
-    # totalreclaw 2.0.0, matching the TS plugin's default path.
-    return rerank(query, query_embedding, candidates, top_k=top_k, apply_source_weights=True)
+    # Retrieval v2 Tier 1 source-weighting: OFF by default as of 2026-06-08
+    # (benchmark showed tie-or-worse; see APPLY_SOURCE_WEIGHTS_DEFAULT).
+    return rerank(query, query_embedding, candidates, top_k=top_k, apply_source_weights=APPLY_SOURCE_WEIGHTS_DEFAULT)
 
 
 async def forget_fact(

--- a/python/tests/test_operations.py
+++ b/python/tests/test_operations.py
@@ -4,7 +4,7 @@ import base64
 from unittest.mock import AsyncMock, patch
 
 from totalreclaw.crypto import derive_keys_from_mnemonic, encrypt
-from totalreclaw.operations import store_fact, search_facts, forget_fact, export_facts
+from totalreclaw.operations import store_fact, search_facts, forget_fact, export_facts, APPLY_SOURCE_WEIGHTS_DEFAULT
 from totalreclaw.relay import RelayClient
 
 TEST_MNEMONIC = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
@@ -315,3 +315,41 @@ class TestExportFacts:
         assert len(results) == 1
         assert results[0]["text"] == "Test memory"
         assert results[0]["importance"] == 0.7
+
+
+class TestSourceWeightsDefault:
+    """APPLY_SOURCE_WEIGHTS_DEFAULT must be False (2026-06-08 benchmark)."""
+
+    def test_constant_is_false(self):
+        assert APPLY_SOURCE_WEIGHTS_DEFAULT is False
+
+    @pytest.mark.asyncio
+    @patch("totalreclaw.operations.rerank")
+    async def test_search_facts_passes_default_to_rerank(self, mock_rerank):
+        """search_facts must pass APPLY_SOURCE_WEIGHTS_DEFAULT to rerank()."""
+        from totalreclaw.reranker import RerankerResult
+
+        mock_rerank.return_value = []
+        keys = derive_keys_from_mnemonic(TEST_MNEMONIC)
+        relay = AsyncMock(spec=RelayClient)
+        relay.query_subgraph = AsyncMock(
+            return_value={"data": {"blindIndexes": [], "facts": []}}
+        )
+
+        await search_facts(
+            query="hello world test",
+            keys=keys,
+            owner="0x1234",
+            relay=relay,
+        )
+
+        # rerank may not be called if no candidates; that's OK — the test
+        # validates the default is False (done above). But if rerank IS
+        # called, apply_source_weights must equal the default (False).
+        for call in mock_rerank.call_args_list:
+            kw = call.kwargs
+            if "apply_source_weights" in kw:
+                assert kw["apply_source_weights"] is APPLY_SOURCE_WEIGHTS_DEFAULT, (
+                    f"search_facts passed apply_source_weights={kw['apply_source_weights']!r}; "
+                    f"expected APPLY_SOURCE_WEIGHTS_DEFAULT ({APPLY_SOURCE_WEIGHTS_DEFAULT!r})"
+                )

--- a/python/tests/test_recall_format.py
+++ b/python/tests/test_recall_format.py
@@ -246,7 +246,7 @@ class TestHermesRecallDateField:
         state = MagicMock()
         state.get_client.return_value = mock_client
 
-        with patch("totalreclaw.hermes.tools.get_embedding", side_effect=Exception("no model")):
+        with patch("totalreclaw.embedding.get_embedding", side_effect=Exception("no model")):
             response = await recall({"query": "fireworks"}, state)
 
         data = json.loads(response)
@@ -278,7 +278,7 @@ class TestHermesRecallDateField:
         state = MagicMock()
         state.get_client.return_value = mock_client
 
-        with patch("totalreclaw.hermes.tools.get_embedding", side_effect=Exception("no model")):
+        with patch("totalreclaw.embedding.get_embedding", side_effect=Exception("no model")):
             response = await recall({"query": "dark mode"}, state)
 
         data = json.loads(response)
@@ -308,7 +308,7 @@ class TestHermesRecallDateField:
         state = MagicMock()
         state.get_client.return_value = mock_client
 
-        with patch("totalreclaw.hermes.tools.get_embedding", side_effect=Exception("no model")):
+        with patch("totalreclaw.embedding.get_embedding", side_effect=Exception("no model")):
             response = await recall({"query": "legacy"}, state)
 
         data = json.loads(response)

--- a/python/tests/test_recall_format.py
+++ b/python/tests/test_recall_format.py
@@ -1,0 +1,317 @@
+"""Tests for recall context formatting with dates (2026-06-08 benchmark feature).
+
+Validates:
+  - _fmt_date: Unix-seconds → 'YYYY-MM-DD', '' for None/invalid.
+  - auto_recall / auto_recall_async: date tags + current-date header rendered
+    when created_at is present; omitted (no parentheses) when absent.
+  - hermes tools.recall JSON: 'date' field present per memory.
+"""
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from totalreclaw.agent.recall import _fmt_date, _format_recall_context
+
+
+# ---------------------------------------------------------------------------
+# _fmt_date
+# ---------------------------------------------------------------------------
+
+
+class TestFmtDate:
+    def test_valid_unix_seconds_float(self):
+        # 2024-01-15 00:00:00 UTC
+        ts = datetime(2024, 1, 15, tzinfo=timezone.utc).timestamp()
+        assert _fmt_date(ts) == "2024-01-15"
+
+    def test_valid_unix_seconds_int(self):
+        ts = int(datetime(2023, 6, 1, tzinfo=timezone.utc).timestamp())
+        assert _fmt_date(ts) == "2023-06-01"
+
+    def test_valid_unix_seconds_string(self):
+        ts = str(int(datetime(2025, 12, 31, tzinfo=timezone.utc).timestamp()))
+        assert _fmt_date(ts) == "2025-12-31"
+
+    def test_none_returns_empty(self):
+        assert _fmt_date(None) == ""
+
+    def test_zero_returns_empty(self):
+        # 0 is falsy — treated as absent
+        assert _fmt_date(0) == ""
+
+    def test_invalid_string_returns_empty(self):
+        assert _fmt_date("not-a-number") == ""
+
+    def test_negative_timestamp(self):
+        # Negative Unix timestamps are valid (pre-1970) but unusual; just
+        # verify no exception is raised and a date string is returned.
+        result = _fmt_date(-1)
+        # Either a formatted date or "" — no exception.
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# _format_recall_context
+# ---------------------------------------------------------------------------
+
+
+def _make_result(text: str, category: str = "claim", created_at=None):
+    """Build a minimal RerankerResult-like object."""
+    r = SimpleNamespace()
+    r.text = text
+    r.category = category
+    r.created_at = created_at
+    return r
+
+
+class TestFormatRecallContext:
+    def test_header_includes_current_date(self):
+        results = [_make_result("likes tea", created_at=None)]
+        output = _format_recall_context(results)
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        assert f"The current date is {today}." in output
+
+    def test_header_includes_reasoning_nudge(self):
+        results = [_make_result("likes tea")]
+        output = _format_recall_context(results)
+        assert "reason carefully" in output
+        assert "compute differences precisely" in output
+
+    def test_result_with_created_at_includes_date_tag(self):
+        ts = datetime(2024, 3, 5, tzinfo=timezone.utc).timestamp()
+        results = [_make_result("prefers dark mode", category="preference", created_at=ts)]
+        output = _format_recall_context(results)
+        assert "(2024-03-05)" in output
+        assert "- [preference] (2024-03-05) prefers dark mode" in output
+
+    def test_result_without_created_at_omits_parentheses(self):
+        results = [_make_result("prefers dark mode", category="preference", created_at=None)]
+        output = _format_recall_context(results)
+        # No empty parens "()" and no date field
+        assert "()" not in output
+        assert "- [preference] prefers dark mode" in output
+
+    def test_mixed_results_date_and_no_date(self):
+        ts = datetime(2024, 6, 1, tzinfo=timezone.utc).timestamp()
+        results = [
+            _make_result("fact with date", category="claim", created_at=ts),
+            _make_result("fact without date", category="episode", created_at=None),
+        ]
+        output = _format_recall_context(results)
+        assert "(2024-06-01)" in output
+        assert "- [episode] fact without date" in output
+        assert "()" not in output
+
+    def test_section_header_present(self):
+        results = [_make_result("some memory")]
+        output = _format_recall_context(results)
+        assert output.startswith("## Relevant memories from TotalReclaw\n")
+
+    def test_multiple_results_all_rendered(self):
+        results = [_make_result(f"memory {i}") for i in range(3)]
+        output = _format_recall_context(results)
+        for i in range(3):
+            assert f"memory {i}" in output
+
+
+# ---------------------------------------------------------------------------
+# auto_recall (sync)
+# ---------------------------------------------------------------------------
+
+
+class TestAutoRecallFormat:
+    def _make_state(self, results):
+        """Build a minimal AgentState mock that returns `results` from recall."""
+        mock_client = MagicMock()
+
+        async def _recall(query, top_k=8):
+            return results
+
+        mock_client.recall = _recall
+
+        state = MagicMock()
+        state.is_configured.return_value = True
+        state.get_client.return_value = mock_client
+        return state
+
+    def test_returns_none_when_no_results(self):
+        from totalreclaw.agent.recall import auto_recall
+        state = self._make_state([])
+        assert auto_recall("query", state) is None
+
+    def test_date_in_output_when_created_at_set(self):
+        from totalreclaw.agent.recall import auto_recall
+        ts = datetime(2024, 9, 20, tzinfo=timezone.utc).timestamp()
+        results = [_make_result("user likes tea", category="preference", created_at=ts)]
+        state = self._make_state(results)
+        output = auto_recall("what do I like?", state)
+        assert output is not None
+        assert "(2024-09-20)" in output
+
+    def test_no_parens_when_created_at_none(self):
+        from totalreclaw.agent.recall import auto_recall
+        results = [_make_result("user likes tea", category="preference", created_at=None)]
+        state = self._make_state(results)
+        output = auto_recall("what do I like?", state)
+        assert output is not None
+        assert "()" not in output
+        assert "user likes tea" in output
+
+    def test_header_contains_today(self):
+        from totalreclaw.agent.recall import auto_recall
+        results = [_make_result("some fact", created_at=None)]
+        state = self._make_state(results)
+        output = auto_recall("test", state)
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        assert today in output
+
+
+# ---------------------------------------------------------------------------
+# auto_recall_async
+# ---------------------------------------------------------------------------
+
+
+class TestAutoRecallAsyncFormat:
+    def _make_state(self, results):
+        mock_client = MagicMock()
+
+        async def _recall(query, top_k=8):
+            return results
+
+        mock_client.recall = _recall
+
+        state = MagicMock()
+        state.is_configured.return_value = True
+        state.get_client.return_value = mock_client
+        return state
+
+    @pytest.mark.asyncio
+    async def test_date_in_output_when_created_at_set(self):
+        from totalreclaw.agent.recall import auto_recall_async
+        ts = datetime(2025, 1, 1, tzinfo=timezone.utc).timestamp()
+        results = [_make_result("works at Nexus", category="claim", created_at=ts)]
+        state = self._make_state(results)
+        output = await auto_recall_async("where does Pedro work?", state)
+        assert output is not None
+        assert "(2025-01-01)" in output
+
+    @pytest.mark.asyncio
+    async def test_no_parens_when_created_at_none(self):
+        from totalreclaw.agent.recall import auto_recall_async
+        results = [_make_result("works at Nexus", category="claim", created_at=None)]
+        state = self._make_state(results)
+        output = await auto_recall_async("where?", state)
+        assert output is not None
+        assert "()" not in output
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_results(self):
+        from totalreclaw.agent.recall import auto_recall_async
+        state = self._make_state([])
+        assert await auto_recall_async("query", state) is None
+
+
+# ---------------------------------------------------------------------------
+# hermes tools.recall — date field in JSON response
+# ---------------------------------------------------------------------------
+
+
+class TestHermesRecallDateField:
+    @pytest.mark.asyncio
+    async def test_date_field_present_when_created_at_set(self):
+        from totalreclaw.hermes.tools import recall
+
+        ts = datetime(2024, 7, 4, tzinfo=timezone.utc).timestamp()
+        mock_result = SimpleNamespace(
+            id="fact-1",
+            text="user likes fireworks",
+            category="episode",
+            created_at=ts,
+            rrf_score=0.8765,
+        )
+
+        mock_client = MagicMock()
+
+        async def _recall(query, query_embedding=None, top_k=8):
+            return [mock_result]
+
+        mock_client.recall = _recall
+
+        state = MagicMock()
+        state.get_client.return_value = mock_client
+
+        with patch("totalreclaw.hermes.tools.get_embedding", side_effect=Exception("no model")):
+            response = await recall({"query": "fireworks"}, state)
+
+        data = json.loads(response)
+        assert data["count"] == 1
+        mem = data["memories"][0]
+        assert mem["date"] == "2024-07-04"
+        assert mem["type"] == "episode"
+        assert mem["id"] == "fact-1"
+
+    @pytest.mark.asyncio
+    async def test_date_field_empty_string_when_no_created_at(self):
+        from totalreclaw.hermes.tools import recall
+
+        mock_result = SimpleNamespace(
+            id="fact-2",
+            text="likes dark mode",
+            category="preference",
+            created_at=None,
+            rrf_score=0.5,
+        )
+
+        mock_client = MagicMock()
+
+        async def _recall(query, query_embedding=None, top_k=8):
+            return [mock_result]
+
+        mock_client.recall = _recall
+
+        state = MagicMock()
+        state.get_client.return_value = mock_client
+
+        with patch("totalreclaw.hermes.tools.get_embedding", side_effect=Exception("no model")):
+            response = await recall({"query": "dark mode"}, state)
+
+        data = json.loads(response)
+        mem = data["memories"][0]
+        assert mem["date"] == ""
+
+    @pytest.mark.asyncio
+    async def test_result_missing_created_at_attr_gracefully(self):
+        """Results that lack the created_at attribute entirely should not crash."""
+        from totalreclaw.hermes.tools import recall
+
+        # Deliberately omit created_at to simulate legacy results
+        mock_result = SimpleNamespace(
+            id="fact-3",
+            text="some legacy memory",
+            category="claim",
+            rrf_score=0.3,
+        )
+
+        mock_client = MagicMock()
+
+        async def _recall(query, query_embedding=None, top_k=8):
+            return [mock_result]
+
+        mock_client.recall = _recall
+
+        state = MagicMock()
+        state.get_client.return_value = mock_client
+
+        with patch("totalreclaw.hermes.tools.get_embedding", side_effect=Exception("no model")):
+            response = await recall({"query": "legacy"}, state)
+
+        data = json.loads(response)
+        mem = data["memories"][0]
+        # Should degrade to empty string, not raise
+        assert mem["date"] == ""


### PR DESCRIPTION
## What

Two adapter-only changes to the Hermes recall path, both backed by a 2026-06-08 agent-experienced benchmark (generation-step harness, `@totalreclaw/core@2.4.0`, Sonnet-gated):

1. **Surface memory dates in recall context.** `auto_recall` (sync+async) and the `totalreclaw_recall` tool now render each memory's `created_at` as `(YYYY-MM-DD)`, with a current-date + date-reasoning-nudge header. `created_at` already flowed end-to-end (subgraph → `RerankerResult.created_at`); the formatters just dropped it. Pure rendering — no core/reranker/subgraph change.

2. **Default Retrieval-v2 Tier-1 source-weighting OFF** (`APPLY_SOURCE_WEIGHTS_DEFAULT = False`). The benchmark showed it tie-or-worse on the shipped retrieval path (recall is saturated, Hit@8 ~100%, so provenance reweighting only reorders).

## Why (evidence)

The agent already retrieves the right facts (Hit@8 ~100%) but couldn't see *when* each was recorded. Surfacing dates:

| metric | before | after |
|---|---|---|
| temporal-reasoning (LongMemEval, Sonnet gate) | 36.1% | **81.2%** (+45.1pp) |
| overall LongMemEval (glm-4.6 A/B) | 65.2% | **80.6%** (+15.4pp) |

Zero category regression. glm-4.6 inner-loop agreed (+44pp). ~15–20× the measured noise floor. Source-weights-off: tie on LongMemEval, +12pp on LOCOMO (removes a peer-human footgun).

Details: `totalreclaw-internal` `docs/benchmarks/2026-06-07-agent-experienced-baseline.md` + `docs/plans/2026-06-07-agent-accuracy-program-design.md`.

## Tests

`python -m pytest tests/` → **1477 passed, 13 skipped, zero regressions**; 26 new (`test_recall_format.py` + `test_operations.py`).

## Gate note

No live Hermes agent E2E harness exists; the generation benchmark is the agent-faithful proof (it measures the exact recall-context format this PR produces). Live confidence rides in QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)