### PR TITLE
fix(python): bump base 2.4.4→2.4.5 so RCs are reachable (post-stable-promote)

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -12,7 +12,19 @@ name = "totalreclaw"
 # which would have caused stable builds to mis-publish AND broke the
 # regex-based mutation logic on subsequent RCs. Keep this at the next
 # stable target with NO rc suffix. F3 fix in rc.24.
-version = "2.4.4"
+#
+# CRITICAL POST-PROMOTE RULE (added 2026-06-10): the moment a stable
+# version ships, BUMP THIS to the next target. `2.4.4` stable promoted
+# 2026-06-06 but this base was left at `2.4.4`, so every later RC cut as
+# `2.4.4rcN` (rc8/rc9/rc10). PEP 440 ranks a final release ABOVE its own
+# pre-releases (`2.4.4` > `2.4.4rc10`), so `pip install --pre --upgrade
+# totalreclaw` — the documented "latest RC" path — silently resolved to
+# `2.4.4` STABLE, NOT the RC. The RCs were unreachable except by exact
+# pin. Verified: dry-run "Would install totalreclaw-2.4.4". Fix: base is
+# now `2.4.5`, so RCs cut as `2.4.5rcN` outrank `2.4.4` and the
+# version-agnostic install path lands them. NEVER leave the base equal to
+# an already-published stable.
+version = "2.4.5"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Problem

`2.4.4` stable promoted 2026-06-06, but `python/pyproject.toml` base stayed at `2.4.4`. Every RC since cut as `2.4.4rcN` (rc8/rc9/rc10).

PEP 440 ranks a final release **above** its own pre-releases: `2.4.4 > 2.4.4rc10`. So the documented latest-RC install — `pip install --pre --upgrade totalreclaw` — silently resolves to **2.4.4 STABLE**, not the RC. Verified by dry-run: `Would install totalreclaw-2.4.4`.

**Impact:** anyone QA-ing 'latest RC' via the version-agnostic path has been running 2.4.4 stable (core 2.5.0 → the multibyte 'é' import crash; rc7 content → no import Pro-gate, no `totalreclaw_status` account-id). The RCs were only reachable by exact `==2.4.4rcN` pin.

## Fix

Bump base → `2.4.5`. RCs now cut as `2.4.5rcN`, which outrank `2.4.4` and are reachable via `--pre --upgrade`. Adds a CRITICAL POST-PROMOTE RULE comment so the base is bumped the instant a stable ships.

Next: cut `2.4.5rc1` carrying all of rc8/rc9/rc10 (import + core>=2.5.2 multilingual fix + account-id PR #341).

🤖 Generated with [Claude Code](https://claude.com/claude-code)