### PR TITLE
fix(hermes): register totalreclaw_top_up so the agent can reach it (internal#412)

### DIFF
--- a/python/src/totalreclaw/hermes/__init__.py
+++ b/python/src/totalreclaw/hermes/__init__.py
@@ -201,6 +201,18 @@ def register(ctx):
         is_async=True,
         description=schemas.UPGRADE["description"],
     )
+    # #396 — one-time top-up pack purchase (Stripe checkout). schemas.TOPUP +
+    # tools.top_up shipped in rc10 and the relay path is live, but the
+    # register_tool() call was never wired in, so the tool was absent from the
+    # agent's manifest and no user could reach it (#412). Mirrors upgrade above.
+    ctx.register_tool(
+        name="totalreclaw_top_up",
+        toolset="totalreclaw",
+        schema=schemas.TOPUP,
+        handler=lambda args, **kw: tools.top_up(args, state, **kw),
+        is_async=True,
+        description=schemas.TOPUP["description"],
+    )
     ctx.register_tool(
         name="totalreclaw_debrief",
         toolset="totalreclaw",

--- a/python/src/totalreclaw/hermes/plugin.yaml
+++ b/python/src/totalreclaw/hermes/plugin.yaml
@@ -18,6 +18,7 @@ provides_tools:
   - totalreclaw_import_status
   - totalreclaw_import_abort
   - totalreclaw_upgrade
+  - totalreclaw_top_up
   - totalreclaw_debrief
 provides_hooks:
   - on_session_start

--- a/python/tests/test_hermes_plugin.py
+++ b/python/tests/test_hermes_plugin.py
@@ -686,9 +686,13 @@ class TestRegister:
         # test_hermes_plugin_manifest_parity.py + this test must agree.
         # imp-1 — `totalreclaw_import_status` + `totalreclaw_import_abort`
         # added (background import Phase 1). Count → 16 stable, 17 RC.
+        # #412 — `totalreclaw_top_up` (#396) wired into ``register()`` +
+        # plugin.yaml. schemas.TOPUP + tools.top_up shipped in rc10 but the
+        # register_tool() call was missing, so the tool was absent from the
+        # agent manifest and unreachable. Count → 17 stable, 18 RC.
         from totalreclaw import __version__
         from totalreclaw.hermes.qa_bug_report import is_rc_build
-        expected_tools = 17 if is_rc_build(__version__) else 16
+        expected_tools = 18 if is_rc_build(__version__) else 17
         assert ctx.register_tool.call_count == expected_tools, (
             f"expected {expected_tools} tools for version {__version__!r}, "
             f"got {ctx.register_tool.call_count}"
@@ -713,6 +717,9 @@ class TestRegister:
         assert "totalreclaw_import_from" in tool_names
         assert "totalreclaw_import_batch" in tool_names
         assert "totalreclaw_upgrade" in tool_names
+        # #412 — top_up (#396) must be wired so the agent can reach the
+        # one-time top-up checkout; was defined but never registered.
+        assert "totalreclaw_top_up" in tool_names
         assert "totalreclaw_debrief" in tool_names
 
         # Check hook names

--- a/python/tests/test_hermes_plugin_manifest_parity.py
+++ b/python/tests/test_hermes_plugin_manifest_parity.py
@@ -199,3 +199,42 @@ class TestPluginYamlParity:
             "Hermes chat agent will see no pair tool and pairing flow "
             "dead-ends. This is exactly the rc.4 user-reported bug."
         )
+
+    def test_issue_412_top_up_registered_and_advertised(self):
+        """``totalreclaw_top_up`` (#396) MUST appear in both the manifest
+        and the register() call.
+
+        Context — S5 re-QA regression (2026-07-04, #412)
+        ------------------------------------------------
+        The one-time top-up purchase tool shipped in rc10: ``schemas.TOPUP``
+        + ``tools.top_up`` exist and the relay Stripe-checkout path is live
+        (verified in #404). But the ``ctx.register_tool`` call was never
+        wired into ``register()`` AND the name was never added to
+        ``plugin.yaml::provides_tools`` — so the tool was absent from the
+        agent's manifest and no user could ever reach it via chat. The
+        agent honestly reported "I don't have a tool for that" (sessions
+        ``20260704_170451_97d461`` / ``20260704_170748_0f92f2``).
+
+        Because the tool drifted out of BOTH the manifest and register()
+        in lockstep, the ``test_every_manifest_tool_is_registered`` parity
+        check above passed vacuously. This dedicated test pins the tool
+        into both halves so the feature can't silently ship dead again —
+        the same failure class as the #112-125 in-code warning.
+        """
+        manifest_names = set(_manifest_tool_names())
+        assert "totalreclaw_top_up" in manifest_names, (
+            "plugin.yaml is missing totalreclaw_top_up — the one-time "
+            "top-up purchase tool (#396). Without it in the manifest the "
+            "parity shield can't catch a missing register() call."
+        )
+
+        ctx = _register_with_mock_ctx()
+        registered_names = {
+            call.kwargs["name"] for call in ctx.register_tool.call_args_list
+        }
+        assert "totalreclaw_top_up" in registered_names, (
+            "register() never wired totalreclaw_top_up — the tool is "
+            "defined (schemas.TOPUP + tools.top_up) and its relay path "
+            "works, but the agent never sees it in its manifest, so no "
+            "user can reach the top-up checkout. This is the #412 bug."
+        )


### PR DESCRIPTION
## What broke
On Hermes 2.4.5rc10 a user asking to buy a one-time top-up pack of extra memories is told *"I don't have a tool for that"* — the `totalreclaw_top_up` feature ships dead.

## What's fixed
`register()` now wires `totalreclaw_top_up` into the agent manifest (mirroring `totalreclaw_upgrade`) and `plugin.yaml::provides_tools` lists it. `schemas.TOPUP` + `tools.top_up` + the relay Stripe path already existed and work (verified in internal#404); only the registration was missing.

## Impact after fix
The agent can now route a "buy more memories / top-up pack" request to `totalreclaw_top_up`, which mints the Stripe checkout URL. First time this purchase surface is reachable via chat (the sibling `totalreclaw_upgrade` checkout is already live via the identical mechanism).

## Verification
Unit: `test_issue_412_top_up_registered_and_advertised` + the existing manifest-parity shield now cover the tool; negative control confirms both fail if the register block is removed. Full `test_hermes_plugin*` suite green (74 passed). Live S5-A chat re-QA on a published RC is **pending your call** (see below).

---
Root cause: same class as the in-code `__init__.py` ~112-125 warning — a tool defined + advertised but never wired into `register()`. Because `top_up` was missing from *both* the manifest and `register()`, the parity test passed vacuously; this PR pins it into both.

Resolves internal issue p-diogo/totalreclaw-internal#412 (S5 re-QA blocker under umbrella internal#403).

⚠️ **Held for review, not auto-merged** — exposes a user-facing Stripe-checkout/purchase surface (billing hard-rail), and you have an RC publish from `main` in flight that does not include this fix. Your call on whether to merge + re-cut, or bundle into the next RC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)