### PR TITLE
feat(core): raise UserOp batch ceiling 15 → 30 (#392 Part 2)

### DIFF
--- a/rust/totalreclaw-core/src/userop.rs
+++ b/rust/totalreclaw-core/src/userop.rs
@@ -34,8 +34,12 @@ pub const ENTRYPOINT_ADDRESS: &str = "0x0000000071727De22E5E9d8BAf0edAc6f37da032
 /// SimpleAccountFactory address (v0.7, same on all EVM chains).
 pub const SIMPLE_ACCOUNT_FACTORY: &str = "0x91E60e0613810449d098b0b5Ec8b51A0FE8c8985";
 
-/// Max batch size (matches extraction cap).
-pub const MAX_BATCH_SIZE: usize = 15;
+/// Max facts per batched UserOp (`executeBatch`). #392 Part 2 raised this from
+/// 15 → 30 so imports emit fewer UserOps (Pimlico bills per-UserOp). This is
+/// the UserOp batch ceiling — independent of the 15-fact-per-extraction cap.
+/// The relay's `MAX_FACT_COUNT` billing clamp and the python/TS client caps
+/// MUST stay in sync with this (else the relay under-counts quota per UserOp).
+pub const MAX_BATCH_SIZE: usize = 30;
 
 // ABI definitions using alloy sol! macro
 sol! {
@@ -387,9 +391,19 @@ mod tests {
 
     #[test]
     fn test_oversized_batch_rejected() {
-        let payloads: Vec<Vec<u8>> = (0..16).map(|i| vec![i as u8]).collect();
+        // One over MAX_BATCH_SIZE must still reject.
+        let payloads: Vec<Vec<u8>> = (0..(MAX_BATCH_SIZE + 1)).map(|i| vec![i as u8]).collect();
         let result = encode_batch_call(&payloads);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_batch_at_max_size_accepted() {
+        // #392 Part 2: the UserOp batch ceiling is 30 so imports cut UserOp
+        // count. 30 payloads must encode; 31 must still reject.
+        let payloads: Vec<Vec<u8>> = (0..30).map(|i| vec![i as u8]).collect();
+        let encoded = encode_batch_call(&payloads).unwrap();
+        assert_eq!(&encoded[..4], &[0x47, 0xe1, 0xda, 0x2a]); // executeBatch selector
     }
 
     // ---- chain/env-aware DataEdge (#366) ----


### PR DESCRIPTION
Part 2 of #392 — the gating foundation. `encode_batch_call` enforced `MAX_BATCH_SIZE=15`, capping facts per `executeBatch` UserOp at 15. This raises it to **30** so imports (and any batched write) emit fewer UserOps — Pimlico bills **per-UserOp**, so 30/UserOp ~halves the UserOp count vs 15 (direct cost reduction, and now that Pro quota is per-fact-enforced, fewer UserOps don't change the user's bill).

This is the **UserOp batch ceiling**, independent of the 15-fact-per-extraction cap (the old comment conflated them).

## Why core first
Clients construct batched UserOps via `totalreclaw_core.encode_batch_call`, which enforces the cap in Rust. No client can build a >15-fact UserOp until core ships this — so it's the gate for the rest of Part 2.

## Companion caps (MUST stay in sync, else the relay under-counts quota per UserOp)
| site | current | → |
|---|---|---|
| **core** `userop.rs MAX_BATCH_SIZE` (this PR) | 15 | **30** |
| relay `MAX_FACT_COUNT` (billing clamp) | 15 | 30 |
| python `userop.MAX_BATCH_SIZE` | 15 | 30 |
| python `IMPORT_MAX_BATCH_SIZE` | 15 | 30 |
| TS client cap | 15 | 30 |

The relay + python changes come as follow-up PRs **after this core release** (python imports core via PyO3; `remember_batch(30)` errors in Rust until core is released). I'll sequence them.

## ⚠️ Gate before deploy: staging validation
A 30-fact `executeBatch` UserOp must be confirmed accepted by the Pimlico bundler + DataEdge (gas/calldata limits) on the **isolated staging** environment before any client ships/deploys this. I'll write that E2E; it needs a staging run (staging access).

## Tests
`test_batch_at_max_size_accepted` (30 encodes) added; `test_oversized_batch_rejected` now uses `MAX_BATCH_SIZE+1` (31). Full core lib suite **623 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)