### PR TITLE
fix(hermes): totalreclaw_upgrade KeyError on missing session_id

### DIFF
--- a/python/src/totalreclaw/hermes/tools.py
+++ b/python/src/totalreclaw/hermes/tools.py
@@ -559,14 +559,18 @@ async def upgrade(args: dict, state: "PluginState", **kwargs) -> str:
                 pass
 
         checkout = await client._relay.create_checkout()
-        return json.dumps({
+        payload = {
             "checkout_url": checkout.checkout_url,
-            "session_id": checkout.session_id,
             "message": (
                 f"Open this URL in your browser to complete the upgrade "
                 f"to Pro: {checkout.checkout_url}"
             ),
-        })
+        }
+        # The relay does not return a Stripe session id; only include the
+        # field if some future relay build starts sending one.
+        if checkout.session_id:
+            payload["session_id"] = checkout.session_id
+        return json.dumps(payload)
     except Exception as e:
         logger.error("totalreclaw_upgrade failed: %s", e)
         return json.dumps({"error": f"Failed to create checkout session: {e}"})

--- a/python/src/totalreclaw/relay.py
+++ b/python/src/totalreclaw/relay.py
@@ -102,7 +102,13 @@ class BillingStatus:
 @dataclass
 class CheckoutResponse:
     checkout_url: str
-    session_id: str
+    # The relay's POST /v1/billing/checkout success payload is
+    # ``{success, checkout_url}`` — it does NOT return a session id (the
+    # Stripe Session id stays server-side). The client never uses it, so it
+    # is optional; hard-reading ``data["session_id"]`` here is what raised
+    # ``KeyError: 'session_id'`` and surfaced as "Failed to create checkout
+    # session: 'session_id'" on every upgrade attempt.
+    session_id: Optional[str] = None
 
 
 class RelayClient:
@@ -306,7 +312,16 @@ class RelayClient:
         )
         resp.raise_for_status()
         data = resp.json()
-        return CheckoutResponse(checkout_url=data["checkout_url"], session_id=data["session_id"])
+        # The relay returns HTTP 200 even on its own error path, with
+        # ``{success: false, error_code, error_message}`` and NO
+        # ``checkout_url`` (see relay src/routes/billing.ts). Detect that and
+        # raise a readable error instead of a bare ``KeyError: 'checkout_url'``.
+        checkout_url = data.get("checkout_url")
+        if not checkout_url:
+            detail = data.get("error_message") or data.get("error_code") or "relay returned no checkout_url"
+            raise RuntimeError(f"relay checkout failed: {detail}")
+        # ``session_id`` is optional — the relay does not send it.
+        return CheckoutResponse(checkout_url=checkout_url, session_id=data.get("session_id"))
 
     async def close(self):
         """Close any cached httpx clients across all loops we've touched.

--- a/python/tests/test_upgrade_tool.py
+++ b/python/tests/test_upgrade_tool.py
@@ -109,6 +109,90 @@ class TestUpgradeTool:
         assert "relay down" in result["error"]
 
 
+class _FakeHttpResp:
+    """Minimal stand-in for an httpx.Response (status 200, JSON body)."""
+
+    def __init__(self, data: dict) -> None:
+        self._data = data
+
+    def raise_for_status(self) -> None:  # relay always returns HTTP 200
+        return None
+
+    def json(self) -> dict:
+        return self._data
+
+
+def _relay_returning(data: dict):
+    """Build a RelayClient whose POST returns ``data`` (no real network)."""
+    from totalreclaw.relay import RelayClient
+
+    client = RelayClient(relay_url="https://api-staging.totalreclaw.xyz")
+    client._wallet_address = "0xa1db0bdbacf82b65dbd464f25b07432fd2f9c47e"
+    http = MagicMock()
+    http.post = AsyncMock(return_value=_FakeHttpResp(data))
+    client._get_http = AsyncMock(return_value=http)
+    return client
+
+
+class TestCreateCheckoutContract:
+    """Regression: relay POST /v1/billing/checkout returns ``{success, checkout_url}``
+    with NO ``session_id``. The client used to hard-read ``data["session_id"]`` →
+    ``KeyError: 'session_id'`` → "Failed to create checkout session: 'session_id'"
+    on every upgrade. (errors.log 2026-06-10 00:26, pop-os prod 2.4.5rc1.)
+    """
+
+    @pytest.mark.asyncio
+    async def test_success_without_session_id_does_not_raise(self) -> None:
+        # Exactly what the relay returns on success (src/routes/billing.ts:52).
+        client = _relay_returning(
+            {"success": True, "checkout_url": "https://checkout.stripe.com/c/pay/cs_live_xyz"}
+        )
+        resp = await client.create_checkout()
+        assert resp.checkout_url == "https://checkout.stripe.com/c/pay/cs_live_xyz"
+        assert resp.session_id is None  # optional — relay never sends it
+
+    @pytest.mark.asyncio
+    async def test_success_with_session_id_is_passed_through(self) -> None:
+        # Forward-compat: if a future relay starts returning session_id, keep it.
+        client = _relay_returning(
+            {"success": True, "checkout_url": "https://x", "session_id": "cs_test_1"}
+        )
+        resp = await client.create_checkout()
+        assert resp.session_id == "cs_test_1"
+
+    @pytest.mark.asyncio
+    async def test_error_path_200_without_checkout_url_raises_readable(self) -> None:
+        # Relay error path: HTTP 200 + {success:false, error_message} and NO
+        # checkout_url (src/routes/billing.ts:56-66). Must raise a readable
+        # error, not a bare KeyError.
+        client = _relay_returning(
+            {"success": False, "error_code": "CONFIG_ERROR", "error_message": "Stripe not configured"}
+        )
+        with pytest.raises(RuntimeError) as ei:
+            await client.create_checkout()
+        assert "Stripe not configured" in str(ei.value)
+
+    @pytest.mark.asyncio
+    async def test_upgrade_tool_end_to_end_without_session_id(self) -> None:
+        """The full tool path over a relay that omits session_id: returns the URL,
+        omits the session_id key, and never raises ``KeyError``."""
+        from totalreclaw.hermes.tools import upgrade
+
+        state = _make_state()
+        mock_client = MagicMock()
+        mock_client._ensure_address = AsyncMock()
+        mock_client._relay = _relay_returning(
+            {"success": True, "checkout_url": "https://checkout.stripe.com/c/pay/cs_live_q"}
+        )
+        state._client = mock_client
+
+        result = json.loads(await upgrade({}, state))
+        assert result.get("checkout_url") == "https://checkout.stripe.com/c/pay/cs_live_q"
+        assert "session_id" not in result  # dropped when the relay omits it
+        assert "https://checkout.stripe.com/c/pay/cs_live_q" in result.get("message", "")
+        assert "error" not in result
+
+
 class TestUpgradeRegistration:
     def test_register_wires_upgrade_tool(self) -> None:
         """``register()`` must include ``totalreclaw_upgrade`` in the tool set."""


### PR DESCRIPTION
## Bug
`totalreclaw_upgrade` → `Failed to create checkout session: 'session_id'` on every attempt (pop-os prod Hermes 2.4.5rc1, errors.log 2026-06-10 00:26).

## Root cause
Client↔relay contract mismatch:
- **Relay** `src/routes/billing.ts:52` returns `{ success: true, checkout_url }` on success — **no `session_id`**.
- **Client** `relay.py:309` hard-read `data["session_id"]` → `KeyError`. The client never actually uses session_id (the upgrade tool only surfaces `checkout_url`).

Also: the relay's error path returns **HTTP 200** + `{success:false, error_message}` with no `checkout_url`, so `raise_for_status()` passes and `data["checkout_url"]` would KeyError too.

## Fix (client-side; relay unchanged)
- `CheckoutResponse.session_id` → `Optional[str] = None`.
- `create_checkout()` uses `data.get("session_id")`; raises a readable `RuntimeError` when `checkout_url` is absent (the 200-error path).
- Upgrade tool omits `session_id` from its JSON when the relay doesn't send it.

## Tests
4 new regression tests (success w/ + w/o session_id, 200-error path, end-to-end tool). Upgrade + relay + session-id suites: 32 green.

Tests target staging relay only; no recovery phrase / credentials touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)