### PR TITLE
refactor(hermes): shared memory entry points recall_for_query + ingest_turn (#351 §5.1)

### DIFF
--- a/python/src/totalreclaw/hermes/hooks.py
+++ b/python/src/totalreclaw/hermes/hooks.py
@@ -646,9 +646,9 @@ def pre_llm_call(state: "PluginState", **kwargs) -> Optional[dict]:
         logger.debug("import-completion injection skipped: %s", e)
 
     if is_first_turn and user_message:
-        # Auto-recall relevant memories for the first turn
+        # Auto-recall relevant memories for the first turn (shared entry point).
         try:
-            memories_ctx = auto_recall(user_message, state, top_k=8)
+            memories_ctx = recall_for_query(state, user_message, top_k=8)
             if memories_ctx:
                 context_parts.append(memories_ctx)
         except Exception as e:
@@ -660,43 +660,42 @@ def pre_llm_call(state: "PluginState", **kwargs) -> Optional[dict]:
     return {"context": "\n\n".join(context_parts)}
 
 
-def post_llm_call(state: "PluginState", **kwargs) -> None:
-    """Auto-extract facts every N turns.
+# ---------------------------------------------------------------------------
+# Hook-free shared memory entry points (Hermes provider conformance §5.1).
+#
+# Recall and extract already live in the cross-client agent layer
+# (``agent.recall.auto_recall`` / ``agent.lifecycle.auto_extract``). These two
+# wrappers expose the Hermes-side *orchestration* (turn bookkeeping, interval
+# gating, extraction-LLM resolution) as plain functions that take a
+# ``PluginState`` and no Hermes hook kwargs — so the lifecycle hooks below AND
+# the Hermes ``MemoryProvider`` (§5.2: ``prefetch`` → ``recall_for_query``,
+# ``sync_turn`` → ``ingest_turn``) can share one code path. No behavior change
+# vs the previous inline ``pre_llm_call`` / ``post_llm_call`` logic.
+# ---------------------------------------------------------------------------
 
-    Bug #5: when Hermes's LLM config can't be resolved AND no fallback
-    env-vars are set, we surface a one-time quota-channel warning so the
-    user sees the failure in their next assistant turn. Prior behavior
-    was a debug-only log; users hit 7+ natural-conversation turns and
-    watched no memories appear, with nothing to explain why.
+
+def recall_for_query(
+    state: "PluginState", query: str, *, top_k: int = 8
+) -> Optional[str]:
+    """Recall a context block for *query* (hook-free).
+
+    Thin wrapper over the shared ``agent.recall.auto_recall``; the single
+    entry point the Hermes hook (``pre_llm_call``) and the provider
+    (``prefetch``) both call.
     """
-    # Always track turns and messages (client may be configured mid-session)
-    state.increment_turn()
-    user_msg = kwargs.get("user_message", "")
-    state.add_message("user", user_msg)
-    state.add_message("assistant", kwargs.get("assistant_response", ""))
+    return auto_recall(query, state, top_k=top_k)
 
-    # 2.4.4rc2 (F7) — track this turn's user message in the pending-
-    # auto-extract buffer so subsequent manual `totalreclaw_remember`
-    # calls can suppress duplicates. Idempotent for empty messages.
-    state.track_pending_extract(user_msg)
 
-    # Fix #191 safety net — same rationale as in pre_llm_call. If the
-    # user paired between on_session_start and now, this picks up the
-    # creds without a gateway restart. Idempotent + cheap.
-    if _maybe_reconfigure_from_disk(state):
-        _eager_account_register(state)
+def _resolve_extraction_llm_config(state: "PluginState"):
+    """Resolve the LLM config for auto-extraction.
 
-    if not state.is_configured():
-        return
-
-    extraction_interval = state.get_extraction_interval()
-    if state.turn_count % extraction_interval != 0:
-        return
-
-    # Resolve LLM config and surface a user-visible warning if it fails.
+    Hermes config first, then env-var detection (so non-Hermes-hosted agents
+    work). If neither resolves, surface a one-time quota-channel warning so the
+    user sees *why* memories stopped appearing (Bug #5). Returns the config or
+    ``None`` — ``auto_extract`` treats ``None`` as a safe silent skip.
+    """
     llm_config = _get_hermes_llm_config()
     if llm_config is None:
-        # Also try env-var detection so non-Hermes-hosted agents work.
         try:
             from totalreclaw.agent.llm_client import detect_llm_config
             llm_config = detect_llm_config()
@@ -704,8 +703,6 @@ def post_llm_call(state: "PluginState", **kwargs) -> None:
             llm_config = None
 
     if llm_config is None:
-        # Surface once per session via the existing quota-warning channel
-        # so the user sees an explanation in their next assistant turn.
         _warned_attr = "_totalreclaw_llm_missing_warned"
         if not getattr(state, _warned_attr, False):
             setattr(state, _warned_attr, True)
@@ -722,15 +719,62 @@ def post_llm_call(state: "PluginState", **kwargs) -> None:
                 "TotalReclaw: no LLM config for auto-extraction; surfacing "
                 "one-time warning via quota channel"
             )
-        # Fall through — ``_auto_extract`` will itself log the silent-skip
-        # path; it's safe to call with ``llm_config=None``. Callers that
-        # mock ``extract_facts_llm`` directly still see the wiring path.
+    return llm_config
 
-    # Extract and store facts (use Hermes LLM config so model name is resolved)
+
+def ingest_turn(
+    state: "PluginState", user_message: str, assistant_response: str
+) -> None:
+    """Record a completed turn and run interval-gated auto-extraction (hook-free).
+
+    The shared core of ``post_llm_call``: bookkeeping always runs (the client
+    may be configured mid-session); extraction runs only when configured and on
+    the Nth turn. Reused by the Hermes ``MemoryProvider.sync_turn`` (§5.2).
+    Mirrors the previous inline ``post_llm_call`` behavior exactly.
+    """
+    # Always track turns and messages (client may be configured mid-session).
+    state.increment_turn()
+    state.add_message("user", user_message)
+    state.add_message("assistant", assistant_response)
+    # 2.4.4rc2 (F7) — pending-extract buffer so later manual
+    # `totalreclaw_remember` calls can suppress duplicates. Idempotent on "".
+    state.track_pending_extract(user_message)
+
+    if not state.is_configured():
+        return
+
+    if state.turn_count % state.get_extraction_interval() != 0:
+        return
+
+    llm_config = _resolve_extraction_llm_config(state)
+    # Fall through with llm_config possibly None — ``_auto_extract`` logs the
+    # silent-skip path itself; callers that mock ``extract_facts_llm`` directly
+    # still exercise the wiring.
     try:
         _auto_extract(state, mode="turn", llm_config=llm_config)
     except Exception as e:
         logger.warning("TotalReclaw post_llm_call extraction failed: %s", e)
+
+
+def post_llm_call(state: "PluginState", **kwargs) -> None:
+    """Auto-extract facts every N turns (Hermes ``post_llm_call`` hook).
+
+    Hermes-hook-specific wrapper around :func:`ingest_turn`: the only extra is
+    the Fix #191 mid-session reconfigure (pick up creds if the user paired
+    between ``on_session_start`` and now, without a gateway restart). Reordering
+    the reconfigure ahead of the turn bookkeeping is behavior-equivalent — the
+    two touch disjoint state (creds vs turn-count/messages).
+    """
+    # Fix #191 safety net — pick up a mid-session pair before ingest_turn
+    # decides whether the user is configured. Idempotent + cheap.
+    if _maybe_reconfigure_from_disk(state):
+        _eager_account_register(state)
+
+    ingest_turn(
+        state,
+        kwargs.get("user_message", ""),
+        kwargs.get("assistant_response", ""),
+    )
 
 
 def on_session_end(state: "PluginState", **kwargs) -> None:

--- a/python/tests/test_hermes_shared_memory_entrypoints.py
+++ b/python/tests/test_hermes_shared_memory_entrypoints.py
@@ -1,0 +1,85 @@
+"""§5.1 — hook-free shared memory entry points (provider conformance, #351).
+
+``recall_for_query`` and ``ingest_turn`` are the single code path that both the
+Hermes lifecycle hooks (``pre_llm_call`` / ``post_llm_call``) and the future
+``MemoryProvider`` (``prefetch`` / ``sync_turn``, §5.2) call. These tests lock
+the contract so §5.2 can depend on them, and assert ``post_llm_call`` is now a
+thin wrapper over ``ingest_turn``.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from totalreclaw.hermes import hooks
+
+
+def _state(*, configured=True, turn_count=3, interval=3) -> MagicMock:
+    s = MagicMock()
+    s.is_configured.return_value = configured
+    s.turn_count = turn_count
+    s.get_extraction_interval.return_value = interval
+    return s
+
+
+class TestRecallForQuery:
+    def test_delegates_to_auto_recall(self):
+        s = _state()
+        with patch.object(hooks, "auto_recall", return_value="CTX") as ar:
+            out = hooks.recall_for_query(s, "who am I?", top_k=8)
+        assert out == "CTX"
+        ar.assert_called_once_with("who am I?", s, top_k=8)
+
+
+class TestIngestTurn:
+    def test_always_records_the_turn(self):
+        s = _state(configured=False)  # even unconfigured, bookkeeping runs
+        hooks.ingest_turn(s, "u", "a")
+        s.increment_turn.assert_called_once()
+        assert s.add_message.call_count == 2
+        s.add_message.assert_any_call("user", "u")
+        s.add_message.assert_any_call("assistant", "a")
+        s.track_pending_extract.assert_called_once_with("u")
+
+    def test_unconfigured_skips_extract(self):
+        s = _state(configured=False)
+        with patch.object(hooks, "_auto_extract") as ax:
+            hooks.ingest_turn(s, "u", "a")
+        ax.assert_not_called()
+
+    def test_off_interval_skips_extract(self):
+        s = _state(configured=True, turn_count=3, interval=5)  # 3 % 5 != 0
+        with patch.object(hooks, "_auto_extract") as ax:
+            hooks.ingest_turn(s, "u", "a")
+        ax.assert_not_called()
+
+    def test_on_interval_runs_extract_with_resolved_config(self):
+        s = _state(configured=True, turn_count=6, interval=3)  # 6 % 3 == 0
+        sentinel = object()
+        with patch.object(hooks, "_resolve_extraction_llm_config", return_value=sentinel), \
+             patch.object(hooks, "_auto_extract") as ax:
+            hooks.ingest_turn(s, "u", "a")
+        ax.assert_called_once_with(s, mode="turn", llm_config=sentinel)
+
+    def test_extract_exception_is_swallowed(self):
+        s = _state(configured=True, turn_count=3, interval=3)
+        with patch.object(hooks, "_resolve_extraction_llm_config", return_value=None), \
+             patch.object(hooks, "_auto_extract", side_effect=RuntimeError("boom")):
+            hooks.ingest_turn(s, "u", "a")  # must not raise
+
+
+class TestPostLlmCallDelegates:
+    def test_post_llm_call_reconfigures_then_ingests(self):
+        s = _state()
+        with patch.object(hooks, "_maybe_reconfigure_from_disk", return_value=False) as rc, \
+             patch.object(hooks, "ingest_turn") as it:
+            hooks.post_llm_call(s, user_message="u", assistant_response="a")
+        rc.assert_called_once_with(s)
+        it.assert_called_once_with(s, "u", "a")
+
+    def test_post_llm_call_eager_register_on_midsession_pair(self):
+        s = _state()
+        with patch.object(hooks, "_maybe_reconfigure_from_disk", return_value=True), \
+             patch.object(hooks, "_eager_account_register") as er, \
+             patch.object(hooks, "ingest_turn"):
+            hooks.post_llm_call(s, user_message="u", assistant_response="a")
+        er.assert_called_once_with(s)


### PR DESCRIPTION
First implementation step of #351 (Hermes provider conformance).

## What
Lift the Hermes-side memory **orchestration** out of the lifecycle hooks into two hook-free functions on top of the already-shared agent layer (`agent.recall.auto_recall` / `agent.lifecycle.auto_extract`):
- `recall_for_query(state, query, top_k=8) -> Optional[str]`
- `ingest_turn(state, user_message, assistant_response) -> None` (record → interval-gate → resolve-llm → extract)
- `_resolve_extraction_llm_config(state)` (factored llm resolution + one-time warning)

`post_llm_call` becomes a thin wrapper (Fix #191 reconfigure → `ingest_turn`); `pre_llm_call` routes first-turn recall through `recall_for_query`.

## Why
§5.2 will wire `MemoryProvider.prefetch -> recall_for_query` and `.sync_turn -> ingest_turn`, so Hermes auto-memory runs through **one** code path instead of the current hooks-vs-provider split (the root of the double-fire). This is the safe, behavior-neutral groundwork.

## Safety
**Pure refactor, zero behavior change.** The only reordering (reconfigure ahead of turn bookkeeping) is behavior-equivalent — the two touch disjoint state. 8 new entry-point tests + full parity across the hook suite (**143 passed**: test_v2_02, test_rc2_enforcement_hooks, test_memq3, test_v1_hooks, test_issue_101, test_issue_191_192, test_hermes_plugin, test_import_quota_gate).

Refs: #351 (tracking), design PR #350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)