### PR TITLE
feat(import): per-conversation Crystals + import provenance (import_source) (#356)

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     # >=2.5.3: exposes format_memory_date / recall_context_header /
     # format_recall_context so Hermes recall.py delegates to the shared
     # core formatter (zero-behavior-change refactor, chore/wire-hermes-recall-core).
-    "totalreclaw-core>=2.5.3,<3.0.0",
+    "totalreclaw-core>=2.5.4,<3.0.0",
     "httpx>=0.27",
     "onnxruntime>=1.24",
     "numpy>=1.26",

--- a/python/src/totalreclaw/import_engine.py
+++ b/python/src/totalreclaw/import_engine.py
@@ -69,6 +69,63 @@ IMPORT_MAX_BATCH_SIZE = 15
 # the cost claim self-verifying and tolerates future free-tier import flows.
 _GNOSIS_CHAIN_ID = 100
 
+# #356 — Crystal (session-summary) constants. One Crystal per imported
+# conversation: a `type="summary"` claim whose metadata.subtype="session_crystal"
+# ties it (+ the conversation's atomic facts) to a shared session_id. The SPA
+# renders this as a session card headline; the atomic facts sit beneath.
+_CRYSTAL_IMPORTANCE = 8           # anchored "high" per the v1 importance rubric
+_METADATA_SUBTYPE_SESSION_CRYSTAL = "session_crystal"
+# Valid v1 MemorySource for imported memories (the old "import" was not a valid
+# MemorySource — see #356 Problem 2).
+_IMPORT_PROVENANCE = "external"
+
+
+def _uuid7() -> str:
+    """Return a UUIDv7 (time-ordered) string.
+
+    Python's stdlib has no ``uuid.uuid7`` before 3.14, so we build one: 48-bit
+    big-endian Unix-ms timestamp, version nibble 7, RFC-4122 variant, the rest
+    random. Time-ordered so a vault reader can sort sessions chronologically
+    without a separate timestamp. Encrypted-blob-only — never on-chain.
+    """
+    import os
+    import uuid
+
+    unix_ms = int(time.time() * 1000) & ((1 << 48) - 1)
+    b = bytearray(unix_ms.to_bytes(6, "big") + os.urandom(10))
+    b[6] = (b[6] & 0x0F) | 0x70  # version 7
+    b[8] = (b[8] & 0x3F) | 0x80  # RFC-4122 variant
+    return str(uuid.UUID(bytes=bytes(b)))
+
+
+def _as_str_list(v) -> list:
+    """Coerce an LLM-returned value into a clean list[str] (≤8 entries)."""
+    if not isinstance(v, list):
+        return []
+    out = [str(x).strip() for x in v if isinstance(x, (str, int, float)) and str(x).strip()]
+    return out[:8]
+
+
+def _extract_json_object(raw: str):
+    """Best-effort parse of the first top-level JSON object in *raw*.
+
+    LLMs often wrap JSON in prose / code fences; grab the outermost
+    ``{ ... }`` and parse it. Returns the dict or None.
+    """
+    import json
+
+    if not raw:
+        return None
+    start = raw.find("{")
+    end = raw.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        return None
+    try:
+        obj = json.loads(raw[start:end + 1])
+        return obj if isinstance(obj, dict) else None
+    except Exception:
+        return None
+
 
 class ImportEngine:
     """Agent-agnostic batch import engine.
@@ -228,11 +285,11 @@ class ImportEngine:
 
         if has_chunks:
             return await self._process_chunk_batch(
-                parsed, offset, batch_size, start_ms,
+                parsed, offset, batch_size, start_ms, source,
             )
         else:
             return await self._process_fact_batch(
-                parsed, offset, batch_size, start_ms,
+                parsed, offset, batch_size, start_ms, source,
             )
 
     # ── Internal: Chunk Batch (conversation-based sources) ───────────────
@@ -243,8 +300,16 @@ class ImportEngine:
         offset: int,
         batch_size: int,
         start_ms: int,
+        source: str = "",
     ) -> BatchImportResult:
-        """Process a batch of conversation chunks via LLM extraction."""
+        """Process a batch of conversation chunks via LLM extraction.
+
+        #356: each chunk is treated as one **session** — every fact it produces
+        shares a freshly-minted UUIDv7 ``session_id`` and carries
+        ``source="external"`` + ``metadata.import_source=<source>``; a single
+        Crystal (session-summary) claim per conversation is emitted alongside
+        the atomic facts so the SPA can render a session card.
+        """
         total_chunks = len(parsed.chunks)
         batch = parsed.chunks[offset:offset + batch_size]
         chunks_processed = len(batch)
@@ -335,6 +400,20 @@ class ImportEngine:
                 if not extracted:
                     chunks_with_no_facts += 1
                 facts_extracted += len(extracted)
+
+                # #356 — this conversation = one session. Tag every atomic fact
+                # with the shared session_id + external provenance + provider,
+                # then emit a Crystal (session summary) so the SPA groups them
+                # under a real headline instead of day-grouping loose facts.
+                session_id = _uuid7()
+                for f in extracted:
+                    self._tag_import_fact(f, session_id, source)
+                if extracted:
+                    crystal = await self._make_crystal(
+                        chunk, extracted, session_id, source
+                    )
+                    if crystal is not None:
+                        all_extracted.append(crystal)
                 all_extracted.extend(extracted)
             except Exception as e:
                 extraction_failures += 1
@@ -400,8 +479,16 @@ class ImportEngine:
         offset: int,
         batch_size: int,
         start_ms: int,
+        source: str = "",
     ) -> BatchImportResult:
-        """Process a batch of pre-structured facts (Mem0, MCP Memory, etc.)."""
+        """Process a batch of pre-structured facts (Mem0, MCP Memory, etc.).
+
+        #356: fact-based sources have no conversation boundaries, so (per the
+        spec) we don't mint per-conversation sessions or Crystals here — but we
+        still stamp external provenance + ``import_source`` so the SPA badges
+        "Imported from <source>". Conversation sources (Crystals) are the
+        priority and get the full treatment in ``_process_chunk_batch``.
+        """
         total = len(parsed.facts)
         batch = parsed.facts[offset:offset + batch_size]
         processed = len(batch)
@@ -431,6 +518,10 @@ class ImportEngine:
                 'text': fact.text,
                 'type': fact.type,
                 'importance': fact.importance,
+                # #356 — external provenance + provider badge (no session/Crystal
+                # for flat fact sources).
+                'provenance': _IMPORT_PROVENANCE,
+                'extra_metadata': ({'import_source': source} if source else None),
             }
             for fact in batch
         ]
@@ -614,10 +705,123 @@ class ImportEngine:
         except Exception:
             pass
 
-        return {
+        payload = {
             "text": text,
             "importance": importance_normalized,
             "embedding": embedding,
+        }
+        # #356 — carry v1 provenance + typed metadata (session_id, import_source,
+        # Crystal fields) through to the canonical claim. Imports set
+        # provenance="external"; the engine attaches per-conversation session_id +
+        # import_source in extra_metadata. Only include keys that are present so
+        # non-import callers are unaffected.
+        if fact.get("provenance"):
+            payload["provenance"] = fact["provenance"]
+        if fact.get("fact_type"):
+            payload["fact_type"] = fact["fact_type"]
+        if fact.get("extra_metadata"):
+            payload["extra_metadata"] = fact["extra_metadata"]
+        return payload
+
+    @staticmethod
+    def _tag_import_fact(fact: dict, session_id: str, source: str) -> None:
+        """Stamp an imported atomic fact (in place) with v1 external provenance
+        + session/provider metadata (#356)."""
+        fact["provenance"] = _IMPORT_PROVENANCE
+        meta = fact.get("extra_metadata")
+        if not isinstance(meta, dict):
+            meta = {}
+        meta["session_id"] = session_id
+        if source:
+            meta["import_source"] = source
+        fact["extra_metadata"] = meta
+
+    @staticmethod
+    def _crystal_prompt(chunk, facts: list[dict]) -> str:
+        """Build the one-shot summary prompt for a conversation's Crystal."""
+        title = (getattr(chunk, "title", None) or "Untitled conversation")
+        msgs = getattr(chunk, "messages", None) or []
+        # Cap the transcript we feed the summarizer (first + last few turns is
+        # plenty to characterize a conversation; keeps tokens bounded).
+        def _msg_text(m):
+            if isinstance(m, dict):
+                return f"{m.get('role', 'user')}: {(m.get('text') or m.get('content') or '')}"
+            return str(m)
+        head = [_msg_text(m) for m in msgs[:6]]
+        tail = [_msg_text(m) for m in msgs[-4:]] if len(msgs) > 6 else []
+        transcript = "\n".join(head + (["..."] + tail if tail else []))[:4000]
+        fact_lines = "\n".join(f"- {f.get('text', '')}" for f in facts[:20])[:2000]
+        return (
+            "Summarize this single conversation into a compact JSON object. "
+            "Return ONLY JSON, no prose. Schema:\n"
+            '{"summary": "<=200-char one-line gist", '
+            '"key_outcomes": ["decisions/results"], '
+            '"open_threads": ["unresolved follow-ups"], '
+            '"topics_discussed": ["short topic tags"]}\n\n'
+            f"Title: {title}\n\nTranscript:\n{transcript}\n\n"
+            f"Facts already extracted from it:\n{fact_lines}\n"
+        )
+
+    async def _make_crystal(
+        self, chunk, facts: list[dict], session_id: str, source: str
+    ) -> Optional[dict]:
+        """Build one Crystal (session-summary) claim for an imported conversation.
+
+        Uses ``self._llm_completion`` for a single summary call; falls back to a
+        synthetic Crystal (no LLM enrichment) when the LLM is unavailable or
+        errors, so a session card always has a headline. Returns a fact-dict
+        ready for the store path (``type="summary"``, ``subtype="session_crystal"``,
+        shared ``session_id`` + provenance/provider).
+        """
+        # A Crystal is a session SUMMARY — it needs a summarizer. When no
+        # ``llm_completion`` is wired we skip it rather than emit a low-value
+        # title-only synthetic (the atomic facts still carry the shared
+        # session_id + provenance, so they remain grouped). "One summary call
+        # per conversation" per #356.
+        if self._llm_completion is None:
+            return None
+
+        title = (getattr(chunk, "title", None) or "Imported conversation").strip()
+        summary_text: Optional[str] = None
+        key_outcomes: list = []
+        open_threads: list = []
+        topics: list = []
+
+        if self._llm_completion is not None:
+            try:
+                raw = await self._llm_completion(self._crystal_prompt(chunk, facts))
+                data = _extract_json_object(raw) if raw else None
+                if isinstance(data, dict):
+                    s = (data.get("summary") or "").strip()
+                    summary_text = s or None
+                    key_outcomes = _as_str_list(data.get("key_outcomes"))
+                    open_threads = _as_str_list(data.get("open_threads"))
+                    topics = _as_str_list(data.get("topics_discussed"))
+            except Exception as e:  # never let a Crystal failure break the import
+                logger.debug("crystal summary LLM call failed: %s", e)
+
+        if not summary_text:
+            summary_text = f"Imported conversation: {title}"
+
+        meta: dict = {
+            "subtype": _METADATA_SUBTYPE_SESSION_CRYSTAL,
+            "session_id": session_id,
+        }
+        if source:
+            meta["import_source"] = source
+        if key_outcomes:
+            meta["key_outcomes"] = key_outcomes
+        if open_threads:
+            meta["open_threads"] = open_threads
+        if topics:
+            meta["topics_discussed"] = topics
+
+        return {
+            "text": summary_text[:512],
+            "importance": _CRYSTAL_IMPORTANCE,
+            "fact_type": "summary",
+            "provenance": _IMPORT_PROVENANCE,
+            "extra_metadata": meta,
         }
 
     async def _store_fact(self, fact: dict) -> str:
@@ -631,6 +835,12 @@ class ImportEngine:
             embedding=payload["embedding"],
             importance=payload["importance"],
             source="import",
+            # #356 — v1 provenance + typed metadata (session_id, import_source,
+            # Crystal fields). Defaults preserve prior behavior for callers that
+            # don't set them.
+            provenance=payload.get("provenance", "user"),
+            fact_type=payload.get("fact_type", "claim"),
+            extra_metadata=payload.get("extra_metadata"),
         )
 
     async def _resolve_chain_id_safely(self) -> Optional[int]:

--- a/python/src/totalreclaw/operations.py
+++ b/python/src/totalreclaw/operations.py
@@ -430,6 +430,11 @@ async def store_fact_batch(
         reasoning = raw.get("reasoning")
         volatility = raw.get("volatility")
         extracted_at = raw.get("extracted_at")
+        # Per-fact typed metadata (#356): session_id + import_source for
+        # imports, Crystal fields for session-summary claims. Threaded into the
+        # canonical claim's ``metadata`` exactly like the single-fact
+        # ``store_fact`` path; absent for normal writes.
+        extra_metadata = raw.get("extra_metadata")
 
         # v1 canonical claim — identical shape to ``store_fact``.
         fact_stub = {
@@ -447,6 +452,7 @@ async def store_fact_batch(
             importance=importance_int,
             created_at=extracted_at or shared_timestamp,
             claim_id=fact_id,
+            extra_metadata=extra_metadata,
         )
 
         encrypted_blob = encrypt(blob_plaintext, keys.encryption_key)

--- a/python/tests/test_gemini_json_import_engine.py
+++ b/python/tests/test_gemini_json_import_engine.py
@@ -39,10 +39,13 @@ class _RecordingClient:
         self._fail_texts = set(fail_texts or [])
         self._n = 0
 
-    async def remember(self, text, embedding=None, importance=None, source=None):
+    async def remember(self, text, embedding=None, importance=None, source=None,
+                       provenance=None, fact_type=None, extra_metadata=None, **kw):
         self.calls.append({
             "text": text, "embedding": embedding,
             "importance": importance, "source": source,
+            "provenance": provenance, "fact_type": fact_type,
+            "extra_metadata": extra_metadata,
         })
         if text in self._fail_texts:
             # Mimic the relay's content-fingerprint dedup response.
@@ -93,12 +96,21 @@ def test_gemini_json_flows_through_engine_to_store(monkeypatch) -> None:
     assert result.errors == []
 
     # Every store carried an embedding and the import provenance tag.
+    # No llm_completion → no Crystal; just the 2 atomic facts.
     assert len(client.calls) == 2
     assert all(c["embedding"] == [0.1, 0.2, 0.3] for c in client.calls)
     assert all(c["source"] == "import" for c in client.calls)
     stored = {c["text"] for c in client.calls}
     assert "User moved to Berlin for a new job" in stored
     assert "User is allergic to peanuts" in stored
+
+    # #356 — every imported fact has v1 external provenance + provider +
+    # a session_id; both facts of one conversation share that session_id.
+    assert all(c["provenance"] == "external" for c in client.calls)
+    metas = [c["extra_metadata"] or {} for c in client.calls]
+    assert all(m.get("import_source") == "gemini" for m in metas)
+    session_ids = {m.get("session_id") for m in metas}
+    assert len(session_ids) == 1 and None not in session_ids  # one shared session
 
 
 def test_gemini_json_duplicate_is_skipped_not_errored(monkeypatch) -> None:

--- a/python/tests/test_import_crystals.py
+++ b/python/tests/test_import_crystals.py
@@ -1,0 +1,205 @@
+"""#356 — per-conversation Crystals + import provenance.
+
+Each imported conversation = one session: a Crystal (type=summary,
+subtype=session_crystal) + its atomic facts sharing a UUIDv7 session_id, every
+claim tagged source=external + metadata.import_source=<provider>.
+
+No network: a recording client captures the batched payloads; embedding +
+LLM are stubbed.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+
+import pytest
+
+from totalreclaw.import_engine import (
+    ImportEngine,
+    _uuid7,
+    _extract_json_object,
+    _as_str_list,
+)
+
+
+class _BatchClient:
+    """Records remember_batch payloads; pretends to be on Gnosis (chain 100)."""
+
+    def __init__(self):
+        self.batches = []
+        self._n = 0
+
+    async def _ensure_chain_id(self):
+        return 100
+
+    async def remember_batch(self, payloads, source=None):
+        self.batches.append({"payloads": list(payloads), "source": source})
+        ids = [f"f{self._n + i}" for i in range(len(payloads))]
+        self._n += len(payloads)
+        return ids
+
+
+def _install_fake_embedding(monkeypatch):
+    import totalreclaw.embedding as emb
+    monkeypatch.setattr(emb, "get_embedding", lambda t: [0.1, 0.2, 0.3])
+
+
+_GEMINI_ONE_CONVO = json.dumps([
+    {
+        "header": "Gemini Apps",
+        "title": "Prompted I just moved to Berlin for a new job",
+        "time": "2026-05-14T09:21:03.512Z",
+        "products": ["Gemini Apps"],
+        "subtitles": [{"name": "Congrats on the move to Berlin!"}],
+    },
+])
+
+
+def _payloads(client):
+    return [p for b in client.batches for p in b["payloads"]]
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+
+def test_uuid7_is_valid_version_7():
+    s = _uuid7()
+    u = uuid.UUID(s)
+    assert u.version == 7
+    # variant nibble is RFC-4122 (10xx)
+    assert (u.int >> 62) & 0b11 == 0b10
+
+
+def test_uuid7_is_time_ordered():
+    a, b = _uuid7(), _uuid7()
+    # First 48 bits (ms timestamp) are non-decreasing.
+    assert uuid.UUID(a).int >> 80 <= uuid.UUID(b).int >> 80
+
+
+def test_extract_json_object_from_fenced_prose():
+    raw = "Here you go:\n```json\n{\"summary\": \"x\", \"key_outcomes\": [\"a\"]}\n```\nDone"
+    obj = _extract_json_object(raw)
+    assert obj == {"summary": "x", "key_outcomes": ["a"]}
+
+
+def test_as_str_list_coerces_and_caps():
+    assert _as_str_list(["a", "", "  b ", 3]) == ["a", "b", "3"]
+    assert _as_str_list("nope") == []
+    assert len(_as_str_list([str(i) for i in range(20)])) == 8
+
+
+# ── Crystal emission ─────────────────────────────────────────────────────
+
+
+def test_crystal_emitted_with_llm(monkeypatch):
+    _install_fake_embedding(monkeypatch)
+    client = _BatchClient()
+
+    async def fake_extract(messages, timestamp):
+        return [{"text": "User moved to Berlin", "type": "fact", "importance": 8}]
+
+    async def fake_completion(prompt):
+        return (
+            '{"summary": "User relocated to Berlin for a new job", '
+            '"key_outcomes": ["moved to Berlin"], "open_threads": [], '
+            '"topics_discussed": ["relocation", "work"]}'
+        )
+
+    engine = ImportEngine(
+        client=client, llm_extract=fake_extract, llm_completion=fake_completion
+    )
+    result = asyncio.run(
+        engine.process_batch(source="gemini", content=_GEMINI_ONE_CONVO)
+    )
+    assert result.is_complete
+
+    payloads = _payloads(client)
+    crystals = [
+        p for p in payloads
+        if (p.get("extra_metadata") or {}).get("subtype") == "session_crystal"
+    ]
+    atomic = [
+        p for p in payloads
+        if (p.get("extra_metadata") or {}).get("subtype") != "session_crystal"
+    ]
+    assert len(crystals) == 1, "exactly one Crystal per conversation"
+    assert len(atomic) == 1
+
+    cm = crystals[0]["extra_metadata"]
+    assert crystals[0]["fact_type"] == "summary"
+    assert crystals[0]["provenance"] == "external"
+    assert crystals[0]["text"] == "User relocated to Berlin for a new job"
+    assert cm["import_source"] == "gemini"
+    assert cm["key_outcomes"] == ["moved to Berlin"]
+    assert cm["topics_discussed"] == ["relocation", "work"]
+
+    # Crystal + atomic fact share the SAME session_id.
+    assert cm["session_id"] == atomic[0]["extra_metadata"]["session_id"]
+    # Atomic fact carries external provenance + provider.
+    assert atomic[0]["provenance"] == "external"
+    assert atomic[0]["extra_metadata"]["import_source"] == "gemini"
+
+
+def test_crystal_synthetic_fallback_on_bad_llm(monkeypatch):
+    _install_fake_embedding(monkeypatch)
+    client = _BatchClient()
+
+    async def fake_extract(messages, timestamp):
+        return [{"text": "User moved to Berlin", "type": "fact", "importance": 8}]
+
+    async def bad_completion(prompt):
+        return "sorry, I can't help with that"  # no JSON
+
+    engine = ImportEngine(
+        client=client, llm_extract=fake_extract, llm_completion=bad_completion
+    )
+    asyncio.run(engine.process_batch(source="gemini", content=_GEMINI_ONE_CONVO))
+
+    crystals = [
+        p for p in _payloads(client)
+        if (p.get("extra_metadata") or {}).get("subtype") == "session_crystal"
+    ]
+    # LLM exists but returned garbage → still a Crystal, synthetic headline.
+    assert len(crystals) == 1
+    assert crystals[0]["text"].startswith("Imported conversation:")
+    assert crystals[0]["extra_metadata"]["import_source"] == "gemini"
+
+
+def test_no_crystal_without_llm_completion(monkeypatch):
+    _install_fake_embedding(monkeypatch)
+    client = _BatchClient()
+
+    async def fake_extract(messages, timestamp):
+        return [{"text": "User moved to Berlin", "type": "fact", "importance": 8}]
+
+    # No llm_completion → no Crystal, but atomic facts still get session_id.
+    engine = ImportEngine(client=client, llm_extract=fake_extract)
+    asyncio.run(engine.process_batch(source="gemini", content=_GEMINI_ONE_CONVO))
+
+    payloads = _payloads(client)
+    assert all(
+        (p.get("extra_metadata") or {}).get("subtype") != "session_crystal"
+        for p in payloads
+    )
+    assert all(p["provenance"] == "external" for p in payloads)
+    assert all(p["extra_metadata"]["session_id"] for p in payloads)
+
+
+# ── operations: metadata threads into the canonical claim ────────────────
+
+
+def test_build_canonical_claim_carries_import_source():
+    from totalreclaw.claims_helper import build_canonical_claim_v1
+
+    blob = build_canonical_claim_v1(
+        {"text": "User moved to Berlin", "type": "claim", "source": "external"},
+        importance=8,
+        created_at="2026-05-14T09:21:03Z",
+        claim_id="01902d40-7a2b-7f12-9c44-1c5e7d2af6a1",
+        extra_metadata={"session_id": "s1", "import_source": "gemini"},
+    )
+    doc = json.loads(blob)
+    assert doc["metadata"]["import_source"] == "gemini"
+    assert doc["metadata"]["session_id"] == "s1"
+    assert doc["source"] == "external"

--- a/rust/totalreclaw-core/Cargo.lock
+++ b/rust/totalreclaw-core/Cargo.lock
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "totalreclaw-core"
-version = "2.5.3"
+version = "2.5.4"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/rust/totalreclaw-core/Cargo.toml
+++ b/rust/totalreclaw-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "totalreclaw-core"
-version = "2.5.3"
+version = "2.5.4"
 edition = "2021"
 description = "TotalReclaw core — E2EE crypto, reranker, wallet, UserOp, store/search pipelines. Single source of truth for all clients."
 license = "MIT"

--- a/rust/totalreclaw-core/pyproject.toml
+++ b/rust/totalreclaw-core/pyproject.toml
@@ -7,7 +7,7 @@ name = "totalreclaw-core"
 # Keep in lockstep with Cargo.toml [package].version. maturin uses THIS value
 # for the PyPI wheel version; Cargo.toml drives crates.io + the wasm-pack npm
 # package. Both MUST match or the PyPI wheel ships under the wrong version.
-version = "2.5.3"
+version = "2.5.4"
 description = "TotalReclaw crypto core — E2EE, LSH, blind indices, protobuf encoding (Rust)"
 requires-python = ">=3.10"
 license = { text = "MIT" }

--- a/rust/totalreclaw-core/src/claims.rs
+++ b/rust/totalreclaw-core/src/claims.rs
@@ -751,6 +751,15 @@ pub struct MemoryMetadataV1 {
     /// Crystal: file paths touched during the session (coding-agent sessions).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub files_affected: Vec<String>,
+
+    /// Provenance: the external provider an imported memory originated from —
+    /// `"gemini"`, `"chatgpt"`, `"claude"`, `"mem0"`, etc. Set on every claim
+    /// the import pipeline writes (alongside `source = External`), so a vault
+    /// reader (SPA) can badge "Imported from <provider>". Encrypted-blob-only —
+    /// never on-chain. `None` for memories that weren't imported; pre-existing
+    /// claims without this key parse fine via serde default (back-compat).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub import_source: Option<String>,
 }
 
 impl MemoryMetadataV1 {
@@ -768,6 +777,7 @@ impl MemoryMetadataV1 {
             && self.lessons.is_empty()
             && self.topics_discussed.is_empty()
             && self.files_affected.is_empty()
+            && self.import_source.is_none()
     }
 
     /// True when [`subtype`](Self::subtype) is the documented session-Crystal
@@ -2397,6 +2407,7 @@ mod tests {
                 "Crystal".to_string(),
             ],
             files_affected: vec!["rust/totalreclaw-core/src/claims.rs".to_string()],
+            import_source: None,
         });
         c
     }
@@ -2415,6 +2426,53 @@ mod tests {
         // Surface JSON shape matches spec §3.2 example
         assert!(json.contains("\"subtype\":\"session_crystal\""));
         assert!(json.contains("\"session_id\":\"01902d40-7a2b-7f12-9c44-1c5e7d2af6a1\""));
+    }
+
+    #[test]
+    fn memory_metadata_v1_import_source_round_trip() {
+        // Imported atomic fact: source=External + provenance import_source.
+        let mut c = minimal_v1_claim();
+        c.source = MemorySource::External;
+        c.metadata = Some(MemoryMetadataV1 {
+            session_id: Some("01902d40-7a2b-7f12-9c44-1c5e7d2af6a1".to_string()),
+            import_source: Some("gemini".to_string()),
+            ..Default::default()
+        });
+        let json = serde_json::to_string(&c).unwrap();
+        let back: MemoryClaimV1 = serde_json::from_str(&json).unwrap();
+        assert_eq!(c, back);
+        assert_eq!(
+            back.metadata.as_ref().unwrap().import_source.as_deref(),
+            Some("gemini")
+        );
+        assert!(json.contains("\"import_source\":\"gemini\""));
+    }
+
+    #[test]
+    fn memory_metadata_v1_import_source_omitted_when_none() {
+        // A claim without import_source must NOT serialize the key (keeps the
+        // canonical blob lean) AND must parse fine (back-compat for pre-import
+        // claims that never had the field).
+        let mut m = MemoryMetadataV1::default();
+        assert!(m.is_empty());
+        m.session_id = Some("s".to_string());
+        let json = serde_json::to_string(&m).unwrap();
+        assert!(!json.contains("import_source"));
+        // Older blob shape (no import_source key) parses to None.
+        let parsed: MemoryMetadataV1 =
+            serde_json::from_str(r#"{"session_id":"s"}"#).unwrap();
+        assert!(parsed.import_source.is_none());
+    }
+
+    #[test]
+    fn memory_metadata_v1_import_source_counts_for_is_empty() {
+        // import_source alone must make is_empty() false (so it survives the
+        // skip_serializing_if collapse on MemoryClaimV1::metadata).
+        let m = MemoryMetadataV1 {
+            import_source: Some("chatgpt".to_string()),
+            ..Default::default()
+        };
+        assert!(!m.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Closes #356. Imports now present as **session cards** in the SPA: each conversation = one session (a Crystal + its atomic facts sharing a `session_id`), every claim tagged `source=external` + `metadata.import_source=<provider>`.

## Core (shared-core-first)
`MemoryMetadataV1` gains `import_source: Option<String>` (serde `skip_serializing_if`), included in `is_empty()`. **Serde-driven — no binding code; auto-propagates to PyO3 + WASM on recompile.** Pre-import claims without the key still parse (back-compat). Core **2.5.3 → 2.5.4**. 3 new tests; 622 core tests green.

## Python import pipeline
- **import_engine**: each chunk (= conversation) mints a **UUIDv7 session_id**; every atomic fact tagged `provenance=external` + `metadata.{session_id, import_source}`; **one Crystal per conversation** (`type=summary`, `subtype=session_crystal`, importance 8, shared session_id + `key_outcomes`/`open_threads`/`topics_discussed` from a single `llm_completion` call, synthetic-headline fallback on LLM failure). Crystals emit only when a summarizer is wired. Fact-based sources (mem0) get provenance + `import_source` (no per-convo session — conversation sources are the priority).
- **operations.store_fact_batch**: thread per-fact `extra_metadata` into the canonical claim (the batch path previously dropped it).
- Python core floor → `>=2.5.4`.

No adapter changes: provider = the `source` arg; conversation boundaries = parsed chunks. Phrase-safety untouched (content + grouping only).

## Tests
8 new Crystal/provenance/helper tests + updated gemini-engine flow; **214 python regression + 622 core green**.

## Release sequencing
CI builds core from source (passes with 2.5.4). After merge: publish **core 2.5.4** (npm WASM + PyPI + crates), then cut a **python rc** (requires core 2.5.4) for the user to E2E the import → SPA session cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)