### PR TITLE
feat(recall): wire TS clients (plugin/MCP/NanoClaw) to core 2.5.3 date formatter

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -39,7 +39,7 @@
     "@noble/hashes": "^2.0.1",
     "@scure/bip39": "^2.0.1",
     "@totalreclaw/client": "^1.3.0",
-    "@totalreclaw/core": "^2.4.0",
+    "@totalreclaw/core": "^2.5.3",
     "permissionless": "^0.3.4",
     "porter-stemmer": "^0.9.1",
     "tslib": "^2.8.1",

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1298,6 +1298,8 @@ async function handleRecallSubgraph(
     );
 
     // 8. Format results
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const subgraphCore = require('@totalreclaw/core') as typeof import('@totalreclaw/core');
     const memories = reranked.map((r) => ({
       fact_id: r.id,
       fact_text: r.text,
@@ -1312,6 +1314,9 @@ async function handleRecallSubgraph(
       age_days: r.createdAt
         ? Math.floor((Date.now() / 1000 - r.createdAt) / 86400)
         : 0,
+      date: r.createdAt != null
+        ? subgraphCore.formatMemoryDate(BigInt(r.createdAt))
+        : '',
     }));
 
     return {

--- a/mcp/src/tools/recall.ts
+++ b/mcp/src/tools/recall.ts
@@ -153,6 +153,7 @@ export async function handleRecall(
     const memories = weighted.map(({ r, category, source, scope, weightedScore, sourceWeight }) => {
       const ageMs = Date.now() - r.fact.createdAt.getTime();
       const ageDays = Math.floor(ageMs / (1000 * 60 * 60 * 24));
+      const createdAtUnix = BigInt(Math.floor(r.fact.createdAt.getTime() / 1000));
       return {
         fact_id: r.fact.id,
         fact_text: r.fact.text,
@@ -165,6 +166,7 @@ export async function handleRecall(
         importance: Math.round((r.fact.metadata.importance ?? 0.5) * 10),
         age_days: ageDays,
         decay_score: r.decayAdjustedScore,
+        date: core.formatMemoryDate(createdAtUnix),
       };
     });
 

--- a/skill-nanoclaw/package-lock.json
+++ b/skill-nanoclaw/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@totalreclaw/skill-nanoclaw",
-  "version": "3.1.0",
+  "version": "3.1.1-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/skill-nanoclaw",
-      "version": "3.1.0",
+      "version": "3.1.1-rc.1",
       "license": "MIT",
       "dependencies": {
         "@totalreclaw/client": "^1.2.0",
-        "@totalreclaw/core": "^2.2.0"
+        "@totalreclaw/core": "^2.5.3"
       },
       "devDependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.81",
@@ -34,14 +34,14 @@
     },
     "../client": {
       "name": "@totalreclaw/client",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.0.1",
+        "@noble/hashes": "^2.0.1",
         "@scure/bip39": "^2.0.1",
         "@totalreclaw/core": "^1.1.0",
-        "argon2": "^0.31.0",
         "permissionless": "^0.3.4",
         "protobufjs": "^7.2.5",
         "viem": "^2.46.3"
@@ -62,11 +62,6 @@
       "optionalDependencies": {
         "keytar": "^7.9.0"
       }
-    },
-    "../rust/totalreclaw-core/pkg": {
-      "name": "@totalreclaw/core",
-      "version": "2.2.0",
-      "license": "MIT"
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
       "version": "0.2.81",
@@ -1309,8 +1304,10 @@
       "link": true
     },
     "node_modules/@totalreclaw/core": {
-      "resolved": "../rust/totalreclaw-core/pkg",
-      "link": true
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@totalreclaw/core/-/core-2.5.3.tgz",
+      "integrity": "sha512-W0lVgV5lv6VsIts/YOU32msSUh5Jj4hCir+MRKub+KhB5wb9nGbYNaj7MBH1DewMI8Rp6TGgfSr7gr3iV/sqmw==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/skill-nanoclaw/package.json
+++ b/skill-nanoclaw/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "@totalreclaw/client": "^1.2.0",
-    "@totalreclaw/core": "^2.2.0"
+    "@totalreclaw/core": "^2.5.3"
   },
   "peerDependencies": {
     "@totalreclaw/mcp-server": "^3.0.0"

--- a/skill-nanoclaw/src/hooks/before-agent-start.ts
+++ b/skill-nanoclaw/src/hooks/before-agent-start.ts
@@ -1,4 +1,5 @@
 import type { TotalReclaw } from '@totalreclaw/client';
+import * as core from '@totalreclaw/core';
 import {
   getBillingContext,
   fetchBillingStatus,
@@ -18,6 +19,7 @@ export interface BeforeAgentStartOutput {
     text: string;
     score: number;
     type: string;
+    createdAt?: number;
   }>;
   latencyMs: number;
 }
@@ -47,6 +49,7 @@ export async function beforeAgentStart(
       text: r.fact.text,
       score: r.score,
       type: r.fact.metadata.tags?.find(t => ALL_TYPES.has(t)) || 'claim',
+      createdAt: r.fact.createdAt ? Math.floor(r.fact.createdAt.getTime() / 1000) : undefined,
     }));
 
     // --- Billing check ---
@@ -88,10 +91,11 @@ export async function beforeAgentStart(
   }
 }
 
-function formatMemoriesForContext(memories: Array<{ text: string; score: number; type: string }>): string {
-  const lines = ['## Relevant Memories\n'];
-  for (const m of memories) {
-    lines.push(`- [${m.type}] ${m.text}`);
-  }
-  return lines.join('\n');
+function formatMemoriesForContext(memories: Array<{ text: string; score: number; type: string; createdAt?: number }>): string {
+  const items = memories.map(m => ({
+    category: m.type,
+    text: m.text,
+    created_at: m.createdAt ?? 0,
+  }));
+  return core.formatRecallContext(JSON.stringify(items), BigInt(Math.floor(Date.now() / 1000)));
 }

--- a/skill-nanoclaw/tests/hooks.test.js
+++ b/skill-nanoclaw/tests/hooks.test.js
@@ -45,7 +45,7 @@ describe('beforeAgentStart', () => {
 
     expect(result.memories).toHaveLength(1);
     expect(result.memories[0].text).toBe('User prefers TypeScript');
-    expect(result.contextString).toContain('## Relevant Memories');
+    expect(result.contextString).toContain('## Relevant memories from TotalReclaw');
   });
 
   it('should filter by namespace', async () => {

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -4327,7 +4327,7 @@ const plugin = {
             // 4. Request more candidates than needed so we can re-rank client-side.
             // 5. Decrypt candidates (text + embeddings) and build reranker input.
             const rerankerCandidates: RerankerCandidate[] = [];
-            const metaMap = new Map<string, { metadata: Record<string, unknown>; timestamp: number }>();
+            const metaMap = new Map<string, { metadata: Record<string, unknown>; timestamp: number; category?: string }>();
 
             if (isSubgraphMode()) {
               // --- Subgraph search path ---
@@ -4518,6 +4518,9 @@ const plugin = {
                 memories: reranked.map((m) => ({
                   factId: m.id,
                   text: m.text,
+                  date: m.createdAt != null
+                    ? getSmartImportWasm().formatMemoryDate(BigInt(m.createdAt))
+                    : '',
                 })),
               },
             };
@@ -7001,7 +7004,7 @@ const plugin = {
 
             // 5. Decrypt subgraph results and build reranker input.
             const rerankerCandidates: RerankerCandidate[] = [];
-            const hookMetaMap = new Map<string, { importance: number; age: string }>();
+            const hookMetaMap = new Map<string, { importance: number; age: string; category?: string }>();
 
             for (const result of subgraphResults) {
               try {
@@ -7076,15 +7079,19 @@ const plugin = {
 
             // Relevance gate removed in rc.22 (see recall tool comment).
 
-            // 7. Build context string.
-            const lines = reranked.map((m, i) => {
+            // 7. Build context string using core's unified recall formatter (adds dates + header).
+            const recallItems = reranked.map((m) => {
               const meta = hookMetaMap.get(m.id);
-              const importance = meta?.importance ?? 5;
-              const age = meta?.age ?? '';
-              const typeTag = meta?.category ? `[${meta.category}] ` : '';
-              return `${i + 1}. ${typeTag}${m.text} (importance: ${importance}/10, ${age})`;
+              return {
+                category: meta?.category ?? 'claim',
+                text: m.text,
+                created_at: m.createdAt ?? 0,
+              };
             });
-            const contextString = `## Relevant Memories\n\n${lines.join('\n')}`;
+            const contextString = getSmartImportWasm().formatRecallContext(
+              JSON.stringify(recallItems),
+              BigInt(Math.floor(Date.now() / 1000)),
+            );
 
             return { prependContext: consumeBannerForPrepend() + contextString + welcomeBack + billingWarning };
           }
@@ -7125,7 +7132,7 @@ const plugin = {
 
           // 5. Decrypt candidates (text + embeddings) and build reranker input.
           const rerankerCandidates: RerankerCandidate[] = [];
-          const hookMetaMap = new Map<string, { importance: number; age: string }>();
+          const hookMetaMap = new Map<string, { importance: number; age: string; category?: string }>();
 
           for (const candidate of candidates) {
             try {
@@ -7181,14 +7188,17 @@ const plugin = {
 
           // Relevance gate removed in rc.22 (see recall tool comment).
 
-          // 7. Build context string.
-          const lines = reranked.map((m, i) => {
-            const meta = hookMetaMap.get(m.id);
-            const importance = meta?.importance ?? 5;
-            const age = meta?.age ?? '';
-            return `${i + 1}. ${m.text} (importance: ${importance}/10, ${age})`;
-          });
-          const contextString = `## Relevant Memories\n\n${lines.join('\n')}`;
+          // 7. Build context string using core's unified recall formatter (adds dates + header).
+          // Server mode has no category metadata, so we use 'claim' as default.
+          const srvRecallItems = reranked.map((m) => ({
+            category: 'claim',
+            text: m.text,
+            created_at: m.createdAt ?? 0,
+          }));
+          const contextString = getSmartImportWasm().formatRecallContext(
+            JSON.stringify(srvRecallItems),
+            BigInt(Math.floor(Date.now() / 1000)),
+          );
 
           return { prependContext: consumeBannerForPrepend() + contextString + welcomeBack + billingWarning };
         } catch (err: unknown) {

--- a/skill/plugin/package-lock.json
+++ b/skill/plugin/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@scure/bip39": "^2.2.0",
         "@totalreclaw/client": "^1.3.0",
-        "@totalreclaw/core": "^2.4.0",
+        "@totalreclaw/core": "^2.5.3",
         "@types/qrcode": "^1.5.6",
         "@types/ws": "^8.5.12",
         "qrcode": "^1.5.4",
@@ -817,9 +817,9 @@
       "license": "MIT"
     },
     "node_modules/@totalreclaw/core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@totalreclaw/core/-/core-2.4.0.tgz",
-      "integrity": "sha512-IyGfGW7b2G9NbVZU3c7oPGpaBGZDpQ3aVsGX2mXQ/6aiXy/EZWLL6Ux4lFXiroCM3A7EPv/gediokOeBVoZbEw==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@totalreclaw/core/-/core-2.5.3.tgz",
+      "integrity": "sha512-W0lVgV5lv6VsIts/YOU32msSUh5Jj4hCir+MRKub+KhB5wb9nGbYNaj7MBH1DewMI8Rp6TGgfSr7gr3iV/sqmw==",
       "license": "MIT"
     },
     "node_modules/@types/node": {

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@scure/bip39": "^2.2.0",
     "@totalreclaw/client": "^1.3.0",
-    "@totalreclaw/core": "^2.5.1",
+    "@totalreclaw/core": "^2.5.3",
     "@types/qrcode": "^1.5.6",
     "@types/ws": "^8.5.12",
     "qrcode": "^1.5.4",


### PR DESCRIPTION
## What
Phase C of cross-client recall alignment — wire the 3 TS clients to the shared `@totalreclaw/core` 2.5.3 recall-context formatter, so they surface dates in recall like Hermes (date + current-date + temporal-reasoning nudge). All bump `@totalreclaw/core` → `^2.5.3`.

| client | change |
|---|---|
| **NanoClaw** | thread `createdAt` into memories; `formatMemoriesForContext` → `core.formatRecallContext`. Typecheck clean. |
| **OpenClaw plugin** | both `before_agent_start` auto-recall injections → `core.formatRecallContext`; `recall` tool gains a `date` field via `core.formatMemoryDate`. Hot-cache fallback paths left as-is (no `createdAt` available). |
| **MCP** | self-hosted + managed recall tool JSON gains a `date` field via `core.formatMemoryDate`. |

API note: the WASM bindings take `bigint` (i64) — callers pass `BigInt(...)`.

## Why
One shared formatter, no drift. Behavior change is intentional: these clients now show dates (the +45pp-temporal lever, benchmark-validated). Plan: `totalreclaw-internal docs/plans/2026-06-10-cross-client-recall-alignment.md`.

## Tests / build
- **MCP**: typecheck clean (0 errors); `npx jest recall` 4/4 pass.
- **NanoClaw**: typecheck clean (0 errors); recall header test updated to new format.
- **Plugin**: builds (`tsc --noCheck`, the CI path); the wiring adds **zero new type errors** (remaining strict errors are all pre-existing — contradiction-sync/embedder-loader/commander/etc.).

## Note
ZeroClaw needs no change — it returns structured `MemoryEntry` with `pub timestamp` (date already exposed; consumer formats) and source-weights are already off (#349). Publishing these parked clients is deferred per the strategic pivot; code is aligned now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)