### PR TITLE
SPA: make qa-vault QA driver flow-adaptive for passkey Keeper (#329)

### DIFF
--- a/docs/guides/qa-autopilot.md
+++ b/docs/guides/qa-autopilot.md
@@ -39,7 +39,14 @@ Each planned surface ships as its own PR following the same template as the vaul
 
 ## Vault SPA autopilot (jobs[0])
 
-End-to-end regression harness for the vault SPA at `app/`. Drives a headless browser through the recovery-phrase → `/vault` flow against any deployed URL, captures console + network + visible errors, and opens an issue on the public repo when something regresses.
+End-to-end regression harness for the vault SPA at `app/`. Drives a headless browser to the vault against any deployed URL, captures console + network + visible errors, and opens an issue on the public repo when something regresses.
+
+The driver is **flow-adaptive** — it detects the entry surface at runtime and drives whichever the app presents:
+
+- **Legacy phrase-entry** (current production): paste-and-derive form (`input[placeholder="word 1"]`) → submit → `/vault`.
+- **Passkey "Keeper"** (PR #329, `feat/spa-functional`): the app routes to `/bootstrap`. The driver attaches a CDP WebAuthn virtual authenticator (`ctap2` / `internal` / PRF-capable — mirroring the SPA's own E2E at `app/e2e/bootstrap-unlock.mjs`), then drives the **"I have a recovery phrase" → restore** flow. Restore derives keys from the *same* known QA phrase (so it lands on the real vault with real memories, equivalent to the legacy flow) and enrols a passkey via the virtual authenticator; the SPA then lands on `/memory`.
+
+Both surfaces converge on the vault view (`/vault` legacy, `/memory` passkey), and the report's `reachedVault` is true for either — so the internal workflow's jq gate is surface-agnostic and needs **no change** when #329 merges. The stdout summary adds a `surface` field (`legacy` | `passkey` | `unknown`) for triage; all pre-existing keys (`reachedVault`, `pageErrorCount`, `consoleErrorCount`, `networkFailureCount`, `visibleError`) are preserved. Phrase-safety is unchanged: phrase only from keychain/env, redacted from all output paths.
 
 ## Pieces
 

--- a/tools/qa-vault.mjs
+++ b/tools/qa-vault.mjs
@@ -1,19 +1,39 @@
 /**
- * QA driver for the vault SPA — reads the dummy recovery phrase from the
- * macOS keychain, walks the paste-and-derive flow, and emits a structured
- * report of what the browser saw (console + network + final URL + screenshot).
+ * QA driver for the vault SPA — flow-adaptive.
+ *
+ * The SPA is mid-migration from a Phase-1 recovery-phrase entry flow to a
+ * passkey-based "Keeper" flow (PR #329, feat/spa-functional). Production and PR
+ * previews can therefore present EITHER surface. This driver detects which one
+ * the app lands on at runtime and drives it accordingly:
+ *
+ *   - LEGACY (phrase-entry): the current production flow. Paste-and-derive form
+ *     with `input[placeholder="word 1"]`, submit, land on /vault. UNCHANGED.
+ *   - PASSKEY (#329 "Keeper"): app routes to /bootstrap. A fresh browser context
+ *     has no local vault, so the app shows the choose screen. We attach a CDP
+ *     WebAuthn virtual authenticator (mirroring the config in the SPA's own E2E,
+ *     app/e2e/bootstrap-unlock.mjs — ctap2/internal/PRF) and drive the
+ *     "I have a recovery phrase" → restore flow: it derives keys from the SAME
+ *     known QA phrase (so it lands on the real vault with real memories, exactly
+ *     like the legacy flow) and enrols a passkey via the virtual authenticator.
+ *     Post-restore the SPA navigates to /vault which its router redirects to the
+ *     real post-auth surface (/memory).
+ *
+ * Either way the driver asserts the SAME downstream invariants: it reached the
+ * vault, the memory surface rendered, and there were no console/page/network
+ * errors. `reachedVault` in the report is true for BOTH /vault (legacy) and
+ * /memory (passkey) so the internal workflow's gate is unchanged.
  *
  * The phrase NEVER leaves this process: it's pulled from the keychain via
- * `security`, held in process memory only, typed into the page via
- * Playwright's keyboard, and never logged. The script's stdout / stderr
- * are safe to surface back to the operator.
+ * `security` (or QA_RECOVERY_PHRASE in CI), held in process memory only, typed
+ * into the page via Playwright, and never logged. stdout / stderr are safe to
+ * surface back to the operator.
  *
  * Usage:
  *   node tools/qa-vault.mjs <url> [--headed]
  *
  * Examples:
  *   node tools/qa-vault.mjs http://localhost:5173
- *   node tools/qa-vault.mjs https://pr-237.totalreclaw-app.pages.dev --headed
+ *   node tools/qa-vault.mjs https://pr-329.totalreclaw-app.pages.dev --headed
  *
  * Prereqs:
  *   security add-generic-password -a totalreclaw -s totalreclaw-qa-phrase -U -w
@@ -75,6 +95,144 @@ function redactPhrase(text, phrase) {
   return out;
 }
 
+/**
+ * Attach a CDP WebAuthn virtual authenticator so the passkey flow can enrol /
+ * assert credentials headlessly. Config mirrors the SPA's own E2E
+ * (app/e2e/bootstrap-unlock.mjs) EXACTLY, including hasPrf — PRF-wrap is the
+ * crux of the Keeper flow, so the authenticator must advertise it.
+ * Returns the authenticatorId (informational; never contains secret material).
+ */
+async function attachVirtualAuthenticator(context, page) {
+  const cdp = await context.newCDPSession(page);
+  await cdp.send("WebAuthn.enable");
+  const { authenticatorId } = await cdp.send("WebAuthn.addVirtualAuthenticator", {
+    options: {
+      protocol: "ctap2",
+      transport: "internal",
+      hasResidentKey: true,
+      hasUserVerification: true,
+      hasPrf: true,
+      automaticPresenceSimulation: true,
+      isUserVerified: true,
+    },
+  });
+  return authenticatorId;
+}
+
+/**
+ * Decide which surface the app rendered. Races the two known entry markers:
+ *   - legacy phrase-entry form: input[placeholder="word 1"]
+ *   - passkey Keeper: /bootstrap or /unlock URL, or the choose-screen copy.
+ * Returns "legacy" | "passkey" | "unknown".
+ */
+async function detectSurface(page) {
+  // URL is the fastest signal for the passkey build (router lands on
+  // /bootstrap for a fresh context, /unlock if a wrapped vault is cached).
+  const url = page.url();
+  if (/\/(bootstrap|unlock)(\b|\/|$)/.test(url)) return "passkey";
+
+  try {
+    const marker = await Promise.race([
+      page
+        .waitForSelector('input[placeholder="word 1"]', { timeout: 12000 })
+        .then(() => "legacy"),
+      // Keeper choose-screen / restore entry points.
+      page
+        .waitForSelector(
+          'text=Create a new vault, text=I have a recovery phrase, text=Unlock with passkey',
+          { timeout: 12000 },
+        )
+        .then(() => "passkey"),
+    ]);
+    return marker;
+  } catch {
+    // Neither marker within the window — re-check URL in case a late redirect
+    // moved us onto a passkey route.
+    if (/\/(bootstrap|unlock)(\b|\/|$)/.test(page.url())) return "passkey";
+    return "unknown";
+  }
+}
+
+/**
+ * LEGACY path: the current production flow. Paste phrase into word-1 (handler
+ * splits to all 12), submit, wait for /vault or a visible error. Unchanged
+ * from the pre-#329 driver.
+ */
+async function driveLegacy(page, phrase) {
+  await page.fill('input[placeholder="word 1"]', phrase);
+  await page.click('button[type="submit"]');
+  try {
+    await Promise.race([
+      page.waitForURL(/\/vault/, { timeout: 20000 }),
+      page.waitForSelector("text=Failed to fetch", { timeout: 20000 }),
+      page.waitForSelector("text=API ", { timeout: 20000 }),
+      page.waitForSelector("text=Invalid", { timeout: 20000 }),
+    ]);
+  } catch {
+    /* timeout — capture whatever state the page is in */
+  }
+}
+
+/**
+ * PASSKEY path (#329): drive the Keeper restore-from-phrase flow. This derives
+ * keys from the SAME known QA phrase, so it lands on the real vault with real
+ * memories (equivalent to the legacy flow), while exercising passkey enrolment
+ * via the virtual authenticator.
+ *
+ * Requires attachVirtualAuthenticator() to have run first.
+ *
+ * The phrase is typed into the restore textarea and never logged. We do NOT use
+ * the "Create a new vault" branch: it would mint a throwaway vault + phrase each
+ * run and land on an empty vault, which can't assert real memories render.
+ */
+async function drivePasskey(page, phrase) {
+  // If the app cached a wrapped vault it may show /unlock instead of /bootstrap.
+  // A fresh CI context won't, but handle it defensively: prefer the passkey
+  // unlock button; fall back to the recovery-phrase route if offered.
+  if (/\/unlock(\b|\/|$)/.test(page.url())) {
+    const unlockBtn = page.getByRole("button", { name: "Unlock with passkey" });
+    if (await unlockBtn.isVisible().catch(() => false)) {
+      await unlockBtn.click();
+      await page
+        .waitForURL(/\/(memory|vault)(\b|\/|$)/, { timeout: 20000 })
+        .catch(() => {});
+      return;
+    }
+  }
+
+  // Choose screen → "I have a recovery phrase" (restore). Wait for the choose
+  // screen to settle (PRF gate resolves "checking" → "choose").
+  await page
+    .getByText("I have a recovery phrase", { exact: false })
+    .waitFor({ timeout: 15000 });
+  await page.getByText("I have a recovery phrase", { exact: false }).click();
+
+  // Restore screen: paste phrase into the textarea, click Restore vault.
+  await page.waitForSelector(
+    'textarea[placeholder="twelve words separated by spaces"]',
+    { timeout: 10000 },
+  );
+  await page.fill(
+    'textarea[placeholder="twelve words separated by spaces"]',
+    phrase,
+  );
+  await page.getByRole("button", { name: "Restore vault" }).click();
+
+  // doBootstrap: derive keys → relay (/v1/smart-account, /v1/register) → enrol
+  // passkey (virtual authenticator) → wrap → navigate /vault → router redirect
+  // → /memory. Also watch for a visible error so we don't hang the full window.
+  try {
+    await Promise.race([
+      page.waitForURL(/\/(memory|vault)(\b|\/|$)/, { timeout: 30000 }),
+      page.waitForSelector("text=Failed to fetch", { timeout: 30000 }),
+      page.waitForSelector("text=couldn’t", { timeout: 30000 }),
+      page.waitForSelector("text=Invalid", { timeout: 30000 }),
+    ]);
+  } catch {
+    /* timeout — capture whatever state the page is in */
+  }
+}
+
 async function run() {
   mkdirSync(REPORT_DIR, { recursive: true });
   const phrase = loadPhrase();
@@ -127,6 +285,18 @@ async function run() {
     });
   });
 
+  // Attach the WebAuthn virtual authenticator BEFORE navigation so a passkey
+  // build can enrol during bootstrap/restore. Harmless for the legacy flow
+  // (no WebAuthn calls are made there). authenticatorId is informational only.
+  let virtualAuthenticatorId = null;
+  try {
+    virtualAuthenticatorId = await attachVirtualAuthenticator(ctx, page);
+  } catch (err) {
+    // Non-fatal: the legacy flow doesn't need it. Record so a passkey failure
+    // downstream is explicable.
+    pageErrors.push({ message: `virtual authenticator setup failed: ${redactPhrase(err.message, phrase)}`, stack: "" });
+  }
+
   let navError = null;
   try {
     await page.goto(TARGET_URL, { waitUntil: "domcontentloaded", timeout: 30000 });
@@ -134,31 +304,14 @@ async function run() {
     navError = err.message;
   }
 
-  // Wait for the paste form to render.
-  let formReady = false;
-  try {
-    await page.waitForSelector('input[placeholder="word 1"]', { timeout: 10000 });
-    formReady = true;
-  } catch {
-    formReady = false;
-  }
+  // Detect which surface rendered, then drive it.
+  const surface = await detectSurface(page);
+  const formReady = surface === "legacy" || surface === "passkey";
 
-  if (formReady) {
-    // Paste the full phrase into word-1; handler splits to all 12 words.
-    await page.fill('input[placeholder="word 1"]', phrase);
-    // Tap submit.
-    await page.click('button[type="submit"]');
-    // Allow up to 20s for either /vault navigation or visible error to settle.
-    try {
-      await Promise.race([
-        page.waitForURL(/\/vault/, { timeout: 20000 }),
-        page.waitForSelector("text=Failed to fetch", { timeout: 20000 }),
-        page.waitForSelector("text=API ", { timeout: 20000 }),
-        page.waitForSelector("text=Invalid", { timeout: 20000 }),
-      ]);
-    } catch {
-      /* timeout — capture whatever state the page is in */
-    }
+  if (surface === "legacy") {
+    await driveLegacy(page, phrase);
+  } else if (surface === "passkey") {
+    await drivePasskey(page, phrase);
   }
 
   // Give a beat for React Query / paginated subgraph calls to settle.
@@ -166,7 +319,7 @@ async function run() {
 
   const finalUrl = page.url();
   const visibleError = await page
-    .locator("p.text-red-600, [role='alert']")
+    .locator("p.text-red-600, [role='alert'], p.text-clay-deep")
     .first()
     .textContent()
     .catch(() => null);
@@ -176,13 +329,19 @@ async function run() {
 
   await browser.close();
 
+  // Both surfaces converge on a vault view: legacy → /vault, passkey → /memory.
+  // Treat either as "reached the vault" so the internal workflow's gate is
+  // surface-agnostic.
+  const reachedVault = /\/(vault|memory)(\b|\/|$)/.test(finalUrl);
+
   const report = {
     target: TARGET_URL,
     stamp,
+    surface,
     navError,
     formReady,
     finalUrl,
-    reachedVault: /\/vault/.test(finalUrl),
+    reachedVault,
     visibleError: redactPhrase(visibleError, phrase),
     pageErrors,
     consoleErrors: consoleEvents.filter((e) => e.type === "error"),
@@ -196,8 +355,12 @@ async function run() {
   writeFileSync(reportPath, JSON.stringify(report, null, 2));
 
   // Compact stdout summary so the operator sees the headline without grepping.
+  // NOTE: the internal qa-autopilot workflow jq-parses these keys —
+  // reachedVault, pageErrorCount, consoleErrorCount, networkFailureCount,
+  // visibleError. Keep them; new fields (surface) are additive.
   const summary = {
     target: report.target,
+    surface: report.surface,
     reachedVault: report.reachedVault,
     finalUrl: report.finalUrl,
     visibleError: report.visibleError,


### PR DESCRIPTION
## Why

The daily **qa-autopilot** cron (07:30 UTC, prod) and preview-deploy runs drive `tools/qa-vault.mjs`. Today the driver only knows the **Phase-1 recovery-phrase** flow. When **PR #329** ("The Keeper", `feat/spa-functional`) merges, the app routes the entry surface to **`/bootstrap`** (passkey bootstrap; recovery-phrase becomes the recovery path). The driver doesn't know that flow, so it fails with **`reachedVault=false, no errors`** — the exact symptom the **June qa-autopilot triage** recorded — and files **false regression issues** on every cron run.

This makes the driver **flow-adaptive** so the cron keeps passing across the #329 cutover with no manual intervention.

## What

`tools/qa-vault.mjs` now **detects the entry surface at runtime** and drives whichever the app presents:

- **Legacy phrase-entry** (current production) — **unchanged**: paste-and-derive form (`input[placeholder="word 1"]`) → submit → `/vault`.
- **Passkey "Keeper"** (#329): the app routes to `/bootstrap`. The driver attaches a **CDP WebAuthn virtual authenticator** (`ctap2` / `internal` / `hasPrf:true` / resident key / UV — **mirroring the SPA's own E2E `app/e2e/bootstrap-unlock.mjs` exactly**, since PRF-wrap is the crux), then drives the **"I have a recovery phrase" → restore** flow. Restore derives keys from the **same known QA phrase**, so it lands on the **real vault with real memories** (equivalent to the legacy flow) and **enrols a passkey** via the virtual authenticator. The SPA then lands on `/memory`.
  - The **create-new-vault** branch was deliberately not used: it mints a throwaway phrase+vault per run and lands on an empty vault, which can't assert real memories render. Restore-from-phrase is production-representative.

Both surfaces converge on the vault view (`/vault` legacy, `/memory` passkey). `report.reachedVault` is true for **either**, so the internal workflow's `jq` gate is **surface-agnostic and needs no change** when #329 merges. The stdout summary gains an additive **`surface`** field (`legacy` | `passkey` | `unknown`) for triage; every key the internal workflow parses (`reachedVault`, `pageErrorCount`, `consoleErrorCount`, `networkFailureCount`, `visibleError`) is preserved.

**Phrase-safety unchanged**: phrase only from keychain / `QA_RECOVERY_PHRASE` env; redaction (full phrase + any contiguous 3-word slice) applied to all new output paths too. **No new dependencies** — bare `playwright` already exposes `newCDPSession` + `WebAuthn.*` CDP.

Docs: `docs/guides/qa-autopilot.md` updated with the flow-adaptive behavior.

## Validation (both paths, local, headless)

**(4a) Production regression guard — `https://totalreclaw-app.pages.dev`**
\`\`\`
surface: legacy   reachedVault: true   finalUrl: …/vault   exit 0
pageErrors 0 · consoleErrors 0 · networkFailures 0 · visibleError null
\`\`\`
Identical to pre-change behavior — the production cron keeps passing exactly as before.

**(4b) PR #329 preview — `https://pr-329.totalreclaw-app.pages.dev` (head `073517c`)**
\`\`\`
surface: passkey   reachedVault: true   finalUrl: …/memory   exit 0
pageErrors 0 · consoleErrors 0 · networkFailures 0 · visibleError null
relay calls: GET /v1/smart-account?…&chain=100 → 200 · POST /v1/register → 200 · POST /v1/subgraph → 200
\`\`\`
Full pipeline fired: passkey enrolled via the virtual authenticator, keys derived from the real QA phrase (chain 100 / Gnosis), the real vault decrypted and the memory surface rendered.

## Note for the #329 author

**Merging #329 requires no change to this driver.** Once this lands, the qa-autopilot cron auto-detects `/bootstrap` and drives the restore→passkey path; the internal workflow gate is unchanged (it parses the same summary keys, and `reachedVault` is true for `/memory` too). One caveat to keep in mind: the branch currently navigates post-auth to `/vault`, which has **no route** in `App.tsx` — the `*` catch-all bounces it through `/` to `/memory`. It works, but it's an incidental redirect; if you add a real `/vault` route or change the post-auth landing, the driver already accepts **either** `/vault` or `/memory`, so it stays green.

## Refs
- June qa-autopilot triage finding: driver fails on `/bootstrap` with `reachedVault=false, no errors`.
- PR #329 `feat/spa-functional` — passkey bootstrap/unlock; virtual-authenticator E2E at `app/e2e/bootstrap-unlock.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)