### PR TITLE
feat(hermes): single-driver provider — shared state + hook gating (#351 §5.3)

### DIFF
--- a/python/src/totalreclaw/hermes/__init__.py
+++ b/python/src/totalreclaw/hermes/__init__.py
@@ -12,14 +12,18 @@ from __future__ import annotations
 import logging
 
 from . import schemas, tools, hooks, pair_tool
-from .state import PluginState
+from .state import PluginState, get_shared_state
 
 logger = logging.getLogger(__name__)
 
 
 def register(ctx):
     """Called by Hermes plugin system at startup."""
-    state = PluginState()
+    # Provider conformance §5.3 (#351): the entry-point plugin and the
+    # MemoryProvider sidecar must share ONE PluginState so the provider's
+    # per-turn recall/extract and the plugin's tools/hooks observe the same
+    # buffer + turn counter + the `_provider_active` single-driver flag.
+    state = get_shared_state()
 
     # 2.3.1 first-run onboarding parity with plugin 3.3.0. Emit the
     # welcome + branch-question copy to stdout the first time the

--- a/python/src/totalreclaw/hermes/hooks.py
+++ b/python/src/totalreclaw/hermes/hooks.py
@@ -645,7 +645,13 @@ def pre_llm_call(state: "PluginState", **kwargs) -> Optional[dict]:
     except Exception as e:  # never let notification break the turn
         logger.debug("import-completion injection skipped: %s", e)
 
-    if is_first_turn and user_message:
+    # Single-driver gate (§5.3, #351): when TotalReclaw is the ACTIVE Hermes
+    # MemoryProvider, its ``prefetch`` already supplies recall for every turn —
+    # so the hook must NOT also auto-recall (that was the double-injection). The
+    # flag is set by the provider's ``initialize``; it stays False on dormant
+    # installs / non-provider clients, where the hook remains the recall driver.
+    _provider_driven = getattr(state, "_provider_active", False) is True
+    if is_first_turn and user_message and not _provider_driven:
         # Auto-recall relevant memories for the first turn (shared entry point).
         try:
             memories_ctx = recall_for_query(state, user_message, top_k=8)
@@ -766,9 +772,18 @@ def post_llm_call(state: "PluginState", **kwargs) -> None:
     two touch disjoint state (creds vs turn-count/messages).
     """
     # Fix #191 safety net — pick up a mid-session pair before ingest_turn
-    # decides whether the user is configured. Idempotent + cheap.
+    # decides whether the user is configured. Always runs (the provider does
+    # not handle mid-session reconfigure), so it stays outside the gate below.
     if _maybe_reconfigure_from_disk(state):
         _eager_account_register(state)
+
+    # Single-driver gate (§5.3, #351): when TotalReclaw is the active provider,
+    # its ``sync_turn`` (→ ``ingest_turn``) already records the turn + runs the
+    # interval-gated extraction. Running ``ingest_turn`` here too would
+    # double-count the turn and double-extract. The flag is False on dormant
+    # installs / non-provider clients, where this hook remains the extract driver.
+    if getattr(state, "_provider_active", False) is True:
+        return
 
     ingest_turn(
         state,

--- a/python/src/totalreclaw/hermes/memory_provider.py
+++ b/python/src/totalreclaw/hermes/memory_provider.py
@@ -111,10 +111,13 @@ class TotalReclawMemoryProvider(_MemoryProviderBase):  # type: ignore[misc,valid
     def __init__(self, state: Optional["PluginState"] = None) -> None:
         super().__init__()
         if state is None:
-            # Default path — Hermes' loader instantiates with no args.
-            # Lazy-import to avoid a circular import at module load.
-            from .state import PluginState
-            state = PluginState()
+            # Default path — Hermes' loader instantiates with no args. Use the
+            # PROCESS-SHARED state (§5.3) so this provider and the entry-point
+            # plugin's tools/hooks observe the same client + buffer + turn
+            # counter + `_provider_active` flag. Lazy-import avoids a circular
+            # import at module load.
+            from .state import get_shared_state
+            state = get_shared_state()
         self._state = state
         self._session_id: Optional[str] = None
 
@@ -137,27 +140,32 @@ class TotalReclawMemoryProvider(_MemoryProviderBase):  # type: ignore[misc,valid
         return self._state.is_configured()
 
     def initialize(self, session_id: str, **kwargs: Any) -> None:
-        """Per-session init. Matches the generic plugin's session-start path."""
+        """Per-session init + single-driver activation (§5.3).
+
+        Sets the ``_provider_active`` flag on the shared state. From here the
+        plugin's ``pre_llm_call``/``post_llm_call`` hooks SKIP recall + extract
+        (this provider's ``prefetch``/``sync_turn`` own them) — that's the
+        single-driver split that ends the double-fire.
+
+        Session lifecycle (setup, billing, banner, debrief) is DELEGATED to the
+        plugin's ``on_session_start``/``on_session_finalize`` hooks, which always
+        run on Hermes (entry-point plugin) and are well-tested. So this no longer
+        calls ``on_session_start`` itself — doing so would double it.
+        """
         self._session_id = session_id
-
-        from .hooks import on_session_start
-
-        try:
-            on_session_start(self._state, session_id=session_id, **kwargs)
-        except Exception as exc:
-            logger.warning("TotalReclaw MemoryProvider.initialize failed: %s", exc)
+        # Mark this process as provider-driven so the lifecycle hooks defer
+        # recall/extract to us. getattr-default-False elsewhere keeps dormant
+        # installs (provider never initialized) on the legacy hook path.
+        self._state._provider_active = True  # type: ignore[attr-defined]
 
     def shutdown(self) -> None:
-        """Best-effort flush at agent exit. Mirrors ``on_session_finalize``."""
-        if not self._state.is_configured():
-            return
+        """Best-effort flush at agent exit.
 
-        from .hooks import on_session_finalize
-
-        try:
-            on_session_finalize(self._state)
-        except Exception as exc:
-            logger.warning("TotalReclaw MemoryProvider.shutdown failed: %s", exc)
+        Session-end flush/debrief is delegated to the plugin's
+        ``on_session_finalize`` hook (single-driver §5.3) — calling it here too
+        would double the debrief. No-op beyond that.
+        """
+        return
 
     # ------------------------------------------------------------------
     # Tool surface
@@ -322,18 +330,16 @@ class TotalReclawMemoryProvider(_MemoryProviderBase):  # type: ignore[misc,valid
     # ------------------------------------------------------------------
 
     def on_turn_start(self, turn_number: int, message: str, **kwargs: Any) -> None:
-        """Per-user-turn tick.
+        """Per-user-turn tick — intentionally a counting no-op (§5.3).
 
-        Upstream bug NousResearch/hermes-agent#7193: this hook does not
-        fire for some configs. The generic plugin's ``post_llm_call``
-        keeps the turn counter accurate as a fallback. To avoid
-        double-counting on configs where BOTH hooks fire, we trust the
-        caller-supplied ``turn_number`` when valid, otherwise increment.
+        Turn counting is owned solely by ``sync_turn`` (via ``ingest_turn``),
+        which Hermes drives every turn through ``memory_manager.sync_all`` —
+        reliable, unlike ``on_turn_start`` (upstream NousResearch/hermes-agent
+        #7193 doesn't fire it for some configs). Incrementing here too would
+        double-count against ``sync_turn``. Kept as a no-op so the ABC hook
+        stays satisfied without touching the turn counter.
         """
-        if isinstance(turn_number, int) and turn_number >= 0:
-            self._state._turn_count = turn_number  # type: ignore[attr-defined]
-        else:
-            self._state.increment_turn()
+        return
 
     def on_pre_compress(self, messages: Optional[List[Dict[str, Any]]] = None, **kwargs: Any) -> str:
         """Hermes compaction hook — extract facts before context discard."""
@@ -359,23 +365,15 @@ class TotalReclawMemoryProvider(_MemoryProviderBase):  # type: ignore[misc,valid
         return _summarize_facts_for_compression(stored)
 
     def on_session_end(self, messages: Optional[List[Dict[str, Any]]] = None, **kwargs: Any) -> None:
-        """Session-boundary hook — flush + debrief.
+        """Session-boundary hook — intentionally a no-op (§5.3).
 
-        Mirrors the generic plugin's ``on_session_finalize``. Safe to
-        run alongside it: ``auto_extract`` is idempotent via the
-        unprocessed-buffer pointer, and the debrief writes a single
-        session-summary fact that's embedding-deduped against any
-        debrief written by the parallel hook in the same session.
+        Flush + debrief is delegated to the plugin's ``on_session_finalize``
+        hook, which always runs on Hermes (entry-point plugin) and is the
+        single, well-tested session-end path. Running it here too would double
+        the debrief (the old "embedding-deduped alongside" band-aid is no longer
+        needed under the single-driver split).
         """
-        if not self._state.is_configured():
-            return
-
-        from .hooks import on_session_finalize
-
-        try:
-            on_session_finalize(self._state, **kwargs)
-        except Exception as exc:
-            logger.warning("TotalReclaw on_session_end finalize failed: %s", exc)
+        return
 
     def on_memory_write(self, action: str, target: str, content: str) -> None:
         """Mirror Hermes-side ``add user-fact`` writes into TotalReclaw.

--- a/python/src/totalreclaw/hermes/state.py
+++ b/python/src/totalreclaw/hermes/state.py
@@ -4,6 +4,8 @@ This module provides ``PluginState`` as a backward-compatible alias for
 ``AgentState`` from the generic ``totalreclaw.agent`` layer. New code
 should use ``AgentState`` directly.
 """
+from typing import Optional
+
 from totalreclaw.agent.state import (  # noqa: F401
     AgentState as PluginState,
     DEFAULT_EXTRACTION_INTERVAL,
@@ -12,3 +14,23 @@ from totalreclaw.agent.state import (  # noqa: F401
     BILLING_CACHE_TTL,
     STORE_DEDUP_THRESHOLD,
 )
+
+# Process-wide shared state (provider conformance §5.3 — #351).
+#
+# The Hermes entry-point plugin (``register()``) and the MemoryProvider sidecar
+# (``TotalReclawMemoryProvider``) are loaded by SEPARATE Hermes mechanisms, but
+# they MUST observe the same state: same TotalReclaw client, message buffer,
+# turn counter, billing cache, and the ``_provider_active`` single-driver flag.
+# Without a shared instance the provider's ``sync_turn`` would record into a
+# different buffer than the plugin's tools read, turn counts would diverge, and
+# the gating flag set by the provider would be invisible to the hooks. Both call
+# ``get_shared_state()`` so there is exactly one ``PluginState`` per process.
+_SHARED_STATE: "Optional[PluginState]" = None
+
+
+def get_shared_state() -> "PluginState":
+    """Return the process-wide shared :class:`PluginState` (lazy singleton)."""
+    global _SHARED_STATE
+    if _SHARED_STATE is None:
+        _SHARED_STATE = PluginState()
+    return _SHARED_STATE

--- a/python/tests/test_hermes_provider_single_driver.py
+++ b/python/tests/test_hermes_provider_single_driver.py
@@ -1,0 +1,99 @@
+"""§5.3 (#351) — single-driver: shared state + hook gating.
+
+When TotalReclaw is the active Hermes MemoryProvider, the provider owns
+auto-recall (``prefetch``) + auto-extract (``sync_turn``); the lifecycle hooks
+must defer (no double-fire). The provider and the entry-point plugin must also
+share ONE ``PluginState``. These tests lock both.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import totalreclaw.hermes.state as state_mod
+from totalreclaw.hermes import hooks
+from totalreclaw.hermes.state import get_shared_state
+from totalreclaw.hermes.memory_provider import TotalReclawMemoryProvider
+
+
+def _reset_shared():
+    state_mod._SHARED_STATE = None
+
+
+class TestSharedState:
+    def test_get_shared_state_is_singleton(self):
+        _reset_shared()
+        assert get_shared_state() is get_shared_state()
+
+    def test_provider_default_uses_shared_state(self):
+        _reset_shared()
+        provider = TotalReclawMemoryProvider()
+        assert provider._state is get_shared_state()
+
+    def test_explicit_state_overrides_shared(self):
+        _reset_shared()
+        custom = MagicMock()
+        provider = TotalReclawMemoryProvider(custom)
+        assert provider._state is custom
+
+    def test_initialize_sets_provider_active_on_shared_state(self):
+        _reset_shared()
+        provider = TotalReclawMemoryProvider()
+        provider.initialize(session_id="s1")
+        assert get_shared_state()._provider_active is True
+
+
+def _gate_state(provider_active) -> MagicMock:
+    s = MagicMock()
+    s.is_configured.return_value = True
+    s._provider_active = provider_active  # real bool, not an auto-Mock
+    s.turn_count = 1
+    s.get_extraction_interval.return_value = 1
+    s.get_quota_warning.return_value = None
+    return s
+
+
+class TestPreLlmCallGate:
+    def test_skips_recall_when_provider_active(self):
+        s = _gate_state(True)
+        with patch.object(hooks, "recall_for_query") as rq, \
+             patch.object(hooks, "_maybe_reconfigure_from_disk", return_value=False):
+            hooks.pre_llm_call(s, user_message="who am I?", is_first_turn=True)
+        rq.assert_not_called()
+
+    def test_recalls_when_not_provider_active(self):
+        s = _gate_state(False)
+        with patch.object(hooks, "recall_for_query", return_value="") as rq, \
+             patch.object(hooks, "_maybe_reconfigure_from_disk", return_value=False):
+            hooks.pre_llm_call(s, user_message="who am I?", is_first_turn=True)
+        rq.assert_called_once()
+
+    def test_recalls_when_flag_is_a_mock_not_true(self):
+        # Defensive: an auto-created MagicMock attr must NOT trip the gate
+        # (gate is ``is True``), so legacy/mocked states still recall.
+        s = MagicMock()
+        s.is_configured.return_value = True
+        s.turn_count = 1
+        s.get_extraction_interval.return_value = 1
+        s.get_quota_warning.return_value = None
+        # note: s._provider_active is an auto-Mock (truthy, but not ``is True``)
+        with patch.object(hooks, "recall_for_query", return_value="") as rq, \
+             patch.object(hooks, "_maybe_reconfigure_from_disk", return_value=False):
+            hooks.pre_llm_call(s, user_message="who am I?", is_first_turn=True)
+        rq.assert_called_once()
+
+
+class TestPostLlmCallGate:
+    def test_skips_ingest_when_provider_active_but_keeps_reconfigure(self):
+        s = _gate_state(True)
+        with patch.object(hooks, "ingest_turn") as it, \
+             patch.object(hooks, "_maybe_reconfigure_from_disk", return_value=False) as rc:
+            hooks.post_llm_call(s, user_message="u", assistant_response="a")
+        it.assert_not_called()
+        rc.assert_called_once_with(s)  # reconfigure still runs (provider doesn't)
+
+    def test_ingests_when_not_provider_active(self):
+        s = _gate_state(False)
+        with patch.object(hooks, "ingest_turn") as it, \
+             patch.object(hooks, "_maybe_reconfigure_from_disk", return_value=False):
+            hooks.post_llm_call(s, user_message="u", assistant_response="a")
+        it.assert_called_once_with(s, "u", "a")

--- a/python/tests/test_memory_provider.py
+++ b/python/tests/test_memory_provider.py
@@ -45,27 +45,25 @@ def _make_state(configured: bool = True) -> PluginState:
 
 
 class TestOnTurnStart:
-    """Test 1 — on_turn_start increments / overrides turn counter when fired."""
+    """§5.3 — on_turn_start is a counting no-op; sync_turn owns the counter."""
 
-    def test_overrides_to_supplied_turn_number(self):
+    def test_does_not_touch_turn_count_with_number(self):
         state = _make_state()
         provider = TotalReclawMemoryProvider(state)
-
         provider.on_turn_start(turn_number=5, message="hi")
+        # No longer sets the counter — sync_turn (via ingest_turn) owns it.
+        assert state.turn_count == 0
 
-        assert state.turn_count == 5
-
-    def test_increments_when_turn_number_missing(self):
+    def test_does_not_increment_when_turn_number_missing(self):
         state = _make_state()
         provider = TotalReclawMemoryProvider(state)
-        # baseline
         state.increment_turn()
         state.increment_turn()
         assert state.turn_count == 2
 
         provider.on_turn_start(turn_number=None, message="hi")
 
-        assert state.turn_count == 3
+        assert state.turn_count == 2  # unchanged — no double-count vs sync_turn
 
 
 # ---------------------------------------------------------------------------
@@ -295,27 +293,24 @@ class TestCoreLifecycle:
         provider = TotalReclawMemoryProvider(state)
         assert provider.is_available() is False
 
-    def test_initialize_invokes_session_start_hook(self):
+    def test_initialize_sets_provider_active_and_delegates_session_start(self):
+        # §5.3: initialize sets the single-driver flag and does NOT call
+        # on_session_start (the plugin's hook owns session lifecycle — calling
+        # it here too would double it).
         state = _make_state()
         provider = TotalReclawMemoryProvider(state)
 
         with patch("totalreclaw.hermes.hooks.on_session_start") as on_start:
             provider.initialize(session_id="sess-1", platform="cli")
 
-        on_start.assert_called_once()
+        on_start.assert_not_called()
         assert provider._session_id == "sess-1"
+        assert state._provider_active is True
 
-    def test_shutdown_runs_session_finalize(self):
+    def test_shutdown_delegates_finalize_to_plugin(self):
+        # §5.3: shutdown no longer calls on_session_finalize — the plugin's
+        # on_session_finalize hook is the single session-end debrief path.
         state = _make_state(configured=True)
-        provider = TotalReclawMemoryProvider(state)
-
-        with patch("totalreclaw.hermes.hooks.on_session_finalize") as finalize:
-            provider.shutdown()
-
-        finalize.assert_called_once()
-
-    def test_shutdown_skipped_when_unconfigured(self):
-        state = _make_state(configured=False)
         provider = TotalReclawMemoryProvider(state)
 
         with patch("totalreclaw.hermes.hooks.on_session_finalize") as finalize:


### PR DESCRIPTION
Third step of #351 — the single-driver reconciliation that ends the double-fire.

## Two parts

**1. Shared `PluginState`.** `register()` and the `MemoryProvider` sidecar are loaded by separate Hermes mechanisms, but each created its **own** `PluginState` (the provider default was `PluginState()`, not a singleton). An activated provider and the plugin's tools/hooks would therefore observe disjoint buffers, turn counters, and the gating flag. New `get_shared_state()` lazy singleton; both `register()` and the provider default use it.

**2. Single-driver split.** `provider.initialize` sets `state._provider_active = True`. The lifecycle hooks gate on it (`... is True`, so a `MagicMock` attr can't trip it):
- `pre_llm_call`: skips auto-recall when provider-active (`prefetch` supplies it)
- `post_llm_call`: skips `ingest_turn` when provider-active (`sync_turn` does record+extract); **keeps** the Fix #191 mid-session reconfigure (the provider doesn't do it)

The provider stops duplicating what the plugin hooks own:
- `initialize` no longer calls `on_session_start` (plugin hook owns session start)
- `on_session_end`/`shutdown` no longer call `on_session_finalize` (plugin hook owns the single session-end debrief — drops the old dedup band-aid)
- `on_turn_start` is a counting no-op (`sync_turn` → `ingest_turn` is the sole, reliable counter via `memory_manager.sync_all`; `on_turn_start` is flaky per upstream #7193)

## Safety — still DORMANT
The gate is only `True` once a **loaded** provider runs `initialize`. Pre-activation (sidecar path #346 not merged) the provider never loads, `_provider_active` stays unset, and every hook keeps its legacy behavior. Non-Hermes clients (OpenClaw/MCP/ZeroClaw) are untouched — different integration code.

## Tests
3 provider tests updated to new behavior + 11 new single-driver tests (shared-state singleton, both-share-state, `initialize`-sets-flag, pre/post gating both ways, MagicMock-can't-trip-gate). Provider + entrypoint suites green (80 passed). 2 pre-existing local failures are stale-core (`format_recall_context`) — proven to reproduce on clean `main`; CI builds core fresh.

Next: **§5.4** activation (installer + un-draft #346) → **live E2E gate** on pop-os before anything flips on.

Refs: #351, design #350, §5.1 #354, §5.2 #358.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
