### PR TITLE
fix(hermes): cache ImportEngine across import_batch calls (#389)

### DIFF
--- a/python/src/totalreclaw/hermes/tools.py
+++ b/python/src/totalreclaw/hermes/tools.py
@@ -730,6 +730,41 @@ def _make_extractor(state: "PluginState"):
     return extract
 
 
+def _get_or_create_import_engine(state: "PluginState", source: str, file_path: Optional[str]):
+    """Return a cached ``ImportEngine`` for ``(source, file_path)``, creating one if needed.
+
+    The agent's manual paging flow drives multi-batch imports through repeated
+    ``totalreclaw_import_batch`` tool calls (one per offset). Each call lands as
+    a fresh tool invocation, so without this cache the engine — and its
+    smart-import profile + session-assignment state — is rebuilt every call,
+    paying the 17-25 min profiling pass per batch on large imports (#389).
+
+    Only ``file_path`` imports are cached. ``content``-based imports have no
+    stable cache key, so they keep the per-call engine (uncached) behaviour.
+    """
+    from totalreclaw.import_engine import ImportEngine
+
+    cache = getattr(state, "_import_engines", None)
+    if cache is None:
+        cache = {}
+        state._import_engines = cache
+
+    cache_key = (source, file_path) if file_path else None
+    if cache_key is not None:
+        engine = cache.get(cache_key)
+        if engine is not None:
+            return engine
+
+    engine = ImportEngine(
+        client=state.get_client(),
+        llm_extract=_make_extractor(state),
+        llm_completion=_make_llm_completion(state),
+    )
+    if cache_key is not None:
+        cache[cache_key] = engine
+    return engine
+
+
 def _make_llm_completion(state: "PluginState"):
     """Build an async prompt-only LLM completion callable for smart-import.
 
@@ -983,13 +1018,7 @@ async def import_batch(args: dict, state: "PluginState", **kwargs) -> str:
         return json.dumps({"error": "No source specified"})
 
     try:
-        from totalreclaw.import_engine import ImportEngine
-
-        engine = ImportEngine(
-            client=client,
-            llm_extract=_make_extractor(state),
-            llm_completion=_make_llm_completion(state),
-        )
+        engine = _get_or_create_import_engine(state, source, file_path)
         result = await engine.process_batch(
             source=source,
             file_path=file_path,

--- a/python/src/totalreclaw/import_engine.py
+++ b/python/src/totalreclaw/import_engine.py
@@ -594,7 +594,11 @@ class ImportEngine:
             )
         elif chunks_with_no_facts > 0:
             errors.append(
-                f"{chunks_with_no_facts}/{attempted} chunks produced 0 facts (possible LLM failures)"
+                f"{chunks_with_no_facts}/{attempted} chunks produced 0 facts — either the "
+                "LLM returned an empty response (timeout / rate limit / model "
+                "declined) or every candidate was filtered below the import "
+                "thresholds (text < 5 chars or importance < 6). Set "
+                "TOTALRECLAW_LOG=DEBUG to log per-chunk extractor responses."
             )
 
         smart_import_summary = None

--- a/python/tests/test_issue_389_import_batch_engine_cache.py
+++ b/python/tests/test_issue_389_import_batch_engine_cache.py
@@ -1,0 +1,176 @@
+"""Regression tests for issue #389 — Gemini import ~58min per 25-chunk batch.
+
+Root cause: ``totalreclaw_import_batch`` (hermes/tools.py) instantiated a fresh
+``ImportEngine`` on every tool call, so the engine's smart-import context
+(``_smart_ctx``, ``_smart_import_attempted``) and session-grouping caches
+(``_session_assignments``, ``_session_ids``, ``_processed_chunk_indices``, ...)
+were thrown away after every batch. Large imports re-ran the 17-25 min
+profile pass on each batch → ~52 hour total for a 1344-chunk file.
+
+Fix: cache ``ImportEngine`` instances on ``PluginState._import_engines``,
+keyed by ``(source, file_path)``. Content-only imports (no ``file_path``)
+remain uncached because they lack a stable cache key.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _bare_state():
+    """A minimal stand-in for PluginState that avoids hermes-config disk reads."""
+    state = MagicMock()
+    state._import_engines = None  # exercise the lazy-init branch
+    state.get_client = MagicMock(return_value=MagicMock())
+    return state
+
+
+def test_engine_is_cached_by_source_and_file_path(monkeypatch):
+    """Two calls with identical (source, file_path) return the same engine."""
+    from totalreclaw.hermes import tools
+
+    state = _bare_state()
+    monkeypatch.setattr(tools, "_make_extractor", lambda s: AsyncMock())
+    monkeypatch.setattr(tools, "_make_llm_completion", lambda s: AsyncMock())
+
+    engine1 = tools._get_or_create_import_engine(state, "gemini", "/tmp/a.html")
+    engine2 = tools._get_or_create_import_engine(state, "gemini", "/tmp/a.html")
+
+    assert engine1 is engine2, "same (source, file_path) must reuse the engine"
+
+
+def test_different_file_paths_get_different_engines(monkeypatch):
+    from totalreclaw.hermes import tools
+
+    state = _bare_state()
+    monkeypatch.setattr(tools, "_make_extractor", lambda s: AsyncMock())
+    monkeypatch.setattr(tools, "_make_llm_completion", lambda s: AsyncMock())
+
+    e_a = tools._get_or_create_import_engine(state, "gemini", "/tmp/a.html")
+    e_b = tools._get_or_create_import_engine(state, "gemini", "/tmp/b.html")
+
+    assert e_a is not e_b
+
+
+def test_different_sources_get_different_engines(monkeypatch):
+    from totalreclaw.hermes import tools
+
+    state = _bare_state()
+    monkeypatch.setattr(tools, "_make_extractor", lambda s: AsyncMock())
+    monkeypatch.setattr(tools, "_make_llm_completion", lambda s: AsyncMock())
+
+    e_gemini = tools._get_or_create_import_engine(state, "gemini", "/tmp/x.html")
+    e_chatgpt = tools._get_or_create_import_engine(state, "chatgpt", "/tmp/x.html")
+
+    assert e_gemini is not e_chatgpt
+
+
+def test_content_only_imports_are_not_cached(monkeypatch):
+    """No stable cache key without ``file_path`` — each call gets a fresh engine."""
+    from totalreclaw.hermes import tools
+
+    state = _bare_state()
+    monkeypatch.setattr(tools, "_make_extractor", lambda s: AsyncMock())
+    monkeypatch.setattr(tools, "_make_llm_completion", lambda s: AsyncMock())
+
+    e1 = tools._get_or_create_import_engine(state, "gemini", None)
+    e2 = tools._get_or_create_import_engine(state, "gemini", None)
+
+    assert e1 is not e2
+
+
+@pytest.mark.asyncio
+async def test_import_batch_reuses_engine_across_calls(monkeypatch):
+    """End-to-end: two ``import_batch`` tool calls on the same file use one engine.
+
+    Bug-shape assertion: pre-patch this test fails because each ``import_batch``
+    invocation created a fresh ``ImportEngine``, so the instance counter would
+    show 2 instead of 1.
+    """
+    from totalreclaw.hermes import tools
+    import totalreclaw.import_engine as ie
+
+    instance_count = 0
+    real_init = ie.ImportEngine.__init__
+
+    def counting_init(self, *args, **kwargs):
+        nonlocal instance_count
+        instance_count += 1
+        real_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(ie.ImportEngine, "__init__", counting_init)
+    monkeypatch.setattr(tools, "_make_extractor", lambda s: AsyncMock())
+    monkeypatch.setattr(tools, "_make_llm_completion", lambda s: AsyncMock())
+
+    # Stub process_batch so we don't trip on missing adapters / files / LLMs.
+    async def fake_process_batch(self, **kwargs):
+        from totalreclaw.import_adapters.types import BatchImportResult
+        return BatchImportResult(
+            success=True,
+            batch_offset=kwargs.get("offset", 0),
+            batch_size=kwargs.get("batch_size", 25),
+            chunks_processed=25,
+            total_chunks=100,
+            facts_extracted=10,
+            facts_stored=10,
+            remaining_chunks=75,
+            is_complete=False,
+            duration_ms=1000,
+        )
+    monkeypatch.setattr(ie.ImportEngine, "process_batch", fake_process_batch)
+
+    state = _bare_state()
+    args_b0 = {"source": "gemini", "file_path": "/tmp/big.html",
+               "offset": 0, "batch_size": 25}
+    args_b1 = {"source": "gemini", "file_path": "/tmp/big.html",
+               "offset": 25, "batch_size": 25}
+
+    r0 = json.loads(await tools.import_batch(args_b0, state))
+    r1 = json.loads(await tools.import_batch(args_b1, state))
+
+    assert r0["batch_offset"] == 0
+    assert r1["batch_offset"] == 25
+    assert instance_count == 1, (
+        f"expected one engine across two batch calls, got {instance_count}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_import_batch_content_only_creates_fresh_engine(monkeypatch):
+    """Content-only imports (no file_path) keep the per-call engine behaviour."""
+    from totalreclaw.hermes import tools
+    import totalreclaw.import_engine as ie
+
+    instance_count = 0
+    real_init = ie.ImportEngine.__init__
+
+    def counting_init(self, *args, **kwargs):
+        nonlocal instance_count
+        instance_count += 1
+        real_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(ie.ImportEngine, "__init__", counting_init)
+    monkeypatch.setattr(tools, "_make_extractor", lambda s: AsyncMock())
+    monkeypatch.setattr(tools, "_make_llm_completion", lambda s: AsyncMock())
+
+    async def fake_process_batch(self, **kwargs):
+        from totalreclaw.import_adapters.types import BatchImportResult
+        return BatchImportResult(
+            success=True, batch_offset=0, batch_size=25,
+            chunks_processed=0, total_chunks=0, facts_extracted=0,
+            facts_stored=0, remaining_chunks=0, is_complete=True, duration_ms=1,
+        )
+    monkeypatch.setattr(ie.ImportEngine, "process_batch", fake_process_batch)
+
+    state = _bare_state()
+    args = {"source": "gemini", "content": "<html>...</html>",
+            "offset": 0, "batch_size": 25}
+
+    await tools.import_batch(args, state)
+    await tools.import_batch(args, state)
+
+    assert instance_count == 2, (
+        "content-only imports have no cache key; engines must not be reused"
+    )


### PR DESCRIPTION
## What broke
Importing a large Gemini Takeout HTML file (1344 chunks) via per-batch agent paging stretched to ~52 hours because every `totalreclaw_import_batch` tool call rebuilt the 17–25 min smart-import profile pass.

## What's fixed
`PluginState._import_engines` now caches `ImportEngine` per `(source, file_path)`, so the smart-import profile + triage + session-grouping caches survive across batch calls. The pipeline now runs exactly once per import.

## Impact after fix
A 1344-chunk Gemini import drops from ~52 h to ~1 h (one ~25 min profile pass + N batches at ~1 min triage + extraction each on glm-5-turbo). Cross-batch Crystal session_ids also stabilise (same bug pattern). The misleading "possible LLM failures" diagnostic now names the importance-filter path explicitly.

## Verification
- New `test_issue_389_import_batch_engine_cache.py` — 6 tests covering cache hit, key separation by source/file, content-only opt-out, and end-to-end via `tools.import_batch`. Bug-shape FAILS pre-patch (5/6 red), PASSES post-patch (6/6 green).
- Full python suite: **1584 passed**, 13 skipped, 1 xfailed (2m22s).

Closes #389
QA report: pending RC2.4.5rc6 publish + scoped staging probe.

🤖 Auto-triage pipeline (Phase 3) — see internal-issue-389 thread.