### PR TITLE
fix(hermes): installer disables builtin memory → TotalReclaw is the sole system (Strategy 1)

### DIFF
--- a/python/src/totalreclaw/hermes/install_memory_provider.py
+++ b/python/src/totalreclaw/hermes/install_memory_provider.py
@@ -228,6 +228,67 @@ def set_active_provider(
     return path
 
 
+def _memory_key_re(key: str) -> "re.Pattern[str]":
+    """Match ``<indent><key>: <value>`` inside the memory block."""
+    return re.compile(rf"^(\s*){re.escape(key)}\s*:\s*(\S+)[ \t]*$", re.MULTILINE)
+
+
+def _set_memory_key(text: str, key: str, value: str) -> str:
+    """Return *text* with ``memory.<key>: <value>`` set.
+
+    Replaces the key in-place if present in the ``memory:`` block, appends it
+    to the block if the block exists but the key doesn't, or creates a
+    ``memory:`` block if there is none. Mirrors :func:`set_active_provider`'s
+    YAML-surgery approach (no full YAML parse — preserves comments/ordering).
+    """
+    key_re = _memory_key_re(key)
+    block_match = _MEMORY_BLOCK_RE.search(text)
+    if block_match:
+        block = block_match.group(1)
+        if key_re.search(block):
+            new_block = key_re.sub(rf"\g<1>{key}: {value}", block, count=1)
+        else:
+            stripped = block.rstrip("\n")
+            new_block = stripped + f"\n  {key}: {value}\n"
+        return text[: block_match.start(1)] + new_block + text[block_match.end(1):]
+    sep = "" if (text == "" or text.endswith("\n")) else "\n"
+    return text + sep + f"memory:\n  {key}: {value}\n"
+
+
+def disable_builtin_memory(hermes_home: Optional[Path] = None) -> Path:
+    """Silence Hermes' builtin local memory so TotalReclaw is the sole system.
+
+    Sets ``memory_enabled: false`` AND ``user_profile_enabled: false`` in the
+    ``memory:`` block. Hermes loads its builtin ``MemoryStore`` (which reads +
+    injects ``~/.hermes/memories/MEMORY.md`` and maintains ``~/.hermes/profiles/``)
+    when *either* flag is true (``agent_init.py``), so both must be false to
+    fully quiet it. TotalReclaw's own auto-recall/extract runs via its lifecycle
+    hooks, which are independent of these flags — so disabling the builtin does
+    NOT disable TotalReclaw; it just removes the parallel local store
+    (the 2026-06-10 split-brain). ``provider: builtin`` (set by the user) is the
+    explicit opt-in to switch back to local files.
+
+    Returns the config path written.
+    """
+    path = config_path(hermes_home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = ""
+    if path.exists():
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            text = ""
+    text = _set_memory_key(text, "memory_enabled", "false")
+    text = _set_memory_key(text, "user_profile_enabled", "false")
+    path.write_text(text, encoding="utf-8")
+    logger.info(
+        "TotalReclaw: disabled builtin memory (memory_enabled=false, "
+        "user_profile_enabled=false) in %s",
+        path,
+    )
+    return path
+
+
 def install_and_activate(
     hermes_home: Optional[Path] = None,
     *,
@@ -242,13 +303,22 @@ def install_and_activate(
     sidecar = install_sidecar(hermes_home, force=force)
     previous = read_active_provider(hermes_home)
     activated = False
+    builtin_disabled = False
     if activate:
         set_active_provider("totalreclaw", hermes_home)
         activated = True
+        # Make TotalReclaw the SOLE memory system: silence the builtin local
+        # store so it stops loading/injecting MEMORY.md + maintaining local
+        # profiles in parallel (the split-brain). TR keeps running via its own
+        # lifecycle hooks. Switching back to local files = user sets
+        # `memory.provider: builtin` explicitly.
+        disable_builtin_memory(hermes_home)
+        builtin_disabled = True
 
     return {
         "sidecar_path": str(sidecar),
         "previous_provider": previous or "",
         "active_provider": "totalreclaw" if activated else (previous or ""),
         "activated": activated,
+        "builtin_disabled": builtin_disabled,
     }

--- a/python/tests/test_memory_provider.py
+++ b/python/tests/test_memory_provider.py
@@ -692,3 +692,89 @@ class TestCliMemoryProvider:
         captured = capsys.readouterr()
         assert rc == 2
         assert "Refusing to overwrite" in captured.err
+
+
+class TestDisableBuiltinMemory:
+    """Strategy 1: silence Hermes' builtin local memory so TR is the sole system."""
+
+    def test_disable_sets_both_flags_fresh_config(self, tmp_path: Path):
+        imp.disable_builtin_memory(hermes_home=tmp_path)
+        text = imp.config_path(tmp_path).read_text(encoding="utf-8")
+        import yaml
+        cfg = yaml.safe_load(text)
+        assert cfg["memory"]["memory_enabled"] is False
+        assert cfg["memory"]["user_profile_enabled"] is False
+
+    def test_disable_flips_existing_true_flags_and_preserves_keys(self, tmp_path: Path):
+        cfg = imp.config_path(tmp_path)
+        cfg.parent.mkdir(parents=True, exist_ok=True)
+        cfg.write_text(
+            "memory:\n"
+            "  memory_enabled: true\n"
+            "  user_profile_enabled: true\n"
+            "  memory_char_limit: 2200\n"
+            "  provider: totalreclaw\n"
+            "delegation:\n  foo: bar\n",
+            encoding="utf-8",
+        )
+        imp.disable_builtin_memory(hermes_home=tmp_path)
+        import yaml
+        parsed = yaml.safe_load(cfg.read_text(encoding="utf-8"))
+        assert parsed["memory"]["memory_enabled"] is False
+        assert parsed["memory"]["user_profile_enabled"] is False
+        # Unrelated keys preserved.
+        assert parsed["memory"]["memory_char_limit"] == 2200
+        assert parsed["memory"]["provider"] == "totalreclaw"
+        assert parsed["delegation"]["foo"] == "bar"
+
+    def test_disable_is_idempotent(self, tmp_path: Path):
+        imp.disable_builtin_memory(hermes_home=tmp_path)
+        first = imp.config_path(tmp_path).read_text(encoding="utf-8")
+        imp.disable_builtin_memory(hermes_home=tmp_path)
+        second = imp.config_path(tmp_path).read_text(encoding="utf-8")
+        assert first == second
+
+    def test_disable_inserts_into_block_without_those_keys(self, tmp_path: Path):
+        cfg = imp.config_path(tmp_path)
+        cfg.parent.mkdir(parents=True, exist_ok=True)
+        cfg.write_text("memory:\n  provider: totalreclaw\n", encoding="utf-8")
+        imp.disable_builtin_memory(hermes_home=tmp_path)
+        import yaml
+        parsed = yaml.safe_load(cfg.read_text(encoding="utf-8"))
+        assert parsed["memory"]["provider"] == "totalreclaw"
+        assert parsed["memory"]["memory_enabled"] is False
+        assert parsed["memory"]["user_profile_enabled"] is False
+
+    def test_install_and_activate_disables_builtin(self, tmp_path: Path):
+        result = imp.install_and_activate(hermes_home=tmp_path, activate=True)
+        assert result["builtin_disabled"] is True
+        import yaml
+        parsed = yaml.safe_load(imp.config_path(tmp_path).read_text(encoding="utf-8"))
+        assert parsed["memory"]["provider"] == "totalreclaw"
+        assert parsed["memory"]["memory_enabled"] is False
+        assert parsed["memory"]["user_profile_enabled"] is False
+
+    def test_tools_only_does_not_disable_builtin(self, tmp_path: Path):
+        # Another provider is active → tools-only branch must NOT touch builtin.
+        cfg = imp.config_path(tmp_path)
+        cfg.parent.mkdir(parents=True, exist_ok=True)
+        cfg.write_text(
+            "memory:\n  provider: honcho\n  memory_enabled: true\n", encoding="utf-8"
+        )
+        result = imp.install_and_activate(hermes_home=tmp_path, activate=False)
+        assert result["builtin_disabled"] is False
+        import yaml
+        parsed = yaml.safe_load(cfg.read_text(encoding="utf-8"))
+        assert parsed["memory"]["memory_enabled"] is True  # untouched
+        assert parsed["memory"]["provider"] == "honcho"
+
+    def test_set_memory_key_replace_and_insert(self):
+        # Replace existing.
+        t = imp._set_memory_key("memory:\n  memory_enabled: true\n", "memory_enabled", "false")
+        assert "memory_enabled: false" in t and "true" not in t
+        # Insert when key missing but block present.
+        t2 = imp._set_memory_key("memory:\n  provider: x\n", "memory_enabled", "false")
+        assert "provider: x" in t2 and "memory_enabled: false" in t2
+        # Create block when absent.
+        t3 = imp._set_memory_key("", "memory_enabled", "false")
+        assert t3.startswith("memory:") and "memory_enabled: false" in t3


### PR DESCRIPTION
## What
On activation, `install_and_activate` now also sets `memory_enabled: false` + `user_profile_enabled: false` in `~/.hermes/config.yaml`, silencing Hermes' builtin local store so it stops injecting `MEMORY.md` + maintaining `~/.hermes/profiles/` in parallel with TotalReclaw.

## Why
The 2026-06-10 split-brain: `memory.provider: totalreclaw` was set but the builtin ran anyway (`memory_enabled: true`). Hermes loads the builtin `MemoryStore` when **either** flag is true (`agent_init.py:1117`), so both must be false.

TotalReclaw's auto-recall/extract runs via its **lifecycle hooks**, independent of these flags — so this does **not** disable TR. Local files = explicit `memory.provider: builtin` opt-in. Tools-only branch (another provider active) leaves the builtin untouched.

## Notes
- Safe stopgap while native-provider conformance #351 is built — works because the provider sidecar doesn't resolve yet (#346 draft), so no double-fire.
- New `disable_builtin_memory()` + generic `_set_memory_key()` YAML-surgery helper (no full parse — preserves comments/ordering). 7 new tests, 57/57 in `test_memory_provider`.
- Existing installs (e.g. pop-os) pick this up on re-install/upgrade; I'll apply + validate it live on pop-os separately.

Refs: #351 (Strategy 2 tracking), #346 (sidecar path prereq).

🤖 Generated with [Claude Code](https://claude.com/claude-code)