### PR TITLE
fix(core): smart_import truncate panics on multibyte UTF-8 — import crash (2.5.2)

### DIFF
--- a/rust/totalreclaw-core/Cargo.lock
+++ b/rust/totalreclaw-core/Cargo.lock
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "totalreclaw-core"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/rust/totalreclaw-core/Cargo.toml
+++ b/rust/totalreclaw-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "totalreclaw-core"
-version = "2.5.1"
+version = "2.5.2"
 edition = "2021"
 description = "TotalReclaw core — E2EE crypto, reranker, wallet, UserOp, store/search pipelines. Single source of truth for all clients."
 license = "MIT"

--- a/rust/totalreclaw-core/pyproject.toml
+++ b/rust/totalreclaw-core/pyproject.toml
@@ -7,7 +7,7 @@ name = "totalreclaw-core"
 # Keep in lockstep with Cargo.toml [package].version. maturin uses THIS value
 # for the PyPI wheel version; Cargo.toml drives crates.io + the wasm-pack npm
 # package. Both MUST match or the PyPI wheel ships under the wrong version.
-version = "2.5.1"
+version = "2.5.2"
 description = "TotalReclaw crypto core — E2EE, LSH, blind indices, protobuf encoding (Rust)"
 requires-python = ">=3.10"
 license = { text = "MIT" }

--- a/rust/totalreclaw-core/src/debrief.rs
+++ b/rust/totalreclaw-core/src/debrief.rs
@@ -111,7 +111,13 @@ pub fn parse_debrief_response(response: &str) -> Vec<DebriefItem> {
             Some(t) if t.trim().len() >= 5 => {
                 let trimmed = t.trim();
                 if trimmed.len() > 512 {
-                    trimmed[..512].to_string()
+                    // Snap to a char boundary so multibyte/accented text never
+                    // panics (byte 512 can land inside a multi-byte char).
+                    let mut end = 512;
+                    while end > 0 && !trimmed.is_char_boundary(end) {
+                        end -= 1;
+                    }
+                    trimmed[..end].to_string()
                 } else {
                     trimmed.to_string()
                 }

--- a/rust/totalreclaw-core/src/smart_import.rs
+++ b/rust/totalreclaw-core/src/smart_import.rs
@@ -485,13 +485,22 @@ fn strip_code_fences(s: &str) -> String {
     result
 }
 
-/// Truncate a message to a maximum length, appending "..." if truncated.
+/// Truncate a message to a maximum byte length, appending "..." if truncated.
+///
+/// Snaps the cut down to the nearest UTF-8 char boundary so non-Latin / accented
+/// text never panics. A raw `&trimmed[..max_len]` byte slice panics when
+/// `max_len` lands inside a multi-byte char (e.g. Portuguese 'é' at byte 300) —
+/// which crashed the whole import background task. (Regression: 2026-06.)
 fn truncate_message(s: &str, max_len: usize) -> String {
     let trimmed = s.trim();
     if trimmed.len() <= max_len {
         trimmed.to_string()
     } else {
-        format!("{}...", &trimmed[..max_len])
+        let mut end = max_len;
+        while end > 0 && !trimmed.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}...", &trimmed[..end])
     }
 }
 
@@ -1467,6 +1476,31 @@ mod tests {
     #[test]
     fn test_truncate_message_trims_whitespace() {
         assert_eq!(truncate_message("  hello  ", 10), "hello");
+    }
+
+    #[test]
+    fn test_truncate_message_utf8_boundary_does_not_panic() {
+        // 'é' is 2 bytes. Put it so the cut (max_len) lands INSIDE it: 299 'a's
+        // (299 bytes) + 'é' (bytes 299..301) → byte index 300 is not a char
+        // boundary. The old raw byte slice panicked here (real import crash on
+        // Portuguese Gemini data). Must truncate safely instead.
+        let s = "a".repeat(299) + "é" + "tail";
+        let out = truncate_message(&s, 300);
+        assert!(out.ends_with("..."));
+        // Snapped down before 'é' → 299 'a's + "..."
+        assert_eq!(out, "a".repeat(299) + "...");
+    }
+
+    #[test]
+    fn test_truncate_message_multibyte_throughout() {
+        // All-multibyte string; truncating at various byte caps must never panic.
+        let s = "héllo wörld ".repeat(50); // accents throughout
+        for cap in [1usize, 2, 3, 7, 10, 50, 101, 300] {
+            let out = truncate_message(&s, cap);
+            // Output is valid UTF-8 by construction (String) — assert no panic +
+            // length sanity (<= cap + "..." worth of bytes, snapped down).
+            assert!(out.len() <= s.len() + 3);
+        }
     }
 
     #[test]


### PR DESCRIPTION
**Root cause of 'import not succeeding' (found in a pop-os Hermes gateway log):**
```
panicked at src/smart_import.rs:494: end byte index 300 is not a char boundary; it is inside 'é'
```
`truncate_message` raw-byte-sliced `&trimmed[..300]` for the smart-import message summaries. With accented/non-Latin text (Portuguese Gemini data), byte 300 falls inside a multi-byte char → Rust panic → the import background task crashes silently → the agent reports 'import didn't start'.

**Fix:** snap the cut down to the nearest char boundary. +2 regression tests (the exact 'é-at-byte-300' case + an all-multibyte sweep).

Bumps core **2.5.2**. rc9's `totalreclaw-core>=2.5.1` floor accepts it, so **upgrading core alone fixes the import** — no new python RC strictly required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)