### PR TITLE
feat(hermes): MemoryProvider prefetch + sync_turn (#351 §5.2)

### DIFF
--- a/python/src/totalreclaw/hermes/memory_provider.py
+++ b/python/src/totalreclaw/hermes/memory_provider.py
@@ -261,6 +261,63 @@ class TotalReclawMemoryProvider(_MemoryProviderBase):  # type: ignore[misc,valid
         )
 
     # ------------------------------------------------------------------
+    # Native auto-memory (provider conformance §5.2 — #351)
+    #
+    # These are the two methods every other Hermes memory provider
+    # (honcho/mem0/supermemory/…) implements; they are what makes the
+    # native ``memory`` flow route through TotalReclaw. Both delegate to
+    # the shared hook-free entry points in ``hooks.py`` (§5.1), so the
+    # provider and the legacy lifecycle hooks share ONE code path.
+    #
+    # DORMANT until activation (#346 sidecar path + §5.3): the provider is
+    # not discovered yet, so these don't run live. §5.3 gates the plugin's
+    # ``pre_llm_call``/``post_llm_call`` memory work off when TR is the
+    # active provider (single driver) AND reconciles turn counting — at
+    # which point ``sync_turn`` (driven every turn via
+    # ``memory_manager.sync_all``) becomes the sole turn counter and the
+    # ``on_turn_start`` override below is dropped. Landing these now (while
+    # dormant) keeps the activation PR small and reviewable.
+    # ------------------------------------------------------------------
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        """Auto-recall context for the upcoming turn (native memory path).
+
+        Delegates to the shared ``hooks.recall_for_query`` — the same recall
+        the plugin's ``pre_llm_call`` uses. Returns "" when unconfigured or on
+        any error (the manager treats empty as "no context", never fatal).
+        """
+        if not self._state.is_configured():
+            return ""
+        try:
+            from .hooks import recall_for_query
+
+            return recall_for_query(self._state, query, top_k=8) or ""
+        except Exception as exc:  # pragma: no cover — non-fatal per ABC contract
+            logger.warning("TotalReclaw MemoryProvider.prefetch failed: %s", exc)
+            return ""
+
+    def sync_turn(
+        self,
+        user_content: str,
+        assistant_content: str,
+        *,
+        session_id: str = "",
+        messages: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        """Persist a completed turn (native auto-extract path).
+
+        Delegates to the shared ``hooks.ingest_turn`` — record the turn +
+        interval-gated extraction, the same logic the plugin's
+        ``post_llm_call`` runs. Idempotent + safe on errors.
+        """
+        try:
+            from .hooks import ingest_turn
+
+            ingest_turn(self._state, user_content, assistant_content)
+        except Exception as exc:  # pragma: no cover — non-fatal per ABC contract
+            logger.warning("TotalReclaw MemoryProvider.sync_turn failed: %s", exc)
+
+    # ------------------------------------------------------------------
     # Optional lifecycle hooks
     # ------------------------------------------------------------------
 

--- a/python/tests/test_memory_provider.py
+++ b/python/tests/test_memory_provider.py
@@ -778,3 +778,56 @@ class TestDisableBuiltinMemory:
         # Create block when absent.
         t3 = imp._set_memory_key("", "memory_enabled", "false")
         assert t3.startswith("memory:") and "memory_enabled: false" in t3
+
+
+class TestNativeAutoMemory:
+    """§5.2 (#351) — prefetch/sync_turn delegate to the shared §5.1 entry points."""
+
+    def test_prefetch_delegates_to_recall_for_query(self):
+        state = _make_state(configured=True)
+        provider = TotalReclawMemoryProvider(state)
+        with patch("totalreclaw.hermes.hooks.recall_for_query", return_value="CTX") as rq:
+            out = provider.prefetch("who am I?", session_id="s1")
+        assert out == "CTX"
+        rq.assert_called_once_with(state, "who am I?", top_k=8)
+
+    def test_prefetch_empty_when_unconfigured(self):
+        state = _make_state(configured=False)
+        provider = TotalReclawMemoryProvider(state)
+        with patch("totalreclaw.hermes.hooks.recall_for_query") as rq:
+            assert provider.prefetch("q") == ""
+        rq.assert_not_called()
+
+    def test_prefetch_swallows_errors(self):
+        state = _make_state(configured=True)
+        provider = TotalReclawMemoryProvider(state)
+        with patch("totalreclaw.hermes.hooks.recall_for_query", side_effect=RuntimeError("x")):
+            assert provider.prefetch("q") == ""
+
+    def test_prefetch_none_becomes_empty(self):
+        state = _make_state(configured=True)
+        provider = TotalReclawMemoryProvider(state)
+        with patch("totalreclaw.hermes.hooks.recall_for_query", return_value=None):
+            assert provider.prefetch("q") == ""
+
+    def test_sync_turn_delegates_to_ingest_turn(self):
+        state = _make_state(configured=True)
+        provider = TotalReclawMemoryProvider(state)
+        with patch("totalreclaw.hermes.hooks.ingest_turn") as it:
+            provider.sync_turn("u", "a", session_id="s1")
+        it.assert_called_once_with(state, "u", "a")
+
+    def test_sync_turn_accepts_messages_kwarg(self):
+        state = _make_state(configured=True)
+        provider = TotalReclawMemoryProvider(state)
+        with patch("totalreclaw.hermes.hooks.ingest_turn") as it:
+            provider.sync_turn(
+                "u", "a", session_id="s1", messages=[{"role": "user", "content": "u"}]
+            )
+        it.assert_called_once_with(state, "u", "a")
+
+    def test_sync_turn_swallows_errors(self):
+        state = _make_state(configured=True)
+        provider = TotalReclawMemoryProvider(state)
+        with patch("totalreclaw.hermes.hooks.ingest_turn", side_effect=RuntimeError("x")):
+            provider.sync_turn("u", "a")  # must not raise


### PR DESCRIPTION
Second step of #351 (provider conformance).

## What
Implement the two methods every other Hermes provider has — the native auto-recall / auto-persist surface — both delegating to the §5.1 shared entry points:
- `prefetch(query)` → `hooks.recall_for_query(state, query, top_k=8)`
- `sync_turn(u, a, ...)` → `hooks.ingest_turn(state, u, a)`

One code path for provider + legacy hooks; signatures match the ABC + `memory_manager` call sites exactly.

## Safety — DORMANT
The provider sidecar isn't discovered yet (#346 path fix is draft), so these don't run live. This PR is additive + inert until activation. **§5.3** then gates the plugin's `pre_llm_call`/`post_llm_call` memory work off when TR is the active provider (single driver) + reconciles turn counting (sync_turn becomes the sole counter via `memory_manager.sync_all`; the `on_turn_start` override is dropped). **§5.4** activates (installer + #346). Activation gated on live E2E.

7 new delegation tests; **64/64** in `test_memory_provider`.

Refs: #351, design #350, §5.1 #354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)