### PR TITLE
fix(skill): prohibit credentials.json access during reinstall (phrase-safety hygiene)

### DIFF
--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -38,6 +38,8 @@ Do not describe storage as `"local"`, `"local-only"`, `"stored locally"`, `"on d
 
 The 12-word recovery phrase MUST NEVER enter chat or the agent's LLM context. The plugin's browser-based pair flow handles phrase generation and import. Never echo it, never ask the user to paste it, never pass it to any tool. If the user pastes one anyway, tell them it's compromised and re-pair for a fresh wallet.
 
+**HARD guardrail — install/reinstall/upgrade flows:** During install, reinstall, upgrade, or any verification steps, the agent MUST NOT read, list, cat, show, display, or inspect `credentials.json`, `~/.totalreclaw/credentials.json`, `~/.totalreclaw*/credentials.json`, `~/.openclaw/plugins/totalreclaw/credentials.json`, or ANY credentials/phrase/key/secrets file — for ANY reason, including "verifying the install." These files contain encryption key material and Smart Account addresses that MUST NOT enter the LLM context. Never run `ls`, `find`, `cat`, `show`, or similar commands against plugin directories to "check files."
+
 ## Install
 
 ```


### PR DESCRIPTION
During a reinstall on 2026-07-03, the OpenClaw agent tried to `show ~/.openclaw/plugins/totalreclaw/credentials.json` (incorrect path, but the ATTEMPT is the problem). The install/reinstall/upgrade flow must NEVER read, list, cat, or display credentials.json or any credentials/phrase/key file. credentials.json holds encryption key material + Smart Account addresses; it must never enter LLM context.

**Fix:** Added explicit guardrail in SKILL.md Phrase-safety section prohibiting any credentials file inspection during install/reinstall/upgrade flows, even for 'verification' purposes.

**Verification:**
- Scanner-clean (0 flags)
- phrase-safety-registry.test.ts: 15/15 passed
- No changes to crypto code or plugin logic — instruction edit only