### PR TITLE
fix(python): actionable error when a stale core wheel rejects a MAX_BATCH_SIZE batch

### DIFF
--- a/python/src/totalreclaw/userop.py
+++ b/python/src/totalreclaw/userop.py
@@ -168,15 +168,12 @@ def encode_execute_batch_calldata_for_data_edge(
     when ``len(protobuf_payloads) == 1`` so a batch-of-1 is byte-identical
     to the single-fact fast path — this preserves gas parity with the TS
     plugin's ``encodeBatchCalls`` helper.
-    The Rust core returns ``execute(...)`` calldata (not ``executeBatch``)
-    when ``len(protobuf_payloads) == 1`` so a batch-of-1 is byte-identical
-    to the single-fact fast path — this preserves gas parity with the TS
-    plugin's ``encodeBatchCalls`` helper.
 
     Parameters
     ----------
     protobuf_payloads : list of bytes
-        One raw protobuf payload per fact. Must contain 1..15 entries.
+        One raw protobuf payload per fact. Must contain
+        1..:data:`MAX_BATCH_SIZE` entries.
 
     Returns
     -------
@@ -198,12 +195,30 @@ def encode_execute_batch_calldata_for_data_edge(
             f"Batch size {len(protobuf_payloads)} exceeds maximum of "
             f"{MAX_BATCH_SIZE}"
         )
-    if data_edge_address is not None:
-        calldata_bytes = totalreclaw_core.encode_batch_call(
-            protobuf_payloads, data_edge_address
-        )
-    else:
-        calldata_bytes = totalreclaw_core.encode_batch_call(protobuf_payloads)
+    try:
+        if data_edge_address is not None:
+            calldata_bytes = totalreclaw_core.encode_batch_call(
+                protobuf_payloads, data_edge_address
+            )
+        else:
+            calldata_bytes = totalreclaw_core.encode_batch_call(
+                protobuf_payloads
+            )
+    except ValueError as exc:
+        # The batch passed our own ceiling check above, so a core-side
+        # "exceeds maximum" means the installed wheel enforces a smaller
+        # ceiling than this client — i.e. a totalreclaw-core older than
+        # the pyproject floor (< 2.5.5 kept the pre-#392 ceiling of 15).
+        if "exceeds maximum" in str(exc):
+            raise ValueError(
+                f"totalreclaw-core rejected a "
+                f"{len(protobuf_payloads)}-fact batch that this client "
+                f"allows (MAX_BATCH_SIZE={MAX_BATCH_SIZE}): {exc}. The "
+                f"installed core wheel is older than the required floor "
+                f"and enforces the pre-#392 ceiling — upgrade with "
+                f"pip install -U 'totalreclaw-core>=2.5.5'."
+            ) from exc
+        raise
     return "0x" + calldata_bytes.hex()
 
 

--- a/python/tests/test_userop_batch.py
+++ b/python/tests/test_userop_batch.py
@@ -98,7 +98,8 @@ class TestBatchCalldataFixtureParity:
         assert len(calldata_hex[2:]) // 2 == entry["expected_calldata_bytes"]
 
     def test_fixture_covers_required_sizes(self) -> None:
-        # Spec minimum: N = 1, 3, 5, 10. We also cover 15 (MAX_BATCH_SIZE).
+        # Spec minimum: N = 1, 3, 5, 10. We also cover 15 (the pre-#392
+        # ceiling; MAX_BATCH_SIZE is 30 since core 2.5.5).
         required = {"n1", "n3", "n5", "n10"}
         assert required.issubset(BATCH_FIXTURE.keys())
 
@@ -199,10 +200,37 @@ class TestBatchValidation:
             encode_execute_batch_calldata_for_data_edge(payloads)
 
     def test_exact_max_size_accepted(self) -> None:
-        # 15 must work (not raise)
+        # Exactly MAX_BATCH_SIZE payloads must encode (not raise). Requires
+        # an installed core whose ceiling matches ours (core >= 2.5.5 for
+        # the 30 ceiling, #392 Part 2).
         payloads = [bytes([i]) for i in range(MAX_BATCH_SIZE)]
         calldata_hex = encode_execute_batch_calldata_for_data_edge(payloads)
         assert calldata_hex.startswith("0x47e1da2a")
+
+    def test_stale_core_ceiling_mismatch_gives_actionable_error(self) -> None:
+        # A core wheel older than the pyproject floor (< 2.5.5) enforces a
+        # 15 ceiling, so a batch that passes our MAX_BATCH_SIZE=30 check
+        # dies inside the core with a bare "Batch size 30 exceeds maximum
+        # of 15" — indistinguishable from a caller bug. That exact drift
+        # produced a confusing field failure (#392 Part 2 rollout); the
+        # encoder must translate it into an upgrade hint.
+        def _old_core_reject(*_args, **_kwargs):
+            raise ValueError(
+                "crypto error: Batch size 30 exceeds maximum of 15"
+            )
+
+        payloads = [bytes([i]) for i in range(MAX_BATCH_SIZE)]
+        with patch(
+            "totalreclaw.userop.totalreclaw_core.encode_batch_call",
+            side_effect=_old_core_reject,
+        ):
+            with pytest.raises(
+                ValueError, match="totalreclaw-core.*older"
+            ) as excinfo:
+                encode_execute_batch_calldata_for_data_edge(payloads)
+        # The hint must carry the client ceiling and the upgrade action.
+        assert str(MAX_BATCH_SIZE) in str(excinfo.value)
+        assert "pip install" in str(excinfo.value)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Context — diagnosis of the reported `test_exact_max_size_accepted` failure

The reported failure (`ValueError` at `userop.py:206` on origin/main) does **not** reproduce in a clean environment: on origin/main with the pinned `totalreclaw-core>=2.5.5`, `tests/test_userop_batch.py` passes (24 passed, 1 skipped). **Neither the code nor the test is wrong** — the #392 Part 2 ceiling raise (15 → 30) shipped in sync across all three load-bearing caps:

| site | value | shipped in |
|---|---|---|
| core `userop.rs MAX_BATCH_SIZE` | 30 | #379, released as core **2.5.5** (PyPI wheel verified to accept 30) |
| relay `MAX_FACT_COUNT` billing clamp | 30 | totalreclaw-relay#26 (merged, verified on relay `origin/main`) |
| python `userop.MAX_BATCH_SIZE` + `IMPORT_MAX_BATCH_SIZE` | 30 | #382 |

The failure reproduces **only** with a stale `totalreclaw-core < 2.5.5` installed (violating the pyproject floor): core 2.5.4 raises `ValueError('crypto error: Batch size 30 exceeds maximum of 15')` from the `encode_batch_call` call site — exactly line 206. So the env that 'verified' the failure had a pre-#392 core wheel; `pip install -e .` (or `pip install -U totalreclaw-core`) fixes it.

## What this PR changes

That failure mode was needlessly confusing — a version-drift problem masquerading as a validation bug. This PR:

1. **Translates the core-side rejection into an actionable error.** The batch already passed the client's own `MAX_BATCH_SIZE` check, so a core-side "exceeds maximum" can only mean the installed wheel enforces a smaller ceiling. The error now names the client ceiling and the upgrade command (`pip install -U 'totalreclaw-core>=2.5.5'`), chained `from` the original.
2. **Fixes stale docs from the #392 rollout**: the `1..15 entries` docstring (ceiling is `MAX_BATCH_SIZE`), a duplicated docstring paragraph, and two test comments still claiming 15 is the max.

## Tests

- New `test_stale_core_ceiling_mismatch_gives_actionable_error` (TDD: watched it fail with the bare core message first).
- End-to-end verified against a real `totalreclaw-core==2.5.4` install — the 30-fact batch now fails with the upgrade hint.
- `tests/test_userop_batch.py`: **24 passed, 1 skipped**. Affected neighbors (`test_import_engine_batching`, `test_operations`, `test_client`, `test_nonce_serialization_rc3`, `test_pin_batch_cross_impl_parity`): **78 passed**.

Side note (not this PR): the parked TS `client/src/userop/batcher.ts` still caps at 15 — safe (below the ceiling), just not yet raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)