### PR TITLE
fix(hermes): register totalreclaw_top_up in the live plugin manifest (internal#412)

### DIFF
--- a/python/src/totalreclaw/hermes/__init__.py
+++ b/python/src/totalreclaw/hermes/__init__.py
@@ -201,6 +201,18 @@ def register(ctx):
         is_async=True,
         description=schemas.UPGRADE["description"],
     )
+    # #392 top-up packs — one-time over-quota purchases. Schema + handler
+    # shipped in 2.4.5rc10 but were never registered here (internal#412:
+    # rc10 S5 re-QA found the tool absent from the live manifest, so the
+    # agent could not invoke it regardless of prompt steering).
+    ctx.register_tool(
+        name="totalreclaw_top_up",
+        toolset="totalreclaw",
+        schema=schemas.TOPUP,
+        handler=lambda args, **kw: tools.top_up(args, state, **kw),
+        is_async=True,
+        description=schemas.TOPUP["description"],
+    )
     ctx.register_tool(
         name="totalreclaw_debrief",
         toolset="totalreclaw",

--- a/python/src/totalreclaw/hermes/plugin.yaml
+++ b/python/src/totalreclaw/hermes/plugin.yaml
@@ -18,6 +18,7 @@ provides_tools:
   - totalreclaw_import_status
   - totalreclaw_import_abort
   - totalreclaw_upgrade
+  - totalreclaw_top_up
   - totalreclaw_debrief
 provides_hooks:
   - on_session_start

--- a/python/tests/test_hermes_plugin.py
+++ b/python/tests/test_hermes_plugin.py
@@ -686,9 +686,12 @@ class TestRegister:
         # test_hermes_plugin_manifest_parity.py + this test must agree.
         # imp-1 — `totalreclaw_import_status` + `totalreclaw_import_abort`
         # added (background import Phase 1). Count → 16 stable, 17 RC.
+        # internal#412 — `totalreclaw_top_up` registered (schema + handler
+        # shipped in 2.4.5rc10 but never wired into register(), so the
+        # agent could not invoke it). Count → 17 stable, 18 RC.
         from totalreclaw import __version__
         from totalreclaw.hermes.qa_bug_report import is_rc_build
-        expected_tools = 17 if is_rc_build(__version__) else 16
+        expected_tools = 18 if is_rc_build(__version__) else 17
         assert ctx.register_tool.call_count == expected_tools, (
             f"expected {expected_tools} tools for version {__version__!r}, "
             f"got {ctx.register_tool.call_count}"
@@ -713,6 +716,10 @@ class TestRegister:
         assert "totalreclaw_import_from" in tool_names
         assert "totalreclaw_import_batch" in tool_names
         assert "totalreclaw_upgrade" in tool_names
+        # internal#412 — top_up must be in the LIVE manifest (rc10 shipped
+        # the handler without registering it; no steering can invoke an
+        # unregistered tool).
+        assert "totalreclaw_top_up" in tool_names
         assert "totalreclaw_debrief" in tool_names
 
         # Check hook names


### PR DESCRIPTION
Fixes [totalreclaw-internal#412](https://github.com/p-diogo/totalreclaw-internal/issues/412) (rc10 S5 re-QA, umbrella internal#403): `totalreclaw_top_up`'s schema + handler shipped in 2.4.5rc10 but were **never registered** in `hermes/__init__.py register()` — the tool was absent from the model's function list, so the agent could not invoke it regardless of guide steering (#418 alone was a no-op). Only the dormant MemoryProvider path carried the schema.

- Registers the tool (mirrors `totalreclaw_upgrade`), updates `plugin.yaml` (manifest↔register parity), bumps the registration-count test to 17 stable / 18 RC + adds the name assert.
- Tests: registration + manifest-parity suites 73/73; full suite 1660 pass (the one `test_userop_batch` failure is the known environmental stale-core-wheel case from #410 — not a code bug).
- After merge: needs **rc11** publish + scoped S5 re-QA (routing + `cs_test_` checkout) — that's the remaining stable-gate path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)