### PR TITLE
feat(hermes): totalreclaw_status returns account ID (address) + core>=2.5.2 floor

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -35,7 +35,9 @@ dependencies = [
     # parse_gemini was ADDED in core 2.5.1 — PyPI core 2.5.0 (published
     # 2026-06-05 for #366) predates it, so the floor must be 2.5.1 or the
     # adapter raises AttributeError at runtime against a 2.5.0 wheel.
-    "totalreclaw-core>=2.5.1,<3.0.0",
+    # >=2.5.2: fixes a UTF-8 byte-slice panic in smart_import/debrief that
+    # crashed imports of accented/non-Latin corpora (e.g. Portuguese 'é').
+    "totalreclaw-core>=2.5.2,<3.0.0",
     "httpx>=0.27",
     "onnxruntime>=1.24",
     "numpy>=1.26",

--- a/python/src/totalreclaw/hermes/tools.py
+++ b/python/src/totalreclaw/hermes/tools.py
@@ -441,11 +441,28 @@ async def status(args: dict, state: "PluginState", **kwargs) -> str:
 
     try:
         billing = await client.status()
+        # Surface the account identity so the agent can answer "what's my
+        # account ID / address?" — previously NO tool exposed it, so the agent
+        # had nothing to report. The Smart Account address IS the account ID;
+        # it is a public on-chain address (NOT the recovery phrase) and safe to
+        # show. Resolve it if status() didn't already.
+        sa = getattr(client, "_wallet_address", None)
+        if not sa:
+            try:
+                ensure = getattr(client, "_ensure_address", None)
+                if callable(ensure):
+                    await ensure()
+                sa = getattr(client, "_wallet_address", None)
+            except Exception:
+                sa = None
         return json.dumps({
             "tier": billing.tier,
             "free_writes_used": billing.free_writes_used,
             "free_writes_limit": billing.free_writes_limit,
             "expires_at": billing.expires_at,
+            "account_id": sa,
+            "wallet_address": sa,
+            "eoa_address": getattr(client, "_eoa_address", None),
         })
     except Exception as e:
         logger.error("totalreclaw_status failed: %s", e)

--- a/python/tests/test_status_account_id.py
+++ b/python/tests/test_status_account_id.py
@@ -1,0 +1,59 @@
+"""totalreclaw_status must expose the account ID (Smart Account address).
+
+SKILL.md line 76 already promises status "Returns tier, used / limit, and
+smart-account address" — but the tool only returned tier/quota, so when a user
+asked "what's my account ID/address?" the agent had nothing to report. This
+locks the address into the status response (it's a public on-chain address, NOT
+the recovery phrase, so safe to surface).
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_status_includes_account_id_and_addresses():
+    from totalreclaw.hermes import tools
+    from totalreclaw.hermes.state import PluginState
+
+    state = PluginState()
+    client = MagicMock()
+    client.status = AsyncMock(return_value=MagicMock(
+        tier="pro", free_writes_used=3, free_writes_limit=1500,
+        expires_at="2027-06-10",
+    ))
+    client._wallet_address = "0xa1db0bdbacf82b65dbd464f25b07432fd2f9c47e"
+    client._eoa_address = "0x05651cf715043fcae41620f158f835fa73eff917"
+    state._client = client
+
+    res = json.loads(await tools.status({}, state))
+    assert res["tier"] == "pro"
+    assert res["account_id"] == client._wallet_address
+    assert res["wallet_address"] == client._wallet_address
+    assert res["eoa_address"] == client._eoa_address
+
+
+@pytest.mark.asyncio
+async def test_status_resolves_address_lazily_if_unset():
+    from totalreclaw.hermes import tools
+    from totalreclaw.hermes.state import PluginState
+
+    state = PluginState()
+    client = MagicMock()
+    client.status = AsyncMock(return_value=MagicMock(
+        tier="free", free_writes_used=0, free_writes_limit=250, expires_at=None,
+    ))
+    client._wallet_address = None
+    client._eoa_address = "0x05651cf715043fcae41620f158f835fa73eff917"
+
+    async def _ensure():
+        client._wallet_address = "0xa1db0bdbacf82b65dbd464f25b07432fd2f9c47e"
+    client._ensure_address = AsyncMock(side_effect=_ensure)
+    state._client = client
+
+    res = json.loads(await tools.status({}, state))
+    client._ensure_address.assert_awaited()  # resolved on demand
+    assert res["account_id"] == "0xa1db0bdbacf82b65dbd464f25b07432fd2f9c47e"


### PR DESCRIPTION
**User QA:** asked the agent for their account ID/address — got nothing. `totalreclaw_status` returned only tier/quota, even though SKILL.md line 76 already promises it returns the smart-account address.

**Fix:** status now returns `account_id` / `wallet_address` (the Smart Account, resolved lazily) + `eoa_address`. Public on-chain address (not the recovery phrase) → safe to surface. Aligns code with the SKILL.md contract. 2 tests.

Also bumps the python core floor to `>=2.5.2` (the UTF-8 import-crash fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)