### PR TITLE
chore(core): bump 2.5.4 → 2.5.5 for release

### DIFF
--- a/rust/totalreclaw-core/Cargo.lock
+++ b/rust/totalreclaw-core/Cargo.lock
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "totalreclaw-core"
-version = "2.5.4"
+version = "2.5.5"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/rust/totalreclaw-core/Cargo.toml
+++ b/rust/totalreclaw-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "totalreclaw-core"
-version = "2.5.4"
+version = "2.5.5"
 edition = "2021"
 description = "TotalReclaw core — E2EE crypto, reranker, wallet, UserOp, store/search pipelines. Single source of truth for all clients."
 license = "MIT"


### PR DESCRIPTION
Ships #379 (UserOp batch ceiling 15 -> 30) plus unreleased core state on main.
2.5.4 already published (PyPI/npm/crates); this is the next publish.

Co-Authored-By: Claude <noreply@anthropic.com>
