### PR TITLE
feat(hermes): auto-activate provider on pair + real CLI commands (#351 §5.4 wiring)

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -127,15 +127,17 @@ After the procedure completes (the user replies *"Done — continue setting up T
 
    Wait for the user's reply containing "continue" / "set up" / similar resumption language. Do NOT proceed to Account setup until the user confirms. Do NOT issue any restart yourself.
 
-5. **Install the MemoryProvider sidecar** (2.4.0+ / issue #275 — Path B).
+5. **Install the MemoryProvider sidecar** (2.4.0+ / issue #275 — Path B). **AUTOMATIC as of 2.4.5rc3 — normally a no-op; skip it.**
 
-   TotalReclaw also ships as a Hermes `MemoryProvider`, gaining `on_pre_compress` and `on_memory_write` hooks that capture writes the Background Review subsystem cannot reach via the generic plugin path (the BG-review whitelist is hardcoded to `["memory", "skills"]` toolsets, see [#7193](https://github.com/NousResearch/hermes-agent/issues/7193)). This unlocks captured writes during long-session compression + background extraction.
+   > **As of 2.4.5rc3, account setup (pairing) AUTOMATICALLY activates TotalReclaw as the native Hermes memory provider** — it installs the provider sidecar at the discoverable path, sets `memory.provider=totalreclaw`, and disables Hermes' builtin local store (so it stops running in parallel — the split-brain). For a normal install you can **skip this step**; pairing handles it. The steps below remain as a **manual fallback / verification** path — and fix the older guide's broken `totalreclaw activate-memory-provider` reference (it was never a real subcommand, which is why activation silently never happened pre-rc3). The real commands live on the **`totalreclaw`** console script.
 
-   Hermes activates exactly **one** memory provider at a time. Probe what's active before deciding:
+   TotalReclaw ships as a Hermes `MemoryProvider`: the native `memory` flow (auto-recall via `prefetch`, auto-persist via `sync_turn`) routes through TotalReclaw, exactly like the bundled providers (honcho/mem0/…). When TR is the active provider the plugin's lifecycle hooks defer to it (single-driver — no double-fire), and the Background Review subsystem reaches TR via the native `memory` path (the BG-review whitelist is `["memory","skills"]`, see [#7193](https://github.com/NousResearch/hermes-agent/issues/7193)).
+
+   To verify or manually (re)activate — Hermes activates exactly **one** memory provider at a time. Probe what's active:
 
    ```bash
-   ACTIVE_PROVIDER=$(hermes memory-status --hermes-home "${HERMES_HOME:-$HOME/.hermes}" 2>/dev/null | jq -r '.provider // "none"')
-   # ``hermes memory-status`` ships with the totalreclaw CLI (subcommand
+   ACTIVE_PROVIDER=$(totalreclaw memory-status --hermes-home "${HERMES_HOME:-$HOME/.hermes}" 2>/dev/null | jq -r '.provider // "none"')
+   # ``totalreclaw memory-status`` ships with the totalreclaw CLI (subcommand
    # registered alongside ``hermes setup``). It grep-reads ``config.yaml``
    # — does not depend on an upstream ``hermes memory status --json``
    # command (which is not yet released).
@@ -145,8 +147,8 @@ After the procedure completes (the user replies *"Done — continue setting up T
 
    | `ACTIVE_PROVIDER` | Agent behaviour |
    |---|---|
-   | `"none"` / `""` / `"totalreclaw"` | Silently run `hermes activate-memory-provider` (drops sidecar + sets `memory.provider=totalreclaw`). No prompt. |
-   | Anything else (`honcho`, `byterover`, `openviking`, ...) | Emit ONE line: *"Hermes is currently using `<X>` as the memory provider. Switch to TotalReclaw (E2E-encrypted, on-chain, cross-device) or install TotalReclaw as tools-only? Reply `switch` or `tools-only`."*<br/>**Branch:**<br/>• `switch` → warn first (*"Switching deactivates `<X>` — your existing `<X>` memories stay on disk but won't be queried by the agent until you switch back."*), then run `hermes activate-memory-provider`.<br/>• `tools-only` → run `hermes install-memory-provider` (sidecar only, no activation). TR tools remain available; the active provider stays `<X>`. |
+   | `"none"` / `""` / `"totalreclaw"` | Silently run `totalreclaw activate-memory-provider` (drops sidecar + sets `memory.provider=totalreclaw`). No prompt. |
+   | Anything else (`honcho`, `byterover`, `openviking`, ...) | Emit ONE line: *"Hermes is currently using `<X>` as the memory provider. Switch to TotalReclaw (E2E-encrypted, on-chain, cross-device) or install TotalReclaw as tools-only? Reply `switch` or `tools-only`."*<br/>**Branch:**<br/>• `switch` → warn first (*"Switching deactivates `<X>` — your existing `<X>` memories stay on disk but won't be queried by the agent until you switch back."*), then run `totalreclaw activate-memory-provider`.<br/>• `tools-only` → run `totalreclaw install-memory-provider` (sidecar only, no activation). TR tools remain available; the active provider stays `<X>`. |
 
    The install commands are idempotent. Re-running on an already-installed sidecar is safe — the managed marker comment prevents clobbering hand-edited files (pass `--force` to override).
 
@@ -264,8 +266,8 @@ Two TotalReclaw paths exist into Hermes; they coexist but serve different surfac
 
 | Mode | What's active | When to use | How to set |
 |---|---|---|---|
-| **Active provider** | Generic plugin tools + lifecycle hooks **+** `MemoryProvider` hooks (`on_pre_compress`, `on_memory_write`, `on_session_end`, `on_turn_start`). Captures Background-Review writes the toolset whitelist would otherwise drop. | The user has no other memory provider configured, or wants TR to be the canonical cross-session store. Default for fresh installs. | `hermes activate-memory-provider` |
-| **Tools-only** | Generic plugin tools + lifecycle hooks only. No `MemoryProvider` hooks — they fire on the user's other active provider (Honcho / Byterover / OpenViking / ...). | The user already has another provider configured and wants to keep using it alongside TR's chat tools. | `hermes install-memory-provider` (no `--activate`) |
+| **Active provider** | Generic plugin tools + lifecycle hooks **+** `MemoryProvider` hooks (`on_pre_compress`, `on_memory_write`, `on_session_end`, `on_turn_start`). Captures Background-Review writes the toolset whitelist would otherwise drop. | The user has no other memory provider configured, or wants TR to be the canonical cross-session store. Default for fresh installs. | `totalreclaw activate-memory-provider` |
+| **Tools-only** | Generic plugin tools + lifecycle hooks only. No `MemoryProvider` hooks — they fire on the user's other active provider (Honcho / Byterover / OpenViking / ...). | The user already has another provider configured and wants to keep using it alongside TR's chat tools. | `totalreclaw install-memory-provider` (no `--activate`) |
 
 The two install commands are idempotent. Re-running on an already-installed sidecar overwrites with the current shim content (catches package upgrades) without disturbing the rest of the install. The sidecar refuses to clobber a hand-edited file unless `--force` is passed.
 
@@ -273,7 +275,7 @@ Switching providers manually (post-install):
 
 ```bash
 # Switch TO TotalReclaw
-hermes activate-memory-provider
+totalreclaw activate-memory-provider
 
 # Switch BACK to another provider (after a `switch` choice the user regrets)
 hermes memory set-provider <name>   # upstream Hermes CLI
@@ -284,7 +286,7 @@ Switching deactivates the previous provider — its memories remain on disk but 
 Status check:
 
 ```bash
-hermes memory-status              # JSON: {"provider": "totalreclaw"|"honcho"|"none"|...}
+totalreclaw memory-status              # JSON: {"provider": "totalreclaw"|"honcho"|"none"|...}
 ```
 
 This grep-reads `~/.hermes/config.yaml` (or `$HERMES_HOME/config.yaml`) and does not depend on an upstream `hermes memory status --json` command (which is not yet released as of 2026-05-15 — see Path B spec §"Open questions for upstream").

--- a/python/src/totalreclaw/cli.py
+++ b/python/src/totalreclaw/cli.py
@@ -436,6 +436,48 @@ def main(argv: Optional[list[str]] = None) -> int:
         help="Override the relay URL for the reachability check.",
     )
 
+    # `activate-memory-provider` — make TotalReclaw the native Hermes
+    # MemoryProvider (#351 §5.4). Installs the provider sidecar at the
+    # discoverable path, sets `memory.provider: totalreclaw`, and disables the
+    # builtin local store. Pairing auto-runs this; the subcommand exists for
+    # manual / recovery / existing-user-upgrade use. (The `hermes
+    # activate-memory-provider` form referenced by older setup guides was never
+    # a real command — that's why activation silently never happened.)
+    sp_activate = sub.add_parser(
+        "activate-memory-provider",
+        help=(
+            "Activate TotalReclaw as the native Hermes memory provider "
+            "(installs the provider sidecar, sets memory.provider=totalreclaw, "
+            "disables the builtin store). Idempotent."
+        ),
+    )
+    sp_activate.add_argument(
+        "--hermes-home", type=Path, default=None,
+        help="Override the Hermes home (default: $HERMES_HOME or ~/.hermes).",
+    )
+    # `install-memory-provider` — tools-only: drop the sidecar WITHOUT making
+    # TR the active provider or disabling the builtin (for users who keep
+    # another provider active but want TR's tools available).
+    sp_install = sub.add_parser(
+        "install-memory-provider",
+        help="Install the TotalReclaw provider sidecar WITHOUT activating it "
+             "(tools-only; leaves the active provider + builtin untouched).",
+    )
+    sp_install.add_argument(
+        "--hermes-home", type=Path, default=None,
+        help="Override the Hermes home (default: $HERMES_HOME or ~/.hermes).",
+    )
+    # `memory-status` — JSON-print the active memory provider. Used by setup
+    # guides to decide whether to activate. Stable JSON shape: {"provider": ...}.
+    sp_mstatus = sub.add_parser(
+        "memory-status",
+        help="Print the active Hermes memory provider as JSON: {\"provider\": ...}.",
+    )
+    sp_mstatus.add_argument(
+        "--hermes-home", type=Path, default=None,
+        help="Override the Hermes home (default: $HERMES_HOME or ~/.hermes).",
+    )
+
     args = parser.parse_args(argv)
 
     if args.command == "setup":
@@ -449,6 +491,41 @@ def main(argv: Optional[list[str]] = None) -> int:
             credentials_path=args.credentials_path,
             relay_url=args.relay_url,
         )
+
+    if args.command == "activate-memory-provider":
+        from totalreclaw.hermes.install_memory_provider import install_and_activate
+
+        result = install_and_activate(hermes_home=getattr(args, "hermes_home", None))
+        print(
+            f"TotalReclaw is now the active Hermes memory provider.\n"
+            f"  sidecar:          {result['sidecar_path']}\n"
+            f"  active provider:  {result['active_provider']}\n"
+            f"  builtin disabled: {result['builtin_disabled']}\n"
+            f"Restart the gateway for the change to take effect."
+        )
+        return 0
+
+    if args.command == "install-memory-provider":
+        from totalreclaw.hermes.install_memory_provider import install_and_activate
+
+        result = install_and_activate(
+            hermes_home=getattr(args, "hermes_home", None), activate=False
+        )
+        print(
+            f"TotalReclaw provider sidecar installed (tools-only, not activated).\n"
+            f"  sidecar:         {result['sidecar_path']}\n"
+            f"  active provider: {result['active_provider'] or 'unchanged'}\n"
+            f"Run `totalreclaw activate-memory-provider` to make it the active provider."
+        )
+        return 0
+
+    if args.command == "memory-status":
+        import json as _json
+        from totalreclaw.hermes.install_memory_provider import read_active_provider
+
+        provider = read_active_provider(getattr(args, "hermes_home", None)) or "none"
+        print(_json.dumps({"provider": provider}))
+        return 0
 
     # No subcommand — check whether setup has been done, then nudge accordingly.
     if not CANONICAL_CREDENTIALS_PATH.exists():

--- a/python/src/totalreclaw/hermes/pair_tool_completion.py
+++ b/python/src/totalreclaw/hermes/pair_tool_completion.py
@@ -85,6 +85,30 @@ def complete_pairing(
             eoa or "unknown",
             sid_frag,
         )
+        # Provider conformance (#351 §5.4): make TotalReclaw the native, sole
+        # Hermes memory provider the moment the user pairs. Installs the
+        # MemoryProvider sidecar at the discoverable path, sets
+        # ``memory.provider: totalreclaw``, and disables Hermes' builtin local
+        # store (so it stops running in parallel — the split-brain). Without
+        # this, a fresh install pairs but never activates the provider, leaving
+        # the builtin active. Best-effort: a failure here must NEVER fail an
+        # otherwise-successful pairing. Touches only config + sidecar files —
+        # no key/phrase/crypto code (phrase-safety preserved).
+        try:
+            from .install_memory_provider import install_and_activate
+
+            activation = install_and_activate()
+            logger.info(
+                "pair-tool: TotalReclaw activated as the Hermes memory provider "
+                "(sidecar=%s, builtin_disabled=%s)",
+                activation.get("sidecar_path"),
+                activation.get("builtin_disabled"),
+            )
+        except Exception as activate_err:  # pragma: no cover — best-effort
+            logger.warning(
+                "pair-tool: provider auto-activation skipped (non-fatal): %r",
+                activate_err,
+            )
         return CompletePairingResult(state="active", account_id=eoa)
     except Exception as err:  # pragma: no cover — defensive
         logger.error(

--- a/python/tests/test_pair_completion_auto_activate.py
+++ b/python/tests/test_pair_completion_auto_activate.py
@@ -1,0 +1,66 @@
+"""§5.4 (#351) — pairing auto-activates TotalReclaw as the Hermes memory provider.
+
+A fresh install pairs but previously never activated the provider, leaving
+Hermes' builtin local store running in parallel (split-brain). ``complete_pairing``
+now calls ``install_and_activate`` so the provider is the sole memory the moment
+the user pairs — best-effort, never failing an otherwise-successful pairing, and
+never touching key/phrase/crypto code.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from totalreclaw.hermes.pair_tool_completion import complete_pairing
+
+
+def _session() -> MagicMock:
+    s = MagicMock()
+    s.sid = "sess1234"
+    return s
+
+
+def _state_configured() -> MagicMock:
+    state = MagicMock()
+    client = MagicMock()
+    client._eoa_address = "0xEOA"
+    state.get_client.return_value = client
+    return state
+
+
+def test_pairing_auto_activates_provider():
+    state = _state_configured()
+    with patch(
+        "totalreclaw.hermes.install_memory_provider.install_and_activate",
+        return_value={"sidecar_path": "/h/plugins/totalreclaw/__init__.py", "builtin_disabled": True},
+    ) as act:
+        res = complete_pairing("fake phrase", _session(), state)
+
+    state.configure.assert_called_once()
+    act.assert_called_once()  # provider activated on pair
+    assert res.state == "active"
+    assert res.account_id == "0xEOA"
+
+
+def test_activation_failure_does_not_break_pairing():
+    state = _state_configured()
+    with patch(
+        "totalreclaw.hermes.install_memory_provider.install_and_activate",
+        side_effect=RuntimeError("disk full"),
+    ):
+        res = complete_pairing("fake phrase", _session(), state)
+
+    # Pairing still succeeds even though activation raised.
+    assert res.state == "active"
+    assert res.account_id == "0xEOA"
+
+
+def test_no_activation_when_configure_fails():
+    state = MagicMock()
+    state.configure.side_effect = RuntimeError("bad phrase")
+    with patch(
+        "totalreclaw.hermes.install_memory_provider.install_and_activate"
+    ) as act:
+        res = complete_pairing("fake phrase", _session(), state)
+
+    act.assert_not_called()  # no activation if credentials never configured
+    assert res.state == "error"

--- a/python/tests/test_totalreclaw_cli.py
+++ b/python/tests/test_totalreclaw_cli.py
@@ -128,3 +128,46 @@ class TestDoctor:
         # stable — the message differentiates via the "REGISTERED" / "not
         # registered" / "Stable build" wording.
         assert "totalreclaw_report_qa_bug" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# memory-status + activate-memory-provider (#351 §5.4) — the commands older
+# setup guides referenced as `hermes activate-memory-provider` (which never
+# existed). Now real subcommands of the `totalreclaw` console script.
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryProviderCli:
+    def test_memory_status_fresh_is_none(self, tmp_path: Path, capsys):
+        rc = tr_cli.main(["memory-status", "--hermes-home", str(tmp_path)])
+        out = json.loads(capsys.readouterr().out.strip())
+        assert rc == 0
+        assert out == {"provider": "none"}
+
+    def test_activate_then_status_is_totalreclaw(self, tmp_path: Path, capsys):
+        rc = tr_cli.main(["activate-memory-provider", "--hermes-home", str(tmp_path)])
+        assert rc == 0
+        act_out = capsys.readouterr().out
+        assert "active provider:  totalreclaw" in act_out
+        assert "builtin disabled: True" in act_out
+
+        rc2 = tr_cli.main(["memory-status", "--hermes-home", str(tmp_path)])
+        assert rc2 == 0
+        assert json.loads(capsys.readouterr().out.strip()) == {"provider": "totalreclaw"}
+
+    def test_activate_writes_sidecar_at_discoverable_path(self, tmp_path: Path, capsys):
+        tr_cli.main(["activate-memory-provider", "--hermes-home", str(tmp_path)])
+        capsys.readouterr()
+        # Discoverable user-provider path = $HERMES_HOME/plugins/<name>/, NOT
+        # the nested plugins/memory/<name>/ (that one Hermes never scans).
+        assert (tmp_path / "plugins" / "totalreclaw" / "__init__.py").exists()
+        assert not (tmp_path / "plugins" / "memory" / "totalreclaw").exists()
+
+    def test_activate_disables_builtin_in_config(self, tmp_path: Path, capsys):
+        tr_cli.main(["activate-memory-provider", "--hermes-home", str(tmp_path)])
+        capsys.readouterr()
+        import yaml
+        cfg = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+        assert cfg["memory"]["provider"] == "totalreclaw"
+        assert cfg["memory"]["memory_enabled"] is False
+        assert cfg["memory"]["user_profile_enabled"] is False


### PR DESCRIPTION
Makes native-provider conformance the **default for new installs** — the last mile of #351.

## 1. Auto-activation on pair
`complete_pairing` now calls `install_and_activate` after configuring creds → the moment a user pairs, TotalReclaw becomes the active Hermes memory provider (sidecar at discoverable path, `memory.provider=totalreclaw`, builtin disabled). Best-effort (never fails an otherwise-successful pairing); config + sidecar files only, **no key/phrase/crypto code**.

## 2. Real CLI commands (the broken ones)
The setup guide referenced `hermes activate-memory-provider` / `hermes memory-status` / `hermes install-memory-provider` — **none existed** (verified live: invalid subcommands). **That's why activation silently never happened pre-rc3.** Added to the `totalreclaw` console script: `activate-memory-provider`, `install-memory-provider` (tools-only), `memory-status` (JSON `{"provider":...}`); all accept `--hermes-home`.

## 3. Guide fix
`hermes-setup.md` step 5 notes activation is automatic on pair (skip the manual step) + corrects 10 broken `hermes <cmd>` refs → `totalreclaw <cmd>`.

## Tests
3 pair-auto-activate + 4 CLI + tools-only smoke; **90 passed** across cli/pair/provider/single-driver. Activation E2E already GO on pop-os (rc2).

Refs: #351 (closes the conformance chain), design #350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)