### PR TITLE
feat(retrieval): disable source-weights across all clients (recall alignment)

### DIFF
--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1294,7 +1294,7 @@ async function handleRecallSubgraph(
       decryptedCandidates,
       k,
       weights,
-      /* applySourceWeights (Retrieval v2 Tier 1) */ true,
+      /* applySourceWeights (Retrieval v2 Tier 1) */ false,
     );
 
     // 8. Format results

--- a/mcp/src/tools/recall.ts
+++ b/mcp/src/tools/recall.ts
@@ -139,12 +139,14 @@ export async function handleRecall(
       return { r, category, source, scope };
     });
 
-    // Retrieval v2 Tier 1: multiply final score by source weight from core.
+    // Source-weights off (recall alignment 2026-06-08; tie-or-worse on shipped path).
+    // Preserve source/source_weight fields in output for observability but do not
+    // multiply into the ranking score.
     const core = getWasm();
     const weighted = parsedMap
       .map(({ r, category, source, scope }) => {
-        const w = source ? core.sourceWeight(source) : core.legacyClaimFallbackWeight();
-        return { r, category, source, scope, weightedScore: r.score * w, sourceWeight: w };
+        const sourceWeight = source ? core.sourceWeight(source) : core.legacyClaimFallbackWeight();
+        return { r, category, source, scope, weightedScore: r.score, sourceWeight };
       })
       .sort((a, b) => b.weightedScore - a.weightedScore);
 

--- a/mcp/tests/recall-source-weight.test.ts
+++ b/mcp/tests/recall-source-weight.test.ts
@@ -1,9 +1,11 @@
 /**
- * Retrieval v2 Tier 1 — recall source-weighted ordering test.
+ * Recall ordering test — source-weighting DISABLED (alignment 2026-06-08).
  *
  * Mocks the `@totalreclaw/client` client and verifies that `handleRecall`
- * applies the core's source-weight multiplier to produce user-favoring
- * ordering when two candidates tie on base score.
+ * ranks purely by BASE score and does NOT multiply by the provenance
+ * source-weight (the 2026-06-08 agent-experienced benchmark showed source
+ * weighting tie-or-worse on the shipped path). `source` / `source_weight`
+ * are still surfaced in the output for observability, but must not affect order.
  */
 
 export {};
@@ -50,41 +52,43 @@ function makeV1Fact(id: string, text: string, source: string, baseScore: number)
   };
 }
 
-describe('handleRecall — Retrieval v2 Tier 1 source weighting', () => {
+describe('handleRecall — source-weighting disabled (ranks by base score)', () => {
   beforeEach(() => {
     mockRecall.mockReset();
   });
 
-  test('user source beats assistant source when base scores are equal', async () => {
-    // Two candidates with identical base score, different sources.
-    const assistantFact = makeV1Fact('assistant-fact-id', 'Sheraton Grande Sukhumvit', 'assistant', 0.8);
+  test('source weight does NOT override base score (assistant w/ higher base beats user)', async () => {
+    // Discriminating case: under the OLD Tier-1 weighting, user(0.8 × 1.0)=0.80
+    // would beat assistant(0.85 × 0.85)=0.7225 → user first. With weighting OFF,
+    // ranking is by base score → the higher-base assistant fact ranks first.
+    const assistantFact = makeV1Fact('assistant-fact-id', 'Sheraton Grande Sukhumvit', 'assistant', 0.85);
     const userFact = makeV1Fact('user-fact-id', 'I want to go to Bangkok', 'user', 0.8);
-    mockRecall.mockResolvedValueOnce([assistantFact, userFact]);
+    mockRecall.mockResolvedValueOnce([userFact, assistantFact]);
 
     const client = createMockClient() as any;
     const out = await handleRecall(client, { query: 'Bangkok trip' });
     const body = JSON.parse(out.content[0].text);
     expect(body.memories).toHaveLength(2);
 
-    // User claim must rank first because sourceWeight(user)=1.0,
-    // sourceWeight(assistant)=0.85 (v2-lenient, core 2.4.0+).
-    expect(body.memories[0].fact_id).toBe('user-fact-id');
-    expect(body.memories[0].source).toBe('user');
-    expect(body.memories[1].fact_id).toBe('assistant-fact-id');
-    expect(body.memories[1].source).toBe('assistant');
+    // Higher base score wins regardless of provenance.
+    expect(body.memories[0].fact_id).toBe('assistant-fact-id');
+    expect(body.memories[1].fact_id).toBe('user-fact-id');
 
-    // Weighted scores reflect the multiplier.
-    expect(body.memories[0].score).toBeGreaterThan(body.memories[1].score);
-    expect(body.memories[0].source_weight).toBe(1.0);
-    expect(body.memories[1].source_weight).toBe(0.85);
+    // score == base_score (no source-weight multiplication).
+    expect(body.memories[0].score).toBeCloseTo(0.85);
+    expect(body.memories[0].score).toBe(body.memories[0].base_score);
+    expect(body.memories[1].score).toBeCloseTo(0.8);
+    // source_weight still surfaced for observability, but does not affect order.
+    expect(body.memories[0].source_weight).toBeDefined();
   });
 
-  test('unspecified / missing source falls back to legacy fallback weight', async () => {
+  test('source weight is informational only — equal base scores keep their base score', async () => {
+    // Two equal-base candidates, different sources. Neither is reweighted:
+    // both keep score == base_score; user is NOT promoted over assistant.
     const noSourceFact = {
       fact: {
         id: 'no-source',
-        // plain-text blob (no v1 schema)
-        text: 'legacy text',
+        text: 'legacy text', // plain-text blob (no v1 schema)
         embedding: [1, 0, 0],
         metadata: { importance: 0.6, tags: [] },
         decayScore: 0.6,
@@ -101,11 +105,11 @@ describe('handleRecall — Retrieval v2 Tier 1 source weighting', () => {
     const client = createMockClient() as any;
     const out = await handleRecall(client, { query: 'test' });
     const body = JSON.parse(out.content[0].text);
-    expect(body.memories[0].fact_id).toBe('user-id'); // user > fallback
-    expect(body.memories[0].source_weight).toBe(1.0);
-    expect(body.memories[1].fact_id).toBe('no-source');
-    // Fallback weight applied (legacy; should be the core constant).
-    expect(body.memories[1].source_weight).toBeLessThan(1.0);
+    // Both keep base score 1.0 — no provenance reweighting promotes one over the other.
+    for (const m of body.memories) {
+      expect(m.score).toBe(m.base_score);
+      expect(m.score).toBeCloseTo(1.0);
+    }
   });
 
   test('all-assistant candidates still return top-k ordered by base score', async () => {

--- a/rust/totalreclaw-memory/Cargo.lock
+++ b/rust/totalreclaw-memory/Cargo.lock
@@ -3199,7 +3199,7 @@ dependencies = [
 
 [[package]]
 name = "totalreclaw-core"
-version = "2.1.1"
+version = "2.5.2"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -3214,6 +3214,7 @@ dependencies = [
  "k256",
  "pbkdf2",
  "rand 0.8.5",
+ "regex",
  "serde",
  "serde_json",
  "sha2",

--- a/rust/totalreclaw-memory/src/backend.rs
+++ b/rust/totalreclaw-memory/src/backend.rs
@@ -555,7 +555,9 @@ impl TotalReclawMemory {
             &rerank_candidates,
             limit,
             RerankerConfig {
-                apply_source_weights: true,
+                // source-weights off (recall alignment 2026-06-08; tie-or-worse on shipped path)
+                apply_source_weights: false,
+                ..RerankerConfig::default()
             },
         )?;
 

--- a/rust/totalreclaw-memory/src/store.rs
+++ b/rust/totalreclaw-memory/src/store.rs
@@ -319,6 +319,8 @@ pub fn build_memory_claim_v1(input: &V1StoreInput) -> MemoryClaimV1 {
         // v1.1 additive field: pin_status is user-controlled via totalreclaw_pin.
         // Extraction-path claims start unpinned (field absent).
         pin_status: None,
+        // v1.2 additive field: structured metadata bag (reserved for future use).
+        metadata: None,
     }
 }
 

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -4483,7 +4483,7 @@ const plugin = {
               rerankerCandidates,
               k,
               INTENT_WEIGHTS[queryIntent],
-              /* applySourceWeights (Retrieval v2 Tier 1) */ true,
+              /* applySourceWeights (Retrieval v2 Tier 1) */ false,
             );
 
             if (reranked.length === 0) {
@@ -7050,7 +7050,7 @@ const plugin = {
               rerankerCandidates,
               8,
               INTENT_WEIGHTS[hookQueryIntent],
-              /* applySourceWeights (Retrieval v2 Tier 1) */ true,
+              /* applySourceWeights (Retrieval v2 Tier 1) */ false,
             );
 
             // Update hot cache with reranked results.
@@ -7174,7 +7174,7 @@ const plugin = {
             rerankerCandidates,
             8,
             INTENT_WEIGHTS[srvHookIntent],
-            /* applySourceWeights (Retrieval v2 Tier 1) */ true,
+            /* applySourceWeights (Retrieval v2 Tier 1) */ false,
             );
 
           if (reranked.length === 0) return undefined;


### PR DESCRIPTION
## What
Align all clients on **source-weights OFF** by removing explicit `apply_source_weights=true` overrides (core's `RerankerConfig` already defaults `false`). Matches Hermes (already off, PR #338).

| client | change |
|---|---|
| ZeroClaw (Rust) | `backend.rs` `apply_source_weights: false` + `..RerankerConfig::default()`; **+ fix pre-existing compile break** — `store.rs` `MemoryClaimV1.metadata: None` (field added in core 2.5.x), Cargo.lock core `2.1.1→2.5.2` |
| OpenClaw plugin | 3 `rerank()` call sites (recall tool, before_agent_start, HTTP auto-recall) → `false` |
| MCP (self-hosted) | `index.ts` rerank call → `false` |
| MCP (managed) | `recall.ts` stop multiplying score by source weight; keep `source_weight` in output for observability |
| NanoClaw | no change — recalls via MCP / shared client which already defaults `false` |
| Hermes | already off (PR #338) |

## Why
2026-06-08 agent-experienced benchmark: source-weights **tie-or-worse** on the shipped retrieval path (recall saturated → provenance reweighting only reorders). Tie on LongMemEval, +12pp on LOCOMO with it off. See `totalreclaw-internal` `docs/benchmarks/2026-06-07-agent-experienced-baseline.md`.

## Tests
ZeroClaw `cargo test`: **51 pass**. Plugin tests pass (reranker tests pass both flags explicitly). MCP builds (pre-existing `trajectory-poller.ts` type errors unrelated).

## Scope note
This is the **source-weights** half of the cross-client recall alignment. The **date-surfacing** half (hoist recall-context formatter to core, wire all clients) is a separate sequenced effort — plan: `totalreclaw-internal` `docs/plans/2026-06-10-cross-client-recall-alignment.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)