### PR TITLE
feat(hermes): per-conversation session hygiene (honor host session_id + idle rollover)

### DIFF
--- a/docs/guides/hermes-session-hygiene.md
+++ b/docs/guides/hermes-session-hygiene.md
@@ -1,0 +1,51 @@
+# Hermes session hygiene (per-conversation grouping)
+
+TotalReclaw ties a session's **Crystal** (summary) and its atomic memories
+together with a `session_id`. The web vault groups memories by that id. So the
+quality of the grouping depends entirely on when Hermes starts a new session.
+
+## The problem this fixes
+
+Hermes runs as **one process**. Before this change, the TotalReclaw plugin
+minted **one `session_id` per process lifecycle** and ignored the `session_id`
+Hermes passes to `on_session_start`. If you talk to your agent through **several
+parallel conversations at once** — e.g. multiple Telegram chats / group chats /
+forum topics on the same bot — their turns all landed under the **same
+`session_id`**, so unrelated memories interleaved into **one Crystal**.
+
+## What changed
+
+Two plugin-side mitigations (no host changes required):
+
+1. **Honor the host's `session_id`.** `on_session_start` now derives the
+   TotalReclaw session key deterministically from the `session_id` Hermes
+   provides. If your host distinguishes conversations (passes a distinct id per
+   chat/topic), TotalReclaw **inherits that boundary** automatically — parallel
+   conversations get separate sessions and separate Crystals.
+
+2. **Idle-timeout rollover.** When TotalReclaw mints its own id (the host does
+   *not* distinguish conversations), a turn that arrives after a long silence
+   **rolls into a fresh session** first: the idle session is flushed +
+   debriefed, then a new `session_id` starts for the incoming turn. A long gap
+   almost always means a new topic, so bursty parallel conversations separated
+   in time stop merging.
+
+   - Env: **`TOTALRECLAW_SESSION_IDLE_MINUTES`** (default **60**). Set `0` to
+     disable. Host-derived sessions (case 1) are never idle-rolled — the host
+     owns that boundary.
+
+## What is *not* fixed (host-side)
+
+If two conversations are **truly interleaved in real time** and Hermes does
+**not** pass a per-conversation id on every turn, the plugin cannot tell the
+turns apart — Hermes' `pre_llm_call` / `post_llm_call` hooks currently carry only
+the message text, no `chat_id` / `message_thread_id`. The complete fix needs the
+**host** to pass a conversation id (e.g. Telegram `chat_id` + `message_thread_id`)
+into the per-turn hooks; the plugin already knows how to scope by it (mechanism
+1). Until then, use idle rollover, or the explicit "new session" fast-follow.
+
+## Tips
+
+- Chatting about a genuinely new topic after a break? The idle rollover already
+  gives you a clean new session at the default 60 min. Lower
+  `TOTALRECLAW_SESSION_IDLE_MINUTES` if your conversations turn over faster.

--- a/python/src/totalreclaw/agent/state.py
+++ b/python/src/totalreclaw/agent/state.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import time
+import uuid
 from pathlib import Path
 from typing import Optional
 
@@ -103,6 +104,41 @@ def _uuid7() -> str:
     return f"{h[0:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:32]}"
 
 
+# Fixed namespace for deriving a STABLE per-conversation session id from a host
+# identifier (e.g. a Hermes session_id / Telegram chat id). Same host id → same
+# UUID for the life of the process, so a conversation's memories share one key.
+_SESSION_NAMESPACE = uuid.UUID("b7f3c2a4-0e5d-4a6b-9c1f-2d3e4f5a6b7c")
+
+
+def _session_id_from_host(external_id: str) -> str:
+    """Derive a deterministic UUIDv5 session id from a host-provided id.
+
+    Used so that when the agent host distinguishes conversations (passes a
+    distinct id per chat/topic), TotalReclaw inherits that boundary instead of
+    minting one global id per process. Deterministic: the same conversation id
+    always maps to the same session key.
+    """
+    return str(uuid.uuid5(_SESSION_NAMESPACE, external_id))
+
+
+def _session_idle_seconds() -> int:
+    """Idle gap (seconds) after which a new turn rolls into a fresh session.
+
+    ``TOTALRECLAW_SESSION_IDLE_MINUTES`` (default 60). ``0`` disables rollover.
+    A long silence almost always means a new conversation/topic — rolling keeps
+    unrelated bursts from interleaving into one session Crystal when the host
+    doesn't distinguish parallel conversations for us.
+    """
+    raw = os.environ.get("TOTALRECLAW_SESSION_IDLE_MINUTES")
+    if raw is None:
+        return 60 * 60
+    try:
+        minutes = int(raw)
+    except (TypeError, ValueError):
+        return 60 * 60
+    return max(0, minutes) * 60
+
+
 def _normalize_for_dedup(text: str) -> str:
     """Normalize a message for substring-comparison dedup.
 
@@ -181,6 +217,11 @@ class AgentState:
         self._quota_warning: Optional[str] = None
         self._server_url = server_url
         self._session_id: Optional[str] = None
+        # True when the current session id was derived from a host-provided id
+        # (the host distinguishes conversations for us → don't idle-roll it).
+        self._session_id_from_host: bool = False
+        # monotonic() of the last turn — drives idle-timeout session rollover.
+        self._last_activity: float = 0.0
         # 2.4.4rc2 (F7) — auto-extract pending-queue tracking. Each
         # post_llm_call appends an entry for the just-completed turn's
         # user message; the totalreclaw_remember tool consults this
@@ -359,19 +400,49 @@ class AgentState:
         """Current session UUIDv7, or ``None`` when no session active."""
         return self._session_id
 
-    def start_session(self) -> str:
-        """Generate + store a fresh UUIDv7 for the current session.
+    def start_session(self, external_id: Optional[str] = None) -> str:
+        """Start a session, returning its id.
 
-        Returns the new id so callers (hooks, tests) can log it.
-        Repeated calls produce fresh, time-ordered ids — each call is
-        treated as the start of a new session.
+        If *external_id* is given (a host-provided conversation/session id, e.g.
+        the ``session_id`` Hermes passes to ``on_session_start``), the session
+        key is derived deterministically from it — so when the host distinguishes
+        conversations (per Telegram chat/topic), TotalReclaw inherits that
+        boundary instead of collapsing every parallel conversation into one id.
+        Otherwise a fresh time-ordered UUIDv7 is minted. Repeated calls start a
+        new session; the last-activity clock is reset either way.
         """
-        self._session_id = _uuid7()
+        if external_id:
+            self._session_id = _session_id_from_host(external_id)
+            self._session_id_from_host = True
+        else:
+            self._session_id = _uuid7()
+            self._session_id_from_host = False
+        self._last_activity = time.monotonic()
         return self._session_id
 
     def end_session(self) -> None:
         """Clear the session id. Idempotent."""
         self._session_id = None
+        self._session_id_from_host = False
+
+    def note_activity(self) -> None:
+        """Record that a turn just happened (feeds idle-timeout rollover)."""
+        self._last_activity = time.monotonic()
+
+    def should_roll_idle_session(self, idle_seconds: int) -> bool:
+        """True when the active session has been idle past *idle_seconds*.
+
+        Only rolls sessions we minted ourselves — a host-derived session id
+        means the host owns the conversation boundary, so we never split it on a
+        timer. Disabled when ``idle_seconds <= 0`` or no session/activity yet.
+        """
+        if idle_seconds <= 0:
+            return False
+        if self._session_id is None or self._session_id_from_host:
+            return False
+        if self._last_activity <= 0:
+            return False
+        return (time.monotonic() - self._last_activity) >= idle_seconds
 
     # Turn tracking
     def reset_turn_counter(self) -> None:

--- a/python/src/totalreclaw/hermes/hooks.py
+++ b/python/src/totalreclaw/hermes/hooks.py
@@ -25,6 +25,7 @@ from totalreclaw.agent.loop_runner import run_sync
 from totalreclaw.agent.pending_drain import drain_pending, has_pending
 from totalreclaw.agent.recall import auto_recall
 from totalreclaw.agent.extraction import extract_facts_llm, extract_facts_heuristic
+from totalreclaw.agent.state import _session_idle_seconds
 from totalreclaw.relay import _HARDCODED_DEFAULT_URL
 
 logger = logging.getLogger(__name__)
@@ -408,11 +409,13 @@ def on_session_start(state: "PluginState", **kwargs) -> None:
         state._totalreclaw_debrief_nudge_turn = -1
     if hasattr(state, "_totalreclaw_debrief_skip_count"):
         state._totalreclaw_debrief_skip_count = 0
-    # memq-3 — assign a fresh UUIDv7 to AgentState so per-session
-    # artefacts (extraction → Crystal → debrief) can be keyed by it.
-    # Runs before the unconfigured-state early-return so log-only
-    # sessions still get an id.
-    state.start_session()
+    # memq-3 — assign a session id to AgentState so per-session artefacts
+    # (extraction → Crystal → debrief) can be keyed by it. Honor the host's
+    # session_id when present (issue: parallel Telegram conversations otherwise
+    # collapse into one id) — if Hermes distinguishes conversations, we inherit
+    # that boundary; otherwise a fresh UUIDv7 is minted. Runs before the
+    # unconfigured-state early-return so log-only sessions still get an id.
+    state.start_session(external_id=(session_id or None))
 
     # 2.3.7rc3 — reset the setup-nudge latch so each new session gets
     # one proactive nudge. Without this, an unconfigured user who
@@ -550,6 +553,42 @@ def _drain_into_state(state: "PluginState", batches: list[list[dict]]) -> int:
     return total
 
 
+def _maybe_roll_idle_session(state: "PluginState") -> None:
+    """Roll into a fresh session when the previous turn was long ago.
+
+    A long silence almost always means a new conversation/topic. When the host
+    does NOT distinguish parallel conversations for us (Hermes passes no
+    per-turn chat id), this idle-timeout rollover keeps unrelated bursts from
+    interleaving into one session Crystal: flush + debrief the idle session,
+    then start a fresh one for the incoming turn. Only rolls sessions we minted
+    ourselves (see ``AgentState.should_roll_idle_session``); host-derived ids
+    are left alone. Best-effort — never raises into the turn.
+    """
+    try:
+        if not state.should_roll_idle_session(_session_idle_seconds()):
+            return
+        if not state.is_configured():
+            state.start_session()
+            state.reset_turn_counter()
+            return
+        logger.info("TotalReclaw: rolling idle session before new turn")
+        stored: list[str] = []
+        if state.has_unprocessed_messages():
+            try:
+                stored = _auto_extract(state, mode="full", llm_config=_get_hermes_llm_config())
+            except Exception as e:
+                logger.warning("TotalReclaw idle-roll flush failed: %s", e)
+        try:
+            _session_debrief(state, stored_fact_texts=stored)
+        except Exception as e:
+            logger.warning("TotalReclaw idle-roll debrief failed: %s", e)
+        state.clear_messages()
+        state.start_session()  # fresh id for the resumed conversation
+        state.reset_turn_counter()
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning("TotalReclaw idle-roll check failed: %s", e)
+
+
 def pre_llm_call(state: "PluginState", **kwargs) -> Optional[dict]:
     """Auto-recall on first turn, inject memories, quota warnings, the
     unconfigured-user setup nudge (Bug #6), and the configured-user
@@ -567,6 +606,10 @@ def pre_llm_call(state: "PluginState", **kwargs) -> Optional[dict]:
     built-in ``memory`` for fact/preference/directive/commitment/episode
     intents.
     """
+    # Before recall: roll into a fresh session if this turn resumes after a
+    # long idle gap (guards against parallel conversations interleaving).
+    _maybe_roll_idle_session(state)
+
     user_message = kwargs.get("user_message", "")
     is_first_turn = kwargs.get("is_first_turn", False)
 
@@ -833,6 +876,10 @@ def post_llm_call(state: "PluginState", **kwargs) -> None:
     the reconfigure ahead of the turn bookkeeping is behavior-equivalent — the
     two touch disjoint state (creds vs turn-count/messages).
     """
+    # Record turn time for idle-timeout session rollover (every turn, either
+    # driver). Kept before the provider gate so activity tracks in both modes.
+    state.note_activity()
+
     # Fix #191 safety net — pick up a mid-session pair before ingest_turn
     # decides whether the user is configured. Always runs (the provider does
     # not handle mid-session reconfigure), so it stays outside the gate below.

--- a/python/src/totalreclaw/hermes/hooks.py
+++ b/python/src/totalreclaw/hermes/hooks.py
@@ -565,6 +565,9 @@ def _maybe_roll_idle_session(state: "PluginState") -> None:
     are left alone. Best-effort — never raises into the turn.
     """
     try:
+        # Tolerate legacy state subclasses / test mocks without the new API.
+        if not hasattr(state, "should_roll_idle_session"):
+            return
         if not state.should_roll_idle_session(_session_idle_seconds()):
             return
         if not state.is_configured():
@@ -878,7 +881,9 @@ def post_llm_call(state: "PluginState", **kwargs) -> None:
     """
     # Record turn time for idle-timeout session rollover (every turn, either
     # driver). Kept before the provider gate so activity tracks in both modes.
-    state.note_activity()
+    # hasattr-guarded to tolerate legacy state subclasses / test mocks.
+    if hasattr(state, "note_activity"):
+        state.note_activity()
 
     # Fix #191 safety net — pick up a mid-session pair before ingest_turn
     # decides whether the user is configured. Always runs (the provider does

--- a/python/tests/test_issue_148_interpreter_shutdown_drain.py
+++ b/python/tests/test_issue_148_interpreter_shutdown_drain.py
@@ -211,7 +211,7 @@ class _FakeState:
     # memq-3 — ``hooks.on_session_start`` now calls ``state.start_session()``
     # to mint a fresh UUIDv7 per session. The fake just returns a fixed id;
     # tests don't depend on its value.
-    def start_session(self) -> str:
+    def start_session(self, external_id=None) -> str:
         return "fake-session-id"
 
 

--- a/python/tests/test_issue_169_owner_key_stability.py
+++ b/python/tests/test_issue_169_owner_key_stability.py
@@ -210,7 +210,7 @@ class _FakeState:
 
     # memq-3 — ``hooks.on_session_start`` now calls ``state.start_session()``
     # to mint a fresh UUIDv7 per session. Tests don't depend on the id.
-    def start_session(self) -> str:
+    def start_session(self, external_id=None) -> str:
         return "fake-session-id"
 
 

--- a/python/tests/test_session_hygiene.py
+++ b/python/tests/test_session_hygiene.py
@@ -8,12 +8,18 @@ import time
 
 import pytest
 
+import totalreclaw.agent.state as state_mod
 from totalreclaw.agent.state import (
     AgentState,
     _session_id_from_host,
     _session_idle_seconds,
 )
 from totalreclaw.hermes import hooks
+
+
+def _advance_clock(monkeypatch, base: float, delta: float) -> None:
+    """Pin state.time.monotonic to base+delta (robust vs fresh-boot clocks)."""
+    monkeypatch.setattr(state_mod.time, "monotonic", lambda: base + delta)
 
 
 # ── honoring a host-provided conversation id ──────────────────────────
@@ -41,24 +47,24 @@ def test_start_session_no_host_mints_uuid7():
 
 
 # ── idle-timeout rollover eligibility ─────────────────────────────────
-def test_should_roll_only_when_idle_and_self_minted():
+def test_should_roll_only_when_idle_and_self_minted(monkeypatch):
     s = AgentState()
     # no session yet
     assert s.should_roll_idle_session(3600) is False
     # fresh minted session, no gap
     s.start_session()
     assert s.should_roll_idle_session(3600) is False
-    # simulate a long gap since the last turn
-    s._last_activity = time.monotonic() - 10_000
+    # advance the clock past the idle window (real _last_activity, no negatives)
+    _advance_clock(monkeypatch, s._last_activity, 10_000)
     assert s.should_roll_idle_session(3600) is True
     # disabled by config
     assert s.should_roll_idle_session(0) is False
 
 
-def test_host_derived_session_never_idle_rolls():
+def test_host_derived_session_never_idle_rolls(monkeypatch):
     s = AgentState()
     s.start_session(external_id="telegram:chat=9")
-    s._last_activity = time.monotonic() - 10_000
+    _advance_clock(monkeypatch, s._last_activity, 10_000)
     # the host owns this conversation boundary — never split it on a timer
     assert s.should_roll_idle_session(3600) is False
 
@@ -80,7 +86,7 @@ def test_maybe_roll_rotates_session_id(monkeypatch):
     # force the cheap unconfigured branch — no network / real vault
     monkeypatch.setattr(s, "is_configured", lambda: False)
     first = s.start_session()
-    s._last_activity = time.monotonic() - 10_000
+    _advance_clock(monkeypatch, s._last_activity, 10_000)
     hooks._maybe_roll_idle_session(s)
     assert s.session_id is not None
     assert s.session_id != first, "an idle turn must start a fresh session id"

--- a/python/tests/test_session_hygiene.py
+++ b/python/tests/test_session_hygiene.py
@@ -1,0 +1,95 @@
+"""Per-conversation session hygiene: honor host session_id + idle rollover.
+
+Guards against parallel conversations (e.g. multiple Telegram chats through one
+Hermes process) collapsing into a single session_id and interleaving unrelated
+facts into one Crystal. See ``agent/state.py`` + ``hermes/hooks.py``.
+"""
+import time
+
+import pytest
+
+from totalreclaw.agent.state import (
+    AgentState,
+    _session_id_from_host,
+    _session_idle_seconds,
+)
+from totalreclaw.hermes import hooks
+
+
+# ── honoring a host-provided conversation id ──────────────────────────
+def test_start_session_derives_stable_id_from_host():
+    s = AgentState()
+    a = s.start_session(external_id="telegram:chat=42:topic=7")
+    b = s.start_session(external_id="telegram:chat=42:topic=7")
+    assert a == b, "same conversation id must map to the same session key"
+    assert a == _session_id_from_host("telegram:chat=42:topic=7")
+
+
+def test_start_session_distinct_hosts_distinct_ids():
+    s = AgentState()
+    a = s.start_session(external_id="telegram:chat=1")
+    b = s.start_session(external_id="telegram:chat=2")
+    assert a != b, "distinct conversations must get distinct session keys"
+
+
+def test_start_session_no_host_mints_uuid7():
+    s = AgentState()
+    a = s.start_session()
+    b = s.start_session()
+    assert a != b, "minted sessions are fresh each call"
+    assert not s._session_id_from_host
+
+
+# ── idle-timeout rollover eligibility ─────────────────────────────────
+def test_should_roll_only_when_idle_and_self_minted():
+    s = AgentState()
+    # no session yet
+    assert s.should_roll_idle_session(3600) is False
+    # fresh minted session, no gap
+    s.start_session()
+    assert s.should_roll_idle_session(3600) is False
+    # simulate a long gap since the last turn
+    s._last_activity = time.monotonic() - 10_000
+    assert s.should_roll_idle_session(3600) is True
+    # disabled by config
+    assert s.should_roll_idle_session(0) is False
+
+
+def test_host_derived_session_never_idle_rolls():
+    s = AgentState()
+    s.start_session(external_id="telegram:chat=9")
+    s._last_activity = time.monotonic() - 10_000
+    # the host owns this conversation boundary — never split it on a timer
+    assert s.should_roll_idle_session(3600) is False
+
+
+def test_idle_seconds_env(monkeypatch):
+    monkeypatch.delenv("TOTALRECLAW_SESSION_IDLE_MINUTES", raising=False)
+    assert _session_idle_seconds() == 3600
+    monkeypatch.setenv("TOTALRECLAW_SESSION_IDLE_MINUTES", "0")
+    assert _session_idle_seconds() == 0  # disabled
+    monkeypatch.setenv("TOTALRECLAW_SESSION_IDLE_MINUTES", "30")
+    assert _session_idle_seconds() == 1800
+    monkeypatch.setenv("TOTALRECLAW_SESSION_IDLE_MINUTES", "nonsense")
+    assert _session_idle_seconds() == 3600  # falls back to default
+
+
+# ── the hook path rolls the session id ────────────────────────────────
+def test_maybe_roll_rotates_session_id(monkeypatch):
+    s = AgentState()
+    # force the cheap unconfigured branch — no network / real vault
+    monkeypatch.setattr(s, "is_configured", lambda: False)
+    first = s.start_session()
+    s._last_activity = time.monotonic() - 10_000
+    hooks._maybe_roll_idle_session(s)
+    assert s.session_id is not None
+    assert s.session_id != first, "an idle turn must start a fresh session id"
+    assert s.turn_count == 0
+
+
+def test_maybe_roll_noop_when_fresh(monkeypatch):
+    s = AgentState()
+    monkeypatch.setattr(s, "is_configured", lambda: False)
+    first = s.start_session()  # just started → not idle
+    hooks._maybe_roll_idle_session(s)
+    assert s.session_id == first, "a fresh session must not roll"


### PR DESCRIPTION
## Problem
Talking to Hermes through **parallel conversations on one bot** (multiple Telegram chats / group chats / forum topics) made unrelated memories **interleave into one Crystal**. Confirmed root cause of the mixed session-grouping seen in the vault SPA.

## Root cause (Hermes is one process)
- The plugin minted **one `session_id` per process lifecycle** (`agent/state.py` `start_session` → global `_SHARED_STATE` singleton) and **ignored the `session_id` Hermes passes to `on_session_start`**.
- The per-turn hooks (`pre_llm_call`/`post_llm_call`) carry only message text — **no `chat_id`/`message_thread_id`** — so the plugin can't tell interleaved conversations apart on its own.

## What changed (plugin-side, no host change needed)
1. **Honor the host `session_id`.** `on_session_start` now derives the session key deterministically (UUIDv5) from Hermes' `session_id` when present → if the host distinguishes conversations, TotalReclaw **inherits that boundary** (parallel chats → separate sessions/Crystals). Falls back to a fresh UUIDv7 when absent (unchanged behavior).
2. **Idle-timeout rollover.** A turn arriving after a long silence flushes + debriefs the idle session and starts a fresh one before ingesting the new turn. Env `TOTALRECLAW_SESSION_IDLE_MINUTES` (default **60**, `0` = off). Only rolls self-minted sessions; host-derived ids are never split on a timer.

## Not fixed here (host-side follow-up)
Two conversations **truly interleaved in real time** still merge, because Hermes doesn't pass a per-conversation id on every turn. The complete fix needs the **host** to forward `chat_id` + `message_thread_id` into the per-turn hooks; the plugin already knows how to scope by a host id (mechanism 1). Tracked as a follow-up.

**Fast-follow:** an explicit `totalreclaw_new_session` tool (manual boundary) — deferred to keep this PR focused (tool needs manifest + register() + guide).

## Tests
- **8 new** unit tests (`test_session_hygiene.py`): deterministic host-id derivation, distinct ids, uuid7 fallback, idle-roll eligibility, host-derived-never-rolls, env parsing, hook rotates id, fresh no-op.
- **212 existing** session/hook/state tests pass (no regressions).

## E2E (mandatory, open item)
Full validation needs a **live Hermes + Telegram** setup with parallel conversations — cannot run in CI here. Requesting @p-diogo verify on the real bot (set `TOTALRECLAW_SESSION_IDLE_MINUTES` low to exercise rollover quickly).

## Docs
`docs/guides/hermes-session-hygiene.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)