### PR TITLE
fix(hermes): install guide gaps + activate-memory-provider --force (#390)

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -107,6 +107,14 @@ After the procedure completes (the user replies *"Done — continue setting up T
    ```bash
    IN_DOCKER=$(grep -q -E 'docker|containerd' /proc/1/cgroup 2>/dev/null && echo yes || echo no)
    HAS_MSG_BOT="$(printenv | grep -E '^HERMES_(TELEGRAM|DISCORD|SLACK|MATRIX|FEISHU|WHATSAPP)_(BOT_TOKEN|HOMESERVER|APP_ID|PHONE_NUMBER_ID)=' | head -1)"
+   # Fallback (#390): some Hermes gateway deployments expose only
+   # HERMES_SESSION_PLATFORM=<telegram|discord|slack|matrix|feishu|whatsapp> —
+   # the bot-token vars live in a separate secret store the agent shell can't see.
+   # Without this fallback the probe falls into the "Detection fails / ambiguous"
+   # row and asks the user a question that the env already answered.
+   [ -z "$HAS_MSG_BOT" ] && printenv HERMES_SESSION_PLATFORM 2>/dev/null \
+     | grep -q -E '^(telegram|discord|slack|matrix|feishu|whatsapp)$' \
+     && HAS_MSG_BOT="HERMES_SESSION_PLATFORM=$(printenv HERMES_SESSION_PLATFORM)"
    HAS_SYSTEMCTL=$(command -v systemctl >/dev/null 2>&1 && echo yes || echo no)
    HAS_LAUNCHCTL=$(command -v launchctl >/dev/null 2>&1 && echo yes || echo no)
    ```
@@ -127,7 +135,22 @@ After the procedure completes (the user replies *"Done — continue setting up T
 
    Wait for the user's reply containing "continue" / "set up" / similar resumption language. Do NOT proceed to Account setup until the user confirms. Do NOT issue any restart yourself.
 
-5. **Install the MemoryProvider sidecar** (2.4.0+ / issue #275 — Path B). **AUTOMATIC as of 2.4.5rc3 — normally a no-op; skip it.**
+5. **(SILENT — emit nothing on the GO path.) Verify the plugin tools bound after restart (#390).** Entry-point auto-discovery (step 3 explainer) is usually fine, but a small fraction of Hermes deployments don't re-scan entry points on a single restart, leaving `totalreclaw_pair` and the rest unregistered — and the agent then can't proceed because *every* Account-setup step routes through plugin-registered tools. Probe + auto-fallback to the manual manifest install:
+   ```bash
+   if ! ( "$(dirname "$HERMES_PYTHON")/hermes" tools list 2>/dev/null | grep -q '\btotalreclaw' \
+          || hermes tools list 2>/dev/null | grep -q '\btotalreclaw' ); then
+     "$(dirname "$HERMES_PYTHON")/hermes" plugins install p-diogo/totalreclaw-hermes --enable 2>/dev/null \
+       || hermes plugins install p-diogo/totalreclaw-hermes --enable
+     # Manifest write requires ANOTHER restart for the tools to bind. Re-emit the
+     # surface-matched restart line from step 4 ONCE and wait for the user.
+     NEEDS_SECOND_RESTART=yes
+   fi
+   ```
+   - If `NEEDS_SECOND_RESTART=yes`: re-emit the matching restart line from the step-4 matrix verbatim (same surface — Telegram / docker / systemd / launchd / standalone), wait for the user's continuation reply, then re-run the `tools list | grep` probe ONE MORE time.
+   - If after the second restart `tools list` still shows no `totalreclaw`: surface the failure verbatim (`> Couldn't bind the totalreclaw plugin tools after install. Check 'hermes plugins list' / 'hermes tools list' and the gateway logs.`) and **stop** — do NOT proceed to Account setup with no tools bound (the `totalreclaw_pair` call below would fail and there is no CLI fallback per the phrase-safety rule).
+   - If the probe passed on the first restart: proceed silently to Account setup.
+
+6. **Install the MemoryProvider sidecar** (2.4.0+ / issue #275 — Path B). **AUTOMATIC as of 2.4.5rc3 — normally a no-op; skip it.**
 
    > **As of 2.4.5rc3, account setup (pairing) AUTOMATICALLY activates TotalReclaw as the native Hermes memory provider** — it installs the provider sidecar at the discoverable path, sets `memory.provider=totalreclaw`, and disables Hermes' builtin local store (so it stops running in parallel — the split-brain). For a normal install you can **skip this step**; pairing handles it. The steps below remain as a **manual fallback / verification** path — and fix the older guide's broken `totalreclaw activate-memory-provider` reference (it was never a real subcommand, which is why activation silently never happened pre-rc3). The real commands live on the **`totalreclaw`** console script.
 
@@ -152,7 +175,7 @@ After the procedure completes (the user replies *"Done — continue setting up T
 
    The install commands are idempotent. Re-running on an already-installed sidecar is safe — the managed marker comment prevents clobbering hand-edited files (pass `--force` to override).
 
-6. **Disable the agent's built-in `memory` tool** (rc6 QA F3/#371 — required; it was being skipped). Hermes' built-in `memory` toolset competes with TotalReclaw for "remember / recall" intents — with both active the agent writes to the built-in `MEMORY.md` / `USER.md` instead of the TotalReclaw vault, causing split-brain memory (QA observed this on the forget path). Run:
+7. **Disable the agent's built-in `memory` tool** (rc6 QA F3/#371 — required; it was being skipped). Hermes' built-in `memory` toolset competes with TotalReclaw for "remember / recall" intents — with both active the agent writes to the built-in `MEMORY.md` / `USER.md` instead of the TotalReclaw vault, causing split-brain memory (QA observed this on the forget path). Run:
    ```bash
    "$(dirname "$HERMES_PYTHON")/hermes" tools disable memory 2>/dev/null || hermes tools disable memory
    ```
@@ -165,6 +188,8 @@ After the procedure completes (the user replies *"Done — continue setting up T
 The agent never generates the recovery phrase. Only the user's browser does, via the `totalreclaw_pair` tool.
 
 **This section starts AUTOMATICALLY after the user confirms `done` to the install-procedure step 4 `/restart` request.** Do not ask "want me to set up your account?". The user already consented by sending the install prompt.
+
+> **Precondition (#390):** `totalreclaw_pair` is a *plugin-registered tool*, not a CLI subcommand — it only resolves once the plugin has bound after gateway restart. Install-procedure step 5 (`Verify the plugin tools bound after restart`) is the gate; do NOT skip it. If step 5 reported a fallback restart was needed, only enter this section after the SECOND restart and after the verify probe returned `totalreclaw` present in `hermes tools list`.
 
 1. Check whether credentials already exist:
    ```bash

--- a/python/src/totalreclaw/cli.py
+++ b/python/src/totalreclaw/cli.py
@@ -455,6 +455,12 @@ def main(argv: Optional[list[str]] = None) -> int:
         "--hermes-home", type=Path, default=None,
         help="Override the Hermes home (default: $HERMES_HOME or ~/.hermes).",
     )
+    sp_activate.add_argument(
+        "--force", action="store_true", default=False,
+        help="Overwrite a hand-edited sidecar (default: refuse). "
+             "Surfaced because install_sidecar() raises with a 'Pass --force' "
+             "hint; without this flag the hint was unreachable (#390).",
+    )
     # `install-memory-provider` — tools-only: drop the sidecar WITHOUT making
     # TR the active provider or disabling the builtin (for users who keep
     # another provider active but want TR's tools available).
@@ -466,6 +472,10 @@ def main(argv: Optional[list[str]] = None) -> int:
     sp_install.add_argument(
         "--hermes-home", type=Path, default=None,
         help="Override the Hermes home (default: $HERMES_HOME or ~/.hermes).",
+    )
+    sp_install.add_argument(
+        "--force", action="store_true", default=False,
+        help="Overwrite a hand-edited sidecar (default: refuse).",
     )
     # `memory-status` — JSON-print the active memory provider. Used by setup
     # guides to decide whether to activate. Stable JSON shape: {"provider": ...}.
@@ -495,7 +505,14 @@ def main(argv: Optional[list[str]] = None) -> int:
     if args.command == "activate-memory-provider":
         from totalreclaw.hermes.install_memory_provider import install_and_activate
 
-        result = install_and_activate(hermes_home=getattr(args, "hermes_home", None))
+        try:
+            result = install_and_activate(
+                hermes_home=getattr(args, "hermes_home", None),
+                force=getattr(args, "force", False),
+            )
+        except RuntimeError as exc:
+            sys.stderr.write(f"{exc}\n")
+            return 2
         print(
             f"TotalReclaw is now the active Hermes memory provider.\n"
             f"  sidecar:          {result['sidecar_path']}\n"
@@ -508,9 +525,15 @@ def main(argv: Optional[list[str]] = None) -> int:
     if args.command == "install-memory-provider":
         from totalreclaw.hermes.install_memory_provider import install_and_activate
 
-        result = install_and_activate(
-            hermes_home=getattr(args, "hermes_home", None), activate=False
-        )
+        try:
+            result = install_and_activate(
+                hermes_home=getattr(args, "hermes_home", None),
+                activate=False,
+                force=getattr(args, "force", False),
+            )
+        except RuntimeError as exc:
+            sys.stderr.write(f"{exc}\n")
+            return 2
         print(
             f"TotalReclaw provider sidecar installed (tools-only, not activated).\n"
             f"  sidecar:         {result['sidecar_path']}\n"

--- a/python/tests/test_totalreclaw_cli.py
+++ b/python/tests/test_totalreclaw_cli.py
@@ -171,3 +171,69 @@ class TestMemoryProviderCli:
         assert cfg["memory"]["provider"] == "totalreclaw"
         assert cfg["memory"]["memory_enabled"] is False
         assert cfg["memory"]["user_profile_enabled"] is False
+
+    # ------------------------------------------------------------------
+    # #390: the top-level CLI must surface the `--force` flag that
+    # install_sidecar() advertises in its error message. Pre-fix, the
+    # error said "Pass force=True (or --force on the CLI) to replace it"
+    # but the console-script CLI didn't register --force, leaving users
+    # stuck whenever they hit a hand-edited sidecar (e.g. after manual
+    # plugin debugging).
+    # ------------------------------------------------------------------
+
+    def test_issue_390_activate_memory_provider_accepts_force(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """`totalreclaw activate-memory-provider --force` overwrites a hand-edited sidecar."""
+        # Seed a hand-edited (managed-marker-less) sidecar at the discoverable path.
+        sidecar_dir = tmp_path / "plugins" / "totalreclaw"
+        sidecar_dir.mkdir(parents=True)
+        hand_edited = "# hand-rolled sidecar by the user — no managed-marker\n"
+        (sidecar_dir / "__init__.py").write_text(hand_edited, encoding="utf-8")
+
+        # Without --force the CLI must refuse cleanly (exit 2, error on stderr).
+        rc_no_force = tr_cli.main(
+            ["activate-memory-provider", "--hermes-home", str(tmp_path)]
+        )
+        captured_no_force = capsys.readouterr()
+        assert rc_no_force == 2
+        assert "Refusing to overwrite" in captured_no_force.err
+        assert "--force" in captured_no_force.err
+        # The hand-edited file is untouched.
+        assert (sidecar_dir / "__init__.py").read_text(encoding="utf-8") == hand_edited
+
+        # With --force the CLI overwrites it.
+        rc_force = tr_cli.main(
+            ["activate-memory-provider", "--hermes-home", str(tmp_path), "--force"]
+        )
+        captured_force = capsys.readouterr()
+        assert rc_force == 0
+        assert "active provider:  totalreclaw" in captured_force.out
+        # The managed marker is now present.
+        rewritten = (sidecar_dir / "__init__.py").read_text(encoding="utf-8")
+        assert "managed-by: totalreclaw.hermes.install_memory_provider" in rewritten
+
+    def test_issue_390_install_memory_provider_accepts_force(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """`totalreclaw install-memory-provider --force` overwrites a hand-edited sidecar (tools-only path)."""
+        sidecar_dir = tmp_path / "plugins" / "totalreclaw"
+        sidecar_dir.mkdir(parents=True)
+        (sidecar_dir / "__init__.py").write_text("# user-authored\n", encoding="utf-8")
+
+        rc_no_force = tr_cli.main(
+            ["install-memory-provider", "--hermes-home", str(tmp_path)]
+        )
+        captured_no_force = capsys.readouterr()
+        assert rc_no_force == 2
+        assert "Refusing to overwrite" in captured_no_force.err
+
+        rc_force = tr_cli.main(
+            ["install-memory-provider", "--hermes-home", str(tmp_path), "--force"]
+        )
+        captured_force = capsys.readouterr()
+        assert rc_force == 0
+        # tools-only path: provider is NOT switched to totalreclaw.
+        assert "tools-only" in captured_force.out
+        rewritten = (sidecar_dir / "__init__.py").read_text(encoding="utf-8")
+        assert "managed-by: totalreclaw.hermes.install_memory_provider" in rewritten


### PR DESCRIPTION
## What broke
Agent-driven `totalreclaw 2.4.5rc5` install on a Hermes gateway hit four gaps between the setup guide and runtime: surface-detection missed `HERMES_SESSION_PLATFORM`, entry-point auto-discovery had no explicit post-restart verify, `activate-memory-provider` refused a hand-edited sidecar with a `--force` hint that the top-level CLI didn't actually expose, and there was no precondition note that `totalreclaw_pair` is plugin-registered (silently broken when the plugin didn't load).

## What's fixed
- `docs/guides/hermes-setup.md`: fallback to `HERMES_SESSION_PLATFORM` in the surface probe; new discrete step 5 (`Verify the plugin tools bound after restart`) with auto-fallback to the manual manifest install + second restart; new precondition note at the top of Account setup pointing back to step 5.
- `python/src/totalreclaw/cli.py`: register `--force` on `activate-memory-provider` AND `install-memory-provider` in the top-level (console-script) parser; thread `force=` through `install_and_activate()`; wrap in `try/except RuntimeError` for a clean exit 2 + stderr instead of an unhandled traceback. (The nested `hermes/cli.py` had `--force` since PR #234, but PR #361's top-level shim shadowed it without preserving the flag — the user-facing CLI was unreachable.)

## Impact after fix
- Telegram / Discord / Slack / Matrix / Feishu / WhatsApp gateways exposing only `HERMES_SESSION_PLATFORM` now get the matching messaging-platform restart line, not the ambiguity prompt.
- Entry-point auto-discovery failures self-heal: probe → manifest fallback → second restart → re-probe → either bind or surface failure verbatim. No more silent dead-end at `totalreclaw_pair`.
- Hand-edited sidecars can finally be replaced: `totalreclaw activate-memory-provider --force` (or `install-memory-provider --force`) overwrites cleanly; the existing `Pass --force` error hint is no longer a dead reference.

## Verification
- 2 new regression tests on the CLI flag fail on `2.4.5rc5` (uncaught `RuntimeError` exposing the hand-edited refusal) and pass on this branch. Full python suite **1586 passed / 13 skipped / 1 xfailed**.
- Published `2.4.5rc7` to PyPI off this branch; live `totalreclaw activate-memory-provider --help` now lists `--force`, refusal returns exit 2 + clear stderr, `--force` succeeds with managed marker written. Live VPS repro confirmed.
- Docs changes are non-shipping (markdown). No publish-side QA required.

Closes #390