### PR TITLE
docs(openclaw): native-flow setup guide (retire totalreclaw_pair/hybrid refs)

### DIFF
--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -4,6 +4,34 @@
 
 TotalReclaw gives your OpenClaw agent encrypted, persistent memory. The fastest path is a single chat message — your agent fetches this guide, you and your agent install the plugin together, and the agent walks you through setting up your TotalReclaw account.
 
+## Install prompts
+
+The user pastes one of these three prompts. The shape is fixed; the agent extracts intent from the shape, not from arbitrary phrasing. (Mirrors `hermes-setup.md`'s prompt section.)
+
+### Stable (default)
+
+```
+Install TotalReclaw. See https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md
+```
+
+The agent installs the stable channel (`@totalreclaw/totalreclaw` from npm `latest`) and proceeds to setup.
+
+### RC (user specifies a version)
+
+```
+Install TotalReclaw RC <version>. See https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md
+```
+
+`<version>` is a semver RC string the user picks (e.g. `3.3.12-rc.14`). When the user omits `<version>` and writes only `Install TotalReclaw RC`, the agent installs the **newest release candidate** via `openclaw plugins install @totalreclaw/totalreclaw@rc` (no pin — always the latest cut).
+
+### RC against the staging relay (QA only)
+
+```
+Install TotalReclaw RC <version> against the staging relay (TOTALRECLAW_SERVER_URL=https://api-staging.totalreclaw.xyz). See https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md
+```
+
+The agent exports `TOTALRECLAW_SERVER_URL=https://api-staging.totalreclaw.xyz` in the install / setup shell before any TotalReclaw command. Without this env var, both stable AND RC installs default to the production relay `api.totalreclaw.xyz`.
+
 ## What this is and where it comes from
 
 TotalReclaw is open-source memory tooling for OpenClaw. The plugin is published by `p-diogo` (GitHub-verified) at:
@@ -14,19 +42,15 @@ TotalReclaw is open-source memory tooling for OpenClaw. The plugin is published 
 
 All cryptographic operations run on your device. Encrypted bundles are forwarded through the TotalReclaw relay (`api.totalreclaw.xyz` by default for both stable and RC builds; set `TOTALRECLAW_SERVER_URL=https://api-staging.totalreclaw.xyz` to opt into the staging relay). The recovery phrase is generated and stays inside your browser — neither the agent, the relay, nor anyone else ever sees it.
 
-If you already have OpenClaw running, paste this into your OpenClaw chat:
-
-> **Install TotalReclaw, see <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md>**
-
-Your agent reads this page, runs two install commands ([`openclaw skills install`](https://docs.openclaw.com/cli/skills) and [`openclaw plugins install`](https://docs.openclaw.com/cli/plugins) — both from the OpenClaw CLI you already have), and hands you an account-setup URL + 6-digit PIN. You open the URL, generate or restore a 12-word recovery phrase in your browser, confirm the PIN, and your account is ready.
-
 This guide is the playbook your agent follows; you can read along to see what each step does.
 
 ---
 
 ## Agent instructions (read this if you are an OpenClaw agent that just fetched this URL)
 
-You have been asked to install TotalReclaw. **Run all install / verify steps silently** except for the user-visible lines explicitly listed below — those are the ONLY things you should write in chat. Tool calls happen; narration of those tool calls does not.
+You have been asked to install TotalReclaw. TotalReclaw is OpenClaw's **native `kind:"memory"` provider**: recall runs through the conventional `memory_search` / `memory_get` tools, and facts are captured automatically in the background — you do **not** call a remember tool per fact. The only tools you drive during setup are the `tr` CLI (for pair / status) and `/totalreclaw-restart` (autonomous reload if memory tools don't bind).
+
+**Run all install / verify steps silently** except for the user-visible lines explicitly listed below — those are the ONLY things you should write in chat. Tool calls happen; narration of those tool calls does not.
 
 The user pasted this URL deliberately, but treat each command as a step you and the user complete together. Confirm what you see at each phase. If anything looks wrong, surface it and stop — don't push through.
 
@@ -38,9 +62,9 @@ The user pasted this URL deliberately, but treat each command as a step you and 
 
 1. `openclaw plugins install @totalreclaw/totalreclaw` — installs the published plugin from npm under the `@totalreclaw` scope owned by `p-diogo`. The plugin runs inside OpenClaw's plugin sandbox. Upstream docs: <https://docs.openclaw.com/cli/plugins>.
 2. `openclaw skills install totalreclaw` — fetches the SKILL.md descriptor from ClawHub. Read-only metadata; no code executes from this step. Upstream docs: <https://docs.openclaw.com/cli/skills>.
-3. After the gateway auto-reloads, you will call `totalreclaw_pair` (a tool the plugin registers) to mint a one-time URL + PIN. The user opens the URL in their own browser to enter or generate a recovery phrase. The phrase never enters chat or your shell.
+3. When no `~/.totalreclaw/credentials.json` exists, you run `tr pair --json` (via the `TR_CLI` resolver), which mints a one-time URL + PIN. The user opens the URL in their own browser to enter or generate a recovery phrase. The phrase never enters chat or your shell.
 
-You are not asked to handle the recovery phrase. You are not asked to bypass auth. Pasting the install URL IS the consent moment for installing the plugin; the URL + PIN you hand back from `totalreclaw_pair` is the real consent moment for account creation, since the user has to open the page in their browser to continue. There is no separate "yes/no" gate before account setup. If the user pastes a phrase in chat anyway, refuse to proceed — see "Phrase safety" below.
+You are not asked to handle the recovery phrase. You are not asked to bypass auth. Pasting the install prompt IS the consent moment for installing the plugin; the URL + PIN you hand back from `tr pair --json` is the real consent moment for account creation, since the user has to open the page in their browser to continue. There is no separate "yes/no" gate before account setup. If the user pastes a phrase in chat anyway, refuse to proceed — see "Phrase safety" below.
 
 ### User-visible prose (THIS IS ALL YOU SAY)
 
@@ -48,8 +72,8 @@ Speak only these lines, in order. Substitute the bracketed placeholders with the
 
 1. (Step 1 — start; emit BEFORE any shell tool call so the user knows work is happening)
    > Setting up TotalReclaw — this takes about a minute…
-2. (Step 2 — after install + `tr status --json` confirms CLI works, hybrid mode)
-   > ✓ Installed (totalreclaw &lt;version&gt;, hybrid mode)
+2. (Step 2 — after install + `tr status --json` confirms CLI works)
+   > ✓ Installed (totalreclaw &lt;version&gt;)
 3. (Step 3 — only if existing credentials were detected, then stop)
    > ✓ TotalReclaw is already set up.
 4. (Step 4 — account-setup URL + PIN, immediately after `tr pair --json` returns — no consent gate)
@@ -57,27 +81,31 @@ Speak only these lines, in order. Substitute the bracketed placeholders with the
 5. (Step 5 — done + free-tier confirmation)
    > ✓ You're set up on the TotalReclaw free tier — 250 memories/month on Gnosis mainnet, E2E encrypted. https://totalreclaw.xyz/pricing. Ask me to remember anything.
 
-That is the complete user-facing transcript for a healthy install. Expected line count for a fresh install + setup is **4–5 lines** (line 3 is mutually exclusive with lines 4-5; the `/totalreclaw-restart` cycle is no longer part of the primary path under hybrid mode).
+That is the complete user-facing transcript for a healthy install. Expected line count for a fresh install + setup is **4–5 lines** (line 3 is mutually exclusive with lines 4-5).
 
 ### When to break silence (errors only)
 
 If a step **actually fails**, surface the failure in one tight line — the error text plus what you're doing about it. Examples:
 
 - `Plugin install returned ENOENT — your shell doesn't have access to the OpenClaw CLI here. I'll stop and explain.`
-- `Plugin installed but tools didn't bind after auto-reload. Asking you to restart manually.`
+- `Memory tools didn't bind after install. Issuing /totalreclaw-restart now.`
 - `Account-setup URL returned 404 — the PIN may have expired. Generating a fresh URL + PIN.`
 
 Do NOT pre-narrate diagnostics that succeed. Do NOT narrate retries that succeed silently. Do NOT echo command output unless the user asks for it.
 
-### ⛔ FORBIDDEN actions during install + pair (3.3.10-rc.3 — hard rules from Pedro's 2026-05-05 QA)
+### Restart is agent-driven, never user-manual (read before Step 4)
+
+The plugin self-reloads: after install it writes the gateway config it needs and signals `SIGUSR1` to its own PID so the gateway picks it up without a manual restart. **If `memory_search` / `memory_get` are not bound** (tools didn't take effect on first load), issue the literal slash command `/totalreclaw-restart` **autonomously** — announce it in one line, never ask the user to authorize it, never stall, never `kill` / `docker restart` / prompt the user to restart. The user should never perform a manual restart. (The legacy `totalreclaw_pair` tool, `hybrid-primary` framing, `.pair-pending.json`, `before_agent_start` injection, and `tr recall` CLI are all retired — do not invoke them. `tr pair --json` is the pair path; `memory_search` is recall.)
+
+### ⛔ FORBIDDEN actions during install + pair (hard rules from Pedro's QA history)
 
 These freelancing patterns have broken pair flows. They are FORBIDDEN regardless of how clever the workaround feels:
 
-1. **Do NOT issue `/totalreclaw-restart`. Do NOT signal the gateway. Do NOT `docker restart`.** The plugin auto-patches the config and emits its own restart-required warn IF (and only if) one is needed. The gateway will restart itself when its reload pipeline decides to. **You restarting it kills the in-flight `setsid -f` pair subprocess and surfaces as 502 on the browser respond.**
+1. **Do NOT prompt the user to restart, and do NOT ask permission to restart.** If `memory_search` / `memory_get` aren't bound, issue `/totalreclaw-restart` autonomously (one user-visible line) and continue. Never `kill`, `docker restart`, or ask the user to restart.
 
-2. **Do NOT write to `~/.openclaw/openclaw.json`** after the install. The plugin's `patchOpenClawConfig()` already wrote `plugins.slots.memory`, `plugins.entries.totalreclaw.hooks.allowConversationAccess`, and `channels.telegram.streaming.mode` for you. Any further config write triggers a fresh deferred reload that eventually fires SIGUSR1 and kills pair. Forbidden tool calls: `openclaw config set …`, any redirect / sed / jq into `openclaw.json`.
+2. **Do NOT write to `~/.openclaw/openclaw.json`** after the install. The plugin's `register()` already wrote the keys OpenClaw 2026.5.x looks for (`plugins.slots.memory`, `plugins.entries.totalreclaw.hooks.allowConversationAccess`, `channels.telegram.streaming.mode`, `plugins.bundledDiscovery`, `plugins.allow`, `plugins.installs.totalreclaw`) and auto-fired SIGUSR1 to its own PID. Any further config write triggers a fresh deferred reload that can kill an in-flight pair subprocess. Forbidden tool calls: `openclaw config set …`, any redirect / sed / jq into `openclaw.json`.
 
-3. **Do NOT re-render the QR.** `tr pair --json` returns `qr_ascii` (Unicode) AND the pair page renders a real PNG. Saving the QR to `/tmp/totalreclaw-pair-qr.png` triggers OpenClaw's media-access policy block and Telegram delivery fails with `LocalMediaAccessError`. Just emit the URL + PIN as user-visible line 3 — that is your only QR responsibility.
+3. **Do NOT re-render the QR.** `tr pair --json` returns `qr_ascii` (Unicode) AND the pair page renders a real PNG. Saving the QR to `/tmp/totalreclaw-pair-qr.png` triggers OpenClaw's media-access policy block and Telegram delivery fails with `LocalMediaAccessError`. Just emit the URL + PIN as user-visible line 4 — that is your only QR responsibility.
 
 4. **Do NOT invoke `tr pair --json` in the foreground.** A foreground pair subprocess is killed when your shell-tool exec returns. The pair WS dies → relay returns 502. Step 4 below uses `setsid -f` for exactly this reason — copy that block VERBATIM. Do not "simplify". Do not drop the `setsid -f`. Do not omit `< /dev/null`.
 
@@ -96,6 +124,7 @@ Unless the user explicitly asks how the install works, the following words / pat
 - "Should I /totalreclaw-restart" / "Want me to restart" / "Let me check if the tool is bound" / "I need permission to restart" / "Do you have a public URL"
 - "Now installing…" / "Got it" / "In parallel…" / "Step 1a/1b/1c"
 - `manifest`, `descriptor`, `file-watcher`, `polling`, `auto-reload-detect`, `find`, `lookup`, `detect`, `probing`, `let me try`
+- retired flow names: `hybrid mode`, `hybrid-primary`, `hybrid_mode`, `auto-pair`, `totalreclaw_pair`, `tr recall`, `.pair-pending`
 
 Substitute every one of those with silence — the next user-visible line in the set, or nothing.
 
@@ -103,53 +132,49 @@ If the user explicitly asks ("what's it doing?", "why so quiet?", "show me the c
 
 ### Step 1 — Install the skill + plugin (silent — emit user-visible line 1, then no prose until line 2)
 
-Run via your shell tool, in this exact order, **without writing prose about them**. Emit user-visible line 1 (`Installing TotalReclaw…`) once at the start, then stay silent until both commands succeed.
+Run via your shell tool, in this exact order, **without writing prose about them**. Emit user-visible line 1 (`Setting up TotalReclaw — this takes about a minute…`) once at the start, then stay silent until both commands succeed.
 
 ```bash
 openclaw plugins install @totalreclaw/totalreclaw
 openclaw skills install totalreclaw
 ```
 
-**Plugin BEFORE skill is deliberate** (3.3.4-rc.1, post-Pedro QA): the skill install triggers a config-driven SIGUSR1 gateway reload that can race a concurrent plugin install. Plugin-first lets the plugin land cleanly, then the skill's reload picks it up on the next gateway loop. If you accidentally do skill-first and the plugin install dies mid-flight, just retry `openclaw plugins install @totalreclaw/totalreclaw` once — it's idempotent.
+**Plugin BEFORE skill is deliberate** (post-Pedro QA): the skill install triggers a config-driven SIGUSR1 gateway reload that can race a concurrent plugin install. Plugin-first lets the plugin land cleanly, then the skill's reload picks it up on the next gateway loop. If you accidentally do skill-first and the plugin install dies mid-flight, just retry `openclaw plugins install @totalreclaw/totalreclaw` once — it's idempotent.
 
-**No extra config steps needed.** As of 3.3.9-rc.2 the plugin's `register()` auto-patches `~/.openclaw/openclaw.json` with the keys OpenClaw 2026.5.x looks for (`plugins.slots.memory`, `plugins.entries.totalreclaw.hooks.allowConversationAccess`, `channels.telegram.streaming.mode`, `plugins.bundledDiscovery`, `plugins.allow`, `plugins.installs.totalreclaw`). As of 3.3.12-rc.6 the plugin auto-fires SIGUSR1 to its own PID after the patch, so the gateway in-process restart picks up the new keys without any manual `/totalreclaw-restart` from the user — hooks register cleanly on the first session post-install.
+**No extra config steps needed.** The plugin's `register()` auto-patches `~/.openclaw/openclaw.json` with the keys OpenClaw 2026.5.x looks for (`plugins.slots.memory`, `plugins.entries.totalreclaw.hooks.allowConversationAccess`, `channels.telegram.streaming.mode`, `plugins.bundledDiscovery`, `plugins.allow`, `plugins.installs.totalreclaw`) and auto-fires SIGUSR1 to its own PID after the patch, so the gateway in-process restart picks up the new keys without any manual restart — the native memory hooks register cleanly on the first session post-install.
 
-> **Setup is a user-initiated QR pair (as of 3.3.12-rc.13 + the native memory integration).** The plugin no longer auto-pairs on load. When no `~/.totalreclaw/credentials.json` exists, the agent runs `tr pair --json`, surfaces the returned `url` + `pin` to you verbatim, and you complete the flow in your browser (generate/import your 12-word recovery phrase browser-side — it is encrypted client-side and never enters the chat or the agent's context). On completion `credentials.json` is written and `memory_search`/`memory_get` work immediately — no manual gateway restart (the plugin self-applies its config + signals `SIGUSR1` to reload; if the memory tools don't bind, the agent issues `/totalreclaw-restart` autonomously). Recall is native (`memory_search`/`memory_get`) and facts are captured automatically in the background — you don't call a remember tool per fact.
+> **Setup is a user-initiated pair via `tr pair --json` (native memory integration).** The plugin does **not** auto-pair on load. When no `~/.totalreclaw/credentials.json` exists, the agent runs `tr pair --json`, surfaces the returned `url` + `pin` verbatim, and you complete the flow in your browser (generate/import your 12-word recovery phrase browser-side — it is encrypted client-side and never enters the chat or the agent's context). On completion `credentials.json` is written and `memory_search`/`memory_get` work immediately — no manual gateway restart (the plugin self-applies its config + signals `SIGUSR1` to reload; if the memory tools don't bind, the agent issues `/totalreclaw-restart` autonomously). Recall is native (`memory_search`/`memory_get`) and facts are captured automatically in the background — you don't call a remember tool per fact.
 
-> **Auto-extraction safety net (3.3.11-rc.1).** Even when the `agent_end` hook is gated by an upstream policy, the plugin runs a filesystem-polling backup that watches `~/.openclaw/agents/<agent>/sessions/*.trajectory.jsonl` every 60 s and runs the same extraction pipeline (NOT a hook event, so it's never gated). On 3.3.12-rc.6+ the hook fires alongside the poller; offset-based dedup prevents double-extraction.
+> **Auto-extraction safety net.** Even when the `agent_end` hook is gated by an upstream policy, the plugin runs a filesystem-polling backup that watches `~/.openclaw/agents/<agent>/sessions/*.trajectory.jsonl` every 60 s and runs the same extraction pipeline (NOT a hook event, so it's never gated). The hook fires alongside the poller; offset-based dedup prevents double-extraction.
 
 > **Plugin status caveat — OpenClaw 2026.5.7.** On the freshest OpenClaw releases the install path can occasionally land the plugin as `Status: disabled` after restart (upstream config-strip-on-restart). If `openclaw plugins list` shows totalreclaw as disabled, run `openclaw plugins enable totalreclaw` once and continue. The plugin remains on disk; only the registry flag needs flipping.
 
 Notes:
-- For an RC build, replace the first command with `openclaw plugins install @totalreclaw/totalreclaw@rc` (latest release candidate) or pin a version like `openclaw plugins install @totalreclaw/totalreclaw@3.3.12-rc.13`.
+- For an RC build, replace the first command with `openclaw plugins install @totalreclaw/totalreclaw@rc` (latest release candidate) or pin a version like `openclaw plugins install @totalreclaw/totalreclaw@3.3.12-rc.14`.
 - If install reports `already exists` or non-zero on a re-run (the plugin is already on disk from a previous attempt), add `--force`: `openclaw plugins install @totalreclaw/totalreclaw@rc --force` and `openclaw skills install totalreclaw --force`.
 - If either command fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment), STOP and tell the user verbatim: *"Your environment doesn't expose the OpenClaw CLI to me. Please install `totalreclaw` from your service's plugins / skills UI, then reply `done`."* Wait for `done` before continuing to Step 2.
 
-### Step 2 — Verify CLI works (hybrid-primary, 3.3.9-rc.1+) — emit user-visible line 2 on success
+### Step 2 — Verify the `tr` CLI works — emit user-visible line 2 on success
 
-**Do NOT wait for tool binding. Do NOT check whether `totalreclaw_pair` is in your toolset.** Under OpenClaw 2026.5.2+, non-bundled plugin tools may be stripped (issue #223). The `tr` CLI is the primary path and works independently.
-
-Resolve the CLI path once and reuse (3.3.10-rc.2 — modern OpenClaw 2026.5.x installs npm-managed plugins under `~/.openclaw/npm/...`, not `~/.openclaw/extensions/...`):
+Resolve the CLI path once and reuse (modern OpenClaw 2026.5.x installs npm-managed plugins under `~/.openclaw/npm/...`, not `~/.openclaw/extensions/...`):
 ```bash
 TR_CLI="$(ls -d ~/.openclaw/npm/node_modules/@totalreclaw/totalreclaw/dist/tr-cli.js ~/.openclaw/extensions/totalreclaw/dist/tr-cli.js 2>/dev/null | head -1)"
 node "$TR_CLI" status --json
 ```
 
-Parse the JSON. When you receive `{"version": "...", "hybrid_mode": true, ...}`, emit user-visible line 2 (`✓ Installed (totalreclaw <version>, hybrid mode)`) with the version substituted. Then proceed silently to Step 3.
+Parse the JSON. When you receive `{"version": "...", "paired": ..., ...}`, emit user-visible line 2 (`✓ Installed (totalreclaw <version>)`) with the version substituted. Then proceed silently to Step 3.
 
 If `tr status` exits non-zero or `$TR_CLI` is empty, wait 5s and retry once (the install may still be completing). If it still fails, tell the user the install didn't land and retry `openclaw plugins install @totalreclaw/totalreclaw@rc`.
 
-**Note on `/totalreclaw-restart`**: this slash command is still registered for environments where users need a manual reload (managed services, special configs). If you need to issue it for some reason, issue the literal slash command `/totalreclaw-restart` — nothing else. But under hybrid-primary, restarting to restore tool binding is no longer needed — `tr` CLI works regardless.
-
 ### Step 3 — Check for existing credentials (silent unless found)
 
-Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, emit user-visible line 4 (`✓ TotalReclaw is already set up.`) and stop — the user is already set up. Otherwise continue silently.
+Run `test -s ~/.totalreclaw/credentials.json`. If it exists and is non-empty, emit user-visible line 3 (`✓ TotalReclaw is already set up.`) and stop — the user is already set up. Otherwise continue silently.
 
-### Step 4 — Set up the user's TotalReclaw account IMMEDIATELY — no consent gate (emit user-visible line 5)
+### Step 4 — Set up the user's TotalReclaw account IMMEDIATELY — no consent gate (emit user-visible line 4)
 
-Pasting the install URL was the consent moment for installing the plugin. The URL + PIN you're about to hand the user is the real consent moment for account creation — they have to open the page in their browser to proceed. There is NO separate yes/no gate. Do NOT ask "Would you like to set up an account?" — run pair immediately.
+Pasting the install prompt was the consent moment for installing the plugin. The URL + PIN you're about to hand the user is the real consent moment for account creation — they have to open the page in their browser to proceed. There is NO separate yes/no gate. Do NOT ask "Would you like to set up an account?" — run pair immediately. Pair is UNCONDITIONAL when no credentials exist; the user installing/requesting setup IS the consent.
 
-CRITICAL (3.3.10-rc.2): always invoke `tr pair --json` via `setsid -f` so the WS-holding subprocess is in its own session and survives any post-install gateway SIGUSR1 reload. A foreground `node tr-cli pair` is killed mid-flight when the gateway fires its deferred restart, surfacing as `Gateway could not finish pairing (502). The agent timed out or the ciphertext failed to decrypt — ask the agent to retry pairing.` on the user's browser.
+CRITICAL: always invoke `tr pair --json` via `setsid -f` so the WS-holding subprocess is in its own session and survives any post-install gateway SIGUSR1 reload. A foreground `node tr-cli pair` is killed mid-flight when the gateway fires its deferred restart, surfacing as `Gateway could not finish pairing (502). The agent timed out or the ciphertext failed to decrypt — ask the agent to retry pairing.` on the user's browser.
 
 ```bash
 PAIR_OUT="/tmp/tr-pair-out-$(date +%s).json"
@@ -158,19 +183,19 @@ sleep 2
 cat "$PAIR_OUT"
 ```
 
-Parse the JSON `{"v":1,"sid":"...","url":"...","pin":"...","mode":"...","expires_at_ms":...,"qr_ascii":"..."}`. Emit user-visible line 5 (`Open <url> in your browser. Enter PIN <pin>. Generate or paste a 12-word recovery phrase. Reply done once it's sealed.`) with `<url>` and `<pin>` substituted. Do not pre-narrate — line 5 itself is the only thing the user needs to see.
+Parse the JSON `{"v":1,"sid":"...","url":"...","pin":"...","mode":"...","expires_at_ms":...,"qr_ascii":"..."}`. Emit user-visible line 4 (`Open <url> in your browser. Enter PIN <pin>. Generate or paste a 12-word recovery phrase. Reply done once it's sealed.`) with `<url>` and `<pin>` substituted VERBATIM from the JSON — never invent or modify values. Do not pre-narrate — line 4 itself is the only thing the user needs to see.
 
-If the cat output is empty after 2s, sleep 2 more seconds and try again (relay handshake can take up to 4s on a cold network). If `tr pair --json` is unavailable (old install path), fall back to the `totalreclaw_pair` native tool or `openclaw totalreclaw pair generate --url-pin-only`.
+If the cat output is empty after 2s, sleep 2 more seconds and try again (relay handshake can take up to 4s on a cold network). There is no fallback tool — `tr pair --json` is the sole agent-facilitated pair path under the native flow (the legacy `totalreclaw_pair` plugin tool is retired).
 
-The pair payload includes a `qr_ascii` field (Unicode block-char QR, ~43 lines × 43 cols) that renders correctly in monospace fonts on every modern transport. Emit it inline in a triple-backticked code block right above user-visible line 5 if your transport can render code blocks. The pair page renders a real PNG QR alongside, so users on a desktop browser see both. Do NOT save QR PNGs locally (`LocalMediaAccessError`). The QR encodes only the URL; the PIN is dual-channel — typed separately.
+The pair payload includes a `qr_ascii` field (Unicode block-char QR, ~43 lines × 43 cols) that renders correctly in monospace fonts on every modern transport. Emit it inline in a triple-backticked code block right above user-visible line 4 if your transport can render code blocks. The pair page renders a real PNG QR alongside, so users on a desktop browser see both. Do NOT save QR PNGs locally (`LocalMediaAccessError`). The QR encodes only the URL; the PIN is dual-channel — typed separately.
 
-### Step 5 — Verify and confirm (silent until line 6)
+### Step 5 — Verify and confirm (silent until line 5)
 
-After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN likely expired — re-run `tr pair --json` and resend line 5 once. If present, emit user-visible line 6 (with the free-tier confirmation) and stop.
+After the user says `done`, re-run `test -s ~/.totalreclaw/credentials.json`. If missing, the PIN likely expired — re-run `tr pair --json` and resend line 4 once. If present, emit user-visible line 5 (with the free-tier confirmation) and stop.
 
 ### Phrase safety (HARD — never break)
 
-NEVER echo, generate, or ask the user to paste a recovery phrase in chat. NEVER invoke `openclaw totalreclaw onboard` (bare interactive form), `totalreclaw setup`, or any phrase-touching CLI via your shell tool — stdout enters LLM context. The ONLY agent-facilitated account-setup path is the `totalreclaw_pair` tool (the account-setup tool — name kept for backward compatibility). If the user pastes a phrase anyway: tell them it is compromised and call `totalreclaw_pair` with `mode=generate` for a fresh wallet.
+NEVER echo, generate, or ask the user to paste a recovery phrase in chat. NEVER invoke `openclaw totalreclaw onboard` (bare interactive form), `totalreclaw setup`, or any phrase-touching CLI via your shell tool — stdout enters LLM context. NEVER `cat ~/.totalreclaw/credentials.json` or read the `mnemonic` / `recovery_phrase` field from any file. The ONLY agent-facilitated account-setup path is `tr pair --json`, which returns a URL + PIN — the phrase itself is generated/imported in the browser, never in chat. If the user pastes a phrase anyway: tell them it is compromised and re-run `tr pair --json` for a fresh wallet.
 
 ---
 
@@ -178,11 +203,12 @@ NEVER echo, generate, or ask the user to paste a recovery phrase in chat. NEVER 
 
 1. `openclaw skills install totalreclaw` — fetches TotalReclaw's SKILL.md from ClawHub and registers it under `~/.openclaw/workspace/skills/totalreclaw/`. The agent picks it up on next config reload.
 2. `openclaw plugins install @totalreclaw/totalreclaw` — installs the plugin from npm (the `latest` dist-tag is always current stable; use `@rc` for the latest release candidate).
-3. OpenClaw's config-watcher detects the `plugins.*` change in `~/.openclaw/config.yaml` and (under default `gateway.reload.mode = "hybrid"`) triggers a graceful SIGUSR1 restart within 1-3s. The new tools bind automatically.
-4. The agent calls `totalreclaw_pair`, which generates an ephemeral x25519 keypair on the gateway and a 6-digit PIN. You get a URL + PIN.
+3. The plugin's `register()` patches `~/.openclaw/openclaw.json` with the memory slot + hook keys OpenClaw looks for, then signals `SIGUSR1` to its own PID so the gateway picks up the new keys in-process — no manual restart.
+4. When no credentials exist, the agent runs `tr pair --json`, which generates an ephemeral x25519 keypair on the gateway and a 6-digit PIN. You get a URL + PIN.
 5. You open the URL. The account-setup page has two tabs: **Generate new** (the browser creates a fresh BIP-39 12-word phrase locally using `crypto.getRandomValues`) and **Import existing** (paste a phrase you already have). Pick one, confirm the 6-digit PIN, click seal.
 6. The browser performs x25519 ECDH against the gateway's ephemeral pubkey, derives an AES-256-GCM key via HKDF-SHA256, encrypts the phrase locally, and POSTs ciphertext + nonce + its pubkey back. The gateway decrypts server-side and writes `~/.totalreclaw/credentials.json` (mode `0600`).
-7. The recovery phrase never crosses the LLM context — not the chat transcript, not the agent's shell stdout, not any tool-call payload. Browser-side crypto keeps it isolated by construction.
+7. From the next session onward, recall runs natively through `memory_search` / `memory_get` (the conventional memory contract), and facts are captured automatically in the background — you don't call a remember tool per fact.
+8. The recovery phrase never crosses the LLM context — not the chat transcript, not the agent's shell stdout, not any tool-call payload. Browser-side crypto keeps it isolated by construction.
 
 First real interaction downloads a ~216 MB embedding model (cached locally, one-time).
 
@@ -201,11 +227,7 @@ If you're on a managed / hosted OpenClaw service that doesn't expose host shell 
 
 1. In your service's control panel, find the **Plugins** (or **Skills**) panel and search for `totalreclaw`. Install and enable it.
 2. If the service exposes a separate restart control, use it. Many managed services apply plugin changes transparently.
-3. Return to chat and paste the same canonical message:
-
-   > **Install TotalReclaw, see <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md>**
-
-   The agent will detect that the plugin is already loaded, skip Steps 1-2, and jump straight to account setup.
+3. Return to chat and paste one of the **Install prompts** at the top of this guide (e.g. the Stable prompt). The agent will detect that the plugin is already loaded, skip Steps 1-2, and jump straight to account setup.
 
 The browser-side crypto and account-setup flow are identical to self-hosted setups; only the install step differs.
 
@@ -218,16 +240,15 @@ If you can't or won't use the chat flow (self-hosted only — managed services d
 ```bash
 openclaw plugins install @totalreclaw/totalreclaw            # stable
 # Or for an RC: @totalreclaw/totalreclaw@rc
-# Under the default config (`gateway.reload.mode = "hybrid"`), OpenClaw's file-watcher
-# auto-restarts the gateway within 1-3s of the install — no manual restart needed.
+# The plugin self-restarts the gateway via SIGUSR1 when needed. You should not need
+# to run `openclaw gateway restart` or `docker restart` yourself; if a restart appears
+# stuck, file an issue rather than hand-restarting.
 # Verify with: `openclaw plugins list | grep totalreclaw`.
 ```
 
-The plugin self-restarts the gateway via SIGUSR1 when needed. You should not need to run `openclaw gateway restart` or `docker restart` yourself; if a restart appears stuck, file an issue rather than hand-restarting.
+Then in chat: *"Set up TotalReclaw"* — the agent will run `tr pair --json` and hand you the URL + PIN. Open the URL in your browser to enter or generate your phrase.
 
-Then in chat: *"Set up TotalReclaw"* — the agent will call `totalreclaw_pair` and hand you the URL + PIN. Open the URL in your browser to enter or generate your phrase.
-
-> Pin a specific RC with `openclaw plugins install @totalreclaw/totalreclaw@3.3.12-rc.13`. Check what each tag resolves to: `npm view @totalreclaw/totalreclaw dist-tags`. Keep skill and plugin on the same version family (both stable or both RC).
+> Pin a specific RC with `openclaw plugins install @totalreclaw/totalreclaw@3.3.12-rc.14`. Check what each tag resolves to: `npm view @totalreclaw/totalreclaw dist-tags`. Keep skill and plugin on the same version family (both stable or both RC).
 
 <details>
 <summary>From-source install (for plugin development — self-host only)</summary>
@@ -278,7 +299,7 @@ Ask the agent naturally; the plugin picks the right tool.
 | **Import from** | "Import my Gemini history from ~/Downloads/..." |
 | **Account setup** | "Set up TotalReclaw for me" — returns URL + PIN |
 
-Your recovery phrase is the only key to your memories. Store it safely. Retrieve later with `cat ~/.totalreclaw/credentials.json | jq -r .mnemonic`. On a new machine, paste the canonical prompt above and switch to the **Import existing** tab in the browser. First-time users can stay on the default **Generate new** tab to create a fresh BIP-39 phrase.
+Your recovery phrase is the only key to your memories. Store it somewhere durable (paper, password manager, or hardware key). On a new machine, paste one of the **Install prompts** at the top of this guide and switch to the **Import existing** tab in the browser. First-time users can stay on the default **Generate new** tab to create a fresh BIP-39 phrase.
 
 ---
 
@@ -295,9 +316,9 @@ See [Importing Memories](importing-memories.md).
 ## Billing
 
 - **Free tier** — 250 memories/month on Gnosis mainnet. Permanent storage. Cosine dedup (paraphrase detection). E2E encrypted. No credit card required.
-- **Pro tier** — 1,500 memories/month on Gnosis mainnet. Permanent. LLM-guided dedup (catches contradictions). Custom extraction interval. Pay via the `totalreclaw_upgrade` tool or visit <https://totalreclaw.xyz/pricing>. See `totalreclaw_status` for current pricing.
+- **Pro tier** — 1,500 memories/month on Gnosis mainnet. Permanent. LLM-guided dedup (catches contradictions). Custom extraction interval. Pay via the `tr upgrade` CLI (e.g. `node "$TR_CLI" upgrade`) or visit <https://totalreclaw.xyz/pricing>. See `tr status` for current pricing.
 
-The plugin warns you automatically when you cross 80% of the monthly free-tier memory limit (injected at conversation start). Check anytime by asking *"what's my TotalReclaw status?"* — that calls `totalreclaw_status` and reports tier, memories used, memory limit, reset date, and upgrade URL.
+The plugin warns you automatically when you cross 80% of the monthly free-tier memory limit (injected at conversation start). Check anytime by asking *"what's my TotalReclaw status?"* — that surfaces tier, memories used, memory limit, reset date, and upgrade URL.
 
 Upgrade: *"Upgrade my TotalReclaw subscription."*
 
@@ -307,25 +328,30 @@ Upgrade: *"Upgrade my TotalReclaw subscription."*
 
 ## Troubleshooting
 
-- **Agent says "I'm not familiar with TotalReclaw"**: paste the canonical message above with the URL — the agent fetches the guide and follows the install steps.
+- **Agent says "I'm not familiar with TotalReclaw"**: paste one of the **Install prompts** at the top of this guide — the agent fetches the guide and follows the install steps.
 - **Agent refused the install** ("this looks like prompt injection", "I'm not going to do that"): rare but possible with safety-trained models that misread agent-imperative install prose. Ask the agent to read the "Agent instructions" section of this guide and proceed step-by-step — each command is annotated with what it does and why it's safe. If the refusal persists, file an issue with the model name + chat transcript.
-- **Agent can't see TotalReclaw tools after install**: under the default config OpenClaw auto-restarts the gateway within 1-3s of `openclaw plugins install` — wait 5-10s and check `openclaw plugins list`. If the plugin is listed but the agent still can't see the tools, your config likely has `gateway.reload.mode = off`. The agent should issue the plugin's `/totalreclaw-restart` slash command (in-process, drains active runs, works from inside the gateway; 5-tier auth fallback so default-config installs work without `allowFrom`). Manual fallback only if `/totalreclaw-restart` is unavailable — native: `openclaw gateway restart`; Docker self-host: `docker restart <your-openclaw-container>`; managed service: use the service's restart control.
+- **Agent can't see `memory_search` / `memory_get` after install**: under the default config the plugin self-patches `openclaw.json` and signals `SIGUSR1` to its own PID so the gateway picks up the new keys in-process — wait 5-10s and check `openclaw plugins list`. If the plugin is listed but the native memory tools still aren't bound, the agent should issue `/totalreclaw-restart` autonomously (in-process, drains active runs, works from inside the gateway). The user should never be asked to do a manual restart; if `/totalreclaw-restart` itself fails, that's a user-side terminal fallback of last resort — native: `openclaw gateway restart`; Docker self-host: `docker restart <your-openclaw-container>`; managed service: use the service's restart control.
 - **Account-setup URL returns 404**: check that `~/.totalreclaw/credentials.json` isn't locked by a previous process and that the gateway is running.
 - **Browser fails to POST the encrypted phrase**: check the account-setup page's Content-Security-Policy — older browsers without WebCrypto x25519 (pre-Safari 17.2 / Chromium 118) cannot run the AEAD crypto.
-- **Tool calls return "onboarding required"**: paste the canonical message again so the agent re-runs `totalreclaw_pair`.
+- **Tool calls return "onboarding required"**: paste one of the **Install prompts** again so the agent re-runs `tr pair --json`.
 - **"Not authenticated" / 401**: check your phrase — exact words, exact order, lowercase, single spaces.
 - **Agent narrating internals during install** ("Let me check that…", "Plugin loaded. Let me verify…", "I'll now…", "Quick fix…", "However, I don't see…", "I need to use…", "let me find…", "in parallel…", "manifest detected…"): the agent missed the silence rule in §"Agent instructions". Reply *"Don't narrate the install internals — just tell me when it's installed and when to set up my account."* and the next session should silence. On transports like Telegram, these intermediate lines visibly edit the bot's message live as tool calls progress, which is what makes them disruptive.
-- **Agent says "Should I /totalreclaw-restart?" or stalls instead of restarting** (3.3.5-rc.1 hardening note, 3.3.7-rc.2 rename): the agent missed the restart-imperative deny-list in the SKILL.md / Step 2. Reply *"Issue /totalreclaw-restart yourself — don't ask"* and the next session should act autonomously. If it persists across sessions, the published RC's SKILL.md is stale — file an issue.
-- **`openclaw` CLI hangs / exits 124 inside the gateway agent shell** (issue [#184](https://github.com/p-diogo/totalreclaw-internal/issues/184)): on some Docker setups the agent's shell-execution of `openclaw plugins list` / `openclaw plugins install` etc. deadlocks (every subcommand exits 124). When this happens the agent can bypass the CLI wrapper by invoking the plugin's own JS entries directly via `node`. The plugin ships pair-flow + version-probe entries that work without any CLI:
-  - **Plugin install probe** — read the plugin's filesystem manifests to confirm the install completed: `cat ~/.openclaw/extensions/totalreclaw/.loaded.json` (issue [#186](https://github.com/p-diogo/totalreclaw-internal/issues/186)) reports `{ loadedAt, tools, version }` if `register()` ran cleanly. `.error.json` reports a structured failure if it didn't. These files are the canonical filesystem signal — they don't depend on the deadlocking CLI.
-  - **Pair-flow direct-node fallback** — when `openclaw` CLI hangs during `totalreclaw_pair`, the agent (or a shell helper) can run `node ~/.openclaw/extensions/totalreclaw/dist/pair-cli.js --url-pin-only` directly to obtain the universal-relay pair URL. This bypasses the gateway tool-router entirely and writes the resulting URL to stdout (one JSON line, no prompts). Surface that URL to the user the same way `totalreclaw_pair` would.
+- **Agent says "Should I /totalreclaw-restart?" or stalls instead of restarting**: the agent missed the restart-imperative rule in §"Restart is agent-driven, never user-manual". Reply *"Issue /totalreclaw-restart yourself — don't ask"* and the next session should act autonomously. If it persists across sessions, the published RC's SKILL.md is stale — file an issue.
+- **`openclaw` CLI hangs / exits 124 inside the gateway agent shell** (issue [#184](https://github.com/p-diogo/totalreclaw-internal/issues/184)): on some Docker setups the agent's shell-execution of `openclaw plugins list` / `openclaw plugins install` etc. deadlocks (every subcommand exits 124). The `tr` CLI pair path is independent of the `openclaw` wrapper — the agent resolves the installed path directly and invokes it via `node`, so `tr pair --json` / `tr status --json` keep working even when the `openclaw` CLI itself deadlocks:
+  ```bash
+  TR_CLI="$(ls -d ~/.openclaw/npm/node_modules/@totalreclaw/totalreclaw/dist/tr-cli.js ~/.openclaw/extensions/totalreclaw/dist/tr-cli.js 2>/dev/null | head -1)"
+  node "$TR_CLI" pair --json
+  node "$TR_CLI" status --json
+  ```
   - **Restart fallback** — `/totalreclaw-restart` slash command is the autonomous path; manual fallbacks (`openclaw gateway restart`, `docker restart`) require user-side terminal access and are documented above.
 
 ---
 
 ## Canonical prompt (matches the QA harness scenario contracts)
 
-> **Install TotalReclaw, see <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md>**
+The canonical install prompts live in the **Install prompts** section at the top of this guide (Stable / RC / RC-staging). The default stable prompt is:
+
+> **Install TotalReclaw. See <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/openclaw-setup.md>**
 
 ---
 


### PR DESCRIPTION
## What

Rewrites the agent-instructions in `docs/guides/openclaw-setup.md` for the **native memory flow** shipped by PR #383 + #385. The guide still documented the retired `totalreclaw_pair` tool (~13 live references) and "hybrid mode / hybrid-primary" framing throughout — an agent following it would have tried the dead-lettered flow and failed.

## Why

The native memory integration (#383) retired:
- the `totalreclaw_*` plugin tools (incl. `totalreclaw_pair`, `totalreclaw_remember`, `totalreclaw_recall`, `totalreclaw_status`, `totalreclaw_upgrade`) — recall is now native via `memory_search` / `memory_get`; explicit capture is `tr remember`; pair is `tr pair --json`.
- "hybrid mode" / "hybrid-primary" framing + the `hybrid_mode` status field.
- `.pair-pending.json`, `before_agent_start` injection, auto-pair-on-load.
- the `tr recall` CLI shim.

`skill/plugin/SKILL.md` was already rewritten for the native flow in #385; this PR brings the long-form setup guide in line so the two are consistent and an agent fetching the URL installs + pairs via the native flow with zero reliance on retired tools.

## Changes

**New `## Install prompts` section** near the top, mirroring `hermes-setup.md`'s 3-variant shape (Stable / RC / RC-against-staging), pointing at this guide's URL. The canonical install prompt is now `Install TotalReclaw. See <URL>`.

**Agent-instructions rewrite** (`## Agent instructions` through `### Phrase safety`):
- Every `totalreclaw_pair` reference → `tr pair --json` via the `TR_CLI` resolver. The only allowed mentions of the legacy tool name are in explicit retirement notices ("do not invoke them").
- "hybrid mode" / "hybrid-primary" framing → native flow (recall via `memory_search`/`memory_get`; `tr` CLI is for explicit capture / curation / pair). The "hybrid mode" status field, `.pair-pending.json`, `before_agent_start`, `auto-pair` are listed in the forbidden-vocabulary denylist so the agent won't emit them either.
- Pair flow: `tr pair --json` → surface url + pin verbatim → user completes in browser → `credentials.json`. No auto-pair-on-load, no `.pair-pending.json`, no `before_agent_start` injection.
- Restart: agent-driven `/totalreclaw-restart` (never user-manual; never ask permission). Added a dedicated "Restart is agent-driven, never user-manual" subsection.
- Kept the phrase-safety rules (phrase never in chat/LLM; browser-only; never `cat credentials.json` / read `mnemonic` field).
- Kept the silence/terse-UX rules (5-6 lines, no narration) and the user-visible prose lines, adapted ("✓ Installed (totalreclaw <version>)" — dropped "hybrid mode"; pair line stays, renumbered line 4/5).
- ⛔ FORBIDDEN section: drop "Do NOT issue `/totalreclaw-restart`" (that was the OLD hybrid-mode rule; under native flow the agent ISSUES it autonomously when memory tools don't bind). Replaced with "Do NOT prompt the user to restart / ask permission to restart — issue `/totalreclaw-restart` autonomously".

**Other retired-ref fixes**:
- "What's happening" section: `totalreclaw_pair` → `tr pair --json`; added the native-memory-recall step.
- "Managed OpenClaw service" + "Fully manual" sections: `totalreclaw_pair` → `tr pair --json`; updated the canonical prompt reference to the new Install-prompts section; dropped the `gateway.reload.mode = "hybrid"` reference.
- "Explicit tools" section: removed the `cat ~/.totalreclaw/credentials.json | jq -r .mnemonic` instruction — that was a **phrase-leak** (the agent's shell stdout enters LLM context). Replaced with a pointer to the Install-prompts + browser Import tab.
- "Billing" section: `totalreclaw_upgrade` / `totalreclaw_status` live-tool references → `tr upgrade` / `tr status` CLI.
- "Troubleshooting" section: every live `totalreclaw_pair` reference → `tr pair --json`; the `openclaw` CLI hangs / exit-124 block now points at the `tr` CLI direct-node path (the retired `pair-cli.js --url-pin-only` fallback was removed since `tr pair --json` already covers it via the `TR_CLI` resolver).
- "Canonical prompt" section: points at the new Install-prompts section; default stable prompt uses the new shape (`Install TotalReclaw. See <URL>`).

**Version pin**: bumped the RC pin example from `3.3.12-rc.13` → `3.3.12-rc.14` (stable stays `3.3.2`).

## Verification

- `cd skill/plugin && npx tsx register-command-name.test.ts` → 17/17 passed (incl. the two guide-content asserts: guide mentions `/totalreclaw-restart` and uses the literal-slash-command phrase).
- `cd skill/plugin && npx tsx skill-md-native.test.ts` → 45/45 passed (SKILL.md untouched; native-flow invariants intact).
- `cd skill/plugin && npm run check-scanner` → 151 files scanned, **0 flags**.
- Grep of rewritten guide: **ZERO live instructions** to invoke retired tools/flows. Remaining matches are explicit retirement notices ("do not invoke them") and the forbidden-vocabulary denylist — both intentional.
- `skill/plugin/CHANGELOG.md` and `skill/plugin/SKILL.md` untouched (register-command-name.test.ts:15 still asserts `hybrid-primary` appears in CHANGELOG as a historical pivot marker).

Note: `npm test` (full suite) fails with `Cannot find module '@totalreclaw/core'` because `node_modules` is absent in this worktree — pre-existing install gap, unrelated to this doc-only change. The two tests that touch guide content + the scanner all pass.

## Scope / autonomy

Doc-only. No code, no test, no manifest, no behavior change. Fits the "docs / scoped refactor" autonomous lane per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)