### PR TITLE
chore(core): bump pyproject 2.5.4 → 2.5.5 (PyPI version source)

### DIFF
--- a/rust/totalreclaw-core/pyproject.toml
+++ b/rust/totalreclaw-core/pyproject.toml
@@ -7,7 +7,7 @@ name = "totalreclaw-core"
 # Keep in lockstep with Cargo.toml [package].version. maturin uses THIS value
 # for the PyPI wheel version; Cargo.toml drives crates.io + the wasm-pack npm
 # package. Both MUST match or the PyPI wheel ships under the wrong version.
-version = "2.5.4"
+version = "2.5.5"
 description = "TotalReclaw crypto core — E2EE, LSH, blind indices, protobuf encoding (Rust)"
 requires-python = ">=3.10"
 license = { text = "MIT" }


### PR DESCRIPTION
publish-pypi reads [project].version from pyproject.toml (not Cargo.toml),
so the 2.5.5 wheel built as 2.5.4 and hit "file already exists". Sync it.

Co-Authored-By: Claude <noreply@anthropic.com>
