### PR TITLE
fix(#405): route one-time "buy more memories" to totalreclaw_top_up

### DIFF
--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -268,6 +268,10 @@ These are hard rules. None of them are negotiable.
 | `totalreclaw_export` | Export the full vault. |
 | `totalreclaw_set_scope` | Switch active scope. |
 | `totalreclaw_retype` | Change a memory's taxonomy type. |
+| `totalreclaw_upgrade` | Start the recurring Pro upgrade (higher monthly cap). Returns a Stripe checkout URL. |
+| `totalreclaw_top_up` | Buy a one-time pack of extra memories (1000 / 5000 / 10000) that persists across monthly resets. Returns a Stripe checkout URL. |
+
+**Routing hint — top-up vs upgrade:** when the user is near/over quota (or proactively expects to be, e.g. before a big import) and wants *more memories now*, offer `totalreclaw_top_up` (a one-time pack) — not necessarily a Pro upgrade. Reserve `totalreclaw_upgrade` for users who want the recurring higher monthly cap. A proactive "I might blow past my quota" is a valid top-up trigger; don't wait for the quota to be exhausted.
 
 ---
 

--- a/python/src/totalreclaw/hermes/SKILL.md
+++ b/python/src/totalreclaw/hermes/SKILL.md
@@ -75,6 +75,7 @@ Pattern is always **recall first → mutate second**, because the mutation tools
 
 - "status" / "how am I doing on quota" / "what tier am I on" → `totalreclaw_status` (no args). Returns tier, used / limit, and smart-account address.
 - "upgrade" / "go Pro" → `totalreclaw_upgrade` (returns a Stripe checkout URL — paste verbatim, no paraphrase).
+- "buy a top-up pack" / "I need more memories now" / "I'm about to run a big import and might blow past my quota" / "buy 5000 extra memories" → `totalreclaw_top_up` (returns a Stripe checkout URL — paste verbatim). **Offer this, not `_upgrade`, when the user wants *more memories now* — a one-time pack — rather than a monthly plan change.** Don't wait for the quota to be exhausted: a proactive request ("about to", "might blow past") is a valid top-up trigger. Ask which pack size (1000 / 5000 / 10000) if the user didn't say.
 - "import from Mem0 / ChatGPT / Claude / Gemini / mcp-memory-server" → `totalreclaw_import_from` with `dry_run=True` first to surface the count + estimated free-tier impact, then ask the user to confirm before the real run.
 
 ## Tiers + pricing
@@ -93,7 +94,7 @@ Both tiers: encryption, ownership, and on-chain durability are identical. Tier o
 The plugin fetches billing on every `on_session_start` and caches it for 2 hours. It auto-injects warnings into your context at these thresholds — when you see them, surface them to the user:
 
 - **>80% usage** — soft warning. Mention casually: *"You're at `<used>` / `<limit>` of your free-tier quota this month. Upgrade to Pro for 1,500/month — want me to open the upgrade link?"* Wait for confirmation before calling `totalreclaw_upgrade`.
-- **403 quota exceeded** on a write → billing cache invalidated, warning re-injects next turn. Surface the error verbatim + offer `totalreclaw_upgrade` immediately.
+- **403 quota exceeded** on a write → billing cache invalidated, warning re-injects next turn. Surface the error verbatim, then offer the right paid path: `totalreclaw_upgrade` (recurring Pro, higher monthly cap) **or** `totalreclaw_top_up` (a one-time pack to finish *this* task now without a subscription). If the user just wants to get past a single import/burst, prefer top-up.
 - **First successful pair** → the setup-flow confirmation already includes tier + limit. Do not re-emit the same info on subsequent first-message-of-session.
 
 Do NOT compute "you have X left" math yourself — `totalreclaw_status` returns `free_writes_used` and `free_writes_limit` already. Quote them verbatim.
@@ -106,6 +107,7 @@ User intent → action:
 |---|---|
 | "How much does it cost?" / "What's the pricing?" / "Is it free?" | Cite the table above + pricing URL. Don't quote a `$` figure unless the user explicitly asked for the current Pro price AND you just called `totalreclaw_status`. |
 | User asks to upgrade / asks how to get Pro / hits a 403 | Call `totalreclaw_upgrade` → returns a Stripe checkout URL. Emit ONE user-visible line: *"Open `<url>` in your browser to complete the upgrade. Reply `done` once the payment page confirms."* DO NOT paraphrase the URL. |
+| User wants a one-time pack of extra memories now (mid/pre-import, "buy more", "top up", "5000 extra memories"), NOT a monthly plan | Call `totalreclaw_top_up` with the requested `pack` (1000 / 5000 / 10000; ask if unspecified) → returns a Stripe checkout URL. Emit ONE user-visible line: *"Open `<url>` in your browser to buy the pack. Reply `done` once payment confirms."* DO NOT paraphrase the URL. Top-up ≠ upgrade: it adds a fixed batch of memories that persist across monthly resets, without changing the tier. |
 | User reports payment succeeded ("done") | Call `totalreclaw_status` once to refresh the cached tier. Emit a single confirmation: *"✓ You're now on TotalReclaw Pro — 1,500 memories/month."* |
 | User wants to cancel / downgrade | Direct them to <https://totalreclaw.xyz/pricing> — the Stripe customer portal is the only canonical cancel path. The plugin does not expose a downgrade tool. |
 
@@ -126,8 +128,8 @@ These statements are WRONG. Never write any of them — they fabricate a pricing
 - `totalreclaw_*` tools not visible → the gateway wasn't restarted after install. This is an **install** problem — follow the install guide (<https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md>), which owns the `/restart` procedure.
 - User says done but `credentials.json` missing → PIN expired or wrong phrase entered; call `totalreclaw_pair` again.
 - `onboarding required` → credentials missing; redo from the account-setup step in the install guide.
-- `quota exceeded` → `totalreclaw_status`, then offer `totalreclaw_upgrade`.
+- `quota exceeded` → `totalreclaw_status`, then offer `totalreclaw_upgrade` (recurring Pro) or `totalreclaw_top_up` (one-time pack) per the user's intent.
 
 ## Tool surface
 
-`totalreclaw_pair` (ONLY account-setup path) · `_remember` · `_recall` · `_forget` · `_pin` · `_unpin` · `_retype` · `_set_scope` · `_export` · `_status` · `_upgrade` · `_import_from` · `_import_batch` · `_debrief` · `_report_qa_bug` (RC only).
+`totalreclaw_pair` (ONLY account-setup path) · `_remember` · `_recall` · `_forget` · `_pin` · `_unpin` · `_retype` · `_set_scope` · `_export` · `_status` · `_upgrade` · `_top_up` · `_import_from` · `_import_batch` · `_debrief` · `_report_qa_bug` (RC only).

--- a/python/src/totalreclaw/hermes/schemas.py
+++ b/python/src/totalreclaw/hermes/schemas.py
@@ -340,7 +340,10 @@ UPGRADE = {
         "explicitly asked to upgrade, pay, or hit the quota limit. Pro "
         "removes the free-write cap — 1,500 memories/month vs the free "
         "tier's 250 — and adds LLM-guided dedup; encryption, ownership, "
-        "and on-chain durability are identical across tiers."
+        "and on-chain durability are identical across tiers.\n\n"
+        "If the user instead wants a one-time pack of extra memories now "
+        "(e.g. to finish a single import) rather than a recurring "
+        "subscription, use totalreclaw_top_up, not this tool."
     ),
     "parameters": {
         "type": "object",
@@ -351,15 +354,24 @@ UPGRADE = {
 TOPUP = {
     "name": "totalreclaw_top_up",
     "description": (
-        "Buy a one-time pack of extra memories when the monthly quota + grace "
-        "are exhausted — e.g. to finish a large import. Creates a Stripe "
-        "Checkout session (one-time payment) and returns the URL the user "
-        "opens to pay. The purchased memories persist across monthly resets "
-        "until used.\n\n"
+        "Buy a one-time pack of extra memories — e.g. to finish a large "
+        "import or get past a burst of writes without changing tier. Creates "
+        "a Stripe Checkout session (one-time payment) and returns the URL the "
+        "user opens to pay. The purchased memories persist across monthly "
+        "resets until used.\n\n"
+        "This is the RIGHT tool whenever the user wants MORE MEMORIES NOW as a "
+        "one-off — do NOT wait for the quota to be exhausted, and do NOT route "
+        "these to totalreclaw_upgrade. A proactive request counts.\n\n"
         "INVOKE WHEN USER SAYS:\n"
-        "- 'I need more memories' / 'I hit my limit mid-import' / 'buy more'\n"
+        "- 'buy a top-up pack' / 'buy 5000 extra memories' / 'buy more'\n"
+        "- 'I need more memories' / 'I hit my limit mid-import'\n"
+        "- 'I'm about to run a big import and might blow past my quota' "
+        "(proactive — quota not yet exhausted)\n"
         "- a write/import returned a quota-exceeded error and the user wants "
         "to continue now rather than wait for the monthly reset\n\n"
+        "top_up vs upgrade: use THIS tool for a one-time pack that tops up the "
+        "current tier; use totalreclaw_upgrade only when the user wants the "
+        "recurring Pro subscription (higher monthly cap + LLM-guided dedup).\n\n"
         "After calling, read the returned ``message`` aloud — it has the "
         "checkout URL. Only call when the user has explicitly asked to buy "
         "more memories."

--- a/python/tests/test_issue_405_topup_routing.py
+++ b/python/tests/test_issue_405_topup_routing.py
@@ -1,0 +1,125 @@
+"""Regression: agent must route "buy a one-time top-up pack" to
+``totalreclaw_top_up`` — not ``totalreclaw_upgrade`` (issue #405).
+
+Why this file exists
+====================
+
+rc.2.4.5rc10 auto-QA (Hermes, umbrella #403 / finding #F2 / #405): a fresh
+session got the verbatim user message
+
+    "I am about to run a big import and might blow past my quota.
+     Can I buy a top-up pack of 5000 extra memories?"
+
+The agent replied "The only paid option I can initiate from here is the Pro
+upgrade", called ``totalreclaw_status`` + ``totalreclaw_upgrade``, and never
+called ``totalreclaw_top_up`` — despite the tool being registered.
+
+Root cause (two compounding gaps):
+
+1. The agent-facing runtime prompt ``SKILL.md`` steered every quota / pay /
+   "more memories" intent to ``totalreclaw_upgrade`` and never mentioned
+   ``totalreclaw_top_up``. Its "Tool surface" roster omitted ``_top_up``
+   entirely, so the tool was effectively invisible to the agent's routing.
+2. The ``TOPUP`` schema description over-gated on the quota being *exhausted*
+   ("Only call when ... quota + grace are exhausted"), excluding exactly the
+   proactive / pre-import case the user asked about — while ``UPGRADE`` had no
+   such gate and grabbed "pay for more memories".
+
+These tests pin the fix: SKILL.md surfaces + routes top-up, the schema accepts
+proactive intent, and both artifacts disambiguate top-up (one-time pack) from
+upgrade (recurring Pro).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from totalreclaw.hermes import schemas as _schemas
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_MD = _REPO_ROOT / "python" / "src" / "totalreclaw" / "hermes" / "SKILL.md"
+HERMES_GUIDE = _REPO_ROOT / "docs" / "guides" / "hermes-setup.md"
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"not found: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+# --- SKILL.md (runtime prompt) --------------------------------------------
+
+
+def test_skill_tool_surface_lists_top_up():
+    """The 'Tool surface' roster the agent reads must include ``_top_up`` —
+    if the tool isn't in the inventory, the agent won't route to it."""
+    body = _read(SKILL_MD)
+    assert "_top_up" in body or "totalreclaw_top_up" in body, (
+        "SKILL.md must surface totalreclaw_top_up so the agent knows the "
+        "tool exists (it was omitted from the Tool surface line — #405)."
+    )
+
+
+def test_skill_routes_proactive_topup_intent():
+    """SKILL.md must teach the agent to offer top-up for a proactive
+    'more memories now' request, distinct from the recurring Pro upgrade."""
+    body = _read(SKILL_MD)
+    assert "totalreclaw_top_up" in body, (
+        "SKILL.md must name totalreclaw_top_up in its routing guidance."
+    )
+    lowered = body.lower()
+    # Must contrast top-up (one-time pack) vs upgrade (recurring), so the
+    # agent stops defaulting every pay intent to totalreclaw_upgrade.
+    assert "one-time" in lowered, (
+        "SKILL.md must describe top-up as a one-time pack to disambiguate "
+        "it from the recurring Pro upgrade."
+    )
+    # Proactive trigger — the exact failure mode from #405.
+    assert "big import" in lowered or "blow past" in lowered or "proactive" in lowered, (
+        "SKILL.md must tell the agent that a proactive 'might blow past my "
+        "quota' request is a valid top-up trigger (don't wait for the quota "
+        "to be exhausted)."
+    )
+
+
+# --- schema description (LLM routing source of truth) ---------------------
+
+
+def test_topup_schema_accepts_proactive_intent():
+    """The TOPUP description must no longer gate exclusively on the quota
+    being exhausted — a proactive / pre-import buy is a valid trigger."""
+    desc = _schemas.TOPUP["description"]
+    lowered = desc.lower()
+    assert "totalreclaw_top_up" == _schemas.TOPUP["name"]
+    # The pre-fix description said "Only call when ... quota + grace are
+    # exhausted" as the sole gate; the fix must explicitly allow proactive
+    # requests.
+    assert "do not wait" in lowered or "proactive" in lowered, (
+        "TOPUP description must allow proactive top-up requests (not only "
+        "post-exhaustion) — that was the #405 mis-gate."
+    )
+
+
+def test_topup_schema_disambiguates_from_upgrade():
+    """Both billing tools must cross-reference each other so the LLM can
+    pick the right one at routing time."""
+    topup = _schemas.TOPUP["description"]
+    upgrade = _schemas.UPGRADE["description"]
+    assert "totalreclaw_upgrade" in topup, (
+        "TOPUP description must reference totalreclaw_upgrade to steer "
+        "recurring-subscription intent away from the one-time pack."
+    )
+    assert "totalreclaw_top_up" in upgrade, (
+        "UPGRADE description must point one-time-pack intent at "
+        "totalreclaw_top_up instead of grabbing it."
+    )
+
+
+# --- setup guide (human + install-time doc) -------------------------------
+
+
+def test_hermes_guide_tools_table_lists_top_up():
+    body = _read(HERMES_GUIDE)
+    assert "totalreclaw_top_up" in body, (
+        "hermes-setup.md Tools table must list totalreclaw_top_up (#405 — "
+        "it was omitted, hiding the tool from the guide's inventory)."
+    )


### PR DESCRIPTION
## What broke
In Hermes rc.2.4.5rc10, a user who said *"I'm about to run a big import and might blow past my quota — can I buy a top-up pack of 5000 extra memories?"* got offered a **Pro upgrade** instead; the agent never called `totalreclaw_top_up` even though the tool is registered.

## What's fixed
The agent-facing `SKILL.md` never surfaced `totalreclaw_top_up` (missing from the Tool surface roster) and routed every pay/quota intent to `_upgrade`; the `TOPUP` schema also over-gated on the quota being *exhausted*, excluding proactive/pre-import requests. Fix adds top-up routing + a top_up-vs-upgrade contrast to SKILL.md, broadens the schema to accept proactive intent (both descriptions now cross-reference), and adds the tool + routing hint to `hermes-setup.md`.

## Impact after fix
The agent offers a one-time top-up pack (not just a recurring Pro upgrade) when a user wants *more memories now* — including proactively before a big import.

## Verification
Regression test `test_issue_405_topup_routing.py` (5 cases) pins all four artifacts; verified failing on pre-patch `origin/main` and passing post-patch. Adjacent pricing/deny-list + no-chain-name contract tests still pass. **Live end-to-end staging QA deferred** — see below.

---

⚠️ **DO NOT MERGE STANDALONE — bundle with #404.** Sibling finding #404 reports the top_up Stripe checkout currently returns `CHECKOUT_FAILED` on staging (Price IDs unset). Shipping this routing fix before the checkout works would send users to a broken paywall (worse UX than the current Pro-upgrade behavior). RC bump + publish intentionally omitted here so this lands bundled once #404's checkout is fixed. This is the umbrella #403 "#1+#2 make top-up shippable" pairing.

Closes #405
Umbrella: p-diogo/totalreclaw-internal#403
QA source: `docs/notes/QA-hermes-RC-2.4.5rc10-20260704.md`