### PR TITLE
feat(hermes): totalreclaw_top_up tool for over-quota top-ups (#392)

### DIFF
--- a/python/src/totalreclaw/hermes/memory_provider.py
+++ b/python/src/totalreclaw/hermes/memory_provider.py
@@ -95,6 +95,7 @@ _TOOL_HANDLERS = (
     ("totalreclaw_import_status", "tools", "import_status"),
     ("totalreclaw_import_abort", "tools", "import_abort"),
     ("totalreclaw_upgrade", "tools", "upgrade"),
+    ("totalreclaw_top_up", "tools", "top_up"),
     ("totalreclaw_debrief", "tools", "debrief"),
 )
 
@@ -196,6 +197,7 @@ class TotalReclawMemoryProvider(_MemoryProviderBase):  # type: ignore[misc,valid
             schemas.IMPORT_STATUS,
             schemas.IMPORT_ABORT,
             schemas.UPGRADE,
+            schemas.TOPUP,
             schemas.DEBRIEF,
         ]
 

--- a/python/src/totalreclaw/hermes/schemas.py
+++ b/python/src/totalreclaw/hermes/schemas.py
@@ -348,6 +348,35 @@ UPGRADE = {
     },
 }
 
+TOPUP = {
+    "name": "totalreclaw_top_up",
+    "description": (
+        "Buy a one-time pack of extra memories when the monthly quota + grace "
+        "are exhausted — e.g. to finish a large import. Creates a Stripe "
+        "Checkout session (one-time payment) and returns the URL the user "
+        "opens to pay. The purchased memories persist across monthly resets "
+        "until used.\n\n"
+        "INVOKE WHEN USER SAYS:\n"
+        "- 'I need more memories' / 'I hit my limit mid-import' / 'buy more'\n"
+        "- a write/import returned a quota-exceeded error and the user wants "
+        "to continue now rather than wait for the monthly reset\n\n"
+        "After calling, read the returned ``message`` aloud — it has the "
+        "checkout URL. Only call when the user has explicitly asked to buy "
+        "more memories."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "pack": {
+                "type": "string",
+                "enum": ["1000", "5000", "10000"],
+                "description": "Number of memories to buy: 1000, 5000, or 10000.",
+            },
+        },
+        "required": ["pack"],
+    },
+}
+
 DEBRIEF = {
     "name": "totalreclaw_debrief",
     "description": (

--- a/python/src/totalreclaw/hermes/tools.py
+++ b/python/src/totalreclaw/hermes/tools.py
@@ -64,6 +64,7 @@ _INTERNAL_TOOL_NAMES = (
     "totalreclaw_set_scope",
     "totalreclaw_retype",
     "totalreclaw_upgrade",
+    "totalreclaw_top_up",
     "totalreclaw_export",
     "totalreclaw_report_qa_bug",
 )
@@ -579,6 +580,41 @@ async def upgrade(args: dict, state: "PluginState", **kwargs) -> str:
     except Exception as e:
         logger.error("totalreclaw_upgrade failed: %s", e)
         return json.dumps({"error": f"Failed to create checkout session: {e}"})
+
+
+async def top_up(args: dict, state: "PluginState", **kwargs) -> str:
+    """Buy a one-time pack of extra memories (#392).
+
+    For when the monthly quota + grace are exhausted (e.g. mid-import) and the
+    user wants more memories now rather than waiting for the reset. ``pack`` is
+    the facts count: ``"1000"``, ``"5000"``, or ``"10000"``. Returns the
+    checkout URL the agent should read back verbatim.
+    """
+    client = state.get_client()
+    if not client:
+        return json.dumps(
+            {"error": "TotalReclaw not configured. Call totalreclaw_pair to set up — browser-side crypto keeps the phrase out of this chat."}
+        )
+    pack = str(args.get("pack") or "").strip()
+    if pack not in ("1000", "5000", "10000"):
+        return json.dumps({"error": "Invalid or missing 'pack'. Choose 1000, 5000, or 10000 (memories)."})
+
+    try:
+        ensure_addr = getattr(client, "_ensure_address", None)
+        if callable(ensure_addr):
+            try:
+                await ensure_addr()
+            except Exception:
+                pass
+        checkout = await client._relay.create_topup(pack)
+        return json.dumps({
+            "checkout_url": checkout.checkout_url,
+            "pack": pack,
+            "message": f"Open this URL in your browser to buy +{pack} memories: {checkout.checkout_url}",
+        })
+    except Exception as e:
+        logger.error("totalreclaw_top_up failed: %s", e)
+        return json.dumps({"error": f"Failed to create top-up checkout session: {e}"})
 
 
 # ── Debrief (explicit invocation) ────────────────────────────────────────────

--- a/python/src/totalreclaw/relay.py
+++ b/python/src/totalreclaw/relay.py
@@ -325,6 +325,28 @@ class RelayClient:
         # ``session_id`` is optional — the relay does not send it.
         return CheckoutResponse(checkout_url=checkout_url, session_id=data.get("session_id"))
 
+    async def create_topup(self, pack: str) -> CheckoutResponse:
+        """Create a one-time top-up Checkout session (#392).
+
+        ``pack`` is the facts count (``"1000"`` | ``"5000"`` | ``"10000"``).
+        Mirrors :meth:`create_checkout` but hits ``/v1/billing/topup``
+        (mode='payment'); the relay credits ``topup_writes_purchased`` via the
+        Stripe webhook on completion.
+        """
+        http = await self._get_http()
+        resp = await http.post(
+            f"{self._relay_url}/v1/billing/topup",
+            headers=self._base_headers(),
+            json={"wallet_address": self._wallet_address, "pack": pack},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        checkout_url = data.get("checkout_url")
+        if not checkout_url:
+            detail = data.get("error_message") or data.get("error_code") or "relay returned no checkout_url"
+            raise RuntimeError(f"relay top-up failed: {detail}")
+        return CheckoutResponse(checkout_url=checkout_url, session_id=data.get("session_id"))
+
     async def close(self):
         """Close any cached httpx clients across all loops we've touched.
 


### PR DESCRIPTION
Client side of the top-up mechanism (relay #27). Adds the agent-facing tool
that creates a one-time Stripe Checkout session for a memory pack (1000 /
5000 / 10000) when the monthly quota + grace are exhausted — e.g. to finish
a large import. Mirrors totalreclaw_upgrade.

- relay.RelayClient.create_topup(pack): POST /v1/billing/topup.
- schemas.TOPUP: tool schema (pack enum 1000/5000/10000).
- tools.top_up: handler — resolves address, calls create_topup, returns URL.
- Registered in _INTERNAL_TOOL_NAMES + _TOOL_HANDLERS + get_tool_schemas.

Safe to ship before the Stripe products exist: the relay returns
PACK_UNAVAILABLE for any pack without a configured priceId, which the tool
surfaces as a readable error. Verified end-to-end wiring (schema + handler +
fn + relay method + schema-list) and 80 hermes-tool tests pass.

Co-Authored-By: Claude <noreply@anthropic.com>
