### PR TITLE
fix(#407): mem0 dry-run import estimate no longer 21 min for 3 facts

### DIFF
--- a/python/src/totalreclaw/import_engine.py
+++ b/python/src/totalreclaw/import_engine.py
@@ -296,31 +296,50 @@ class ImportEngine:
         processable = total_chunks if has_chunks else total_facts
         num_batches = max(1, int(math.ceil(processable / DEFAULT_BATCH_SIZE)))
 
-        # Time estimate accounting for concurrent extraction (#378) and
-        # one-time profiling (#373).  Per batch: ceil(chunks / concurrency)
-        # extraction waves × per-chunk wall-clock, plus on-chain UserOp
-        # writes.  Profiling runs once (first batch).
-        conc = _import_concurrency()
-        chunks_per_batch = min(DEFAULT_BATCH_SIZE, processable)
-        extraction_waves = math.ceil(chunks_per_batch / conc)
-        extraction_per_batch = extraction_waves * SECONDS_PER_CHUNK_SEQ
-        userop_per_batch = (
-            math.ceil(estimated_from_chunks / num_batches / IMPORT_MAX_BATCH_SIZE)
-            * SECONDS_PER_USEROP
-        )
-        # Per-batch wall-clock = extraction waves + UserOp writes + amortised
-        # nonce-retry/resubmission overhead (#401). The overhead constant
-        # captures the observed ~12 retry events / 54 batches from the
-        # 2026-06-29 run and is added unconditionally (retries happen on
-        # nearly every batch in practice).
-        per_batch_s = (
-            extraction_per_batch
-            + userop_per_batch
-            + USEROP_OVERHEAD_PER_BATCH
-        )
-        estimated_minutes = round(
-            (SECONDS_PROFILING + num_batches * per_batch_s) / 60, 1
-        )
+        # Time estimate. Two regimes with very different cost profiles:
+        #
+        #  • Blind chunk extraction (ChatGPT/Claude/Gemini conversation
+        #    imports): each batch runs ceil(chunks / concurrency) LLM
+        #    extraction waves × per-chunk wall-clock plus on-chain UserOp
+        #    writes, and a one-time profiling pass (#373) calibrates the
+        #    extractor on the first batch.
+        #
+        #  • Pre-structured facts (mem0): facts are already atomic and are
+        #    stored directly via client.remember with NO LLM extraction and
+        #    NO profiling — the only real cost is the on-chain UserOp writes.
+        #    Applying the profiling constant + per-chunk extraction wall-clock
+        #    here made a 3-fact import read as ~21 min (#407); the true cost
+        #    is a handful of seconds of on-chain writes.
+        if has_chunks:
+            conc = _import_concurrency()
+            chunks_per_batch = min(DEFAULT_BATCH_SIZE, processable)
+            extraction_waves = math.ceil(chunks_per_batch / conc)
+            extraction_per_batch = extraction_waves * SECONDS_PER_CHUNK_SEQ
+            userop_per_batch = (
+                math.ceil(estimated_from_chunks / num_batches / IMPORT_MAX_BATCH_SIZE)
+                * SECONDS_PER_USEROP
+            )
+            # Per-batch wall-clock = extraction waves + UserOp writes + amortised
+            # nonce-retry/resubmission overhead (#401). The overhead constant
+            # captures the observed ~12 retry events / 54 batches from the
+            # 2026-06-29 run and is added unconditionally (retries happen on
+            # nearly every batch in practice).
+            per_batch_s = (
+                extraction_per_batch
+                + userop_per_batch
+                + USEROP_OVERHEAD_PER_BATCH
+            )
+            estimated_minutes = round(
+                (SECONDS_PROFILING + num_batches * per_batch_s) / 60, 1
+            )
+        else:
+            # Pre-structured facts: on-chain UserOp writes only (one UserOp per
+            # fact) plus the amortised nonce-retry/resubmission overhead per
+            # processing batch. No profiling, no LLM extraction.
+            userop_s = total_facts * SECONDS_PER_USEROP
+            estimated_minutes = round(
+                (userop_s + num_batches * USEROP_OVERHEAD_PER_BATCH) / 60, 1
+            )
 
         return {
             "source": source,

--- a/python/tests/test_mem0_adapter.py
+++ b/python/tests/test_mem0_adapter.py
@@ -309,3 +309,38 @@ class TestMem0ImportEngineIntegration:
         assert result.is_complete is True
         # All three stored with the import engine's source tag.
         assert fake_client.remember.await_count == 3
+
+    def test_issue_407_small_mem0_estimate_is_not_profiling_dominated(self) -> None:
+        """Regression for #407: a tiny pre-structured (mem0) import must not
+        advertise ~21 min.
+
+        The estimate formula unconditionally added the one-time smart-import
+        profiling constant (~20 min) plus per-chunk LLM-extraction wall-clock,
+        neither of which applies to pre-structured facts (mem0 stores facts
+        directly via ``client.remember`` with no extraction and no profiling).
+        A 3-fact import therefore read as 21.1 min. The pre-structured path
+        should cost only on-chain UserOp writes — well under a minute for a
+        handful of facts.
+        """
+        from unittest.mock import MagicMock
+
+        from totalreclaw.import_engine import ImportEngine
+
+        fixture = json.dumps({
+            "memories": [
+                {"id": "m1", "memory": "User prefers dark mode always", "categories": ["preference"]},
+                {"id": "m2", "memory": "User works on the TotalReclaw project", "categories": ["fact"]},
+                {"id": "m3", "memory": "Decided to use PostgreSQL for the DB", "categories": ["decision"]},
+            ]
+        })
+
+        engine = ImportEngine(client=MagicMock(), llm_extract=None)
+        est = engine.estimate(source="mem0", content=fixture)
+
+        assert est["total_facts"] == 3
+        assert est["total_chunks"] == 0
+        assert est["has_facts"] is True
+        # Pre-#407 this was 21.1. A 3-fact on-chain write is well under a minute.
+        assert est["estimated_minutes"] < 1.0, (
+            f"3-fact mem0 estimate should be < 1 min, got {est['estimated_minutes']}"
+        )


### PR DESCRIPTION
## What broke
A dry-run of a tiny mem0 import (3 pre-structured facts) advertised **21 minutes** — reading as broken for what is really a few seconds of work.

## What's fixed
`ImportEngine.estimate()` was charging the one-time smart-import **profiling** (~20 min) and per-chunk **LLM-extraction** wall-clock to *every* source. Those only apply to blind conversation-chunk imports (ChatGPT/Claude/Gemini). Pre-structured sources (mem0) store atomic facts directly with no extraction and no profiling, so the estimate now counts only the on-chain UserOp writes.

## Impact after fix
3-fact mem0 dry-run now estimates **0.3 min** (was 21.1); a 1000-fact mem0 import estimates **18.3 min**. Conversation-import estimates (the `has_chunks` path) are unchanged — that branch is byte-identical.

## Verification
Deterministic regression test `test_issue_407_small_mem0_estimate_is_not_profiling_dominated` (asserts a 3-fact mem0 estimate < 1 min) — fails pre-patch (21.1), passes post-patch. Full `python/tests/test_mem0_adapter.py` (19) + import-engine/extraction/gemini/smart-import/preflight suites (44) green. `estimate()` is a pure dry-run function — no LLM chat flow involved, so unit repro is the QA.

Closes p-diogo/totalreclaw-internal#407
Umbrella: p-diogo/totalreclaw-internal#403 (Finding #4, independent / narrow-fix)