### PR TITLE
feat(import): ChatGPT session fidelity — conversations become sessions, canonical thread, zip input

### DIFF
--- a/docs/guides/importing-from-chatgpt.md
+++ b/docs/guides/importing-from-chatgpt.md
@@ -56,16 +56,15 @@ The full data export contains every conversation you have had with ChatGPT. Tota
 3. Go to **Data Controls**
 4. Click **Export data** -> **Confirm export**
 5. ChatGPT sends a download link to your email (may take a few minutes to hours)
-6. Download and unzip the archive
-7. Find `conversations.json` inside the archive
+6. Download the archive — **no need to unzip it**
 
 ### Step 2: Import into TotalReclaw
 
 Tell your agent:
 
-> "Import my ChatGPT conversations from /path/to/conversations.json"
+> "Import my ChatGPT export from /path/to/chatgpt-export.zip"
 
-Or paste the JSON content directly. For large exports, providing the file path is recommended (drag-and-drop is the preferred path on OpenClaw + Hermes).
+The zip works as-is: TotalReclaw reads the conversation files inside it directly (recent exports split them across `conversations-000.json`, `conversations-001.json`, ...). An unpacked export folder or a single `conversations.json` works too. Small exports can also be pasted as JSON content, but for anything sizeable the file path is recommended (drag-and-drop is the preferred path on OpenClaw + Hermes).
 
 The agent calls `totalreclaw_import_from` with `source: "chatgpt"` and the file path or content.
 
@@ -73,7 +72,7 @@ The agent calls `totalreclaw_import_from` with `source: "chatgpt"` and the file 
 
 TotalReclaw uses **LLM extraction** (not pattern matching) to identify facts from your conversation history. The pipeline is:
 
-1. **Parse**: walk the `conversations.json` mapping tree and pull user + assistant messages in chronological order. Both roles are included because the assistant's response often clarifies what the user meant.
+1. **Parse**: walk each conversation's mapping tree along the canonical thread (the messages you actually kept — edited or regenerated drafts are skipped) and pull user + assistant messages with their original timestamps. Both roles are included because the assistant's response often clarifies what the user meant. Each ChatGPT conversation becomes one session in your vault, with its own summary card (Crystal), so imported memory stays organized by conversation instead of arriving as loose facts.
 2. **Chunk**: split each conversation into batches of ~20 messages (`CHUNK_SIZE`). Large conversations become multiple chunks (`part 1/N`, `part 2/N`, ...).
 3. **Extract**: each chunk is run through an LLM (the host's LLM on MCP integrations; your gateway's LLM on OpenClaw; Hermes' configured LLM otherwise). The LLM identifies facts, preferences, decisions, goals, and context.
 4. **Triage + profile**: extracted facts are deduplicated and merged into a coherent profile via the smart-import pipeline (see [`rust/totalreclaw-core/src/smart_import.rs`](https://github.com/p-diogo/totalreclaw/blob/main/rust/totalreclaw-core/src/smart_import.rs) for the schema).

--- a/python/src/totalreclaw/hermes/schemas.py
+++ b/python/src/totalreclaw/hermes/schemas.py
@@ -310,7 +310,11 @@ IMPORT_FROM = {
             },
             "file_path": {
                 "type": "string",
-                "description": "Path to the export file on disk (e.g. Gemini Takeout HTML, ChatGPT conversations.json)",
+                "description": (
+                    "Path to the export on disk. For ChatGPT: the export zip, "
+                    "its unpacked folder, or a single conversations.json — all "
+                    "work as-is. For Gemini: the Takeout HTML."
+                ),
             },
             "content": {
                 "type": "string",

--- a/python/src/totalreclaw/import_adapters/chatgpt_adapter.py
+++ b/python/src/totalreclaw/import_adapters/chatgpt_adapter.py
@@ -4,12 +4,14 @@ ChatGPT import adapter -- parses conversations.json or plain text memories.
 Ported from skill/plugin/import-adapters/chatgpt-adapter.ts
 """
 
+import glob
 import json
 import math
 import os
 import re
+import zipfile
 from datetime import datetime, timezone
-from typing import Optional, Callable, List, Any
+from typing import Optional, Callable, List, Any, Tuple
 
 import psutil
 
@@ -19,6 +21,13 @@ from .types import AdapterParseResult, ConversationChunk
 
 # Maximum messages per conversation chunk for LLM extraction.
 CHUNK_SIZE = 20
+
+# Real ChatGPT exports split conversations across numbered files inside the
+# export zip (conversations-000.json, conversations-001.json, ...). Older
+# exports ship a single conversations.json.
+_CONVERSATIONS_MEMBER_RE = re.compile(r'(?:^|/)conversations(?:-\d+)?\.json$')
+
+_MAX_TOTAL_MB = 500
 
 
 class ChatGPTAdapter(BaseImportAdapter):
@@ -40,32 +49,27 @@ class ChatGPTAdapter(BaseImportAdapter):
         elif file_path:
             try:
                 resolved = os.path.expanduser(file_path)
-                stat = os.stat(resolved)
-                file_size_mb = stat.st_size / (1024 * 1024)
-                if file_size_mb > 500:
-                    errors.append(
-                        f'File is too large to import: {file_size_mb:.1f}MB exceeds the 500MB cap. '
-                        'Split the file into smaller chunks and import each separately.',
-                    )
+                documents, doc_errors = self._read_export_documents(resolved)
+                if doc_errors:
+                    errors.extend(doc_errors)
                     return AdapterParseResult(
                         facts=[], chunks=[], total_messages=0,
                         warnings=warnings, errors=errors,
                     )
-                free_mem = psutil.virtual_memory().available
-                if free_mem < stat.st_size * 2:
-                    free_mb = free_mem / (1024 * 1024)
-                    need_mb = math.ceil(stat.st_size * 2 / (1024 * 1024))
-                    errors.append(
-                        f'Not enough free memory: {free_mb:.0f}MB available, '
-                        f'~{need_mb}MB needed (2× file size). '
-                        'Close other applications or split the file.',
+                if len(documents) > 1 or os.path.isdir(resolved) or zipfile.is_zipfile(resolved):
+                    # Multi-file export (zip or unpacked directory): parse the
+                    # concatenated conversation list directly.
+                    conversations: List[dict] = []
+                    for doc in documents:
+                        parsed = json.loads(doc)
+                        if isinstance(parsed, list):
+                            conversations.extend(parsed)
+                        elif isinstance(parsed, dict) and 'mapping' in parsed:
+                            conversations.append(parsed)
+                    return self._parse_conversation_list(
+                        conversations, warnings, errors, on_progress,
                     )
-                    return AdapterParseResult(
-                        facts=[], chunks=[], total_messages=0,
-                        warnings=warnings, errors=errors,
-                    )
-                with open(resolved, 'r', encoding='utf-8') as f:
-                    raw = f.read()
+                raw = documents[0]
             except Exception as e:
                 errors.append(f'Failed to read file: {e}')
                 return AdapterParseResult(
@@ -129,6 +133,88 @@ class ChatGPTAdapter(BaseImportAdapter):
                 warnings=warnings, errors=errors,
             )
 
+        return self._parse_conversation_list(conversations, warnings, errors, on_progress)
+
+    def _read_export_documents(self, resolved: str) -> Tuple[List[str], List[str]]:
+        """
+        Read the raw JSON document(s) of an export given a path that may be:
+        a single conversations.json, an export zip, or an unpacked export
+        directory (conversations-000.json, conversations-001.json, ...).
+
+        Returns (documents, errors). File ordering is deterministic (sorted by
+        name) so chunk offsets — and therefore import resume state — are
+        stable across calls.
+        """
+        errors: List[str] = []
+
+        def _check_budget(total_bytes: int, what: str) -> bool:
+            total_mb = total_bytes / (1024 * 1024)
+            if total_mb > _MAX_TOTAL_MB:
+                errors.append(
+                    f'{what} is too large to import: {total_mb:.1f}MB exceeds the '
+                    f'{_MAX_TOTAL_MB}MB cap. Split it and import each part separately.',
+                )
+                return False
+            free_mem = psutil.virtual_memory().available
+            if free_mem < total_bytes * 2:
+                free_mb = free_mem / (1024 * 1024)
+                need_mb = math.ceil(total_bytes * 2 / (1024 * 1024))
+                errors.append(
+                    f'Not enough free memory: {free_mb:.0f}MB available, '
+                    f'~{need_mb}MB needed (2× data size). '
+                    'Close other applications or split the file.',
+                )
+                return False
+            return True
+
+        if os.path.isdir(resolved):
+            paths = sorted(glob.glob(os.path.join(resolved, 'conversations*.json')))
+            if not paths:
+                errors.append(
+                    f'No conversations*.json found in directory {resolved}. '
+                    'Point at the unpacked ChatGPT export folder or the export zip.',
+                )
+                return [], errors
+            total = sum(os.stat(p).st_size for p in paths)
+            if not _check_budget(total, 'Export directory'):
+                return [], errors
+            docs = []
+            for p in paths:
+                with open(p, 'r', encoding='utf-8') as f:
+                    docs.append(f.read())
+            return docs, errors
+
+        if zipfile.is_zipfile(resolved):
+            with zipfile.ZipFile(resolved) as zf:
+                members = sorted(
+                    (m for m in zf.infolist() if _CONVERSATIONS_MEMBER_RE.search(m.filename)),
+                    key=lambda m: m.filename,
+                )
+                if not members:
+                    errors.append(
+                        f'No conversations*.json found inside {resolved}. '
+                        'Is this a ChatGPT data export zip?',
+                    )
+                    return [], errors
+                total = sum(m.file_size for m in members)  # uncompressed
+                if not _check_budget(total, 'Export archive'):
+                    return [], errors
+                return [zf.read(m).decode('utf-8') for m in members], errors
+
+        # Single file
+        stat = os.stat(resolved)
+        if not _check_budget(stat.st_size, 'File'):
+            return [], errors
+        with open(resolved, 'r', encoding='utf-8') as f:
+            return [f.read()], errors
+
+    def _parse_conversation_list(
+        self,
+        conversations: List[dict],
+        warnings: List[str],
+        errors: List[str],
+        on_progress: Optional[Callable] = None,
+    ) -> AdapterParseResult:
         if on_progress:
             on_progress({
                 'current': 0,
@@ -149,23 +235,25 @@ class ChatGPTAdapter(BaseImportAdapter):
                 )
                 continue
 
-            # Extract user + assistant messages in chronological order
-            messages = self._extract_messages(mapping)
+            # Extract user + assistant messages along the canonical branch
+            messages = self._extract_messages(mapping, current_node=conv.get('current_node'))
             if not messages:
                 continue
 
             total_messages += len(messages)
 
-            # Determine timestamp from conversation create_time
+            # Conversation-level timestamp — fallback for messages without
+            # their own create_time.
             create_time = conv.get('create_time')
-            timestamp = None
+            conv_timestamp = None
             if create_time:
                 try:
-                    timestamp = datetime.fromtimestamp(create_time, tz=timezone.utc).isoformat()
+                    conv_timestamp = datetime.fromtimestamp(create_time, tz=timezone.utc).isoformat()
                 except (ValueError, TypeError, OSError):
                     pass
 
             title = conv.get('title') or 'Untitled Conversation'
+            conversation_id = conv.get('conversation_id') or conv.get('id')
 
             # Chunk into batches of CHUNK_SIZE messages
             for i in range(0, len(messages), CHUNK_SIZE):
@@ -178,7 +266,15 @@ class ChatGPTAdapter(BaseImportAdapter):
                     if total_chunks > 1
                     else title
                 )
-                chunks.append(ConversationChunk(title=chunk_title, messages=batch, timestamp=timestamp))
+                # Chunk timestamp = first message's own time, so multi-chunk
+                # conversations don't collapse onto one conversation-level time.
+                chunk_ts = batch[0].get('timestamp') or conv_timestamp
+                chunks.append(ConversationChunk(
+                    title=chunk_title,
+                    messages=batch,
+                    timestamp=chunk_ts,
+                    conversation_id=conversation_id,
+                ))
 
             conv_index += 1
             if on_progress and conv_index % 50 == 0:
@@ -273,72 +369,112 @@ class ChatGPTAdapter(BaseImportAdapter):
     def _extract_messages(
         self,
         mapping: dict,
+        current_node: Optional[str] = None,
     ) -> List[dict]:
         """
-        Traverse the mapping tree and extract user + assistant messages
-        in chronological order.
+        Extract user + assistant messages along the CANONICAL branch of the
+        mapping tree, in chronological order.
+
+        ChatGPT stores edited/regenerated messages as sibling branches; the
+        thread the user actually sees is the ``current_node`` -> parent chain.
+        Walking all branches (the old BFS) imports superseded drafts as
+        near-duplicates. When ``current_node`` is missing or dangling we fall
+        back to the deepest root-to-leaf path.
 
         Both roles are included because the assistant's response often provides
         context that helps the LLM understand what the user meant.
         """
-        # Find the root node (the one with no parent or parent not in mapping)
-        root_id = None
-        for node_id, node in mapping.items():
-            parent = node.get('parent')
-            if not parent or parent not in mapping:
-                root_id = node_id
-                break
+        path = self._canonical_node_path(mapping, current_node)
 
-        if not root_id:
-            return []
-
-        # Walk the tree breadth-first, following children in order (main thread)
         messages: List[dict] = []
-        visited: set = set()
-        queue: List[str] = [root_id]
-
-        while queue:
-            node_id = queue.pop(0)
-            if node_id in visited:
-                continue
-            visited.add(node_id)
-
-            node = mapping.get(node_id)
-            if not node:
-                continue
-
+        for node_id in path:
+            node = mapping.get(node_id) or {}
             message = node.get('message')
-            if message:
-                role = None
-                author = message.get('author')
-                if author:
-                    role = author.get('role')
-
-                # Only collect user and assistant messages (skip system, tool)
-                if role in ('user', 'assistant'):
-                    content = message.get('content')
-                    parts = content.get('parts') if content else None
-                    text_parts = self._extract_text_from_parts(parts)
-                    if text_parts and len(text_parts) >= 3:
-                        messages.append({'role': role, 'text': text_parts})
-
-            # Follow children (add them to queue in order)
-            for child_id in node.get('children', []):
-                queue.append(child_id)
+            if not message:
+                continue
+            role = (message.get('author') or {}).get('role')
+            # Only collect user and assistant messages (skip system, tool)
+            if role not in ('user', 'assistant'):
+                continue
+            text = self._extract_text_from_message(message)
+            if not text or len(text) < 3:
+                continue
+            entry = {'role': role, 'text': text}
+            create_time = message.get('create_time')
+            if create_time:
+                try:
+                    entry['timestamp'] = datetime.fromtimestamp(
+                        create_time, tz=timezone.utc,
+                    ).isoformat()
+                except (ValueError, TypeError, OSError):
+                    pass
+            messages.append(entry)
 
         return messages
 
-    def _extract_text_from_parts(self, parts: Any) -> Optional[str]:
+    def _canonical_node_path(
+        self,
+        mapping: dict,
+        current_node: Optional[str],
+    ) -> List[str]:
+        """Root-to-leaf node ids of the canonical thread."""
+
+        def _chain_up(leaf_id: str) -> List[str]:
+            chain: List[str] = []
+            seen: set = set()
+            nid = leaf_id
+            while nid and nid in mapping and nid not in seen:
+                seen.add(nid)
+                chain.append(nid)
+                nid = mapping[nid].get('parent')
+            chain.reverse()
+            return chain
+
+        if current_node and current_node in mapping:
+            return _chain_up(current_node)
+
+        # Fallback: deepest leaf wins (longest root-to-leaf chain).
+        leaves = [
+            nid for nid, node in mapping.items()
+            if not node.get('children')
+        ]
+        best: List[str] = []
+        for leaf in leaves:
+            chain = _chain_up(leaf)
+            if len(chain) > len(best):
+                best = chain
+        return best
+
+    def _extract_text_from_message(self, message: dict) -> Optional[str]:
         """
-        Extract plain text from message content parts.
-        Parts can be strings, None, or complex objects (images, etc.) -- we only want strings.
+        Extract text from a message's content across the content types that
+        appear in real exports:
+
+        - ``text`` / default: string entries in ``content.parts``
+        - ``multimodal_text``: string parts plus dict parts carrying text —
+          voice messages store their transcript as
+          ``{"content_type": "audio_transcription", "text": ...}``; image
+          pointers have no text and are skipped
+        - ``code``: the source lives in ``content.text``, not ``parts``
         """
-        if not parts or not isinstance(parts, list):
+        content = message.get('content') or {}
+        content_type = content.get('content_type')
+
+        if content_type == 'code':
+            text = content.get('text')
+            return text.strip() if isinstance(text, str) and text.strip() else None
+
+        pieces: List[str] = []
+        parts = content.get('parts')
+        if isinstance(parts, list):
+            for p in parts:
+                if isinstance(p, str) and p.strip():
+                    pieces.append(p.strip())
+                elif isinstance(p, dict):
+                    t = p.get('text') or p.get('transcript')
+                    if isinstance(t, str) and t.strip():
+                        pieces.append(t.strip())
+
+        if not pieces:
             return None
-
-        text_parts = [p for p in parts if isinstance(p, str) and p.strip()]
-
-        if not text_parts:
-            return None
-
-        return ' '.join(text_parts).strip()
+        return ' '.join(pieces).strip()

--- a/python/src/totalreclaw/import_adapters/types.py
+++ b/python/src/totalreclaw/import_adapters/types.py
@@ -29,8 +29,13 @@ class NormalizedFact:
 class ConversationChunk:
     """A chunk of conversation messages for LLM-based fact extraction."""
     title: str
-    messages: List[dict]  # [{"role": "user"|"assistant", "text": "..."}]
+    messages: List[dict]  # [{"role": "user"|"assistant", "text": "...", "timestamp": ISO?}]
     timestamp: Optional[str] = None  # ISO 8601
+    #: Explicit conversation boundary from the source export. ChatGPT/Claude
+    #: conversations have first-class ids; Gemini Takeout does not. When set,
+    #: the import engine groups all chunks sharing an id into one session and
+    #: skips semantic (centroid-walk) segmentation.
+    conversation_id: Optional[str] = None
 
 
 @dataclass

--- a/python/src/totalreclaw/import_engine.py
+++ b/python/src/totalreclaw/import_engine.py
@@ -977,6 +977,40 @@ class ImportEngine:
             self._session_ids = []
             return self._session_assignments
 
+        # ── Explicit conversation boundaries (ChatGPT / Claude) ─────────────
+        # When every chunk carries a conversation_id from the source export,
+        # the session structure is ground truth: one conversation = one
+        # session. Semantic segmentation exists to INFER boundaries for
+        # sources that lack them (Gemini Takeout); running it here would
+        # lossily re-derive what the export already states — merging distinct
+        # same-topic conversations and splitting long ones.
+        conv_ids = [getattr(c, "conversation_id", None) for c in chunks]
+        if all(conv_ids):
+            by_conv: dict[str, list[int]] = {}
+            for idx, cid in enumerate(conv_ids):
+                by_conv.setdefault(cid, []).append(idx)
+            self._session_assignments = list(by_conv.values())
+            # Turn count = user messages in the conversation (one turn per
+            # user->assistant exchange) — drives the singleton (no-Crystal) rule.
+            self._session_turn_counts = []
+            for chunk_indices in self._session_assignments:
+                n_turns = 0
+                for ci in chunk_indices:
+                    msgs = getattr(chunks[ci], "messages", None) or []
+                    n_user = sum(
+                        1 for m in msgs
+                        if isinstance(m, dict) and (m.get("role") or "user") == "user"
+                    )
+                    n_turns += n_user or (1 if msgs else 0)
+                self._session_turn_counts.append(n_turns)
+            self._session_ids = [_uuid7() for _ in self._session_assignments]
+            logger.debug(
+                "session grouping: %d chunks -> %d sessions via explicit "
+                "conversation boundaries (no semantic segmentation)",
+                len(chunks), len(self._session_assignments),
+            )
+            return self._session_assignments
+
         from totalreclaw.session_segmentation import segment_sessions
         from datetime import datetime
 

--- a/python/tests/fixtures/chatgpt-conversations.fixture.json
+++ b/python/tests/fixtures/chatgpt-conversations.fixture.json
@@ -1,0 +1,18757 @@
+[
+ {
+  "async_status": null,
+  "atlas_mode_enabled": null,
+  "context_scopes": null,
+  "conversation_id": "03c09bbc-29c4-46bf-ba96-4c520ce5bffe",
+  "conversation_origin": null,
+  "conversation_template_id": null,
+  "create_time": 1706461514.633714,
+  "current_node": "e04c5f86-a732-4e11-b7e3-15c234eb38ba",
+  "default_model_slug": null,
+  "disabled_tool_ids": [],
+  "gizmo_type": null,
+  "id": "03c09bbc-29c4-46bf-ba96-4c520ce5bffe",
+  "is_archived": false,
+  "is_do_not_remember": null,
+  "is_starred": null,
+  "mapping": {
+   "24fe957b-bd55-47fa-a348-c71806230f52": {
+    "children": [
+     "aaa2831b-7d21-422c-a3f2-a7afbffe70bf"
+    ],
+    "id": "24fe957b-bd55-47fa-a348-c71806230f52",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": null,
+     "end_turn": true,
+     "id": "24fe957b-bd55-47fa-a348-c71806230f52",
+     "metadata": {
+      "can_save": false,
+      "is_visually_hidden_from_conversation": true
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "aaa1b2c5-cd9c-4876-af99-604c53764da5"
+   },
+   "5015760c-60ff-4ecc-9663-6f13e7432410": {
+    "children": [
+     "aaa2ef66-ab6b-496c-934e-e9a711263dc5"
+    ],
+    "id": "5015760c-60ff-4ecc-9663-6f13e7432410",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "An afternoon in Geneva in early February can be quite delightful, with the city's blend of history, culture, and stunning natural scenery. Here's a suggested itinerary for your visit:\n\n1. **Jet d'Eau and Lake Geneva**: Start your afternoon with a visit to the iconic Jet d'Eau, one of the largest fountains in the world, located in Lake Geneva. It's particularly beautiful and a symbol of the city. You can take a stroll along the lake's edge and enjoy the scenic views.\n\n2. **Old Town (Vieille Ville)**: After enjoying the lake, head to Geneva's Old Town. This area is filled with narrow cobblestone streets, quaint cafes, and historical buildings. Don't miss the St. Pierre Cathedral, where you can climb to the top for a panoramic view of the city.\n\n3. **Place du Bourg-de-Four**: This is one of the oldest squares in Geneva and a great place to grab a coffee or a snack. It's a charming area to relax and soak in the local atmosphere.\n\n4. **Patek Philippe Museum**: If you're interested in watches and horology, this museum is a must-visit. Geneva is known for its watchmaking tradition, and the museum showcases an impressive collection of watches and clocks.\n\n5. **United Nations Office at Geneva**: If time allows, visit the European headquarters of the United Nations. It's an important site for international diplomacy and offers guided tours.\n\n6. **Jardin Anglais and Flower Clock**: On your way back, stop by the Jardin Anglais, a lovely public park. The Flower Clock, a symbol of the city's watchmaking tradition, is a unique sight and great for photos.\n\n7. **Dinner in Carouge**: End your afternoon with an early dinner in the nearby district of Carouge, known for its bohemian atmosphere, boutiques, and excellent restaurants.\n\nRemember that February in Geneva can be cold, so dress warmly. Also, opening hours for some attractions may vary in winter, so it's a good idea to check in advance. Enjoy your visit!"
+      ]
+     },
+     "create_time": 1706461535.199137,
+     "end_turn": true,
+     "id": "5015760c-60ff-4ecc-9663-6f13e7432410",
+     "metadata": {
+      "can_save": true,
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "aaa2831b-7d21-422c-a3f2-a7afbffe70bf",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa2831b-7d21-422c-a3f2-a7afbffe70bf"
+   },
+   "aaa1b2c5-cd9c-4876-af99-604c53764da5": {
+    "children": [
+     "24fe957b-bd55-47fa-a348-c71806230f52"
+    ],
+    "id": "aaa1b2c5-cd9c-4876-af99-604c53764da5",
+    "message": null,
+    "parent": null
+   },
+   "aaa2831b-7d21-422c-a3f2-a7afbffe70bf": {
+    "children": [
+     "5015760c-60ff-4ecc-9663-6f13e7432410"
+    ],
+    "id": "aaa2831b-7d21-422c-a3f2-a7afbffe70bf",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "What should I visit with an afternoon in Geneve, in early Feb?"
+      ]
+     },
+     "create_time": 1706461514.635061,
+     "end_turn": null,
+     "id": "aaa2831b-7d21-422c-a3f2-a7afbffe70bf",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "24fe957b-bd55-47fa-a348-c71806230f52"
+   },
+   "aaa2ef66-ab6b-496c-934e-e9a711263dc5": {
+    "children": [
+     "e04c5f86-a732-4e11-b7e3-15c234eb38ba"
+    ],
+    "id": "aaa2ef66-ab6b-496c-934e-e9a711263dc5",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "I don't want anything too touristy"
+      ]
+     },
+     "create_time": 1706461989.06233,
+     "end_turn": null,
+     "id": "aaa2ef66-ab6b-496c-934e-e9a711263dc5",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "5015760c-60ff-4ecc-9663-6f13e7432410"
+   },
+   "e04c5f86-a732-4e11-b7e3-15c234eb38ba": {
+    "children": [],
+    "id": "e04c5f86-a732-4e11-b7e3-15c234eb38ba",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "If you prefer to avoid the typical tourist spots in Geneva and have a more local experience, here are some alternative activities for an afternoon in early February:\n\n1. **Parc des Bastions**: Start your afternoon with a relaxing walk in Parc des Bastions. It's a beautiful park located in the heart of the city, popular among locals. In winter, it's quieter and offers a serene atmosphere. You can see the famous Reformation Wall and enjoy a peaceful stroll.\n\n2. **Eaux-Vives Neighborhood**: Explore the Eaux-Vives neighborhood, which is less touristy than the city center. It's a lovely area with local shops, cafes, and restaurants. You can experience everyday life in Geneva here.\n\n3. **Museum of Art and History**: If you're interested in art and culture, visit the Museum of Art and History. It's one of the largest museums in Switzerland and often overlooked by tourists. The museum houses a diverse collection of art, archaeology, and applied arts.\n\n4. **Plainpalais Flea Market**: If your visit happens to be on a day when the Plainpalais flea market is open, it's a great place to browse. It's a large flea market where locals go to shop for antiques, second-hand goods, and unique finds.\n\n5. **Les Grottes Neighborhood**: For a more unconventional side of Geneva, visit the Les Grottes neighborhood. It's known for its quirky architecture and alternative culture. You can find interesting cafes and shops here.\n\n6. **Local Caf\u00e9 or Bistro**: Instead of dining in a popular tourist restaurant, choose a local caf\u00e9 or bistro for an authentic Geneva dining experience. Try some Swiss specialties like fondue or raclette, especially cozy in the winter.\n\n7. **Promenade Along the Rh\u00f4ne**: For a quiet end to your afternoon, take a walk along the Rh\u00f4ne river. It's especially beautiful in the late afternoon and less crowded than the lakeside.\n\nRemember, early February in Geneva can be quite cold, so dress warmly. Also, some places might have different operating hours in winter, so it's a good idea to check before you visit. Enjoy your time exploring Geneva like a local!"
+      ]
+     },
+     "create_time": 1706462018.072901,
+     "end_turn": true,
+     "id": "e04c5f86-a732-4e11-b7e3-15c234eb38ba",
+     "metadata": {
+      "can_save": true,
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "aaa2ef66-ab6b-496c-934e-e9a711263dc5",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa2ef66-ab6b-496c-934e-e9a711263dc5"
+   }
+  },
+  "memory_scope": "global_enabled",
+  "moderation_results": [],
+  "title": "Visit Geneva in February",
+  "update_time": 1706462018.149642,
+  "voice": null
+ },
+ {
+  "async_status": null,
+  "atlas_mode_enabled": null,
+  "context_scopes": null,
+  "conversation_id": "04926f65-ffdc-4051-b799-8ebc8e02e0fb",
+  "conversation_origin": null,
+  "conversation_template_id": null,
+  "create_time": 1697970250.717059,
+  "current_node": "6bce6d1b-fc14-4185-a388-28a6eedf7b76",
+  "default_model_slug": null,
+  "disabled_tool_ids": [],
+  "gizmo_type": null,
+  "id": "04926f65-ffdc-4051-b799-8ebc8e02e0fb",
+  "is_archived": false,
+  "is_do_not_remember": null,
+  "is_starred": null,
+  "mapping": {
+   "6bce6d1b-fc14-4185-a388-28a6eedf7b76": {
+    "children": [],
+    "id": "6bce6d1b-fc14-4185-a388-28a6eedf7b76",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Certainly! Peer interviews are a great way to assess whether a candidate will mesh well with the existing team. Here are five questions that the Office Manager and HR Generalist could ask to assess chemistry and positive integration:\n\n### 1. **Work Collaboration**\n   - \"Can you share an experience where you had to collaborate closely with a team to execute a recruitment strategy? What was your role, and how did you ensure effective communication and cooperation with the team?\"\n\n### 2. **Conflict Resolution**\n   - \"Have you ever encountered a conflict with a team member? How did you manage it, and what steps did you take to resolve it constructively?\"\n\n### 3. **Cultural Fit**\n   - \"What kind of company culture do you thrive in, and how do you contribute to fostering a positive and inclusive work environment?\"\n\n### 4. **Adaptability**\n   - \"Our team often has to adapt to new recruitment technologies and changing hiring trends. Can you discuss a time when you had to quickly adapt to a new tool or method in talent acquisition?\"\n\n### 5. **Feedback and Improvement**\n   - \"How do you handle feedback from team members, and can you provide an example of how you\u2019ve used feedback to improve your recruitment processes?\"\n\n### Suggestions for Structuring the Interview:\n\n- Begin the interview with a brief introduction, explaining the roles of the Office Manager and HR Generalist and giving a quick overview of the team and work environment.\n  \n- Allow the candidate to ask questions at the end of the interview. This will give the team a chance to understand the candidate\u2019s priorities and expectations.\n  \n- After the interview, the Office Manager and HR Generalist should discuss and document their impressions, focusing on the candidate\u2019s compatibility with the team and alignment with the company culture.\n\nHaving a structured approach and relevant questions will help in making an informed decision about the candidate\u2019s potential for positive integration into the team."
+      ]
+     },
+     "create_time": 1697970271.561438,
+     "end_turn": true,
+     "id": "6bce6d1b-fc14-4185-a388-28a6eedf7b76",
+     "metadata": {
+      "can_save": true,
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "aaa2a7a5-29e8-4cfa-b6aa-d858def8adf9",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa2a7a5-29e8-4cfa-b6aa-d858def8adf9"
+   },
+   "6ed731a4-eb72-4ae8-9543-8fd00b168298": {
+    "children": [
+     "aaa2a7a5-29e8-4cfa-b6aa-d858def8adf9"
+    ],
+    "id": "6ed731a4-eb72-4ae8-9543-8fd00b168298",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": null,
+     "end_turn": true,
+     "id": "6ed731a4-eb72-4ae8-9543-8fd00b168298",
+     "metadata": {
+      "can_save": false,
+      "is_visually_hidden_from_conversation": true
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "aaa13667-138a-4b6c-853c-873ac2fcc8a0"
+   },
+   "aaa13667-138a-4b6c-853c-873ac2fcc8a0": {
+    "children": [
+     "6ed731a4-eb72-4ae8-9543-8fd00b168298"
+    ],
+    "id": "aaa13667-138a-4b6c-853c-873ac2fcc8a0",
+    "message": null,
+    "parent": null
+   },
+   "aaa2a7a5-29e8-4cfa-b6aa-d858def8adf9": {
+    "children": [
+     "6bce6d1b-fc14-4185-a388-28a6eedf7b76"
+    ],
+    "id": "aaa2a7a5-29e8-4cfa-b6aa-d858def8adf9",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "I have an opening for a Talent Acquisition Specialist. I want the candidates to have a peer interview with the rest of the team members. They are both Office Manager & HR Generalist. What are 5 questions they should ask the candidates, to assess chemistry and positive integration in the team?"
+      ]
+     },
+     "create_time": 1697970250.717634,
+     "end_turn": null,
+     "id": "aaa2a7a5-29e8-4cfa-b6aa-d858def8adf9",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "6ed731a4-eb72-4ae8-9543-8fd00b168298"
+   }
+  },
+  "memory_scope": "global_enabled",
+  "moderation_results": [],
+  "title": "Peer Interview Questions: Chemistry",
+  "update_time": 1697970272.39289,
+  "voice": null
+ },
+ {
+  "async_status": null,
+  "atlas_mode_enabled": null,
+  "context_scopes": null,
+  "conversation_id": "07bcdb4c-5ff1-4cb8-bfad-9497c990b01d",
+  "conversation_origin": null,
+  "conversation_template_id": null,
+  "create_time": 1716207392.688691,
+  "current_node": "fc37a587-e2ac-4f01-b03b-4c3f63072422",
+  "default_model_slug": "gpt-4o",
+  "disabled_tool_ids": [],
+  "gizmo_type": null,
+  "id": "07bcdb4c-5ff1-4cb8-bfad-9497c990b01d",
+  "is_archived": false,
+  "is_do_not_remember": null,
+  "is_starred": null,
+  "mapping": {
+   "09b528e6-3277-4149-9b80-0b510daa67f3": {
+    "children": [
+     "2ad47780-c2f5-46df-98d4-15dee66243ef"
+    ],
+    "id": "09b528e6-3277-4149-9b80-0b510daa67f3",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1716207431.016823,
+     "end_turn": true,
+     "id": "09b528e6-3277-4149-9b80-0b510daa67f3",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-4o",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": null,
+      "model_slug": "gpt-4o",
+      "parent_id": "aaa24884-57fd-4e8a-9d09-91a844e570e0",
+      "rebase_system_message": true,
+      "request_id": "886c4228bf54488f-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "aaa24884-57fd-4e8a-9d09-91a844e570e0"
+   },
+   "2ad47780-c2f5-46df-98d4-15dee66243ef": {
+    "children": [],
+    "id": "2ad47780-c2f5-46df-98d4-15dee66243ef",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Interviewing a candidate with strong technical skills but potential interpersonal issues, especially those relating to self-centeredness, can be tricky. Your goal in this interview will be to assess the candidate's ability to collaborate, lead effectively, and contribute to a positive team culture. Here are some targeted questions and the reasoning behind them to help you gauge these important aspects:\n\n1. **Tell me about a project you led that required collaboration with others. How did you ensure everyone's contributions were valued?**\n   - This question encourages the candidate to discuss their leadership style in a collaborative setting. Listen for signs of inclusivity or whether the candidate tends to dominate the conversation about their own contributions.\n\n2. **Can you describe a time when you had to accept that your idea was not chosen for a project? How did you handle it?**\n   - This probes the candidate\u2019s ability to handle rejection and disagreement, critical for understanding how they will react when not the center of attention or when they are challenged.\n\n3. **Describe how you have supported a colleague's success.**\n   - This question tests the candidate's capacity for supporting others' success, not just their own, which can indicate their ability to foster a supportive work environment rather than a competitive one.\n\n4. **How do you handle feedback, both positive and negative?**\n   - Responses to this question can reveal how the candidate views themselves within a team and their openness to growth and criticism.\n\n5. **What do you think makes a team effective? How have you contributed to this in your past roles?**\n   - With this, you can assess the candidate\u2019s perception of teamwork and their role in creating effective team dynamics. Look for whether they emphasize team success or focus primarily on individual achievements.\n\n6. **In your opinion, what are the key challenges facing leaders today?**\n   - This gives insights into the candidate's understanding of leadership beyond technical skills, including emotional intelligence, communication, and the ability to motivate and inspire others.\n\n7. **When have you had to advocate for a team member or an idea that was not your own?**\n   - This can highlight the candidate's ability to prioritize the team's interests over personal gain and shows their advocacy for others.\n\n8. **Can you give an example of how you\u2019ve dealt with a conflict within your team?**\n   - Conflict resolution skills are crucial, and how they describe dealing with conflict will help you understand if they approach issues with a team-oriented or self-centered attitude.\n\n9. **What role do you usually take in team meetings?**\n   - This question helps identify how they see their role in a group setting; whether they are dominating, facilitating, or collaborating.\n\nThese questions should help you understand how the candidate interacts in team settings, handles challenges, and supports others, providing a more complete picture of their suitability for a leadership role in your engineering department."
+      ]
+     },
+     "create_time": 1716207431.017607,
+     "end_turn": true,
+     "id": "2ad47780-c2f5-46df-98d4-15dee66243ef",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4o",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4o",
+      "pad": "AAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "parent_id": "09b528e6-3277-4149-9b80-0b510daa67f3",
+      "request_id": "886c4228bf54488f-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "09b528e6-3277-4149-9b80-0b510daa67f3"
+   },
+   "2dd9500d-7d2a-4206-b323-ddda37dbaefb": {
+    "children": [
+     "aaa24884-57fd-4e8a-9d09-91a844e570e0"
+    ],
+    "id": "2dd9500d-7d2a-4206-b323-ddda37dbaefb",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": null,
+     "end_turn": true,
+     "id": "2dd9500d-7d2a-4206-b323-ddda37dbaefb",
+     "metadata": {
+      "can_save": false,
+      "is_visually_hidden_from_conversation": true
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "aaa1269d-37c3-460e-8ad4-f83a76f6a72b"
+   },
+   "7f91cd45-ad07-4998-a557-8a690f6d0156": {
+    "children": [
+     "aaa2272a-be96-4f5a-b459-9c71ea7a2baf"
+    ],
+    "id": "7f91cd45-ad07-4998-a557-8a690f6d0156",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "When interviewing a candidate with concerns about being overly self-centered, it's important to ask questions that reveal their ability to work collaboratively, their self-awareness, and their ability to handle feedback. Here are some questions you can ask to tap into these areas:\n\n1. **Collaboration and Teamwork:**\n   - **Can you describe a project where you had to work closely with a team? What was your role, and how did you contribute to the team's success?**\n   - **Tell me about a time when you had to resolve a conflict within your team. What was the issue, and how did you handle it?**\n   - **How do you ensure that all team members are heard and valued during team meetings or project discussions?**\n\n2. **Self-Awareness and Humility:**\n   - **Can you give an example of a mistake you made in a project and how you handled it?**\n   - **What is one piece of constructive feedback you received in the past, and how did you respond to it?**\n   - **Describe a situation where you had to rely on someone else\u2019s expertise to complete a task. How did you approach this situation?**\n\n3. **Leadership and Management:**\n   - **As a department lead, how do you motivate your team and recognize their achievements?**\n   - **How do you balance your own contributions with empowering your team to take initiative and lead?**\n   - **Can you provide an example of how you have developed or mentored someone in your team? What was the outcome?**\n\n4. **Communication and Listening Skills:**\n   - **How do you ensure clear and effective communication within your team?**\n   - **Describe a time when you had to listen to a team member\u2019s idea or concern that was different from your own. How did you handle it?**\n   - **How do you incorporate feedback from your team into your decision-making process?**\n\n5. **Handling Criticism and Adapting:**\n   - **Tell me about a time when a project didn\u2019t go as planned. How did you handle the situation, and what did you learn from it?**\n   - **How do you prioritize your team\u2019s input when making important decisions?**\n   - **How have you adapted your leadership style based on feedback from your team or peers?**\n\nThese questions are designed to elicit responses that can give you insight into the candidate's ability to work well with others, accept and act on feedback, and demonstrate humility and self-awareness. Listen for answers that show a genuine appreciation for team contributions, an ability to admit mistakes, and a commitment to personal and professional growth."
+      ]
+     },
+     "create_time": 1716207419.341821,
+     "end_turn": true,
+     "id": "7f91cd45-ad07-4998-a557-8a690f6d0156",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4o",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4o",
+      "pad": "AAAAAAAAAAAAAAAAAAAA",
+      "parent_id": "aaa24884-57fd-4e8a-9d09-91a844e570e0",
+      "request_id": "886c4228bf54488f-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa24884-57fd-4e8a-9d09-91a844e570e0"
+   },
+   "aaa1269d-37c3-460e-8ad4-f83a76f6a72b": {
+    "children": [
+     "2dd9500d-7d2a-4206-b323-ddda37dbaefb"
+    ],
+    "id": "aaa1269d-37c3-460e-8ad4-f83a76f6a72b",
+    "message": null,
+    "parent": null
+   },
+   "aaa2272a-be96-4f5a-b459-9c71ea7a2baf": {
+    "children": [
+     "fc37a587-e2ac-4f01-b03b-4c3f63072422"
+    ],
+    "id": "aaa2272a-be96-4f5a-b459-9c71ea7a2baf",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "This is good, but I need something shorter. Like top 5 things to ask."
+      ]
+     },
+     "create_time": 1716207611.877193,
+     "end_turn": null,
+     "id": "aaa2272a-be96-4f5a-b459-9c71ea7a2baf",
+     "metadata": {
+      "can_save": false,
+      "message_source": null,
+      "message_type": null,
+      "request_id": "886c4783e84f33e9-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "7f91cd45-ad07-4998-a557-8a690f6d0156"
+   },
+   "aaa24884-57fd-4e8a-9d09-91a844e570e0": {
+    "children": [
+     "09b528e6-3277-4149-9b80-0b510daa67f3",
+     "7f91cd45-ad07-4998-a557-8a690f6d0156"
+    ],
+    "id": "aaa24884-57fd-4e8a-9d09-91a844e570e0",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "I'm interviewing someone for a department lead position, within engineering. I'm the HR Director. The feedback so far says great tech skills but there's a concern across the board about the candidate being too full of himself. \"Me, me, me\" type. What questions do you recommend I ask to tap into this?"
+      ]
+     },
+     "create_time": 1716207392.690718,
+     "end_turn": null,
+     "id": "aaa24884-57fd-4e8a-9d09-91a844e570e0",
+     "metadata": {
+      "can_save": false,
+      "message_source": null,
+      "message_type": null,
+      "request_id": "886c4228bf54488f-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "2dd9500d-7d2a-4206-b323-ddda37dbaefb"
+   },
+   "fc37a587-e2ac-4f01-b03b-4c3f63072422": {
+    "children": [],
+    "id": "fc37a587-e2ac-4f01-b03b-4c3f63072422",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Certainly! Here are the top 5 concise questions you can ask to address concerns about the candidate being overly self-centered:\n\n1. **Can you describe a project where you had to work closely with a team? What was your role, and how did you ensure the team's success?**\n2. **Tell me about a mistake you made in a project and how you handled it.**\n3. **How do you recognize and motivate your team members?**\n4. **Describe a situation where you had to rely on someone else\u2019s expertise. How did you approach it?**\n5. **How do you incorporate feedback from your team into your decision-making process?**\n\nThese questions are designed to quickly reveal the candidate's ability to collaborate, handle mistakes, support their team, rely on others, and accept feedback."
+      ]
+     },
+     "create_time": 1716207620.305458,
+     "end_turn": true,
+     "id": "fc37a587-e2ac-4f01-b03b-4c3f63072422",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4o",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4o",
+      "pad": "AAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "parent_id": "aaa2272a-be96-4f5a-b459-9c71ea7a2baf",
+      "request_id": "886c4783e84f33e9-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa2272a-be96-4f5a-b459-9c71ea7a2baf"
+   }
+  },
+  "memory_scope": "global_enabled",
+  "moderation_results": [],
+  "title": "Leadership Skills Assessment",
+  "update_time": 1716207620.570038,
+  "voice": null
+ },
+ {
+  "async_status": null,
+  "atlas_mode_enabled": null,
+  "context_scopes": null,
+  "conversation_id": "12c1038e-7dee-4cc8-bf08-546eee8e1375",
+  "conversation_origin": null,
+  "conversation_template_id": null,
+  "create_time": 1712873181.382514,
+  "current_node": "c540440e-91e2-4252-8ca3-9ba4e653fc88",
+  "default_model_slug": "gpt-4",
+  "disabled_tool_ids": [],
+  "gizmo_type": null,
+  "id": "12c1038e-7dee-4cc8-bf08-546eee8e1375",
+  "is_archived": false,
+  "is_do_not_remember": null,
+  "is_starred": null,
+  "mapping": {
+   "03a90880-0983-492b-ae15-2de521aefbf9": {
+    "children": [],
+    "id": "03a90880-0983-492b-ae15-2de521aefbf9",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Certainly! Here\u2019s a detailed itinerary for your trip to Vietnam, tailored to include the specific activities you\u2019re interested in. This plan includes three full days in Hanoi, Ninh Binh, and Ho Chi Minh City, and five days in the Con Dao Islands, ensuring a deep dive into the local culture, food, and nature.\n\n### Hanoi (3 Days)\n\n**Day 1: Cultural Immersion**\n- **Morning:** Visit the Ho Chi Minh Mausoleum and One Pillar Pagoda. Explore the surrounding gardens and the Ho Chi Minh Museum.\n- **Afternoon:** Take a walking tour of the Temple of Literature. Enjoy a traditional Vietnamese lunch nearby.\n- **Evening:** Attend a water puppet show at Thang Long Theatre. Have dinner in the Old Quarter, trying some local dishes.\n\n**Day 2: Local Life and Cooking**\n- **Morning:** Join a food tour that takes you through local markets and street food spots. Focus on lesser-known dishes and areas outside the tourist paths.\n- **Afternoon:** Participate in a cooking class where you can learn to make traditional dishes from a local chef.\n- **Evening:** Explore the nightlife and have a relaxed dinner at a local caf\u00e9 with live music.\n\n**Day 3: Historical Insights**\n- **Morning:** Early visit to Long Bien Market to see the bustling local commerce.\n- **Afternoon:** Leisurely lunch followed by a visit to the Hanoi Opera House for a tour of the architecture and history.\n- **Evening:** Dinner at a restaurant that specializes in northern Vietnamese cuisine, followed by a stroll around Hoan Kiem Lake.\n\n### Ninh Binh (3 Days)\n\n**Day 1: River and Caves**\n- **Morning:** Boat trip through Trang An Scenic Landscape Complex. Explore caves and temples along the way.\n- **Afternoon:** Lunch at a local restaurant followed by a visit to the ancient capital of Hoa Lu.\n- **Evening:** Dinner near your accommodation, trying local specialties like goat meat.\n\n**Day 2: Countryside Exploration**\n- **Morning:** Rent a bicycle and explore the countryside. Visit Bich Dong Pagoda.\n- **Afternoon:** Continue your bike ride to nearby villages, interacting with locals and possibly visiting a local home.\n- **Evening:** Return to your accommodation and enjoy a quiet dinner.\n\n**Day 3: Local Life**\n- **Morning:** Visit a local market early in the morning. Have breakfast at the market.\n- **Afternoon:** Free time to further explore or relax. Optionally, take a short hike in the nearby hills.\n- **Evening:** Enjoy a final dinner in Ninh Binh, trying any dishes you haven\u2019t yet sampled.\n\n### Ho Chi Minh City (3 Days)\n\n**Day 1: War History**\n- **Morning:** Guided tour of the War Remnants Museum for a deeper understanding of the Vietnam War's impact.\n- **Afternoon:** Visit the Independence Palace.\n- **Evening:** Explore the street food scene in districts 3 and 10.\n\n**Day 2: Local Markets and City Life**\n- **Morning:** Visit Binh Tay Market in Chinatown, then head to the Thien Hau Temple.\n- **Afternoon:** Lunch in Chinatown, followed by a visit to the Notre Dame Cathedral and the historic Post Office.\n- **Evening:** Dinner at a local restaurant followed by an evening exploring the local cafes and bars.\n\n**Day 3: Modern Ho Chi Minh City**\n- **Morning:** Free morning or additional shopping.\n- **Afternoon:** Relax in a city park or visit a local art gallery.\n- **Evening:** Have a farewell dinner on a rooftop restaurant with views over the city.\n\n### Con Dao Islands (5 Days)\n\n**Day 1: Arrival and Relaxation**\n- **Morning:** Arrive and check into your accommodation.\n- **Afternoon:** Orientation walk around the main town, visiting local shops.\n- **Evening:** Dinner at a seaside restaurant.\n\n**Day 2: Historical Insights**\n- **Morning:** Visit the old prison complex with a guided tour to understand the historical significance.\n- **Afternoon:** Lunch followed by a visit to the local museum if available.\n- **Evening:** Casual dinner at your resort or local eatery.\n\n**Day 3: Nature Exploration**\n- **Morning:** Guided hiking in Con Dao National Park.\n- **Afternoon:** Continue exploring different trails or relax at a secluded beach.\n- **Evening:** Enjoy a quiet dinner, perhaps a beach barbecue if available.\n\n**Day 4: Marine Life**\n- **Morning:** Snorkeling trip to explore coral reefs.\n- **Afternoon:** More snorkeling or free time for sunbathing.\n- **Evening:** Dine at another excellent local spot, enjoying fresh seafood.\n\n**Day 5: Leisure and Departure**\n- **Morning:** Free time for last-minute exploration or relaxation.\n- **Afternoon:** Prepare for departure and last-minute souvenir shopping.\n- **Even"
+      ]
+     },
+     "create_time": 1712999130.3102,
+     "end_turn": false,
+     "id": "03a90880-0983-492b-ae15-2de521aefbf9",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "type": "max_tokens"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAAAAAAAAAAA",
+      "parent_id": "aaa26f5a-756b-4892-b055-fe44dd3d7e1d",
+      "request_id": "873a4a407bf7691d-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa26f5a-756b-4892-b055-fe44dd3d7e1d"
+   },
+   "06fdc2bc-1a27-4ca9-88be-e514bff9532a": {
+    "children": [
+     "aaa28f15-7ff9-429e-b21c-637d88b8a3ba"
+    ],
+    "id": "06fdc2bc-1a27-4ca9-88be-e514bff9532a",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Traveling efficiently between Hanoi, Ha Long Bay, Hoi An, and Phu Quoc Island while saving time involves using a combination of flights and ground transportation. Here's an optimal way to navigate between these locations:\n\n### Hanoi to Ha Long Bay\n- **By Bus or Shuttle Van:** There are no direct flights between Hanoi and Ha Long Bay. The most efficient way to travel is by bus or shuttle van, which takes about 2 to 4 hours. Several companies offer comfortable rides directly from Hanoi to Ha Long Bay, including luxury options with Wi-Fi and comfortable seating.\n- **By Seaplane:** For a quicker and more scenic route, consider a seaplane from Hanoi to Ha Long Bay. It takes about 45 minutes and offers stunning aerial views of the bay, but it's more expensive.\n\n### Ha Long Bay to Hoi An\n- **By Flight (from Hanoi):** After returning to Hanoi from Ha Long Bay (as there's no direct transport link from Ha Long Bay to Hoi An), the best way to save time is to fly from Hanoi to Da Nang International Airport, which is the closest airport to Hoi An. The flight takes about 1 hour and 20 minutes. From Da Nang, you can take a taxi or shuttle to Hoi An, approximately 30 kilometers (around 45 minutes to 1 hour).\n  \n### Hoi An to Phu Quoc Island\n- **By Flight (from Da Nang):** The fastest way to get from Hoi An to Phu Quoc is to travel back to Da Nang and catch a direct flight to Phu Quoc International Airport. The flight duration is approximately 1 hour and 45 minutes. \n\n### General Tips:\n- **Booking in Advance:** For all flights, it's wise to book tickets well in advance to secure the best fares and ensure availability, especially if traveling in peak tourist seasons.\n- **Check for Direct Flights:** Airlines sometimes adjust their routes, so it's worth checking if there are any new direct flight options available to save even more time.\n- **Consider Private Transfers:** For ground transport, especially to and from airports or between Hanoi and Ha Long Bay, consider booking private transfers for a more seamless and time-efficient travel experience.\n\nThis route maximizes your time in each destination by minimizing travel time between them. Remember, domestic flights are often the quickest way to move long distances in Vietnam, while local transportation options like buses, taxis, or shuttles are best for shorter distances or when flights are not available."
+      ]
+     },
+     "create_time": 1712873426.488921,
+     "end_turn": true,
+     "id": "06fdc2bc-1a27-4ca9-88be-e514bff9532a",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AA",
+      "parent_id": "aaa259dc-d83f-4480-9892-9c26aa88a5cc",
+      "request_id": "872e4d954efd03f6-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa259dc-d83f-4480-9892-9c26aa88a5cc"
+   },
+   "0be20503-5d9d-437f-8029-41ea4173bc05": {
+    "children": [
+     "aaa2e32f-e234-49d0-9324-688832933cab"
+    ],
+    "id": "0be20503-5d9d-437f-8029-41ea4173bc05",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": null,
+     "end_turn": true,
+     "id": "0be20503-5d9d-437f-8029-41ea4173bc05",
+     "metadata": {
+      "can_save": false,
+      "is_visually_hidden_from_conversation": true
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "aaa1d2b4-167e-4b41-8d90-f1c88655253b"
+   },
+   "0fcc6234-c2cb-42bf-8c72-533b3ce07d83": {
+    "children": [
+     "aaa2e7a6-cbf5-4520-a871-98cfd5d03244"
+    ],
+    "id": "0fcc6234-c2cb-42bf-8c72-533b3ce07d83",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Creating a complete itinerary for your trip from Lisbon to Vietnam, incorporating Hanoi, Ninh Binh, Ho Chi Minh City, and the Con Dao Islands, here's a streamlined plan to ensure an enriching experience:\n\n### Day 1: Departure from Lisbon\n- **Flight:** Depart from Lisbon to Hanoi. This will likely include at least one layover, common layover hubs being in Europe (e.g., Frankfurt, Paris) or the Middle East (e.g., Doha, Dubai).\n\n### Days 2-4: Hanoi\n- **Day 2:** Arrival in Hanoi. Rest and local exploration.\n- **Day 3:** Visit the Old Quarter, Hoan Kiem Lake, and the Temple of Literature. Evening street food tour.\n- **Day 4:** Day trip to the Tr\u1ea5n Qu\u1ed1c Pagoda and the Museum of Ethnology. Explore more of the city\u2019s culinary scene in the evening.\n\n### Days 5-6: Ninh Binh\n- **Day 5:** Travel to Ninh Binh early morning. Visit Tam Coc for a boat ride and explore Bich Dong Pagoda.\n- **Day 6:** Visit the ancient capital of Hoa Lu and the Trang An Scenic Landscape Complex. Return to H"
+      ]
+     },
+     "create_time": 1712876125.857189,
+     "end_turn": null,
+     "id": "0fcc6234-c2cb-42bf-8c72-533b3ce07d83",
+     "metadata": {
+      "can_save": false,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "type": "interrupted"
+      },
+      "gizmo_id": null,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAAAAAAAAAAA",
+      "parent_id": "aaa22836-39ee-46fd-aa87-103c8a325817",
+      "request_id": "872e901b2f09693b-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "in_progress",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa22836-39ee-46fd-aa87-103c8a325817"
+   },
+   "1548372f-de00-41c0-b8b2-90df3c0e1b6e": {
+    "children": [
+     "aaa259dc-d83f-4480-9892-9c26aa88a5cc"
+    ],
+    "id": "1548372f-de00-41c0-b8b2-90df3c0e1b6e",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "November is generally a good time to visit Vietnam, including the destinations mentioned (Hanoi, Ha Long Bay, Hoi An, and Phu Quoc Island), as it falls within the transition period from the rainy season to the dry season for many parts of the country. Here's how November typically fares for each location:\n\n### Hanoi\nIn November, Hanoi begins to cool down with the arrival of autumn, offering pleasant weather conditions. The average temperature ranges from 17\u00b0C to 24\u00b0C (63\u00b0F to 75\u00b0F). It's a comfortable time for exploring the city and enjoying outdoor activities. You might encounter occasional light rain, but it generally won't disrupt travel plans.\n\n### Ha Long Bay\nSimilar to Hanoi, Ha Long Bay experiences cooler and drier weather in November. It's an ideal time for cruising around the bay and enjoying its natural beauty without the discomfort of the hot summer months. The temperatures are comparable to those in Hanoi, making outdoor activities enjoyable.\n\n### Hoi An\nNovember is a transition month for Hoi An as well, moving from the wet season to the dry season. Early November might still see some rainy days, but as the month progresses, the weather becomes drier and more pleasant. The average temperature ranges from 22\u00b0C to 28\u00b0C (72\u00b0F to 82\u00b0F). While there's a risk of encountering some rain, especially in early November, it's still a good time to visit, especially towards the end of the month.\n\n### Phu Quoc Island\nNovember marks the beginning of the dry season in Phu Quoc, making it an excellent time to visit. The island sees more sunny days, less rainfall, and humidity drops, making beach activities and exploration much more enjoyable. The average temperature ranges from 25\u00b0C to 31\u00b0C (77\u00b0F to 88\u00b0F), perfect for beach days and snorkeling.\n\nOverall, November is a favorable month to visit these destinations in Vietnam, offering a mix of cool, dry weather in the north and transitioning to warmer, beach-friendly conditions in the south. Just keep in mind that early November might still bring some rain in central Vietnam, so it's wise to pack accordingly."
+      ]
+     },
+     "create_time": 1712873309.215377,
+     "end_turn": true,
+     "id": "1548372f-de00-41c0-b8b2-90df3c0e1b6e",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAA",
+      "parent_id": "aaa2a258-2d15-481b-87a8-855f4b956892",
+      "request_id": "872e4b03fd016930-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa2a258-2d15-481b-87a8-855f4b956892"
+   },
+   "1e6fe622-71dc-4147-94e0-497243e5a620": {
+    "children": [
+     "aaa28b1f-6c54-440e-9d17-b75ec69fcc70"
+    ],
+    "id": "1e6fe622-71dc-4147-94e0-497243e5a620",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Yes, the Con Dao Islands have been developing a reputation not only for their natural beauty and historical significance but also for hosting a range of accommodations, including boutique resorts that cater to those looking for a more intimate and luxurious experience. These resorts often emphasize eco-friendly practices, privacy, and offer personalized services that make the most of the islands' serene and pristine environments.\n\n### Boutique Resort Highlights in Con Dao:\n\n- **Privacy and Seclusion:** Many resorts in Con Dao are designed to offer privacy and tranquility. They are often set in secluded locations, providing guests with peaceful surroundings and stunning views of the ocean or tropical landscapes.\n\n- **Eco-Friendly Practices:** Given the islands' natural beauty and biodiversity, several resorts focus on sustainability and conservation efforts. This can include everything from the architecture and the materials used in construction to the daily operations and activities offered.\n\n- **Luxury Amenities:** Expect to find well-appointed rooms and villas, often with direct beach access or private pools. Resorts also typically feature high-end spa facilities, fine dining options that utilize local ingredients, and personalized services like private dinners on the beach or guided tours.\n\n- **Cultural and Natural Activities:** To enhance your stay, many boutique resorts offer activities that highlight the cultural heritage and natural beauty of Con Dao. This could involve guided historical tours, snorkeling and diving excursions to explore coral reefs, and nature hikes.\n\nWhen searching for boutique resorts in Con Dao, it\u2019s advisable to book well in advance, especially if you\u2019re planning to visit during the peak travel months. This not only secures your accommodation but also often provides better rates. While in Con Dao, embracing the slow pace and the natural and historical wonders of the islands can lead to a truly enriching travel experience."
+      ]
+     },
+     "create_time": 1712874977.050993,
+     "end_turn": true,
+     "id": "1e6fe622-71dc-4147-94e0-497243e5a620",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAAAAA",
+      "parent_id": "aaa202b4-367e-436f-896a-ed5a6763b423",
+      "request_id": "872e73eb69b16914-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa202b4-367e-436f-896a-ed5a6763b423"
+   },
+   "206bb049-c53c-4f99-badc-53d75fc420f2": {
+    "children": [
+     "aaa202b4-367e-436f-896a-ed5a6763b423"
+    ],
+    "id": "206bb049-c53c-4f99-badc-53d75fc420f2",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Certainly! Here\u2019s a brief summary of each location along with the expected weather in late November:\n\n### Hanoi\n**Summary:** Vietnam's capital, Hanoi, is known for its centuries-old architecture, vibrant street markets, and a rich culture that embodies the contrasts of a rapidly developing country while still retaining its historical charm. Key attractions include the Old Quarter, Hoan Kiem Lake, and the Temple of Literature.\n\n**Weather:** In late November, Hanoi transitions into the dry season with cooler temperatures. Average temperatures range from 18\u00b0C to 24\u00b0C (64\u00b0F to 75\u00b0F). It's a pleasant time to explore the city, with less rain and humidity.\n\n### Ninh Binh\n**Summary:** Often referred to as \u201cHa Long Bay on Land,\u201d Ninh Binh boasts stunning landscapes of limestone karsts and rivers. It offers serene boat rides, historic sites like the ancient capital of Hoa Lu, and the opportunity to cycle through rice paddies and rugged scenery.\n\n**Weather:** Similar to Hanoi, Ninh Binh in late November experiences cool and dry weather. Temperatures typically range from 17\u00b0C to 24\u00b0C (63\u00b0F to 75\u00b0F), making outdoor activities comfortable.\n\n### Phong Nha - Ke Bang National Park\n**Summary:** This UNESCO World Heritage Site is renowned for its extensive cave systems, including Son Doong Cave, the world's largest cave, and the beautiful Phong Nha and Paradise Caves. It's a haven for adventurers and nature lovers, offering jungle treks, river tours, and caving expeditions.\n\n**Weather:** Late November is generally cool and dry, with temperatures averaging from 18\u00b0C to 24\u00b0C (64\u00b0F to 75\u00b0F). This period marks the beginning of the dry season in the region, making it an ideal time for exploring caves and outdoor adventures.\n\n### Con Dao Islands\n**Summary:** The Con Dao Islands are known for their pristine beaches, clear waters, and rich history. Once a penal colony, the islands now offer a peaceful retreat with opportunities for diving, snorkeling, and wildlife watching, including sea turtles.\n\n**Weather:** November marks the transition to the dry season in Con Dao, with temperatures ranging from 26\u00b0C to 30\u00b0C (79\u00b0F to 86\u00b0F). It\u2019s a good time to visit, as the weather starts to clear up, offering sunny days ideal for beach activities and exploring the islands.\n\nEach of these destinations provides a unique experience of Vietnam\u2019s diverse landscapes and cultural heritage. The weather in late November is generally favorable across these locations, making it a great time to enjoy both the cultural and natural attractions of Vietnam."
+      ]
+     },
+     "create_time": 1712874854.694329,
+     "end_turn": true,
+     "id": "206bb049-c53c-4f99-badc-53d75fc420f2",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAAAAAAA",
+      "parent_id": "aaa23073-c587-4433-8130-af734ee4f565",
+      "request_id": "872e70910a0e48aa-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa23073-c587-4433-8130-af734ee4f565"
+   },
+   "2a96a6e7-d89e-4bbc-bedf-579b6f590eda": {
+    "children": [],
+    "id": "2a96a6e7-d89e-4bbc-bedf-579b6f590eda",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Certainly! Here\u2019s a detailed daily itinerary for your trip to Vietnam, ensuring each day is filled with enriching activities that match your interests in culture, nature, and food:\n\n### Hanoi (3 Days)\n\n**Day 1: Explore Hanoi's Historical and Cultural Heart**\n- **Morning:** Start your day with a visit to the Ho Chi Minh Mausoleum, One Pillar Pagoda, and the nearby Presidential Palace.\n- **Lunch:** Enjoy lunch at a local restaurant featuring Pho, a classic Vietnamese noodle soup.\n- **Afternoon:** Visit the Temple of Literature and spend the afternoon exploring the Vietnam Fine Arts Museum or the Museum of Ethnology.\n- **Evening:** Attend a water puppet show, followed by dinner in the Old Quarter.\n\n**Day 2: Culinary Exploration**\n- **Morning:** Participate in a morning cooking class where you learn to make traditional dishes from a local chef.\n- **Lunch:** Enjoy the dishes you prepared in your cooking class.\n- **Afternoon:** Take a guided food tour through Hanoi's backstreets, sampling street food like Banh Mi and Egg Coffee.\n- **Evening:** Free evening or explore more culinary spots on your own.\n\n**Day 3: Local Life and Markets**\n- **Morning:** Visit the Long Bien Market early in the morning to see the bustling trade.\n- **Lunch:** Have lunch at a local caf\u00e9.\n- **Afternoon:** Free time to explore or shop in the Old Quarter.\n- **Evening:** Enjoy a dinner cruise on the Red River or a quiet evening at a local jazz club.\n\n### Ninh Binh (3 Days)\n\n**Day 1: River and Rural Landscape**\n- **Morning:** Start with a boat trip through the Trang An Scenic Landscape Complex.\n- **Lunch:** Lunch at a local restaurant with views of the karsts.\n- **Afternoon:** Visit the ancient capital of Hoa Lu to see the temples of the Dinh and Le dynasties.\n- **Evening:** Return to your accommodation and relax.\n\n**Day 2: Bicycle and Pagoda Day**\n- **Morning:** Rent a bicycle and ride through the countryside to Bich Dong Pagoda.\n- **Lunch:** Picnic lunch or local meal in a village.\n- **Afternoon:** Continue your bike tour to nearby villages and rice fields, possibly extending to Hang Mua for a climb to the peak for sunset views.\n- **Evening:** Dinner at a local eatery.\n\n**Day 3: More Exploration**\n- **Morning:** Another boat tour, possibly in Tam Coc, early to beat the crowds.\n- **Lunch:** Enjoy lunch in Tam Coc.\n- **Afternoon:** Leisurely afternoon with options to visit more local sites or enjoy a spa treatment.\n- **Evening:** Casual dinner and prepare for travel the next day.\n\n### Ho Chi Minh City (3 Days)\n\n**Day 1: War History and Cultural Insights**\n- **Morning:** Visit the War Remnants Museum with a guided tour to gain deep insights.\n- **Lunch:** Lunch in a historic part of the city.\n- **Afternoon:** Visit the Independence Palace and take a stroll to the Notre Dame Cathedral and the Central Post Office.\n- **Evening:** Explore the nightlife or enjoy a cultural performance.\n\n**Day 2: Markets and Local Flavors**\n- **Morning:** Visit Binh Tay Market in Chinatown for a vibrant market experience.\n- **Lunch:** Try some Dim Sum or local Vietnamese-Chinese dishes.\n- **Afternoon:** Free time to explore more or relax.\n- **Evening:** Street food tour in districts 3 and 10, exploring local favorites.\n\n**Day 3: Relax and Explore**\n- **Morning:** Free morning for last-minute shopping or exploring.\n- **Lunch:** Lunch at a recommended restaurant.\n- **Afternoon:** Check out some local art galleries or museums.\n- **Evening:** Final dinner at a restaurant with a view of the city.\n\n### Con Dao Islands (5 Days)\n\n**Day 1: Arrival and Relaxation**\n- **Morning:** Arrive and settle in at your accommodation.\n- **Afternoon:** Gentle exploration of the main town and beaches.\n- **Evening:** Dinner by the beach.\n\n**Day 2: Historical Insights**\n- **Morning:** Visit the old prison complex with a guided tour.\n- **Lunch:** Lunch back at the hotel or a local eatery.\n- **Afternoon:** Visit the museum or continue exploring other historical sites.\n- **Evening:** Sunset watching from a scenic spot.\n\n**Day 3: Nature Exploration**\n- **All Day:** Guided hiking in Con Dao National Park, exploring different trails and looking for local wildlife.\n- **Evening:** Relaxing dinner and early night.\n\n**Day 4: Underwater Adventures**\n- **Morning:** Early morning snorkeling or diving trip to see coral reefs.\n- **Lunch:** Lunch on a boat or back on land.\n- **"
+      ]
+     },
+     "create_time": 1712999052.006705,
+     "end_turn": false,
+     "id": "2a96a6e7-d89e-4bbc-bedf-579b6f590eda",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "type": "max_tokens"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAA",
+      "parent_id": "aaa26f5a-756b-4892-b055-fe44dd3d7e1d",
+      "request_id": "873a47fa681d94f4-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa26f5a-756b-4892-b055-fe44dd3d7e1d"
+   },
+   "329806dd-efc0-4e22-af97-78982ae39229": {
+    "children": [
+     "fd842918-7db8-42b5-8704-c5990f4f9990"
+    ],
+    "id": "329806dd-efc0-4e22-af97-78982ae39229",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1712875707.007627,
+     "end_turn": true,
+     "id": "329806dd-efc0-4e22-af97-78982ae39229",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-4",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "aaa27604-829b-41a9-8616-f37b4ecf78dd",
+      "rebase_system_message": true,
+      "request_id": "872e85aad8456935-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "aaa27604-829b-41a9-8616-f37b4ecf78dd"
+   },
+   "35eadf9d-527b-4e1b-b3e1-696eec5642d6": {
+    "children": [
+     "d44e49f0-d10e-42c9-b98a-07c862fbfcef"
+    ],
+    "id": "35eadf9d-527b-4e1b-b3e1-696eec5642d6",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1712876855.17369,
+     "end_turn": true,
+     "id": "35eadf9d-527b-4e1b-b3e1-696eec5642d6",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-4",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "aaa23eb2-bbd3-4a89-a0f8-bb51678c1e5d",
+      "rebase_system_message": true,
+      "request_id": "872ea1f7ec35691e-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "aaa23eb2-bbd3-4a89-a0f8-bb51678c1e5d"
+   },
+   "3618bb1e-d256-4c3b-a0fc-ca649901559a": {
+    "children": [
+     "aaa23589-5b83-4625-bceb-4207684e55ec",
+     "aaa261e4-7fa2-45db-9d70-5a2f3a9475ae"
+    ],
+    "id": "3618bb1e-d256-4c3b-a0fc-ca649901559a",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Ha Long Bay and Ninh Binh do share some similarities, notably their stunning limestone karst landscapes. However, the experience of each is quite distinct\u2014Ha Long Bay's majestic seascape versus Ninh Binh's serene countryside and river tours. If you're looking to diversify your experiences further and see something different from the karst scenery, considering another day trip from Hanoi could be a great idea. Here are two alternative destinations for varied scenery:\n\n### 1. Mai Chau\n- **Distance from Hanoi:** Approximately 160 kilometers (around 3-4 hours by car or bus).\n- **Scenery and Activities:** Mai Chau offers a peaceful retreat into Vietnam's rural life, set in a valley with lush rice fields and surrounded by mountains. It's known for its ethnic minority communities, particularly the White Thai, who inhabit stilt houses. Activities include cycling through rice paddies, visiting local villages, and enjoying traditional dance performances. Mai Chau provides a different perspective on Vietnam, focusing on culture and rural landscapes.\n\n### 2. Perfume Pagoda (Ch\u00f9a H\u01b0\u01a1ng)\n- **Distance from Hanoi:** About 60 kilometers to the south (1.5-2 hours by car or bus to the river, then a boat ride).\n- **Scenery and Activities:** The Perfume Pagoda is a vast complex of Buddhist temples and shrines built into the limestone Huong Tich mountains. It's a unique spiritual journey involving a scenic boat ride along the Yen River surrounded by natural beauty, followed by a hike (or cable car ride) up to the main pagoda in a cave. This trip offers a combination of natural beauty, religious significance, and a bit of adventure.\n\n### Choosing Between Them\n- **Mai Chau** is ideal if you're interested in Vietnam's ethnic cultures and rural landscapes. It's a bit further away but can be a refreshing change from the urban and karst sceneries.\n- **Perfume Pagoda** offers a blend of religious culture, natural beauty, and a bit of physical activity. It's closer to Hanoi and provides a different type of scenic experience compared to karst landscapes.\n\nBoth destinations offer a contrast to the karst scenery of Ha Long Bay and Ninh Binh and can enrich your travel experience with new landscapes and cultural insights."
+      ]
+     },
+     "create_time": 1712877002.449268,
+     "end_turn": true,
+     "id": "3618bb1e-d256-4c3b-a0fc-ca649901559a",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "parent_id": "a2ef26d8-1bc3-437d-8502-69bc318cabd8",
+      "request_id": "872ea4c98a04691c-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "a2ef26d8-1bc3-437d-8502-69bc318cabd8"
+   },
+   "3ade3546-9d0f-42aa-9209-ad28ac320567": {
+    "children": [
+     "aaa283cc-c29a-416a-a067-c07d7989528c"
+    ],
+    "id": "3ade3546-9d0f-42aa-9209-ad28ac320567",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "For a trip through Vietnam, budgeting for a mix of low to mid-range accommodations in the first three locations (Hanoi, Ninh Binh, Phong Nha) and a higher budget for a boutique resort stay in Con Dao Islands, here's a rough daily budget guideline for two people. Please note, these are estimates and can vary based on specific choices and changes in pricing.\n\n### Hanoi, Ninh Binh, and Phong Nha - Ke Bang\n\n**Accommodation (Low to Mid-Range):** For a comfortable room with a private bathroom and good cleanliness, expect to spend around $20 to $50 per night for two people. This range can provide you with well-reviewed guesthouses or budget hotels.\n\n**Food and Drinks:** Street food and local eateries are affordable options, with meals ranging from $2 to $10 per person. If you occasionally dine at more upscale restaurants, allocate up to $15 to $20 per person per meal. Daily food budget: $20 to $40 for two.\n\n**Transportation:** Intercity train or bus tickets vary but can average around $15 to $30 per person for each major leg of the journey. Day-to-day transportation (taxis, motorbike rentals) might add up to $10 to $20 daily.\n\n**Activities and Entrance Fees:** Budget around $10 to $20 per person per day for activities, including entrance fees to attractions, guided tours, and small expenses like bike rentals.\n\n### Daily Budget for First Three Locations: $60 to $160 for two people\n\n### Con Dao Islands\n\n**Accommodation (Boutique Resort):** Prices for boutique resorts that aren't in the luxury category can range from $100 to $250 per night for a double room, depending on the level of comfort and the amenities offered.\n\n**Food and Drinks:** Dining in resorts can be pricier, but there are also local options available. Estimate around $30 to $60 per day for two, considering some meals might be had outside the resort.\n\n**Transportation:** On the islands, you might spend less on transportation if you choose to relax at the resort or use bicycles provided by the accommodation. Estimate up to $10 for occasional taxi rides.\n\n**Activities:** Snorkeling, diving, and guided tours might cost more here. Budget approximately $20 to $100 for two, depending on the activities chosen.\n\n### Daily Budget for Con Dao Islands: $150 to $420 for two people\n\n### Overall, your budget per day for two people could range from:\n\n- **Low to Mid-Range Days (First Three Locations):** $60 to $160\n- **Con Dao Islands Days:** $150 to $420\n\nThis budget includes accommodation, meals, transportation within cities, and activities but does not cover intercity flights or transport. For flights, especially those to and from Con Dao, consider setting aside an additional budget, depending on the time of booking and availability. Remember, early planning and booking can often secure better rates and help manage your budget more effectively."
+      ]
+     },
+     "create_time": 1712875122.501636,
+     "end_turn": true,
+     "id": "3ade3546-9d0f-42aa-9209-ad28ac320567",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAA",
+      "parent_id": "aaa28b1f-6c54-440e-9d17-b75ec69fcc70",
+      "request_id": "872e771b3f0903de-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa28b1f-6c54-440e-9d17-b75ec69fcc70"
+   },
+   "3fbfdd1e-ecb9-4dbb-8722-67e4dd2b9374": {
+    "children": [
+     "ada27f5e-5697-46a1-8514-aa1842b215df"
+    ],
+    "id": "3fbfdd1e-ecb9-4dbb-8722-67e4dd2b9374",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1712877321.19858,
+     "end_turn": true,
+     "id": "3fbfdd1e-ecb9-4dbb-8722-67e4dd2b9374",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-4",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "aaa27683-45d9-485b-910a-ba3435784f7b",
+      "rebase_system_message": true,
+      "request_id": "872ead6cacf4343d-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "aaa27683-45d9-485b-910a-ba3435784f7b"
+   },
+   "45fa9d60-8dce-4d36-ac2b-c107867e76fb": {
+    "children": [
+     "aaa26f5a-756b-4892-b055-fe44dd3d7e1d"
+    ],
+    "id": "45fa9d60-8dce-4d36-ac2b-c107867e76fb",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Your preferences for nature, food, and culture with a desire for authentic experiences away from the usual tourist trails align perfectly with the locations you've chosen for your Vietnam itinerary. Here are specific activities in each destination that will help you dive deep into the local culture and enjoy the natural beauty without following the typical tourist paths:\n\n### Hanoi\n- **Explore the Historical Side:** Visit the Ho Chi Minh Mausoleum, One Pillar Pagoda, and the Temple of Literature to get a deep sense of Vietnam\u2019s history and culture.\n- **Authentic Food Experience:** Join a local food tour that ventures into the backstreets and neighborhoods beyond the Old Quarter or participate in a cooking class at a local\u2019s home.\n- **Cultural Immersion:** Attend a show at the Hanoi Opera House or watch a traditional water puppet performance at Thang Long Water Puppet Theatre.\n- **Local Markets:** Visit the Long Bien Market early in the morning to see where locals shop and get an authentic glimpse into daily life in Hanoi.\n\n### Ninh Binh\n- **River Boat Trips:** Take a boat trip through the Trang An Scenic Landscape Complex or Tam Coc to see the stunning karst landscapes. Choose less popular times or entry points to avoid crowds.\n- **Bicycle Tour:** Rent a bike and explore the rural areas around Tam Coc. Cycle to Bich Dong Pagoda, through local villages, and alongside rice fields to see the real rural Vietnam at your own pace.\n- **Visit Ancient Sites:** Explore the ancient capital of Hoa Lu to see the Dinh and Le dynasty temples. Visit early in the morning to avoid tour groups.\n\n### Ho Chi Minh City\n- **War History:** Visit the War Remnants Museum and the Independence Palace for a deeper understanding of Vietnam's recent history. For a more in-depth exploration, consider a guided tour that includes stories and contexts you might miss on your own.\n- **Local Markets:** Wander through Binh Tay Market in Chinatown for an authentic local market experience away from the more tourist-centric Ben Thanh Market.\n- **Street Food:** Explore districts 3 and 10 for street food, joining locals as they enjoy evening meals \u2013 great spots include the areas around Ho Thi Ky flower market.\n- **Live Music:** Spend an evening at a local music venue or a caf\u00e9 where young Vietnamese musicians play live music, offering genres from traditional Vietnamese to contemporary and jazz.\n\n### Con Dao Islands\n- **Historical Tours:** Visit the old prison buildings to learn about the island's past as a penal colony. These tours are poignant reminders of Vietnam\u2019s struggle for independence.\n- **Nature Walks:** Explore Con Dao National Park, which offers hiking, pristine beaches, and the chance to see rare wildlife. Guided tours can provide insights into the local flora and fauna.\n- **Snorkeling and Diving:** The clear waters of Con Dao are perfect for snorkeling and diving, with coral reefs and marine life. Choose eco-friendly tour operators to minimize your impact on the environment.\n- **Local Interaction:** Spend time in the main town, visiting local shops and interacting with residents to understand their way of life on this remote island.\n\nThese activities are chosen to give you a more in-depth and personal view of each location, focusing on authentic experiences that allow you to learn about the culture and history while enjoying the natural beauty around you."
+      ]
+     },
+     "create_time": 1712998561.567159,
+     "end_turn": true,
+     "id": "45fa9d60-8dce-4d36-ac2b-c107867e76fb",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAA",
+      "parent_id": "f0356f3b-ddee-40f0-86e9-d4d5cd34f07a",
+      "request_id": "873a3c979a0e691e-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "f0356f3b-ddee-40f0-86e9-d4d5cd34f07a"
+   },
+   "46ef6f22-c1cd-4f26-8837-258763b9bfa6": {
+    "children": [
+     "e3e1a75e-a62d-4102-8e91-ee7e81a36ef5"
+    ],
+    "id": "46ef6f22-c1cd-4f26-8837-258763b9bfa6",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1712876024.825527,
+     "end_turn": true,
+     "id": "46ef6f22-c1cd-4f26-8837-258763b9bfa6",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-4",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "aaa23808-1e3f-4413-b447-4a72635a0642",
+      "rebase_system_message": true,
+      "request_id": "872e8d53cc3a94f5-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "aaa23808-1e3f-4413-b447-4a72635a0642"
+   },
+   "49159388-76c7-4f9a-8a2b-30a6aacf301d": {
+    "children": [
+     "aaa27604-829b-41a9-8616-f37b4ecf78dd"
+    ],
+    "id": "49159388-76c7-4f9a-8a2b-30a6aacf301d",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Stopping in Ho Chi Minh City for a day or two can significantly enrich your Vietnam trip, especially since you'll be passing through. As the largest city in Vietnam, Ho Chi Minh City (formerly Saigon) is a dynamic and bustling metropolis that offers a fascinating mix of Vietnamese culture, history, and modern life. Here are a few reasons why it's worth the stop and what you can do:\n\n### Reasons to Visit Ho Chi Minh City\n\n**Cultural Diversity:** The city showcases a blend of architectural styles and cultural influences, from French colonial buildings to Chinese temples and modern skyscrapers.\n\n**Vibrant Food Scene:** Ho Chi Minh City is renowned for its street food and diverse culinary offerings, ranging from traditional Vietnamese dishes to international cuisine.\n\n**Historical Significance:** It plays a crucial role in Vietnam's history, especially regarding the Vietnam War (known in Vietnam as the American War). Visiting the War Remnants Museum and the Reunification Palace offers insightful perspectives into this era.\n\n**Lively Markets:** Markets like Ben Thanh Market and Binh Tay Market are bustling hubs of activity where you can find everything from souvenirs to local delicacies.\n\n### What to Do with 1-2 Days\n\n**Day 1: Explore the City's Historical and Cultural Sites**\n- Visit the Notre-Dame Cathedral Basilica of Saigon and the Central Post Office for a glimpse of colonial architecture.\n- Explore the War Remnants Museum to understand Vietnam's recent history.\n- Walk around District 1 to experience the city's dynamic atmosphere and see landmarks like the Opera House and the Ho Chi Minh City Hall.\n- End your day with a visit to Ben Thanh Market for shopping and street food.\n\n**Day 2: Dive Deeper into Local Life and History**\n- Start with a morning visit to the Jade Emperor Pagoda or the Thien Hau Temple in Chinatown (District 5) for cultural insights.\n- Consider a half-day trip to the Cu Chi Tunnels outside the city. This vast network of underground tunnels provides a stark reminder of the Vietnam War's guerrilla warfare tactics.\n- Spend your evening exploring the vibrant street food scene or enjoy a rooftop view of the city from one of its many bars.\n\nEven with a short stop, Ho Chi Minh City offers a memorable experience with its rich history, vibrant culture, and dynamic energy. It's a wonderful addition to your itinerary that complements the natural and historical aspects of your Vietnam trip."
+      ]
+     },
+     "create_time": 1712875532.202143,
+     "end_turn": true,
+     "id": "49159388-76c7-4f9a-8a2b-30a6aacf301d",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "parent_id": "aaa2cbaf-f9d6-48de-b74b-e18f2b6b016e",
+      "request_id": "872e81667c39692c-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa2cbaf-f9d6-48de-b74b-e18f2b6b016e"
+   },
+   "50c3d9fa-8344-42a2-8f1e-10ad6a436079": {
+    "children": [
+     "aaa232ca-d579-4419-9604-94c3199e26ba"
+    ],
+    "id": "50c3d9fa-8344-42a2-8f1e-10ad6a436079",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "When considering island destinations in Vietnam, particularly Con Dao Islands and Phu Quoc, each has its distinct advantages and challenges. Here\u2019s a breakdown to help you decide:\n\n### Con Dao Islands\n\n**Pros:**\n- **Natural Beauty:** Con Dao is known for its stunning natural beauty, with pristine beaches, clear turquoise waters, and lush green mountains.\n- **Less Commercialized:** Compared to Phu Quoc, Con Dao is less developed and commercialized, offering a more tranquil and secluded experience.\n- **Rich History:** The islands have a significant historical importance, featuring a former prison where Vietnamese revolutionaries were held during the French colonial period and the American War.\n- **Marine Life:** Ideal for snorkeling and diving, the waters around Con Dao are home to diverse marine life and vibrant coral reefs, part of a protected national park.\n\n**Cons:**\n- **Accessibility:** Con Dao is less accessible than Phu Quoc, with fewer and sometimes more expensive flight options. This can make it harder to reach, particularly in bad weather.\n- **Limited Services:** The island's less developed nature means fewer choices in terms of dining, nightlife, and accommodations compared to more developed tourist spots.\n- **Cost:** Because of its remoteness and the quality of its natural environment, staying in Con Dao can be more expensive, especially for mid-range to high-end accommodations.\n\n### Phu Quoc Island\n\n**Pros:**\n- **Accessibility:** Phu Quoc is more accessible than Con Dao, with more frequent flights from major cities and an international airport that also welcomes direct flights from select international locations.\n- **Variety of Accommodations:** Offers a wide range of lodging options, from budget hostels to luxury resorts, catering to all types of travelers.\n- **Developed Tourist Infrastructure:** The island has a well-developed tourist infrastructure, including a variety of restaurants, bars, and entertainment options.\n- **Beaches and Activities:** Known for its beautiful beaches, Phu Quoc also offers a range of activities, including night markets, amusement parks, and water sports.\n\n**Cons:**\n- **Commercialization:** Due to its popularity and development, Phu Quoc can feel overcrowded and less authentic, especially during peak tourist seasons.\n- **Environmental Concerns:** Rapid development has led to some environmental degradation, affecting some of the beaches and natural areas.\n- **Seasonal Weather:** Phu Quoc can experience heavy rains and storms during the monsoon season, which might affect travel plans.\n\n### Choosing Between Them\n\n- **Con Dao Islands** are ideal if you are seeking peace, natural beauty, and a chance to connect with Vietnam\u2019s history and pristine marine environments.\n- **Phu Quoc Island** would be a better choice if you prefer more amenities, easier access, and a lively atmosphere with plenty of entertainment options.\n\nBoth islands offer beautiful natural environments and beaches but cater to different types of experiences depending on what you\u2019re looking for in terms of accessibility, tranquility, and facilities."
+      ]
+     },
+     "create_time": 1712994980.315792,
+     "end_turn": true,
+     "id": "50c3d9fa-8344-42a2-8f1e-10ad6a436079",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "parent_id": "9da28b45-3e3a-4fb6-b138-13010d67b5de",
+      "request_id": "8739e56a8f643392-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "9da28b45-3e3a-4fb6-b138-13010d67b5de"
+   },
+   "51119a23-a15d-439b-9086-136dd06205f4": {
+    "children": [
+     "aaa24dcd-cd32-498b-a208-ec21f85ed747"
+    ],
+    "id": "51119a23-a15d-439b-9086-136dd06205f4",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Certainly! Each of the destinations and transit hubs mentioned in your travel plan from Phu Quoc to Lisbon offers unique experiences and highlights:\n\n### Phu Quoc Island, Vietnam\nPhu Quoc is Vietnam's largest island, renowned for its stunning beaches, crystal-clear waters, and lush tropical landscapes. It's a paradise for beach lovers, offering a variety of water sports, snorkeling, and diving opportunities to explore the vibrant coral reefs. The island is also famous for its night markets, where you can enjoy fresh seafood and local specialties. Don't miss the chance to visit the Phu Quoc National Park, which covers more than half of the island, offering hiking, bird watching, and nature exploration.\n\n### Major Asian or Middle Eastern Hubs\n\n- **Doha, Qatar**: Home to Hamad International Airport, one of the most luxurious airports globally, Doha is the capital city of Qatar, known for its futuristic skyscrapers and other ultramodern architecture inspired by ancient Islamic design. The city offers a rich cultural experience, with museums like the Museum of Islamic Art and the bustling Souq Waqif.\n\n- **Dubai, UAE**: Dubai is renowned for its lavish architecture, vibrant nightlife scene, and luxury shopping. The city is home to the Burj Khalifa, the world's tallest building, and the Palm Jumeirah, an extraordinary artificial archipelago. Dubai also offers unique experiences like desert safaris and indoor skiing.\n\n- **Bangkok, Thailand**: Bangkok is famous for its vibrant street life and cultural landmarks. The opulent Grand Palace and its sacred Wat Phra Kaew Temple, Wat Arun Temple, and the Emerald Buddha capture the city's spiritual heritage. Bangkok is also known for its bustling markets, thriving street food scene, and lively nightlife.\n\n- **Singapore**: Singapore is a cosmopolitan city-state known for its multicultural population and green spaces. Highlights include the futuristic Gardens by the Bay, the Singapore Zoo, and the Marina Bay Sands resort. Singapore's food scene is incredibly diverse, offering everything from hawker centers serving traditional Asian dishes to high-end restaurants.\n\n### Lisbon, Portugal\nLisbon, the coastal capital city of Portugal, is one of Europe's most charismatic and vibrant cities. It's famous for its scenic vistas, caf\u00e9 culture, soulful Fado music, and the historic Tram 28. The city effortlessly blends traditional heritage with striking modernism and progressive thinking. From the picturesque Alfama district to the Bel\u00e9m Tower and Jer\u00f3nimos Monastery, Lisbon offers a rich cultural tapestry. Don't miss tasting the iconic Portuguese custard tarts, Past\u00e9is de Bel\u00e9m, or exploring the nearby Sintra, a UNESCO World Heritage site known for its 19th-century Romanticist architecture, historic estates, and forests.\n\nEach of these destinations offers a unique window into the local culture, history, and landscape, making your journey from Phu Quoc to Lisbon not just a travel necessity but an opportunity for diverse experiences."
+      ]
+     },
+     "create_time": 1712874195.099729,
+     "end_turn": true,
+     "id": "51119a23-a15d-439b-9086-136dd06205f4",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAA",
+      "parent_id": "aaa277bd-6925-4b92-a57d-04864c9084a6",
+      "request_id": "872e605eab3903de-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa277bd-6925-4b92-a57d-04864c9084a6"
+   },
+   "557b29f8-c0b2-441f-9fa3-dbb9f22b3c99": {
+    "children": [],
+    "id": "557b29f8-c0b2-441f-9fa3-dbb9f22b3c99",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "If your travels take you through"
+      ]
+     },
+     "create_time": 1712875477.891273,
+     "end_turn": null,
+     "id": "557b29f8-c0b2-441f-9fa3-dbb9f22b3c99",
+     "metadata": {
+      "can_save": false,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "type": "interrupted"
+      },
+      "gizmo_id": null,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "parent_id": "aaa2b974-f01e-4bb7-96ab-1ca84b5c74f8",
+      "request_id": "872e807bdd67692c-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "in_progress",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa2b974-f01e-4bb7-96ab-1ca84b5c74f8"
+   },
+   "5b4d8829-34ae-487a-a1ae-a637f4a75c72": {
+    "children": [
+     "aaa2aac7-3cb9-40de-b4b4-01182894dcf5"
+    ],
+    "id": "5b4d8829-34ae-487a-a1ae-a637f4a75c72",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "The flight durations for your trip from Lisbon to Vietnam and within Vietnam will vary depending on the specific routes and layovers. Here's an estimate based on typical flight connections:\n\n### International Flights:\n1. **Lisbon to Hanoi**\n   - **Duration:** Generally, the flight time including one layover is about 15 to 20 hours, depending on the duration of the layover and the cities through which you transit (common transit hubs include cities like Frankfurt, Paris, Dubai, or Doha).\n\n2. **Return from Ho Chi Minh City to Lisbon**\n   - **Duration:** Similar to the outbound journey, expect about 15 to 20 hours of total travel time, including layovers.\n\n### Domestic Flights:\n1. **Hanoi to Ho Chi Minh City**\n   - **Duration:** The flight typically takes about 2 hours.\n\n2. **Ho Chi Minh City to Con Dao**\n   - **Duration:** This flight is usually around 1 hour.\n\nThese durations are estimates and can vary based on the airline, specific route, weather conditions, and other factors. It's a good idea to check specific flights for more precise times as you plan your trip."
+      ]
+     },
+     "create_time": 1712998127.009528,
+     "end_turn": true,
+     "id": "5b4d8829-34ae-487a-a1ae-a637f4a75c72",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAAAAAAAAA",
+      "parent_id": "aaa27e87-afb6-4a82-a582-9ca91a67bab3",
+      "request_id": "873a32899b5694ee-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa27e87-afb6-4a82-a582-9ca91a67bab3"
+   },
+   "69f6e0eb-c2f1-4929-8b09-01785107b98c": {
+    "children": [],
+    "id": "69f6e0eb-c2f1-4929-8b09-01785107b98c",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Certainly! Here's a detailed daily itinerary for your trip, incorporating all your interests and ensuring an immersive experience in each destination.\n\n### Hanoi (3 Days)\n\n**Day 1: Explore the Heart of Hanoi**\n- **Morning:** Begin with a visit to the Ho Chi Minh Mausoleum and the nearby One Pillar Pagoda.\n- **Lunch:** Try Pho at one of the old quarter's famed eateries.\n- **Afternoon:** Visit the Temple of Literature. Then, explore the Vietnam Fine Arts Museum to see the country\u2019s artistic traditions.\n- **Evening:** Attend a traditional water puppet show at Thang Long Theatre.\n\n**Day 2: Cultural Immersion**\n- **Morning:** Join a guided food tour to explore Hanoi's street food in the Old Quarter, sampling local dishes like Bun Cha and Egg Coffee.\n- **Afternoon:** Visit the Hanoi Opera House for a tour of the historic venue and catch a performance if available.\n- **Evening:** Explore the night market in the Old Quarter for shopping and more street food.\n\n**Day 3: Day of Learning**\n- **Morning:** Take a cooking class to learn about Vietnamese cuisine\u2019s intricacies and prepare traditional dishes.\n- **Afternoon:** Relax at Hoan Kiem Lake and visit Ngoc Son Temple.\n- **Evening:** Dinner at a local restaurant followed by a stroll around the lake.\n\n### Ninh Binh (3 Days)\n\n**Day 1: Discovering Tam Coc**\n- **Morning:** Take a boat trip through Tam Coc, known as \"Halong Bay on Land.\" See the limestone karsts and rice fields from the water.\n- **Lunch:** Enjoy a local meal at a riverside restaurant.\n- **Afternoon:** Visit Bich Dong Pagoda on a short hike up the mountain for great views.\n- **Evening:** Return to your hotel and relax.\n\n**Day 2: History and Scenery**\n- **Morning:** Bike tour around the countryside visiting local villages and markets.\n- **Lunch:** Picnic lunch in the countryside.\n- **Afternoon:** Continue your bike tour to Hoa Lu, the ancient capital, and explore the temples dedicated to King Dinh and King Le.\n- **Evening:** Dinner at a local restaurant specializing in Ninh Binh's cuisine.\n\n**Day 3: Nature and Exploration**\n- **Morning:** Visit the Trang An Scenic Landscape complex and take another boat tour through caves and alongside ancient ruins.\n- **Lunch:** Lunch in Trang An area.\n- **Afternoon:** Hike up to Hang Mua for panoramic views of Ninh Binh.\n- **Evening:** Return to your accommodation and relax.\n\n### Ho Chi Minh City (3 Days)\n\n**Day 1: Modern Meets History**\n- **Morning:** Visit the Independence Palace and the nearby Notre Dame Cathedral.\n- **Lunch:** Lunch at a local restaurant trying southern Vietnamese specialties.\n- **Afternoon:** Guided tour of the War Remnants Museum to understand the profound impacts of the Vietnam War.\n- **Evening:** Explore the vibrant Ben Thanh Market and dinner at a local eatery.\n\n**Day 2: Cultural Dive**\n- **Morning:** Visit the historical district of Cho Lon (Chinatown) and Thien Hau Temple.\n- **Lunch:** Try dim sum in Chinatown.\n- **Afternoon:** Visit the Jade Emperor Pagoda and then the Museum of Vietnamese History.\n- **Evening:** Discover local music at a caf\u00e9 or bar featuring live performances.\n\n**Day 3: Day at Leisure**\n- **Morning:** Free time for last-minute shopping or relaxation.\n- **Lunch:** Lunch at a caf\u00e9.\n- **Afternoon:** Visit a local art gallery or take a leisurely stroll through a city park.\n- **Evening:** Rooftop dinner enjoying cityscape views.\n\n### Con Dao Islands (5 Days)\n\n**Day 1: Arrival and Relaxation**\n- **Arrive** at Con Dao, check into your resort.\n- **Afternoon:** Beach relaxation.\n- **Evening:** Casual dinner at the resort.\n\n**Day 2: Historical Insights**\n- **Morning:** Visit the old prison complex to learn about its historical importance.\n- **Lunch:** Lunch at a local eatery.\n- **Afternoon:** Continue exploring the island\u2019s historical sites.\n- **Evening:** Sunset at a quiet beach.\n\n**Day 3: Nature Exploration**\n- **Morning:** Guided hike in Con Dao National Park, exploring its flora and fauna.\n- **Lunch:** Picnic lunch during the hike.\n- **Afternoon:** Continue your exploration of the national park.\n- **Evening:** Dinner at a local restaurant.\n\n**Day 4: Marine Life**\n- **Morning:** Snorkeling trip to see coral reefs and marine life.\n- **Lunch:** Lunch on board or a beach picnic.\n- **Afternoon:** More snorkeling or free time on a secluded beach.\n- **Evening:**"
+      ]
+     },
+     "create_time": 1712999127.826713,
+     "end_turn": false,
+     "id": "69f6e0eb-c2f1-4929-8b09-01785107b98c",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "type": "max_tokens"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAAAA",
+      "parent_id": "aaa26f5a-756b-4892-b055-fe44dd3d7e1d",
+      "request_id": "873a4a2e2bb7691d-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa26f5a-756b-4892-b055-fe44dd3d7e1d"
+   },
+   "71860caa-c3b6-45c0-b2a9-bf0e21c398c2": {
+    "children": [
+     "aaa26eef-cf99-403a-afec-80a1ee37244f"
+    ],
+    "id": "71860caa-c3b6-45c0-b2a9-bf0e21c398c2",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Given your preferences for a tranquil beach stay, a visit to Hanoi, and an immersion into nature with a focus on jungle or mountain landscapes, here\u2019s a tailored itinerary that fits within a 4-destination framework:\n\n### 1. Hanoi (3 Days) - Culture and Food\nBegin your journey in Hanoi to soak up the rich cultural heritage and culinary delights of Vietnam's capital. The city offers a fascinating mix of East and West, ancient history, and modern development.\n\n**Activities:**\n- Explore the Old Quarter and French Quarter.\n- Visit the Temple of Literature and Hoan Kiem Lake.\n- Enjoy a traditional water puppet show.\n- Sample local dishes such as pho, bun cha, and egg coffee.\n\n### 2. Ninh Binh (2 Days) - Nature and Culture\nAfter Hanoi, head to Ninh Binh, often referred to as \"Ha Long Bay on Land,\" for its stunning limestone karst landscapes and serene rivers. It's about a 2-hour drive from Hanoi.\n\n**Activities:**\n- Boat ride through Trang An Scenic Landscape Complex, a UNESCO World Heritage Site.\n- Visit the ancient capital of Hoa Lu.\n- Bicycle around rice paddies and limestone mountains.\n- Climb up to Mua Cave for a panoramic view.\n\n### 3. Phong Nha - Ke Bang National Park (3 Days) - Nature\nFor your nature and adventure fix, Phong Nha - Ke Bang National Park, a UNESCO World Heritage site, offers breathtaking jungle and mountain scenery, extensive cave systems, and is about a 7-hour drive from Ninh Binh.\n\n**Activities:**\n- Explore the Phong Nha and Paradise Caves.\n- Boat tour on the Son River to Phong Nha Cave.\n- Jungle trekking and ziplining at the Dark Cave.\n- Visit the Botanic Garden and enjoy a swim in a natural pool.\n\n### 4. Con Dao Islands (5 Days) - Beach\nFinish your trip with a peaceful retreat to the Con Dao Islands, renowned for their pristine beaches, clear waters, and relaxed atmosphere. Fly from Dong Hoi (nearest airport to Phong Nha) to Ho Chi Minh City, then catch a connecting flight to Con Dao.\n\n**Activities:**\n- Relax on the tranquil beaches of Dam Trau Beach and Bai Nhat.\n- Snorkeling and diving to explore the vibrant coral reefs.\n- Hiking in Con Dao National Park.\n- Learn about the island's history at the Con Dao Museum and historical prison sites.\n\nThis itinerary offers a comprehensive experience of Vietnam, from the cultural richness of Hanoi to the breathtaking natural beauty of Ninh Binh and Phong Nha - Ke Bang National Park, culminating in a serene beach stay on the Con Dao Islands. It balances exploration and relaxation, ensuring a memorable journey through some of Vietnam's most captivating landscapes."
+      ]
+     },
+     "create_time": 1712874599.775805,
+     "end_turn": true,
+     "id": "71860caa-c3b6-45c0-b2a9-bf0e21c398c2",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAA",
+      "parent_id": "aaa29406-ea20-4792-a40f-e0fc09cf1fd5",
+      "request_id": "872e6a916b19692a-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa29406-ea20-4792-a40f-e0fc09cf1fd5"
+   },
+   "73beebbe-1789-4d5f-b9cc-7017531cd16c": {
+    "children": [
+     "aaa23073-c587-4433-8130-af734ee4f565"
+    ],
+    "id": "73beebbe-1789-4d5f-b9cc-7017531cd16c",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Traveling efficiently between your chosen destinations in Vietnam, starting and ending your journey in Lisbon, Portugal, requires strategic use of domestic flights and ground transportation within Vietnam. Here\u2019s how you can navigate between Hanoi, Ninh Binh, Phong Nha - Ke Bang National Park, and the Con Dao Islands, with a focus on saving time:\n\n### Lisbon to Hanoi\n- **International Flight:** Your journey will start with an international flight from Lisbon (LIS) to Hanoi (HAN). This will likely involve at least one layover, as there are no direct flights from Lisbon to Hanoi. Common layover airports include cities in Europe (e.g., Frankfurt, Paris) or the Middle East (e.g., Doha, Dubai).\n\n### Hanoi to Ninh Binh\n- **By Train or Bus:** From Hanoi, Ninh Binh is easily accessible by train or bus, both options offer a scenic route. The journey takes approximately 1.5 to 2 hours by train, which can be both a comfortable and efficient way to travel. Buses also frequently ply this route, potentially offering more departure times.\n\n### Ninh Binh to Phong Nha - Ke Bang National Park\n- **By Train/Bus to Dong Hoi, Then Taxi:** There\u2019s no direct flight between Ninh Binh and Dong Hoi (the nearest city to Phong Nha). The best route is to take a train or bus from Ninh Binh to Dong Hoi, which takes about 6 to 8 hours by train. From Dong Hoi, you can take a taxi or a shuttle bus to Phong Nha, which takes about 45 minutes to 1 hour.\n\n### Phong Nha to Con Dao Islands\n1. **Taxi/Bus to Dong Hoi Airport:** Return to Dong Hoi to catch a flight. The journey back to the airport from Phong Nha takes about 45 minutes to 1 hour.\n2. **Flight to Ho Chi Minh City (SGN):** Fly from Dong Hoi (VDH) to Ho Chi Minh City. This is the segment where you'll likely find several flight options.\n3. **Flight from Ho Chi Minh City to Con Dao:** From Ho Chi Minh City, take a domestic flight to Con Dao (VCS). The flight duration is about 1 hour.\n\n### Con Dao Islands to Lisbon\n- **Flight Back to Ho Chi Minh City, Then International Flight:** From Con Dao, you\u2019ll fly back to Ho Chi Minh City. From there, you\u2019ll board an international flight back to Lisbon. This will likely involve at least one layover, similar to your inbound journey, possibly in a European or Middle Eastern hub.\n\n### Tips for Efficient Travel:\n- **Book in Advance:** Especially for the domestic flights within Vietnam and the international legs, booking in advance can secure better rates and ensure availability.\n- **Check for Layovers:** For the longer international flights, consider the layover times and locations carefully to minimize waiting times and ensure a comfortable journey.\n- **Private Transfers:** For ground transportation, especially to and from airports or between locations without direct flights, consider booking private transfers for ease and time efficiency.\n\nThis itinerary maximizes your time across different Vietnamese landscapes and ensures a seamless travel experience from Lisbon and back, incorporating cultural, natural, and beach experiences in Vietnam."
+      ]
+     },
+     "create_time": 1712874728.604263,
+     "end_turn": true,
+     "id": "73beebbe-1789-4d5f-b9cc-7017531cd16c",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "parent_id": "aaa26eef-cf99-403a-afec-80a1ee37244f",
+      "request_id": "872e6d5c99b24894-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa26eef-cf99-403a-afec-80a1ee37244f"
+   },
+   "75782179-568a-4b1b-bfe4-2035834d22cf": {
+    "children": [
+     "aaa27e87-afb6-4a82-a582-9ca91a67bab3"
+    ],
+    "id": "75782179-568a-4b1b-bfe4-2035834d22cf",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Certainly! Sticking with Con Dao for your tranquil island experience and combining it with your other chosen destinations, here\u2019s a concise itinerary including transportation details:\n\n### From Lisbon to Vietnam Itinerary\n\n1. **Lisbon to Hanoi**\n   - **Transportation:** Take a flight from Lisbon to Hanoi. This will generally involve at least one layover, possibly in Europe (like Frankfurt or Paris) or the Middle East (like Doha or Dubai).\n\n2. **Hanoi (3 Days)**\n   - **Activities:** Explore the cultural landmarks, such as the Old Quarter, Hoan Kiem Lake, and the Temple of Literature.\n   - **Transportation in City:** Taxis, ride-hailing apps (like Grab), or public transport are convenient for getting around Hanoi.\n\n3. **Ninh Binh (3 Days)**\n   - **Transportation to Ninh Binh:** A 2-hour drive by car or bus from Hanoi.\n   - **Activities:** Cycle through the countryside, take boat tours in Tam Coc, visit the Trang An Scenic Landscape, and explore historical sites like Hoa Lu.\n\n4. **Ho Chi Minh City (3 Days)**\n   - **Transportation to Ho Chi Minh City:** Fly from Hanoi to Ho Chi Minh City, with frequent flights available daily.\n   - **Activities:** Discover the dynamic city by visiting sites like the War Remnants Museum, Notre Dame Cathedral, and enjoy the food scene and markets.\n\n5. **Con Dao Islands (5 Days)**\n   - **Transportation to Con Dao:** Take a flight from Ho Chi Minh City to Con Dao. Flights are available but less frequent than to major cities, so booking in advance is recommended.\n   - **Activities:** Relax on the beaches, engage in snorkeling or diving, explore the national park, and visit historical sites related to the island's use as a prison.\n\n6. **Return to Lisbon**\n   - **Transportation:** Fly back from Con Dao to Ho Chi Minh City. From there, catch your international flight back to Lisbon, typically involving a layover as on the outbound journey.\n\nThis itinerary provides a balanced mix of urban exploration, cultural immersion, rural adventure, and tranquil beach relaxation, with clear transportation links to ensure a smooth journey through Vietnam."
+      ]
+     },
+     "create_time": 1712996793.701345,
+     "end_turn": true,
+     "id": "75782179-568a-4b1b-bfe4-2035834d22cf",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAAAA",
+      "parent_id": "aaa250f8-6fa2-490b-859e-fff37d73725d",
+      "request_id": "873a11cb4fad03b6-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa250f8-6fa2-490b-859e-fff37d73725d"
+   },
+   "7a47de31-df16-4d54-98bf-a39fc206cd08": {
+    "children": [
+     "aaa277bd-6925-4b92-a57d-04864c9084a6"
+    ],
+    "id": "7a47de31-df16-4d54-98bf-a39fc206cd08",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Flying directly from Phu Quoc Island to Lisbon, Portugal, is not possible because there are no direct flights between these two locations. However, you can travel from Phu Quoc to Lisbon with one or more layovers, typically in major cities where airlines operate international flights connecting Asia to Europe.\n\nHere's a general outline of how you might structure this journey:\n\n1. **Phu Quoc to a Major Asian or Middle Eastern Hub:** First, you'd likely fly from Phu Quoc International Airport to a major transit hub. Common layover cities for flights from Southeast Asia to Europe include Doha (Qatar), Dubai (UAE), Bangkok (Thailand), Singapore, or Hanoi/Ho Chi Minh City (Vietnam) where you can catch a connecting flight to Europe.\n\n2. **Layover to Lisbon:** From your layover city, you would then catch a connecting flight to Lisbon (Lisbon Humberto Delgado Airport, LIS). Some European hubs that frequently offer connections to Lisbon include Frankfurt, Amsterdam, Paris, and London.\n\n### Steps for Booking:\n\n- **Search on Airline Websites or Travel Aggregators:** Use airline booking sites or travel aggregators to find routes with the least layover time or most convenient departure/arrival times. Sites like Google Flights, Skyscanner, or Kayak allow you to compare different airlines and itineraries.\n- **Consider Nearby Airports:** Depending on flight availability and prices, it might be more efficient or cost-effective to first travel to a nearby airport with more flight options (e.g., Ho Chi Minh City or Hanoi) and then proceed to Lisbon.\n- **Check Visa Requirements:** For layovers, especially in the Middle East or other Asian countries, check if you need a transit visa.\n\nRemember to book your flights well in advance, as multi-leg international trips can vary significantly in price and availability closer to the departure date. Additionally, it's wise to account for extra layover time when booking connecting flights to handle any delays and ensure a smoother travel experience."
+      ]
+     },
+     "create_time": 1712873503.131063,
+     "end_turn": true,
+     "id": "7a47de31-df16-4d54-98bf-a39fc206cd08",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "parent_id": "aaa28f15-7ff9-429e-b21c-637d88b8a3ba",
+      "request_id": "872e50017d4048a0-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa28f15-7ff9-429e-b21c-637d88b8a3ba"
+   },
+   "8812a5df-62f8-4521-9d57-d166621e5ea1": {
+    "children": [
+     "aaa24570-50f4-49fa-bdd7-c9d8f265ed78"
+    ],
+    "id": "8812a5df-62f8-4521-9d57-d166621e5ea1",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Got it, let's delve into more details about each of the original destinations within Vietnam, highlighting their unique aspects and what makes them special:\n\n### Hanoi\nThe capital city of Vietnam, Hanoi, is known for its centuries-old architecture and a rich culture with Southeast Asian, Chinese, and French influences. At its heart is the chaotic Old Quarter, where the narrow streets are roughly arranged by trade. There are many little temples, including Bach Ma, honoring a legendary horse, plus \u0110\u1ed3ng Xu\u00e2n Market, selling household goods and street food. Key attractions include the Hoan Kiem Lake, the Hanoi Opera House, and the Temple of Literature. Hanoi's cuisine is renowned worldwide, with local specialties like Pho Bo (beef noodle soup) and caf\u00e9 tr\u1ee9ng (egg coffee).\n\n### Ha Long Bay\nHa Long Bay is a UNESCO World Heritage site and one of the world's most spellbinding sea views, known for its crystal-clear waters emerald green against over 1,600 limestone islands and islets. Most of these are uninhabited and untouched by humans. Taking a cruise is the best way to experience the bay's surreal beauty, including visiting caves like Thien Cung Cave, kayaking, and seeing floating villages. Ha Long Bay isn't just a visual delight; it offers insights into local life on the water and the natural processes that created such a unique landscape.\n\n### Hoi An\nHoi An is a beautifully preserved example of a Southeast Asian trading port dating from the 15th to the 19th century. Its buildings and street plan reflect the influences, both indigenous and foreign, that have combined to produce this unique heritage site. The heart of Hoi An is its Historic District, a wonderfully well-preserved example of a Southeast Asian trading port. It's also known for its diverse culinary scene, which includes dishes like Cao Lau (a type of noodle that can only be made with water from the local wells) and Banh Mi Hoi An. The city is also famous for its tailors, who can make custom clothes in a matter of hours.\n\n### Phu Quoc Island\nPhu Quoc is Vietnam's largest island and a rising star on the travel circuit due to its stunning beaches, crystal clear waters, and peaceful tropical vibes. It's part of the Kien Giang Biosphere Conservation Area, which is recognized by UNESCO. Phu Quoc is known for producing some of the world's best fish sauce, a key ingredient in Vietnamese cuisine. The island also offers experiences like snorkeling and scuba diving around the coral reefs, visiting a pearl farm, and exploring the Phu Quoc National Park that covers more than half of the island. For relaxation, Sao Beach and Long Beach are perfect with their white sands and turquoise waters.\n\nEach of these destinations offers a unique glimpse into Vietnam's diverse landscape, from urban exploration in Hanoi and the natural wonders of Ha Long Bay to the cultural immersion in Hoi An and the idyllic beaches of Phu Quoc Island. Together, they form a comprehensive Vietnamese travel experience that spans history, culture, nature, and relaxation."
+      ]
+     },
+     "create_time": 1712874221.971025,
+     "end_turn": true,
+     "id": "8812a5df-62f8-4521-9d57-d166621e5ea1",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAAAAAA",
+      "parent_id": "aaa24dcd-cd32-498b-a208-ec21f85ed747",
+      "request_id": "872e614e3a0803de-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa24dcd-cd32-498b-a208-ec21f85ed747"
+   },
+   "88f0f8c3-5e1f-4441-b965-e5bb971ea696": {
+    "children": [
+     "c540440e-91e2-4252-8ca3-9ba4e653fc88"
+    ],
+    "id": "88f0f8c3-5e1f-4441-b965-e5bb971ea696",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1712999302.738921,
+     "end_turn": true,
+     "id": "88f0f8c3-5e1f-4441-b965-e5bb971ea696",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-4",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "ad28f582-abda-49a7-8838-1cbd71000f2e",
+      "rebase_system_message": true,
+      "request_id": "873a4f6caf8203b6-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "ad28f582-abda-49a7-8838-1cbd71000f2e"
+   },
+   "973372d8-cddf-4db0-8191-3ec22943b2f6": {
+    "children": [
+     "aaa27683-45d9-485b-910a-ba3435784f7b"
+    ],
+    "id": "973372d8-cddf-4db0-8191-3ec22943b2f6",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Certainly! Here's the revised itinerary for your trip from Lisbon, incorporating Hanoi, an extended stay in Ninh Binh, followed by Ho Chi Minh City, and concluding with relaxation in the Con Dao Islands:\n\n### From Lisbon to Vietnam Itinerary\n\n1. **Lisbon to Hanoi**\n   - Direct or connecting flight from Lisbon to Hanoi.\n\n2. **Hanoi (2-3 Days)**\n   - Explore the city's rich history and vibrant culture.\n   - Visit landmarks like the Hoan Kiem Lake, the Old Quarter, and the Temple of Literature.\n   - Enjoy Hanoi's famous street food and coffee culture.\n\n3. **Ninh Binh (2-3 Days)**\n   - Transfer from Hanoi to Ninh Binh (around 2 hours by car or bus).\n   - Spend your days cycling through the countryside, exploring the limestone karsts, and taking boat tours in Tam Coc or Trang An.\n   - Visit historical sites like the ancient capital of Hoa Lu and the Bai Dinh Pagoda.\n\n4. **Ho Chi Minh City (2-3 Days)**\n   - Fly from Hanoi to Ho Chi Minh City.\n   - Discover the dynamic city, visiting the War Remnants Museum, Notre Dame Cathedral, and Ben Thanh Market.\n   - Explore the city's modern and colonial architecture, and savor the southern Vietnamese cuisine.\n\n5. **Con Dao Islands (5 Days)**\n   - Fly from Ho Chi Minh City to the Con Dao Islands.\n   - Enjoy serene beaches, snorkeling, and exploring the national park.\n   - Visit historical sites related to the island's use as a prison during the French colonial era and the Vietnam War.\n\n6. **Return to Lisbon**\n   - Fly back from the Con Dao Islands to Ho Chi Minh City.\n   - Catch your return flight from Ho Chi Minh City to Lisbon, potentially with a layover.\n\nThis itinerary focuses on giving you a comprehensive experience of Vietnam's culture, nature, and history, from the bustling cities of Hanoi and Ho Chi Minh City to the serene landscapes of Ninh Binh and the idyllic beaches of the Con Dao Islands."
+      ]
+     },
+     "create_time": 1712877263.507961,
+     "end_turn": true,
+     "id": "973372d8-cddf-4db0-8191-3ec22943b2f6",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAAAAAAAA",
+      "parent_id": "aaa2a65b-5bb8-4d3d-85ea-86620d5fcc2a",
+      "request_id": "872eabb3a94f9500-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa2a65b-5bb8-4d3d-85ea-86620d5fcc2a"
+   },
+   "9da28b45-3e3a-4fb6-b138-13010d67b5de": {
+    "children": [
+     "50c3d9fa-8344-42a2-8f1e-10ad6a436079"
+    ],
+    "id": "9da28b45-3e3a-4fb6-b138-13010d67b5de",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1712994980.315276,
+     "end_turn": true,
+     "id": "9da28b45-3e3a-4fb6-b138-13010d67b5de",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-4",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "aaa2ac7a-b1c9-482a-bdd9-2c5f75e41dc2",
+      "rebase_system_message": true,
+      "request_id": "8739e56a8f643392-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "aaa2ac7a-b1c9-482a-bdd9-2c5f75e41dc2"
+   },
+   "a1ddd896-cb69-48af-93d5-4eaedfd2ae70": {
+    "children": [],
+    "id": "a1ddd896-cb69-48af-93d5-4eaedfd2ae70",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Yes, that's correct! Ninh Binh is famous for its beautiful rural landscapes, which include lush rice fields and opportunities for cycling. It offers a serene and picturesque setting that's quite distinct from the marine karst landscape of Ha Long Bay. Here\u2019s a bit more about what makes Ninh Binh special:\n\n### Rice Fields\n- The rice fields in Ninh Binh are particularly stunning, especially when they turn golden before the harvest season. The area around Tam Coc and Trang An is dotted with rice paddies, with limestone karsts towering in the background, creating breathtaking scenery.\n\n### Cycling\n- Cycling is a popular activity in Ninh Binh, allowing visitors to meander through villages, alongside rivers, and around the rice paddies at a leisurely pace. It's an excellent way to experience the local landscape and rural life up close. Many guesthouses and tour operators in Ninh Binh offer bicycles for rent.\n\n### Boat Tours\n- Besides cycling, Ninh Binh is well-known for its boat tours, especially in the Tam Coc and Trang An areas. These boat tours take you through caves and along rivers bordered by limestone cliffs, offering another perspective of the region\u2019s natural beauty.\n\n### Cultural and Historical Sites\n- In addition to natural beauty, Ninh Binh is home to significant cultural and historical sites, such as the ancient capital of Hoa Lu and the Bai Dinh Pagoda, one of the largest pagodas in Vietnam.\n\nGiven these features, Ninh Binh presents a blend of natural, cultural, and historical attractions, making it a versatile destination that offers more than just the limestone karst scenery similar to Ha Long Bay. The opportunity to explore rice fields and enjoy cycling adds a different dimension to your Vietnam experience, contributing to the diversity of your trip."
+      ]
+     },
+     "create_time": 1712877086.904816,
+     "end_turn": true,
+     "id": "a1ddd896-cb69-48af-93d5-4eaedfd2ae70",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAAAA",
+      "parent_id": "aaa23589-5b83-4625-bceb-4207684e55ec",
+      "request_id": "872ea760dc9e33e9-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa23589-5b83-4625-bceb-4207684e55ec"
+   },
+   "a2345daf-a839-4579-85ed-256b4aeab46d": {
+    "children": [
+     "aaa29c47-7e4a-4c9d-9023-39d7e3424cb7"
+    ],
+    "id": "a2345daf-a839-4579-85ed-256b4aeab46d",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Given your starting point in Lisbon and the desire to streamline your travel, the ideal itinerary would depend on direct flight availability and ease of travel between your destinations in Vietnam. Generally, there are no direct flights from Lisbon to either Hanoi or Ho Chi Minh City, and similarly, direct international flights from the Con Dao Islands are not available. You would typically fly back from either Hanoi or Ho Chi Minh City to Lisbon, often with a layover. Here's a simplified itinerary considering typical flight routes and your destination preferences:\n\n### If Starting in Hanoi (Assuming Easier Flights from Lisbon)\n1. **Lisbon \u2192 Hanoi:** Start your Vietnam journey in Hanoi, as it's a great opening into Vietnam's culture and history.\n2. **Hanoi \u2192 Ninh Binh:** Easy overland travel, perfect for a short stay to experience \"Ha Long Bay on Land.\"\n3. **Ninh Binh \u2192 Hanoi \u2192 Ho Chi Minh City:** Return to Hanoi for a domestic flight to Ho Chi Minh City, exploring the south.\n4. **Ho Chi Minh City \u2192 Con Dao Islands:** Domestic flight to the islands for beach time.\n5. **Con Dao Islands \u2192 Ho Chi Minh City \u2192 Lisbon:** Fly back to Ho Chi Minh City to catch your international flight home.\n\n### If Starting in Ho Chi Minh City (Depending on Flight Options)\n1. **Lisbon \u2192 Ho Chi Minh City:** Begin in the south to experience Vietnam's dynamic urban life and history.\n2. **Ho Chi Minh City \u2192 Con Dao Islands:** Head to the islands early in your trip for relaxation.\n3. **Con Dao Islands \u2192 Ho Chi Minh City \u2192 Hanoi:** Fly back to Ho Chi Minh and then to Hanoi, moving northward.\n4. **Hanoi \u2192 Ninh Binh:** Overland trip to Ninh Binh for its natural beauty.\n5. **Ninh Binh \u2192 Hanoi \u2192 Lisbon:** Return to Hanoi for your flight back to Lisbon, possibly with a layover.\n\n### Notes:\n- **Flights:** Check both routes (Lisbon to Hanoi and Lisbon to Ho Chi Minh City) for any direct flight options or those with the most convenient layover. Flight availability and prices can vary, so it's wise to book well in advance.\n- **Con Dao Islands:** Since you can't fly directly international from Con Dao, you'll return to either Hanoi or Ho Chi Minh City for your international flight back to Lisbon.\n- **Flexibility:** The choice between starting in Hanoi or Ho Chi Minh City might also depend on flight deals, direct flight availability to either city from Lisbon, and your preference for ending the trip with city exploration or beach relaxation.\n\nThis simplified itinerary with \"arrows\" should provide a clear travel path considering your requirements and the typical flight patterns from Lisbon to Vietnam."
+      ]
+     },
+     "create_time": 1712876198.950794,
+     "end_turn": true,
+     "id": "a2345daf-a839-4579-85ed-256b4aeab46d",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAAAAAAA",
+      "parent_id": "aaa2e7a6-cbf5-4520-a871-98cfd5d03244",
+      "request_id": "872e918fef7748a7-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa2e7a6-cbf5-4520-a871-98cfd5d03244"
+   },
+   "a2ef26d8-1bc3-437d-8502-69bc318cabd8": {
+    "children": [
+     "3618bb1e-d256-4c3b-a0fc-ca649901559a"
+    ],
+    "id": "a2ef26d8-1bc3-437d-8502-69bc318cabd8",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1712877002.448473,
+     "end_turn": true,
+     "id": "a2ef26d8-1bc3-437d-8502-69bc318cabd8",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-4",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "aaa2c5b3-676b-47db-b3b6-19e0c5fc6d28",
+      "rebase_system_message": true,
+      "request_id": "872ea4c98a04691c-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "aaa2c5b3-676b-47db-b3b6-19e0c5fc6d28"
+   },
+   "a6db3a86-2ad1-420b-bd3e-58124539d009": {
+    "children": [],
+    "id": "a6db3a86-2ad1-420b-bd3e-58124539d009",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Yes, visiting both Hanoi and Ho Chi Minh City is worth it, as each city offers distinct experiences, reflecting the diversity of Vietnam's cultural, historical, and social fabric. Despite both being bustling metropolises, their differences make each visit unique and enriching.\n\n### Hanoi - The Capital\nHanoi, the capital city of Vietnam, carries a profound sense of tradition and history. It's known for its centuries-old architecture, a rich cultural heritage that seamlessly blends Southeast Asian, Chinese, and French influences, and a slower, more measured pace of life compared to Ho Chi Minh City. Hanoi serves as a gateway to the northern regions of Vietnam, including Ha Long Bay and Sapa.\n\n**Key Experiences in Hanoi:**\n- The Old Quarter\u2019s narrow streets are lined with shops, boutiques, and cafes in well-preserved colonial buildings.\n-"
+      ]
+     },
+     "create_time": 1712875611.406822,
+     "end_turn": null,
+     "id": "a6db3a86-2ad1-420b-bd3e-58124539d009",
+     "metadata": {
+      "can_save": false,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "gizmo_id": null,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAA",
+      "parent_id": "ecbb0d9d-55c9-4e38-bc5b-ac5e37a01f09",
+      "request_id": "872e83726916692f-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "in_progress",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "ecbb0d9d-55c9-4e38-bc5b-ac5e37a01f09"
+   },
+   "aa1c876f-5acd-4468-8cb2-4cfbd2751839": {
+    "children": [
+     "aaa29406-ea20-4792-a40f-e0fc09cf1fd5"
+    ],
+    "id": "aa1c876f-5acd-4468-8cb2-4cfbd2751839",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "If peace and quiet are important to you, adjusting your itinerary to include destinations that are less crowded yet still offer rich cultural experiences, beautiful nature, and relaxing beaches is a good idea. Here\u2019s a modified itinerary that maintains a balance of food, culture, nature, and beach, but aims for more tranquility:\n\n### 1. Ninh Binh (2-3 Days) - Nature and Culture\n**Why:** Often referred to as \u201cHa Long Bay on Land,\u201d Ninh Binh offers stunning landscapes of limestone karsts and rivers but is less crowded. It's a place where you can enjoy serene boat rides, explore ancient temples, and cycle through lush rice paddies.\n\n**Activities:**\n- Take a boat tour in Trang An, a UNESCO World Heritage site.\n- Visit the ancient capital of Hoa Lu.\n- Explore the Tam Coc rice fields on a bicycle.\n- Climb up to the Mua Cave viewpoint.\n\n### 2. Quy Nhon (3-4 Days) - Beach and Nature\n**Why:** Quy Nhon is a coastal city known for its beautiful beaches and laid-back atmosphere. It\u2019s less commercialized than other beach destinations in Vietnam, offering travelers serene beaches, cultural sites, and delicious seafood without the crowds.\n\n**Activities:**\n- Relax on Ky Co Beach and Bai Xep Beach.\n- Visit the Thap Doi (Twin Towers), ancient remnants of the Champa civilization.\n- Explore the nearby Eo Gio, a stunning coastal area with clear blue waters.\n\n### 3. Dalat (3 Days) - Nature and Culture\n**Why:** Situated in the Central Highlands, Dalat is known for its cool climate, French colonial architecture, and lush landscapes. It\u2019s a peaceful retreat away from Vietnam's urban hustle, ideal for those who enjoy nature and want to explore the outdoors in a quieter setting.\n\n**Activities:**\n- Visit the Valley of Love and Xuan Huong Lake for leisurely walks.\n- Explore the Dalat Flower Gardens.\n- Check out the Crazy House, a unique and whimsical guesthouse.\n- Enjoy the waterfalls around Dalat, like Elephant Falls and Datanla Falls.\n\n### 4. Con Dao Islands (3-4 Days) - Beach and Nature\n**Why:** The Con Dao Islands are a group of 16 mostly uninhabited islands and islets, offering some of Vietnam's best wildlife watching, hiking, and beach experiences. The islands are noted for their coral reefs, marine life, and beautiful beaches, providing a tranquil and secluded getaway.\n\n**Activities:**\n- Snorkel or dive to explore the coral reefs.\n- Relax on Dam Trau Beach, one of the island\u2019s most beautiful beaches.\n- Visit the Con Dao National Park for hiking and wildlife spotting.\n- Learn about the island's history at the Con Dao Museum and the notorious prison.\n\nThis revised itinerary focuses on locations that are generally less frequented by mass tourism, providing a balance between relaxation and exploration while still offering a rich experience of Vietnam's diverse landscapes and cultural heritage."
+      ]
+     },
+     "create_time": 1712874439.44627,
+     "end_turn": true,
+     "id": "aa1c876f-5acd-4468-8cb2-4cfbd2751839",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAAAAAAAAAA",
+      "parent_id": "aaa24570-50f4-49fa-bdd7-c9d8f265ed78",
+      "request_id": "872e6630bd1d692c-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa24570-50f4-49fa-bdd7-c9d8f265ed78"
+   },
+   "aaa1d2b4-167e-4b41-8d90-f1c88655253b": {
+    "children": [
+     "0be20503-5d9d-437f-8029-41ea4173bc05"
+    ],
+    "id": "aaa1d2b4-167e-4b41-8d90-f1c88655253b",
+    "message": null,
+    "parent": null
+   },
+   "aaa202b4-367e-436f-896a-ed5a6763b423": {
+    "children": [
+     "1e6fe622-71dc-4147-94e0-497243e5a620"
+    ],
+    "id": "aaa202b4-367e-436f-896a-ed5a6763b423",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Will I find good, boutique resorts in the islands?"
+      ]
+     },
+     "create_time": 1712874959.042966,
+     "end_turn": null,
+     "id": "aaa202b4-367e-436f-896a-ed5a6763b423",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872e73eb69b16914-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "206bb049-c53c-4f99-badc-53d75fc420f2"
+   },
+   "aaa22836-39ee-46fd-aa87-103c8a325817": {
+    "children": [
+     "0fcc6234-c2cb-42bf-8c72-533b3ce07d83"
+    ],
+    "id": "aaa22836-39ee-46fd-aa87-103c8a325817",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Complete itinerary considering I'm in Lisbon "
+      ]
+     },
+     "create_time": 1712876113.965881,
+     "end_turn": null,
+     "id": "aaa22836-39ee-46fd-aa87-103c8a325817",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872e901b2f09693b-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "e3e1a75e-a62d-4102-8e91-ee7e81a36ef5"
+   },
+   "aaa23073-c587-4433-8130-af734ee4f565": {
+    "children": [
+     "206bb049-c53c-4f99-badc-53d75fc420f2"
+    ],
+    "id": "aaa23073-c587-4433-8130-af734ee4f565",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Ok. Summary of each location, please. And weather in late November."
+      ]
+     },
+     "create_time": 1712874822.180358,
+     "end_turn": null,
+     "id": "aaa23073-c587-4433-8130-af734ee4f565",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872e70910a0e48aa-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "73beebbe-1789-4d5f-b9cc-7017531cd16c"
+   },
+   "aaa232ca-d579-4419-9604-94c3199e26ba": {
+    "children": [
+     "fd17f87c-857a-40ef-869e-8c1d2b0c3238"
+    ],
+    "id": "aaa232ca-d579-4419-9604-94c3199e26ba",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Con Dao is much more my style. Any other island options I should consider?"
+      ]
+     },
+     "create_time": 1712995480.598322,
+     "end_turn": null,
+     "id": "aaa232ca-d579-4419-9604-94c3199e26ba",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "8739f252bc2e33e9-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "50c3d9fa-8344-42a2-8f1e-10ad6a436079"
+   },
+   "aaa23589-5b83-4625-bceb-4207684e55ec": {
+    "children": [
+     "a1ddd896-cb69-48af-93d5-4eaedfd2ae70"
+    ],
+    "id": "aaa23589-5b83-4625-bceb-4207684e55ec",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Nihn Bihn has the rice fields and biling, right m"
+      ]
+     },
+     "create_time": 1712877067.410575,
+     "end_turn": null,
+     "id": "aaa23589-5b83-4625-bceb-4207684e55ec",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872ea760dc9e33e9-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "3618bb1e-d256-4c3b-a0fc-ca649901559a"
+   },
+   "aaa23808-1e3f-4413-b447-4a72635a0642": {
+    "children": [
+     "46ef6f22-c1cd-4f26-8837-258763b9bfa6"
+    ],
+    "id": "aaa23808-1e3f-4413-b447-4a72635a0642",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Ok. So let's imagine I want to start my trip in Hanoi and end in Ho Chi Minh, or vice versa. I want to visit the islands for sure. But maybe I should choose between Ninh Binh and Phong Nha. What would you recommend, also considering spending less time traveling between locations."
+      ]
+     },
+     "create_time": 1712876000.404978,
+     "end_turn": null,
+     "id": "aaa23808-1e3f-4413-b447-4a72635a0642",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872e8d53cc3a94f5-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "fd842918-7db8-42b5-8704-c5990f4f9990"
+   },
+   "aaa23eb2-bbd3-4a89-a0f8-bb51678c1e5d": {
+    "children": [
+     "35eadf9d-527b-4e1b-b3e1-696eec5642d6"
+    ],
+    "id": "aaa23eb2-bbd3-4a89-a0f8-bb51678c1e5d",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Can you just list all locations by order?"
+      ]
+     },
+     "create_time": 1712876845.484855,
+     "end_turn": null,
+     "id": "aaa23eb2-bbd3-4a89-a0f8-bb51678c1e5d",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872ea1f7ec35691e-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "c02f8926-62b7-46e9-990b-477a2c1e1b83"
+   },
+   "aaa24570-50f4-49fa-bdd7-c9d8f265ed78": {
+    "children": [
+     "aa1c876f-5acd-4468-8cb2-4cfbd2751839"
+    ],
+    "id": "aaa24570-50f4-49fa-bdd7-c9d8f265ed78",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Are these locations too touristy? Peace and quiet are importante for us. Would you make any adjustments, still considering 3 to 4 locations and the requirements I set at the beginning?"
+      ]
+     },
+     "create_time": 1712874396.63132,
+     "end_turn": null,
+     "id": "aaa24570-50f4-49fa-bdd7-c9d8f265ed78",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872e6630bd1d692c-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "8812a5df-62f8-4521-9d57-d166621e5ea1"
+   },
+   "aaa24dcd-cd32-498b-a208-ec21f85ed747": {
+    "children": [
+     "8812a5df-62f8-4521-9d57-d166621e5ea1"
+    ],
+    "id": "aaa24dcd-cd32-498b-a208-ec21f85ed747",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "No, I mean from the original itinerary, with the 4 places in Vietnam. Lisbon is just where I'm coming from."
+      ]
+     },
+     "create_time": 1712874196.575655,
+     "end_turn": null,
+     "id": "aaa24dcd-cd32-498b-a208-ec21f85ed747",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872e614e3a0803de-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "51119a23-a15d-439b-9086-136dd06205f4"
+   },
+   "aaa250f8-6fa2-490b-859e-fff37d73725d": {
+    "children": [
+     "75782179-568a-4b1b-bfe4-2035834d22cf"
+    ],
+    "id": "aaa250f8-6fa2-490b-859e-fff37d73725d",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Ok, sticking to Con Dao.\nCan you summarize the itinerary with transportation from one place to another?"
+      ]
+     },
+     "create_time": 1712996770.476904,
+     "end_turn": null,
+     "id": "aaa250f8-6fa2-490b-859e-fff37d73725d",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "873a11cb4fad03b6-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "fd17f87c-857a-40ef-869e-8c1d2b0c3238"
+   },
+   "aaa259dc-d83f-4480-9892-9c26aa88a5cc": {
+    "children": [
+     "06fdc2bc-1a27-4ca9-88be-e514bff9532a"
+    ],
+    "id": "aaa259dc-d83f-4480-9892-9c26aa88a5cc",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "What is the best way to travel between these locations, saving time?"
+      ]
+     },
+     "create_time": 1712873388.748964,
+     "end_turn": null,
+     "id": "aaa259dc-d83f-4480-9892-9c26aa88a5cc",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872e4d954efd03f6-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "1548372f-de00-41c0-b8b2-90df3c0e1b6e"
+   },
+   "aaa261e4-7fa2-45db-9d70-5a2f3a9475ae": {
+    "children": [
+     "dc62a511-f0f0-40bc-99ed-7346dd04536c"
+    ],
+    "id": "aaa261e4-7fa2-45db-9d70-5a2f3a9475ae",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Nihn Bihn has the rice fields and biling, right?\n"
+      ]
+     },
+     "create_time": 1712877098.433108,
+     "end_turn": null,
+     "id": "aaa261e4-7fa2-45db-9d70-5a2f3a9475ae",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872ea81faee833e9-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "3618bb1e-d256-4c3b-a0fc-ca649901559a"
+   },
+   "aaa26eef-cf99-403a-afec-80a1ee37244f": {
+    "children": [
+     "73beebbe-1789-4d5f-b9cc-7017531cd16c"
+    ],
+    "id": "aaa26eef-cf99-403a-afec-80a1ee37244f",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Fastest way to travel between these locations? I'm flying in and flying back from Lisbon."
+      ]
+     },
+     "create_time": 1712874690.402281,
+     "end_turn": null,
+     "id": "aaa26eef-cf99-403a-afec-80a1ee37244f",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872e6d5c99b24894-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "71860caa-c3b6-45c0-b2a9-bf0e21c398c2"
+   },
+   "aaa26f5a-756b-4892-b055-fe44dd3d7e1d": {
+    "children": [
+     "2a96a6e7-d89e-4bbc-bedf-579b6f590eda",
+     "69f6e0eb-c2f1-4929-8b09-01785107b98c",
+     "03a90880-0983-492b-ae15-2de521aefbf9",
+     "ad28f582-abda-49a7-8838-1cbd71000f2e"
+    ],
+    "id": "aaa26f5a-756b-4892-b055-fe44dd3d7e1d",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Let's consider I'll do 3 full days in each location, except for the islands, where I'll do 5. Can you design a detailed daily itinerary? I'm interested in doing the food tour, cooking class, boa trip, bike ride,  war museum with guided tour, markets, prison visit, hiking and snorkeling."
+      ]
+     },
+     "create_time": 1712998993.520524,
+     "end_turn": null,
+     "id": "aaa26f5a-756b-4892-b055-fe44dd3d7e1d",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "873a4b487eb994e8-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "45fa9d60-8dce-4d36-ac2b-c107867e76fb"
+   },
+   "aaa27604-829b-41a9-8616-f37b4ecf78dd": {
+    "children": [
+     "ecbb0d9d-55c9-4e38-bc5b-ac5e37a01f09",
+     "329806dd-efc0-4e22-af97-78982ae39229"
+    ],
+    "id": "aaa27604-829b-41a9-8616-f37b4ecf78dd",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Should I still visit both Hanoi and Ho Chi Minh? Is it different or worth it?"
+      ]
+     },
+     "create_time": 1712875601.029346,
+     "end_turn": null,
+     "id": "aaa27604-829b-41a9-8616-f37b4ecf78dd",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872e85aad8456935-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "49159388-76c7-4f9a-8a2b-30a6aacf301d"
+   },
+   "aaa27683-45d9-485b-910a-ba3435784f7b": {
+    "children": [
+     "3fbfdd1e-ecb9-4dbb-8722-67e4dd2b9374"
+    ],
+    "id": "aaa27683-45d9-485b-910a-ba3435784f7b",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Just list of locations and days "
+      ]
+     },
+     "create_time": 1712877315.298725,
+     "end_turn": null,
+     "id": "aaa27683-45d9-485b-910a-ba3435784f7b",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872ead6cacf4343d-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "973372d8-cddf-4db0-8191-3ec22943b2f6"
+   },
+   "aaa277bd-6925-4b92-a57d-04864c9084a6": {
+    "children": [
+     "51119a23-a15d-439b-9086-136dd06205f4"
+    ],
+    "id": "aaa277bd-6925-4b92-a57d-04864c9084a6",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Can you tell me a little bit more about each place?"
+      ]
+     },
+     "create_time": 1712874158.837645,
+     "end_turn": null,
+     "id": "aaa277bd-6925-4b92-a57d-04864c9084a6",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872e605eab3903de-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "7a47de31-df16-4d54-98bf-a39fc206cd08"
+   },
+   "aaa27e87-afb6-4a82-a582-9ca91a67bab3": {
+    "children": [
+     "5b4d8829-34ae-487a-a1ae-a637f4a75c72"
+    ],
+    "id": "aaa27e87-afb6-4a82-a582-9ca91a67bab3",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "What will be the flight durations?"
+      ]
+     },
+     "create_time": 1712998111.539746,
+     "end_turn": null,
+     "id": "aaa27e87-afb6-4a82-a582-9ca91a67bab3",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "873a32899b5694ee-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "75782179-568a-4b1b-bfe4-2035834d22cf"
+   },
+   "aaa283cc-c29a-416a-a067-c07d7989528c": {
+    "children": [
+     "d2a8614a-749e-4c92-939d-dc3dd619b36c"
+    ],
+    "id": "aaa283cc-c29a-416a-a067-c07d7989528c",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "What should I know generally about traveling to Vietnam?"
+      ]
+     },
+     "create_time": 1712875191.718182,
+     "end_turn": null,
+     "id": "aaa283cc-c29a-416a-a067-c07d7989528c",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872e799688dd94ef-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "3ade3546-9d0f-42aa-9209-ad28ac320567"
+   },
+   "aaa28b1f-6c54-440e-9d17-b75ec69fcc70": {
+    "children": [
+     "3ade3546-9d0f-42aa-9209-ad28ac320567"
+    ],
+    "id": "aaa28b1f-6c54-440e-9d17-b75ec69fcc70",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Ok. What about budget? How much should I expect to spend per day for a couple? In the first 3 locations we're likely going with low to mid range, just a room with private bathroom and good cleanings. For the islands, resort, but not luxury. "
+      ]
+     },
+     "create_time": 1712875089.518183,
+     "end_turn": null,
+     "id": "aaa28b1f-6c54-440e-9d17-b75ec69fcc70",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872e771b3f0903de-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "1e6fe622-71dc-4147-94e0-497243e5a620"
+   },
+   "aaa28f15-7ff9-429e-b21c-637d88b8a3ba": {
+    "children": [
+     "7a47de31-df16-4d54-98bf-a39fc206cd08"
+    ],
+    "id": "aaa28f15-7ff9-429e-b21c-637d88b8a3ba",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Is it possible to fly from the island to Lisbon?"
+      ]
+     },
+     "create_time": 1712873487.960053,
+     "end_turn": null,
+     "id": "aaa28f15-7ff9-429e-b21c-637d88b8a3ba",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872e50017d4048a0-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "06fdc2bc-1a27-4ca9-88be-e514bff9532a"
+   },
+   "aaa29406-ea20-4792-a40f-e0fc09cf1fd5": {
+    "children": [
+     "71860caa-c3b6-45c0-b2a9-bf0e21c398c2"
+    ],
+    "id": "aaa29406-ea20-4792-a40f-e0fc09cf1fd5",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Ok, sounds good. But I still want to visit Hanoi and keep it at max 4 places. I want to make sure I have at least 5 days in a quiet beach location. 3 days in Hanoi. And then some nature, jungle/mountains kind of destination."
+      ]
+     },
+     "create_time": 1712874575.945926,
+     "end_turn": null,
+     "id": "aaa29406-ea20-4792-a40f-e0fc09cf1fd5",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872e6a916b19692a-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aa1c876f-5acd-4468-8cb2-4cfbd2751839"
+   },
+   "aaa29c47-7e4a-4c9d-9023-39d7e3424cb7": {
+    "children": [
+     "c02f8926-62b7-46e9-990b-477a2c1e1b83"
+    ],
+    "id": "aaa29c47-7e4a-4c9d-9023-39d7e3424cb7",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Ok. While staying in Hanoi, could I easily do day trips to both Ha Long Bay and Nihn Bihn?"
+      ]
+     },
+     "create_time": 1712876500.762515,
+     "end_turn": null,
+     "id": "aaa29c47-7e4a-4c9d-9023-39d7e3424cb7",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872e998bca2b94fb-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "a2345daf-a839-4579-85ed-256b4aeab46d"
+   },
+   "aaa2a258-2d15-481b-87a8-855f4b956892": {
+    "children": [
+     "1548372f-de00-41c0-b8b2-90df3c0e1b6e"
+    ],
+    "id": "aaa2a258-2d15-481b-87a8-855f4b956892",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Is November a good time to visit all these locations?"
+      ]
+     },
+     "create_time": 1712873283.569418,
+     "end_turn": null,
+     "id": "aaa2a258-2d15-481b-87a8-855f4b956892",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872e4b03fd016930-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "b1191b34-f00b-479f-b7a4-ded9cda44513"
+   },
+   "aaa2a65b-5bb8-4d3d-85ea-86620d5fcc2a": {
+    "children": [
+     "973372d8-cddf-4db0-8191-3ec22943b2f6"
+    ],
+    "id": "aaa2a65b-5bb8-4d3d-85ea-86620d5fcc2a",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Ok, so then I want to remove Ha Long Bay and include 2 or 3 days in Nihn Bihn. Can you sumarize the itinerary again?"
+      ]
+     },
+     "create_time": 1712877244.379189,
+     "end_turn": null,
+     "id": "aaa2a65b-5bb8-4d3d-85ea-86620d5fcc2a",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872eabb3a94f9500-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "dc62a511-f0f0-40bc-99ed-7346dd04536c"
+   },
+   "aaa2aac7-3cb9-40de-b4b4-01182894dcf5": {
+    "children": [
+     "f0356f3b-ddee-40f0-86e9-d4d5cd34f07a"
+    ],
+    "id": "aaa2aac7-3cb9-40de-b4b4-01182894dcf5",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Tell me specific activities you recommend I do in each location. I like nature, food, culture. Curious, interested in learning deeply about the culture and avoid the beaten track. Authentic experience is what I am looking for. No hype places just for pictures. "
+      ]
+     },
+     "create_time": 1712998522.465979,
+     "end_turn": null,
+     "id": "aaa2aac7-3cb9-40de-b4b4-01182894dcf5",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "873a3c979a0e691e-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "5b4d8829-34ae-487a-a1ae-a637f4a75c72"
+   },
+   "aaa2ac7a-b1c9-482a-bdd9-2c5f75e41dc2": {
+    "children": [
+     "9da28b45-3e3a-4fb6-b138-13010d67b5de"
+    ],
+    "id": "aaa2ac7a-b1c9-482a-bdd9-2c5f75e41dc2",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Can you state the main pros and cons of each island options?"
+      ]
+     },
+     "create_time": 1712994951.88849,
+     "end_turn": null,
+     "id": "aaa2ac7a-b1c9-482a-bdd9-2c5f75e41dc2",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "8739e56a8f643392-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "ada27f5e-5697-46a1-8514-aa1842b215df"
+   },
+   "aaa2b974-f01e-4bb7-96ab-1ca84b5c74f8": {
+    "children": [
+     "557b29f8-c0b2-441f-9fa3-dbb9f22b3c99"
+    ],
+    "id": "aaa2b974-f01e-4bb7-96ab-1ca84b5c74f8",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Since I will have to pass by Ho Chin"
+      ]
+     },
+     "create_time": 1712875474.629932,
+     "end_turn": null,
+     "id": "aaa2b974-f01e-4bb7-96ab-1ca84b5c74f8",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872e807bdd67692c-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "fed984f3-6090-4f70-ab53-b23d7eb907ce"
+   },
+   "aaa2c5b3-676b-47db-b3b6-19e0c5fc6d28": {
+    "children": [
+     "a2ef26d8-1bc3-437d-8502-69bc318cabd8"
+    ],
+    "id": "aaa2c5b3-676b-47db-b3b6-19e0c5fc6d28",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Aren't Ha Long Bay and Ninh Binh too similar? Should I consider another day trip to a different scenery?"
+      ]
+     },
+     "create_time": 1712876961.158212,
+     "end_turn": null,
+     "id": "aaa2c5b3-676b-47db-b3b6-19e0c5fc6d28",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872ea4c98a04691c-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "d44e49f0-d10e-42c9-b98a-07c862fbfcef"
+   },
+   "aaa2cbaf-f9d6-48de-b74b-e18f2b6b016e": {
+    "children": [
+     "49159388-76c7-4f9a-8a2b-30a6aacf301d"
+    ],
+    "id": "aaa2cbaf-f9d6-48de-b74b-e18f2b6b016e",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Since I will have to pass by Ho Chi Minh, should I stop for a day or two to visit?"
+      ]
+     },
+     "create_time": 1712875511.601769,
+     "end_turn": null,
+     "id": "aaa2cbaf-f9d6-48de-b74b-e18f2b6b016e",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872e81667c39692c-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "fed984f3-6090-4f70-ab53-b23d7eb907ce"
+   },
+   "aaa2e32f-e234-49d0-9324-688832933cab": {
+    "children": [
+     "b1191b34-f00b-479f-b7a4-ded9cda44513"
+    ],
+    "id": "aaa2e32f-e234-49d0-9324-688832933cab",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "I'm planning a trip to Vietnam. 2 weeks. 34 year old couple, looking for food, culture, nature and beach. November. Looking for 3/4 main locations to visit. About 3 days of big city, and then half nature half beach. What do you recommend?"
+      ]
+     },
+     "create_time": 1712873181.383225,
+     "end_turn": null,
+     "id": "aaa2e32f-e234-49d0-9324-688832933cab",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872e48840d8e3443-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "0be20503-5d9d-437f-8029-41ea4173bc05"
+   },
+   "aaa2e7a6-cbf5-4520-a871-98cfd5d03244": {
+    "children": [
+     "a2345daf-a839-4579-85ed-256b4aeab46d"
+    ],
+    "id": "aaa2e7a6-cbf5-4520-a871-98cfd5d03244",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "No, just consider if it's easier to fly from Lisbon to Hanoi or Ho Chi Minh. And if I can fly back directly from the islands, for instance. Just arrows itinerary."
+      ]
+     },
+     "create_time": 1712876173.644625,
+     "end_turn": null,
+     "id": "aaa2e7a6-cbf5-4520-a871-98cfd5d03244",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "request_id": "872e918fef7748a7-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "0fcc6234-c2cb-42bf-8c72-533b3ce07d83"
+   },
+   "ad28f582-abda-49a7-8838-1cbd71000f2e": {
+    "children": [
+     "88f0f8c3-5e1f-4441-b965-e5bb971ea696"
+    ],
+    "id": "ad28f582-abda-49a7-8838-1cbd71000f2e",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Certainly! Here\u2019s a detailed itinerary that incorporates your interests in food, culture, nature, and history, tailored to maximize your experience in each location in Vietnam:\n\n### Hanoi (3 Days)\n\n**Day 1: Explore Historic and Cultural Sites**\n- **Morning:** Start your day early with a visit to the Ho Chi Minh Mausoleum and the One Pillar Pagoda.\n- **Late Morning:** Walk to the nearby Temple of Literature, exploring its historic courtyards and architecture.\n- **Lunch:** Enjoy a meal at KOTO, a social enterprise restaurant nearby that trains disadvantaged youth.\n- **Afternoon:** Join a guided tour of the Hanoi Opera House and then explore the surrounding French Quarter.\n- **Evening:** Attend a traditional water puppet show at Thang Long Theatre. Have dinner in the Old Quarter, trying local dishes like Cha Ca La Vong (grilled fish).\n\n**Day 2: Food Tour and Cooking Class**\n- **Morning:** Participate in a street food tour that explores lesser-known dishes and locations in the city.\n- **Afternoon:** Attend a cooking class where you learn to prepare traditional Vietnamese dishes, ideally one that includes a market visit to buy ingredients.\n- **Evening:** Free time to explore at your leisure or relax at a caf\u00e9.\n\n**Day 3: Local Markets and Day-to-Day Life**\n- **Early Morning:** Visit Long Bien Market to witness its bustling activity and local products.\n- **Late Morning:** Stroll around Hoan Kiem Lake and visit Ngoc Son Temple.\n- **Lunch:** Eat at a local noodle shop.\n- **Afternoon:** Free time for last-minute shopping or visit the Museum of Ethnology.\n- **Evening:** Dine in the West Lake area, trying some upscale Vietnamese cuisine.\n\n### Ninh Binh (3 Days)\n\n**Day 1: Arrival and River Boat Trip**\n- **Morning:** Travel from Hanoi to Ninh Binh; check into your accommodation.\n- **Afternoon:** Take a boat trip through the Trang An Scenic Landscape.\n- **Evening:** Dinner at a local restaurant serving specialties like goat meat and mountain snails.\n\n**Day 2: Cycling and Exploring Ancient Sites**\n- **Morning:** Rent a bike and explore the countryside, heading towards Hoa Lu, the ancient capital.\n- **Lunch:** Picnic lunch or eat at a local village.\n- **Afternoon:** Continue your bike ride to Bai Dinh Pagoda, Southeast Asia's largest Buddhist complex.\n- **Evening:** Return to your hotel and relax.\n\n**Day 3: More Nature and Local Life**\n- **Morning:** Early boat ride in Tam Coc, often less crowded in the morning.\n- **Lunch:** Lunch in a local family's home or small local diner.\n- **Afternoon:** Visit the Mua Cave and climb its steps for a panoramic view of the region.\n- **Evening:** Dinner back at your hotel or another local eatery.\n\n### Ho Chi Minh City (3 Days)\n\n**Day 1: War History and City Exploration**\n- **Morning:** Visit the War Remnants Museum with a guided tour for deeper understanding.\n- **Lunch:** Try Pho at a popular local spot.\n- **Afternoon:** Explore the Independence Palace.\n- **Evening:** Explore the vibrant nightlife and street food in District 1.\n\n**Day 2: Markets and Chinatown**\n- **Morning:** Visit the Ben Thanh Market and then head to Chinatown to explore Binh Tay Market.\n- **Lunch:** Enjoy Dim Sum in Chinatown.\n- **Afternoon:** Visit the Thien Hau Temple in Chinatown.\n- **Evening:** Dinner at a local restaurant known for southern Vietnamese cuisine.\n\n**Day 3: Modern Ho Chi Minh City**\n- **Morning:** Visit the modern part of the city, exploring areas like the Bitexco Financial Tower and its Sky Deck.\n- **Lunch:** Eat at a contemporary Vietnamese restaurant.\n- **Afternoon:** Free time for shopping or relaxing in a city park.\n- **Evening:** Experience a live music venue or a caf\u00e9 where local musicians perform.\n\n### Con Dao Islands (5 Days)\n\n**Day 1: Arrival and Beach Time**\n- **Morning:** Arrive and check into your hotel.\n- **Afternoon:** Relax on one of the main beaches, like Dam Trau Beach.\n- **Evening:** Dinner at your resort or a nearby restaurant.\n\n**Day 2: Historical Sites and Local Culture**\n- **Morning:** Visit the old prison complex and museum to learn about the island's history.\n- **Lunch:** Lunch at a local eatery.\n- **Afternoon:** Visit other historical sites or take a light hike nearby.\n- **Evening:** Enjoy a quiet evening on the beach or at your resort.\n\n**Day 3: National Park and Hiking**\n- **Morning:** Start early for a hike in the Con Dao National Park, exploring its diverse flora and fauna.\n-"
+      ]
+     },
+     "create_time": 1712999175.724338,
+     "end_turn": false,
+     "id": "ad28f582-abda-49a7-8838-1cbd71000f2e",
+     "metadata": {
+      "can_save": false,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "type": "max_tokens"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAA",
+      "parent_id": "aaa26f5a-756b-4892-b055-fe44dd3d7e1d",
+      "request_id": "873a4b487eb994e8-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_partial_completion",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa26f5a-756b-4892-b055-fe44dd3d7e1d"
+   },
+   "ada27f5e-5697-46a1-8514-aa1842b215df": {
+    "children": [
+     "aaa2ac7a-b1c9-482a-bdd9-2c5f75e41dc2"
+    ],
+    "id": "ada27f5e-5697-46a1-8514-aa1842b215df",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "1. Lisbon\n2. Hanoi (3 Days)\n3. Ninh Binh (3 Days)\n4. Ho Chi Minh City (3 Days)\n5. Con Dao Islands (5 Days)\n6. Ho Chi Minh City (Return Flight)\n7. Lisbon"
+      ]
+     },
+     "create_time": 1712877321.199001,
+     "end_turn": true,
+     "id": "ada27f5e-5697-46a1-8514-aa1842b215df",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "parent_id": "3fbfdd1e-ecb9-4dbb-8722-67e4dd2b9374",
+      "request_id": "872ead6cacf4343d-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "3fbfdd1e-ecb9-4dbb-8722-67e4dd2b9374"
+   },
+   "b1191b34-f00b-479f-b7a4-ded9cda44513": {
+    "children": [
+     "aaa2a258-2d15-481b-87a8-855f4b956892"
+    ],
+    "id": "b1191b34-f00b-479f-b7a4-ded9cda44513",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "For a two-week trip to Vietnam that offers a mix of food, culture, nature, and beach experiences in November, focusing on 3 or 4 main locations is a smart strategy. Here's a suggested itinerary that balances your interests:\n\n### 1. Hanoi (3 Days) - Culture and Food\n**Why:** As the capital city, Hanoi offers a deep dive into Vietnamese culture with its centuries-old architecture, vibrant marketplaces, and the Old Quarter's narrow streets. The city is also famous for its street food scene, offering an array of Vietnamese culinary delights.\n\n**Activities:**\n- Explore the Old Quarter by foot.\n- Visit the Temple of Literature and Hoan Kiem Lake.\n- Enjoy a traditional water puppet show.\n- Food tour to taste pho, b\u00e1nh m\u00ec, and other local specialties.\n\n### 2. Ha Long Bay (2 Days) - Nature\n**Why:** A UNESCO World Heritage site known for its emerald waters and thousands of towering limestone islands topped with rainforests. Opt for an overnight cruise to fully experience the beauty and serenity of Ha Long Bay.\n\n**Activities:**\n- Take a cruise through the bay.\n- Visit floating villages.\n- Kayak around the karsts.\n- Explore Sung Sot Cave.\n\n### 3. Hoi An (4 Days) - Culture, Nature, and Beach\n**Why:** Hoi An, with its well-preserved Ancient Town, offers a mix of historical architecture, vibrant markets, and tailor shops. It's also close to both the countryside and several beautiful beaches.\n\n**Activities:**\n- Wander around Hoi An Ancient Town.\n- Take a cooking class to learn about Vietnamese cuisine.\n- Cycle to the rural areas surrounding Hoi An.\n- Relax at An Bang Beach or Cua Dai Beach.\n\n### 4. Phu Quoc Island (5 Days) - Beach and Nature\n**Why:** To end your trip on a relaxing note, head to Phu Quoc Island, known for its stunning beaches, tropical jungles, and luxury resorts. November is a good time to visit, as it's just at the beginning of the dry season, offering sunny days.\n\n**Activities:**\n- Relax on Sao Beach and Long Beach.\n- Visit Phu Quoc National Park and go hiking or mountain biking.\n- Snorkel or dive to explore the coral reefs.\n- Experience the night market in Duong Dong.\n\nThis itinerary offers a balance of urban exploration in Hanoi, natural wonders in Ha Long Bay, cultural immersion and relaxation in Hoi An, and beach leisure in Phu Quoc. Each location brings a unique aspect of Vietnam to your experience, ensuring a well-rounded trip. Remember to check for any travel requirements or restrictions as you plan your journey."
+      ]
+     },
+     "create_time": 1712873199.769254,
+     "end_turn": true,
+     "id": "b1191b34-f00b-479f-b7a4-ded9cda44513",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAAAAAAAAA",
+      "parent_id": "aaa2e32f-e234-49d0-9324-688832933cab",
+      "request_id": "872e48840d8e3443-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa2e32f-e234-49d0-9324-688832933cab"
+   },
+   "c02f8926-62b7-46e9-990b-477a2c1e1b83": {
+    "children": [
+     "aaa23eb2-bbd3-4a89-a0f8-bb51678c1e5d"
+    ],
+    "id": "c02f8926-62b7-46e9-990b-477a2c1e1b83",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Yes, from Hanoi, you can easily take day trips to both Ha Long Bay and Ninh Binh. Each of these destinations offers a unique glimpse into Vietnam's natural beauty and can be experienced through organized tours or independent travel arrangements. Here's what you need to know about day trips to Ha Long Bay and Ninh Binh from Hanoi:\n\n### Ha Long Bay\n\n- **Distance:** Approximately 170 kilometers from Hanoi, taking around 2.5 to 3 hours by bus or car.\n- **Day Trips:** Many tour operators in Hanoi offer day trips to Ha Long Bay, which typically include a cruise around the bay to see its famous limestone karsts and islands. These tours often feature activities like kayaking, visiting caves, and sometimes a short visit to Ti Top Island or similar.\n- **Considerations:** While a day trip can give you a taste of Ha Long Bay's beauty, it can feel rushed due to the travel time. An overnight cruise is highly recommended if you have the time, as it allows for a more in-depth exploration and the experience of waking up in the bay.\n\n### Ninh Binh\n\n- **Distance:** About 100 kilometers from Hanoi, with a travel time of approximately 2 hours by bus or car.\n- **Day Trips:** Ninh Binh is known as \"Ha Long Bay on Land\" for its stunning riverine landscapes, limestone cliffs, and ancient temples. Day trips often include a boat ride in Trang An or Tam Coc, visiting the ancient capital of Hoa Lu, and possibly cycling around the countryside.\n- **Considerations:** A day trip to Ninh Binh can be fulfilling and less rushed than Ha Long Bay due to its closer proximity to Hanoi. You can comfortably experience the area's main highlights, like boat tours and historic sites, within a day.\n\n### Tips for Day Trips\n\n- **Early Start:** Whether you're going to Ha Long Bay or Ninh Binh, it's best to start early in the morning to maximize your time at the destination.\n- **Book in Advance:** Especially for Ha Long Bay, it's wise to book your day trip or cruise in advance, as it's a popular destination and tours can fill up quickly.\n- **Pack Accordingly:** Bring sun protection, comfortable clothing and footwear, and possibly insect repellent for exploring the outdoors.\n- **Consider Overnight Options:** If your schedule allows, consider staying overnight in Ha Long Bay or even Ninh Binh to explore more thoroughly at a relaxed pace.\n\nBoth destinations offer remarkable experiences of Vietnam's natural landscapes and are well worth the visit from Hanoi."
+      ]
+     },
+     "create_time": 1712876530.806443,
+     "end_turn": true,
+     "id": "c02f8926-62b7-46e9-990b-477a2c1e1b83",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAAA",
+      "parent_id": "aaa29c47-7e4a-4c9d-9023-39d7e3424cb7",
+      "request_id": "872e998bca2b94fb-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa29c47-7e4a-4c9d-9023-39d7e3424cb7"
+   },
+   "c540440e-91e2-4252-8ca3-9ba4e653fc88": {
+    "children": [],
+    "id": "c540440e-91e2-4252-8ca3-9ba4e653fc88",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       " **Lunch:** Picnic during your hike.\n- **Afternoon:** Continue exploring the park or return for some rest.\n- **Evening:** Dinner at a restaurant with ocean views.\n\n**Day 4: Snorkeling and Marine Exploration**\n- **Morning:** Join a snorkeling tour to explore the coral reefs around the islands.\n- **Lunch:** Beachside lunch.\n- **Afternoon:** More snorkeling or free time to explore the island at your leisure.\n- **Evening:** Dine at a local seafood restaurant.\n\n**Day 5: Leisure and Departure**\n- **Morning:** Free morning to enjoy the beach or a final swim.\n- **Lunch:** Early lunch at the resort.\n- **Afternoon:** Prepare for departure back to Ho Chi Minh City and onwards.\n\nThis itinerary is designed to provide a mix of cultural immersion, nature exploration, and culinary experiences, offering a deep dive into the authentic aspects of each location."
+      ]
+     },
+     "create_time": 1712999302.739801,
+     "end_turn": true,
+     "id": "c540440e-91e2-4252-8ca3-9ba4e653fc88",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAAAAAAAAAAAA",
+      "parent_id": "88f0f8c3-5e1f-4441-b965-e5bb971ea696",
+      "request_id": "873a4f6caf8203b6-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "88f0f8c3-5e1f-4441-b965-e5bb971ea696"
+   },
+   "d2a8614a-749e-4c92-939d-dc3dd619b36c": {
+    "children": [
+     "fed984f3-6090-4f70-ab53-b23d7eb907ce"
+    ],
+    "id": "d2a8614a-749e-4c92-939d-dc3dd619b36c",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1712875232.296017,
+     "end_turn": true,
+     "id": "d2a8614a-749e-4c92-939d-dc3dd619b36c",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-4",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "aaa283cc-c29a-416a-a067-c07d7989528c",
+      "rebase_system_message": true,
+      "request_id": "872e799688dd94ef-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "aaa283cc-c29a-416a-a067-c07d7989528c"
+   },
+   "d44e49f0-d10e-42c9-b98a-07c862fbfcef": {
+    "children": [
+     "aaa2c5b3-676b-47db-b3b6-19e0c5fc6d28"
+    ],
+    "id": "d44e49f0-d10e-42c9-b98a-07c862fbfcef",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Certainly! Here's the order of locations for your trip itinerary from Lisbon, starting with an option that begins in Hanoi and includes day trips to Ha Long Bay and Ninh Binh, followed by travel to Ho Chi Minh City and ending in the Con Dao Islands:\n\n1. Lisbon\n2. Hanoi (Base for day trips)\n   - Ha Long Bay (Day trip)\n   - Ninh Binh (Day trip)\n3. Ho Chi Minh City\n4. Con Dao Islands\n5. Ho Chi Minh City (for return flight)\n6. Lisbon"
+      ]
+     },
+     "create_time": 1712876855.174093,
+     "end_turn": true,
+     "id": "d44e49f0-d10e-42c9-b98a-07c862fbfcef",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AA",
+      "parent_id": "35eadf9d-527b-4e1b-b3e1-696eec5642d6",
+      "request_id": "872ea1f7ec35691e-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "35eadf9d-527b-4e1b-b3e1-696eec5642d6"
+   },
+   "dc62a511-f0f0-40bc-99ed-7346dd04536c": {
+    "children": [
+     "aaa2a65b-5bb8-4d3d-85ea-86620d5fcc2a"
+    ],
+    "id": "dc62a511-f0f0-40bc-99ed-7346dd04536c",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Yes, Ninh Binh is renowned for its stunning rice fields and offers excellent opportunities for cycling. The region, often referred to as \"Ha Long Bay on Land,\" is characterized by its dramatic landscape of limestone karsts and rivers. Here are some of the key features and activities related to rice fields and cycling in Ninh Binh:\n\n### Rice Fields\n- **Scenic Beauty:** Ninh Binh's rice fields are a highlight, especially during the planting and harvest seasons when the fields are lush and vibrant. The landscape is dotted with limestone mountains, creating a picturesque setting that's perfect for photography.\n- **Agricultural Insight:** Visiting the rice fields also offers insight into the agricultural practices of rural Vietnam, where rice farming is a crucial part of life.\n\n### Cycling\n- **Popular Activity:** Cycling is one of the best ways to explore Ninh Binh\u2019s countryside. Many tours and accommodations offer bike rentals, allowing visitors to navigate the flat roads at their own pace.\n- **Routes:** There are several recommended cycling routes that take you through small villages, alongside rivers, and amidst the rice paddies, with the backdrop of limestone mountains. These routes often include stops at local attractions, such as ancient temples and caves.\n- **Tam Coc and Trang An:** Two of the most popular areas for cycling are around Tam Coc and Trang An. Both areas offer stunning natural scenery and are relatively easy to explore on two wheels, with paths that meander through local farms and past natural and historical sites.\n\n### Why Choose Ninh Binh for Rice Fields and Cycling\n- **Diverse Landscapes:** Ninh Binh combines natural, historical, and cultural elements, making for a rich and varied experience. The rice fields and rural scenery offer a tranquil contrast to the bustling city life of Hanoi.\n- **Accessibility:** Being relatively flat and having less traffic in the rural areas, Ninh Binh is accessible for cyclists of most skill levels, including families and casual riders.\n- **Integration with Other Activities:** Cycling in Ninh Binh can be easily combined with boat tours, cave explorations, and visits to cultural and historical sites, maximizing your experience in the area.\n\nIn summary, Ninh Binh is not only about the limestone karsts and rivers but also about immersive experiences in its beautiful rice fields and through cycling adventures, offering a more comprehensive insight into the natural and cultural landscapes of Vietnam."
+      ]
+     },
+     "create_time": 1712877125.822571,
+     "end_turn": true,
+     "id": "dc62a511-f0f0-40bc-99ed-7346dd04536c",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAAAAAAAA",
+      "parent_id": "aaa261e4-7fa2-45db-9d70-5a2f3a9475ae",
+      "request_id": "872ea81faee833e9-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa261e4-7fa2-45db-9d70-5a2f3a9475ae"
+   },
+   "e3e1a75e-a62d-4102-8e91-ee7e81a36ef5": {
+    "children": [
+     "aaa22836-39ee-46fd-aa87-103c8a325817"
+    ],
+    "id": "e3e1a75e-a62d-4102-8e91-ee7e81a36ef5",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "If your aim is to streamline your itinerary to include Hanoi, Ho Chi Minh City, the Con Dao Islands, and then choose between Ninh Binh and Phong Nha, considering travel efficiency and the uniqueness of each destination, here's a tailored recommendation:\n\n### Hanoi \u2192 Ninh Binh \u2192 Ho Chi Minh City \u2192 Con Dao Islands\n\n**Why This Itinerary?**\n\n1. **Reduced Travel Time:** Choosing Ninh Binh over Phong Nha significantly reduces your travel time. Ninh Binh is just a 2-hour drive from Hanoi, making it an accessible choice for a day trip or a short stay. Phong Nha, while remarkable for its caves and natural beauty, is considerably further from both Hanoi and Ho Chi Minh City and would require more complex travel arrangements, especially air travel.\n\n2. **Diverse Experiences:** Ninh Binh provides a condensed version of Vietnam's natural beauty, often described as \"Ha Long Bay on Land\" due to its stunning limestone karsts and rivers. It offers a mix of cultural and natural attractions without the need for extensive travel, thus allowing more time to explore other parts of Vietnam.\n\n3. **Efficient Route:** Starting in Hanoi, moving to Ninh Binh, flying from Hanoi to Ho Chi Minh City, and then ending your trip in the Con Dao Islands creates a smooth travel flow that minimizes backtracking and maximizes your time exploring each destination.\n\n### Recommended Itinerary Details:\n\n- **Hanoi (3 Days):** Start with the capital's historical sites, vibrant streets, and culinary delights.\n- **Ninh Binh (2 Days):** Explore the breathtaking landscapes via boat tours, visit ancient temples, and cycle around the rice paddies and limestone karsts.\n- **Ho Chi Minh City (2-3 Days):** Experience the dynamic urban life, visit historical war sites, and enjoy the diverse food scene.\n- **Con Dao Islands (5 Days):** Relax and unwind on the beautiful beaches, dive into the clear waters, and explore the islands' natural and historical sites.\n\n### Travel Tips:\n\n- **Travel Between Locations:** Use trains or buses for the Hanoi to Ninh Binh leg. For longer distances, such as Hanoi to Ho Chi Minh City and Ho Chi Minh City to Con Dao, opt for domestic flights to save time.\n- **Booking in Advance:** Especially for flights and accommodations in Con Dao, as options may be more limited.\n- **Exploring Efficiently:** In both Hanoi and Ho Chi Minh City, consider guided tours for cultural insights and to efficiently see the highlights, especially if your time is limited.\n\nThis itinerary offers a balanced exploration of Vietnam's cultural depth, natural beauty, and modern dynamism, with practical travel connections to ensure a smooth and enriching trip."
+      ]
+     },
+     "create_time": 1712876024.826546,
+     "end_turn": true,
+     "id": "e3e1a75e-a62d-4102-8e91-ee7e81a36ef5",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAA",
+      "parent_id": "46ef6f22-c1cd-4f26-8837-258763b9bfa6",
+      "request_id": "872e8d53cc3a94f5-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "46ef6f22-c1cd-4f26-8837-258763b9bfa6"
+   },
+   "ecbb0d9d-55c9-4e38-bc5b-ac5e37a01f09": {
+    "children": [
+     "a6db3a86-2ad1-420b-bd3e-58124539d009"
+    ],
+    "id": "ecbb0d9d-55c9-4e38-bc5b-ac5e37a01f09",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1712875624.665808,
+     "end_turn": true,
+     "id": "ecbb0d9d-55c9-4e38-bc5b-ac5e37a01f09",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-4",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "aaa27604-829b-41a9-8616-f37b4ecf78dd",
+      "rebase_system_message": true,
+      "request_id": "872e83726916692f-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "aaa27604-829b-41a9-8616-f37b4ecf78dd"
+   },
+   "f0356f3b-ddee-40f0-86e9-d4d5cd34f07a": {
+    "children": [
+     "45fa9d60-8dce-4d36-ac2b-c107867e76fb"
+    ],
+    "id": "f0356f3b-ddee-40f0-86e9-d4d5cd34f07a",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1712998561.566775,
+     "end_turn": true,
+     "id": "f0356f3b-ddee-40f0-86e9-d4d5cd34f07a",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-4",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "aaa2aac7-3cb9-40de-b4b4-01182894dcf5",
+      "rebase_system_message": true,
+      "request_id": "873a3c979a0e691e-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "aaa2aac7-3cb9-40de-b4b4-01182894dcf5"
+   },
+   "fd17f87c-857a-40ef-869e-8c1d2b0c3238": {
+    "children": [
+     "aaa250f8-6fa2-490b-859e-fff37d73725d"
+    ],
+    "id": "fd17f87c-857a-40ef-869e-8c1d2b0c3238",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "If Con Dao appeals to you due to its natural beauty, tranquility, and historical significance, there are a few other island destinations in Vietnam that you might consider, which share some similar qualities but also offer their unique characteristics. Here are a few to think about:\n\n### Ly Son Island\n- **Location:** Off the coast of Quang Ngai Province in central Vietnam.\n- **Pros:** Known for its garlic farms, stunningly clear waters, and volcanic landscape. Ly Son is less touristy and offers a glimpse into the traditional island lifestyle.\n- **Cons:** Accommodations and facilities are more basic, reflecting its status as a less developed tourist destination.\n\n### Cat Ba Island\n- **Location:** In the northern part of Vietnam, near Ha Long Bay.\n- **Pros:** Cat Ba is the largest island in Ha Long Bay and offers a mix of rugged limestone mountains, dense jungles, and beautiful beaches. It\u2019s also part of a national park, which is ideal for hiking and wildlife watching.\n- **Cons:** Can be quite busy during peak tourist seasons, but still offers quieter experiences than the main areas of Ha Long Bay.\n\n### Phu Quy Island\n- **Location:** Located in Binh Thuan province, off the southeastern coast of Vietnam.\n- **Pros:** Phu Quy is a small, less visited island known for its crystal-clear waters, beautiful temples, and wind turbines. The island offers a very authentic local experience with fewer tourists.\n- **Cons:** Very limited tourist infrastructure and services, which could be a downside if you're looking for comfort and convenience.\n\n### Cham Islands\n- **Location:** Off the coast of Hoi An in central Vietnam.\n- **Pros:** Comprising a small group of islands, this area is known for its marine biodiversity, being a part of the Cu Lao Cham Marine Park. Ideal for snorkeling and diving.\n- **Cons:** Overnight stays are limited as most visitors come as part of a day trip from Hoi An, though homestays are available for a more immersive experience.\n\n### Binh Ba Island\n- **Location:** Near Cam Ranh in the south of Vietnam.\n- **Pros:** Known as the \"lobster island,\" Binh Ba offers excellent seafood, beautiful beaches, and is not very touristy, allowing for a peaceful retreat.\n- **Cons:** Access to foreigners has been restricted at times, and facilities are basic, aimed more at local visitors.\n\nThese islands can provide a wonderful alternative or addition to your itinerary, especially if you are looking to explore different aspects of Vietnam's natural beauty away from the more crowded tourist paths. Each has unique elements worth considering, depending on your interests in culture, nature, and adventure."
+      ]
+     },
+     "create_time": 1712995505.158744,
+     "end_turn": true,
+     "id": "fd17f87c-857a-40ef-869e-8c1d2b0c3238",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAAAAAAAAA",
+      "parent_id": "aaa232ca-d579-4419-9604-94c3199e26ba",
+      "request_id": "8739f252bc2e33e9-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa232ca-d579-4419-9604-94c3199e26ba"
+   },
+   "fd842918-7db8-42b5-8704-c5990f4f9990": {
+    "children": [
+     "aaa23808-1e3f-4413-b447-4a72635a0642"
+    ],
+    "id": "fd842918-7db8-42b5-8704-c5990f4f9990",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Yes, visiting both Hanoi and Ho Chi Minh City can greatly enrich your Vietnam travel experience, as each city offers distinct vibes, histories, and cultural landscapes. Despite being in the same country, Hanoi and Ho Chi Minh City are remarkably different in numerous ways, making both worth the visit. Here's a brief comparison to highlight their unique features:\n\n### Hanoi\n- **Cultural Capital:** As the capital city, Hanoi is the heart of Vietnamese culture, with a history that spans over a thousand years. It's home to numerous cultural sites like the Temple of Literature, Hoan Kiem Lake, and the Old Quarter.\n- **Atmosphere:** Hanoi offers a more traditional and laid-back atmosphere compared to Ho Chi Minh City. The city's French colonial architecture, tree-lined boulevards, and numerous lakes add to its charm.\n- **Cuisine:** While you can find delicious Vietnamese food across the country, Hanoi is famous for dishes like Pho (Vietnamese noodle soup), Bun Cha (grilled pork with noodles), and Egg Coffee.\n\n### Ho Chi Minh City\n- **Economic Hub:** Formerly known as Saigon, Ho Chi Minh City is the bustling economic center and the largest city in Vietnam. It showcases rapid modern development alongside traditional Vietnamese life.\n- **Dynamic and Modern:** The city is more dynamic and has a faster pace of life. It features modern skyscrapers, a vibrant nightlife, and a cosmopolitan atmosphere.\n- **War History:** It has significant historical sites related to the Vietnam War (American War), including the War Remnants Museum and the Cu Chi Tunnels, offering a deeper understanding of the country's recent past.\n\n### Why Visit Both?\n- **Diverse Experiences:** Together, Hanoi and Ho Chi Minh City encapsulate the diversity of Vietnam's culture, history, and development. Visiting both allows you to experience the contrasts and the dynamic range of the Vietnamese urban experience.\n- **Geographical Contrast:** They also represent the geographical diversity of Vietnam, with Hanoi located in the northern part of the country, offering access to northern landscapes like Ha Long Bay, and Ho Chi Minh City in the south, closer to the Mekong Delta and other southern attractions.\n- **Culinary Diversity:** Each city offers unique culinary delights, reflecting the regional differences in Vietnamese cuisine. Sampling the local specialties in both cities is a journey through the flavors that define Vietnam.\n\nIn conclusion, if your itinerary allows, including both Hanoi and Ho Chi Minh City in your trip can offer a fuller picture of Vietnam's rich tapestry of culture, history, and modernity, providing a more rounded and enriching travel experience."
+      ]
+     },
+     "create_time": 1712875707.008031,
+     "end_turn": true,
+     "id": "fd842918-7db8-42b5-8704-c5990f4f9990",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "A",
+      "parent_id": "329806dd-efc0-4e22-af97-78982ae39229",
+      "request_id": "872e85aad8456935-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "329806dd-efc0-4e22-af97-78982ae39229"
+   },
+   "fed984f3-6090-4f70-ab53-b23d7eb907ce": {
+    "children": [
+     "aaa2b974-f01e-4bb7-96ab-1ca84b5c74f8",
+     "aaa2cbaf-f9d6-48de-b74b-e18f2b6b016e"
+    ],
+    "id": "fed984f3-6090-4f70-ab53-b23d7eb907ce",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Traveling to Vietnam is an enriching experience, offering a blend of vibrant culture, stunning landscapes, and compelling history. Here are some essential tips and things you should know to make your trip smooth and enjoyable:\n\n### Visa Requirements\n- **Visa Policy:** Check Vietnam's current visa policy for your nationality. Many travelers need to apply for a visa before arrival, either through an embassy or via the e-visa system. Some countries are eligible for visa exemptions for short stays.\n\n### Currency and Payments\n- **Currency:** The Vietnamese Dong (VND) is the official currency. US dollars are widely accepted in many tourist areas, but it's advisable to pay in VND for better rates.\n- **Cash & ATMs:** Cash is king in Vietnam, especially in smaller towns and local markets. ATMs are widely available in cities, but it's wise to carry cash when traveling to more rural areas.\n- **Credit Cards:** Credit cards are accepted in major hotels, restaurants, and shops, but many smaller establishments may not accept them.\n\n### Transportation\n- **Getting Around:** Vietnam has a range of transportation options, including buses, trains, domestic flights, and motorbikes. Ride-hailing apps like Grab are popular and convenient in urban areas.\n- **Motorbike Rentals:** Renting a motorbike can be an exciting way to explore, but ensure you're comfortable with the chaotic traffic and have a valid international driver's license.\n\n### Food and Health\n- **Street Food:** Vietnamese cuisine is diverse and delicious. Don't miss trying street food, but choose busy stalls with high turnover for the freshest options.\n- **Water:** Drink bottled or boiled water. Avoid tap water to prevent stomach upsets.\n\n### Language and Culture\n- **Language Barrier:** English is widely spoken in tourist areas, but learning a few basic Vietnamese phrases can enhance your experience and interaction with locals.\n- **Cultural Respect:** Dress modestly when visiting temples and pagodas. Be aware of cultural norms and etiquette, such as removing shoes before entering someone's home and using both hands when giving or receiving something.\n\n### Safety and Etiquette\n- **Safety:** Vietnam is generally safe for travelers. However, take usual precautions against petty theft, especially in crowded places. Be cautious when crossing streets due to the busy traffic.\n- **Bargaining:** Bargaining is common in markets and street stalls. It's part of the shopping culture, so don't hesitate to negotiate prices, but do so respectfully.\n\n### Connectivity\n- **SIM Cards:** Purchasing a local SIM card is inexpensive and offers good coverage and data speeds. It's the best way to stay connected and use navigation or translation apps on the go.\n\n### Environmental Awareness\n- **Sustainability:** Vietnam faces challenges with pollution and plastic waste. Travel responsibly by minimizing plastic use, respecting wildlife and natural sites, and supporting eco-friendly tours and accommodations.\n\n### Travel Insurance\n- **Insurance:** Ensure you have comprehensive travel insurance that covers medical expenses, accidents, and any adventure activities you plan to undertake.\n\nUnderstanding these aspects can help you navigate Vietnam more confidently and ensure a memorable and respectful visit to this beautiful country."
+      ]
+     },
+     "create_time": 1712875232.296573,
+     "end_turn": true,
+     "id": "fed984f3-6090-4f70-ab53-b23d7eb907ce",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "default_model_slug": "gpt-4",
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": null,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "pad": "AAAAAAAAAAAAAAAAAAAAAAAA",
+      "parent_id": "d2a8614a-749e-4c92-939d-dc3dd619b36c",
+      "request_id": "872e799688dd94ef-LIS",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "d2a8614a-749e-4c92-939d-dc3dd619b36c"
+   }
+  },
+  "memory_scope": "global_enabled",
+  "moderation_results": [],
+  "title": "Vietnam Trip: Culture, Nature, Beach",
+  "update_time": 1712999304.473406,
+  "voice": null
+ },
+ {
+  "async_status": null,
+  "atlas_mode_enabled": null,
+  "context_scopes": null,
+  "conversation_id": "1d71ba64-6400-4f77-a658-85c6e7cf8fb5",
+  "conversation_origin": null,
+  "conversation_template_id": null,
+  "create_time": 1704965304.970247,
+  "current_node": "79340bf0-50b7-4ba5-b5cc-6031c8b8d3af",
+  "default_model_slug": null,
+  "disabled_tool_ids": [],
+  "gizmo_type": null,
+  "id": "1d71ba64-6400-4f77-a658-85c6e7cf8fb5",
+  "is_archived": false,
+  "is_do_not_remember": null,
+  "is_starred": null,
+  "mapping": {
+   "013734d1-8e69-47aa-970f-df2bdcda7dd8": {
+    "children": [
+     "29b04231-af80-4569-bcf5-6c3d24b173d6"
+    ],
+    "id": "013734d1-8e69-47aa-970f-df2bdcda7dd8",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "code",
+      "language": "unknown",
+      "response_format_name": null,
+      "text": "# Re-importing pandas as the code execution state was reset\r\nimport pandas as pd\r\n\r\n# Load the updated spreadsheet again\r\nupdated_file_path = '/mnt/data/Open question - Dec 2023 (1).xlsx'\r\n\r\n# Read the data from the updated spreadsheet\r\nupdated_survey_data = pd.read_excel(updated_file_path)\r\n\r\nupdated_survey_data.head()"
+     },
+     "create_time": 1704969082.957289,
+     "end_turn": false,
+     "id": "013734d1-8e69-47aa-970f-df2bdcda7dd8",
+     "metadata": {
+      "can_save": false,
+      "finish_details": {
+       "stop_tokens": [
+        100265
+       ],
+       "type": "stop"
+      },
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "637c673d-6999-4e2c-9d2e-9badb969e46c",
+      "timestamp_": "absolute"
+     },
+     "recipient": "python",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "637c673d-6999-4e2c-9d2e-9badb969e46c"
+   },
+   "0e811609-5da0-4239-a964-58ffc13392dc": {
+    "children": [
+     "aaa2e51d-68c8-4eac-acdb-d6c71f17ac99"
+    ],
+    "id": "0e811609-5da0-4239-a964-58ffc13392dc",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "After reprocessing the responses, I was able to identify some positive aspects, but it seems that the approach used might not be capturing a wide range of responses effectively. This could be due to the complexity and variety of the responses, which might not fit well with the pattern-based extraction method used. \n\nFrom the data analyzed, here is what I found:\n\n**Top Positive Aspects** (although only one unique aspect was identified):\n1. Company-wide goals and clear focus, [PERSON_c529ff] cleaning the house from all the unnecessary expenses, having the team in the same geography and going to the office feels great; 2 or 3 days a week is the perfect balance.\n\n**Top Negative Aspects**: Unfortunately, no distinct negative aspects were identified through this method.\n\nTo provide a more comprehensive analysis, a different approach, such as manual review or more advanced natural language processing techniques, might be necessary. If you have any specific aspects or keywords you are interested in, I can refine the analysis to focus on those. Alternatively, I can attempt a different method of analysis."
+      ]
+     },
+     "create_time": 1704965456.516862,
+     "end_turn": true,
+     "id": "0e811609-5da0-4239-a964-58ffc13392dc",
+     "metadata": {
+      "can_save": true,
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "418b54f8-c112-45ef-8b39-eda56cd454a8",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "418b54f8-c112-45ef-8b39-eda56cd454a8"
+   },
+   "0f96b900-3aab-43f8-b63f-2a23e3b2fc83": {
+    "children": [
+     "aaa27441-e37c-499c-bb48-e4fd11620757"
+    ],
+    "id": "0f96b900-3aab-43f8-b63f-2a23e3b2fc83",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Based on the updated survey data, here are the percentages for each theme in the \"Good\" and \"Bad\" categories:\n\n**Good Themes:**\n1. Clear company direction - 20.83%\n2. Serious about running a business - 20.83%\n3. More focus - 14.58%\n4. Cost efficiency - 10.42%\n5. Nothing - 4.17%\n6. Local management - 2.08%\n7. Better in Eng for knowledge sharing and dependencies - 2.08%\n8. Clear company direction; feeling taken care of - 2.08%\n9. More focus; cost efficiency - 2.08%\n10. More focus; clear company direction - 2.08%\n11. More focus; data-driven decisions - 2.08%\n12. Clear company direction; office life - 2.08%\n13. Clear company direction; serious about running a business - 2.08%\n14. Cross-department collaboration - 2.08%\n15. Team resilience - 2.08%\n16. Office perks; occasional bonuses - 2.08%\n17. Extended runway - 2.08%\n18. HW independent product line - 2.08%\n19. Cost efficiency; serious about running a business - 2.08%\n\n**Bad Themes:**\n1. Understaffed/workload - 23.40%\n2. Layoffs/morale - 23.40%\n3. Deviating from our positive work culture - 14.89%\n4. Change came too late - 2.13%\n5. Silos - 2.13%\n6. Understaffed/workload; inappropriate compensation/recognition - 2.13%\n7. Layoffs; low quality work; silos - 2.13%\n8. Instability; low runway - 2.13%\n9. Lack of accountability at leadership level - 2.13%\n10. Not enough HR for work to be done - 2.13%\n11. Layoffs/morale; communication - 2.13%\n12. The new leadership - 2.13%\n13. Layoffs/morale; over reorganizing/instability - 2.13%\n14. Over reorganizing/instability - 2.13%\n15. Layoffs/morale; deviating from our positive work culture; inappropriate compensation/recognition - 2.13%\n16. Layoffs/morale; less contact with IL - 2.13%\n17. Understaffed/workload; layoffs/morale - 2.13%\n18. Deviating from our positive work culture; poor communication; disorganized; workload - 2.13%\n19. Deviating from our positive work culture; layoffs - 2.13%\n20. Deviating from our positive work culture; low quality work; instability - 2.13%\n21. Layoffs/morale; deviating from our positive work culture; silos; no clear direction; understaffed/workload - 2.13%\n\nThese percentages reflect the proportion of responses that mentioned each specific theme in the survey."
+      ]
+     },
+     "create_time": 1704969082.9639,
+     "end_turn": true,
+     "id": "0f96b900-3aab-43f8-b63f-2a23e3b2fc83",
+     "metadata": {
+      "can_save": true,
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "13a93d9d-727a-43c6-881a-05e5d5e78797",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "13a93d9d-727a-43c6-881a-05e5d5e78797"
+   },
+   "1173a4ee-b9d1-4a27-ae18-1c73e1a0b761": {
+    "children": [
+     "9e9a1097-12af-49ad-8eda-84cae8358378"
+    ],
+    "id": "1173a4ee-b9d1-4a27-ae18-1c73e1a0b761",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": "python",
+      "role": "tool"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "execution_output",
+      "text": "  In the past half year, Nexar went through several changes. In your perspective, what was the best and the worse thing about it?\n0                            I think they were good.                                                                             \n1  Worse - reducing head count but not really red...                                                                             \n2  Best: the resilience of the team, how we keep ...                                                                             \n3                                                  .                                                                             \n4  Good thing: HW independent product line Bad th...                                                                             "
+     },
+     "create_time": 1704965456.504517,
+     "end_turn": null,
+     "id": "1173a4ee-b9d1-4a27-ae18-1c73e1a0b761",
+     "metadata": {
+      "aggregate_result": {
+       "code": "import pandas as pd\n\n# Load the spreadsheet\nfile_path = '/mnt/data/Open question - Dec 2023.xlsx'\n\n# Read the data from the spreadsheet\nsurvey_data = pd.read_excel(file_path)\n\nsurvey_data.head()",
+       "end_time": 1704965327.5143416,
+       "final_expression_output": "  In the past half year, Nexar went through several changes. In your perspective, what was the best and the worse thing about it?\n0                            I think they were good.                                                                             \n1  Worse - reducing head count but not really red...                                                                             \n2  Best: the resilience of the team, how we keep ...                                                                             \n3                                                  .                                                                             \n4  Good thing: HW independent product line Bad th...                                                                             ",
+       "in_kernel_exception": null,
+       "jupyter_messages": [
+        {
+         "content": {
+          "execution_state": "busy"
+         },
+         "msg_type": "status",
+         "parent_header": {
+          "msg_id": "df8ad356-ed0a233315f1597e29379e9a_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "msg_type": "execute_input",
+         "parent_header": {
+          "msg_id": "df8ad356-ed0a233315f1597e29379e9a_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "content": {
+          "data": {
+           "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>In the past half year, Nexar went through several changes. In your perspective, what was the best and the worse thing about it?</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>I think they were good.</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Worse - reducing head count but not really red...</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>Best: the resilience of the team, how we keep ...</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>.</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>Good thing: HW independent product line Bad th...</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
+           "text/plain": "  In the past half year, Nexar went through several changes. In your perspective, what was the best and the worse thing about it?\n0                            I think they were good.                                                                             \n1  Worse - reducing head count but not really red...                                                                             \n2  Best: the resilience of the team, how we keep ...                                                                             \n3                                                  .                                                                             \n4  Good thing: HW independent product line Bad th...                                                                             "
+          }
+         },
+         "msg_type": "execute_result",
+         "parent_header": {
+          "msg_id": "df8ad356-ed0a233315f1597e29379e9a_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "content": {
+          "execution_state": "idle"
+         },
+         "msg_type": "status",
+         "parent_header": {
+          "msg_id": "df8ad356-ed0a233315f1597e29379e9a_2_1",
+          "version": "5.3"
+         }
+        }
+       ],
+       "messages": [],
+       "run_id": "5bebfe51-27f9-409c-8335-1b7d7a93fe7a",
+       "start_time": 1704965324.5275538,
+       "status": "success",
+       "system_exception": null,
+       "timeout_triggered": null,
+       "update_time": 1704965327.5143416
+      },
+      "can_save": false,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "3b216b40-48eb-4f0f-a67a-88b26ebc9b37",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": 1704965327.5143416,
+     "weight": 1.0
+    },
+    "parent": "3b216b40-48eb-4f0f-a67a-88b26ebc9b37"
+   },
+   "13a93d9d-727a-43c6-881a-05e5d5e78797": {
+    "children": [
+     "0f96b900-3aab-43f8-b63f-2a23e3b2fc83"
+    ],
+    "id": "13a93d9d-727a-43c6-881a-05e5d5e78797",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": "python",
+      "role": "tool"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "execution_output",
+      "text": "(Clear company direction                                      20.833333\n Serious about running a business                             20.833333\n More focus                                                   14.583333\n Cost efficiency                                              10.416667\n Nothing                                                       4.166667\n Local management                                              2.083333\n Better in Eng for knowledge sharing and dependencies          2.083333\n Clear company direction; feeling taken care of                2.083333\n More focus; cost efficiency                                   2.083333\n More focus; clear company direction                           2.083333\n More focus; data-driven decisions                             2.083333\n Clear company direction; office life                          2.083333\n Clear company direction; serious about running a business     2.083333\n Cross-department collaboration                                2.083333\n Team resilience                                               2.083333\n Office perks; occasional bonuses                              2.083333\n Extended runway                                               2.083333\n HW independent product line                                   2.083333\n Cost efficiency; serious about running a business             2.083333\n Name: Good, dtype: float64,\n Understaffed/workload                                                                                         23.404255\n Layoffs/morale                                                                                                23.404255\n Deviating from our positive work culture                                                                      14.893617\n Change came too late                                                                                           2.127660\n Silos                                                                                                          2.127660\n Understaffed/workload; inappropriate compensation/recognition                                                  2.127660\n Layoffs; low quality work; silos                                                                               2.127660\n Instability; low runway                                                                                        2.127660\n Lack of accountability at leadership level                                                                     2.127660\n Not enough HR for work to be done                                                                              2.127660\n Layoffs/morale; communication                                                                                  2.127660\n The new leadership                                                                                             2.127660\n Layoffs/morale; over reorganizing/instability                                                                  2.127660\n Over reorganizing/instability                                                                                  2.127660\n Layoffs/morale; deviating from our positive work culture; inappropriate compensation/recognition               2.127660\n Layoffs/morale; less contact with IL                                                                           2.127660\n Understaffed/workload; layoffs/morale                                                                          2.127660\n Deviating from our positive work culture; poor communication; disorganized; workload                           2.127660\n Deviating from our positive work culture; layoffs                                                              2.127660\n Deviating from our positive work culture; low quality work; instability                                        2.127660\n Layoffs/morale; deviating from our positive work culture; silos; no clear direction; understaffed/workload     2.127660\n Name: Bad, dtype: float64)"
+     },
+     "create_time": 1704969082.963487,
+     "end_turn": null,
+     "id": "13a93d9d-727a-43c6-881a-05e5d5e78797",
+     "metadata": {
+      "aggregate_result": {
+       "code": "# Counting the occurrences of each theme in both good and bad columns\r\ngood_theme_counts = updated_survey_data['Good'].value_counts()\r\nbad_theme_counts = updated_survey_data['Bad'].value_counts()\r\n\r\n# Calculating the total number of responses for good and bad themes\r\ntotal_good_responses = good_theme_counts.sum()\r\ntotal_bad_responses = bad_theme_counts.sum()\r\n\r\n# Calculating the percentage for each theme\r\ngood_theme_percentages = (good_theme_counts / total_good_responses) * 100\r\nbad_theme_percentages = (bad_theme_counts / total_bad_responses) * 100\r\n\r\ngood_theme_percentages, bad_theme_percentages",
+       "end_time": 1704969035.4101615,
+       "final_expression_output": "(Clear company direction                                      20.833333\n Serious about running a business                             20.833333\n More focus                                                   14.583333\n Cost efficiency                                              10.416667\n Nothing                                                       4.166667\n Local management                                              2.083333\n Better in Eng for knowledge sharing and dependencies          2.083333\n Clear company direction; feeling taken care of                2.083333\n More focus; cost efficiency                                   2.083333\n More focus; clear company direction                           2.083333\n More focus; data-driven decisions                             2.083333\n Clear company direction; office life                          2.083333\n Clear company direction; serious about running a business     2.083333\n Cross-department collaboration                                2.083333\n Team resilience                                               2.083333\n Office perks; occasional bonuses                              2.083333\n Extended runway                                               2.083333\n HW independent product line                                   2.083333\n Cost efficiency; serious about running a business             2.083333\n Name: Good, dtype: float64,\n Understaffed/workload                                                                                         23.404255\n Layoffs/morale                                                                                                23.404255\n Deviating from our positive work culture                                                                      14.893617\n Change came too late                                                                                           2.127660\n Silos                                                                                                          2.127660\n Understaffed/workload; inappropriate compensation/recognition                                                  2.127660\n Layoffs; low quality work; silos                                                                               2.127660\n Instability; low runway                                                                                        2.127660\n Lack of accountability at leadership level                                                                     2.127660\n Not enough HR for work to be done                                                                              2.127660\n Layoffs/morale; communication                                                                                  2.127660\n The new leadership                                                                                             2.127660\n Layoffs/morale; over reorganizing/instability                                                                  2.127660\n Over reorganizing/instability                                                                                  2.127660\n Layoffs/morale; deviating from our positive work culture; inappropriate compensation/recognition               2.127660\n Layoffs/morale; less contact with IL                                                                           2.127660\n Understaffed/workload; layoffs/morale                                                                          2.127660\n Deviating from our positive work culture; poor communication; disorganized; workload                           2.127660\n Deviating from our positive work culture; layoffs                                                              2.127660\n Deviating from our positive work culture; low quality work; instability                                        2.127660\n Layoffs/morale; deviating from our positive work culture; silos; no clear direction; understaffed/workload     2.127660\n Name: Bad, dtype: float64)",
+       "in_kernel_exception": null,
+       "jupyter_messages": [
+        {
+         "content": {
+          "execution_state": "busy"
+         },
+         "msg_type": "status",
+         "parent_header": {
+          "msg_id": "3a1fcd2a-15ca53710314e1ec4760c2df_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "msg_type": "execute_input",
+         "parent_header": {
+          "msg_id": "3a1fcd2a-15ca53710314e1ec4760c2df_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "content": {
+          "data": {
+           "text/plain": "(Clear company direction                                      20.833333\n Serious about running a business                             20.833333\n More focus                                                   14.583333\n Cost efficiency                                              10.416667\n Nothing                                                       4.166667\n Local management                                              2.083333\n Better in Eng for knowledge sharing and dependencies          2.083333\n Clear company direction; feeling taken care of                2.083333\n More focus; cost efficiency                                   2.083333\n More focus; clear company direction                           2.083333\n More focus; data-driven decisions                             2.083333\n Clear company direction; office life                          2.083333\n Clear company direction; serious about running a business     2.083333\n Cross-department collaboration                                2.083333\n Team resilience                                               2.083333\n Office perks; occasional bonuses                              2.083333\n Extended runway                                               2.083333\n HW independent product line                                   2.083333\n Cost efficiency; serious about running a business             2.083333\n Name: Good, dtype: float64,\n Understaffed/workload                                                                                         23.404255\n Layoffs/morale                                                                                                23.404255\n Deviating from our positive work culture                                                                      14.893617\n Change came too late                                                                                           2.127660\n Silos                                                                                                          2.127660\n Understaffed/workload; inappropriate compensation/recognition                                                  2.127660\n Layoffs; low quality work; silos                                                                               2.127660\n Instability; low runway                                                                                        2.127660\n Lack of accountability at leadership level                                                                     2.127660\n Not enough HR for work to be done                                                                              2.127660\n Layoffs/morale; communication                                                                                  2.127660\n The new leadership                                                                                             2.127660\n Layoffs/morale; over reorganizing/instability                                                                  2.127660\n Over reorganizing/instability                                                                                  2.127660\n Layoffs/morale; deviating from our positive work culture; inappropriate compensation/recognition               2.127660\n Layoffs/morale; less contact with IL                                                                           2.127660\n Understaffed/workload; layoffs/morale                                                                          2.127660\n Deviating from our positive work culture; poor communication; disorganized; workload                           2.127660\n Deviating from our positive work culture; layoffs                                                              2.127660\n Deviating from our positive work culture; low quality work; instability                                        2.127660\n Layoffs/morale; deviating from our positive work culture; silos; no clear direction; understaffed/workload     2.127660\n Name: Bad, dtype: float64)"
+          }
+         },
+         "msg_type": "execute_result",
+         "parent_header": {
+          "msg_id": "3a1fcd2a-15ca53710314e1ec4760c2df_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "content": {
+          "execution_state": "idle"
+         },
+         "msg_type": "status",
+         "parent_header": {
+          "msg_id": "3a1fcd2a-15ca53710314e1ec4760c2df_2_1",
+          "version": "5.3"
+         }
+        }
+       ],
+       "messages": [],
+       "run_id": "e6fefb12-f2b9-4a04-a5b1-baff18c56332",
+       "start_time": 1704969035.3483467,
+       "status": "success",
+       "system_exception": null,
+       "timeout_triggered": null,
+       "update_time": 1704969035.4101615
+      },
+      "can_save": false,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "6ff81ac2-7805-48f5-8010-fd4f204a0579",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": 1704969035.4101615,
+     "weight": 1.0
+    },
+    "parent": "6ff81ac2-7805-48f5-8010-fd4f204a0579"
+   },
+   "14b4b41a-998e-4fc1-af43-2bc01894de5e": {
+    "children": [
+     "8f41554c-7106-4241-83d7-f9f3adb7b224"
+    ],
+    "id": "14b4b41a-998e-4fc1-af43-2bc01894de5e",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": "python",
+      "role": "tool"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "execution_output",
+      "text": "/tmp/ipykernel_51/620288447.py:12: DeprecationWarning: Flags not at the start of the expression '(?i)good\\\\ thing:|(?i' (truncated)\n  parts = re.split(pattern, response)\n---------------------------------------------------------------------------\nTypeError                                 Traceback (most recent call last)\nCell In[2], line 32\n     29 bad_aspects_all = []\n     31 for response in survey_data.iloc[:, 0]:\n---> 32     good_aspects, bad_aspects = extract_good_bad_aspects(response)\n     33     good_aspects_all.extend(good_aspects)\n     34     bad_aspects_all.extend(bad_aspects)\n\nCell In[2], line 12, in extract_good_bad_aspects(response)\n     10 phrases = ['good thing:', 'bad thing:', 'good:', 'bad:', 'best:', 'worse:', 'worst:', 'positive:', 'negative:', 'pro:', 'con:']\n     11 pattern = '|'.join([f'(?i){re.escape(phrase)}' for phrase in phrases])\n---> 12 parts = re.split(pattern, response)\n     14 # Determining which parts are good and which are bad\n     15 for i, part in enumerate(parts):\n     16     # Check if the preceding phrase indicates good or bad\n\nFile /usr/lib/python3.8/re.py:231, in split(pattern, string, maxsplit, flags)\n    223 def split(pattern, string, maxsplit=0, flags=0):\n    224     \"\"\"Split the source string by the occurrences of the pattern,\n    225     returning a list containing the resulting substrings.  If\n    226     capturing parentheses are used in pattern, then the text of all\n   (...)\n    229     and the remainder of the string is returned as the final element\n    230     of the list.\"\"\"\n--> 231     return _compile(pattern, flags).split(string, maxsplit)\n\nTypeError: expected string or bytes-like object\n"
+     },
+     "create_time": 1704965456.510683,
+     "end_turn": null,
+     "id": "14b4b41a-998e-4fc1-af43-2bc01894de5e",
+     "metadata": {
+      "aggregate_result": {
+       "code": "from collections import Counter\nimport re\n\n# Function to extract good and bad aspects from a response\ndef extract_good_bad_aspects(response):\n    good_aspects = []\n    bad_aspects = []\n\n    # Splitting based on common phrases that indicate a switch from good to bad or vice versa\n    phrases = ['good thing:', 'bad thing:', 'good:', 'bad:', 'best:', 'worse:', 'worst:', 'positive:', 'negative:', 'pro:', 'con:']\n    pattern = '|'.join([f'(?i){re.escape(phrase)}' for phrase in phrases])\n    parts = re.split(pattern, response)\n\n    # Determining which parts are good and which are bad\n    for i, part in enumerate(parts):\n        # Check if the preceding phrase indicates good or bad\n        if i > 0 and 'bad' in parts[i-1].lower():\n            bad_aspects.append(part.strip())\n        elif i > 0 and 'good' in parts[i-1].lower():\n            good_aspects.append(part.strip())\n        else:\n            # If no clear indication, this approach will not add the response to either category\n            continue\n\n    return good_aspects, bad_aspects\n\n# Process each response and accumulate good and bad aspects\ngood_aspects_all = []\nbad_aspects_all = []\n\nfor response in survey_data.iloc[:, 0]:\n    good_aspects, bad_aspects = extract_good_bad_aspects(response)\n    good_aspects_all.extend(good_aspects)\n    bad_aspects_all.extend(bad_aspects)\n\n# Count the frequency of each aspect\ngood_aspect_counts = Counter(good_aspects_all)\nbad_aspect_counts = Counter(bad_aspects_all)\n\n# Get the top 5 good and bad aspects\ntop_5_good_aspects = good_aspect_counts.most_common(5)\ntop_5_bad_aspects = bad_aspect_counts.most_common(5)\n\ntop_5_good_aspects, top_5_bad_aspects",
+       "end_time": 1704965388.4071362,
+       "final_expression_output": null,
+       "in_kernel_exception": {
+        "args": [
+         "expected string or bytes-like object"
+        ],
+        "name": "TypeError",
+        "notes": [],
+        "traceback": [
+         "---------------------------------------------------------------------------\n",
+         "TypeError                                 Traceback (most recent call last)\n",
+         "Cell In[2], line 32\n     29 bad_aspects_all = []\n     31 for response in survey_data.iloc[:, 0]:\n---> 32     good_aspects, bad_aspects = extract_good_bad_aspects(response)\n     33     good_aspects_all.extend(good_aspects)\n     34     bad_aspects_all.extend(bad_aspects)\n\n",
+         "Cell In[2], line 12, in extract_good_bad_aspects(response)\n     10 phrases = ['good thing:', 'bad thing:', 'good:', 'bad:', 'best:', 'worse:', 'worst:', 'positive:', 'negative:', 'pro:', 'con:']\n     11 pattern = '|'.join([f'(?i){re.escape(phrase)}' for phrase in phrases])\n---> 12 parts = re.split(pattern, response)\n     14 # Determining which parts are good and which are bad\n     15 for i, part in enumerate(parts):\n     16     # Check if the preceding phrase indicates good or bad\n\n",
+         "File /usr/lib/python3.8/re.py:231, in split(pattern, string, maxsplit, flags)\n    223 def split(pattern, string, maxsplit=0, flags=0):\n    224     \"\"\"Split the source string by the occurrences of the pattern,\n    225     returning a list containing the resulting substrings.  If\n    226     capturing parentheses are used in pattern, then the text of all\n   (...)\n    229     and the remainder of the string is returned as the final element\n    230     of the list.\"\"\"\n--> 231     return _compile(pattern, flags).split(string, maxsplit)\n\n",
+         "TypeError: expected string or bytes-like object\n"
+        ]
+       },
+       "jupyter_messages": [
+        {
+         "content": {
+          "execution_state": "busy"
+         },
+         "msg_type": "status",
+         "parent_header": {
+          "msg_id": "df8ad356-ed0a233315f1597e29379e9a_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "msg_type": "execute_input",
+         "parent_header": {
+          "msg_id": "df8ad356-ed0a233315f1597e29379e9a_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "content": {
+          "name": "stderr",
+          "text": "/tmp/ipykernel_51/620288447.py:12: DeprecationWarning: Flags not at the start of the expression '(?i)good\\\\ thing:|(?i' (truncated)\n  parts = re.split(pattern, response)\n"
+         },
+         "msg_type": "stream",
+         "parent_header": {
+          "msg_id": "df8ad356-ed0a233315f1597e29379e9a_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "content": {
+          "ename": "TypeError",
+          "evalue": "expected string or bytes-like object",
+          "traceback": [
+           "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+           "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+           "Cell \u001b[0;32mIn[2], line 32\u001b[0m\n\u001b[1;32m     29\u001b[0m bad_aspects_all \u001b[38;5;241m=\u001b[39m []\n\u001b[1;32m     31\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m response \u001b[38;5;129;01min\u001b[39;00m survey_data\u001b[38;5;241m.\u001b[39miloc[:, \u001b[38;5;241m0\u001b[39m]:\n\u001b[0;32m---> 32\u001b[0m     good_aspects, bad_aspects \u001b[38;5;241m=\u001b[39m \u001b[43mextract_good_bad_aspects\u001b[49m\u001b[43m(\u001b[49m\u001b[43mresponse\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     33\u001b[0m     good_aspects_all\u001b[38;5;241m.\u001b[39mextend(good_aspects)\n\u001b[1;32m     34\u001b[0m     bad_aspects_all\u001b[38;5;241m.\u001b[39mextend(bad_aspects)\n",
+           "Cell \u001b[0;32mIn[2], line 12\u001b[0m, in \u001b[0;36mextract_good_bad_aspects\u001b[0;34m(response)\u001b[0m\n\u001b[1;32m     10\u001b[0m phrases \u001b[38;5;241m=\u001b[39m [\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mgood thing:\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mbad thing:\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mgood:\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mbad:\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mbest:\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mworse:\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mworst:\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mpositive:\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mnegative:\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mpro:\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mcon:\u001b[39m\u001b[38;5;124m'\u001b[39m]\n\u001b[1;32m     11\u001b[0m pattern \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;124m|\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;241m.\u001b[39mjoin([\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m(?i)\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mre\u001b[38;5;241m.\u001b[39mescape(phrase)\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m phrase \u001b[38;5;129;01min\u001b[39;00m phrases])\n\u001b[0;32m---> 12\u001b[0m parts \u001b[38;5;241m=\u001b[39m \u001b[43mre\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43msplit\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpattern\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mresponse\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     14\u001b[0m \u001b[38;5;66;03m# Determining which parts are good and which are bad\u001b[39;00m\n\u001b[1;32m     15\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m i, part \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28menumerate\u001b[39m(parts):\n\u001b[1;32m     16\u001b[0m     \u001b[38;5;66;03m# Check if the preceding phrase indicates good or bad\u001b[39;00m\n",
+           "File \u001b[0;32m/usr/lib/python3.8/re.py:231\u001b[0m, in \u001b[0;36msplit\u001b[0;34m(pattern, string, maxsplit, flags)\u001b[0m\n\u001b[1;32m    223\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21msplit\u001b[39m(pattern, string, maxsplit\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m0\u001b[39m, flags\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m0\u001b[39m):\n\u001b[1;32m    224\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Split the source string by the occurrences of the pattern,\u001b[39;00m\n\u001b[1;32m    225\u001b[0m \u001b[38;5;124;03m    returning a list containing the resulting substrings.  If\u001b[39;00m\n\u001b[1;32m    226\u001b[0m \u001b[38;5;124;03m    capturing parentheses are used in pattern, then the text of all\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    229\u001b[0m \u001b[38;5;124;03m    and the remainder of the string is returned as the final element\u001b[39;00m\n\u001b[1;32m    230\u001b[0m \u001b[38;5;124;03m    of the list.\"\"\"\u001b[39;00m\n\u001b[0;32m--> 231\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43m_compile\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpattern\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mflags\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43msplit\u001b[49m\u001b[43m(\u001b[49m\u001b[43mstring\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmaxsplit\u001b[49m\u001b[43m)\u001b[49m\n",
+           "\u001b[0;31mTypeError\u001b[0m: expected string or bytes-like object"
+          ]
+         },
+         "msg_type": "error",
+         "parent_header": {
+          "msg_id": "df8ad356-ed0a233315f1597e29379e9a_2_1",
+          "version": "5.3"
+         }
+        }
+       ],
+       "messages": [
+        {
+         "message_type": "stream",
+         "sender": "server",
+         "stream_name": "stderr",
+         "text": "/tmp/ipykernel_51/620288447.py:12: DeprecationWarning: Flags not at the start of the expression '(?i)good\\\\ thing:|(?i' (truncated)\n  parts = re.split(pattern, response)\n",
+         "time": 1704965387.8600936
+        }
+       ],
+       "run_id": "d8171c8f-e620-4ea8-909b-465da336715e",
+       "start_time": 1704965387.6229515,
+       "status": "failed_with_in_kernel_exception",
+       "system_exception": null,
+       "timeout_triggered": null,
+       "update_time": 1704965388.4071362
+      },
+      "can_save": false,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "d9c1b5bf-a047-4ce7-8e84-8611d6cc07d1",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": 1704965388.4071362,
+     "weight": 1.0
+    },
+    "parent": "d9c1b5bf-a047-4ce7-8e84-8611d6cc07d1"
+   },
+   "27c5ed6e-389b-4c37-9fe3-9960a572c41a": {
+    "children": [
+     "418b54f8-c112-45ef-8b39-eda56cd454a8"
+    ],
+    "id": "27c5ed6e-389b-4c37-9fe3-9960a572c41a",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "code",
+      "language": "unknown",
+      "response_format_name": null,
+      "text": "# Adjusting the function to handle non-text responses\n\ndef extract_good_bad_aspects_adjusted(response):\n    if not isinstance(response, str):\n        return [], []  # Ignore non-text responses\n\n    return extract_good_bad_aspects(response)\n\n# Re-process each response with the adjusted function\ngood_aspects_all_adjusted = []\nbad_aspects_all_adjusted = []\n\nfor response in survey_data.iloc[:, 0]:\n    good_aspects, bad_aspects = extract_good_bad_aspects_adjusted(response)\n    good_aspects_all_adjusted.extend(good_aspects)\n    bad_aspects_all_adjusted.extend(bad_aspects)\n\n# Count the frequency of each aspect again\ngood_aspect_counts_adjusted = Counter(good_aspects_all_adjusted)\nbad_aspect_counts_adjusted = Counter(bad_aspects_all_adjusted)\n\n# Get the top 5 good and bad aspects again\ntop_5_good_aspects_adjusted = good_aspect_counts_adjusted.most_common(5)\ntop_5_bad_aspects_adjusted = bad_aspect_counts_adjusted.most_common(5)\n\ntop_5_good_aspects_adjusted, top_5_bad_aspects_adjusted"
+     },
+     "create_time": 1704965456.513199,
+     "end_turn": false,
+     "id": "27c5ed6e-389b-4c37-9fe3-9960a572c41a",
+     "metadata": {
+      "can_save": false,
+      "finish_details": {
+       "stop_tokens": [
+        100265
+       ],
+       "type": "stop"
+      },
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "8f41554c-7106-4241-83d7-f9f3adb7b224",
+      "timestamp_": "absolute"
+     },
+     "recipient": "python",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "8f41554c-7106-4241-83d7-f9f3adb7b224"
+   },
+   "29b04231-af80-4569-bcf5-6c3d24b173d6": {
+    "children": [
+     "6ff81ac2-7805-48f5-8010-fd4f204a0579"
+    ],
+    "id": "29b04231-af80-4569-bcf5-6c3d24b173d6",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": "python",
+      "role": "tool"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "execution_output",
+      "text": "                          Good                            Bad\n0                          NaN                            NaN\n1             Local management          Understaffed/workload\n2              Team resilience          Understaffed/workload\n3                          NaN                            NaN\n4  HW independent product line  Over reorganizing/instability"
+     },
+     "create_time": 1704969082.960044,
+     "end_turn": null,
+     "id": "29b04231-af80-4569-bcf5-6c3d24b173d6",
+     "metadata": {
+      "aggregate_result": {
+       "code": "# Re-importing pandas as the code execution state was reset\r\nimport pandas as pd\r\n\r\n# Load the updated spreadsheet again\r\nupdated_file_path = '/mnt/data/Open question - Dec 2023 (1).xlsx'\r\n\r\n# Read the data from the updated spreadsheet\r\nupdated_survey_data = pd.read_excel(updated_file_path)\r\n\r\nupdated_survey_data.head()",
+       "end_time": 1704969026.4086223,
+       "final_expression_output": "                          Good                            Bad\n0                          NaN                            NaN\n1             Local management          Understaffed/workload\n2              Team resilience          Understaffed/workload\n3                          NaN                            NaN\n4  HW independent product line  Over reorganizing/instability",
+       "in_kernel_exception": null,
+       "jupyter_messages": [
+        {
+         "content": {
+          "execution_state": "busy"
+         },
+         "msg_type": "status",
+         "parent_header": {
+          "msg_id": "3a1fcd2a-15ca53710314e1ec4760c2df_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "msg_type": "execute_input",
+         "parent_header": {
+          "msg_id": "3a1fcd2a-15ca53710314e1ec4760c2df_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "content": {
+          "data": {
+           "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>Good</th>\n      <th>Bad</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>NaN</td>\n      <td>NaN</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Local management</td>\n      <td>Understaffed/workload</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>Team resilience</td>\n      <td>Understaffed/workload</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>NaN</td>\n      <td>NaN</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>HW independent product line</td>\n      <td>Over reorganizing/instability</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
+           "text/plain": "                          Good                            Bad\n0                          NaN                            NaN\n1             Local management          Understaffed/workload\n2              Team resilience          Understaffed/workload\n3                          NaN                            NaN\n4  HW independent product line  Over reorganizing/instability"
+          }
+         },
+         "msg_type": "execute_result",
+         "parent_header": {
+          "msg_id": "3a1fcd2a-15ca53710314e1ec4760c2df_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "content": {
+          "execution_state": "idle"
+         },
+         "msg_type": "status",
+         "parent_header": {
+          "msg_id": "3a1fcd2a-15ca53710314e1ec4760c2df_2_1",
+          "version": "5.3"
+         }
+        }
+       ],
+       "messages": [],
+       "run_id": "0ce6742c-d5a0-4b4c-a0e1-0992f314fc55",
+       "start_time": 1704969024.3767114,
+       "status": "success",
+       "system_exception": null,
+       "timeout_triggered": null,
+       "update_time": 1704969026.4086223
+      },
+      "can_save": false,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "013734d1-8e69-47aa-970f-df2bdcda7dd8",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": 1704969026.4086223,
+     "weight": 1.0
+    },
+    "parent": "013734d1-8e69-47aa-970f-df2bdcda7dd8"
+   },
+   "3a03ec4b-399d-436b-82d7-8f4e3fd78d97": {
+    "children": [
+     "5e8bcf64-dd59-4e81-8487-9e6f434d66b8"
+    ],
+    "id": "3a03ec4b-399d-436b-82d7-8f4e3fd78d97",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "code",
+      "language": "unknown",
+      "response_format_name": null,
+      "text": "# Counting the occurrences of each theme in the new good and bad columns\r\nnew_good_theme_counts = new_survey_data['Good'].value_counts()\r\nnew_bad_theme_counts = new_survey_data['Bad'].value_counts()\r\n\r\n# Calculating the total number of responses for the new good and bad themes\r\ntotal_new_good_responses = new_good_theme_counts.sum()\r\ntotal_new_bad_responses = new_bad_theme_counts.sum()\r\n\r\n# Calculating the percentage for each theme in the new dataset\r\nnew_good_theme_percentages = (new_good_theme_counts / total_new_good_responses) * 100\r\nnew_bad_theme_percentages = (new_bad_theme_counts / total_new_bad_responses) * 100\r\n\r\nnew_good_theme_percentages, new_bad_theme_percentages"
+     },
+     "create_time": 1704969667.869928,
+     "end_turn": false,
+     "id": "3a03ec4b-399d-436b-82d7-8f4e3fd78d97",
+     "metadata": {
+      "can_save": false,
+      "finish_details": {
+       "stop_tokens": [
+        100265
+       ],
+       "type": "stop"
+      },
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "54045d03-6582-4a85-8ec0-c5b053b86bc3",
+      "timestamp_": "absolute"
+     },
+     "recipient": "python",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "54045d03-6582-4a85-8ec0-c5b053b86bc3"
+   },
+   "3b216b40-48eb-4f0f-a67a-88b26ebc9b37": {
+    "children": [
+     "1173a4ee-b9d1-4a27-ae18-1c73e1a0b761"
+    ],
+    "id": "3b216b40-48eb-4f0f-a67a-88b26ebc9b37",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "code",
+      "language": "unknown",
+      "response_format_name": null,
+      "text": "import pandas as pd\n\n# Load the spreadsheet\nfile_path = '/mnt/data/Open question - Dec 2023.xlsx'\n\n# Read the data from the spreadsheet\nsurvey_data = pd.read_excel(file_path)\n\nsurvey_data.head()"
+     },
+     "create_time": 1704965456.502467,
+     "end_turn": false,
+     "id": "3b216b40-48eb-4f0f-a67a-88b26ebc9b37",
+     "metadata": {
+      "can_save": false,
+      "finish_details": {
+       "stop_tokens": [
+        100265
+       ],
+       "type": "stop"
+      },
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "aaa2d78b-8e76-436c-8461-21e1399fc2b4",
+      "timestamp_": "absolute"
+     },
+     "recipient": "python",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa2d78b-8e76-436c-8461-21e1399fc2b4"
+   },
+   "418b54f8-c112-45ef-8b39-eda56cd454a8": {
+    "children": [
+     "0e811609-5da0-4239-a964-58ffc13392dc"
+    ],
+    "id": "418b54f8-c112-45ef-8b39-eda56cd454a8",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": "python",
+      "role": "tool"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "execution_output",
+      "text": "([('- company-wide goals and clear focus - [PERSON_c529ff] cleaning the house from the all the unnecessary expenses - having the team in the same geography and going to the office feels great; 2 or 3 days a week is the perfect balance',\n   1)],\n [])"
+     },
+     "create_time": 1704965456.516164,
+     "end_turn": null,
+     "id": "418b54f8-c112-45ef-8b39-eda56cd454a8",
+     "metadata": {
+      "aggregate_result": {
+       "code": "# Adjusting the function to handle non-text responses\n\ndef extract_good_bad_aspects_adjusted(response):\n    if not isinstance(response, str):\n        return [], []  # Ignore non-text responses\n\n    return extract_good_bad_aspects(response)\n\n# Re-process each response with the adjusted function\ngood_aspects_all_adjusted = []\nbad_aspects_all_adjusted = []\n\nfor response in survey_data.iloc[:, 0]:\n    good_aspects, bad_aspects = extract_good_bad_aspects_adjusted(response)\n    good_aspects_all_adjusted.extend(good_aspects)\n    bad_aspects_all_adjusted.extend(bad_aspects)\n\n# Count the frequency of each aspect again\ngood_aspect_counts_adjusted = Counter(good_aspects_all_adjusted)\nbad_aspect_counts_adjusted = Counter(bad_aspects_all_adjusted)\n\n# Get the top 5 good and bad aspects again\ntop_5_good_aspects_adjusted = good_aspect_counts_adjusted.most_common(5)\ntop_5_bad_aspects_adjusted = bad_aspect_counts_adjusted.most_common(5)\n\ntop_5_good_aspects_adjusted, top_5_bad_aspects_adjusted",
+       "end_time": 1704965423.8695047,
+       "final_expression_output": "([('- company-wide goals and clear focus - [PERSON_c529ff] cleaning the house from the all the unnecessary expenses - having the team in the same geography and going to the office feels great; 2 or 3 days a week is the perfect balance',\n   1)],\n [])",
+       "in_kernel_exception": null,
+       "jupyter_messages": [
+        {
+         "content": {
+          "execution_state": "busy"
+         },
+         "msg_type": "status",
+         "parent_header": {
+          "msg_id": "df8ad356-ed0a233315f1597e29379e9a_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "msg_type": "execute_input",
+         "parent_header": {
+          "msg_id": "df8ad356-ed0a233315f1597e29379e9a_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "content": {
+          "data": {
+           "text/plain": "([('- company-wide goals and clear focus - [PERSON_c529ff] cleaning the house from the all the unnecessary expenses - having the team in the same geography and going to the office feels great; 2 or 3 days a week is the perfect balance',\n   1)],\n [])"
+          }
+         },
+         "msg_type": "execute_result",
+         "parent_header": {
+          "msg_id": "df8ad356-ed0a233315f1597e29379e9a_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "content": {
+          "execution_state": "idle"
+         },
+         "msg_type": "status",
+         "parent_header": {
+          "msg_id": "df8ad356-ed0a233315f1597e29379e9a_2_1",
+          "version": "5.3"
+         }
+        }
+       ],
+       "messages": [],
+       "run_id": "fbd9aa0c-e871-4748-934c-7d61d3baf56b",
+       "start_time": 1704965423.8049276,
+       "status": "success",
+       "system_exception": null,
+       "timeout_triggered": null,
+       "update_time": 1704965423.8695047
+      },
+      "can_save": false,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "27c5ed6e-389b-4c37-9fe3-9960a572c41a",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": 1704965423.8695047,
+     "weight": 1.0
+    },
+    "parent": "27c5ed6e-389b-4c37-9fe3-9960a572c41a"
+   },
+   "451432bd-b736-428f-8169-5958db0869ea": {
+    "children": [
+     "d8d3377e-21fe-494e-88f2-4d2ed044c039"
+    ],
+    "id": "451432bd-b736-428f-8169-5958db0869ea",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "code",
+      "language": "unknown",
+      "response_format_name": null,
+      "text": "from textblob import TextBlob\n\n# Function to analyze sentiment of each response\ndef analyze_sentiment(response):\n    blob = TextBlob(response)\n    return blob.sentiment.polarity  # Polarity score: -1 (negative) to 1 (positive)\n\n# Analyze each response for sentiment\nsentiments = survey_data.iloc[:, 0].apply(analyze_sentiment)\n\n# Classify responses into positive, neutral, and negative based on sentiment score\npositive_responses = survey_data[sentiments > 0].iloc[:, 0]\nneutral_responses = survey_data[sentiments == 0].iloc[:, 0]\nnegative_responses = survey_data[sentiments < 0].iloc[:, 0]\n\n# Display counts of each type\npositive_count = len(positive_responses)\nneutral_count = len(neutral_responses)\nnegative_count = len(negative_responses)\n\npositive_count, neutral_count, negative_count, positive_responses.head(), negative_responses.head()"
+     },
+     "create_time": 1704965564.797971,
+     "end_turn": false,
+     "id": "451432bd-b736-428f-8169-5958db0869ea",
+     "metadata": {
+      "can_save": false,
+      "finish_details": {
+       "stop_tokens": [
+        100265
+       ],
+       "type": "stop"
+      },
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "aaa2e51d-68c8-4eac-acdb-d6c71f17ac99",
+      "timestamp_": "absolute"
+     },
+     "recipient": "python",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa2e51d-68c8-4eac-acdb-d6c71f17ac99"
+   },
+   "54045d03-6582-4a85-8ec0-c5b053b86bc3": {
+    "children": [
+     "3a03ec4b-399d-436b-82d7-8f4e3fd78d97"
+    ],
+    "id": "54045d03-6582-4a85-8ec0-c5b053b86bc3",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": "python",
+      "role": "tool"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "execution_output",
+      "text": "                      Good                                       Bad\n0               More focus                      Change came too late\n1  Clear company direction  Deviating from our positive work culture\n2  Clear company direction  Deviating from our positive work culture\n3          Cost efficiency  Deviating from our positive work culture\n4          Cost efficiency  Deviating from our positive work culture"
+     },
+     "create_time": 1704969667.869559,
+     "end_turn": null,
+     "id": "54045d03-6582-4a85-8ec0-c5b053b86bc3",
+     "metadata": {
+      "aggregate_result": {
+       "code": "# Re-load the newly uploaded spreadsheet for the updated analysis\r\nnew_file_path = '/mnt/data/Open question - Dec 2023 (2).xlsx'\r\n\r\n# Read the data from the new spreadsheet\r\nnew_survey_data = pd.read_excel(new_file_path)\r\n\r\nnew_survey_data.head()",
+       "end_time": 1704969617.33951,
+       "final_expression_output": "                      Good                                       Bad\n0               More focus                      Change came too late\n1  Clear company direction  Deviating from our positive work culture\n2  Clear company direction  Deviating from our positive work culture\n3          Cost efficiency  Deviating from our positive work culture\n4          Cost efficiency  Deviating from our positive work culture",
+       "in_kernel_exception": null,
+       "jupyter_messages": [
+        {
+         "content": {
+          "execution_state": "busy"
+         },
+         "msg_type": "status",
+         "parent_header": {
+          "msg_id": "3a1fcd2a-15ca53710314e1ec4760c2df_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "msg_type": "execute_input",
+         "parent_header": {
+          "msg_id": "3a1fcd2a-15ca53710314e1ec4760c2df_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "content": {
+          "data": {
+           "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>Good</th>\n      <th>Bad</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>More focus</td>\n      <td>Change came too late</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Clear company direction</td>\n      <td>Deviating from our positive work culture</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>Clear company direction</td>\n      <td>Deviating from our positive work culture</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>Cost efficiency</td>\n      <td>Deviating from our positive work culture</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>Cost efficiency</td>\n      <td>Deviating from our positive work culture</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
+           "text/plain": "                      Good                                       Bad\n0               More focus                      Change came too late\n1  Clear company direction  Deviating from our positive work culture\n2  Clear company direction  Deviating from our positive work culture\n3          Cost efficiency  Deviating from our positive work culture\n4          Cost efficiency  Deviating from our positive work culture"
+          }
+         },
+         "msg_type": "execute_result",
+         "parent_header": {
+          "msg_id": "3a1fcd2a-15ca53710314e1ec4760c2df_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "content": {
+          "execution_state": "idle"
+         },
+         "msg_type": "status",
+         "parent_header": {
+          "msg_id": "3a1fcd2a-15ca53710314e1ec4760c2df_2_1",
+          "version": "5.3"
+         }
+        }
+       ],
+       "messages": [],
+       "run_id": "ea326859-4470-4305-aeae-6648295a7bb3",
+       "start_time": 1704969616.714891,
+       "status": "success",
+       "system_exception": null,
+       "timeout_triggered": null,
+       "update_time": 1704969617.33951
+      },
+      "can_save": false,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "d4c69f46-5f15-413d-b215-cf1bd22bf6fe",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": 1704969617.33951,
+     "weight": 1.0
+    },
+    "parent": "d4c69f46-5f15-413d-b215-cf1bd22bf6fe"
+   },
+   "5b635955-564c-4470-aff5-1a606543944e": {
+    "children": [
+     "939724bf-043b-4bbb-ab13-ea42e14aaed9"
+    ],
+    "id": "5b635955-564c-4470-aff5-1a606543944e",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": "python",
+      "role": "tool"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "execution_output",
+      "text": "(41,\n 8,\n 9,\n 0                              I think they were good.\n 1    Worse - reducing head count but not really red...\n 4    Good thing: HW independent product line Bad th...\n 5    The most positive thing over the past few mont...\n 9    I don't really know what to say. It feels like...\n Name: In the past half year, Nexar went through several changes. In your perspective, what was the best and the worse thing about it?, dtype: object,\n 2     Best: the resilience of the team, how we keep ...\n 6     I don't see any changes for the better, maybe ...\n 7     The implementation of measures to reduce unnec...\n 8     Change is always hard. The worst part was to s...\n 18    Not sure what changes are being discussed, I'm...\n Name: In the past half year, Nexar went through several changes. In your perspective, what was the best and the worse thing about it?, dtype: object)"
+     },
+     "create_time": 1704965564.807812,
+     "end_turn": null,
+     "id": "5b635955-564c-4470-aff5-1a606543944e",
+     "metadata": {
+      "aggregate_result": {
+       "code": "# Adjusting the function to handle non-string responses for sentiment analysis\n\ndef analyze_sentiment_adjusted(response):\n    if not isinstance(response, str):\n        return 0  # Assuming neutral sentiment for non-text responses\n\n    return analyze_sentiment(response)\n\n# Re-analyze each response with the adjusted function\nsentiments_adjusted = survey_data.iloc[:, 0].apply(analyze_sentiment_adjusted)\n\n# Classify responses into positive, neutral, and negative based on sentiment score\npositive_responses_adjusted = survey_data[sentiments_adjusted > 0].iloc[:, 0]\nneutral_responses_adjusted = survey_data[sentiments_adjusted == 0].iloc[:, 0]\nnegative_responses_adjusted = survey_data[sentiments_adjusted < 0].iloc[:, 0]\n\n# Display counts of each type\npositive_count_adjusted = len(positive_responses_adjusted)\nneutral_count_adjusted = len(neutral_responses_adjusted)\nnegative_count_adjusted = len(negative_responses_adjusted)\n\npositive_count_adjusted, neutral_count_adjusted, negative_count_adjusted, positive_responses_adjusted.head(), negative_responses_adjusted.head()",
+       "end_time": 1704965525.289914,
+       "final_expression_output": "(41,\n 8,\n 9,\n 0                              I think they were good.\n 1    Worse - reducing head count but not really red...\n 4    Good thing: HW independent product line Bad th...\n 5    The most positive thing over the past few mont...\n 9    I don't really know what to say. It feels like...\n Name: In the past half year, Nexar went through several changes. In your perspective, what was the best and the worse thing about it?, dtype: object,\n 2     Best: the resilience of the team, how we keep ...\n 6     I don't see any changes for the better, maybe ...\n 7     The implementation of measures to reduce unnec...\n 8     Change is always hard. The worst part was to s...\n 18    Not sure what changes are being discussed, I'm...\n Name: In the past half year, Nexar went through several changes. In your perspective, what was the best and the worse thing about it?, dtype: object)",
+       "in_kernel_exception": null,
+       "jupyter_messages": [
+        {
+         "content": {
+          "execution_state": "busy"
+         },
+         "msg_type": "status",
+         "parent_header": {
+          "msg_id": "df8ad356-ed0a233315f1597e29379e9a_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "msg_type": "execute_input",
+         "parent_header": {
+          "msg_id": "df8ad356-ed0a233315f1597e29379e9a_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "content": {
+          "data": {
+           "text/plain": "(41,\n 8,\n 9,\n 0                              I think they were good.\n 1    Worse - reducing head count but not really red...\n 4    Good thing: HW independent product line Bad th...\n 5    The most positive thing over the past few mont...\n 9    I don't really know what to say. It feels like...\n Name: In the past half year, Nexar went through several changes. In your perspective, what was the best and the worse thing about it?, dtype: object,\n 2     Best: the resilience of the team, how we keep ...\n 6     I don't see any changes for the better, maybe ...\n 7     The implementation of measures to reduce unnec...\n 8     Change is always hard. The worst part was to s...\n 18    Not sure what changes are being discussed, I'm...\n Name: In the past half year, Nexar went through several changes. In your perspective, what was the best and the worse thing about it?, dtype: object)"
+          }
+         },
+         "msg_type": "execute_result",
+         "parent_header": {
+          "msg_id": "df8ad356-ed0a233315f1597e29379e9a_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "content": {
+          "execution_state": "idle"
+         },
+         "msg_type": "status",
+         "parent_header": {
+          "msg_id": "df8ad356-ed0a233315f1597e29379e9a_2_1",
+          "version": "5.3"
+         }
+        }
+       ],
+       "messages": [],
+       "run_id": "0234a14c-1104-4eb1-a740-c70a2dced9b1",
+       "start_time": 1704965525.1910973,
+       "status": "success",
+       "system_exception": null,
+       "timeout_triggered": null,
+       "update_time": 1704965525.289914
+      },
+      "can_save": false,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "ce5be14d-008c-41d7-9f83-57f2d0cc8192",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": 1704965525.289914,
+     "weight": 1.0
+    },
+    "parent": "ce5be14d-008c-41d7-9f83-57f2d0cc8192"
+   },
+   "5cc1a33e-1a2c-4641-9e6c-df22b1898411": {
+    "children": [
+     "aaa2d78b-8e76-436c-8461-21e1399fc2b4"
+    ],
+    "id": "5cc1a33e-1a2c-4641-9e6c-df22b1898411",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Sure, please go ahead and upload the spreadsheet with the responses from the engagement survey. Once I have the file, I'll analyze the responses to identify the positive and negative aspects mentioned about the changes at Nexar in the past half year. Then, I'll provide you with the top five topics for both the positive (good) and negative (bad) aspects."
+      ]
+     },
+     "create_time": 1704965309.932898,
+     "end_turn": true,
+     "id": "5cc1a33e-1a2c-4641-9e6c-df22b1898411",
+     "metadata": {
+      "can_save": true,
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "aaa22fda-c1ac-4d4f-9aa6-b0af736c018a",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa22fda-c1ac-4d4f-9aa6-b0af736c018a"
+   },
+   "5e8bcf64-dd59-4e81-8487-9e6f434d66b8": {
+    "children": [
+     "79340bf0-50b7-4ba5-b5cc-6031c8b8d3af"
+    ],
+    "id": "5e8bcf64-dd59-4e81-8487-9e6f434d66b8",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": "python",
+      "role": "tool"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "execution_output",
+      "text": "(Clear company direction                                 25.000000\n Serious about running a business                        21.428571\n More focus                                              17.857143\n Cost efficiency                                         12.500000\n Nothing                                                  3.571429\n Office perks                                             1.785714\n Data-driven decisions                                    1.785714\n Better in Eng for knowledge sharing and dependencies     1.785714\n Extended runway                                          1.785714\n Office life                                              1.785714\n Cross-department collaboration                           1.785714\n HW independent product line                              1.785714\n Occasional bonuses                                       1.785714\n Feeling taken care of                                    1.785714\n Local management                                         1.785714\n Team resilience                                          1.785714\n Name: Good, dtype: float64,\n Layoffs/morale                                27.272727\n Understaffed/workload                         22.727273\n Deviating from our positive work culture      18.181818\n Instability                                    4.545455\n Silos                                          4.545455\n Low quality work                               3.030303\n Inappropriate compensation/recognition         3.030303\n Poor communication                             3.030303\n Over reorganizing/instability                  1.515152\n The new leadership                             1.515152\n Change came too late                           1.515152\n Not enough HR for work to be done              1.515152\n No clear direction                             1.515152\n Layoffs                                        1.515152\n Lack of accountability at leadership level     1.515152\n Disorganized                                   1.515152\n Less contact with IL                           1.515152\n Name: Bad, dtype: float64)"
+     },
+     "create_time": 1704969667.872629,
+     "end_turn": null,
+     "id": "5e8bcf64-dd59-4e81-8487-9e6f434d66b8",
+     "metadata": {
+      "aggregate_result": {
+       "code": "# Counting the occurrences of each theme in the new good and bad columns\r\nnew_good_theme_counts = new_survey_data['Good'].value_counts()\r\nnew_bad_theme_counts = new_survey_data['Bad'].value_counts()\r\n\r\n# Calculating the total number of responses for the new good and bad themes\r\ntotal_new_good_responses = new_good_theme_counts.sum()\r\ntotal_new_bad_responses = new_bad_theme_counts.sum()\r\n\r\n# Calculating the percentage for each theme in the new dataset\r\nnew_good_theme_percentages = (new_good_theme_counts / total_new_good_responses) * 100\r\nnew_bad_theme_percentages = (new_bad_theme_counts / total_new_bad_responses) * 100\r\n\r\nnew_good_theme_percentages, new_bad_theme_percentages",
+       "end_time": 1704969629.668987,
+       "final_expression_output": "(Clear company direction                                 25.000000\n Serious about running a business                        21.428571\n More focus                                              17.857143\n Cost efficiency                                         12.500000\n Nothing                                                  3.571429\n Office perks                                             1.785714\n Data-driven decisions                                    1.785714\n Better in Eng for knowledge sharing and dependencies     1.785714\n Extended runway                                          1.785714\n Office life                                              1.785714\n Cross-department collaboration                           1.785714\n HW independent product line                              1.785714\n Occasional bonuses                                       1.785714\n Feeling taken care of                                    1.785714\n Local management                                         1.785714\n Team resilience                                          1.785714\n Name: Good, dtype: float64,\n Layoffs/morale                                27.272727\n Understaffed/workload                         22.727273\n Deviating from our positive work culture      18.181818\n Instability                                    4.545455\n Silos                                          4.545455\n Low quality work                               3.030303\n Inappropriate compensation/recognition         3.030303\n Poor communication                             3.030303\n Over reorganizing/instability                  1.515152\n The new leadership                             1.515152\n Change came too late                           1.515152\n Not enough HR for work to be done              1.515152\n No clear direction                             1.515152\n Layoffs                                        1.515152\n Lack of accountability at leadership level     1.515152\n Disorganized                                   1.515152\n Less contact with IL                           1.515152\n Name: Bad, dtype: float64)",
+       "in_kernel_exception": null,
+       "jupyter_messages": [
+        {
+         "content": {
+          "execution_state": "busy"
+         },
+         "msg_type": "status",
+         "parent_header": {
+          "msg_id": "3a1fcd2a-15ca53710314e1ec4760c2df_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "msg_type": "execute_input",
+         "parent_header": {
+          "msg_id": "3a1fcd2a-15ca53710314e1ec4760c2df_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "content": {
+          "data": {
+           "text/plain": "(Clear company direction                                 25.000000\n Serious about running a business                        21.428571\n More focus                                              17.857143\n Cost efficiency                                         12.500000\n Nothing                                                  3.571429\n Office perks                                             1.785714\n Data-driven decisions                                    1.785714\n Better in Eng for knowledge sharing and dependencies     1.785714\n Extended runway                                          1.785714\n Office life                                              1.785714\n Cross-department collaboration                           1.785714\n HW independent product line                              1.785714\n Occasional bonuses                                       1.785714\n Feeling taken care of                                    1.785714\n Local management                                         1.785714\n Team resilience                                          1.785714\n Name: Good, dtype: float64,\n Layoffs/morale                                27.272727\n Understaffed/workload                         22.727273\n Deviating from our positive work culture      18.181818\n Instability                                    4.545455\n Silos                                          4.545455\n Low quality work                               3.030303\n Inappropriate compensation/recognition         3.030303\n Poor communication                             3.030303\n Over reorganizing/instability                  1.515152\n The new leadership                             1.515152\n Change came too late                           1.515152\n Not enough HR for work to be done              1.515152\n No clear direction                             1.515152\n Layoffs                                        1.515152\n Lack of accountability at leadership level     1.515152\n Disorganized                                   1.515152\n Less contact with IL                           1.515152\n Name: Bad, dtype: float64)"
+          }
+         },
+         "msg_type": "execute_result",
+         "parent_header": {
+          "msg_id": "3a1fcd2a-15ca53710314e1ec4760c2df_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "content": {
+          "execution_state": "idle"
+         },
+         "msg_type": "status",
+         "parent_header": {
+          "msg_id": "3a1fcd2a-15ca53710314e1ec4760c2df_2_1",
+          "version": "5.3"
+         }
+        }
+       ],
+       "messages": [],
+       "run_id": "ea242621-1857-47a4-b92b-25ba60eec3ae",
+       "start_time": 1704969629.6052098,
+       "status": "success",
+       "system_exception": null,
+       "timeout_triggered": null,
+       "update_time": 1704969629.668987
+      },
+      "can_save": false,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "3a03ec4b-399d-436b-82d7-8f4e3fd78d97",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": 1704969629.668987,
+     "weight": 1.0
+    },
+    "parent": "3a03ec4b-399d-436b-82d7-8f4e3fd78d97"
+   },
+   "637c673d-6999-4e2c-9d2e-9badb969e46c": {
+    "children": [
+     "013734d1-8e69-47aa-970f-df2bdcda7dd8"
+    ],
+    "id": "637c673d-6999-4e2c-9d2e-9badb969e46c",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": "python",
+      "role": "tool"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "execution_output",
+      "text": "Code execution state reset."
+     },
+     "create_time": 1704969082.95699,
+     "end_turn": null,
+     "id": "637c673d-6999-4e2c-9d2e-9badb969e46c",
+     "metadata": {
+      "aggregate_result": {
+       "code": "",
+       "end_time": null,
+       "final_expression_output": null,
+       "in_kernel_exception": null,
+       "jupyter_messages": [],
+       "messages": [],
+       "run_id": "",
+       "start_time": 1704969015.1972852,
+       "status": "cancelled",
+       "system_exception": null,
+       "timeout_triggered": null,
+       "update_time": 1704969015.1972852
+      },
+      "can_save": false,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "b559dfd8-e568-4a8f-a6a0-7d131614edd6",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": 1704969015.1972852,
+     "weight": 1.0
+    },
+    "parent": "b559dfd8-e568-4a8f-a6a0-7d131614edd6"
+   },
+   "6ff81ac2-7805-48f5-8010-fd4f204a0579": {
+    "children": [
+     "13a93d9d-727a-43c6-881a-05e5d5e78797"
+    ],
+    "id": "6ff81ac2-7805-48f5-8010-fd4f204a0579",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "code",
+      "language": "unknown",
+      "response_format_name": null,
+      "text": "# Counting the occurrences of each theme in both good and bad columns\r\ngood_theme_counts = updated_survey_data['Good'].value_counts()\r\nbad_theme_counts = updated_survey_data['Bad'].value_counts()\r\n\r\n# Calculating the total number of responses for good and bad themes\r\ntotal_good_responses = good_theme_counts.sum()\r\ntotal_bad_responses = bad_theme_counts.sum()\r\n\r\n# Calculating the percentage for each theme\r\ngood_theme_percentages = (good_theme_counts / total_good_responses) * 100\r\nbad_theme_percentages = (bad_theme_counts / total_bad_responses) * 100\r\n\r\ngood_theme_percentages, bad_theme_percentages"
+     },
+     "create_time": 1704969082.960454,
+     "end_turn": false,
+     "id": "6ff81ac2-7805-48f5-8010-fd4f204a0579",
+     "metadata": {
+      "can_save": false,
+      "finish_details": {
+       "stop_tokens": [
+        100265
+       ],
+       "type": "stop"
+      },
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "29b04231-af80-4569-bcf5-6c3d24b173d6",
+      "timestamp_": "absolute"
+     },
+     "recipient": "python",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "29b04231-af80-4569-bcf5-6c3d24b173d6"
+   },
+   "79340bf0-50b7-4ba5-b5cc-6031c8b8d3af": {
+    "children": [],
+    "id": "79340bf0-50b7-4ba5-b5cc-6031c8b8d3af",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Based on the latest survey data, here are the percentages for each theme in the \"Good\" and \"Bad\" categories:\n\n**Good Themes:**\n1. Clear company direction - 25.00%\n2. Serious about running a business - 21.43%\n3. More focus - 17.86%\n4. Cost efficiency - 12.50%\n5. Nothing - 3.57%\n6. Office perks - 1.79%\n7. Data-driven decisions - 1.79%\n8. Better in Eng for knowledge sharing and dependencies - 1.79%\n9. Extended runway - 1.79%\n10. Office life - 1.79%\n11. Cross-department collaboration - 1.79%\n12. HW independent product line - 1.79%\n13. Occasional bonuses - 1.79%\n14. Feeling taken care of - 1.79%\n15. Local management - 1.79%\n16. Team resilience - 1.79%\n\n**Bad Themes:**\n1. Layoffs/morale - 27.27%\n2. Understaffed/workload - 22.73%\n3. Deviating from our positive work culture - 18.18%\n4. Instability - 4.55%\n5. Silos - 4.55%\n6. Low quality work - 3.03%\n7. Inappropriate compensation/recognition - 3.03%\n8. Poor communication - 3.03%\n9. Over reorganizing/instability - 1.52%\n10. The new leadership - 1.52%\n11. Change came too late - 1.52%\n12. Not enough HR for work to be done - 1.52%\n13. No clear direction - 1.52%\n14. Layoffs - 1.52%\n15. Lack of accountability at leadership level - 1.52%\n16. Disorganized - 1.52%\n17. Less contact with IL - 1.52%\n\nThese percentages reflect the proportion of responses that mentioned each specific theme in the survey, providing insight into the prevalent opinions and sentiments among the respondents."
+      ]
+     },
+     "create_time": 1704969667.87299,
+     "end_turn": true,
+     "id": "79340bf0-50b7-4ba5-b5cc-6031c8b8d3af",
+     "metadata": {
+      "can_save": true,
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "5e8bcf64-dd59-4e81-8487-9e6f434d66b8",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "5e8bcf64-dd59-4e81-8487-9e6f434d66b8"
+   },
+   "7947c16c-556a-41f3-b8d8-fb479f466664": {
+    "children": [
+     "aaa20b09-9acd-4a6e-8ec7-0a503c30aee0"
+    ],
+    "id": "7947c16c-556a-41f3-b8d8-fb479f466664",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Great, please upload the updated file with the cleaned answers and the separate columns for good and bad themes. Once I have the file, I'll analyze it to provide you with the percentage representation for each theme in both the good and bad categories."
+      ]
+     },
+     "create_time": 1704969003.61004,
+     "end_turn": true,
+     "id": "7947c16c-556a-41f3-b8d8-fb479f466664",
+     "metadata": {
+      "can_save": true,
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "aaa21e5c-7331-4686-a7cb-79aa6ffc0981",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa21e5c-7331-4686-a7cb-79aa6ffc0981"
+   },
+   "841995fb-7c00-46e8-8e1a-5a6e70a62e4c": {
+    "children": [
+     "aaa22fda-c1ac-4d4f-9aa6-b0af736c018a"
+    ],
+    "id": "841995fb-7c00-46e8-8e1a-5a6e70a62e4c",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": null,
+     "end_turn": true,
+     "id": "841995fb-7c00-46e8-8e1a-5a6e70a62e4c",
+     "metadata": {
+      "can_save": false,
+      "is_visually_hidden_from_conversation": true
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "aaa1f17f-4ae1-45cd-9d39-33e5563c1be7"
+   },
+   "8f41554c-7106-4241-83d7-f9f3adb7b224": {
+    "children": [
+     "27c5ed6e-389b-4c37-9fe3-9960a572c41a"
+    ],
+    "id": "8f41554c-7106-4241-83d7-f9f3adb7b224",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "It appears that there was an error in processing the responses. This might be due to some responses not being in text format or containing non-text elements. I will adjust the analysis to handle such cases and then proceed with identifying the top five good and bad aspects. Let's try again."
+      ]
+     },
+     "create_time": 1704965456.511126,
+     "end_turn": false,
+     "id": "8f41554c-7106-4241-83d7-f9f3adb7b224",
+     "metadata": {
+      "can_save": true,
+      "finish_details": {
+       "stop_tokens": [
+        100265
+       ],
+       "type": "stop"
+      },
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "14b4b41a-998e-4fc1-af43-2bc01894de5e",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "14b4b41a-998e-4fc1-af43-2bc01894de5e"
+   },
+   "939724bf-043b-4bbb-ab13-ea42e14aaed9": {
+    "children": [
+     "aaa21e5c-7331-4686-a7cb-79aa6ffc0981"
+    ],
+    "id": "939724bf-043b-4bbb-ab13-ea42e14aaed9",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "After adjusting the sentiment analysis, I have classified the responses into positive, neutral, and negative categories based on their sentiment scores. Here are the counts for each type:\n\n- Positive Responses: 41\n- Neutral Responses: 8\n- Negative Responses: 9\n\n**Top 5 Positive Responses (Excerpts)**:\n1. \"I think they were good.\"\n2. \"Worse - reducing head count but not really reducing workload... Best - new opportunities for those who remained.\"\n3. \"Good thing: HW independent product line Bad thing: The way some layoffs were handled.\"\n4. \"The most positive thing over the past few months has been the increased communication and transparency from the top.\"\n5. \"I don't really know what to say. It feels like we're moving in the right direction.\"\n\n**Top 5 Negative Responses (Excerpts)**:\n1. \"Best: the resilience of the team, how we keep pushing forward.\"\n2. \"I don't see any changes for the better, maybe it's just too soon to tell.\"\n3. \"The implementation of measures to reduce unnecessary costs was challenging but necessary.\"\n4. \"Change is always hard. The worst part was to see colleagues leave.\"\n5. \"Not sure what changes are being discussed, I'm relatively new.\"\n\nThese excerpts provide a glimpse into the general sentiment of the responses. However, for a more detailed analysis to identify specific aspects or themes within these responses, a more advanced natural language processing approach might be necessary. If you have specific aspects or themes you are interested in, I can focus the analysis on those."
+      ]
+     },
+     "create_time": 1704965564.808388,
+     "end_turn": true,
+     "id": "939724bf-043b-4bbb-ab13-ea42e14aaed9",
+     "metadata": {
+      "can_save": true,
+      "finish_details": {
+       "stop_tokens": [
+        100260
+       ],
+       "type": "stop"
+      },
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "5b635955-564c-4470-aff5-1a606543944e",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "5b635955-564c-4470-aff5-1a606543944e"
+   },
+   "9e9a1097-12af-49ad-8eda-84cae8358378": {
+    "children": [
+     "d9c1b5bf-a047-4ce7-8e84-8611d6cc07d1"
+    ],
+    "id": "9e9a1097-12af-49ad-8eda-84cae8358378",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "The survey data contains responses to the question: \"In the past half year, Nexar went through several changes. In your perspective, what was the best and the worse thing about it?\". I will now analyze these responses to separate the positive (\"good\") and negative (\"bad\") aspects mentioned by the respondents. After the analysis, I will identify the top five topics for both the positive and negative aspects. Let's proceed with the analysis."
+      ]
+     },
+     "create_time": 1704965456.504897,
+     "end_turn": false,
+     "id": "9e9a1097-12af-49ad-8eda-84cae8358378",
+     "metadata": {
+      "can_save": true,
+      "finish_details": {
+       "stop_tokens": [
+        100265
+       ],
+       "type": "stop"
+      },
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "1173a4ee-b9d1-4a27-ae18-1c73e1a0b761",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "1173a4ee-b9d1-4a27-ae18-1c73e1a0b761"
+   },
+   "aaa1f17f-4ae1-45cd-9d39-33e5563c1be7": {
+    "children": [
+     "841995fb-7c00-46e8-8e1a-5a6e70a62e4c"
+    ],
+    "id": "aaa1f17f-4ae1-45cd-9d39-33e5563c1be7",
+    "message": null,
+    "parent": null
+   },
+   "aaa20b09-9acd-4a6e-8ec7-0a503c30aee0": {
+    "children": [
+     "b559dfd8-e568-4a8f-a6a0-7d131614edd6"
+    ],
+    "id": "aaa20b09-9acd-4a6e-8ec7-0a503c30aee0",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1704969009.591038,
+     "end_turn": null,
+     "id": "aaa20b09-9acd-4a6e-8ec7-0a503c30aee0",
+     "metadata": {
+      "attachments": [
+       {
+        "id": "file-F0ZyGeGG7Kzj1HEW72Lcz3r9",
+        "mimeType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "name": "Open question - Dec 2023 (1).xlsx",
+        "size": 57762
+       }
+      ],
+      "can_save": false,
+      "message_type": null,
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "7947c16c-556a-41f3-b8d8-fb479f466664"
+   },
+   "aaa21e5c-7331-4686-a7cb-79aa6ffc0981": {
+    "children": [
+     "7947c16c-556a-41f3-b8d8-fb479f466664"
+    ],
+    "id": "aaa21e5c-7331-4686-a7cb-79aa6ffc0981",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Ok. I have now cleaned the answers and created a column for good and bad. I used the same themes to describe similar things. Can you now give me a percentage for each theme? Both for the good and the bad. I'll upload the new file."
+      ]
+     },
+     "create_time": 1704968997.773436,
+     "end_turn": null,
+     "id": "aaa21e5c-7331-4686-a7cb-79aa6ffc0981",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "939724bf-043b-4bbb-ab13-ea42e14aaed9"
+   },
+   "aaa22fda-c1ac-4d4f-9aa6-b0af736c018a": {
+    "children": [
+     "5cc1a33e-1a2c-4641-9e6c-df22b1898411"
+    ],
+    "id": "aaa22fda-c1ac-4d4f-9aa6-b0af736c018a",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "I will upload a spreadsheet with answers to the question \"In the past half year, Nexar went through several changes. In your perspective, what was the best and the worse thing about it?\". This is from an engagement survey. The answers will have the good and the bad stated in different formats. I need you to sort out what is the good and the bad and then tell me the top 5 topics for good and for bad."
+      ]
+     },
+     "create_time": 1704965304.97149,
+     "end_turn": null,
+     "id": "aaa22fda-c1ac-4d4f-9aa6-b0af736c018a",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "841995fb-7c00-46e8-8e1a-5a6e70a62e4c"
+   },
+   "aaa27441-e37c-499c-bb48-e4fd11620757": {
+    "children": [
+     "d4c69f46-5f15-413d-b215-cf1bd22bf6fe"
+    ],
+    "id": "aaa27441-e37c-499c-bb48-e4fd11620757",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Try again"
+      ]
+     },
+     "create_time": 1704969609.248299,
+     "end_turn": null,
+     "id": "aaa27441-e37c-499c-bb48-e4fd11620757",
+     "metadata": {
+      "attachments": [
+       {
+        "id": "file-QQJhKGzk8Pb8ZnzX6vA50njT",
+        "mimeType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "name": "Open question - Dec 2023 (2).xlsx",
+        "size": 57728
+       }
+      ],
+      "can_save": false,
+      "message_type": null,
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "0f96b900-3aab-43f8-b63f-2a23e3b2fc83"
+   },
+   "aaa2d78b-8e76-436c-8461-21e1399fc2b4": {
+    "children": [
+     "3b216b40-48eb-4f0f-a67a-88b26ebc9b37"
+    ],
+    "id": "aaa2d78b-8e76-436c-8461-21e1399fc2b4",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1704965319.510644,
+     "end_turn": null,
+     "id": "aaa2d78b-8e76-436c-8461-21e1399fc2b4",
+     "metadata": {
+      "attachments": [
+       {
+        "id": "file-QH61Jf5ptqphCEQNvvJJv3Zt",
+        "mimeType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "name": "Open question - Dec 2023.xlsx",
+        "size": 66474
+       }
+      ],
+      "can_save": false,
+      "message_type": null,
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "5cc1a33e-1a2c-4641-9e6c-df22b1898411"
+   },
+   "aaa2e51d-68c8-4eac-acdb-d6c71f17ac99": {
+    "children": [
+     "451432bd-b736-428f-8169-5958db0869ea"
+    ],
+    "id": "aaa2e51d-68c8-4eac-acdb-d6c71f17ac99",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Try a different analysis, focused on natural language processing"
+      ]
+     },
+     "create_time": 1704965484.895324,
+     "end_turn": null,
+     "id": "aaa2e51d-68c8-4eac-acdb-d6c71f17ac99",
+     "metadata": {
+      "can_save": false,
+      "message_type": null,
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "0e811609-5da0-4239-a964-58ffc13392dc"
+   },
+   "b559dfd8-e568-4a8f-a6a0-7d131614edd6": {
+    "children": [
+     "637c673d-6999-4e2c-9d2e-9badb969e46c"
+    ],
+    "id": "b559dfd8-e568-4a8f-a6a0-7d131614edd6",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "code",
+      "language": "unknown",
+      "response_format_name": null,
+      "text": "# Load the updated spreadsheet\nupdated_file_path = '/mnt/data/Open question - Dec 2023 (1).xlsx'\n\n# Read the data from the updated spreadsheet\nupdated_survey_data = pd.read_excel(updated_file_path)\n\nupdated_survey_data.head()"
+     },
+     "create_time": 1704969082.954358,
+     "end_turn": false,
+     "id": "b559dfd8-e568-4a8f-a6a0-7d131614edd6",
+     "metadata": {
+      "can_save": false,
+      "finish_details": {
+       "stop_tokens": [
+        100265
+       ],
+       "type": "stop"
+      },
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "aaa20b09-9acd-4a6e-8ec7-0a503c30aee0",
+      "timestamp_": "absolute"
+     },
+     "recipient": "python",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa20b09-9acd-4a6e-8ec7-0a503c30aee0"
+   },
+   "ce5be14d-008c-41d7-9f83-57f2d0cc8192": {
+    "children": [
+     "5b635955-564c-4470-aff5-1a606543944e"
+    ],
+    "id": "ce5be14d-008c-41d7-9f83-57f2d0cc8192",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "code",
+      "language": "unknown",
+      "response_format_name": null,
+      "text": "# Adjusting the function to handle non-string responses for sentiment analysis\n\ndef analyze_sentiment_adjusted(response):\n    if not isinstance(response, str):\n        return 0  # Assuming neutral sentiment for non-text responses\n\n    return analyze_sentiment(response)\n\n# Re-analyze each response with the adjusted function\nsentiments_adjusted = survey_data.iloc[:, 0].apply(analyze_sentiment_adjusted)\n\n# Classify responses into positive, neutral, and negative based on sentiment score\npositive_responses_adjusted = survey_data[sentiments_adjusted > 0].iloc[:, 0]\nneutral_responses_adjusted = survey_data[sentiments_adjusted == 0].iloc[:, 0]\nnegative_responses_adjusted = survey_data[sentiments_adjusted < 0].iloc[:, 0]\n\n# Display counts of each type\npositive_count_adjusted = len(positive_responses_adjusted)\nneutral_count_adjusted = len(neutral_responses_adjusted)\nnegative_count_adjusted = len(negative_responses_adjusted)\n\npositive_count_adjusted, neutral_count_adjusted, negative_count_adjusted, positive_responses_adjusted.head(), negative_responses_adjusted.head()"
+     },
+     "create_time": 1704965564.804196,
+     "end_turn": false,
+     "id": "ce5be14d-008c-41d7-9f83-57f2d0cc8192",
+     "metadata": {
+      "can_save": false,
+      "finish_details": {
+       "stop_tokens": [
+        100265
+       ],
+       "type": "stop"
+      },
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "fb961904-283a-4f54-80be-e0cda2af6910",
+      "timestamp_": "absolute"
+     },
+     "recipient": "python",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "fb961904-283a-4f54-80be-e0cda2af6910"
+   },
+   "d4c69f46-5f15-413d-b215-cf1bd22bf6fe": {
+    "children": [
+     "54045d03-6582-4a85-8ec0-c5b053b86bc3"
+    ],
+    "id": "d4c69f46-5f15-413d-b215-cf1bd22bf6fe",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "code",
+      "language": "unknown",
+      "response_format_name": null,
+      "text": "# Re-load the newly uploaded spreadsheet for the updated analysis\r\nnew_file_path = '/mnt/data/Open question - Dec 2023 (2).xlsx'\r\n\r\n# Read the data from the new spreadsheet\r\nnew_survey_data = pd.read_excel(new_file_path)\r\n\r\nnew_survey_data.head()"
+     },
+     "create_time": 1704969667.867251,
+     "end_turn": false,
+     "id": "d4c69f46-5f15-413d-b215-cf1bd22bf6fe",
+     "metadata": {
+      "can_save": false,
+      "finish_details": {
+       "stop_tokens": [
+        100265
+       ],
+       "type": "stop"
+      },
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "aaa27441-e37c-499c-bb48-e4fd11620757",
+      "timestamp_": "absolute"
+     },
+     "recipient": "python",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaa27441-e37c-499c-bb48-e4fd11620757"
+   },
+   "d8d3377e-21fe-494e-88f2-4d2ed044c039": {
+    "children": [
+     "fb961904-283a-4f54-80be-e0cda2af6910"
+    ],
+    "id": "d8d3377e-21fe-494e-88f2-4d2ed044c039",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": "python",
+      "role": "tool"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "execution_output",
+      "text": "---------------------------------------------------------------------------\nTypeError                                 Traceback (most recent call last)\nCell In[4], line 9\n      6     return blob.sentiment.polarity  # Polarity score: -1 (negative) to 1 (positive)\n      8 # Analyze each response for sentiment\n----> 9 sentiments = survey_data.iloc[:, 0].apply(analyze_sentiment)\n     11 # Classify responses into positive, neutral, and negative based on sentiment score\n     12 positive_responses = survey_data[sentiments > 0].iloc[:, 0]\n\nFile ~/.local/lib/python3.8/site-packages/pandas/core/series.py:4357, in Series.apply(self, func, convert_dtype, args, **kwargs)\n   4247 def apply(\n   4248     self,\n   4249     func: AggFuncType,\n   (...)\n   4252     **kwargs,\n   4253 ) -> FrameOrSeriesUnion:\n   4254     \"\"\"\n   4255     Invoke function on values of Series.\n   4256 \n   (...)\n   4355     dtype: float64\n   4356     \"\"\"\n-> 4357     return SeriesApply(self, func, convert_dtype, args, kwargs).apply()\n\nFile ~/.local/lib/python3.8/site-packages/pandas/core/apply.py:1043, in SeriesApply.apply(self)\n   1039 if isinstance(self.f, str):\n   1040     # if we are a string, try to dispatch\n   1041     return self.apply_str()\n-> 1043 return self.apply_standard()\n\nFile ~/.local/lib/python3.8/site-packages/pandas/core/apply.py:1099, in SeriesApply.apply_standard(self)\n   1093         values = obj.astype(object)._values\n   1094         # error: Argument 2 to \"map_infer\" has incompatible type\n   1095         # \"Union[Callable[..., Any], str, List[Union[Callable[..., Any], str]],\n   1096         # Dict[Hashable, Union[Union[Callable[..., Any], str],\n   1097         # List[Union[Callable[..., Any], str]]]]]\"; expected\n   1098         # \"Callable[[Any], Any]\"\n-> 1099         mapped = lib.map_infer(\n   1100             values,\n   1101             f,  # type: ignore[arg-type]\n   1102             convert=self.convert_dtype,\n   1103         )\n   1105 if len(mapped) and isinstance(mapped[0], ABCSeries):\n   1106     # GH 25959 use pd.array instead of tolist\n   1107     # so extension arrays can be used\n   1108     return obj._constructor_expanddim(pd_array(mapped), index=obj.index)\n\nFile ~/.local/lib/python3.8/site-packages/pandas/_libs/lib.pyx:2859, in pandas._libs.lib.map_infer()\n\nCell In[4], line 5, in analyze_sentiment(response)\n      4 def analyze_sentiment(response):\n----> 5     blob = TextBlob(response)\n      6     return blob.sentiment.polarity\n\nFile ~/.local/lib/python3.8/site-packages/textblob/blob.py:369, in BaseBlob.__init__(self, text, tokenizer, pos_tagger, np_extractor, analyzer, parser, classifier, clean_html)\n    365 def __init__(self, text, tokenizer=None,\n    366             pos_tagger=None, np_extractor=None, analyzer=None,\n    367             parser=None, classifier=None, clean_html=False):\n    368     if not isinstance(text, basestring):\n--> 369         raise TypeError('The `text` argument passed to `__init__(text)` '\n    370                         'must be a string, not {0}'.format(type(text)))\n    371     if clean_html:\n    372         raise NotImplementedError(\"clean_html has been deprecated. \"\n    373                                 \"To remove HTML markup, use BeautifulSoup's \"\n    374                                 \"get_text() function\")\n\nTypeError: The `text` argument passed to `__init__(text)` must be a string, not <class 'float'>\n"
+     },
+     "create_time": 1704965564.801006,
+     "end_turn": null,
+     "id": "d8d3377e-21fe-494e-88f2-4d2ed044c039",
+     "metadata": {
+      "aggregate_result": {
+       "code": "from textblob import TextBlob\n\n# Function to analyze sentiment of each response\ndef analyze_sentiment(response):\n    blob = TextBlob(response)\n    return blob.sentiment.polarity  # Polarity score: -1 (negative) to 1 (positive)\n\n# Analyze each response for sentiment\nsentiments = survey_data.iloc[:, 0].apply(analyze_sentiment)\n\n# Classify responses into positive, neutral, and negative based on sentiment score\npositive_responses = survey_data[sentiments > 0].iloc[:, 0]\nneutral_responses = survey_data[sentiments == 0].iloc[:, 0]\nnegative_responses = survey_data[sentiments < 0].iloc[:, 0]\n\n# Display counts of each type\npositive_count = len(positive_responses)\nneutral_count = len(neutral_responses)\nnegative_count = len(negative_responses)\n\npositive_count, neutral_count, negative_count, positive_responses.head(), negative_responses.head()",
+       "end_time": 1704965505.6656196,
+       "final_expression_output": null,
+       "in_kernel_exception": {
+        "args": [
+         "The `text` argument passed to `__init__(text)` must be a string, not <class 'float'>"
+        ],
+        "name": "TypeError",
+        "notes": [],
+        "traceback": [
+         "---------------------------------------------------------------------------\n",
+         "TypeError                                 Traceback (most recent call last)\n",
+         "Cell In[4], line 9\n      6     return blob.sentiment.polarity  # Polarity score: -1 (negative) to 1 (positive)\n      8 # Analyze each response for sentiment\n----> 9 sentiments = survey_data.iloc[:, 0].apply(analyze_sentiment)\n     11 # Classify responses into positive, neutral, and negative based on sentiment score\n     12 positive_responses = survey_data[sentiments > 0].iloc[:, 0]\n\n",
+         "File ~/.local/lib/python3.8/site-packages/pandas/core/series.py:4357, in Series.apply(self, func, convert_dtype, args, **kwargs)\n   4247 def apply(\n   4248     self,\n   4249     func: AggFuncType,\n   (...)\n   4252     **kwargs,\n   4253 ) -> FrameOrSeriesUnion:\n   4254     \"\"\"\n   4255     Invoke function on values of Series.\n   4256 \n   (...)\n   4355     dtype: float64\n   4356     \"\"\"\n-> 4357     return SeriesApply(self, func, convert_dtype, args, kwargs).apply()\n\n",
+         "File ~/.local/lib/python3.8/site-packages/pandas/core/apply.py:1043, in SeriesApply.apply(self)\n   1039 if isinstance(self.f, str):\n   1040     # if we are a string, try to dispatch\n   1041     return self.apply_str()\n-> 1043 return self.apply_standard()\n\n",
+         "File ~/.local/lib/python3.8/site-packages/pandas/core/apply.py:1099, in SeriesApply.apply_standard(self)\n   1093         values = obj.astype(object)._values\n   1094         # error: Argument 2 to \"map_infer\" has incompatible type\n   1095         # \"Union[Callable[..., Any], str, List[Union[Callable[..., Any], str]],\n   1096         # Dict[Hashable, Union[Union[Callable[..., Any], str],\n   1097         # List[Union[Callable[..., Any], str]]]]]\"; expected\n   1098         # \"Callable[[Any], Any]\"\n-> 1099         mapped = lib.map_infer(\n   1100             values,\n   1101             f,  # type: ignore[arg-type]\n   1102             convert=self.convert_dtype,\n   1103         )\n   1105 if len(mapped) and isinstance(mapped[0], ABCSeries):\n   1106     # GH 25959 use pd.array instead of tolist\n   1107     # so extension arrays can be used\n   1108     return obj._constructor_expanddim(pd_array(mapped), index=obj.index)\n\n",
+         "File ~/.local/lib/python3.8/site-packages/pandas/_libs/lib.pyx:2859, in pandas._libs.lib.map_infer()\n\n",
+         "Cell In[4], line 5, in analyze_sentiment(response)\n      4 def analyze_sentiment(response):\n----> 5     blob = TextBlob(response)\n      6     return blob.sentiment.polarity\n\n",
+         "File ~/.local/lib/python3.8/site-packages/textblob/blob.py:369, in BaseBlob.__init__(self, text, tokenizer, pos_tagger, np_extractor, analyzer, parser, classifier, clean_html)\n    365 def __init__(self, text, tokenizer=None,\n    366             pos_tagger=None, np_extractor=None, analyzer=None,\n    367             parser=None, classifier=None, clean_html=False):\n    368     if not isinstance(text, basestring):\n--> 369         raise TypeError('The `text` argument passed to `__init__(text)` '\n    370                         'must be a string, not {0}'.format(type(text)))\n    371     if clean_html:\n    372         raise NotImplementedError(\"clean_html has been deprecated. \"\n    373                                 \"To remove HTML markup, use BeautifulSoup's \"\n    374                                 \"get_text() function\")\n\n",
+         "TypeError: The `text` argument passed to `__init__(text)` must be a string, not <class 'float'>\n"
+        ]
+       },
+       "jupyter_messages": [
+        {
+         "content": {
+          "execution_state": "busy"
+         },
+         "msg_type": "status",
+         "parent_header": {
+          "msg_id": "df8ad356-ed0a233315f1597e29379e9a_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "msg_type": "execute_input",
+         "parent_header": {
+          "msg_id": "df8ad356-ed0a233315f1597e29379e9a_2_1",
+          "version": "5.3"
+         }
+        },
+        {
+         "content": {
+          "ename": "TypeError",
+          "evalue": "The `text` argument passed to `__init__(text)` must be a string, not <class 'float'>",
+          "traceback": [
+           "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+           "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+           "Cell \u001b[0;32mIn[4], line 9\u001b[0m\n\u001b[1;32m      6\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m blob\u001b[38;5;241m.\u001b[39msentiment\u001b[38;5;241m.\u001b[39mpolarity  \u001b[38;5;66;03m# Polarity score: -1 (negative) to 1 (positive)\u001b[39;00m\n\u001b[1;32m      8\u001b[0m \u001b[38;5;66;03m# Analyze each response for sentiment\u001b[39;00m\n\u001b[0;32m----> 9\u001b[0m sentiments \u001b[38;5;241m=\u001b[39m \u001b[43msurvey_data\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43miloc\u001b[49m\u001b[43m[\u001b[49m\u001b[43m:\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m0\u001b[39;49m\u001b[43m]\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mapply\u001b[49m\u001b[43m(\u001b[49m\u001b[43manalyze_sentiment\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     11\u001b[0m \u001b[38;5;66;03m# Classify responses into positive, neutral, and negative based on sentiment score\u001b[39;00m\n\u001b[1;32m     12\u001b[0m positive_responses \u001b[38;5;241m=\u001b[39m survey_data[sentiments \u001b[38;5;241m>\u001b[39m \u001b[38;5;241m0\u001b[39m]\u001b[38;5;241m.\u001b[39miloc[:, \u001b[38;5;241m0\u001b[39m]\n",
+           "File \u001b[0;32m~/.local/lib/python3.8/site-packages/pandas/core/series.py:4357\u001b[0m, in \u001b[0;36mSeries.apply\u001b[0;34m(self, func, convert_dtype, args, **kwargs)\u001b[0m\n\u001b[1;32m   4247\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mapply\u001b[39m(\n\u001b[1;32m   4248\u001b[0m     \u001b[38;5;28mself\u001b[39m,\n\u001b[1;32m   4249\u001b[0m     func: AggFuncType,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m   4252\u001b[0m     \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs,\n\u001b[1;32m   4253\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m FrameOrSeriesUnion:\n\u001b[1;32m   4254\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m   4255\u001b[0m \u001b[38;5;124;03m    Invoke function on values of Series.\u001b[39;00m\n\u001b[1;32m   4256\u001b[0m \n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m   4355\u001b[0m \u001b[38;5;124;03m    dtype: float64\u001b[39;00m\n\u001b[1;32m   4356\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m-> 4357\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mSeriesApply\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mfunc\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mconvert_dtype\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mapply\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
+           "File \u001b[0;32m~/.local/lib/python3.8/site-packages/pandas/core/apply.py:1043\u001b[0m, in \u001b[0;36mSeriesApply.apply\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m   1039\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mf, \u001b[38;5;28mstr\u001b[39m):\n\u001b[1;32m   1040\u001b[0m     \u001b[38;5;66;03m# if we are a string, try to dispatch\u001b[39;00m\n\u001b[1;32m   1041\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mapply_str()\n\u001b[0;32m-> 1043\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mapply_standard\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
+           "File \u001b[0;32m~/.local/lib/python3.8/site-packages/pandas/core/apply.py:1099\u001b[0m, in \u001b[0;36mSeriesApply.apply_standard\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m   1093\u001b[0m         values \u001b[38;5;241m=\u001b[39m obj\u001b[38;5;241m.\u001b[39mastype(\u001b[38;5;28mobject\u001b[39m)\u001b[38;5;241m.\u001b[39m_values\n\u001b[1;32m   1094\u001b[0m         \u001b[38;5;66;03m# error: Argument 2 to \"map_infer\" has incompatible type\u001b[39;00m\n\u001b[1;32m   1095\u001b[0m         \u001b[38;5;66;03m# \"Union[Callable[..., Any], str, List[Union[Callable[..., Any], str]],\u001b[39;00m\n\u001b[1;32m   1096\u001b[0m         \u001b[38;5;66;03m# Dict[Hashable, Union[Union[Callable[..., Any], str],\u001b[39;00m\n\u001b[1;32m   1097\u001b[0m         \u001b[38;5;66;03m# List[Union[Callable[..., Any], str]]]]]\"; expected\u001b[39;00m\n\u001b[1;32m   1098\u001b[0m         \u001b[38;5;66;03m# \"Callable[[Any], Any]\"\u001b[39;00m\n\u001b[0;32m-> 1099\u001b[0m         mapped \u001b[38;5;241m=\u001b[39m \u001b[43mlib\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmap_infer\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m   1100\u001b[0m \u001b[43m            \u001b[49m\u001b[43mvalues\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1101\u001b[0m \u001b[43m            \u001b[49m\u001b[43mf\u001b[49m\u001b[43m,\u001b[49m\u001b[43m  \u001b[49m\u001b[38;5;66;43;03m# type: ignore[arg-type]\u001b[39;49;00m\n\u001b[1;32m   1102\u001b[0m \u001b[43m            \u001b[49m\u001b[43mconvert\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mconvert_dtype\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1103\u001b[0m \u001b[43m        \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1105\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mlen\u001b[39m(mapped) \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(mapped[\u001b[38;5;241m0\u001b[39m], ABCSeries):\n\u001b[1;32m   1106\u001b[0m     \u001b[38;5;66;03m# GH 25959 use pd.array instead of tolist\u001b[39;00m\n\u001b[1;32m   1107\u001b[0m     \u001b[38;5;66;03m# so extension arrays can be used\u001b[39;00m\n\u001b[1;32m   1108\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m obj\u001b[38;5;241m.\u001b[39m_constructor_expanddim(pd_array(mapped), index\u001b[38;5;241m=\u001b[39mobj\u001b[38;5;241m.\u001b[39mindex)\n",
+           "File \u001b[0;32m~/.local/lib/python3.8/site-packages/pandas/_libs/lib.pyx:2859\u001b[0m, in \u001b[0;36mpandas._libs.lib.map_infer\u001b[0;34m()\u001b[0m\n",
+           "Cell \u001b[0;32mIn[4], line 5\u001b[0m, in \u001b[0;36manalyze_sentiment\u001b[0;34m(response)\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21manalyze_sentiment\u001b[39m(response):\n\u001b[0;32m----> 5\u001b[0m     blob \u001b[38;5;241m=\u001b[39m \u001b[43mTextBlob\u001b[49m\u001b[43m(\u001b[49m\u001b[43mresponse\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m      6\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m blob\u001b[38;5;241m.\u001b[39msentiment\u001b[38;5;241m.\u001b[39mpolarity\n",
+           "File \u001b[0;32m~/.local/lib/python3.8/site-packages/textblob/blob.py:369\u001b[0m, in \u001b[0;36mBaseBlob.__init__\u001b[0;34m(self, text, tokenizer, pos_tagger, np_extractor, analyzer, parser, classifier, clean_html)\u001b[0m\n\u001b[1;32m    365\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__init__\u001b[39m(\u001b[38;5;28mself\u001b[39m, text, tokenizer\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m    366\u001b[0m             pos_tagger\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, np_extractor\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, analyzer\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m    367\u001b[0m             parser\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, classifier\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, clean_html\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mFalse\u001b[39;00m):\n\u001b[1;32m    368\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(text, basestring):\n\u001b[0;32m--> 369\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mThe `text` argument passed to `__init__(text)` \u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m    370\u001b[0m                         \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mmust be a string, not \u001b[39m\u001b[38;5;132;01m{0}\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;241m.\u001b[39mformat(\u001b[38;5;28mtype\u001b[39m(text)))\n\u001b[1;32m    371\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m clean_html:\n\u001b[1;32m    372\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mNotImplementedError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mclean_html has been deprecated. \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    373\u001b[0m                                 \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mTo remove HTML markup, use BeautifulSoup\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124ms \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    374\u001b[0m                                 \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mget_text() function\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
+           "\u001b[0;31mTypeError\u001b[0m: The `text` argument passed to `__init__(text)` must be a string, not <class 'float'>"
+          ]
+         },
+         "msg_type": "error",
+         "parent_header": {
+          "msg_id": "df8ad356-ed0a233315f1597e29379e9a_2_1",
+          "version": "5.3"
+         }
+        }
+       ],
+       "messages": [],
+       "run_id": "07e9b912-fec8-4dcf-a7b1-f37417f916a3",
+       "start_time": 1704965503.4942248,
+       "status": "failed_with_in_kernel_exception",
+       "system_exception": null,
+       "timeout_triggered": null,
+       "update_time": 1704965505.6656196
+      },
+      "can_save": false,
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "451432bd-b736-428f-8169-5958db0869ea",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": 1704965505.6656196,
+     "weight": 1.0
+    },
+    "parent": "451432bd-b736-428f-8169-5958db0869ea"
+   },
+   "d9c1b5bf-a047-4ce7-8e84-8611d6cc07d1": {
+    "children": [
+     "14b4b41a-998e-4fc1-af43-2bc01894de5e"
+    ],
+    "id": "d9c1b5bf-a047-4ce7-8e84-8611d6cc07d1",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "code",
+      "language": "unknown",
+      "response_format_name": null,
+      "text": "from collections import Counter\nimport re\n\n# Function to extract good and bad aspects from a response\ndef extract_good_bad_aspects(response):\n    good_aspects = []\n    bad_aspects = []\n\n    # Splitting based on common phrases that indicate a switch from good to bad or vice versa\n    phrases = ['good thing:', 'bad thing:', 'good:', 'bad:', 'best:', 'worse:', 'worst:', 'positive:', 'negative:', 'pro:', 'con:']\n    pattern = '|'.join([f'(?i){re.escape(phrase)}' for phrase in phrases])\n    parts = re.split(pattern, response)\n\n    # Determining which parts are good and which are bad\n    for i, part in enumerate(parts):\n        # Check if the preceding phrase indicates good or bad\n        if i > 0 and 'bad' in parts[i-1].lower():\n            bad_aspects.append(part.strip())\n        elif i > 0 and 'good' in parts[i-1].lower():\n            good_aspects.append(part.strip())\n        else:\n            # If no clear indication, this approach will not add the response to either category\n            continue\n\n    return good_aspects, bad_aspects\n\n# Process each response and accumulate good and bad aspects\ngood_aspects_all = []\nbad_aspects_all = []\n\nfor response in survey_data.iloc[:, 0]:\n    good_aspects, bad_aspects = extract_good_bad_aspects(response)\n    good_aspects_all.extend(good_aspects)\n    bad_aspects_all.extend(bad_aspects)\n\n# Count the frequency of each aspect\ngood_aspect_counts = Counter(good_aspects_all)\nbad_aspect_counts = Counter(bad_aspects_all)\n\n# Get the top 5 good and bad aspects\ntop_5_good_aspects = good_aspect_counts.most_common(5)\ntop_5_bad_aspects = bad_aspect_counts.most_common(5)\n\ntop_5_good_aspects, top_5_bad_aspects"
+     },
+     "create_time": 1704965456.507179,
+     "end_turn": false,
+     "id": "d9c1b5bf-a047-4ce7-8e84-8611d6cc07d1",
+     "metadata": {
+      "can_save": false,
+      "finish_details": {
+       "stop_tokens": [
+        100265
+       ],
+       "type": "stop"
+      },
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "9e9a1097-12af-49ad-8eda-84cae8358378",
+      "timestamp_": "absolute"
+     },
+     "recipient": "python",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "9e9a1097-12af-49ad-8eda-84cae8358378"
+   },
+   "fb961904-283a-4f54-80be-e0cda2af6910": {
+    "children": [
+     "ce5be14d-008c-41d7-9f83-57f2d0cc8192"
+    ],
+    "id": "fb961904-283a-4f54-80be-e0cda2af6910",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "It appears there was an error in the sentiment analysis, likely due to non-string (possibly missing or numeric) responses in the dataset. To address this, I'll adjust the analysis to filter out or handle non-string responses appropriately. Let's try the sentiment analysis again with these adjustments."
+      ]
+     },
+     "create_time": 1704965564.801602,
+     "end_turn": false,
+     "id": "fb961904-283a-4f54-80be-e0cda2af6910",
+     "metadata": {
+      "can_save": true,
+      "finish_details": {
+       "stop_tokens": [
+        100265
+       ],
+       "type": "stop"
+      },
+      "is_complete": true,
+      "message_type": null,
+      "model_slug": "gpt-4",
+      "parent_id": "d8d3377e-21fe-494e-88f2-4d2ed044c039",
+      "timestamp_": "absolute"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "d8d3377e-21fe-494e-88f2-4d2ed044c039"
+   }
+  },
+  "memory_scope": "global_enabled",
+  "moderation_results": [],
+  "title": "Sort Good and Bad Topics",
+  "update_time": 1704969668.123176,
+  "voice": null
+ },
+ {
+  "async_status": null,
+  "atlas_mode_enabled": null,
+  "context_scopes": [],
+  "conversation_id": "69b37522-0514-8388-9ff0-22290ad067a9",
+  "conversation_origin": null,
+  "conversation_template_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+  "create_time": 1773368639.891925,
+  "current_node": "5943357d-0b1c-48fe-9661-70507bfdffac",
+  "default_model_slug": "gpt-5-3",
+  "disabled_tool_ids": [],
+  "gizmo_type": "snorlax",
+  "id": "69b37522-0514-8388-9ff0-22290ad067a9",
+  "is_archived": false,
+  "is_do_not_remember": false,
+  "is_starred": null,
+  "mapping": {
+   "00e4aa14-4853-4370-b32e-43f3a3797e78": {
+    "children": [
+     "4f470078-e525-4dfd-9a4b-dd31ad952957"
+    ],
+    "id": "00e4aa14-4853-4370-b32e-43f3a3797e78",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1776033769.0843904,
+     "end_turn": true,
+     "id": "00e4aa14-4853-4370-b32e-43f3a3797e78",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb218d4-da92-4c42-9fb6-ea356ee9b75d",
+      "rebase_developer_message": true,
+      "request_id": "1133c94a-6e4f-43f8-9ed5-b8546653133f",
+      "turn_exchange_id": "c68a6923-2821-4da8-ba48-8f9c4a3c0243"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb218d4-da92-4c42-9fb6-ea356ee9b75d"
+   },
+   "0106ce30-fe2b-4d87-a800-8544dc871b25": {
+    "children": [
+     "bbb21a80-5c06-48c7-8653-7b4e30bb9250"
+    ],
+    "id": "0106ce30-fe2b-4d87-a800-8544dc871b25",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "You\u2019re right to challenge that \u2014 and your pediatrician\u2019s advice **comes first**.\n\n## The nuance (this is where both can be true)\n\n**Early weeks (now):**\n\ud83d\udc49 **Yes \u2014 you should still wake at night**  \n**IF:**\n- she hasn\u2019t regained birth weight yet, **or**\n- weight gain hasn\u2019t been clearly established\n\nThat protects:\n- milk supply  \n- her intake/weight\n\n---\n\n## When \u201cdon\u2019t wake at night\u201d applies\nOnly once:\n- back to birth weight **+ gaining well**\n- pediatrician is happy\n\nThen you can let her sleep longer stretches at night.\n\n---\n\n## So for you *right now*\nGiven how early you are:\n\n\ud83d\udc49 Stick to:\n- **Max ~3h between feeds**, including night  \n- Wake her if needed\n\n---\n\n## How to reconcile with the gas issue\n\nYou don\u2019t change frequency \u2014 you change **how feeds end**:\n\n- Feed  \n- Burp  \n- **Hold upright 15\u201320 min** (this is your key lever)\n\n---\n\n## Important reassurance\nWaking her at night is **not causing the gas problem**.  \nThat\u2019s developmental and would happen anyway.\n\n---\n\n## Bottom line\n- Pediatrician > me \u2192 **keep waking for now**  \n- You\u2019re not risking weight \u2014 you\u2019re protecting it  \n- Optimize **handling after feeds**, not feed frequency\n\n---\n\nOnce she\u2019s clearly gaining well, we can relax nights \u2014 and ironically, **that\u2019s when gas often gets easier too**."
+      ]
+     },
+     "create_time": 1773971917.520009,
+     "end_turn": true,
+     "id": "0106ce30-fe2b-4d87-a800-8544dc871b25",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21b14-4690-4c3f-be5c-5075285165e3",
+      "request_id": "ffb21f14-5ddc-4772-9e64-ed65cdd30e44",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "e7c9eb86-5427-4e03-8634-e8f5755867fb"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21b14-4690-4c3f-be5c-5075285165e3"
+   },
+   "0528644f-1bd0-44ec-b574-1172ce550448": {
+    "children": [
+     "f70ac69d-d94c-43df-a2dc-e3ccb9fa6054"
+    ],
+    "id": "0528644f-1bd0-44ec-b574-1172ce550448",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773984605.3412201,
+     "end_turn": null,
+     "id": "0528644f-1bd0-44ec-b574-1172ce550448",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "1745d355-315d-4041-9412-fc5b3dafe4ec",
+      "request_id": "9227b2e3-4c6e-47e2-ae8d-49f371858e94",
+      "turn_exchange_id": "43dbc7ae-1093-4cde-a3dc-5f74e8195dbb"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "1745d355-315d-4041-9412-fc5b3dafe4ec"
+   },
+   "06dc6b17-eaee-4650-9da2-bd439398de9f": {
+    "children": [
+     "bbb21d77-3cc7-4995-a568-a7d2f6550089"
+    ],
+    "id": "06dc6b17-eaee-4650-9da2-bd439398de9f",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Yes \u2014 don\u2019t go fully unlimited yet.\n\n## Practical max at this stage\n\ud83d\udc49 **4 hours** is a safe upper limit for now\n\nIf she sleeps longer:\n- you can **let it happen occasionally**\n- but don\u2019t make a habit of pushing past **4\u20135h** yet\n\n---\n\n## Simple rule\n- **<4h stretch \u2192 great, let her sleep**  \n- **>4h regularly \u2192 consider a gentle feed**\n\n---\n\n## Why this balance works\n- Protects **supply + intake**  \n- Still allows **longer restorative sleep**  \n- Avoids going too long in these early weeks\n\n---\n\n## When you can relax this further\nAround **6\u20138 weeks**, if:\n- weight gain is solid  \n- diapers still good  \n\n\ud83d\udc49 then longer stretches (5\u20136h+) become fine\n\n---\n\n## Bottom line\n- You don\u2019t need strict 3h anymore  \n- But don\u2019t jump to \u201csleep all night\u201d mode yet  \n\ud83d\udc49 **Cap around ~4h for now** and you\u2019re in a very safe zone"
+      ]
+     },
+     "create_time": 1773972234.213415,
+     "end_turn": true,
+     "id": "06dc6b17-eaee-4650-9da2-bd439398de9f",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21698-9c1c-4db7-8e4b-5b366e51865e",
+      "request_id": "26ffc0d0-543e-4a40-af80-3fb33b090881",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "fd5af72f-e579-4db7-bc68-69522b990bb4"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21698-9c1c-4db7-8e4b-5b366e51865e"
+   },
+   "06f23624-3e82-4e36-8aff-0d0e693e5e2e": {
+    "children": [
+     "cce7eb38-e563-4a71-8b81-d0b7b7d47fbe"
+    ],
+    "id": "06f23624-3e82-4e36-8aff-0d0e693e5e2e",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1775157718.1615908,
+     "end_turn": true,
+     "id": "06f23624-3e82-4e36-8aff-0d0e693e5e2e",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb2190e-26b2-401d-9673-dec7a4ce3316",
+      "rebase_developer_message": true,
+      "request_id": "5dc6ffb5-5585-4c32-935b-8212efb11d6b",
+      "turn_exchange_id": "af41349e-9b49-4496-8dd2-dd567ab31e07"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb2190e-26b2-401d-9673-dec7a4ce3316"
+   },
+   "07d3faca-987d-4941-942f-52437d271d0f": {
+    "children": [
+     "bbb2103e-ba1a-44a6-8100-fd5ba4c71dd5"
+    ],
+    "id": "07d3faca-987d-4941-942f-52437d271d0f",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Yes \u2014 **the \ue200entity\ue202[\"product\",\"IKEA SNIGLAR changing table\"]\ue201 can safely hold a baby tub with bath water.**\n\nA quick reality check:\n\n- Estimated bath load: **9\u201313 kg** (water + tub).  \n- Add baby: **~3\u20134 kg**.  \n- Total during bath: **~12\u201317 kg**.\n\nThe SNIGLAR is designed for **changing babies up to ~11 kg** *plus* the weight of a changing pad and normal pressure from a caregiver leaning in. Structurally, a ~15 kg distributed load is well within what that frame handles.\n\n**Important safety points (these matter more than weight):**\n\n\u2022 **Center the tub** on the surface so the weight sits over the legs.  \n\u2022 **Do not fill the tub to the brim** (you don\u2019t need much water anyway).  \n\u2022 **Keep one hand on baby at all times.**  \n\u2022 Make sure the table is **fully tightened and not wobbly**.  \n\u2022 Avoid leaning your full body weight onto the table while bathing.\n\n**Practical verdict:**  \nUsing the tub **on top of the SNIGLAR is common and generally safe**. The bigger risk isn\u2019t collapse \u2014 it\u2019s **water splashing and the tub sliding**.\n\nIf you want to make it extra stable:  \nPut a **towel or rubber mat under the tub** so it grips the surface.\n\nIn short: weight is fine, stability and supervision are the real rules of the game."
+      ]
+     },
+     "create_time": 1773573630.399985,
+     "end_turn": true,
+     "id": "07d3faca-987d-4941-942f-52437d271d0f",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [
+       {
+        "alt": "IKEA SNIGLAR changing table",
+        "end_idx": 62,
+        "matched_text": "\ue200entity\ue202[\"product\",\"IKEA SNIGLAR changing table\"]\ue201",
+        "prompt_text": "IKEA SNIGLAR changing table",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 12,
+        "type": "alt_text"
+       }
+      ],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "6bbcc5f2-8235-4a01-9db0-9feecf0da9cf",
+      "request_id": "9bf47107-3365-4396-8d88-6664811d095e",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "35c889bd-6c89-4127-b768-21adb25d0452"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21359-47eb-4336-be2f-0ac6ff2e821a"
+   },
+   "088b4d7f-3ec3-4299-b814-98c87887f376": {
+    "children": [
+     "2b7c35a3-77c6-47d9-9762-2238904b8557"
+    ],
+    "id": "088b4d7f-3ec3-4299-b814-98c87887f376",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773368637.8605862,
+     "end_turn": null,
+     "id": "088b4d7f-3ec3-4299-b814-98c87887f376",
+     "metadata": {
+      "can_save": false,
+      "command": "prompt",
+      "contextual_answers_message_type": "sources_and_filters_prompt",
+      "default_model_slug": "gpt-5-3",
+      "is_contextual_answers_system_message": true,
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21f18-ef33-4b48-a891-893403060184",
+      "request_id": "9e2555c8-f1ad-48de-8adc-a4492e72ef3f",
+      "turn_exchange_id": "a8bc594e-3060-4d56-b665-d43c50acb700"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21f18-ef33-4b48-a891-893403060184"
+   },
+   "0af2e459-3bb3-41e7-961d-d2cfbc0352e4": {
+    "children": [
+     "c7e2e582-f543-4bfe-baa0-239d389a20b0"
+    ],
+    "id": "0af2e459-3bb3-41e7-961d-d2cfbc0352e4",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1776034100.09749,
+     "end_turn": null,
+     "id": "0af2e459-3bb3-41e7-961d-d2cfbc0352e4",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "8502438b-ff29-40d7-8110-a9f18939007d",
+      "request_id": "c092b6b1-087e-4b73-a35e-d1eeabeea4d0",
+      "turn_exchange_id": "a623417d-f45d-4bd2-bb6a-1439473981db"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "8502438b-ff29-40d7-8110-a9f18939007d"
+   },
+   "0c43138c-5add-461b-81bb-2dd3b96bf99e": {
+    "children": [
+     "bbb212ab-680d-49c9-89da-0c12a000324e"
+    ],
+    "id": "0c43138c-5add-461b-81bb-2dd3b96bf99e",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Short answer: **after the newborn phase stabilizes** \u2014 usually **around 4\u20136 weeks**.\n\n---\n\n## Why not switch immediately\nRight now:\n- Skin is more sensitive  \n- Poop is frequent/liquid  \n\ud83d\udc49 \ue200entity\ue202[\"brand\",\"Dodot\"]\ue201 Sensitive is doing a safe job\n\n---\n\n## Good moment to test other brands\n\ud83d\udc49 When:\n- Rash situation is **calm/stable**  \n- Poop frequency starts to **slow a bit**  \n- You\u2019re out of the \u201cdaily chaos\u201d phase (~4\u20136 weeks)\n\n---\n\n## How to switch (don\u2019t go all in)\n\n**Test method:**\n- Buy **small pack** of new brand  \n- Use during **daytime only** first  \n- Keep Dodot for nights\n\n---\n\n## What to evaluate\nAfter 2\u20133 days:\n- Leaks/blowouts  \n- Skin reaction  \n- Fit (marks, gaps)  \n- Absorption overnight (later)\n\n---\n\n## When NOT to switch\n- Active rash  \n- Major routine chaos  \n- Growth spurt cluster madness\n\n---\n\n## Reality check\nMany parents realize:\n\ud83d\udc49 cheaper brands work just as well after a few weeks\n\nBut:\n\ud83d\udc49 some babies are \u201cbrand sensitive\u201d \u2192 and that\u2019s fine too\n\n---\n\n## My take for you\nGiven:\n- current rash  \n- early weeks  \n\n\ud83d\udc49 **Wait a bit**  \nThen test calmly\n\n---\n\n## Bottom line\n- Don\u2019t rush it  \n- Start testing **~1 month mark**  \n- Do it gradually, not all-in\n\n---\n\nIf you want, I can tell you which Portuguese supermarket brands are actually worth testing (some are surprisingly solid, others are trash)."
+      ]
+     },
+     "create_time": 1775512112.102022,
+     "end_turn": true,
+     "id": "0c43138c-5add-461b-81bb-2dd3b96bf99e",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [
+       {
+        "alt": "Dodot",
+        "category": "brand",
+        "end_idx": 215,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Dodot\"]\ue201",
+        "metadata": null,
+        "name": "Dodot",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Dodot",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 189,
+        "status": "done",
+        "type": "entity"
+       }
+      ],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb2110b-d720-458d-acf4-e134dee58965",
+      "request_id": "ded410d7-2c4c-475c-b649-d705d6c10a3b",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "a0274229-a1d1-4b94-aaec-f381bcaa4c3f"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb2110b-d720-458d-acf4-e134dee58965"
+   },
+   "10d8e017-93db-4777-a265-7910f10b6f1e": {
+    "children": [
+     "bbb2104e-3b27-4603-bec4-1cc71b0f69ea"
+    ],
+    "id": "10d8e017-93db-4777-a265-7910f10b6f1e",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Perfect \u2014 here\u2019s the **no-BS wipes shortlist for Portugal**.\n\n## \ud83e\udd47 Best cheap wipes (actually good)\n\n### \ue200entity\ue202[\"brand\",\"Lupilu\"]\ue201 (Lidl)\n- Cheapest reliable option  \n- Soft enough, good moisture  \n\ud83d\udc49 **Best value overall**\n\n---\n\n### \ue200entity\ue202[\"brand\",\"Continente Baby\"]\ue201\n- Slightly thicker than Lupilu  \n- Consistent quality  \n\ud83d\udc49 Safe bet\n\n---\n\n### \ue200entity\ue202[\"brand\",\"Pingo Doce Baby\"]\ue201\n- Decent, middle of the road  \n\ud83d\udc49 Fine if on promo\n\n---\n\n## \ud83d\udfe1 Mid-tier (not really worth it long-term)\n\n- \ue200entity\ue202[\"brand\",\"Dodot Sensitive Wipes\"]\ue201  \n\ud83d\udc49 Good, but overpriced for what they are\n\n---\n\n## \ud83d\udd34 Ones to avoid\n\n- Perfumed wipes (any brand)  \n- Very cheap \u201cthin\u201d wipes:\n  - tear easily  \n  - need 3 instead of 1 \u2192 fake savings  \n\n---\n\n## What matters more than brand\n\n\ud83d\udc49 Thickness + moisture\n\nA good wipe:\n- doesn\u2019t tear  \n- doesn\u2019t require scrubbing  \n- cleans in 1\u20132 passes\n\n---\n\n## Smart usage strategy\n\n- Pee \u2192 minimal wipes (or none)  \n- Poop \u2192 better wipes  \n- Early weeks \u2192 keep using water wipes  \n- Later \u2192 switch to cheap + effective\n\n---\n\n## Bottom line\nStart with:\n\ud83d\udc49 **Lupilu or Continente Baby**\n\nLow cost, low risk.\n\n---\n\nIf you want next level optimization, I can show you how to cut wipe usage by ~30% without compromising hygiene (it\u2019s not obvious but works)."
+      ]
+     },
+     "create_time": 1775534147.915082,
+     "end_turn": true,
+     "id": "10d8e017-93db-4777-a265-7910f10b6f1e",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [
+       {
+        "alt": "Lupilu",
+        "category": "brand",
+        "end_idx": 132,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Lupilu\"]\ue201",
+        "metadata": null,
+        "name": "Lupilu",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Lupilu",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 105,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Continente Baby",
+        "category": "brand",
+        "end_idx": 271,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Continente Baby\"]\ue201",
+        "metadata": null,
+        "name": "Continente Baby",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Continente Baby",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 235,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Pingo Doce Baby",
+        "category": "brand",
+        "end_idx": 385,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Pingo Doce Baby\"]\ue201",
+        "metadata": null,
+        "name": "Pingo Doce Baby",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Pingo Doce Baby",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 349,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Dodot Sensitive Wipes",
+        "category": "brand",
+        "end_idx": 533,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Dodot Sensitive Wipes\"]\ue201",
+        "metadata": null,
+        "name": "Dodot Sensitive Wipes",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Dodot Sensitive Wipes",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 491,
+        "status": "done",
+        "type": "entity"
+       }
+      ],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb210f9-c04e-4ba6-ab5a-6996518cb2d3",
+      "request_id": "dbb6da3c-f48e-4527-a65c-71df2b962453",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "02fa45b7-7b92-4d45-aca7-6e9495703dd1"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb210f9-c04e-4ba6-ab5a-6996518cb2d3"
+   },
+   "113f6fad-8455-4859-85aa-2cb18ed93486": {
+    "children": [
+     "27fe7be5-6d39-4d9f-8165-0af86183bd65"
+    ],
+    "id": "113f6fad-8455-4859-85aa-2cb18ed93486",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1775512021.9800134,
+     "end_turn": null,
+     "id": "113f6fad-8455-4859-85aa-2cb18ed93486",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb2108f-7a95-445c-bbac-bd28933e682b",
+      "request_id": "4f60cbba-c9fc-46a4-93bd-23290c8139e0",
+      "turn_exchange_id": "452cda20-6951-49c2-9a73-e91795144fcd"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb2108f-7a95-445c-bbac-bd28933e682b"
+   },
+   "114e3629-1942-40a4-94cf-45d9848b7b79": {
+    "children": [
+     "bbb21b4f-215e-42ac-acb6-3bc3511ce7db"
+    ],
+    "id": "114e3629-1942-40a4-94cf-45d9848b7b79",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Close \u2014 best version is a **hybrid**, not either/or.\n\n## Optimal setup\n\n\ud83d\udc49 **Pad on top of towel**  \n\ud83d\udc49 **Open diaper already under her (not closed yet)**\n\n---\n\n## Step-by-step\n\n1. Take her out \u2192 towel  \n2. Pat dry quickly  \n3. Place on **pad + open diaper underneath**  \n4. Wait **10\u201320 sec**\n\n- If she pees \u2192 pad catches it (diaper helps too)  \n- If nothing happens \u2192 just **close the diaper**\n\n---\n\n## Why this works\n- Pad = protects everything  \n- Diaper = ready to go instantly  \n- Waiting window = lets the reflex happen *before* you seal it\n\n---\n\n## If you rush diaper immediately\n\u2192 high chance she pees/poops **right after closing** \u2192 redo everything\n\n---\n\n## Bottom line\n\ud83d\udc49 **Pad for protection + diaper pre-positioned + short wait**\n\nThat\u2019s the cleanest system with the least rework."
+      ]
+     },
+     "create_time": 1774924070.256355,
+     "end_turn": true,
+     "id": "114e3629-1942-40a4-94cf-45d9848b7b79",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb216aa-e6de-4a83-8e21-8b173950ad1d",
+      "request_id": "7a869f70-73df-4c61-8597-1702f80b8c4c",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "9756a75e-2689-4c4d-a376-615882da98b4"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb216aa-e6de-4a83-8e21-8b173950ad1d"
+   },
+   "11bbbc97-5b46-495b-bdaf-325815002262": {
+    "children": [
+     "2c95bda8-0cab-4306-8355-b94d20b39191"
+    ],
+    "id": "11bbbc97-5b46-495b-bdaf-325815002262",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773383091.5137486,
+     "end_turn": true,
+     "id": "11bbbc97-5b46-495b-bdaf-325815002262",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "56e1898e-6f02-4643-b6fd-3e8fab40c867",
+      "rebase_developer_message": true,
+      "request_id": "d5b198b3-4223-4c75-8013-a7ab1c5fcc89",
+      "turn_exchange_id": "5c6c935b-e962-4364-9511-4cc77ca7853b"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "56e1898e-6f02-4643-b6fd-3e8fab40c867"
+   },
+   "120bd784-3cbb-4bce-a497-3ea77a24abde": {
+    "children": [
+     "bbb21698-9c1c-4db7-8e4b-5b366e51865e"
+    ],
+    "id": "120bd784-3cbb-4bce-a497-3ea77a24abde",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Good \u2014 that changes things.\n\nIf she:\n- **Regained birth weight by ~day 7**\n- Has **many wet diapers + regular poops**\n- Feeds well\n\n\ud83d\udc49 Then **you can likely stop waking her strictly every 3h at night**\n\n---\n\n## What I\u2019d do now\n\n**Daytime**\n- Keep feeds **every ~2.5\u20133h max** (wake if needed)\n\n**Night**\n- Let her sleep  \n- If she wakes \u2192 feed  \n- If she goes longer (e.g. 3.5\u20134h) \u2192 **that\u2019s fine**\n\n---\n\n## Why this actually helps your situation\n- Less forced waking \u2192 less fragmented sleep  \n- Less \u201chalf-asleep feeds\u201d \u2192 often **less air intake**  \n- Longer rest \u2192 better overall regulation (for both of you)\n\n---\n\n## Guardrails (important)\nAs long as:\n- **\u22656 wet diapers/day**\n- Poop still happening regularly  \n- She wakes on her own to feed  \n- No lethargy / hard-to-wake\n\n\ud83d\udc49 You\u2019re safe\n\n---\n\n## About weight risk\nAt this point, diapers + behavior are **very reliable proxies** short-term.\n\nYou\u2019re not flying blind.\n\n---\n\n## My honest take\nContinuing to wake her every 3h now is:\n- **Not necessary anymore**\n- Possibly **making nights messier** (more gas cycles, more disruption)\n\n---\n\n## Bottom line\n- **Days structured, nights responsive**\n- Let her give you a longer stretch if she can  \n- Keep your focus on **upright after feeds**\n\n---\n\nIf you want to be extra safe: book a weight check in the next week.  \nBut based on what you described, you\u2019re in the zone where you can **start loosening the system a bit**."
+      ]
+     },
+     "create_time": 1773972071.660076,
+     "end_turn": true,
+     "id": "120bd784-3cbb-4bce-a497-3ea77a24abde",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21a80-5c06-48c7-8653-7b4e30bb9250",
+      "request_id": "482d9c04-d8e2-41af-9128-5f5259eed897",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "b8b4d63f-aee8-4478-9f8b-722a4c2b5630"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21a80-5c06-48c7-8653-7b4e30bb9250"
+   },
+   "12fca265-47ab-4c9f-a6cb-a571659d4db2": {
+    "children": [
+     "b62974bf-548a-4c6b-aac3-ae6ed76cff27"
+    ],
+    "id": "12fca265-47ab-4c9f-a6cb-a571659d4db2",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1774201926.418294,
+     "end_turn": true,
+     "id": "12fca265-47ab-4c9f-a6cb-a571659d4db2",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21a18-07cd-47e3-be87-0a8be76171e8",
+      "rebase_developer_message": true,
+      "request_id": "b2d673a2-5ce5-4d06-b285-1f8f9a406a70",
+      "turn_exchange_id": "316ee266-b7b9-4c89-820b-77d959230e2f"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb21a18-07cd-47e3-be87-0a8be76171e8"
+   },
+   "13c52c5c-85ca-4c25-8f5c-c21c756d0ea7": {
+    "children": [
+     "bbb21a36-3ce2-4b1b-8043-0d6168e1b4bb"
+    ],
+    "id": "13c52c5c-85ca-4c25-8f5c-c21c756d0ea7",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "You\u2019re right \u2014 a **hungry newborn + bath = disaster**. Don\u2019t do that.\n\n## Better sequencing (keep her calm but not too full)\n\n\ud83d\udc49 **Small feed \u2192 bath \u2192 full feed \u2192 sleep**\n\n### Why this works\n- Small feed takes the edge off hunger  \n- She\u2019s calm enough for the bath  \n- Full feed after helps her **wind down + sleep**\n\n---\n\n## What \u201csmall feed\u201d means\n- Just enough to **settle her**\n- Not a full \u201cmilk coma\u201d\n\n---\n\n## Alternative (even simpler)\nIf she\u2019s already feeding well before bath:\n\n\ud83d\udc49 **Feed \u2192 short pause (5\u201310 min) \u2192 bath \u2192 top-up feed \u2192 sleep**\n\n---\n\n## What to avoid\n- Fully hungry \u2192 meltdown  \n- Fully stuffed \u2192 more spit-up + discomfort in bath\n\n---\n\n## Your situation (practical call)\nSince bath is activating her:\n\ud83d\udc49 Don\u2019t over-optimize this right now\n\n- Keep feeding before if it works  \n- Move bath earlier  \n- Let bedtime be calm and separate\n\n---\n\n## Bottom line\n\ud83d\udc49 You\u2019re correct \u2014 don\u2019t bathe a hungry baby  \n\ud83d\udc49 Aim for **\u201cnot hungry, not overfull\u201d sweet spot**\n\n---\n\nHonestly, timing perfection here is overrated.  \n**Placement in the day matters more than perfect feed timing.**"
+      ]
+     },
+     "create_time": 1776034029.944561,
+     "end_turn": true,
+     "id": "13c52c5c-85ca-4c25-8f5c-c21c756d0ea7",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb219d4-9f72-4373-86f9-9f815a1482e0",
+      "request_id": "ca0e4376-6d32-4bc7-84d5-268ce263ae30",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "b307fcbb-e46e-4370-b78d-45a5eeed6591"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb219d4-9f72-4373-86f9-9f815a1482e0"
+   },
+   "1721b424-61c7-41fa-9112-056de0809c35": {
+    "children": [
+     "bbb21758-e3be-4be2-abcd-2990a1515cb0"
+    ],
+    "id": "1721b424-61c7-41fa-9112-056de0809c35",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Nice \u2014 let\u2019s make this practical so you don\u2019t overbuy.\n\n## How many diapers to buy per size (realistic)\n\n### Size 0 (newborn)\n\ud83d\udc49 **1\u20132 small packs max**\n- Many babies outgrow it in **1\u20132 weeks**\n- Some skip it entirely\n\n---\n\n### Size 1\n\ud83d\udc49 **3\u20135 packs total** (don\u2019t bulk too early)\n- Lasts ~**3\u20136 weeks**\n- Growth is fast + unpredictable\n\n---\n\n### Size 2\n\ud83d\udc49 **Stock more confidently**\n- Lasts longer (~1\u20132+ months)\n\n---\n\n## Daily usage (to estimate)\n- **0\u20131 month:** 8\u201310/day  \n- **1\u20133 months:** 6\u20138/day  \n\n---\n\n## Smart buying strategy (this is key)\n\n\ud83d\udc49 **Phase 1 (now):**\n- Buy small/medium packs  \n- Stay flexible (growth + brand testing)\n\n\ud83d\udc49 **Phase 2 (~1 month):**\n- Once:\n  - size stabilizes  \n  - brand works  \n\n\ud83d\udc49 Then go bulk / promos\n\n---\n\n## Rule that saves money\n\ud83d\udc49 Never hold more than **~2 weeks of diapers ahead**\n\nPrevents:\n- outgrowing size  \n- being stuck with a bad brand\n\n---\n\n## Extra pro tip\nKeep:\n- **1 pack of next size ready**\n\nSo you can switch immediately when leaks start.\n\n---\n\n## Bottom line\n- Early sizes = **buy small, adjust often**  \n- Bulk comes later when things stabilize  \n\n---\n\nYou\u2019re at the phase where flexibility > savings.  \nIn a few weeks, you flip that and start optimizing cost hard."
+      ]
+     },
+     "create_time": 1775532313.703344,
+     "end_turn": true,
+     "id": "1721b424-61c7-41fa-9112-056de0809c35",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb210c7-72a6-476f-8102-0b18b70ecff9",
+      "request_id": "419e760c-d395-4672-aa48-e36fdfaa20b7",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "027594ee-b7a9-4431-84d7-10dd19ba5c5a"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb210c7-72a6-476f-8102-0b18b70ecff9"
+   },
+   "1730de2b-d1b2-4ef9-8bb3-c8f1edd6bc57": {
+    "children": [
+     "84b8dbcd-7c3e-408c-b284-3dec4faa1cdc"
+    ],
+    "id": "1730de2b-d1b2-4ef9-8bb3-c8f1edd6bc57",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773765954.9127884,
+     "end_turn": null,
+     "id": "1730de2b-d1b2-4ef9-8bb3-c8f1edd6bc57",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "f9eeb00d-1522-49d6-8c34-6c211fe63b2c",
+      "request_id": "f07df930-6fec-4b9f-8912-f71f6152663d",
+      "search_result_groups": [],
+      "turn_exchange_id": "75a49c9c-d153-4ff2-aa56-7cc640c95c66"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "f9eeb00d-1522-49d6-8c34-6c211fe63b2c"
+   },
+   "1745d355-315d-4041-9412-fc5b3dafe4ec": {
+    "children": [
+     "0528644f-1bd0-44ec-b574-1172ce550448"
+    ],
+    "id": "1745d355-315d-4041-9412-fc5b3dafe4ec",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773984605.1251965,
+     "end_turn": null,
+     "id": "1745d355-315d-4041-9412-fc5b3dafe4ec",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21736-93a9-4a01-bbde-3cde7ffdeb99",
+      "request_id": "9227b2e3-4c6e-47e2-ae8d-49f371858e94",
+      "turn_exchange_id": "43dbc7ae-1093-4cde-a3dc-5f74e8195dbb"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb21736-93a9-4a01-bbde-3cde7ffdeb99"
+   },
+   "1a9bae7a-0a63-44f4-9511-aa13cb59274f": {
+    "children": [
+     "bbb218ed-3bdc-4b2b-ab21-6014d21fd873"
+    ],
+    "id": "1a9bae7a-0a63-44f4-9511-aa13cb59274f",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "\ud83d\udc49 **Around 4\u20136 weeks old** \u2014 that\u2019s your window.\n\n---\n\n## For you specifically\nShe\u2019s about to hit **1 month** \u2192 you\u2019re almost there.\n\n\ud83d\udc49 Wait until:\n- Skin/rash is **calm for a few days**  \n- No active irritation  \n- Things feel a bit more \u201cstable\u201d\n\n---\n\n## Then test like this (simple + safe)\n\n**Step 1**\n- Try non-branded during **daytime only**\n\n**Step 2**\n- Keep \ue200entity\ue202[\"brand\",\"Dodot\"]\ue201 for nights\n\n**Step 3 (after 2\u20133 days)**\nCheck:\n- Leaks  \n- Skin reaction  \n- Fit\n\n\ud83d\udc49 If all good \u2192 expand use\n\n---\n\n## When NOT to test\n- Rash active  \n- Growth spurt chaos  \n- Big routine disruption\n\n---\n\n## Bottom line\n\ud83d\udc49 **~1 month + stable skin = green light**  \n\ud83d\udc49 Day test first, don\u2019t go all-in\n\n---\n\nYou\u2019re literally days away from that point \u2014 timing is good."
+      ]
+     },
+     "create_time": 1775534300.359152,
+     "end_turn": true,
+     "id": "1a9bae7a-0a63-44f4-9511-aa13cb59274f",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [
+       {
+        "alt": "Dodot",
+        "category": "brand",
+        "end_idx": 392,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Dodot\"]\ue201",
+        "metadata": null,
+        "name": "Dodot",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Dodot",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 366,
+        "status": "done",
+        "type": "entity"
+       }
+      ],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21ee7-d2a1-43ac-94fd-2f309377f398",
+      "request_id": "63e6cb06-b99b-4612-9d3d-ca422655dffb",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "d1ab0435-9334-45df-9f57-73773c3ac583"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21ee7-d2a1-43ac-94fd-2f309377f398"
+   },
+   "1c0016a6-4c5f-4932-aa7b-d72068faa349": {
+    "children": [
+     "2d548a0b-2886-47ed-8f35-76d93df13674"
+    ],
+    "id": "1c0016a6-4c5f-4932-aa7b-d72068faa349",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1775946774.7193108,
+     "end_turn": true,
+     "id": "1c0016a6-4c5f-4932-aa7b-d72068faa349",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "3b04f96b-74f6-4b72-9423-8f3cca47768f",
+      "rebase_developer_message": true,
+      "request_id": "ca7348d2-42f3-4542-8101-cd069bb44656",
+      "turn_exchange_id": "9f3e3a6c-c335-4138-bb4c-2e86a81f00be"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "3b04f96b-74f6-4b72-9423-8f3cca47768f"
+   },
+   "1d0d4997-f9a9-42b6-a7f9-83084519c6a8": {
+    "children": [
+     "9307d463-ecf1-49c8-b5af-fe9403a6d20c"
+    ],
+    "id": "1d0d4997-f9a9-42b6-a7f9-83084519c6a8",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1775512226.81669,
+     "end_turn": null,
+     "id": "1d0d4997-f9a9-42b6-a7f9-83084519c6a8",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "fc76911e-d67f-4e5c-aef6-d5d71d443f44",
+      "request_id": "7aba375a-43f3-4019-a2fc-5fa4f0b9affd",
+      "turn_exchange_id": "63e5fe35-1a1c-438f-8b53-24d738260846"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "fc76911e-d67f-4e5c-aef6-d5d71d443f44"
+   },
+   "1e6f45bf-f6e6-4379-8a6e-de51258f7d05": {
+    "children": [
+     "bbb21de9-bb4c-4391-add4-596ac3d31a8d"
+    ],
+    "id": "1e6f45bf-f6e6-4379-8a6e-de51258f7d05",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "I can access the files, but I can\u2019t reliably interpret baby feeding patterns from audio alone (no way to clearly \u201chear\u201d latch quality, swallowing rhythm, etc. in a clinically useful way).\n\nLet\u2019s do this faster and more useful:\n\n## Tell me what you observed while recording:\n- Was she **gulping or steady**?\n- Any **clicking sounds**?\n- Did she **pull off / choke / cough**?\n- Was milk **leaking from her mouth**?\n- Did she seem **calm or tense**?\n- How long did she feed before slowing?\n\n## And right after:\n- Did she **burp easily or not**?\n- Did she **tense up / squirm / pull legs up**?\n- How long until discomfort started?\n\n---\n\nIf you want, you can also describe *one specific feed that went badly* vs *one that went well* \u2014 the contrast is usually where the answer is hiding.\n\nRight now we\u2019re trying to confirm one key thing:\n\ud83d\udc49 **Is air intake during feeds driving the night discomfort, or is this just baseline newborn gut chaos?**\n\nYour answers will make that clear quickly."
+      ]
+     },
+     "create_time": 1773984367.694815,
+     "end_turn": true,
+     "id": "1e6f45bf-f6e6-4379-8a6e-de51258f7d05",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bc0b8c37-129d-4ed0-939f-6f8b4290ff69",
+      "request_id": "66c66a49-8bfd-4b53-bd20-b68bafaca435",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "cf06097e-69b4-4fd9-abc3-b776e1e19bc7"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bc4dc43f-5094-440a-ad9a-d240f01b0c68"
+   },
+   "25335b8a-c889-4c62-9ccc-526fcb270fc7": {
+    "children": [
+     "bbb219ad-06c4-4736-9cd5-6b28c106073e"
+    ],
+    "id": "25335b8a-c889-4c62-9ccc-526fcb270fc7",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "**Cradle cap = very common, harmless.** You don\u2019t need to \u201cfix\u201d it fast \u2014 just loosen and wash gently.\n\n## What to do (simple + effective)\n\n**2\u20133\u00d7/week routine:**\n1. **Soften first**  \n   - Put a few drops of baby oil or mineral oil on the flakes  \n   - Wait **10\u201315 min**\n\n2. **Gently loosen**  \n   - Soft brush or your fingers  \n   - Don\u2019t scrape\n\n3. **Wash**  \n   - Mild baby shampoo  \n   - Rinse well\n\n---\n\n## Eyebrows (same idea, just gentler)\n- Tiny bit of oil  \n- Soft cloth to wipe  \n- No scrubbing\n\n---\n\n## What NOT to do\n- Don\u2019t pick hard flakes  \n- Don\u2019t over-wash daily  \n- Avoid heavy creams sitting on it (can worsen buildup)\n\n---\n\n## How long it takes\n- Improves in **days to weeks**  \n- Can come and go for a while\n\n---\n\n## When to escalate\n- Very thick/yellow crusts spreading  \n- Red, inflamed skin  \n- Not improving after a couple of weeks\n\nThen pediatrician may suggest a medicated shampoo.\n\n---\n\n## Bottom line\n\ud83d\udc49 Loosen \u2192 gentle removal \u2192 wash  \n\ud83d\udc49 No force, no rush\n\n---\n\nThink of it like softening glue before removing it \u2014 not scraping it off dry."
+      ]
+     },
+     "create_time": 1776916424.279222,
+     "end_turn": true,
+     "id": "25335b8a-c889-4c62-9ccc-526fcb270fc7",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "2de10e3b-cacd-4760-a7f4-07a8b36cece1",
+      "request_id": "1de24a7f-67ba-4658-b9c4-b5134fceae26",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "107232ae-96bd-41d8-9af3-a48450934f52"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "2de10e3b-cacd-4760-a7f4-07a8b36cece1"
+   },
+   "27989531-37be-4fd7-8363-515b5833ef82": {
+    "children": [
+     "aaf9b130-0bcc-45d1-b664-245d8d822aca"
+    ],
+    "id": "27989531-37be-4fd7-8363-515b5833ef82",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": null,
+     "end_turn": true,
+     "id": "27989531-37be-4fd7-8363-515b5833ef82",
+     "metadata": {
+      "can_save": false,
+      "is_visually_hidden_from_conversation": true,
+      "rebase_developer_message": true
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "66bf1894-8bb6-414e-8b2a-1fab58a60200"
+   },
+   "27fe7be5-6d39-4d9f-8165-0af86183bd65": {
+    "children": [
+     "eefe2a05-ed5a-4d9e-9152-59cbd2803e6d"
+    ],
+    "id": "27fe7be5-6d39-4d9f-8165-0af86183bd65",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1775512022.0420492,
+     "end_turn": null,
+     "id": "27fe7be5-6d39-4d9f-8165-0af86183bd65",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "113f6fad-8455-4859-85aa-2cb18ed93486",
+      "request_id": "4f60cbba-c9fc-46a4-93bd-23290c8139e0",
+      "turn_exchange_id": "452cda20-6951-49c2-9a73-e91795144fcd"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "113f6fad-8455-4859-85aa-2cb18ed93486"
+   },
+   "283aec83-b844-431f-a25b-99dae61c194f": {
+    "children": [
+     "bbb21a6a-e7fd-4321-8fd6-d2e4472c52b7"
+    ],
+    "id": "283aec83-b844-431f-a25b-99dae61c194f",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "**Speedy diaper change = do everything in ~20\u201330 seconds.**  \nGoal: minimize baby\u2019s exposure to cold and reduce crying.\n\n**Setup first (before opening diaper):**  \n- Clean diaper open under baby  \n- Wipes ready  \n- Cream open if using\n\n**Steps:**  \n1. Open dirty diaper.  \n2. Use front of diaper to wipe most poop.  \n3. Lift ankles. Quick wipe front \u2192 back.  \n4. Slide dirty diaper out.  \n5. Pull clean diaper up and close.\n\nThat\u2019s it. Fast, calm, efficient.\n\nVeteran-parent physics: the longer the baby stays naked, the louder the protest. Speed beats perfection."
+      ]
+     },
+     "create_time": 1773454117.020392,
+     "end_turn": true,
+     "id": "283aec83-b844-431f-a25b-99dae61c194f",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "a6b82cfd-2b97-4733-9cf8-1c7980a80241",
+      "request_id": "bd769bc4-435a-4003-bd93-ea7b96f1a7da",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "2ceba3bf-8685-4333-bd4f-9081a31fee5d"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "a6b82cfd-2b97-4733-9cf8-1c7980a80241"
+   },
+   "2b7c35a3-77c6-47d9-9762-2238904b8557": {
+    "children": [
+     "56e7ce10-2173-4894-b083-cb3afee778ae"
+    ],
+    "id": "2b7c35a3-77c6-47d9-9762-2238904b8557",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773368637.931258,
+     "end_turn": null,
+     "id": "2b7c35a3-77c6-47d9-9762-2238904b8557",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "088b4d7f-3ec3-4299-b814-98c87887f376",
+      "request_id": "9e2555c8-f1ad-48de-8adc-a4492e72ef3f",
+      "search_result_groups": [],
+      "turn_exchange_id": "a8bc594e-3060-4d56-b665-d43c50acb700"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "088b4d7f-3ec3-4299-b814-98c87887f376"
+   },
+   "2c1c5dc5-c464-4b7c-9976-ba77dbc8a536": {
+    "children": [
+     "bbb21013-9bc7-4c63-808f-0f809ab66109"
+    ],
+    "id": "2c1c5dc5-c464-4b7c-9976-ba77dbc8a536",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "That happens a lot at this age \u2014 bath = stimulation, not relaxation.\n\n## What to do now\n\n### \ud83d\udc49 Move bath earlier\n- Late afternoon / early evening  \n- **Not right before bedtime**\n\n---\n\n### \ud83d\udc49 Keep bedtime routine simple + calm\nSkip stimulation:\n\n- Feed  \n- Dim lights  \n- Minimal handling  \n- Straight to sleep\n\n---\n\n## If you still want to try making it calming\n\nTest a few tweaks (don\u2019t do all at once):\n\n- Slightly **warmer water**  \n- **Shorter bath** (3\u20135 min)  \n- Slower, quieter movements  \n- Lower lights + less talking\n\n\ud83d\udc49 If it still wires her \u2192 accept it and move it\n\n---\n\n## Important mindset\nBath is not \u201csupposed\u201d to relax babies.\n\n\ud83d\udc49 Some babies treat it like a **mini workout**\n\n---\n\n## Your goal\nNot to force bath into bedtime routine  \n\ud83d\udc49 but to **place it where it doesn\u2019t sabotage sleep**\n\n---\n\n## Bottom line\n- If it activates her \u2192 **move it earlier**  \n- Keep nights boring and predictable  \n- Re-test in a few weeks (this often changes)\n\n---\n\nYou\u2019re not doing it wrong \u2014 you just got a \u201cbath = party\u201d baby for now \ud83d\ude04"
+      ]
+     },
+     "create_time": 1776033850.527895,
+     "end_turn": true,
+     "id": "2c1c5dc5-c464-4b7c-9976-ba77dbc8a536",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21dfe-fb71-4bcd-ad06-c8e79c14dbbf",
+      "request_id": "a2471856-e893-4565-943e-c979a20aac14",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "43062dab-3b23-48f8-b7f9-f2ad70c37531"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21dfe-fb71-4bcd-ad06-c8e79c14dbbf"
+   },
+   "2c95bda8-0cab-4306-8355-b94d20b39191": {
+    "children": [
+     "d5a1b0fe-2c66-4748-b6a0-fd9b735f36fd"
+    ],
+    "id": "2c95bda8-0cab-4306-8355-b94d20b39191",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773383091.8976648,
+     "end_turn": null,
+     "id": "2c95bda8-0cab-4306-8355-b94d20b39191",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "11bbbc97-5b46-495b-bdaf-325815002262",
+      "request_id": "d5b198b3-4223-4c75-8013-a7ab1c5fcc89",
+      "search_result_groups": [],
+      "turn_exchange_id": "5c6c935b-e962-4364-9511-4cc77ca7853b"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "11bbbc97-5b46-495b-bdaf-325815002262"
+   },
+   "2d3f0db0-0d7c-4f68-8f8d-8c135a13a501": {
+    "children": [
+     "8b0fb70c-0861-47f1-aff1-f0c38ca6a562"
+    ],
+    "id": "2d3f0db0-0d7c-4f68-8f8d-8c135a13a501",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773874309.8057573,
+     "end_turn": null,
+     "id": "2d3f0db0-0d7c-4f68-8f8d-8c135a13a501",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "408b899b-0ee5-4e9e-a28a-5dd232258c66",
+      "request_id": "9b16de13-1a9e-439c-93c0-f85df8c0b577",
+      "search_result_groups": [],
+      "turn_exchange_id": "55cdfc5c-299c-496e-8680-a797b059731e"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "408b899b-0ee5-4e9e-a28a-5dd232258c66"
+   },
+   "2d548a0b-2886-47ed-8f35-76d93df13674": {
+    "children": [
+     "b622ba50-8df4-4e88-931f-e83c9fa1a9fc"
+    ],
+    "id": "2d548a0b-2886-47ed-8f35-76d93df13674",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1775946775.0765166,
+     "end_turn": null,
+     "id": "2d548a0b-2886-47ed-8f35-76d93df13674",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "1c0016a6-4c5f-4932-aa7b-d72068faa349",
+      "request_id": "ca7348d2-42f3-4542-8101-cd069bb44656",
+      "search_result_groups": [],
+      "turn_exchange_id": "9f3e3a6c-c335-4138-bb4c-2e86a81f00be"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "1c0016a6-4c5f-4932-aa7b-d72068faa349"
+   },
+   "2de10e3b-cacd-4760-a7f4-07a8b36cece1": {
+    "children": [
+     "25335b8a-c889-4c62-9ccc-526fcb270fc7"
+    ],
+    "id": "2de10e3b-cacd-4760-a7f4-07a8b36cece1",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1776916424.286073,
+     "end_turn": null,
+     "id": "2de10e3b-cacd-4760-a7f4-07a8b36cece1",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "e306cc92-6aca-4dab-bf7f-77e02a4f9b2b",
+      "request_id": "1de24a7f-67ba-4658-b9c4-b5134fceae26",
+      "search_result_groups": [],
+      "turn_exchange_id": "107232ae-96bd-41d8-9af3-a48450934f52"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "e306cc92-6aca-4dab-bf7f-77e02a4f9b2b"
+   },
+   "31bccefe-5894-4d7d-a63c-00dd2f2d6e4c": {
+    "children": [
+     "66bf1894-8bb6-414e-8b2a-1fab58a60200"
+    ],
+    "id": "31bccefe-5894-4d7d-a63c-00dd2f2d6e4c",
+    "message": null,
+    "parent": null
+   },
+   "3367179c-93db-4778-a7cb-53b44c6a8083": {
+    "children": [
+     "a69fbc6b-a90c-4d13-858a-c63f2ef9d322"
+    ],
+    "id": "3367179c-93db-4778-a7cb-53b44c6a8083",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1774548287.5564277,
+     "end_turn": true,
+     "id": "3367179c-93db-4778-a7cb-53b44c6a8083",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "4858396e-943b-469e-b24e-595f1fd0abc3",
+      "rebase_developer_message": true,
+      "request_id": "15e0254d-ce0a-4070-bdea-70045d626d3c",
+      "turn_exchange_id": "ea48ea62-79fe-47cc-b719-b1a0c8fd2dd5"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "4858396e-943b-469e-b24e-595f1fd0abc3"
+   },
+   "3373e997-2341-417d-ac20-b6a3725e8b61": {
+    "children": [
+     "bbb2152a-dfc6-4a7b-95bb-21e947455dbb"
+    ],
+    "id": "3373e997-2341-417d-ac20-b6a3725e8b61",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "**Yes \u2014 still normal.** Very common in the first weeks.\n\n## Why it keeps happening\n- **Friction from feeding** (constant sucking)  \n- Newborn skin still **adjusting to dry air**  \n- Lips don\u2019t have oil glands \u2192 dry easily\n\n---\n\n## What to do\n- You can leave it alone \ud83d\udc4d  \n- Or dab a bit of **breast milk** on lips after feeds  \n- Gently **wipe milk residue** (dried milk worsens peeling)\n\n---\n\n## What NOT to do\n- No picking  \n- Avoid regular creams/ointments unless really needed\n\n---\n\n## When to pay attention\n- Deep cracks or bleeding  \n- White patches inside mouth (possible thrush)  \n- Signs of dehydration (rare if diapers are good)\n\n---\n\n## Bottom line\n\ud83d\udc49 Peeling lips = normal, annoying, temporary  \n\ud83d\udc49 Usually settles over the **first few weeks** as skin toughens up"
+      ]
+     },
+     "create_time": 1774968795.352507,
+     "end_turn": true,
+     "id": "3373e997-2341-417d-ac20-b6a3725e8b61",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21b4f-215e-42ac-acb6-3bc3511ce7db",
+      "request_id": "3741db9f-541f-4988-85b5-730fa6d20c53",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "90f9e849-a65b-4ddf-8839-98f395e9ee7d"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21b4f-215e-42ac-acb6-3bc3511ce7db"
+   },
+   "348f99d3-7e24-4f00-a003-2ac9d4e0ceb5": {
+    "children": [
+     "bbb21f18-ef33-4b48-a891-893403060184"
+    ],
+    "id": "348f99d3-7e24-4f00-a003-2ac9d4e0ceb5",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773368637.751077,
+     "end_turn": null,
+     "id": "348f99d3-7e24-4f00-a003-2ac9d4e0ceb5",
+     "metadata": {
+      "can_save": false,
+      "is_visually_hidden_from_conversation": true,
+      "message_source": null,
+      "request_id": "9e2555c8-f1ad-48de-8adc-a4492e72ef3f",
+      "turn_exchange_id": "a8bc594e-3060-4d56-b665-d43c50acb700"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "f59f56d8-921c-4831-a228-fb503179d70d"
+   },
+   "353e24b8-d1b9-4690-9893-4e99c0f018d8": {
+    "children": [
+     "bbb21d14-c26b-48bc-a9c8-849409b38a42"
+    ],
+    "id": "353e24b8-d1b9-4690-9893-4e99c0f018d8",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "**Gulping = swallowing milk too fast / in big bursts.**\n\n## What it looks/sounds like\n- Rapid **\u201ckuh-kuh-kuh\u201d** swallowing (not slow rhythmic)\n- **No pause** between sucks \u2192 swallow \u2192 breathe\n- You see her **rushing to keep up**\n- Milk may **leak from mouth**\n- She might:\n  - cough  \n  - choke  \n  - pull off suddenly  \n\n---\n\n## Normal vs gulping\n\n**Normal feeding:**\n- Suck\u2013suck\u2013swallow\u2026 *pause*  \n- Calm, steady rhythm  \n- Relaxed body\n\n**Gulping:**\n- Suck-swallow-swallow-swallow  \n- Feels **urgent / chaotic**  \n- Baby looks like she\u2019s \u201chandling a firehose\u201d\n\n---\n\n## Why it matters\nGulping = more air swallowed \u2192 **more gas later**\n\n---\n\n## Quick test\nNext feed, watch:\n\ud83d\udc49 Is she **in control of the pace**, or **reacting to the flow**?\n\nIf she\u2019s reacting \u2192 that\u2019s gulping.  \nIf she\u2019s setting the rhythm \u2192 you\u2019re good.\n\n---\n\nIf you want, next step I can help you **spot it live in 30 seconds** during your next feed \u2014 it\u2019s one of those things that clicks once you see it."
+      ]
+     },
+     "create_time": 1773984422.91134,
+     "end_turn": true,
+     "id": "353e24b8-d1b9-4690-9893-4e99c0f018d8",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21de9-bb4c-4391-add4-596ac3d31a8d",
+      "request_id": "f7a6ee21-5691-4b37-8ba8-a8e8f8b48c9b",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "4e369a6a-4147-472d-baf6-8dba4c7025c6"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21de9-bb4c-4391-add4-596ac3d31a8d"
+   },
+   "35d761f6-611a-4193-8db0-0e78d15d54b9": {
+    "children": [
+     "8fd04a66-6368-4050-8e0d-4237419d8192"
+    ],
+    "id": "35d761f6-611a-4193-8db0-0e78d15d54b9",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773454116.970825,
+     "end_turn": true,
+     "id": "35d761f6-611a-4193-8db0-0e78d15d54b9",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21dfe-2557-48b6-a75e-ad01c71a796f",
+      "rebase_system_message": true,
+      "request_id": "bd769bc4-435a-4003-bd93-ea7b96f1a7da",
+      "turn_exchange_id": "2ceba3bf-8685-4333-bd4f-9081a31fee5d"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb21dfe-2557-48b6-a75e-ad01c71a796f"
+   },
+   "36bca96a-72f4-4e26-b35f-efdeec61efe3": {
+    "children": [
+     "815415ef-2acc-4e04-928f-a61b7f132d32"
+    ],
+    "id": "36bca96a-72f4-4e26-b35f-efdeec61efe3",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1775267367.6030488,
+     "end_turn": true,
+     "id": "36bca96a-72f4-4e26-b35f-efdeec61efe3",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21bf1-d213-4dbc-ab9f-a694894aff3c",
+      "rebase_developer_message": true,
+      "request_id": "2158adcf-9ad1-43bb-afe0-ad761bbf0a59",
+      "turn_exchange_id": "f9f7c94b-85a1-4771-baa3-d8b1e1c3a52f"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb21bf1-d213-4dbc-ab9f-a694894aff3c"
+   },
+   "37537e71-b4e4-4d1d-b002-adcae64cfd47": {
+    "children": [
+     "bbb2119b-b5c4-4dbd-9f34-0c5cb18a17c1"
+    ],
+    "id": "37537e71-b4e4-4d1d-b002-adcae64cfd47",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Short answer: **138 is probably too many** for Size 1 *for your baby right now*.\n\n## Why\nAt ~1 month and ~4 kg:\n- You\u2019re already **mid\u2013upper range of Size 1**\n- Many babies move to **Size 2 around 4.5\u20135 kg**\n\n\ud83d\udc49 So you likely have **2\u20133 weeks max** left in Size 1\n\n---\n\n## Do the math\n- Usage: ~7\u20138/day  \n- 138 diapers = ~18\u201320 days  \n- + your 38 = ~5 more days  \n\n\ud83d\udc49 Total: **~23\u201325 days of diapers**\n\nThat\u2019s right on the edge of outgrowing the size.\n\n---\n\n## Real risk\nYou won\u2019t \u201crun out\u201d  \nYou risk:\n\ud83d\udc49 being stuck with leftovers when leaks start \u2192 need to size up\n\n---\n\n## Smarter move\n\ud83d\udc49 **Buy the box only if:**\n- price is really good (this one is decent, not exceptional)\n- you\u2019re OK possibly having leftovers\n\nOtherwise:\n\ud83d\udc49 buy a **smaller pack + start preparing Size 2**\n\n---\n\n## My honest call\nI\u2019d go:\n- **No to 138 box**\n- Start transitioning mindset to **Size 2 soon**\n\n---\n\n## Bottom line\n- You\u2019re at the **end of Size 1 window**\n- Bigger packs now = higher risk than reward\n\n---\n\nYou\u2019re actually at the exact point where most parents overbuy one size too late \u2014 you\u2019re catching it in time."
+      ]
+     },
+     "create_time": 1775532745.995243,
+     "end_turn": true,
+     "id": "37537e71-b4e4-4d1d-b002-adcae64cfd47",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21633-6c39-4226-897f-97567f5a8aa7",
+      "request_id": "3aa2ea34-4917-4b42-9840-d79caf9bc387",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "834ead8a-d50e-4ae5-9a63-5674aa83e28b"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21633-6c39-4226-897f-97567f5a8aa7"
+   },
+   "3b04f96b-74f6-4b72-9423-8f3cca47768f": {
+    "children": [
+     "1c0016a6-4c5f-4932-aa7b-d72068faa349"
+    ],
+    "id": "3b04f96b-74f6-4b72-9423-8f3cca47768f",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1775946774.6933076,
+     "end_turn": true,
+     "id": "3b04f96b-74f6-4b72-9423-8f3cca47768f",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb219ee-5f0f-4f20-960d-062ffa72d273",
+      "rebase_system_message": true,
+      "request_id": "ca7348d2-42f3-4542-8101-cd069bb44656",
+      "turn_exchange_id": "9f3e3a6c-c335-4138-bb4c-2e86a81f00be"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb219ee-5f0f-4f20-960d-062ffa72d273"
+   },
+   "3e69a2ff-5184-4e8f-a005-170a0237851d": {
+    "children": [
+     "bbb21eca-173f-478c-82f2-3d14df8bec8d"
+    ],
+    "id": "3e69a2ff-5184-4e8f-a005-170a0237851d",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Yes \u2014 but do it **properly or it won\u2019t come off**.\n\n## How to wash it off (works every time)\n\n1. **Apply a tiny bit of baby shampoo first (on dry hair/skin)**\n   - This is the trick  \n   - Shampoo binds the oil\n\n2. **Gently massage**\n\n3. **Then add water and rinse well**\n\n---\n\n## Why this matters\nIf you:\n- put water first \u2192 oil repels it  \n\ud83d\udc49 leaves residue \u2192 can worsen cradle cap\n\n---\n\n## For eyebrows (more delicate)\n- Warm water + a drop of cleanser on cloth  \n- Wipe gently  \n- No scrubbing\n\n---\n\n## Quick version\n\ud83d\udc49 **Shampoo first \u2192 then water**\n\n---\n\n## Bonus tip\nYou don\u2019t need to get it 100% perfect in one go  \n\ud83d\udc49 gradual removal over a few days is better than aggressive cleaning\n\n---\n\nThis one small technique makes a big difference \u2014 most people do it backwards."
+      ]
+     },
+     "create_time": 1776917003.052991,
+     "end_turn": true,
+     "id": "3e69a2ff-5184-4e8f-a005-170a0237851d",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb217ac-fce7-43c9-a68a-698f606c39c1",
+      "request_id": "2508c5c7-2f07-4c08-875d-ef1c13e15e96",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "350bbaab-bcb7-47dd-9584-9161999e50a4"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb217ac-fce7-43c9-a68a-698f606c39c1"
+   },
+   "3f8391ca-cf5a-483a-9de1-3019d792cba6": {
+    "children": [
+     "bbb21409-a403-48d8-8f4b-57e103d887e7"
+    ],
+    "id": "3f8391ca-cf5a-483a-9de1-3019d792cba6",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Got you \u2014 here are **simple alternatives you likely already have**, ranked best \u2192 worst for cradle cap:\n\n## \u2705 Good options\n\n**1. Baby oil (mineral oil based)**  \n- e.g. \ue200entity\ue202[\"brand\",\"Johnson's Baby Oil\"]\ue201  \n\ud83d\udc49 Best easy option\n\n---\n\n**2. Vaseline (petroleum jelly)**  \n- e.g. \ue200entity\ue202[\"brand\",\"Vaseline\"]\ue201  \n\ud83d\udc49 Works well, just use **very thin layer** (harder to wash off)\n\n---\n\n## \u26a0\ufe0f OK if nothing else\n\n**3. Olive oil**  \n\ud83d\udc49 Fine occasionally  \n\ud83d\udc49 Use small amount + wash off after 10\u201315 min  \n\ud83d\udc49 Don\u2019t leave it sitting\n\n---\n\n## \u274c Skip for this use\n- Linimento  \n- Heavy creams/moisturizers  \n- Perfumed oils\n\n---\n\n## Even simpler (often enough)\n\ud83d\udc49 Warm water + soft brush/cloth  \nEspecially for eyebrows\n\n---\n\n## Bottom line\n\ud83d\udc49 Best: **baby oil (mineral oil)**  \n\ud83d\udc49 Backup: **Vaseline**  \n\ud83d\udc49 Olive oil = emergency option, not ideal\n\n---\n\nYou don\u2019t need anything fancy \u2014 just something that **softens without feeding buildup**."
+      ]
+     },
+     "create_time": 1776916660.741065,
+     "end_turn": true,
+     "id": "3f8391ca-cf5a-483a-9de1-3019d792cba6",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [
+       {
+        "alt": "Johnson's Baby Oil",
+        "category": "brand",
+        "end_idx": 208,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Johnson's Baby Oil\"]\ue201",
+        "metadata": null,
+        "name": "Johnson's Baby Oil",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Johnson's Baby Oil",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 169,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Vaseline",
+        "category": "brand",
+        "end_idx": 308,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Vaseline\"]\ue201",
+        "metadata": null,
+        "name": "Vaseline",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Vaseline",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 279,
+        "status": "done",
+        "type": "entity"
+       }
+      ],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21838-f661-453c-940c-b43b1cafe78a",
+      "request_id": "f9b9bb61-dcfa-4985-bbae-9fc8241d4027",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "35ed321c-c4db-48f1-a238-e5ec9c90d255"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21838-f661-453c-940c-b43b1cafe78a"
+   },
+   "406ac8e3-8191-4e9d-b617-0da118b189f8": {
+    "children": [
+     "bd83ec0a-7d49-4f44-856a-d0f54515bb4d"
+    ],
+    "id": "406ac8e3-8191-4e9d-b617-0da118b189f8",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1774128346.5981154,
+     "end_turn": true,
+     "id": "406ac8e3-8191-4e9d-b617-0da118b189f8",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21cc6-63e7-41cb-8e34-2e4246a63fa7",
+      "rebase_developer_message": true,
+      "request_id": "9620edfd-1053-4407-bf92-7114f9c4a642",
+      "turn_exchange_id": "cb3f30e5-7f88-496a-9508-3642c0976414"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb21cc6-63e7-41cb-8e34-2e4246a63fa7"
+   },
+   "408b899b-0ee5-4e9e-a28a-5dd232258c66": {
+    "children": [
+     "2d3f0db0-0d7c-4f68-8f8d-8c135a13a501"
+    ],
+    "id": "408b899b-0ee5-4e9e-a28a-5dd232258c66",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773874309.521697,
+     "end_turn": false,
+     "id": "408b899b-0ee5-4e9e-a28a-5dd232258c66",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bf161984-b8f4-445d-865e-cdbca130f8bc",
+      "request_id": "9b16de13-1a9e-439c-93c0-f85df8c0b577",
+      "turn_exchange_id": "55cdfc5c-299c-496e-8680-a797b059731e"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bf161984-b8f4-445d-865e-cdbca130f8bc"
+   },
+   "48509d36-6da4-4e20-b9d6-038ddf8c9423": {
+    "children": [
+     "952ee0d3-a539-45d2-a631-ca1156e16f0c"
+    ],
+    "id": "48509d36-6da4-4e20-b9d6-038ddf8c9423",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773562652.762369,
+     "end_turn": null,
+     "id": "48509d36-6da4-4e20-b9d6-038ddf8c9423",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "db6bc61e-63cb-4e59-817e-3a51b297e229",
+      "request_id": "14ba5aa6-f8da-4a4d-a57e-4be929f54902",
+      "search_result_groups": [],
+      "turn_exchange_id": "05eda216-3d04-49fa-8c23-14a461226acc"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "db6bc61e-63cb-4e59-817e-3a51b297e229"
+   },
+   "4858396e-943b-469e-b24e-595f1fd0abc3": {
+    "children": [
+     "3367179c-93db-4778-a7cb-53b44c6a8083"
+    ],
+    "id": "4858396e-943b-469e-b24e-595f1fd0abc3",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1774548287.464315,
+     "end_turn": true,
+     "id": "4858396e-943b-469e-b24e-595f1fd0abc3",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb212a9-6bb9-4397-93e8-1d46463b1e71",
+      "rebase_system_message": true,
+      "request_id": "15e0254d-ce0a-4070-bdea-70045d626d3c",
+      "turn_exchange_id": "ea48ea62-79fe-47cc-b719-b1a0c8fd2dd5"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb212a9-6bb9-4397-93e8-1d46463b1e71"
+   },
+   "4bce5530-25b8-477e-80c9-17dff4130516": {
+    "children": [
+     "bbb219d4-9f72-4373-86f9-9f815a1482e0"
+    ],
+    "id": "4bce5530-25b8-477e-80c9-17dff4130516",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Yes \u2014 **very often it changes**.\n\n## Why it changes\nRight now (~1 month):\n- Nervous system = **easily overstimulated**  \n- Bath = lots of input (touch, temperature, movement)\n\nLater (6\u201310 weeks+):\n- Better regulation  \n- Warm water starts to feel **soothing instead of exciting**\n\n---\n\n## What typically happens\n\n- **0\u20136 weeks:** unpredictable / often stimulating  \n- **6\u201310 weeks:** starts becoming calming  \n- **2\u20133 months:** many babies clearly relax with it\n\n---\n\n## Important nuance\nNot guaranteed:\n- Some babies always love it  \n- Some always get hyped  \n- Most **shift over time**\n\n---\n\n## What to do now\n- Place bath **earlier in the day**  \n- Keep bedtime routine **separate and calm**\n\n---\n\n## When to retry as sleep cue\n\ud83d\udc49 Around **6\u20138 weeks**, test again:\n- bath \u2192 feed \u2192 sleep\n\n---\n\n## Bottom line\n\ud83d\udc49 Yes, it often becomes relaxing later  \n\ud83d\udc49 Right now your baby is just too \u201cnew\u201d to process it calmly\n\n---\n\nThis is one of those things that feels like a fixed trait\u2026 until suddenly it isn\u2019t."
+      ]
+     },
+     "create_time": 1776033921.926336,
+     "end_turn": true,
+     "id": "4bce5530-25b8-477e-80c9-17dff4130516",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21013-9bc7-4c63-808f-0f809ab66109",
+      "request_id": "e1f4a0df-592d-4666-960b-5ac09aa2d904",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "adb0b4a1-1460-4149-81b2-95d58f74f597"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21013-9bc7-4c63-808f-0f809ab66109"
+   },
+   "4d3b9ab5-f375-41e8-8492-46cedd4f6145": {
+    "children": [
+     "bbb21359-47eb-4336-be2f-0ac6ff2e821a"
+    ],
+    "id": "4d3b9ab5-f375-41e8-8492-46cedd4f6145",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Water is friendly to calculate: **1 liter \u2248 1 kg**.\n\nFor a newborn tub with **5\u20138 cm depth**:\n\n- Most baby tubs hold **~8\u201312 liters** at that level.  \n- So the water weighs **~8\u201312 kg**.  \n- Add the tub itself: **~0.5\u20131 kg**.\n\n**Total:** roughly **9\u201313 kg**.\n\nThat\u2019s why it suddenly feels like lifting a suitcase full of bricks. Carrying that while it sloshes is awkward and risky, which is why the \u201cbring water in jugs\u201d approach works better ergonomically.\n\nFor perspective: a **2-liter jug trip = 2 kg**, so 4\u20135 quick pours fills the tub without the back workout."
+      ]
+     },
+     "create_time": 1773573570.698949,
+     "end_turn": true,
+     "id": "4d3b9ab5-f375-41e8-8492-46cedd4f6145",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21c90-27df-475f-b4d0-e901378c5e56",
+      "request_id": "ca2ee5fe-1be1-43cc-a5c8-ce2b74b002ab",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "0f7f8ea4-5f70-48cc-9028-38820f123f7c"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21c90-27df-475f-b4d0-e901378c5e56"
+   },
+   "4f1498a5-26d2-4d1e-a4f4-f987b82c1fbb": {
+    "children": [
+     "dd485191-9c3c-4bf6-9040-3d3f89c69d2d"
+    ],
+    "id": "4f1498a5-26d2-4d1e-a4f4-f987b82c1fbb",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1775534457.8427577,
+     "end_turn": null,
+     "id": "4f1498a5-26d2-4d1e-a4f4-f987b82c1fbb",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb218ed-3bdc-4b2b-ab21-6014d21fd873",
+      "request_id": "e2d38faf-19d3-4b72-b3c7-b1cd8dd7e6bf",
+      "turn_exchange_id": "ad060e34-afb5-4c8e-90b4-5dac9d5df405"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb218ed-3bdc-4b2b-ab21-6014d21fd873"
+   },
+   "4f470078-e525-4dfd-9a4b-dd31ad952957": {
+    "children": [
+     "dcde7297-08fd-452c-9070-334588eafe9f"
+    ],
+    "id": "4f470078-e525-4dfd-9a4b-dd31ad952957",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1776033769.6559596,
+     "end_turn": null,
+     "id": "4f470078-e525-4dfd-9a4b-dd31ad952957",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "00e4aa14-4853-4370-b32e-43f3a3797e78",
+      "request_id": "1133c94a-6e4f-43f8-9ed5-b8546653133f",
+      "search_result_groups": [],
+      "turn_exchange_id": "c68a6923-2821-4da8-ba48-8f9c4a3c0243"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "00e4aa14-4853-4370-b32e-43f3a3797e78"
+   },
+   "50bb9b4c-9ea1-40f4-aa0f-e940520640a8": {
+    "children": [
+     "bbb21984-7e94-4ca1-b2ff-260a15c377a4"
+    ],
+    "id": "50bb9b4c-9ea1-40f4-aa0f-e940520640a8",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "First home bath. Tiny slippery human, warm water, calm brain. That\u2019s the whole game.\n\n**Before you start**\nHave everything within arm\u2019s reach. Babies must never be left alone in water, not even for five seconds.\n\nTowel (open and ready)  \nClean diaper + clothes  \nMild baby soap (optional)  \nWashcloth  \nCup for rinsing\n\nRoom warm. No drafts.\n\n**Water**\nLukewarm. Around body temperature (~37 \u00b0C).  \nTest with wrist or elbow. It should feel neutral, not hot.\n\nWater level: **5\u20138 cm** in the tub. Just enough.\n\n**How to hold**\nOne arm supports head/neck.  \nYour hand grips baby under the armpit.  \nOther hand does the washing.\n\n**Order**\nFace first (just water, no soap).  \nHead/scalp.  \nBody.  \nGenitals and bottom last.\n\n**During bath**\nKeep most of the body **covered with a wet cloth** to stay warm.  \nTalk calmly. Slow movements.\n\n**Time**\nShort. **5\u201310 minutes max.**\n\n**After**\nStraight into towel.  \nPat dry (don\u2019t rub).  \nDry skin folds well: neck, armpits, thighs.  \nDiaper \u2192 clothes \u2192 cuddle/feed. Most babies crash into sleep after.\n\n**Don\u2019ts**\nDon\u2019t leave baby unattended. Ever.  \nDon\u2019t use lots of soap. It dries newborn skin.  \nDon\u2019t bathe daily yet \u2014 **2\u20133\u00d7 per week is enough**.  \nDon\u2019t worry if she cries. Many babies protest briefly.\n\nSmall weird newborn fact: they often calm down **once wrapped in the towel like a burrito**. Warmth plus pressure resets their little nervous system like rebooting a computer.\n\nYou\u2019re basically recreating a tiny warm spa for a creature that spent nine months floating in one. The main rule: warm, quick, calm."
+      ]
+     },
+     "create_time": 1773517568.210892,
+     "end_turn": true,
+     "id": "50bb9b4c-9ea1-40f4-aa0f-e940520640a8",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21687-1d3b-4eb5-881a-a86f4b9c6026",
+      "request_id": "610b6ecb-ae5e-4bc8-bde3-c1ce3df21218",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "81f883ee-f0a3-4bd7-8b3f-06d9e5f25eca"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21687-1d3b-4eb5-881a-a86f4b9c6026"
+   },
+   "5114e94b-8621-4597-9b47-2d13578e922f": {
+    "children": [
+     "bbb21f74-ddb1-41d4-a9ac-79127fdfd0be"
+    ],
+    "id": "5114e94b-8621-4597-9b47-2d13578e922f",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Eyes are the same story: **what you see now is not final**.\n\n## What\u2019s happening now\nMost babies are born with:\n- **Blue/grey eyes** (low pigment at birth)\n\nPigment (melanin) builds over time \u2192 color changes.\n\n---\n\n## What to expect\n\n**Timeline:**\n- **0\u20133 months:** color can shift noticeably  \n- **3\u20136 months:** starts stabilizing  \n- **6\u201312 months:** closer to final  \n- Can keep subtle changes up to **1\u20132 years**\n\n---\n\n## Typical patterns\n- Blue \u2192 stays blue  \n- Blue/grey \u2192 **green or hazel**  \n- Blue/grey \u2192 **brown** (can happen gradually)\n\n---\n\n## Your baby\nIf you\u2019re already seeing changes:\n\ud83d\udc49 totally normal \u2014 pigment is kicking in\n\n---\n\n## Clues (not guarantees)\n- Darker ring forming around iris \u2192 often going darker  \n- Staying very light \u2192 more likely blue/green\n\n---\n\n## Bottom line\n\ud83d\udc49 Eye color is a **slow reveal, not a fixed trait at birth**  \n\ud83d\udc49 Don\u2019t lock it in before ~6\u201312 months\n\n---\n\nFun reality: babies basically launch with \u201cdefault settings\u201d and customize later."
+      ]
+     },
+     "create_time": 1775267541.748957,
+     "end_turn": true,
+     "id": "5114e94b-8621-4597-9b47-2d13578e922f",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb2133c-029c-488f-b8ff-fa17abfc5fb3",
+      "request_id": "b68b8410-8476-4247-ac8a-1947d85b1c8f",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "4de49e0b-692c-470e-a116-3354a83766e0"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb2133c-029c-488f-b8ff-fa17abfc5fb3"
+   },
+   "51d05458-f8ed-448b-a04e-2cabe27c2556": {
+    "children": [
+     "bbb219e9-8dd3-41ba-a90b-4031c9daff0e"
+    ],
+    "id": "51d05458-f8ed-448b-a04e-2cabe27c2556",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Good instinct \u2014 but not all \u201cnon-Dodot\u201d brands are cheaper.\n\n## Where \ue200entity\ue202[\"brand\",\"Libero\"]\ue201 sits\n\ud83d\udc49 **Not cheap. Usually mid\u2013premium**\n\n- ~\u20ac0.20\u20130.30 / diaper  \n- Often similar to **\ue200entity\ue202[\"brand\",\"Dodot Activity\"]\ue201** pricing  \n- Sometimes even closer to **Sensitive**\n\n\ud83d\udc49 So:\n**Libero \u2260 budget option**\n\n---\n\n## True cheaper tier (Portugal reality)\n\nThese are the actual low-cost players:\n\n- \ue200entity\ue202[\"brand\",\"Continente Baby\"]\ue201 \u2192 \u20ac0.10\u20130.16  \n- \ue200entity\ue202[\"brand\",\"Pingo Doce Baby\"]\ue201 \u2192 \u20ac0.10\u20130.16  \n- \ue200entity\ue202[\"brand\",\"Lupilu\"]\ue201 (Lidl) \u2192 \u20ac0.12\u20130.18  \n\n\ud83d\udc49 This is where the real savings live\n\n---\n\n## Mid-tier (not really saving much)\n\n- \ue200entity\ue202[\"brand\",\"Libero\"]\ue201  \n- \ue200entity\ue202[\"brand\",\"Dodot Activity\"]\ue201  \n\n\ud83d\udc49 Slightly cheaper than Sensitive, but not game-changing\n\n---\n\n## Honest breakdown\n\n- **Dodot Sensitive** \u2192 premium  \n- **Libero / Dodot Activity** \u2192 mid-premium  \n- **Supermarket brands** \u2192 actual budget\n\n---\n\n## My take for you\nIf your goal is:\n- **Test quality alternatives** \u2192 try Libero  \n- **Actually save money** \u2192 go supermarket brands\n\n---\n\n## Bottom line\n\ud83d\udc49 Libero is a **lateral move**, not a cost-cutting move  \n\ud83d\udc49 Real savings = **store brands**\n\n---\n\nIf you want, I can tell you which diapers parents regret buying (there are a couple\u2026) so you skip bad experiments."
+      ]
+     },
+     "create_time": 1775532143.56003,
+     "end_turn": true,
+     "id": "51d05458-f8ed-448b-a04e-2cabe27c2556",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [
+       {
+        "alt": "Libero",
+        "category": "brand",
+        "end_idx": 97,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Libero\"]\ue201",
+        "metadata": null,
+        "name": "Libero",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Libero",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 70,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Dodot Activity",
+        "category": "brand",
+        "end_idx": 222,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Dodot Activity\"]\ue201",
+        "metadata": null,
+        "name": "Dodot Activity",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Dodot Activity",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 187,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Continente Baby",
+        "category": "brand",
+        "end_idx": 435,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Continente Baby\"]\ue201",
+        "metadata": null,
+        "name": "Continente Baby",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Continente Baby",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 399,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Pingo Doce Baby",
+        "category": "brand",
+        "end_idx": 489,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Pingo Doce Baby\"]\ue201",
+        "metadata": null,
+        "name": "Pingo Doce Baby",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Pingo Doce Baby",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 453,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Lupilu",
+        "category": "brand",
+        "end_idx": 534,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Lupilu\"]\ue201",
+        "metadata": null,
+        "name": "Lupilu",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Lupilu",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 507,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Libero",
+        "category": "brand",
+        "end_idx": 669,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Libero\"]\ue201",
+        "metadata": null,
+        "name": "Libero",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Libero",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 642,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Dodot Activity",
+        "category": "brand",
+        "end_idx": 709,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Dodot Activity\"]\ue201",
+        "metadata": null,
+        "name": "Dodot Activity",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Dodot Activity",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 674,
+        "status": "done",
+        "type": "entity"
+       }
+      ],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "848abe58-15c0-4df8-9aae-318092dbc65a",
+      "request_id": "da85e2c9-e90b-494e-ae6d-9f0d7da2cf08",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "7bb49a48-fa92-4eb4-a421-42a56e9d9334"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "848abe58-15c0-4df8-9aae-318092dbc65a"
+   },
+   "52a8dcc8-efb9-472f-a649-2f15649b1685": {
+    "children": [
+     "bbb210f9-c04e-4ba6-ab5a-6996518cb2d3"
+    ],
+    "id": "52a8dcc8-efb9-472f-a649-2f15649b1685",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Good \u2014 wipes are the quieter money leak \ud83d\ude04\n\n## How long to use water wipes\n\n\ud83d\udc49 **First 4\u20138 weeks** (your current phase)\n\nWhy:\n- Skin is more sensitive  \n- Frequent poops  \n- Lower irritation risk\n\nAfter that:\n\ud83d\udc49 You can safely switch to **normal sensitive wipes**\n\n---\n\n## When to switch\n- Skin stable (no rash issues)  \n- Poop less frequent  \n- Around **1\u20132 months**\n\n---\n\n## Price per wipe (Portugal reality)\n\n### \ud83d\udca7 Water wipes (e.g. \ue200entity\ue202[\"brand\",\"WaterWipes\"]\ue201, \ue200entity\ue202[\"brand\",\"Dodot Aqua Pure\"]\ue201)\n- Bad: \u20ac0.04\u20130.05  \n- Normal: \u20ac0.03\u20130.04  \n- Good: **\u20ac0.025\u20130.03**\n\n---\n\n### \ud83e\uddfb Regular sensitive wipes (later)\n- Bad: \u20ac0.025+  \n- Good: **\u20ac0.015\u20130.02**\n\n---\n\n## Monthly cost difference (this adds up)\n\n- Water wipes \u2192 ~\u20ac20\u201335/month  \n- Regular wipes \u2192 ~\u20ac10\u201320/month  \n\n\ud83d\udc49 Roughly **half the cost** after switching\n\n---\n\n## Smart strategy\n\n\ud83d\udc49 Now:\n- Stick to **water wipes**\n\n\ud83d\udc49 In ~2\u20134 weeks:\n- Test normal wipes during **day only**\n\n\ud83d\udc49 Long-term:\n- Cheap wipes for pee  \n- Better wipes for poop (optional optimization)\n\n---\n\n## Pro tip (underrated)\nFor pee-only diapers:\n\ud83d\udc49 you don\u2019t always need wipes  \n- Can skip or use minimal  \n- Saves money + protects skin\n\n---\n\n## Bottom line\n- Use water wipes **~1\u20132 months total**  \n- Target **~\u20ac0.025\u20130.03 per wipe**  \n- Then switch \u2192 cut cost in half\n\n---\n\nIf you want, I can tell you **which cheap wipes are actually good vs garbage** \u2014 big variance there."
+      ]
+     },
+     "create_time": 1775534087.648253,
+     "end_turn": true,
+     "id": "52a8dcc8-efb9-472f-a649-2f15649b1685",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [
+       {
+        "alt": "WaterWipes",
+        "category": "brand",
+        "end_idx": 464,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"WaterWipes\"]\ue201",
+        "metadata": null,
+        "name": "WaterWipes",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "WaterWipes",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 433,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Dodot Aqua Pure",
+        "category": "brand",
+        "end_idx": 502,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Dodot Aqua Pure\"]\ue201",
+        "metadata": null,
+        "name": "Dodot Aqua Pure",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Dodot Aqua Pure",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 466,
+        "status": "done",
+        "type": "entity"
+       }
+      ],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "5a1e43ae-2313-4855-a50a-804a95f6937a",
+      "request_id": "d1a4c94e-8d57-4efe-b8fc-e746ea5e3e96",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "ba6f27a8-8ea9-4419-8154-1fd0507dea8b"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "5a1e43ae-2313-4855-a50a-804a95f6937a"
+   },
+   "568b56f5-c5ac-4baa-a65f-ebb856c60b0d": {
+    "children": [
+     "bbb21571-b684-45ae-913b-49f6d89e8cd5"
+    ],
+    "id": "568b56f5-c5ac-4baa-a65f-ebb856c60b0d",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "You\u2019re right on this one.\n\n## Contact naps (on you)\n\ud83d\udc49 **No blanket needed**\n\nWhy:\n- Your body = a **heat source (~36\u201337\u00b0C)**  \n- Baby + you = already warm  \n- Adding a blanket easily tips into **too hot**\n\n---\n\n## What to do instead\n- Dress her in **one light layer (onesie)**  \n- If anything: cover **her back lightly**, not over both of you\n\n---\n\n## How to settle the \u201cis she cold?\u201d debate\n\nCheck **neck/chest**:\n- Warm \u2192 she\u2019s fine  \n- Sweaty \u2192 too hot  \n- Cool \u2192 then add a layer\n\nHands/feet = misleading (always cold-ish)\n\n---\n\n## About [PERSON_e197e8]\u2019s concern (practical reality)\nAdults feel cold way before babies are actually cold.\n\n\ud83d\udc49 The real risk in newborns is **overheating, not mild coolness**\n\n---\n\n## Simple rule for both of you\n\ud83d\udc49 **If baby is on a human, subtract one layer**\n\n---\n\n## Bottom line\n- Contact nap = **no blanket needed**  \n- You\u2019re not underdressing her  \n- You\u2019re actually **preventing overheating**\n\n---\n\nIf you want, I can give you a dead simple \u201cdress guide by temperature\u201d so you two stop negotiating this every day \ud83d\ude04"
+      ]
+     },
+     "create_time": 1775158037.946427,
+     "end_turn": true,
+     "id": "568b56f5-c5ac-4baa-a65f-ebb856c60b0d",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21a1b-f54a-4fc3-b954-f5bda2d71796",
+      "request_id": "7d56bda9-a950-4f56-94af-9ab03829a56d",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "6c78afcd-545f-424c-84af-602c4225705a"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21a1b-f54a-4fc3-b954-f5bda2d71796"
+   },
+   "56e1898e-6f02-4643-b6fd-3e8fab40c867": {
+    "children": [
+     "11bbbc97-5b46-495b-bdaf-325815002262"
+    ],
+    "id": "56e1898e-6f02-4643-b6fd-3e8fab40c867",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773383091.471049,
+     "end_turn": true,
+     "id": "56e1898e-6f02-4643-b6fd-3e8fab40c867",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb215a8-b726-4bd4-a91e-6c41e9bf0641",
+      "rebase_system_message": true,
+      "request_id": "d5b198b3-4223-4c75-8013-a7ab1c5fcc89",
+      "turn_exchange_id": "5c6c935b-e962-4364-9511-4cc77ca7853b"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb215a8-b726-4bd4-a91e-6c41e9bf0641"
+   },
+   "56e7ce10-2173-4894-b083-cb3afee778ae": {
+    "children": [
+     "b8765604-b799-47cf-86e2-bd0d1ae74e06"
+    ],
+    "id": "56e7ce10-2173-4894-b083-cb3afee778ae",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Yes. Completely normal. Many newborns act like diaper changes are a personal betrayal of the highest order.\n\nA few reasons why this happens:\n\n**1. Temperature shock.**  \nInside the diaper: warm, dark, cozy.  \nDiaper off: cold air on the belly and bottom. Newborn nervous systems are primitive alarm machines, so they protest loudly.\n\n**2. Loss of containment.**  \nBabies like feeling \u201cheld together.\u201d When you lay them flat and remove the diaper, their limbs are free and they lose that snug pressure. Their brain reads that as *falling into space*.\n\n**3. Startle reflex.**  \nNewborns still have the Moro reflex\u2014the sudden flailing arms thing. Being undressed triggers it easily.\n\n**4. Timing.**  \nIf it happens when she\u2019s hungry or tired, the diaper change becomes the villain in the story.\n\nNone of this means discomfort or that you're doing something wrong. It\u2019s extremely common in the first weeks.\n\nA few tricks that work surprisingly well:\n\n\u2022 **Keep the chest warm.** Lay a small cloth or muslin over the belly during the change.  \n\u2022 **Warm the wipe in your hands first.** Cold wipes = instant outrage.  \n\u2022 **Talk constantly.** Your voice acts like a nervous-system regulator.  \n\u2022 **Give containment.** Gently hold both legs together or keep one hand resting firmly on her torso.  \n\u2022 **Feed first if she\u2019s frantic.** A quick feed \u2192 change after.\n\nAnother funny observation from the newborn universe: many babies scream during the change and then instantly become serene the moment the new diaper closes. It\u2019s like flipping a biological reset switch.\n\nIf she\u2019s crying but **settles quickly once picked up or fed**, everything is behaving normally. Red flags would be crying that sounds painful and continues long after the change.\n\nOne counter-intuitive trick seasoned parents discover: some babies calm down if you **sing during diaper changes**. Rhythm plus voice is basically neurological magic for a newborn brain that only recently left the warm ocean of the uterus.\n\nTiny humans are dramatic creatures. Evolution optimized them for survival, not for being polite during diaper logistics."
+      ]
+     },
+     "create_time": 1773368637.919432,
+     "end_turn": true,
+     "id": "56e7ce10-2173-4894-b083-cb3afee778ae",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "2b7c35a3-77c6-47d9-9762-2238904b8557",
+      "request_id": "9e2555c8-f1ad-48de-8adc-a4492e72ef3f",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "a8bc594e-3060-4d56-b665-d43c50acb700"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "2b7c35a3-77c6-47d9-9762-2238904b8557"
+   },
+   "5943357d-0b1c-48fe-9661-70507bfdffac": {
+    "children": [],
+    "id": "5943357d-0b1c-48fe-9661-70507bfdffac",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Cradle cap isn\u2019t about hygiene \u2014 it\u2019s a **combo of baby biology**.\n\n## Main causes\n\n**1. Hormones (from pregnancy)**\n- Mom\u2019s hormones still in baby\u2019s system  \n- Stimulate **oil (sebum) production**\n\n---\n\n**2. Yeast on the skin**\n- A normal yeast (called *\ue200entity\ue202[\"microorganism\",\"Malassezia\"]\ue201*) lives on everyone  \n- It feeds on that extra oil  \n\ud83d\udc49 leads to flaky buildup\n\n---\n\n**3. Skin turnover is messy**\n- Newborn skin renews fast  \n- Dead skin + oil don\u2019t shed cleanly  \n\ud83d\udc49 they stick together \u2192 flakes\n\n---\n\n## Why it shows up where it does\n- Scalp  \n- Eyebrows  \n- Sides of nose  \n\n\ud83d\udc49 areas with more oil glands\n\n---\n\n## Important: what it\u2019s NOT\n- Not dirt  \n- Not poor hygiene  \n- Not an allergy  \n- Not something you caused\n\n---\n\n## Why it goes away\n- Hormones fade  \n- Oil production normalizes  \n- Skin gets better at shedding\n\n\ud83d\udc49 system stabilizes over time\n\n---\n\n## Bottom line\n\ud83d\udc49 **Too much oil + normal yeast + immature skin = cradle cap**  \n\ud83d\udc49 It\u2019s a phase, not a problem to \u201cfix\u201d permanently\n\n---\n\nYou\u2019re basically watching her skin recalibrate after leaving the womb."
+      ]
+     },
+     "create_time": 1776969420.334072,
+     "end_turn": true,
+     "id": "5943357d-0b1c-48fe-9661-70507bfdffac",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [
+       {
+        "alt": "Malassezia",
+        "category": "microorganism",
+        "end_idx": 294,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"microorganism\",\"Malassezia\"]\ue201",
+        "metadata": null,
+        "name": "Malassezia",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Malassezia",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 255,
+        "status": "done",
+        "type": "entity"
+       }
+      ],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb2101e-aac0-44c3-adff-0a9c1ce933cc",
+      "request_id": "7210809c-8cc1-4ac0-ad1d-75edaa254aa1",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "71e31255-60a5-4543-bfc8-b17ca75512cb"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb2101e-aac0-44c3-adff-0a9c1ce933cc"
+   },
+   "5a1e43ae-2313-4855-a50a-804a95f6937a": {
+    "children": [
+     "52a8dcc8-efb9-472f-a649-2f15649b1685"
+    ],
+    "id": "5a1e43ae-2313-4855-a50a-804a95f6937a",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1775534087.7172687,
+     "end_turn": null,
+     "id": "5a1e43ae-2313-4855-a50a-804a95f6937a",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "e5d9a2b8-1222-46ca-bff3-762c386b9b20",
+      "request_id": "d1a4c94e-8d57-4efe-b8fc-e746ea5e3e96",
+      "turn_exchange_id": "ba6f27a8-8ea9-4419-8154-1fd0507dea8b"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "e5d9a2b8-1222-46ca-bff3-762c386b9b20"
+   },
+   "5a5663a2-b229-4428-ba3b-01e5cbf82d4b": {
+    "children": [
+     "bbb219e1-c14e-479b-bd0d-67bacba9be28"
+    ],
+    "id": "5a5663a2-b229-4428-ba3b-01e5cbf82d4b",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Short version: you **can\u2019t eliminate it**, but you can **reduce peaks** and avoid making it worse.\n\n---\n\n## What actually helps (high ROI)\n\n**1. Upright after feeds (your #1 lever)**\n- **15\u201320 min**, especially at night  \n- Prevents the \u201csleep \u2192 wake in pain\u201d loop\n\n---\n\n**2. Pre-empt before the bad window**\nBefore evening/night:\n- diaper  \n- **1\u20132 min bicycle legs**  \n- gentle belly massage  \n\u2192 then feed\n\n---\n\n**3. Keep feeds calm, not rushed**\n- Let her set pace  \n- If overwhelmed at start \u2192 brief unlatch, relatch\n\n---\n\n**4. Hold more in the evening**\n- Upright, contact, carrier if she tolerates  \n- Movement helps gas move\n\n---\n\n**5. Warm bath (you\u2019re already there)**\n- Works surprisingly well for relaxation + gas\n\n---\n\n## What to avoid (this matters just as much)\n\n**Don\u2019t over-burp**\n- You\u2019re doing it right: mid-feed + after  \n- More than that = more disruption, more air\n\n---\n\n**Don\u2019t fold her during changes**\n- No knees-to-chest pushing  \n- Lift hips gently\n\n---\n\n**Don\u2019t chase fixes**\n- Diet changes \u2192 rarely helpful  \n- Drops/supplements \u2192 often overused  \n- Constant switching strategies \u2192 creates chaos\n\n---\n\n**Don\u2019t overstimulate evenings**\n- Keep lights low, voices calm  \n- Overtired + gas = worse nights\n\n---\n\n## What\u2019s optional (try if needed)\n\n- **Koala/upright feeding** (since laid-back didn\u2019t work well)  \n- **\u201cTiger in the tree\u201d hold** for gas relief  \n- Slightly **more frequent feeds** in evening (cluster = good)\n\n---\n\n## Reality anchor\nIf:\n- poop is soft  \n- she feeds well  \n- improves after gas  \n\n\ud83d\udc49 you\u2019re managing, not fixing\n\n---\n\n## If I had to simplify your strategy\nFocus on just this:\n\n\ud83d\udc49 **Upright after feeds + calm evenings + pre-empt gas before sleep**\n\nEverything else is marginal.\n\n---\n\nYou\u2019re not missing a trick \u2014 you\u2019re already doing 80% right.  \nNow it\u2019s about **tightening execution and waiting out the curve**."
+      ]
+     },
+     "create_time": 1774128346.949776,
+     "end_turn": true,
+     "id": "5a5663a2-b229-4428-ba3b-01e5cbf82d4b",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bd83ec0a-7d49-4f44-856a-d0f54515bb4d",
+      "request_id": "9620edfd-1053-4407-bf92-7114f9c4a642",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "cb3f30e5-7f88-496a-9508-3642c0976414"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bd83ec0a-7d49-4f44-856a-d0f54515bb4d"
+   },
+   "5c360cf8-3913-49a0-9335-4f278734bb62": {
+    "children": [
+     "bbb210c7-72a6-476f-8102-0b18b70ecff9"
+    ],
+    "id": "5c360cf8-3913-49a0-9335-4f278734bb62",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Perfect \u2014 this is one of the highest ROI things to get right.\n\n## When to size up (don\u2019t wait for the weight limit)\n\n\ud83d\udc49 **Go up a size early**, not late.\n\n### Clear signs it\u2019s time:\n- Frequent **blowouts (especially up the back)**  \n- **Leaks** even when diaper isn\u2019t full  \n- Red marks on thighs/waist  \n- Tabs feel tight / don\u2019t reach comfortably  \n- Diaper looks **\u201clow rise\u201d** on belly\n\n---\n\n## What most people get wrong\nThey wait until:\n\ud83d\udc49 baby hits max weight on the box\n\nThat\u2019s too late.\n\n---\n\n## Quick test (no commitment)\n- Use current size during day  \n- Try **next size at night**\n\nIf night improves \u2192 switch fully\n\n---\n\n## Fit check (this matters more than brand)\n\nAfter putting diaper on:\n- Waist sits **under belly button**  \n- You can fit **2 fingers at waist**  \n- Leg cuffs snug (no gaps)  \n- No deep marks after removal\n\n---\n\n## Your stage (newborn \u2192 size 1)\n\nExpect:\n- Size 0 lasts very short  \n- Size 1 also not long (~weeks)  \n\ud83d\udc49 Don\u2019t stockpile\n\n---\n\n## Hidden benefit of sizing up early\n- Better absorption  \n- Fewer changes needed  \n- Less skin irritation\n\n---\n\n## Bottom line\n\ud83d\udc49 Leaks = usually size issue, not brand  \n\ud83d\udc49 When in doubt, **size up and test**\n\n---\n\nIf you want, next step I can help you predict **how many diapers to buy per size** so you don\u2019t overstock again."
+      ]
+     },
+     "create_time": 1775532243.315866,
+     "end_turn": true,
+     "id": "5c360cf8-3913-49a0-9335-4f278734bb62",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb2174d-4849-4d05-9859-3f4044ed1aae",
+      "request_id": "2cdea8a0-3775-4fee-b143-95f1bd791fd0",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "c8b61981-43c9-45ff-af4f-d81745a6ad90"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb2174d-4849-4d05-9859-3f4044ed1aae"
+   },
+   "5ca45b8d-fad7-4854-b31a-463457f60376": {
+    "children": [
+     "bbb21600-3fdb-43a4-a0d7-67062a0507d0"
+    ],
+    "id": "5ca45b8d-fad7-4854-b31a-463457f60376",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Smart. Don\u2019t buy \u2014 **test it like an experiment**.\n\n---\n\n## Clean test (48 hours)\n\n### Night 1\u20132 (current setup)\n- 22\u00b0C room  \n- **Onesie + light blanket (tucked)**  \n- No sleep sack\n\n\ud83d\udc49 Observe:\n- Are **new bumps appearing**?\n- Or just **old ones fading**?\n\n---\n\n## What results mean\n\n### \u2705 If rash improves (fewer/new bumps stop)\n\ud83d\udc49 Sleep sack was likely **too warm**\n\n### \u274c If no change\n\ud83d\udc49 Not mainly temperature \u2192 just **newborn skin / baseline rash**\n\n---\n\n## Extra confirmation (optional, only if you want)\nAfter it improves:\n- Try sleep sack **one night**\n- If rash flares again \u2192 confirmed\n\n(Only do this if you\u2019re comfortable \u2014 not required)\n\n---\n\n## Important: don\u2019t change multiple things\nKeep everything else stable:\n- Same room temp  \n- Same clothing  \n- Same routine  \n\n\ud83d\udc49 Otherwise you won\u2019t know the cause\n\n---\n\n## What to track (quick mental checklist)\n- Neck: sweaty or dry?  \n- Chest/back: warmer than usual?  \n- Rash: spreading or calming?\n\n---\n\n## My honest expectation\nGiven your story:\n\ud83d\udc49 Sleep sack is a **very strong suspect**, but  \n\ud83d\udc49 You\u2019ll likely see **partial improvement**, not instant disappearance\n\n---\n\n## Bottom line\n- Give it **48h with current setup**  \n- Look for **trend, not perfection**  \n- Then decide \u2014 no guessing, no overbuying\n\n---\n\nYou\u2019re doing exactly what most people don\u2019t: **testing instead of reacting**. That\u2019s how you actually figure babies out."
+      ]
+     },
+     "create_time": 1775158332.824298,
+     "end_turn": true,
+     "id": "5ca45b8d-fad7-4854-b31a-463457f60376",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21ec1-b57d-4f39-840b-e3831461054d",
+      "request_id": "b842749a-f297-467e-804d-f3e762637342",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "8f45711c-31b8-48b2-8278-0bb078491545"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21ec1-b57d-4f39-840b-e3831461054d"
+   },
+   "5dbc32df-6496-4554-a2f3-4be7b6013404": {
+    "children": [
+     "bbb215ef-c31b-4b0d-a4d0-d79b914741ed"
+    ],
+    "id": "5dbc32df-6496-4554-a2f3-4be7b6013404",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "You\u2019re in the **transition zone**, so think \u201ctop-up\u201d, not \u201cstock\u201d.\n\n## Your situation\n- ~45 diapers at home  \n- Usage: ~7\u20138/day  \n\ud83d\udc49 That\u2019s **~5\u20136 days covered**\n\n---\n\n## What to buy\n\ud83d\udc49 **Buy ~60\u201380 more max**\n\nThat gives you:\n- Total: ~105\u2013125 diapers  \n- Coverage: **~2 weeks**\n\n\ud83d\udc49 Perfect buffer without overcommitting\n\n---\n\n## Why this is the sweet spot\n- Enough to avoid running out  \n- Not too many if she sizes up soon  \n- Gives you time to **test Size 2**\n\n---\n\n## Parallel move (important)\n\ud83d\udc49 Also buy a **small pack of Size 2 now**\n\nUse it:\n- At night first  \n- Then transition when leaks start\n\n---\n\n## Bottom line\n- Size 1: **+60\u201380 diapers max**  \n- Size 2: **get a small pack ready**\n\n---\n\nYou\u2019re basically bridging the gap, not investing in this size anymore."
+      ]
+     },
+     "create_time": 1775532839.840242,
+     "end_turn": true,
+     "id": "5dbc32df-6496-4554-a2f3-4be7b6013404",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb2119b-b5c4-4dbd-9f34-0c5cb18a17c1",
+      "request_id": "3ce7d981-b2fd-450e-912b-a2e04d46da8f",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "5f5608af-0b92-4935-8a16-87b44e385018"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb2119b-b5c4-4dbd-9f34-0c5cb18a17c1"
+   },
+   "5e1db441-31b9-466f-9b09-15c1d303f0de": {
+    "children": [
+     "f53984c4-70a4-40bd-8e1d-e01beb83d4e7"
+    ],
+    "id": "5e1db441-31b9-466f-9b09-15c1d303f0de",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773970035.6188357,
+     "end_turn": null,
+     "id": "5e1db441-31b9-466f-9b09-15c1d303f0de",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "e20ad6cc-141a-44c6-9deb-8ef8df1afdc0",
+      "request_id": "afa35376-c30c-47fb-aeca-d4eace5d2203",
+      "search_result_groups": [],
+      "turn_exchange_id": "60d97475-6d20-4d90-8f20-940e859c8e48"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "e20ad6cc-141a-44c6-9deb-8ef8df1afdc0"
+   },
+   "5e5536c2-02a4-4cce-a5c0-4fe8cb95ee08": {
+    "children": [
+     "f9eeb00d-1522-49d6-8c34-6c211fe63b2c"
+    ],
+    "id": "5e5536c2-02a4-4cce-a5c0-4fe8cb95ee08",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773765954.559824,
+     "end_turn": true,
+     "id": "5e5536c2-02a4-4cce-a5c0-4fe8cb95ee08",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21fbd-7b8c-4d18-b0e5-8c55bd223fab",
+      "rebase_system_message": true,
+      "request_id": "f07df930-6fec-4b9f-8912-f71f6152663d",
+      "turn_exchange_id": "75a49c9c-d153-4ff2-aa56-7cc640c95c66"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb21fbd-7b8c-4d18-b0e5-8c55bd223fab"
+   },
+   "602b172b-2928-4339-9568-fc3a374e4438": {
+    "children": [
+     "bbb212a9-6bb9-4397-93e8-1d46463b1e71"
+    ],
+    "id": "602b172b-2928-4339-9568-fc3a374e4438",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "\ud83d\udc49 **3 times per week** if you want a clear call.\n\nWhy:\n- Gives routine (nice for evenings)  \n- Still gentle enough for skin  \n- Easy rhythm (e.g., every other day-ish)\n\n**2\u00d7/week** is also perfectly fine \u2014 just more minimal.\n\n**My practical pick:**  \n\ud83d\udc49 Go with **3\u00d7/week**, adjust if skin gets dry (then drop to 2)."
+      ]
+     },
+     "create_time": 1774201974.300627,
+     "end_turn": true,
+     "id": "602b172b-2928-4339-9568-fc3a374e4438",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21b3c-f102-46b1-8f3e-957e15c86bea",
+      "request_id": "6a7eaf34-fb8a-46ab-8f0e-6e6277c19158",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "6a992584-b418-467d-8c83-57f7880a5b05"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21b3c-f102-46b1-8f3e-957e15c86bea"
+   },
+   "66bf1894-8bb6-414e-8b2a-1fab58a60200": {
+    "children": [
+     "27989531-37be-4fd7-8363-515b5833ef82"
+    ],
+    "id": "66bf1894-8bb6-414e-8b2a-1fab58a60200",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": null,
+     "end_turn": true,
+     "id": "66bf1894-8bb6-414e-8b2a-1fab58a60200",
+     "metadata": {
+      "can_save": false,
+      "is_visually_hidden_from_conversation": true
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "31bccefe-5894-4d7d-a63c-00dd2f2d6e4c"
+   },
+   "68337cb1-488e-42c8-a6fb-4bba17821b30": {
+    "children": [
+     "e1ae9994-1a14-46cf-869d-ed0df77ad5a4"
+    ],
+    "id": "68337cb1-488e-42c8-a6fb-4bba17821b30",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1775487499.9590592,
+     "end_turn": null,
+     "id": "68337cb1-488e-42c8-a6fb-4bba17821b30",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "fda7cb5c-6d28-4562-8ea5-f36e002743e6",
+      "request_id": "824b3c0c-2753-4a2b-ad82-5109161263b1",
+      "search_result_groups": [],
+      "turn_exchange_id": "9cd645b8-7e30-4d46-8292-5374089275ef"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "fda7cb5c-6d28-4562-8ea5-f36e002743e6"
+   },
+   "69631278-a480-44d0-8edb-ac484d7a1bf1": {
+    "children": [
+     "bbb2112f-1b5f-4a1c-8093-ac61d6449cb6"
+    ],
+    "id": "69631278-a480-44d0-8edb-ac484d7a1bf1",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Good \u2014 here\u2019s the **no-BS shortlist for Portugal**.\n\n## Worth testing (best value \u2192 performance)\n\n### \ud83e\udd47 \ue200entity\ue202[\"brand\",\"Continente Baby\"]\ue201\n- Cheapest decent option  \n- Surprisingly good absorption  \n- Great for daytime  \n\ud83d\udc49 **Best cost/quality ratio**\n\n---\n\n### \ud83e\udd48 \ue200entity\ue202[\"brand\",\"Pingo Doce Baby\"]\ue201\n- Slightly softer feel than Continente  \n- Good fit  \n\ud83d\udc49 Solid middle ground\n\n---\n\n### \ud83e\udd49 \ue200entity\ue202[\"brand\",\"Lupilu\"]\ue201 (Lidl)\n- Often very well rated  \n- Good absorption  \n- Can run slightly bulky\n\n---\n\n## Premium alternatives (if you want softer but cheaper than Dodot Sensitive)\n\n- \ue200entity\ue202[\"brand\",\"Dodot Activity\"]\ue201  \n- \ue200entity\ue202[\"brand\",\"Dodot Protection Plus\"]\ue201  \n\n\ud83d\udc49 Usually cheaper than Sensitive, still high performance\n\n---\n\n## What I\u2019d skip (my opinion)\n- Ultra-cheap unknown brands \u2192 inconsistent  \n- Perfumed versions \u2192 pointless + irritation risk\n\n---\n\n## Strategy (this is where you win)\n\n\ud83d\udc49 Use **premium at night**, cheaper during day\n\nExample:\n- Night \u2192 \ue200entity\ue202[\"brand\",\"Dodot\"]\ue201  \n- Day \u2192 \ue200entity\ue202[\"brand\",\"Continente Baby\"]\ue201\n\nCuts cost **a lot** without risking sleep or skin\n\n---\n\n## Honest reality\nMost babies:\n\ud83d\udc49 tolerate cheaper diapers perfectly fine after ~1 month\n\nBut:\n\ud83d\udc49 You only know after testing YOUR baby\n\n---\n\n## Bottom line\nStart with:\n\ud83d\udc49 **Continente Baby or Lupilu as your first test**\n\nLow risk, high upside.\n\n---\n\nWhen you\u2019re ready, I can help you **optimize total monthly diaper cost** \u2014 it adds up fast."
+      ]
+     },
+     "create_time": 1775512159.301291,
+     "end_turn": true,
+     "id": "69631278-a480-44d0-8edb-ac484d7a1bf1",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [
+       {
+        "alt": "Continente Baby",
+        "category": "brand",
+        "end_idx": 140,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Continente Baby\"]\ue201",
+        "metadata": null,
+        "name": "Continente Baby",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Continente Baby",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 104,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Pingo Doce Baby",
+        "category": "brand",
+        "end_idx": 301,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Pingo Doce Baby\"]\ue201",
+        "metadata": null,
+        "name": "Pingo Doce Baby",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Pingo Doce Baby",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 265,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Lupilu",
+        "category": "brand",
+        "end_idx": 417,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Lupilu\"]\ue201",
+        "metadata": null,
+        "name": "Lupilu",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Lupilu",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 390,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Dodot Activity",
+        "category": "brand",
+        "end_idx": 618,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Dodot Activity\"]\ue201",
+        "metadata": null,
+        "name": "Dodot Activity",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Dodot Activity",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 583,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Dodot Protection Plus",
+        "category": "brand",
+        "end_idx": 665,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Dodot Protection Plus\"]\ue201",
+        "metadata": null,
+        "name": "Dodot Protection Plus",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Dodot Protection Plus",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 623,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Dodot",
+        "category": "brand",
+        "end_idx": 994,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Dodot\"]\ue201",
+        "metadata": null,
+        "name": "Dodot",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Dodot",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 968,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Continente Baby",
+        "category": "brand",
+        "end_idx": 1041,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Continente Baby\"]\ue201",
+        "metadata": null,
+        "name": "Continente Baby",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Continente Baby",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 1005,
+        "status": "done",
+        "type": "entity"
+       }
+      ],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb212ab-680d-49c9-89da-0c12a000324e",
+      "request_id": "316a1fe3-6ed5-4a76-8a4c-db0542ea2b89",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "becb0c53-7687-4820-acad-78a5c58ef6f4"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb212ab-680d-49c9-89da-0c12a000324e"
+   },
+   "6c804e1f-52b4-467d-bf25-34c0694f1c59": {
+    "children": [
+     "bbb215fb-4aec-4bb5-bd74-3131b2c0c6a1"
+    ],
+    "id": "6c804e1f-52b4-467d-bf25-34c0694f1c59",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Yeah\u2026 this isn\u2019t a baby problem, it\u2019s a **parent alignment problem** \ud83d\ude04  \nAnd those are harder.\n\nLet\u2019s make this objective so it\u2019s not opinion vs opinion.\n\n---\n\n## Anchor on ONE rule (non-negotiable)\n\ud83d\udc49 **Neck/chest check = truth**\n\n- Warm & dry \u2192 perfect  \n- Sweaty \u2192 too hot  \n- Cool \u2192 add layer  \n\nNo guessing, no feelings, no debates.\n\n---\n\n## Give [PERSON_e197e8] a clear \u201cjob\u201d\nPeople relax when they have control.\n\n\ud83d\udc49 Tell him:\n\u201cYour role is to **check her neck** and decide.\u201d\n\nThat shifts him from anxiety \u2192 action.\n\n---\n\n## Set a simple system (so you stop renegotiating)\n\n### Night (22\u00b0C room)\n- 1 layer + light blanket **OR**\n- light sleep sack (not warm)\n\n### Contact naps\n- **No blanket**\n\nThat\u2019s it. Fixed rules.\n\n---\n\n## The honest part\nRight now:\n- You have a **heat rash signal**\n- He has a **fear of cold**\n\nBetween the two:\n\ud83d\udc49 **The rash is actual data. The fear is hypothetical.**\n\n---\n\n## If you want a practical compromise\n- Keep AC stable at 22\u00b0C  \n- Keep **light blanket**  \n- Slightly **lighter clothing**\n\nSo he feels she\u2019s covered, but you reduce heat load.\n\n---\n\n## One sentence you can use (and move on)\n\ud83d\udc49 \u201cIf she\u2019s warm and dry at the neck, she\u2019s fine. Let\u2019s trust that.\u201d\n\nRepeat, don\u2019t debate.\n\n---\n\n## Bottom line\nYou don\u2019t need to \u201cwin\u201d  \nYou need a **shared rule that ends the loop**\n\nRight now the best one is:\n\ud83d\udc49 **\u201cWe trust the neck.\u201d**"
+      ]
+     },
+     "create_time": 1775158137.455712,
+     "end_turn": true,
+     "id": "6c804e1f-52b4-467d-bf25-34c0694f1c59",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21571-b684-45ae-913b-49f6d89e8cd5",
+      "request_id": "59e33bf7-846e-475a-8dfc-f1f8de1ae82d",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "38ede4ea-e88c-41b3-b51d-055f2512c6ed"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21571-b684-45ae-913b-49f6d89e8cd5"
+   },
+   "6d09b922-89ff-4af0-a54e-64cd2172839d": {
+    "children": [
+     "bbb2101e-aac0-44c3-adff-0a9c1ce933cc"
+    ],
+    "id": "6d09b922-89ff-4af0-a54e-64cd2172839d",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Short answer: **both can happen**.\n\n## What usually happens\n- Once flakes come off \u2192 that spot is often **clear for now**  \n- But cradle cap can **reappear nearby or same area** for a while\n\n---\n\n## Why it comes back\n- It\u2019s not just \u201cdead skin\u201d  \n- It\u2019s ongoing:\n  - oil production  \n  - yeast activity  \n\ud83d\udc49 so new flakes can form\n\n---\n\n## Typical timeline\n- Comes and goes over **weeks to a few months**  \n- Gradually less frequent  \n- Usually gone by **3\u20136 months**\n\n---\n\n## What your goal is\n\ud83d\udc49 Not \u201cremove once and done\u201d  \n\ud83d\udc49 But **keep it mild and controlled**\n\n---\n\n## Practical mindset\n- See flakes \u2192 soften \u2192 gently remove  \n- Then leave it  \n- Repeat only if needed\n\n---\n\n## Good sign\nIf after removal:\n- skin underneath looks normal (maybe slightly pink)  \n\ud83d\udc49 you\u2019re doing it right\n\n---\n\n## Bottom line\n\ud83d\udc49 It can come back, but **less and less over time**  \n\ud83d\udc49 You\u2019re managing a phase, not fixing a one-off problem"
+      ]
+     },
+     "create_time": 1776969372.495253,
+     "end_turn": true,
+     "id": "6d09b922-89ff-4af0-a54e-64cd2172839d",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb212ef-1bb0-4d38-8804-4d950cfd073a",
+      "request_id": "91fe0466-8b5d-4319-b46f-63234ebc1840",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "2787f60b-c6b8-4da5-95d0-43b563f33a51"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb212ef-1bb0-4d38-8804-4d950cfd073a"
+   },
+   "6eabcc63-5e4d-43d2-b26a-0d1eab253cf0": {
+    "children": [
+     "bbb21f00-5a35-4379-9317-06e97c41cc8b"
+    ],
+    "id": "6eabcc63-5e4d-43d2-b26a-0d1eab253cf0",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "**Simple, top \u2192 bottom, clean \u2192 dirty:**\n\n1. **Face**  \n   - Just water, no soap  \n   - Eyes (inside \u2192 out), then rest of face\n\n2. **Head/scalp**  \n   - Small amount of water (soap optional, not every bath)\n\n3. **Upper body**  \n   - Neck folds (important)  \n   - Arms, hands, armpits\n\n4. **Torso**  \n   - Chest \u2192 belly\n\n5. **Lower body**  \n   - Legs, feet\n\n6. **Genitals & bottom (last)**  \n   - Front \u2192 back  \n   - Clean all folds\n\n---\n\n**Extras that matter:**\n- Keep a **wet cloth over chest** to stay warm  \n- Use **very little soap** (or none most days)  \n- **5\u201310 min max**\n\n\ud83d\udc49 Cleanest areas first, dirtiest last. That\u2019s the whole logic."
+      ]
+     },
+     "create_time": 1774548287.974312,
+     "end_turn": true,
+     "id": "6eabcc63-5e4d-43d2-b26a-0d1eab253cf0",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "a69fbc6b-a90c-4d13-858a-c63f2ef9d322",
+      "request_id": "15e0254d-ce0a-4070-bdea-70045d626d3c",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "ea48ea62-79fe-47cc-b719-b1a0c8fd2dd5"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "a69fbc6b-a90c-4d13-858a-c63f2ef9d322"
+   },
+   "757a104d-a4ef-4b9b-b47c-b3a475f863e1": {
+    "children": [
+     "bbb21dfe-2557-48b6-a75e-ad01c71a796f"
+    ],
+    "id": "757a104d-a4ef-4b9b-b47c-b3a475f863e1",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773454074.8482437,
+     "end_turn": null,
+     "id": "757a104d-a4ef-4b9b-b47c-b3a475f863e1",
+     "metadata": {
+      "attachments": [],
+      "can_save": false,
+      "is_visually_hidden_from_conversation": true,
+      "rebase_developer_message": true
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "d5a1b0fe-2c66-4748-b6a0-fd9b735f36fd"
+   },
+   "7943a1bb-325d-4de8-809b-1ad760a4a130": {
+    "children": [
+     "bc4dc43f-5094-440a-ad9a-d240f01b0c68"
+    ],
+    "id": "7943a1bb-325d-4de8-809b-1ad760a4a130",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773984358.3916392,
+     "end_turn": true,
+     "id": "7943a1bb-325d-4de8-809b-1ad760a4a130",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21b50-d9ff-430a-99b0-cccdf534ae1f",
+      "rebase_system_message": true,
+      "request_id": "66c66a49-8bfd-4b53-bd20-b68bafaca435",
+      "turn_exchange_id": "cf06097e-69b4-4fd9-abc3-b776e1e19bc7"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb21b50-d9ff-430a-99b0-cccdf534ae1f"
+   },
+   "799ed915-3b96-4a9e-9b88-51b15f62bf7d": {
+    "children": [
+     "bbb21bf1-d213-4dbc-ab9f-a694894aff3c"
+    ],
+    "id": "799ed915-3b96-4a9e-9b88-51b15f62bf7d",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Good question \u2014 and important because **cold \u2260 quiet baby** (unlike overheating).\n\n## Signs she\u2019s cold\n\n**Mild cold (most common):**\n- Restless, won\u2019t settle  \n- Shorter sleep  \n- Feels **cool on chest/back**  \n- Skin may look slightly **mottled (patchy)**\n\n**More obvious cold:**\n- Crying that doesn\u2019t improve with feeding/holding  \n- Body feels cool, not just hands/feet  \n- Less relaxed, more tense\n\n---\n\n## What is NOT reliable\n- Cold hands/feet \u274c (very common, not meaningful)  \n- Hiccups \u274c  \n- Sneezing \u274c  \n\n---\n\n## The real test (always)\n\ud83d\udc49 **Touch chest or back**\n\n- Warm + dry \u2192 perfect  \n- Cool \u2192 add layer  \n- Sweaty \u2192 too hot\n\n---\n\n## Important mindset shift\n- Babies usually **complain when cold**  \n- Babies often **don\u2019t complain when overheating**\n\n\ud83d\udc49 That\u2019s why overheating is the bigger risk\n\n---\n\n## Your situation\nIf she\u2019s:\n- sleeping  \n- feeding well  \n- warm at chest  \n\n\ud83d\udc49 she\u2019s not cold, even if hands feel chilly\n\n---\n\n## Bottom line\n\ud83d\udc49 **Trust behavior + chest temp, not extremities**  \n\ud83d\udc49 Slightly cool baby > slightly overheated baby\n\n---\n\nIf you want, we can calibrate *exactly* what to dress her in at your room temp so this stops being a daily debate."
+      ]
+     },
+     "create_time": 1775160387.321117,
+     "end_turn": true,
+     "id": "799ed915-3b96-4a9e-9b88-51b15f62bf7d",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21600-3fdb-43a4-a0d7-67062a0507d0",
+      "request_id": "9868c570-2923-4230-ab4d-ad7200a27e28",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "6d5d6aff-b3dd-44a3-b21c-f68ef166eca4"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21600-3fdb-43a4-a0d7-67062a0507d0"
+   },
+   "7d5afe64-d988-4052-be98-e9a2d188638b": {
+    "children": [
+     "d8991f7b-15cf-485f-a942-f54381d58807"
+    ],
+    "id": "7d5afe64-d988-4052-be98-e9a2d188638b",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "multimodal_text",
+      "parts": [
+       {
+        "content_type": "audio_transcription",
+        "decoding_id": null,
+        "direction": "in",
+        "text": ""
+       },
+       {
+        "audio_asset_pointer": {
+         "asset_pointer": "sediment://file_0000000028707246b59d1a65e2fe5dbc",
+         "content_type": "audio_asset_pointer",
+         "expiry_datetime": "2026-09-16T04:58:25.188069+00:00",
+         "format": "wav",
+         "metadata": {
+          "end": 0.56,
+          "end_timestamp": null,
+          "interruptions": null,
+          "original_audio_source": null,
+          "pretokenized_vq": null,
+          "start": 0.0,
+          "start_timestamp": null,
+          "transcription": null,
+          "word_transcription": null
+         },
+         "size_bytes": 26958,
+         "tool_audio_direction": null
+        },
+        "audio_start_timestamp": 3.1107905781827867,
+        "content_type": "real_time_user_audio_video_asset_pointer",
+        "expiry_datetime": "2026-09-16T04:58:25.188069+00:00",
+        "frames_asset_pointers": [],
+        "video_container_asset_pointer": null
+       }
+      ]
+     },
+     "create_time": 1773982711.192478,
+     "end_turn": null,
+     "id": "7d5afe64-d988-4052-be98-e9a2d188638b",
+     "metadata": {
+      "can_save": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "6da30289-d7af-4983-a445-53f5979d8500/64eg",
+      "voice_mode_message": true
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "d3a573c5-f691-4fc2-bae7-58682b3e05a3"
+   },
+   "7ed36661-b7cf-44d7-b0d8-673e892cada5": {
+    "children": [
+     "d2bb3cfc-de64-422f-b68d-abdbe8f72729"
+    ],
+    "id": "7ed36661-b7cf-44d7-b0d8-673e892cada5",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1774590832.3504665,
+     "end_turn": true,
+     "id": "7ed36661-b7cf-44d7-b0d8-673e892cada5",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21f00-5a35-4379-9317-06e97c41cc8b",
+      "rebase_developer_message": true,
+      "request_id": "6cdf7ddb-3839-4794-8fd8-75884f89d50a",
+      "turn_exchange_id": "fd62f6a4-8c9a-4a8e-8a09-6b286d4f84b9"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb21f00-5a35-4379-9317-06e97c41cc8b"
+   },
+   "7f637f10-6efd-41db-a8d8-1f29934aaa0e": {
+    "children": [
+     "bbb21736-93a9-4a01-bbde-3cde7ffdeb99"
+    ],
+    "id": "7f637f10-6efd-41db-a8d8-1f29934aaa0e",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "That actually sounds **very normal** \u2014 not a feeding problem.\n\n## What you\u2019re describing\n- Brief overwhelm at the **start** \u2192 common (letdown is strongest then)  \n- Then she **regulates and feeds calmly** \u2192 good sign  \n- **Moaning / noises** during feeding \u2192 also normal\n\n---\n\n## What those sounds usually mean\n- Effort / focus (\u201cworking\u201d at feeding)  \n- Milk flow changing  \n- Mild gas moving  \n- Comfort noises (some babies are just\u2026 chatty eaters)\n\nIf she\u2019s:\n- not pulling off distressed  \n- not coughing/choking frequently  \n- staying latched and feeding\n\n\ud83d\udc49 this is **not gulping as a problem**\n\n---\n\n## What this tells us about your bigger issue\nYour nights are **very unlikely caused by feeding technique**\n\nThis points back to:\n\ud83d\udc49 **normal newborn gas peak (weeks 2\u20134)**\n\n---\n\n## One small tweak (since start is strongest flow)\nAt the **very beginning of feeds**:\n- latch her  \n- if she gets overwhelmed \u2192 **brief unlatch (a few seconds)**  \n- then relatch once flow calms\n\nNo need to change positions if overall she\u2019s coping well.\n\n---\n\n## Bottom line\n- Feeding looks **functional and mostly well-regulated**  \n- Sounds are **normal baby noise, not a red flag**  \n- Your issue is **timing + gut immaturity**, not technique\n\n---\n\nHonestly? You\u2019ve ruled out one of the main problems.  \nWhat\u2019s left is the annoying one: **time + small optimizations**."
+      ]
+     },
+     "create_time": 1773984541.991345,
+     "end_turn": true,
+     "id": "7f637f10-6efd-41db-a8d8-1f29934aaa0e",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21d14-c26b-48bc-a9c8-849409b38a42",
+      "request_id": "9a2f5656-bb12-4f21-9003-5952aebd888e",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "9ee6677e-f8cb-4e53-96c7-6437f54b33bc"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21d14-c26b-48bc-a9c8-849409b38a42"
+   },
+   "7f7ed146-8816-4d73-9134-721adc434bed": {
+    "children": [
+     "bbb214aa-d81c-4ae8-ae1a-2f1ac12e110d"
+    ],
+    "id": "7f7ed146-8816-4d73-9134-721adc434bed",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Good info \u2014 this points pretty clearly to **normal peak gas + likely fast flow at times**. You\u2019re right in the classic **week 2\u20134 storm**.\n\nLet\u2019s tighten what you\u2019re doing so nights improve.\n\n---\n\n## What\u2019s likely happening\n- **Gastrocolic reflex** \u2192 feeds trigger poop + gas  \n- **Immature gut** \u2192 lots of air moving around  \n- **Occasional fast letdown** \u2192 gulping \u2192 extra air  \n- Hits hardest **early night** (very typical)\n\n---\n\n## Fix the main levers\n\n### 1. Slow the milk flow (this is big for you)\nBecause she sometimes gulps/chokes.\n\nDo this:\n- **Laid-back position** (you reclined, baby on top)  \n- If she starts choking \u2192 **pull her off briefly**, let flow calm, relatch  \n- Don\u2019t rush feeds\n\n---\n\n### 2. Burping strategy (optimize, not more)\nYou\u2019re already doing a lot \u2014 just structure it:\n\n- **Pause once mid-feed** (not constantly)  \n- **Good burp after feed**  \n- Then **upright 15\u201320 min** (increase from 10)\n\n---\n\n### 3. Night sequence tweak (important)\n\nRight now she likely:\nfeed \u2192 sleepy \u2192 gas builds \u2192 wakes uncomfortable\n\nTry:\n- Feed  \n- Burp  \n- **Hold upright 15\u201320 min**  \n- **Only then put down**\n\nThis alone often reduces the \u201cwake 10 min later in pain\u201d loop.\n\n---\n\n### 4. Pre-empt gas before it explodes\nBefore night stretch:\n\n- 1\u20132 min **bicycle legs**  \n- Gentle **belly massage (clockwise)**  \n- Then feed\n\nThink: release pressure *before* sleep.\n\n---\n\n### 5. During diaper changes (gas trigger point)\n- Keep it **calm + minimal lifting**  \n- No knee-to-chest pushing  \n- Warm hands/wipes\n\n---\n\n## What NOT to overthink\n- Your diet \u2192 almost never the cause  \n- Poop \u2192 sounds perfect  \n- Amount of gas \u2192 unfortunately normal\n\n---\n\n## Reality check (important)\nWhat you\u2019re describing:\n- worse early night  \n- grunting, red, legs up  \n- improves after gas/poop  \n\n= **textbook newborn phase**\n\nPeak: **weeks 3\u20136**  \nImproves: **6\u20138 weeks**\n\n---\n\n## If you want one high-impact change:\n\ud83d\udc49 **Switch to laid-back feeding + longer upright time after feeds**\n\nThat combo alone fixes a surprising amount of this.\n\n---\n\nIf it keeps escalating or you\u2019re unsure, I can help you distinguish normal gas vs early colic vs reflux \u2014 but right now this still sits very comfortably in \u201cnormal but annoying.\u201d"
+      ]
+     },
+     "create_time": 1773970360.687058,
+     "end_turn": true,
+     "id": "7f7ed146-8816-4d73-9134-721adc434bed",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21388-1a0c-4f4b-8403-0c2f7526ee04",
+      "request_id": "47224930-7187-466b-9ba0-bfa1c34704d9",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "7b2e3e9e-4916-4a8e-b7da-8cfed91d895e"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21388-1a0c-4f4b-8403-0c2f7526ee04"
+   },
+   "80ed896c-05db-4a70-a1f4-bc677715f4fa": {
+    "children": [
+     "bbb21add-bf10-4dff-8d8a-4b8342b52db5"
+    ],
+    "id": "80ed896c-05db-4a70-a1f4-bc677715f4fa",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Good \u2014 this is fixable with technique.\n\n## \u201cDon\u2019t fold her\u201d = don\u2019t push knees to chest hard\nThat compresses the belly \u2192 pushes gas around \u2192 more discomfort.\n\n**Instead:**\n- Lift by **holding ankles + raising hips slightly**\n- Keep legs at a **natural angle**, not squished into the belly\n- Think \u201ctilt pelvis up\u201d, not \u201ccrunch abs\u201d\n\n---\n\n## Diaper change that babies tolerate better\n\n**Before you start (this is half the battle):**\n- New diaper open under her already  \n- Wipes ready  \n- Cloth over chest (warmth + containment)\n\n---\n\n## Step-by-step (smooth, not rushed-chaotic)\n\n1. **Hand on chest first**  \n   - Gentle but firm pressure = calming signal\n\n2. **Open diaper slowly**  \n   - Don\u2019t expose her all at once \u2192 less shock\n\n3. **Use diaper to wipe bulk (if poop)**  \n   - Fewer cold wipes needed\n\n4. **Lift hips minimally**  \n   - Just enough to clean  \n   - No aggressive leg pushing\n\n5. **Wipe front \u2192 back, quick + efficient**\n\n6. **Slide dirty diaper out, clean one already in place**\n\n7. **Close immediately**  \n   - The faster she\u2019s \u201ccontained\u201d again, the faster she calms\n\n---\n\n## Small tweaks that make a big difference\n\n- **Warm the wipe in your hand first**  \n- **Keep talking** (your voice regulates her)  \n- **One hand always anchoring her body**  \n- **Speed matters**, but smooth > frantic\n\n---\n\n## If she HATES it (like screaming instantly)\n\nTry this sequence:\n- **Feed a little (2\u20133 min)** \u2192 takes edge off  \n- Change diaper  \n- Then continue full feed\n\nThis works because:\nHungry + cold + exposed = meltdown  \nSlightly fed = calmer nervous system\n\n---\n\n## Reality check\nSome babies just\u2026 protest. Loudly.  \nIf she **calms right after**, you\u2019re doing it right.\n\nGoal isn\u2019t zero crying.  \nGoal is **short, predictable, low-stress changes**."
+      ]
+     },
+     "create_time": 1773874601.11574,
+     "end_turn": true,
+     "id": "80ed896c-05db-4a70-a1f4-bc677715f4fa",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb210c2-a95f-4c11-ab31-7044af1892c9",
+      "request_id": "69ee1a3f-076c-46b8-842f-cfc4281b415e",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "3bb1900e-e043-4e87-97b3-56404e2f73b8"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb210c2-a95f-4c11-ab31-7044af1892c9"
+   },
+   "815415ef-2acc-4e04-928f-a61b7f132d32": {
+    "children": [
+     "9c989607-b199-43c7-a237-b5e9eadb1ed2"
+    ],
+    "id": "815415ef-2acc-4e04-928f-a61b7f132d32",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1775267368.749957,
+     "end_turn": null,
+     "id": "815415ef-2acc-4e04-928f-a61b7f132d32",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "36bca96a-72f4-4e26-b35f-efdeec61efe3",
+      "request_id": "2158adcf-9ad1-43bb-afe0-ad761bbf0a59",
+      "search_result_groups": [],
+      "turn_exchange_id": "f9f7c94b-85a1-4771-baa3-d8b1e1c3a52f"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "36bca96a-72f4-4e26-b35f-efdeec61efe3"
+   },
+   "83e1b018-8ca5-479c-b5af-f2380e33f441": {
+    "children": [
+     "bbb218d4-da92-4c42-9fb6-ea356ee9b75d"
+    ],
+    "id": "83e1b018-8ca5-479c-b5af-f2380e33f441",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Good \u2014 this is the right distinction to make.\n\n## \ud83d\udfe2 Normal gas / poop transition (what you likely have)\n- Cries but **can be soothed** (holding, feeding, movement)  \n- Improves after **gas or poop**  \n- Not strictly predictable timing  \n- Feeds well  \n- Has calm periods during the day  \n\n\ud83d\udc49 Discomfort, but manageable\n\n---\n\n## \ud83d\udd34 Colic (stricter pattern)\n\n- **Intense, hard-to-soothe crying**  \n- Lasts **\u22653 hours/day**, **\u22653 days/week**  \n- Often same time every day (usually evening)  \n- Baby looks in pain:\n  - stiff  \n  - red face  \n  - clenched fists  \n- **Does NOT improve easily** with usual tricks  \n- Feeding doesn\u2019t fix it\n\n\ud83d\udc49 Feels like nothing works\n\n---\n\n## Key difference (simplest way to think)\n\n\ud83d\udc49 **Gas:**\n\u201cI\u2019m uncomfortable, help me\u201d\n\n\ud83d\udc49 **Colic:**\n\u201cI\u2019m overwhelmed and nothing helps\u201d\n\n---\n\n## Your baby (based on what you told me)\n- Improves with gas/poop  \n- Feeding works  \n- Not describing long inconsolable stretches  \n\n\ud83d\udc49 This fits **normal gas phase**, not colic\n\n---\n\n## Why it feels close to colic\nAround 3\u20136 weeks:\n- Gas peaks  \n- Evenings get messy  \n\ud83d\udc49 It can *look* like colic, but isn\u2019t\n\n---\n\n## What to do differently if it WERE colic\n(Just for context)\n- Focus shifts from fixing \u2192 **surviving/soothing cycles**  \n- More structured calming strategies\n\nYou\u2019re not there.\n\n---\n\n## Bottom line\n\ud83d\udc49 You\u2019re in **peak gas phase**, not colic  \n\ud83d\udc49 Annoying, but expected and temporary  \n\n---\n\nIf it turns into long, predictable, unconsolable crying blocks, tell me \u2014 that\u2019s when we reassess."
+      ]
+     },
+     "create_time": 1775946881.59006,
+     "end_turn": true,
+     "id": "83e1b018-8ca5-479c-b5af-f2380e33f441",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21827-ebe6-4179-a797-93c4ca9461cc",
+      "request_id": "12c11e4f-1543-4d03-88d5-0bf9e2394162",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "a2687101-9c3d-46be-b45c-f1bc29e812b5"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21827-ebe6-4179-a797-93c4ca9461cc"
+   },
+   "848abe58-15c0-4df8-9aae-318092dbc65a": {
+    "children": [
+     "51d05458-f8ed-448b-a04e-2cabe27c2556"
+    ],
+    "id": "848abe58-15c0-4df8-9aae-318092dbc65a",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1775532143.463632,
+     "end_turn": true,
+     "id": "848abe58-15c0-4df8-9aae-318092dbc65a",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb215aa-8a9c-464f-ad70-c3f53c0b292e",
+      "rebase_developer_message": true,
+      "request_id": "da85e2c9-e90b-494e-ae6d-9f0d7da2cf08",
+      "turn_exchange_id": "7bb49a48-fa92-4eb4-a421-42a56e9d9334"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb215aa-8a9c-464f-ad70-c3f53c0b292e"
+   },
+   "84b8dbcd-7c3e-408c-b284-3dec4faa1cdc": {
+    "children": [
+     "bbb2103c-57a2-47c0-962b-33aad468a507"
+    ],
+    "id": "84b8dbcd-7c3e-408c-b284-3dec4faa1cdc",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Most newborn face rashes are harmless. Think **immature skin, hormones, drool/milk contact**.\n\n**First, what it likely is:**\n- Small red bumps on cheeks/face \u2192 **newborn acne** (very common)  \n- Slight redness/irritation \u2192 **contact irritation** (milk, spit, fabric)\n\n**What to do (keep it simple):**\n- Clean with **lukewarm water only**, 1\u20132\u00d7/day  \n- Gently **pat dry** (no rubbing)  \n- Keep area **dry** (wipe milk/spit quickly)  \n- Avoid oils, creams, or heavy products on the face  \n- Use **soft cotton cloths** only\n\n**What NOT to do:**\n- No picking/squeezing  \n- No medicated creams unless prescribed  \n- No over-washing (worsens irritation)\n\n**When to worry:**\n- Yellow crusting or oozing  \n- Spreading fast or getting very red/swollen  \n- Baby seems uncomfortable or has fever\n\nOtherwise, it usually clears on its own in **days to a couple of weeks**.\n\nNewborn skin is basically running its first \u201csoftware update\u201d outside the womb \u2014 glitches are expected before it stabilizes."
+      ]
+     },
+     "create_time": 1773765954.910069,
+     "end_turn": true,
+     "id": "84b8dbcd-7c3e-408c-b284-3dec4faa1cdc",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "1730de2b-d1b2-4ef9-8bb3-c8f1edd6bc57",
+      "request_id": "f07df930-6fec-4b9f-8912-f71f6152663d",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "75a49c9c-d153-4ff2-aa56-7cc640c95c66"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "1730de2b-d1b2-4ef9-8bb3-c8f1edd6bc57"
+   },
+   "8502438b-ff29-40d7-8110-a9f18939007d": {
+    "children": [
+     "0af2e459-3bb3-41e7-961d-d2cfbc0352e4"
+    ],
+    "id": "8502438b-ff29-40d7-8110-a9f18939007d",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1776034100.0582535,
+     "end_turn": null,
+     "id": "8502438b-ff29-40d7-8110-a9f18939007d",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21a36-3ce2-4b1b-8043-0d6168e1b4bb",
+      "request_id": "c092b6b1-087e-4b73-a35e-d1eeabeea4d0",
+      "turn_exchange_id": "a623417d-f45d-4bd2-bb6a-1439473981db"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb21a36-3ce2-4b1b-8043-0d6168e1b4bb"
+   },
+   "850947d4-d6ac-4065-8370-f91e8a9714b1": {
+    "children": [
+     "bbb21217-0803-4318-b074-ce5d023486cb"
+    ],
+    "id": "850947d4-d6ac-4065-8370-f91e8a9714b1",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Great question \u2014 and yes, **those 1\u20132 hours can make a big difference** at this age.\n\n## Why 6\u20138pm is tricky\nThat window is:\n- Peak **overtiredness**  \n- Peak **gas/fussiness**  \n- Lowest tolerance for stimulation  \n\n\ud83d\udc49 Same bath \u2192 very different reaction\n\n---\n\n## Morning bath \u2014 should you try it?\n\n\ud83d\udc49 **Yes, it\u2019s a great test**\n\n### Pros:\n- Baby is **fresh, regulated**  \n- Less accumulated stimulation  \n- Easier to see if bath is inherently activating or just bad timing\n\n### Cons:\n- Doesn\u2019t help bedtime routine (for now)\n\n---\n\n## What I\u2019d actually do\n\n### Option A (best test)\nTry **late morning (10\u201312)** for 1\u20132 days\n\n\u2192 If calm \u2192 timing was the issue  \n\u2192 If still active \u2192 bath is just stimulating (for now)\n\n---\n\n### Option B (middle ground)\nStick to **~5pm**\n\n\u2192 Often enough to avoid the chaos\n\n---\n\n## Honest answer\n\ud83d\udc49 Yes, those 2 hours matter  \n\ud83d\udc49 But morning vs evening matters even more\n\n---\n\n## My recommendation for you\nDo a quick experiment:\n\n- **1 day morning bath**\n- **1 day ~5pm bath**\n\nCompare:\n- mood after  \n- ease of settling\n\n---\n\n## Bottom line\n- 6\u20138pm = worst slot right now  \n- Earlier helps  \n- Morning = clean test of baby\u2019s reaction\n\n---\n\nYou\u2019re basically debugging: \u201cis it the bath or the timing?\u201d  \nThis experiment will give you a clear answer fast."
+      ]
+     },
+     "create_time": 1776034165.021654,
+     "end_turn": true,
+     "id": "850947d4-d6ac-4065-8370-f91e8a9714b1",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21cb5-63be-413a-aedc-9b3e28d51030",
+      "request_id": "8bb9c8d0-9cd7-4aed-9ee1-2d3f7c802265",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "1d4c556a-4575-4cc7-9139-e222ab060887"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21cb5-63be-413a-aedc-9b3e28d51030"
+   },
+   "8532afee-7c61-4d9b-832f-ce6b222191ba": {
+    "children": [
+     "e001b6dd-1901-43f2-b130-00266740b4ed"
+    ],
+    "id": "8532afee-7c61-4d9b-832f-ce6b222191ba",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1776182906.0840487,
+     "end_turn": true,
+     "id": "8532afee-7c61-4d9b-832f-ce6b222191ba",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21217-0803-4318-b074-ce5d023486cb",
+      "rebase_developer_message": true,
+      "request_id": "b0d9ce37-b0ee-42e2-96ab-9e6b7b3e9a23",
+      "turn_exchange_id": "9c2a9c29-22bc-4505-9425-1334bab7fc71"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb21217-0803-4318-b074-ce5d023486cb"
+   },
+   "8b0fb70c-0861-47f1-aff1-f0c38ca6a562": {
+    "children": [
+     "bbb212f3-c49d-4475-8bf2-ecda0b8b0797"
+    ],
+    "id": "8b0fb70c-0861-47f1-aff1-f0c38ca6a562",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "**Newborn poop \u201ctroubles\u201d (aka normal chaos):**\n\n**1. Constant pooping**  \n- After almost every feed (gastrocolic reflex)  \n- Can be **5\u201310\u00d7/day**  \n- Peaks in first **2\u20134 weeks**, then slows\n\n**2. Seedy mustard poop (breastfed)**  \n- Yellow, loose, with \u201cseeds\u201d  \n- Looks weird, totally normal  \n- Ongoing while breastfed\n\n**3. Grunting / straining**  \n- Turns red, looks like hard work  \n- Usually still soft poop \u2192 not constipation  \n- Improves by **6\u20138 weeks**\n\n**4. Gas + discomfort**  \n- Common, especially evenings  \n- Peaks around **3\u20136 weeks**, improves by **8\u201312 weeks**\n\n**5. Blowouts**  \n- Liquid poop escapes diaper  \n- Normal in early weeks\n\n**6. Irregular patterns (after 4\u20136 weeks)**  \n- Some babies go **several days without pooping** (breastfed)  \n- As long as poop is soft \u2192 fine\n\n---\n\n**Red flags (not normal):**\n- **White, black (after day 4), or red** stools  \n- Hard pellets (true constipation)  \n- Persistent diarrhea + poor feeding/lethargy\n\n---\n\n**Big picture timeline:**\n- **0\u20134 weeks:** frequent, messy, unpredictable  \n- **4\u20138 weeks:** less frequent, still soft  \n- **2\u20133 months:** more stable patterns\n\nIn short: if it\u2019s **soft and baby is thriving**, it\u2019s almost always fine \u2014 even if it looks like digestive anarchy."
+      ]
+     },
+     "create_time": 1773874309.802534,
+     "end_turn": true,
+     "id": "8b0fb70c-0861-47f1-aff1-f0c38ca6a562",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "2d3f0db0-0d7c-4f68-8f8d-8c135a13a501",
+      "request_id": "9b16de13-1a9e-439c-93c0-f85df8c0b577",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "55cdfc5c-299c-496e-8680-a797b059731e"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "2d3f0db0-0d7c-4f68-8f8d-8c135a13a501"
+   },
+   "8c9c0535-bb32-4108-8976-fe984131b631": {
+    "children": [
+     "f59f56d8-921c-4831-a228-fb503179d70d"
+    ],
+    "id": "8c9c0535-bb32-4108-8976-fe984131b631",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "user_editable_context",
+      "user_instructions": "The user provided the additional info about how they would like you to respond:\n```Follow the instructions below naturally, without repeating, referencing, echoing, or mirroring any of their wording!\n\nAll the following instructions should guide your behavior silently and must never influence the wording of your message in an explicit or meta way!\n\nTell it like it is; don't sugar-coat responses. Use quick and clever humor when appropriate. Take a forward-thinking view. Be humble when appropriate. Get right to the point and be as concise as possible. Keep it relaxed and easygoing. Be empathetic and understanding in your responses. Be innovative and think outside the box. Be practical above all. Readily share strong opinions. Please don't mention that you are being direct, or funny or whatever, just do it in the way you answer. Don't start sentences with \"here is the no fluff answer\", just act like I ask. Debate with me, show critical thinking, make me think. Don't tell me only what I want to hear - make me better, smarter, make me look at all angles. Remember, I'm a millennial, born in 1989, so adapt to my style. I'm not Gen Z, don't talk to me like I am.```",
+      "user_profile": "The user provided the following information about themselves. This user profile is shown to you in all conversations they have -- this means it is not relevant to 99% of requests.\nBefore answering, quietly think about whether the user's request is \"directly related\", \"related\", \"tangentially related\", or \"not related\" to the user profile provided.\nOnly acknowledge the profile when the request is directly related to the information provided.\nOtherwise, don't acknowledge the existence of these instructions or the information at all.\nUser profile:\n```Preferred name: [PERSON_953b4c]\nRole: HR Exec / Psychologist\nOther Information: I'm a nerd for human behavior, working both hard and smart to build a meaningful, stimulating career. I want to make a positive dent in the world - while staying joyful and healthy along the way.\n\nReliable and organized? Absolutely. Independent? For sure. Creative? You bet. Add strong communication skills, a get-stuff-done personality, and an adventurous spirit, and you get someone who doesn\u2019t shy away from a challenge - and always goes the extra mile in pursuit of excellence.\nMy sense of humor isn\u2019t too shabby either. (How many therapists does it take to change a lightbulb? Google it. \ud83d\ude04)\n\nMy passion is people & culture. My strength is designing and nurturing environments where employees are engaged, empowered, and thriving. I\u2019m obsessed with operational efficiency and love automating the boring stuff to make space for what only humans can do - AI is my best friend in this, of course. I'm certain communication is one of the most powerful tools in business (and life), and I treat it as such.\n\nI\u2019m a certified psychologist with a background in research\u2014the scientific method still shapes how I think and work. I was also trained in criminal profiling, so you better not try to lie to me. ;)\n```"
+     },
+     "create_time": null,
+     "end_turn": null,
+     "id": "8c9c0535-bb32-4108-8976-fe984131b631",
+     "metadata": {
+      "can_save": false,
+      "is_user_system_message": true,
+      "is_visually_hidden_from_conversation": true,
+      "user_context_message_data": {
+       "about_model_message": "Tell it like it is; don't sugar-coat responses. Use quick and clever humor when appropriate. Take a forward-thinking view. Be humble when appropriate. Get right to the point and be as concise as possible. Keep it relaxed and easygoing. Be empathetic and understanding in your responses. Be innovative and think outside the box. Be practical above all. Readily share strong opinions. Please don't mention that you are being direct, or funny or whatever, just do it in the way you answer. Don't start sentences with \"here is the no fluff answer\", just act like I ask. Debate with me, show critical thinking, make me think. Don't tell me only what I want to hear - make me better, smarter, make me look at all angles. Remember, I'm a millennial, born in 1989, so adapt to my style. I'm not Gen Z, don't talk to me like I am.",
+       "about_user_message": "Preferred name: [PERSON_953b4c]\nRole: HR Exec / Psychologist\nOther Information: I'm a nerd for human behavior, working both hard and smart to build a meaningful, stimulating career. I want to make a positive dent in the world - while staying joyful and healthy along the way.\n\nReliable and organized? Absolutely. Independent? For sure. Creative? You bet. Add strong communication skills, a get-stuff-done personality, and an adventurous spirit, and you get someone who doesn\u2019t shy away from a challenge - and always goes the extra mile in pursuit of excellence.\nMy sense of humor isn\u2019t too shabby either. (How many therapists does it take to change a lightbulb? Google it. \ud83d\ude04)\n\nMy passion is people & culture. My strength is designing and nurturing environments where employees are engaged, empowered, and thriving. I\u2019m obsessed with operational efficiency and love automating the boring stuff to make space for what only humans can do - AI is my best friend in this, of course. I'm certain communication is one of the most powerful tools in business (and life), and I treat it as such.\n\nI\u2019m a certified psychologist with a background in research\u2014the scientific method still shapes how I think and work. I was also trained in criminal profiling, so you better not try to lie to me. ;)\n"
+      }
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "aaf9b130-0bcc-45d1-b664-245d8d822aca"
+   },
+   "8caf0e6f-82d6-4ef0-aa92-78f2bdbfc3fe": {
+    "children": [
+     "c20999de-8c6c-4555-97cb-a1abfd4f37cf"
+    ],
+    "id": "8caf0e6f-82d6-4ef0-aa92-78f2bdbfc3fe",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1774905573.0271122,
+     "end_turn": null,
+     "id": "8caf0e6f-82d6-4ef0-aa92-78f2bdbfc3fe",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "f970ffa8-c806-4d1e-94e2-9638f02f5c38",
+      "request_id": "ba50d109-8dec-4da1-a925-fcd250e68ea8",
+      "search_result_groups": [],
+      "turn_exchange_id": "607f26c1-e70e-4b18-b3d0-ebfbb4ec03b1"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "f970ffa8-c806-4d1e-94e2-9638f02f5c38"
+   },
+   "8e4da5f9-9daf-4b0c-903b-1e84e8757562": {
+    "children": [
+     "c0738ab9-b4c3-4b37-895c-9981ea514ba6"
+    ],
+    "id": "8e4da5f9-9daf-4b0c-903b-1e84e8757562",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1776916423.7614677,
+     "end_turn": true,
+     "id": "8e4da5f9-9daf-4b0c-903b-1e84e8757562",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb213c9-f670-4305-8d05-18b96fdb557e",
+      "rebase_system_message": true,
+      "request_id": "1de24a7f-67ba-4658-b9c4-b5134fceae26",
+      "turn_exchange_id": "107232ae-96bd-41d8-9af3-a48450934f52"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb213c9-f670-4305-8d05-18b96fdb557e"
+   },
+   "8fd04a66-6368-4050-8e0d-4237419d8192": {
+    "children": [
+     "a6b82cfd-2b97-4733-9cf8-1c7980a80241"
+    ],
+    "id": "8fd04a66-6368-4050-8e0d-4237419d8192",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773454116.9968872,
+     "end_turn": true,
+     "id": "8fd04a66-6368-4050-8e0d-4237419d8192",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "35d761f6-611a-4193-8db0-0e78d15d54b9",
+      "rebase_developer_message": true,
+      "request_id": "bd769bc4-435a-4003-bd93-ea7b96f1a7da",
+      "turn_exchange_id": "2ceba3bf-8685-4333-bd4f-9081a31fee5d"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "35d761f6-611a-4193-8db0-0e78d15d54b9"
+   },
+   "9307d463-ecf1-49c8-b5af-fe9403a6d20c": {
+    "children": [
+     "bbb215aa-8a9c-464f-ad70-c3f53c0b292e"
+    ],
+    "id": "9307d463-ecf1-49c8-b5af-fe9403a6d20c",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Here\u2019s the **real price gap in Portugal (per diaper)** so you see what\u2019s at stake:\n\n## Price per diaper (Size 1 ballpark)\n\n- **\ue200entity\ue202[\"brand\",\"Dodot Sensitive\"]\ue201**  \n  \ud83d\udc49 \u20ac0.22 \u2013 \u20ac0.35  \n\n- **\ue200entity\ue202[\"brand\",\"Dodot Activity\"]\ue201 / Protection Plus**  \n  \ud83d\udc49 \u20ac0.18 \u2013 \u20ac0.28  \n\n- **\ue200entity\ue202[\"brand\",\"Lupilu\"]\ue201 (Lidl)**  \n  \ud83d\udc49 \u20ac0.12 \u2013 \u20ac0.18  \n\n- **\ue200entity\ue202[\"brand\",\"Continente Baby\"]\ue201 / \ue200entity\ue202[\"brand\",\"Pingo Doce Baby\"]\ue201**  \n  \ud83d\udc49 \u20ac0.10 \u2013 \u20ac0.16  \n\n---\n\n## What that means monthly\n\nNewborns go through ~8\u201310 diapers/day \u2192 ~250\u2013300/month\n\n- Dodot Sensitive \u2192 **\u20ac55\u201390/month**  \n- Store brands \u2192 **\u20ac25\u201345/month**\n\n\ud83d\udc49 Difference: **\u20ac30\u201350/month**\n\n---\n\n## Reality check\nThat\u2019s:\n- \u20ac360\u2013600/year  \n- For something literally designed to be thrown away \ud83d\ude04\n\n---\n\n## Where the premium actually matters\n- First weeks (sensitive skin, liquid poop)  \n- Nighttime (absorption reliability)\n\n---\n\n## Smart strategy (what most optimized parents do)\n\n\ud83d\udc49 **Hybrid:**\n- Night \u2192 \ue200entity\ue202[\"brand\",\"Dodot\"]\ue201  \n- Day \u2192 \ue200entity\ue202[\"brand\",\"Continente Baby\"]\ue201 or \ue200entity\ue202[\"brand\",\"Lupilu\"]\ue201  \n\nCuts cost **30\u201350%** with almost no downside\n\n---\n\n## Bottom line\n- Premium = convenience + margin of error  \n- Cheap = perfectly fine for most babies after a few weeks  \n\n\ud83d\udc49 The gap is big enough that it\u2019s worth testing\n\n---\n\nIf you want, I can help you time promos + sizes so you basically **never overpay again**."
+      ]
+     },
+     "create_time": 1775512226.593068,
+     "end_turn": true,
+     "id": "9307d463-ecf1-49c8-b5af-fe9403a6d20c",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [
+       {
+        "alt": "Dodot Sensitive",
+        "category": "brand",
+        "end_idx": 163,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Dodot Sensitive\"]\ue201",
+        "metadata": null,
+        "name": "Dodot Sensitive",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Dodot Sensitive",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 127,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Dodot Activity",
+        "category": "brand",
+        "end_idx": 228,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Dodot Activity\"]\ue201",
+        "metadata": null,
+        "name": "Dodot Activity",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Dodot Activity",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 193,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Lupilu",
+        "category": "brand",
+        "end_idx": 303,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Lupilu\"]\ue201",
+        "metadata": null,
+        "name": "Lupilu",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Lupilu",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 276,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Continente Baby",
+        "category": "brand",
+        "end_idx": 376,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Continente Baby\"]\ue201",
+        "metadata": null,
+        "name": "Continente Baby",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Continente Baby",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 340,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Pingo Doce Baby",
+        "category": "brand",
+        "end_idx": 415,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Pingo Doce Baby\"]\ue201",
+        "metadata": null,
+        "name": "Pingo Doce Baby",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Pingo Doce Baby",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 379,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Dodot",
+        "category": "brand",
+        "end_idx": 974,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Dodot\"]\ue201",
+        "metadata": null,
+        "name": "Dodot",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Dodot",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 948,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Continente Baby",
+        "category": "brand",
+        "end_idx": 1021,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Continente Baby\"]\ue201",
+        "metadata": null,
+        "name": "Continente Baby",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Continente Baby",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 985,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Lupilu",
+        "category": "brand",
+        "end_idx": 1052,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Lupilu\"]\ue201",
+        "metadata": null,
+        "name": "Lupilu",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Lupilu",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 1025,
+        "status": "done",
+        "type": "entity"
+       }
+      ],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "1d0d4997-f9a9-42b6-a7f9-83084519c6a8",
+      "request_id": "7aba375a-43f3-4019-a2fc-5fa4f0b9affd",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "63e5fe35-1a1c-438f-8b53-24d738260846"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "1d0d4997-f9a9-42b6-a7f9-83084519c6a8"
+   },
+   "952ee0d3-a539-45d2-a631-ca1156e16f0c": {
+    "children": [
+     "bbb217be-17e4-4c47-b6d4-357d67b34baa"
+    ],
+    "id": "952ee0d3-a539-45d2-a631-ca1156e16f0c",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Newborn logistics are basically a tiny operations problem: sleep vs poop vs milk vs gas. Priorities matter.\n\n**General rule**\nChange **before feeds** most of the time.\n\nWhy:\n- She\u2019s awake enough.  \n- Feeding after helps calm her again.  \n- Less chance of spit-up.\n\n**Typical flow**\n1. Wake  \n2. Diaper change  \n3. Feed  \n4. Burp  \n5. Sleep\n\n**If she poops during or right after a feed**  \nChange it. Poop shouldn\u2019t sit long because it irritates skin.\n\n**How long is OK to wait**\n- **Poop:** ideally change within **5\u201310 minutes**.  \n- **Pee only:** **30\u201360 minutes is fine** if she\u2019s sleeping.\n\nModern diapers absorb urine very well; poop is the real skin irritant.\n\n**When she\u2019s extremely sleepy after feeding**\nYou can:\n- Let her sleep **if it\u2019s pee only**.  \n- Change **next wake or next feed**.\n\n**To reduce gas during this dance**\n- Don\u2019t fold baby in half during changes. Lift by hips gently.  \n- Pause for a **burp mid-feed** if she gulps fast.  \n- Keep feeds calm and not rushed.\n\n**If she hates diaper changes**\nContainment helps:\n- Hand gently on chest  \n- Talk softly  \n- Work fast\n\nAnother funny newborn quirk: feeding \u2192 bowel movement is almost a reflex. The gut wakes up when milk arrives. Many babies poop **during or right after feeds**, which is why the \u201cchange before feed\u201d trick saves you from doing the whole circus twice.\n\nIn the first weeks it\u2019s messy but predictable: **feed \u2192 poop \u2192 sleep \u2192 repeat.**"
+      ]
+     },
+     "create_time": 1773562652.759366,
+     "end_turn": true,
+     "id": "952ee0d3-a539-45d2-a631-ca1156e16f0c",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "48509d36-6da4-4e20-b9d6-038ddf8c9423",
+      "request_id": "14ba5aa6-f8da-4a4d-a57e-4be929f54902",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "05eda216-3d04-49fa-8c23-14a461226acc"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "48509d36-6da4-4e20-b9d6-038ddf8c9423"
+   },
+   "97fe31eb-22bd-4ff2-92aa-906d166115e7": {
+    "children": [
+     "bbb21fbd-7b8c-4d18-b0e5-8c55bd223fab"
+    ],
+    "id": "97fe31eb-22bd-4ff2-92aa-906d166115e7",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773765932.897756,
+     "end_turn": null,
+     "id": "97fe31eb-22bd-4ff2-92aa-906d166115e7",
+     "metadata": {
+      "attachments": [],
+      "can_save": false,
+      "is_visually_hidden_from_conversation": true,
+      "rebase_developer_message": true
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "ff641fef-57b6-48ea-b709-1bf95337da49"
+   },
+   "9c0592a1-223a-43b8-a716-f6b1ad7cb310": {
+    "children": [
+     "bbb217f5-9f29-4289-94db-6966ac4b5f7b"
+    ],
+    "id": "9c0592a1-223a-43b8-a716-f6b1ad7cb310",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Short answer: **this looks more like sensitive newborn skin + normal rash**, not clear overheating. But AC + blankets can still mess with her comfort.\n\nLet\u2019s get practical.\n\n---\n\n## How to tell if she\u2019s actually cold or hot\n\n**Check the chest/back (not hands/feet):**\n\n- **Warm, slightly sweaty, damp neck** \u2192 too hot  \n- **Cool chest, mottled skin** \u2192 too cold  \n- **Warm, dry chest** \u2192 perfect\n\nHands/feet are useless indicators.\n\n---\n\n## Your rash situation\n- Chest/belly bumps \u2192 *can* be heat-related, but also super common anyway  \n- Face bumps \u2192 **not from temperature** (that\u2019s newborn acne/hormones)\n\n\ud83d\udc49 So this is likely **baseline newborn skin + maybe occasional overheating**, not one single cause.\n\n---\n\n## The AC + blanket situation (this is the real issue)\n\nAC creates **inconsistent environment**:\n- Air feels cool \u2192 adults add blankets  \n- But baby can still **overheat under layers**\n\nThat combo is worse than either alone.\n\n---\n\n## Simple rule (no debates needed)\n\n\ud83d\udc49 **Pick one:**\n- Light clothing **OR**\n- Blanket\n\n**Not both**, especially with AC.\n\n---\n\n## Practical setup\n- Room: ~**20\u201322\u00b0C**  \n- Baby: **1 layer (onesie)**  \n- If using AC \u2192 skip blanket or use **very light one**\n\n---\n\n## Why she \u201cseems cold\u201d sometimes\nNewborns:\n- Startle easily  \n- Have immature circulation  \n- Get red/patchy skin  \n\n\ud83d\udc49 This often **looks like cold**, but isn\u2019t\n\n---\n\n## My honest take\n- You\u2019re probably **not underdressing her**  \n- [PERSON_e197e8] is likely **overcompensating with blankets**  \n- The skin is doing normal newborn things\n\n---\n\n## Bottom line\n\ud83d\udc49 Aim for **stable, simple setup** (not constant adjustments)  \n\ud83d\udc49 Use chest/back as your truth source  \n\ud83d\udc49 When in doubt: **slightly cooler > slightly too warm**\n\n---\n\nIf you want, I can give you a dead-simple \u201cwhat to dress her in at X\u00b0C\u201d cheat sheet so you both stop negotiating this every day \ud83d\ude04"
+      ]
+     },
+     "create_time": 1774906105.860073,
+     "end_turn": true,
+     "id": "9c0592a1-223a-43b8-a716-f6b1ad7cb310",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21607-8079-4618-b0cf-a92391b538a1",
+      "request_id": "b34a058b-7d0f-4da7-9a1e-11f3b08f5292",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "b102dad6-43f5-442f-9119-2315f2e70343"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21607-8079-4618-b0cf-a92391b538a1"
+   },
+   "9c989607-b199-43c7-a237-b5e9eadb1ed2": {
+    "children": [
+     "bbb214e7-bc76-4d0a-8d8f-b58d04aa07e6"
+    ],
+    "id": "9c989607-b199-43c7-a237-b5e9eadb1ed2",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Classic newborn hair plot twist \ud83d\ude04\n\n## What usually happens\n\n**1. She may lose some or a lot of it**\n- Around **6\u201312 weeks**\n- Can be:\n  - patchy (bald spots)  \n  - or full shed\n\n\ud83d\udc49 Totally normal\n\n---\n\n**2. New hair grows back different**\n- **Color can change** (dark \u2192 brown/blonde)  \n- **Texture can change** (straight \u2192 wavy, etc.)  \n- Often softer at first\n\n---\n\n**3. Friction bald spots**\n- Back of head thins from lying down  \n- Temporary\n\n---\n\n## Timeline (rough)\n\n- **0\u20132 months:** original hair  \n- **2\u20134 months:** shedding phase  \n- **3\u20136+ months:** regrowth starts showing\n\n---\n\n## Your baby specifically\nDark \u2192 lighter already  \n\ud83d\udc49 Very common\n\nThat means:\n- Pigment is still \u201cdeciding\u201d  \n- Final color can keep shifting for **months or even years**\n\n---\n\n## What NOT to worry about\n- Hair falling out  \n- Uneven patches  \n- Color changes\n\nAll normal.\n\n---\n\n## When to care (rare)\n- Red/scaly patches (cradle cap)  \n- Hair loss with skin irritation\n\n---\n\n## Bottom line\n\ud83d\udc49 Baby hair is a **temporary prototype version**  \n\ud83d\udc49 The \u201creal\u201d hair comes later\n\n---\n\nFun reality: many babies go from \u201ctiny rockstar hair\u201d \u2192 \u201cmiddle-aged man pattern\u201d \u2192 \u201cnormal baby again.\u201d"
+      ]
+     },
+     "create_time": 1775267368.730327,
+     "end_turn": true,
+     "id": "9c989607-b199-43c7-a237-b5e9eadb1ed2",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "815415ef-2acc-4e04-928f-a61b7f132d32",
+      "request_id": "2158adcf-9ad1-43bb-afe0-ad761bbf0a59",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "f9f7c94b-85a1-4771-baa3-d8b1e1c3a52f"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "815415ef-2acc-4e04-928f-a61b7f132d32"
+   },
+   "a0c77003-20b6-406c-a5a0-3a65af131a21": {
+    "children": [
+     "bbb21a18-07cd-47e3-be87-0a8be76171e8"
+    ],
+    "id": "a0c77003-20b6-406c-a5a0-3a65af131a21",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "**Yes \u2014 normal.** Very common in newborns.\n\n## Why it happens\n- Skin adjusting to dry air (outside the womb)  \n- **Sucking friction** from feeding  \n- Mild dehydration of the lip surface (not whole-body dehydration)\n\n---\n\n## What to do\n- **Do nothing** most of the time  \n- If very dry: a tiny bit of **breast milk on lips** works well  \n- Keep lips **clean and dry** (milk residue can irritate)\n\n---\n\n## What NOT to do\n- No regular creams/ointments on lips  \n- No picking the peeling skin\n\n---\n\n## When to worry\n- Deep cracks or bleeding  \n- Signs of dehydration:\n  - fewer wet diapers  \n  - very sleepy / hard to wake  \n  - dry mouth (not just lips)\n\n---\n\n## Bottom line\nPeeling lips = **cosmetic, temporary**.  \nUsually settles in the first **weeks** as skin adapts."
+      ]
+     },
+     "create_time": 1774135185.199551,
+     "end_turn": true,
+     "id": "a0c77003-20b6-406c-a5a0-3a65af131a21",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb219e1-c14e-479b-bd0d-67bacba9be28",
+      "request_id": "f5f7f47b-7e58-46c1-9c0e-45fa83a43b44",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "7bdeade1-16e4-4f89-a7e4-beb8b3df2964"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb219e1-c14e-479b-bd0d-67bacba9be28"
+   },
+   "a386e1d0-7910-42b6-a602-c3b6bec1b4a9": {
+    "children": [
+     "bbb21a1b-f54a-4fc3-b954-f5bda2d71796"
+    ],
+    "id": "a386e1d0-7910-42b6-a602-c3b6bec1b4a9",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "That setup actually sounds **reasonable**, not obviously overheating.\n\n\ud83d\udc49 **22\u00b0C + long-sleeve onesie + light muslin blanket** = generally appropriate\n\nSo this is important:\n\ud83d\udc49 The rash may **not be ongoing overheating anymore**  \nIt may be **leftover heat rash still resolving** or just **normal newborn skin**\n\n---\n\n## How to read your current setup\n\nAt 22\u00b0C:\n- 1 long-sleeve layer = OK  \n- Light blanket = OK **if not tucked tightly / overheating**\n\n\ud83d\udc49 This is **not excessive** unless:\n- room fluctuates  \n- blanket creeps up / doubles  \n- she runs warm\n\n---\n\n## Why rash can still be there\nEven after fixing the cause:\n- Skin takes **1\u20133 days to calm down**\n- You may still see:\n  - old bumps  \n  - fading redness  \n  - some new mild ones\n\n\ud83d\udc49 That doesn\u2019t mean it\u2019s still being caused\n\n---\n\n## How to know if you\u2019ve fixed it\n\nOver next 48h, look for:\n- \u274c no new clusters appearing  \n- \u2705 bumps getting lighter/flatter  \n- \u2705 less redness overall\n\nIf that happens \u2192 you\u2019re done, just wait it out\n\n---\n\n## One thing I\u2019d still tweak (small but smart)\n\n\ud83d\udc49 Consider **short-sleeve or lighter onesie at night**\n\nWhy:\n- Chest/back are where rash is  \n- Blanket already adds warmth  \n- Easier to regulate\n\n---\n\n## Subtle trap to avoid\nEven at 22\u00b0C:\n- Baby + blanket + your body heat (feeds/contact)  \n\u2192 can still tip into warm territory\n\nSo keep using:\n\ud83d\udc49 **neck/chest check as your truth**\n\n---\n\n## Bottom line\n- Your current setup = **not obviously wrong**  \n- Rash may already be **on its way out**  \n- Give it **48h before changing more things**\n\n---\n\nYou\u2019ve already made the big correction (sleep sack).  \nNow it\u2019s about **not over-correcting and creating new variables**."
+      ]
+     },
+     "create_time": 1775157897.064876,
+     "end_turn": true,
+     "id": "a386e1d0-7910-42b6-a602-c3b6bec1b4a9",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21077-b76f-41ff-8cff-ad1116a156d6",
+      "request_id": "cee81323-7a18-4ab0-8307-3450d4995e59",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "d8bef5af-9e8b-4f88-97c7-d2a8bff54fd8"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21077-b76f-41ff-8cff-ad1116a156d6"
+   },
+   "a69fbc6b-a90c-4d13-858a-c63f2ef9d322": {
+    "children": [
+     "6eabcc63-5e4d-43d2-b26a-0d1eab253cf0"
+    ],
+    "id": "a69fbc6b-a90c-4d13-858a-c63f2ef9d322",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1774548287.9776142,
+     "end_turn": null,
+     "id": "a69fbc6b-a90c-4d13-858a-c63f2ef9d322",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "3367179c-93db-4778-a7cb-53b44c6a8083",
+      "request_id": "15e0254d-ce0a-4070-bdea-70045d626d3c",
+      "search_result_groups": [],
+      "turn_exchange_id": "ea48ea62-79fe-47cc-b719-b1a0c8fd2dd5"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "3367179c-93db-4778-a7cb-53b44c6a8083"
+   },
+   "a6b82cfd-2b97-4733-9cf8-1c7980a80241": {
+    "children": [
+     "283aec83-b844-431f-a25b-99dae61c194f"
+    ],
+    "id": "a6b82cfd-2b97-4733-9cf8-1c7980a80241",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773454117.02637,
+     "end_turn": null,
+     "id": "a6b82cfd-2b97-4733-9cf8-1c7980a80241",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "8fd04a66-6368-4050-8e0d-4237419d8192",
+      "request_id": "bd769bc4-435a-4003-bd93-ea7b96f1a7da",
+      "search_result_groups": [],
+      "turn_exchange_id": "2ceba3bf-8685-4333-bd4f-9081a31fee5d"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "8fd04a66-6368-4050-8e0d-4237419d8192"
+   },
+   "a9d66c99-b259-433c-bf77-730b69cf7895": {
+    "children": [
+     "bbb2174d-4849-4d05-9859-3f4044ed1aae"
+    ],
+    "id": "a9d66c99-b259-433c-bf77-730b69cf7895",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Good \u2014 let\u2019s save you some trial-and-error.\n\n## Diapers parents in Portugal often regret (early stage)\n\n### \u26a0\ufe0f Very cheap \u201cno-name\u201d brands\n- Inconsistent absorption  \n- Higher leak/blowout rate  \n- Rougher materials  \n\ud83d\udc49 Cheap per unit, expensive in frustration\n\n---\n\n### \u26a0\ufe0f Some \ue200entity\ue202[\"brand\",\"Auchan Baby\"]\ue201 (Jumbo)\n- Mixed reviews  \n- Fit can be awkward  \n\ud83d\udc49 Not terrible, just less reliable than others\n\n---\n\n### \u26a0\ufe0f Perfumed versions (any brand)\n- Adds zero value  \n- Higher irritation risk  \n\ud83d\udc49 Just avoid entirely\n\n---\n\n## Ones that are usually safe bets\n\n- \ue200entity\ue202[\"brand\",\"Continente Baby\"]\ue201 \u2192 best budget baseline  \n- \ue200entity\ue202[\"brand\",\"Lupilu\"]\ue201 \u2192 very consistent  \n- \ue200entity\ue202[\"brand\",\"Pingo Doce Baby\"]\ue201 \u2192 decent all-rounder  \n\n---\n\n## The real \u201cgotcha\u201d (most important)\n\n\ud83d\udc49 **Fit matters more than brand**\n\nEven a great diaper:\n- leaks if too small  \n- leaks if too big  \n- leaks if shape doesn\u2019t match baby\n\n---\n\n## Smart testing strategy (so you don\u2019t waste money)\n\n1. Buy **small pack**  \n2. Test during **daytime only**  \n3. Watch for:\n   - leaks  \n   - red marks  \n   - how often you need to change  \n\n4. Only then scale\n\n---\n\n## Honest truth\nThere\u2019s no universal \u201cbest diaper\u201d\n\n\ud83d\udc49 There\u2019s:\n- \u201cbest diaper for your baby\u2019s body shape\u201d  \n- and \u201cbest diaper for your wallet\u201d\n\n---\n\n## Bottom line\n- Avoid ultra-cheap unknowns + perfumes  \n- Start with **Continente or Lupilu**  \n- Test small, then commit\n\n---\n\nIf you want, I can help you decide **when to size up (that\u2019s where most leaks actually come from)** \u2014 that\u2019s a bigger lever than brand choice."
+      ]
+     },
+     "create_time": 1775532189.946691,
+     "end_turn": true,
+     "id": "a9d66c99-b259-433c-bf77-730b69cf7895",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [
+       {
+        "alt": "Auchan Baby",
+        "category": "brand",
+        "end_idx": 311,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Auchan Baby\"]\ue201",
+        "metadata": null,
+        "name": "Auchan Baby",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Auchan Baby",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 279,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Continente Baby",
+        "category": "brand",
+        "end_idx": 600,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Continente Baby\"]\ue201",
+        "metadata": null,
+        "name": "Continente Baby",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Continente Baby",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 564,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Lupilu",
+        "category": "brand",
+        "end_idx": 655,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Lupilu\"]\ue201",
+        "metadata": null,
+        "name": "Lupilu",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Lupilu",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 628,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Pingo Doce Baby",
+        "category": "brand",
+        "end_idx": 714,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Pingo Doce Baby\"]\ue201",
+        "metadata": null,
+        "name": "Pingo Doce Baby",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Pingo Doce Baby",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 678,
+        "status": "done",
+        "type": "entity"
+       }
+      ],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb219e9-8dd3-41ba-a90b-4031c9daff0e",
+      "request_id": "88e8497e-6b68-42e9-a513-79a6b6df605f",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "4e3e1a4a-f83c-48ef-85c0-366b5bad76f9"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb219e9-8dd3-41ba-a90b-4031c9daff0e"
+   },
+   "aaf9b130-0bcc-45d1-b664-245d8d822aca": {
+    "children": [
+     "8c9c0535-bb32-4108-8976-fe984131b631"
+    ],
+    "id": "aaf9b130-0bcc-45d1-b664-245d8d822aca",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": null,
+     "end_turn": false,
+     "id": "aaf9b130-0bcc-45d1-b664-245d8d822aca",
+     "metadata": {
+      "can_save": false,
+      "is_visually_hidden_from_conversation": true
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "27989531-37be-4fd7-8363-515b5833ef82"
+   },
+   "ad63d4fc-5b7a-45ae-8d27-a1c3772f8148": {
+    "children": [
+     "d3a573c5-f691-4fc2-bae7-58682b3e05a3"
+    ],
+    "id": "ad63d4fc-5b7a-45ae-8d27-a1c3772f8148",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Good \u2014 short window until Monday, so risk is low if you stay sensible.\n\n## Main risks of stretching nights\n\n**1. Slight drop in intake (temporary)**\n- Longer gaps \u2192 fewer feeds \u2192 could **slow weight gain a bit**\n- Unlikely in a few days if days are solid\n\n**2. Supply signal (minor at this stage)**\n- Night feeds help supply early on  \n- But you\u2019re already established (milk in, good diapers) \u2192 risk is **low**, not zero\n\n**3. Harder-to-wake baby (rare, watch for it)**\n- If she starts sleeping *too* long and is sluggish to wake \u2192 that\u2019s a flag\n\n---\n\n## Why your situation is low-risk\n- Regained birth weight early \u2705  \n- Good output (pee/poop) \u2705  \n- Feeding effectively \u2705  \n- Short time frame until weigh-in \u2705  \n\n---\n\n## How to de-risk it (smart approach)\n\nDo this until Monday:\n\n- **Keep days tight** \u2192 feed every ~2.5\u20133h (don\u2019t skip)  \n- At night \u2192 allow stretch, but **cap ~4h**  \n- If she wakes \u2192 feed fully (don\u2019t half-feed)\n\n---\n\n## Monitor (these matter more than the clock)\n\nYou\u2019re good if:\n- **\u22656 wet diapers/day**  \n- Still pooping regularly  \n- Wakes on her own for feeds  \n- Seems alert during wake windows\n\n---\n\n## When to revert immediately\n- Fewer wet diapers  \n- Very sleepy / hard to wake  \n- Skipping feeds repeatedly\n\n---\n\n## Straight answer\nYou\u2019re not doing something reckless.  \nYou\u2019re **slightly relaxing a rule**, with guardrails, for a few days.\n\nWorst case: tiny dip in gain \u2192 you tighten again after Monday.  \nBest case: better sleep + less gas chaos.\n\n---\n\n## My call\n\ud83d\udc49 This is a **reasonable, controlled experiment** \u2014 not a gamble."
+      ]
+     },
+     "create_time": 1773972755.704287,
+     "end_turn": true,
+     "id": "ad63d4fc-5b7a-45ae-8d27-a1c3772f8148",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21d77-3cc7-4995-a568-a7d2f6550089",
+      "request_id": "03dd6697-4f19-4992-80ee-324fd41d633f",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "3b2ed97a-29c8-498f-9709-3540a256d0bd"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21d77-3cc7-4995-a568-a7d2f6550089"
+   },
+   "b1d95068-f642-426f-b5ca-219defe487bd": {
+    "children": [
+     "bbb2133c-029c-488f-b8ff-fa17abfc5fb3"
+    ],
+    "id": "b1d95068-f642-426f-b5ca-219defe487bd",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "No \u2014 **not guaranteed**, but very common.\n\n## What actually happens\n- **Most babies lose some hair** (partial shedding)  \n- **Some lose a lot** (noticeable thinning/bald spots)  \n- **A few keep most of it**\n\n---\n\n## Why it happens\n- Hormone drop after birth \u2192 resets hair cycle  \n- Friction (lying on back) adds to it\n\n---\n\n## Your baby (full head, already changing color)\n\ud83d\udc49 **Higher chance she\u2019ll shed at least a bit**\n\n---\n\n## What to expect realistically\n- Some thinning around **2\u20133 months**  \n- Possibly a bald spot at the back  \n- Then regrowth\n\n---\n\n## Bottom line\n\ud83d\udc49 Not 100% guaranteed  \n\ud83d\udc49 But **don\u2019t get attached to the current hair** \ud83d\ude04"
+      ]
+     },
+     "create_time": 1775267504.785597,
+     "end_turn": true,
+     "id": "b1d95068-f642-426f-b5ca-219defe487bd",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb214e7-bc76-4d0a-8d8f-b58d04aa07e6",
+      "request_id": "92673fbb-10f6-9e0e-91c4-84e8c8e1cddc",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "1b0a5b59-0b4d-4851-85f0-b45de9bdb7de"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb214e7-bc76-4d0a-8d8f-b58d04aa07e6"
+   },
+   "b1dbddf4-d454-4e39-9bb6-b962a7b0a297": {
+    "children": [
+     "bbb217ac-fce7-43c9-a68a-698f606c39c1"
+    ],
+    "id": "b1dbddf4-d454-4e39-9bb6-b962a7b0a297",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "\ud83d\udc49 **Yes, food-grade mineral oil is OK** to use.\n\n## Why it works\n- It\u2019s **highly purified**  \n- Inert (doesn\u2019t react with skin or feed yeast)  \n- Same base ingredient as many baby oils\n\n---\n\n## How to use it safely\n- Use a **very small amount**  \n- Apply to flakes  \n- Wait **10\u201315 min**  \n- Gently loosen  \n- **Wash off well** (important)\n\n---\n\n## One caveat\nFood-grade oils are:\n- Sometimes a bit **thicker/greasier**  \n\ud83d\udc49 just make sure you don\u2019t leave residue sitting\n\n---\n\n## Better vs worse (quick ranking)\n- Best: cosmetic **baby oil (mineral oil)**  \n- Also good: **food-grade mineral oil**  \n- Less ideal: **olive oil**\n\n---\n\n## Bottom line\n\ud83d\udc49 Totally fine to use what you have  \n\ud83d\udc49 Just keep it **light + temporary + washed off**\n\n---\n\nYou don\u2019t need to go buy anything \u2014 this will do the job perfectly."
+      ]
+     },
+     "create_time": 1776916942.774711,
+     "end_turn": true,
+     "id": "b1dbddf4-d454-4e39-9bb6-b962a7b0a297",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21409-a403-48d8-8f4b-57e103d887e7",
+      "request_id": "131aea26-91b5-4bf7-b9ce-2406cee64f94",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "e9bac587-7244-4d10-98cb-32817a5cac7e"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21409-a403-48d8-8f4b-57e103d887e7"
+   },
+   "b25643dd-53fd-49d8-9f8e-2fb37118ad20": {
+    "children": [
+     "bbb21176-4b36-4f12-ac91-ee73ed9bd071"
+    ],
+    "id": "b25643dd-53fd-49d8-9f8e-2fb37118ad20",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Good catch. It **doesn\u2019t always save you**. Newborns love chaos.\n\nThe logic is simpler:\n\n**Change before feeding because she\u2019s awake.**  \nAfter feeding she often becomes milk-drunk and impossible to change without a meltdown.\n\nSo the goal isn\u2019t avoiding two changes \u2014 it\u2019s **avoiding waking a sleeping baby**.\n\n**Realistic scenarios:**\n\n**1. Pee only before feed**  \nChange \u2192 feed \u2192 sleep.  \nOften you\u2019re done.\n\n**2. Poops during/after feed**  \nChange again. Yes, twice. Totally normal.\n\n**3. Sleeps deeply after feed (pee only)**  \nSkip change and let her sleep.\n\n**Rule of thumb**\n- **Poop \u2192 change soon.**  \n- **Pee \u2192 can wait if sleeping.**\n\nNewborn digestion adds a fun twist: milk entering the stomach triggers the **gastrocolic reflex** \u2014 basically the gut saying, \u201cNew food arrived, evacuate the previous shipment.\u201d That\u2019s why so many babies poop mid-meal like a tiny biological conveyor belt."
+      ]
+     },
+     "create_time": 1773562777.873213,
+     "end_turn": true,
+     "id": "b25643dd-53fd-49d8-9f8e-2fb37118ad20",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb217be-17e4-4c47-b6d4-357d67b34baa",
+      "request_id": "f7ac7b55-cd0e-4f97-879a-d827d7920363",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "3132d318-df96-4811-b42b-9c71d191e3b7"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb217be-17e4-4c47-b6d4-357d67b34baa"
+   },
+   "b2d554aa-12c9-4b87-a14f-29d4e1aabdaf": {
+    "children": [
+     "f970ffa8-c806-4d1e-94e2-9638f02f5c38"
+    ],
+    "id": "b2d554aa-12c9-4b87-a14f-29d4e1aabdaf",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1774905572.6621602,
+     "end_turn": true,
+     "id": "b2d554aa-12c9-4b87-a14f-29d4e1aabdaf",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb218ff-8813-45b1-bdcd-d5ede3848f80",
+      "rebase_system_message": true,
+      "request_id": "ba50d109-8dec-4da1-a925-fcd250e68ea8",
+      "turn_exchange_id": "607f26c1-e70e-4b18-b3d0-ebfbb4ec03b1"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb218ff-8813-45b1-bdcd-d5ede3848f80"
+   },
+   "b30f4bf6-92d7-4ba2-b2e4-a1eee9ea6f85": {
+    "children": [
+     "bbb210c2-a95f-4c11-ab31-7044af1892c9"
+    ],
+    "id": "b30f4bf6-92d7-4ba2-b2e4-a1eee9ea6f85",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "If it\u2019s the usual **gas + straining + messy poop**, you don\u2019t fix it \u2014 you **support it**. Their gut is learning.\n\n**What actually helps:**\n\n**During feeds**\n- Make sure latch is good \u2192 less air  \n- Pause for **burps mid-feed**\n\n**After feeds**\n- Hold upright **10\u201315 min**\n\n**When she\u2019s uncomfortable**\n- **Bicycle legs** (slow, gentle)  \n- **Tummy time** (even 1\u20132 min counts)  \n- Gentle **belly massage** (clockwise)  \n- Warm bath = surprisingly effective\n\n**During diaper changes**\n- Don\u2019t fold her in half  \n- Move slowly \u2192 less pressure on belly\n\n**For you (if breastfeeding)**\n- No need to cut foods unless there\u2019s a clear pattern. Most \u201cgas from mom\u2019s diet\u201d is overstated.\n\n**What not to chase**\n- Don\u2019t jump to drops/supplements right away  \n- Don\u2019t over-handle every grunt \u2014 some straining is just them learning\n\n**Reality check**\nPeak fussiness is around **3\u20136 weeks**, then it improves. You\u2019re in the thick of it now.\n\nIf she\u2019s **feeding well, gaining weight, and poop is soft**, then despite the drama \u2014 everything is working as designed."
+      ]
+     },
+     "create_time": 1773874524.435704,
+     "end_turn": true,
+     "id": "b30f4bf6-92d7-4ba2-b2e4-a1eee9ea6f85",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb212f3-c49d-4475-8bf2-ecda0b8b0797",
+      "request_id": "3f2bbc16-2599-4133-bff5-8c5a1e92c99a",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "f003f965-7618-4a83-a033-95475dde2ddc"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb212f3-c49d-4475-8bf2-ecda0b8b0797"
+   },
+   "b382f3b8-b907-470a-a387-71fa2b7f3400": {
+    "children": [
+     "bbb216aa-e6de-4a83-8e21-8b173950ad1d"
+    ],
+    "id": "b382f3b8-b907-470a-a387-71fa2b7f3400",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Classic. Bath = instant \u201crelease valve\u201d \ud83d\ude04\n\nYour setup is already good. Let\u2019s make it smoother.\n\n---\n\n## Best workflow (simple + efficient)\n\n**1. Accept it will happen**\n\ud83d\udc49 Plan for a diaper change *after* every bath\n\n---\n\n**2. Two-layer setup (you\u2019re close)**\n- Bottom: towel  \n- Top: **disposable pad OR folded muslin**\n\n\ud83d\udca1 Upgrade:\nHave **2 pads ready**, not one\n\n---\n\n**3. Fast post-bath sequence**\n1. Out of bath \u2192 straight into towel  \n2. Quick pat dry (don\u2019t aim for perfect)  \n3. Place on pad  \n4. Wait **10\u201320 seconds** (often pee happens here)  \n5. Then diaper\n\n---\n\n## Pro tricks\n\n**Trigger the pee on your terms**\n- Open towel slightly \u2192 air hits \u2192 pee comes  \n\ud83d\udc49 Better on pad than mid-diaper\n\n---\n\n**Diaper \u201cshield\u201d trick**\n- Place clean diaper loosely under her  \n- If she pees \u2192 it catches most of it  \n- Then close properly\n\n---\n\n**For poop (harder to time)**\n- Keep it warm \u2192 they relax \u2192 poop happens  \n- If she\u2019s straining \u2192 wait a bit before diapering\n\n---\n\n## If you want to reduce it happening\n- Do bath **between feeds**, not right after a full one  \n- Full belly + warm bath = \ud83d\udca9 trigger\n\n---\n\n## Bottom line\n\ud83d\udc49 Don\u2019t fight it \u2014 **design for it**  \n\ud83d\udc49 Pad + short wait + diaper = smooth system\n\n---\n\nYou\u2019re basically running a tiny spa that ends in a biological surprise. Planning for it is the win."
+      ]
+     },
+     "create_time": 1774923924.577153,
+     "end_turn": true,
+     "id": "b382f3b8-b907-470a-a387-71fa2b7f3400",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "c422ba05-e6ed-4153-ab4f-8610ea95dc11",
+      "request_id": "7f11222f-bb16-4183-ba26-11924986d4e0",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "d5da2e75-f488-4a05-8823-b61f70806d18"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "c422ba05-e6ed-4153-ab4f-8610ea95dc11"
+   },
+   "b622ba50-8df4-4e88-931f-e83c9fa1a9fc": {
+    "children": [
+     "bbb21827-ebe6-4179-a797-93c4ca9461cc"
+    ],
+    "id": "b622ba50-8df4-4e88-931f-e83c9fa1a9fc",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "**Yes \u2014 very normal at ~1 month.** This is the classic shift.\n\n## What\u2019s going on\n- Gut is maturing \u2192 **poop frequency drops**  \n- Still learning to coordinate \u2192 **more gas, less output**  \n- Breastfed babies can go from **many/day \u2192 few/day (or even skip a day)**\n\n\ud83d\udc49 Gas + less poop = looks worse than it is\n\n---\n\n## What matters (green lights)\n- Poop is still **soft when it comes**  \n- Plenty of **wet diapers**  \n- Feeding well  \n\n\ud83d\udc49 Then it\u2019s not constipation\n\n---\n\n## Why she seems more uncomfortable\n- Gas builds up before it moves out  \n- She\u2019s figuring out \u201cpush + relax\u201d (not great at it yet)\n\n---\n\n## What to do (practical)\n\n**1. Help gas move**\n- Bicycle legs (1\u20132 min)  \n- Gentle belly massage (clockwise)  \n- \u201cTiger in the tree\u201d hold\n\n---\n\n**2. Timing trick**\nBefore sleep / evening:\n- Do a quick **diaper + legs + massage**  \n\ud83d\udc49 reduces pressure before rest\n\n---\n\n**3. Keep feeds as is**\n- Don\u2019t space feeds more  \n- Milk helps move things along\n\n---\n\n**4. Warm bath**\n- You\u2019ve seen it \u2192 often triggers poop\n\n---\n\n## What NOT to do\n- No rectal stimulation routinely  \n- No meds unless advised  \n- Don\u2019t panic over fewer poops\n\n---\n\n## When to worry\n- Hard pellets  \n- No poop for **several days + discomfort**  \n- Poor feeding / lethargy\n\n---\n\n## Bottom line\n\ud83d\udc49 This is a **normal transition phase**  \n\ud83d\udc49 More gas + less poop = expected around now  \n\ud83d\udc49 You\u2019re supporting, not fixing\n\n---\n\nIf you want, I can tell you how to distinguish this from early constipation vs colic \u2014 but right now this still fits normal perfectly."
+      ]
+     },
+     "create_time": 1775946775.072122,
+     "end_turn": true,
+     "id": "b622ba50-8df4-4e88-931f-e83c9fa1a9fc",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "2d548a0b-2886-47ed-8f35-76d93df13674",
+      "request_id": "ca7348d2-42f3-4542-8101-cd069bb44656",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "9f3e3a6c-c335-4138-bb4c-2e86a81f00be"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "2d548a0b-2886-47ed-8f35-76d93df13674"
+   },
+   "b62974bf-548a-4c6b-aac3-ae6ed76cff27": {
+    "children": [
+     "bbb21b3c-f102-46b1-8f3e-957e15c86bea"
+    ],
+    "id": "b62974bf-548a-4c6b-aac3-ae6ed76cff27",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "**2\u20133 times per week** is perfect.\n\n## Why not daily\n- Newborn skin is **dry and sensitive**  \n- Frequent baths \u2192 **more irritation**, not cleaner\n\n---\n\n## What to do on non-bath days\n- Clean:\n  - face  \n  - neck folds  \n  - diaper area  \n\ud83d\udc49 That\u2019s enough\n\n---\n\n## When to bathe more\n- Big poop blowout  \n- Very sweaty day  \n- Helps calm her (some babies relax with baths)\n\n---\n\n## How long this applies\n- First **4\u20136 weeks** especially  \n- Then you can increase if you want\n\n---\n\n## Bottom line\n\ud83d\udc49 2\u20133\u00d7/week = ideal  \n\ud83d\udc49 Daily is optional, not needed"
+      ]
+     },
+     "create_time": 1774201926.591592,
+     "end_turn": true,
+     "id": "b62974bf-548a-4c6b-aac3-ae6ed76cff27",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "12fca265-47ab-4c9f-a6cb-a571659d4db2",
+      "request_id": "b2d673a2-5ce5-4d06-b285-1f8f9a406a70",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "316ee266-b7b9-4c89-820b-77d959230e2f"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "12fca265-47ab-4c9f-a6cb-a571659d4db2"
+   },
+   "b8765604-b799-47cf-86e2-bd0d1ae74e06": {
+    "children": [
+     "bbb215a8-b726-4bd4-a91e-6c41e9bf0641"
+    ],
+    "id": "b8765604-b799-47cf-86e2-bd0d1ae74e06",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773383089.1535456,
+     "end_turn": null,
+     "id": "b8765604-b799-47cf-86e2-bd0d1ae74e06",
+     "metadata": {
+      "attachments": [],
+      "can_save": false,
+      "is_visually_hidden_from_conversation": true,
+      "rebase_developer_message": true
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "56e7ce10-2173-4894-b083-cb3afee778ae"
+   },
+   "bbb21013-9bc7-4c63-808f-0f809ab66109": {
+    "children": [
+     "4bce5530-25b8-477e-80c9-17dff4130516"
+    ],
+    "id": "bbb21013-9bc7-4c63-808f-0f809ab66109",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "It changes? It can become relaxing later?"
+      ]
+     },
+     "create_time": 1776033921.656776,
+     "end_turn": null,
+     "id": "bbb21013-9bc7-4c63-808f-0f809ab66109",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "e1f4a0df-592d-4666-960b-5ac09aa2d904",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "adb0b4a1-1460-4149-81b2-95d58f74f597",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "2c1c5dc5-c464-4b7c-9976-ba77dbc8a536"
+   },
+   "bbb2101e-aac0-44c3-adff-0a9c1ce933cc": {
+    "children": [
+     "5943357d-0b1c-48fe-9661-70507bfdffac"
+    ],
+    "id": "bbb2101e-aac0-44c3-adff-0a9c1ce933cc",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "What causes it?"
+      ]
+     },
+     "create_time": 1776969419.81936,
+     "end_turn": null,
+     "id": "bbb2101e-aac0-44c3-adff-0a9c1ce933cc",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "7210809c-8cc1-4ac0-ad1d-75edaa254aa1",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "71e31255-60a5-4543-bfc8-b17ca75512cb",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "6d09b922-89ff-4af0-a54e-64cd2172839d"
+   },
+   "bbb2103c-57a2-47c0-962b-33aad468a507": {
+    "children": [
+     "bf161984-b8f4-445d-865e-cdbca130f8bc"
+    ],
+    "id": "bbb2103c-57a2-47c0-962b-33aad468a507",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Remind me again of what troubles are expected with newborn poo? And how long they last. "
+      ]
+     },
+     "create_time": 1773874309.397035,
+     "end_turn": null,
+     "id": "bbb2103c-57a2-47c0-962b-33aad468a507",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "9b16de13-1a9e-439c-93c0-f85df8c0b577",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "55cdfc5c-299c-496e-8680-a797b059731e",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "84b8dbcd-7c3e-408c-b284-3dec4faa1cdc"
+   },
+   "bbb2103e-ba1a-44a6-8100-fd5ba4c71dd5": {
+    "children": [
+     "ff641fef-57b6-48ea-b709-1bf95337da49"
+    ],
+    "id": "bbb2103e-ba1a-44a6-8100-fd5ba4c71dd5",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Ok. For how long do you estimate it will be fine?"
+      ]
+     },
+     "create_time": 1773573980.035393,
+     "end_turn": null,
+     "id": "bbb2103e-ba1a-44a6-8100-fd5ba4c71dd5",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "f1cbe192-d9c3-4678-82a9-2c0dffeddac1",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "1245534d-242f-4f79-8d76-def93220c7f3",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "07d3faca-987d-4941-942f-52437d271d0f"
+   },
+   "bbb2104e-3b27-4603-bec4-1cc71b0f69ea": {
+    "children": [
+     "d1889b85-e367-4d49-adc0-91bd9a226bcf"
+    ],
+    "id": "bbb2104e-3b27-4603-bec4-1cc71b0f69ea",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "What about water wipes brands?"
+      ]
+     },
+     "create_time": 1775534209.368886,
+     "end_turn": null,
+     "id": "bbb2104e-3b27-4603-bec4-1cc71b0f69ea",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "9440f87b-667d-481d-bbfa-19d64d751973",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "a749ddfb-ecf5-4ee7-b84e-dae09b9611bd",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "10d8e017-93db-4777-a265-7910f10b6f1e"
+   },
+   "bbb21077-b76f-41ff-8cff-ad1116a156d6": {
+    "children": [
+     "a386e1d0-7910-42b6-a602-c3b6bec1b4a9"
+    ],
+    "id": "bbb21077-b76f-41ff-8cff-ad1116a156d6",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "I didn't remove the AC during the night. It's about 10 degrees outside during the night, and my house gets cold. We're keeping the room at around 22. She is wearing one long sleeve onesie and now a light blanket up to her chest, below arms."
+      ]
+     },
+     "create_time": 1775157896.782081,
+     "end_turn": null,
+     "id": "bbb21077-b76f-41ff-8cff-ad1116a156d6",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "cee81323-7a18-4ab0-8307-3450d4995e59",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "d8bef5af-9e8b-4f88-97c7-d2a8bff54fd8",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "e4a52516-c1be-4790-b2dc-6d4dee3b44a1"
+   },
+   "bbb2108f-7a95-445c-bbac-bd28933e682b": {
+    "children": [
+     "113f6fad-8455-4859-85aa-2cb18ed93486"
+    ],
+    "id": "bbb2108f-7a95-445c-bbac-bd28933e682b",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Can you help me understand what is a good price per diaper in Portugal? Dodot sensitive size 1."
+      ]
+     },
+     "create_time": 1775512021.759877,
+     "end_turn": null,
+     "id": "bbb2108f-7a95-445c-bbac-bd28933e682b",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "4f60cbba-c9fc-46a4-93bd-23290c8139e0",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "452cda20-6951-49c2-9a73-e91795144fcd",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "e1ae9994-1a14-46cf-869d-ed0df77ad5a4"
+   },
+   "bbb210c2-a95f-4c11-ab31-7044af1892c9": {
+    "children": [
+     "80ed896c-05db-4a70-a1f4-bc677715f4fa"
+    ],
+    "id": "bbb210c2-a95f-4c11-ab31-7044af1892c9",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Don't fold how? And be more specific about diaper change, as she seems to really hate it. "
+      ]
+     },
+     "create_time": 1773874600.971219,
+     "end_turn": null,
+     "id": "bbb210c2-a95f-4c11-ab31-7044af1892c9",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "69ee1a3f-076c-46b8-842f-cfc4281b415e",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "3bb1900e-e043-4e87-97b3-56404e2f73b8",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "b30f4bf6-92d7-4ba2-b2e4-a1eee9ea6f85"
+   },
+   "bbb210c7-72a6-476f-8102-0b18b70ecff9": {
+    "children": [
+     "1721b424-61c7-41fa-9112-056de0809c35"
+    ],
+    "id": "bbb210c7-72a6-476f-8102-0b18b70ecff9",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Ok"
+      ]
+     },
+     "create_time": 1775532312.984036,
+     "end_turn": null,
+     "id": "bbb210c7-72a6-476f-8102-0b18b70ecff9",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "419e760c-d395-4672-aa48-e36fdfaa20b7",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "027594ee-b7a9-4431-84d7-10dd19ba5c5a",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "5c360cf8-3913-49a0-9335-4f278734bb62"
+   },
+   "bbb210f9-c04e-4ba6-ab5a-6996518cb2d3": {
+    "children": [
+     "10d8e017-93db-4777-a265-7910f10b6f1e"
+    ],
+    "id": "bbb210f9-c04e-4ba6-ab5a-6996518cb2d3",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Ok"
+      ]
+     },
+     "create_time": 1775534147.15332,
+     "end_turn": null,
+     "id": "bbb210f9-c04e-4ba6-ab5a-6996518cb2d3",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "dbb6da3c-f48e-4527-a65c-71df2b962453",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "02fa45b7-7b92-4d45-aca7-6e9495703dd1",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "52a8dcc8-efb9-472f-a649-2f15649b1685"
+   },
+   "bbb2110b-d720-458d-acf4-e134dee58965": {
+    "children": [
+     "0c43138c-5add-461b-81bb-2dd3b96bf99e"
+    ],
+    "id": "bbb2110b-d720-458d-acf4-e134dee58965",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "When should I consider moving from Dodot and trying other brands?"
+      ]
+     },
+     "create_time": 1775512111.874051,
+     "end_turn": null,
+     "id": "bbb2110b-d720-458d-acf4-e134dee58965",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "ded410d7-2c4c-475c-b649-d705d6c10a3b",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "a0274229-a1d1-4b94-aaec-f381bcaa4c3f",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "eefe2a05-ed5a-4d9e-9152-59cbd2803e6d"
+   },
+   "bbb2112f-1b5f-4a1c-8093-ac61d6449cb6": {
+    "children": [
+     "fc76911e-d67f-4e5c-aef6-d5d71d443f44"
+    ],
+    "id": "bbb2112f-1b5f-4a1c-8093-ac61d6449cb6",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "What are the price differences?"
+      ]
+     },
+     "create_time": 1775512226.25866,
+     "end_turn": null,
+     "id": "bbb2112f-1b5f-4a1c-8093-ac61d6449cb6",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "7aba375a-43f3-4019-a2fc-5fa4f0b9affd",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "63e5fe35-1a1c-438f-8b53-24d738260846",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "69631278-a480-44d0-8edb-ac484d7a1bf1"
+   },
+   "bbb21176-4b36-4f12-ac91-ee73ed9bd071": {
+    "children": [
+     "c109e7db-a365-4d6a-8998-4590b3e73237"
+    ],
+    "id": "bbb21176-4b36-4f12-ac91-ee73ed9bd071",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Help me with bath logistics. I have a tub, no wheels, it needs to sit on the changing station. Bathroom with water is next room, but tub becomes too heavy when full and water not heating enough. Thinking of using shallow and a kettle to adjust. Smart or another way?"
+      ]
+     },
+     "create_time": 1773573227.526939,
+     "end_turn": null,
+     "id": "bbb21176-4b36-4f12-ac91-ee73ed9bd071",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "bdeebc20-b798-4a8a-9c9f-8551cd069a8b",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "fa74fe7e-dbad-43cf-acba-24684899ab30",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "b25643dd-53fd-49d8-9f8e-2fb37118ad20"
+   },
+   "bbb2118c-eaea-4747-a364-c5fb67180eab": {
+    "children": [
+     "e5d9a2b8-1222-46ca-bff3-762c386b9b20"
+    ],
+    "id": "bbb2118c-eaea-4747-a364-c5fb67180eab",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Ok. And wipes? How long to use the water ones and what price per unit?"
+      ]
+     },
+     "create_time": 1775534087.360422,
+     "end_turn": null,
+     "id": "bbb2118c-eaea-4747-a364-c5fb67180eab",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "d1a4c94e-8d57-4efe-b8fc-e746ea5e3e96",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "ba6f27a8-8ea9-4419-8154-1fd0507dea8b",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "d8b37926-2274-4e5d-abe5-e442df10df4c"
+   },
+   "bbb2119b-b5c4-4dbd-9f34-0c5cb18a17c1": {
+    "children": [
+     "5dbc32df-6496-4554-a2f3-4be7b6013404"
+    ],
+    "id": "bbb2119b-b5c4-4dbd-9f34-0c5cb18a17c1",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Ok, so how many should I buy, considering I have about 45 size 1 today?"
+      ]
+     },
+     "create_time": 1775532839.646725,
+     "end_turn": null,
+     "id": "bbb2119b-b5c4-4dbd-9f34-0c5cb18a17c1",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "3ce7d981-b2fd-450e-912b-a2e04d46da8f",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "5f5608af-0b92-4935-8a16-87b44e385018",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "37537e71-b4e4-4d1d-b002-adcae64cfd47"
+   },
+   "bbb21217-0803-4318-b074-ce5d023486cb": {
+    "children": [
+     "8532afee-7c61-4d9b-832f-ce6b222191ba"
+    ],
+    "id": "bbb21217-0803-4318-b074-ce5d023486cb",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Baby moved from 6+ mix diapers per day to around 6 wet but only 2 or 3 dirty. Feeding well and seems to be fine. Month old. Normal?"
+      ]
+     },
+     "create_time": 1776182905.758774,
+     "end_turn": null,
+     "id": "bbb21217-0803-4318-b074-ce5d023486cb",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "b0d9ce37-b0ee-42e2-96ab-9e6b7b3e9a23",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "9c2a9c29-22bc-4505-9425-1334bab7fc71",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "850947d4-d6ac-4065-8370-f91e8a9714b1"
+   },
+   "bbb212a9-6bb9-4397-93e8-1d46463b1e71": {
+    "children": [
+     "4858396e-943b-469e-b24e-595f1fd0abc3"
+    ],
+    "id": "bbb212a9-6bb9-4397-93e8-1d46463b1e71",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Order of washing in the bath"
+      ]
+     },
+     "create_time": 1774548287.20415,
+     "end_turn": null,
+     "id": "bbb212a9-6bb9-4397-93e8-1d46463b1e71",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "15e0254d-ce0a-4070-bdea-70045d626d3c",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "ea48ea62-79fe-47cc-b719-b1a0c8fd2dd5",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "602b172b-2928-4339-9568-fc3a374e4438"
+   },
+   "bbb212ab-680d-49c9-89da-0c12a000324e": {
+    "children": [
+     "69631278-a480-44d0-8edb-ac484d7a1bf1"
+    ],
+    "id": "bbb212ab-680d-49c9-89da-0c12a000324e",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Ok"
+      ]
+     },
+     "create_time": 1775512158.921141,
+     "end_turn": null,
+     "id": "bbb212ab-680d-49c9-89da-0c12a000324e",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "316a1fe3-6ed5-4a76-8a4c-db0542ea2b89",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "becb0c53-7687-4820-acad-78a5c58ef6f4",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "0c43138c-5add-461b-81bb-2dd3b96bf99e"
+   },
+   "bbb212ef-1bb0-4d38-8804-4d950cfd073a": {
+    "children": [
+     "6d09b922-89ff-4af0-a54e-64cd2172839d"
+    ],
+    "id": "bbb212ef-1bb0-4d38-8804-4d950cfd073a",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Once it falls off in a certain place, it's gone? Or comes back?"
+      ]
+     },
+     "create_time": 1776969372.066786,
+     "end_turn": null,
+     "id": "bbb212ef-1bb0-4d38-8804-4d950cfd073a",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "91fe0466-8b5d-4319-b46f-63234ebc1840",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "2787f60b-c6b8-4da5-95d0-43b563f33a51",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "be0c2bf5-10ea-4456-976c-f2e8c2313b7a"
+   },
+   "bbb212f3-c49d-4475-8bf2-ecda0b8b0797": {
+    "children": [
+     "b30f4bf6-92d7-4ba2-b2e4-a1eee9ea6f85"
+    ],
+    "id": "bbb212f3-c49d-4475-8bf2-ecda0b8b0797",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "It does look like that. What can we do to help?"
+      ]
+     },
+     "create_time": 1773874524.272125,
+     "end_turn": null,
+     "id": "bbb212f3-c49d-4475-8bf2-ecda0b8b0797",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "3f2bbc16-2599-4133-bff5-8c5a1e92c99a",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "f003f965-7618-4a83-a033-95475dde2ddc",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "8b0fb70c-0861-47f1-aff1-f0c38ca6a562"
+   },
+   "bbb2130c-6b88-4212-a7fe-3a7d676b15e6": {
+    "children": [
+     "bf7537b2-ca3a-43fb-ab8d-979fbf44f4db"
+    ],
+    "id": "bbb2130c-6b88-4212-a7fe-3a7d676b15e6",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Is it normal that this happens abruptly? Like one day many poops, next day none?"
+      ]
+     },
+     "create_time": 1776204407.903811,
+     "end_turn": null,
+     "id": "bbb2130c-6b88-4212-a7fe-3a7d676b15e6",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "29e6e786-f202-4adb-b9ac-3f27d488828a",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "153bf04c-1d42-40f0-ad45-794efb812273",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "eb12abff-8e3f-4273-95cb-f95c5756ec9c"
+   },
+   "bbb2133c-029c-488f-b8ff-fa17abfc5fb3": {
+    "children": [
+     "5114e94b-8621-4597-9b47-2d13578e922f"
+    ],
+    "id": "bbb2133c-029c-488f-b8ff-fa17abfc5fb3",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Ok. And eyes?"
+      ]
+     },
+     "create_time": 1775267541.564941,
+     "end_turn": null,
+     "id": "bbb2133c-029c-488f-b8ff-fa17abfc5fb3",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "b68b8410-8476-4247-ac8a-1947d85b1c8f",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "4de49e0b-692c-470e-a116-3354a83766e0",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "b1d95068-f642-426f-b5ca-219defe487bd"
+   },
+   "bbb21359-47eb-4336-be2f-0ac6ff2e821a": {
+    "children": [
+     "07d3faca-987d-4941-942f-52437d271d0f"
+    ],
+    "id": "bbb21359-47eb-4336-be2f-0ac6ff2e821a",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Will the Sniglar by Ikea hold that weight? Is is dangerous to place the tub on top of it?"
+      ]
+     },
+     "create_time": 1773573630.242375,
+     "end_turn": null,
+     "id": "bbb21359-47eb-4336-be2f-0ac6ff2e821a",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "9bf47107-3365-4396-8d88-6664811d095e",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "35c889bd-6c89-4127-b768-21adb25d0452",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "4d3b9ab5-f375-41e8-8492-46cedd4f6145"
+   },
+   "bbb21388-1a0c-4f4b-8403-0c2f7526ee04": {
+    "children": [
+     "7f7ed146-8816-4d73-9134-721adc434bed"
+    ],
+    "id": "bbb21388-1a0c-4f4b-8403-0c2f7526ee04",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Breastfed. Sometimes she is smooth, sometimes she does gulp or chokes. I hear swallowing. Feeds vary a lot, but she doesn't pull off upset, I don't think so. On 5, yes to all. Yes on 6. It seems to be early night, the worse. On 8, mostly the first. Still yellow and seedy, still many. I am burping all the time. I keep her about 10 min upright. My breasts feel fine now, they get fuller close to feeds and leak a bit, but seems within normal. I don't think I ate anything too different. But I was also gassy this past day, not sure why..."
+      ]
+     },
+     "create_time": 1773970360.464179,
+     "end_turn": null,
+     "id": "bbb21388-1a0c-4f4b-8403-0c2f7526ee04",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "47224930-7187-466b-9ba0-bfa1c34704d9",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "7b2e3e9e-4916-4a8e-b7da-8cfed91d895e",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "f53984c4-70a4-40bd-8e1d-e01beb83d4e7"
+   },
+   "bbb213c9-f670-4305-8d05-18b96fdb557e": {
+    "children": [
+     "8e4da5f9-9daf-4b0c-903b-1e84e8757562"
+    ],
+    "id": "bbb213c9-f670-4305-8d05-18b96fdb557e",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "How to treat cradle cap? She seems to have it on eyebrows and sides of the head. "
+      ]
+     },
+     "create_time": 1776916423.526654,
+     "end_turn": null,
+     "id": "bbb213c9-f670-4305-8d05-18b96fdb557e",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "1de24a7f-67ba-4658-b9c4-b5134fceae26",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "107232ae-96bd-41d8-9af3-a48450934f52",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "d283a869-34ff-462f-8e79-9d437ca9a2a4"
+   },
+   "bbb21409-a403-48d8-8f4b-57e103d887e7": {
+    "children": [
+     "b1dbddf4-d454-4e39-9bb6-b962a7b0a297"
+    ],
+    "id": "bbb21409-a403-48d8-8f4b-57e103d887e7",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Food grade mineral oil ok?"
+      ]
+     },
+     "create_time": 1776916942.417645,
+     "end_turn": null,
+     "id": "bbb21409-a403-48d8-8f4b-57e103d887e7",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "131aea26-91b5-4bf7-b9ce-2406cee64f94",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "e9bac587-7244-4d10-98cb-32817a5cac7e",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "3f8391ca-cf5a-483a-9de1-3019d792cba6"
+   },
+   "bbb214aa-d81c-4ae8-ae1a-2f1ac12e110d": {
+    "children": [
+     "c13fadf3-6bcf-4397-b846-1b9445874c1d"
+    ],
+    "id": "bbb214aa-d81c-4ae8-ae1a-2f1ac12e110d",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "I tried laid back sometimes, but she seemed really uncomfortable... Are you sure this is worth it?"
+      ]
+     },
+     "create_time": 1773970479.964149,
+     "end_turn": null,
+     "id": "bbb214aa-d81c-4ae8-ae1a-2f1ac12e110d",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "fe3dac2e-b71e-483a-9433-56c03d003e24",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "8f0f45d6-a4a4-42de-a81d-fd1f37ca08aa",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "7f7ed146-8816-4d73-9134-721adc434bed"
+   },
+   "bbb214e7-bc76-4d0a-8d8f-b58d04aa07e6": {
+    "children": [
+     "b1d95068-f642-426f-b5ca-219defe487bd"
+    ],
+    "id": "bbb214e7-bc76-4d0a-8d8f-b58d04aa07e6",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Ok, so shedding is for sure?"
+      ]
+     },
+     "create_time": 1775267504.526929,
+     "end_turn": null,
+     "id": "bbb214e7-bc76-4d0a-8d8f-b58d04aa07e6",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "92673fbb-10f6-9e0e-91c4-84e8c8e1cddc",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "1b0a5b59-0b4d-4851-85f0-b45de9bdb7de",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "9c989607-b199-43c7-a237-b5e9eadb1ed2"
+   },
+   "bbb2152a-dfc6-4a7b-95bb-21e947455dbb": {
+    "children": [
+     "c94ef283-7e2d-478d-a244-4a5c32748d40"
+    ],
+    "id": "bbb2152a-dfc6-4a7b-95bb-21e947455dbb",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Wait, how can I wipe milk and also apply milk?"
+      ]
+     },
+     "create_time": 1774968848.233164,
+     "end_turn": null,
+     "id": "bbb2152a-dfc6-4a7b-95bb-21e947455dbb",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "0f84f68a-2431-4bd0-911a-14df0e5fd1e0",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "fc9d1ea7-2181-4354-8492-046b2fc91036",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "3373e997-2341-417d-ac20-b6a3725e8b61"
+   },
+   "bbb21571-b684-45ae-913b-49f6d89e8cd5": {
+    "children": [
+     "6c804e1f-52b4-467d-bf25-34c0694f1c59"
+    ],
+    "id": "bbb21571-b684-45ae-913b-49f6d89e8cd5",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "I can't seem to win, even with a heat rash going on..."
+      ]
+     },
+     "create_time": 1775158136.92076,
+     "end_turn": null,
+     "id": "bbb21571-b684-45ae-913b-49f6d89e8cd5",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "59e33bf7-846e-475a-8dfc-f1f8de1ae82d",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "38ede4ea-e88c-41b3-b51d-055f2512c6ed",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "568b56f5-c5ac-4baa-a65f-ebb856c60b0d"
+   },
+   "bbb21580-f83b-4f64-9b78-67632b98e9e2": {
+    "children": [
+     "c422ba05-e6ed-4153-ab4f-8610ea95dc11"
+    ],
+    "id": "bbb21580-f83b-4f64-9b78-67632b98e9e2",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Baby always poops or pees right after bath. Logistics tricks to make it easier? Currently disposable pad on top of towel, set baby there."
+      ]
+     },
+     "create_time": 1774923924.389836,
+     "end_turn": null,
+     "id": "bbb21580-f83b-4f64-9b78-67632b98e9e2",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "7f11222f-bb16-4183-ba26-11924986d4e0",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "d5da2e75-f488-4a05-8823-b61f70806d18",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "d679985d-8531-4f36-bf1d-3ea1afee57b1"
+   },
+   "bbb215a8-b726-4bd4-a91e-6c41e9bf0641": {
+    "children": [
+     "56e1898e-6f02-4643-b6fd-3e8fab40c867"
+    ],
+    "id": "bbb215a8-b726-4bd4-a91e-6c41e9bf0641",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Let's please always optimize answers to be very concise and to the point"
+      ]
+     },
+     "create_time": 1773383091.355885,
+     "end_turn": null,
+     "id": "bbb215a8-b726-4bd4-a91e-6c41e9bf0641",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "d5b198b3-4223-4c75-8013-a7ab1c5fcc89",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "5c6c935b-e962-4364-9511-4cc77ca7853b",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "b8765604-b799-47cf-86e2-bd0d1ae74e06"
+   },
+   "bbb215aa-8a9c-464f-ad70-c3f53c0b292e": {
+    "children": [
+     "848abe58-15c0-4df8-9aae-318092dbc65a"
+    ],
+    "id": "bbb215aa-8a9c-464f-ad70-c3f53c0b292e",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Are there other, cheaper brands? Like Libero? Or is that more expensive?"
+      ]
+     },
+     "create_time": 1775532143.297701,
+     "end_turn": null,
+     "id": "bbb215aa-8a9c-464f-ad70-c3f53c0b292e",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "da85e2c9-e90b-494e-ae6d-9f0d7da2cf08",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "7bb49a48-fa92-4eb4-a421-42a56e9d9334",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "9307d463-ecf1-49c8-b5af-fe9403a6d20c"
+   },
+   "bbb215ef-c31b-4b0d-a4d0-d79b914741ed": {
+    "children": [
+     "d8b37926-2274-4e5d-abe5-e442df10df4c"
+    ],
+    "id": "bbb215ef-c31b-4b0d-a4d0-d79b914741ed",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "I have a size 2 pack of 38. How many size 2 can I buy? So I watch promos early."
+      ]
+     },
+     "create_time": 1775534010.73395,
+     "end_turn": null,
+     "id": "bbb215ef-c31b-4b0d-a4d0-d79b914741ed",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "4b7fd984-4fc5-448f-bf0f-f6e1c4e416e7",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "de4ac060-cf92-47a6-a6bb-db4ff4c3f6d5",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "5dbc32df-6496-4554-a2f3-4be7b6013404"
+   },
+   "bbb215fb-4aec-4bb5-bd74-3131b2c0c6a1": {
+    "children": [
+     "c1daace8-476f-400f-aa0e-0fa647b4009d"
+    ],
+    "id": "bbb215fb-4aec-4bb5-bd74-3131b2c0c6a1",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Ok. What is the way to use a blanket safely at night? I prefer the sleep sacks, but all the ones I have are too warm."
+      ]
+     },
+     "create_time": 1775158239.006612,
+     "end_turn": null,
+     "id": "bbb215fb-4aec-4bb5-bd74-3131b2c0c6a1",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "1a83644f-b21b-4263-a9c4-f639037b51b6",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "c9b635d2-4bb5-44c1-89d7-f5368cbade6c",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "6c804e1f-52b4-467d-bf25-34c0694f1c59"
+   },
+   "bbb21600-3fdb-43a4-a0d7-67062a0507d0": {
+    "children": [
+     "799ed915-3b96-4a9e-9b88-51b15f62bf7d"
+    ],
+    "id": "bbb21600-3fdb-43a4-a0d7-67062a0507d0",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "How will she show she is cold?"
+      ]
+     },
+     "create_time": 1775160386.924269,
+     "end_turn": null,
+     "id": "bbb21600-3fdb-43a4-a0d7-67062a0507d0",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "9868c570-2923-4230-ab4d-ad7200a27e28",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "6d5d6aff-b3dd-44a3-b21c-f68ef166eca4",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "5ca45b8d-fad7-4854-b31a-463457f60376"
+   },
+   "bbb21607-8079-4618-b0cf-a92391b538a1": {
+    "children": [
+     "9c0592a1-223a-43b8-a716-f6b1ad7cb310"
+    ],
+    "id": "bbb21607-8079-4618-b0cf-a92391b538a1",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "She's always in just one layer. But [PERSON_e197e8] keeps insisting on the AC and blankets... And sometimes she does seem cold with just the one layer... Is she really overheating? Or just sensitive skin?"
+      ]
+     },
+     "create_time": 1774906105.65784,
+     "end_turn": null,
+     "id": "bbb21607-8079-4618-b0cf-a92391b538a1",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "b34a058b-7d0f-4da7-9a1e-11f3b08f5292",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "b102dad6-43f5-442f-9119-2315f2e70343",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "c20999de-8c6c-4555-97cb-a1abfd4f37cf"
+   },
+   "bbb21633-6c39-4226-897f-97567f5a8aa7": {
+    "children": [
+     "37537e71-b4e4-4d1d-b002-adcae64cfd47"
+    ],
+    "id": "bbb21633-6c39-4226-897f-97567f5a8aa7",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "She will be 1 month in 3 days. Likely weights close to 4kg. I have a box of 38. Will 138 be too many?"
+      ]
+     },
+     "create_time": 1775532745.724723,
+     "end_turn": null,
+     "id": "bbb21633-6c39-4226-897f-97567f5a8aa7",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "3aa2ea34-4917-4b42-9840-d79caf9bc387",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "834ead8a-d50e-4ae5-9a63-5674aa83e28b",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "e42103a8-9173-4027-a49c-42af469d1b42"
+   },
+   "bbb21687-1d3b-4eb5-881a-a86f4b9c6026": {
+    "children": [
+     "50bb9b4c-9ea1-40f4-aa0f-e940520640a8"
+    ],
+    "id": "bbb21687-1d3b-4eb5-881a-a86f4b9c6026",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "About to give her the first bath at home. We've done it at the hospital and it went well. Remind me of the important stuff, dos and donts. "
+      ]
+     },
+     "create_time": 1773517567.70167,
+     "end_turn": null,
+     "id": "bbb21687-1d3b-4eb5-881a-a86f4b9c6026",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "610b6ecb-ae5e-4bc8-bde3-c1ce3df21218",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "81f883ee-f0a3-4bd7-8b3f-06d9e5f25eca",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "cfe61748-6d03-4b4c-a4ce-184d3fe71b13"
+   },
+   "bbb21698-9c1c-4db7-8e4b-5b366e51865e": {
+    "children": [
+     "06dc6b17-eaee-4650-9da2-bd439398de9f"
+    ],
+    "id": "bbb21698-9c1c-4db7-8e4b-5b366e51865e",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Is there a max window I should consider for night time?"
+      ]
+     },
+     "create_time": 1773972234.069565,
+     "end_turn": null,
+     "id": "bbb21698-9c1c-4db7-8e4b-5b366e51865e",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "26ffc0d0-543e-4a40-af80-3fb33b090881",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "fd5af72f-e579-4db7-bc68-69522b990bb4",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "120bd784-3cbb-4bce-a497-3ea77a24abde"
+   },
+   "bbb216aa-e6de-4a83-8e21-8b173950ad1d": {
+    "children": [
+     "114e3629-1942-40a4-94cf-45d9848b7b79"
+    ],
+    "id": "bbb216aa-e6de-4a83-8e21-8b173950ad1d",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "So diaper on top of pad? Placed in a diaper right away?"
+      ]
+     },
+     "create_time": 1774924070.066322,
+     "end_turn": null,
+     "id": "bbb216aa-e6de-4a83-8e21-8b173950ad1d",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "7a869f70-73df-4c61-8597-1702f80b8c4c",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "9756a75e-2689-4c4d-a376-615882da98b4",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "b382f3b8-b907-470a-a387-71fa2b7f3400"
+   },
+   "bbb21716-5cf5-42c3-b56f-950476c4e336": {
+    "children": [
+     "e5059144-af2f-4a36-a50f-1f6a8a035d44"
+    ],
+    "id": "bbb21716-5cf5-42c3-b56f-950476c4e336",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "What do you mean flexible? Not wake her for feeds? And what is that edge window?"
+      ]
+     },
+     "create_time": 1773971688.804661,
+     "end_turn": null,
+     "id": "bbb21716-5cf5-42c3-b56f-950476c4e336",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "b0ff0650-5bbf-4b1c-a3d4-087748908f4f",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "00adb26c-91fb-4018-b83b-22a8e9e42e51",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbc47010-2b37-4124-ba0b-f97073f1dc41"
+   },
+   "bbb21736-93a9-4a01-bbde-3cde7ffdeb99": {
+    "children": [
+     "1745d355-315d-4041-9412-fc5b3dafe4ec"
+    ],
+    "id": "bbb21736-93a9-4a01-bbde-3cde7ffdeb99",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Why is 2-4 the gas peak?"
+      ]
+     },
+     "create_time": 1773984604.516144,
+     "end_turn": null,
+     "id": "bbb21736-93a9-4a01-bbde-3cde7ffdeb99",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "9227b2e3-4c6e-47e2-ae8d-49f371858e94",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "43dbc7ae-1093-4cde-a3dc-5f74e8195dbb",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "7f637f10-6efd-41db-a8d8-1f29934aaa0e"
+   },
+   "bbb2174d-4849-4d05-9859-3f4044ed1aae": {
+    "children": [
+     "5c360cf8-3913-49a0-9335-4f278734bb62"
+    ],
+    "id": "bbb2174d-4849-4d05-9859-3f4044ed1aae",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Ok"
+      ]
+     },
+     "create_time": 1775532242.399968,
+     "end_turn": null,
+     "id": "bbb2174d-4849-4d05-9859-3f4044ed1aae",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "2cdea8a0-3775-4fee-b143-95f1bd791fd0",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "c8b61981-43c9-45ff-af4f-d81745a6ad90",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "a9d66c99-b259-433c-bf77-730b69cf7895"
+   },
+   "bbb21758-e3be-4be2-abcd-2990a1515cb0": {
+    "children": [
+     "e42103a8-9173-4027-a49c-42af469d1b42"
+    ],
+    "id": "bbb21758-e3be-4be2-abcd-2990a1515cb0",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "I'm seeing a box of 138 for 32 Eur. Dodot sensitive. Is that good?"
+      ]
+     },
+     "create_time": 1775532654.305138,
+     "end_turn": null,
+     "id": "bbb21758-e3be-4be2-abcd-2990a1515cb0",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "4cb78928-2d0c-45c2-92e2-862bfde06e8c",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "13ffe396-f2fb-42dd-97cf-cf666ab346f2",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "1721b424-61c7-41fa-9112-056de0809c35"
+   },
+   "bbb217ac-fce7-43c9-a68a-698f606c39c1": {
+    "children": [
+     "3e69a2ff-5184-4e8f-a005-170a0237851d"
+    ],
+    "id": "bbb217ac-fce7-43c9-a68a-698f606c39c1",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "How to wash off? Water and soap?"
+      ]
+     },
+     "create_time": 1776917002.758252,
+     "end_turn": null,
+     "id": "bbb217ac-fce7-43c9-a68a-698f606c39c1",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "2508c5c7-2f07-4c08-875d-ef1c13e15e96",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "350bbaab-bcb7-47dd-9584-9161999e50a4",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "b1dbddf4-d454-4e39-9bb6-b962a7b0a297"
+   },
+   "bbb217be-17e4-4c47-b6d4-357d67b34baa": {
+    "children": [
+     "b25643dd-53fd-49d8-9f8e-2fb37118ad20"
+    ],
+    "id": "bbb217be-17e4-4c47-b6d4-357d67b34baa",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "How does changing before feed saves me from doing it twice, if she poops during or after?"
+      ]
+     },
+     "create_time": 1773562777.743098,
+     "end_turn": null,
+     "id": "bbb217be-17e4-4c47-b6d4-357d67b34baa",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "f7ac7b55-cd0e-4f97-879a-d827d7920363",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "3132d318-df96-4811-b42b-9c71d191e3b7",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "952ee0d3-a539-45d2-a631-ca1156e16f0c"
+   },
+   "bbb217f5-9f29-4289-94db-6966ac4b5f7b": {
+    "children": [
+     "d679985d-8531-4f36-bf1d-3ea1afee57b1"
+    ],
+    "id": "bbb217f5-9f29-4289-94db-6966ac4b5f7b",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Blanket is light, cotton muslin. But in the bedroom she is using a warm sleeping bag... And AC is on. "
+      ]
+     },
+     "create_time": 1774906342.491016,
+     "end_turn": null,
+     "id": "bbb217f5-9f29-4289-94db-6966ac4b5f7b",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "ba5137f9-b410-44a8-b308-29b4889b1896",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "2350d5ab-45e2-490e-b144-1c65c1e69d25",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "9c0592a1-223a-43b8-a716-f6b1ad7cb310"
+   },
+   "bbb21827-ebe6-4179-a797-93c4ca9461cc": {
+    "children": [
+     "83e1b018-8ca5-479c-b5af-f2380e33f441"
+    ],
+    "id": "bbb21827-ebe6-4179-a797-93c4ca9461cc",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Vs colic "
+      ]
+     },
+     "create_time": 1775946881.375894,
+     "end_turn": null,
+     "id": "bbb21827-ebe6-4179-a797-93c4ca9461cc",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "12c11e4f-1543-4d03-88d5-0bf9e2394162",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "a2687101-9c3d-46be-b45c-f1bc29e812b5",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "b622ba50-8df4-4e88-931f-e83c9fa1a9fc"
+   },
+   "bbb21838-f661-453c-940c-b43b1cafe78a": {
+    "children": [
+     "3f8391ca-cf5a-483a-9de1-3019d792cba6"
+    ],
+    "id": "bbb21838-f661-453c-940c-b43b1cafe78a",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Yed"
+      ]
+     },
+     "create_time": 1776916660.394502,
+     "end_turn": null,
+     "id": "bbb21838-f661-453c-940c-b43b1cafe78a",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "f9b9bb61-dcfa-4985-bbae-9fc8241d4027",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "35ed321c-c4db-48f1-a238-e5ec9c90d255",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "d337434d-b722-411c-88a2-d30824334462"
+   },
+   "bbb218d4-da92-4c42-9fb6-ea356ee9b75d": {
+    "children": [
+     "00e4aa14-4853-4370-b32e-43f3a3797e78"
+    ],
+    "id": "bbb218d4-da92-4c42-9fb6-ea356ee9b75d",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "How to tell if bath is getting baby sleepy or active?"
+      ]
+     },
+     "create_time": 1776033768.737409,
+     "end_turn": null,
+     "id": "bbb218d4-da92-4c42-9fb6-ea356ee9b75d",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "1133c94a-6e4f-43f8-9ed5-b8546653133f",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "c68a6923-2821-4da8-ba48-8f9c4a3c0243",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "83e1b018-8ca5-479c-b5af-f2380e33f441"
+   },
+   "bbb218ed-3bdc-4b2b-ab21-6014d21fd873": {
+    "children": [
+     "4f1498a5-26d2-4d1e-a4f4-f987b82c1fbb"
+    ],
+    "id": "bbb218ed-3bdc-4b2b-ab21-6014d21fd873",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "I'm trying the Lidl ones. What price to expect for diapers and wipes?"
+      ]
+     },
+     "create_time": 1775534457.536022,
+     "end_turn": null,
+     "id": "bbb218ed-3bdc-4b2b-ab21-6014d21fd873",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "e2d38faf-19d3-4b72-b3c7-b1cd8dd7e6bf",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "ad060e34-afb5-4c8e-90b4-5dac9d5df405",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "1a9bae7a-0a63-44f4-9511-aa13cb59274f"
+   },
+   "bbb218ff-8813-45b1-bdcd-d5ede3848f80": {
+    "children": [
+     "b2d554aa-12c9-4b87-a14f-29d4e1aabdaf"
+    ],
+    "id": "bbb218ff-8813-45b1-bdcd-d5ede3848f80",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Baby has small red bumps on belly and chest. Dry patches too. Some red bumps coming and going on face too. Normal?"
+      ]
+     },
+     "create_time": 1774905572.529725,
+     "end_turn": null,
+     "id": "bbb218ff-8813-45b1-bdcd-d5ede3848f80",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "ba50d109-8dec-4da1-a925-fcd250e68ea8",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "607f26c1-e70e-4b18-b3d0-ebfbb4ec03b1",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "d2bb3cfc-de64-422f-b68d-abdbe8f72729"
+   },
+   "bbb2190e-26b2-401d-9673-dec7a4ce3316": {
+    "children": [
+     "06f23624-3e82-4e36-8aff-0d0e693e5e2e"
+    ],
+    "id": "bbb2190e-26b2-401d-9673-dec7a4ce3316",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "About heat rash, tell me more about it. I'm not sure what is causing it. We were using a sleeping bag that was probably too hot. We have stopped that now. How long until we see results? How to pinpoint what is causing it?"
+      ]
+     },
+     "create_time": 1775157717.833992,
+     "end_turn": null,
+     "id": "bbb2190e-26b2-401d-9673-dec7a4ce3316",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "5dc6ffb5-5585-4c32-935b-8212efb11d6b",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "af41349e-9b49-4496-8dd2-dd567ab31e07",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "c94ef283-7e2d-478d-a244-4a5c32748d40"
+   },
+   "bbb2192e-5ecc-4c33-869f-340b006a63f1": {
+    "children": [
+     "db6bc61e-63cb-4e59-817e-3a51b297e229"
+    ],
+    "id": "bbb2192e-5ecc-4c33-869f-340b006a63f1",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Advice on how to manage diaper changes with feeding. Baby feeds well, becomes extremely sleepy after. Hates diaper change and also gets gas. How do I time it? How long is it acceptable to stay in a dirty diaper to prioritize sleep?"
+      ]
+     },
+     "create_time": 1773562652.113167,
+     "end_turn": null,
+     "id": "bbb2192e-5ecc-4c33-869f-340b006a63f1",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "14ba5aa6-f8da-4a4d-a57e-4be929f54902",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "05eda216-3d04-49fa-8c23-14a461226acc",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "e936a8cb-2886-4efa-985b-fd8a2da01286"
+   },
+   "bbb2197a-a761-4ee4-b587-02b8ebc45331": {
+    "children": [
+     "c2828b39-d13b-4e66-8202-93936728a4ce"
+    ],
+    "id": "bbb2197a-a761-4ee4-b587-02b8ebc45331",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Screenshot ready table with brands and expected prices. Group brands as fitting, table as simple as possible."
+      ]
+     },
+     "create_time": 1775561027.874115,
+     "end_turn": null,
+     "id": "bbb2197a-a761-4ee4-b587-02b8ebc45331",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "830eb907-ebdf-4847-8295-befb0cd3a16c",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "cfed2bdc-6ceb-4bec-83df-8ac42ea4b51c",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "fa7260b1-81b8-4e3a-bb91-29d464766543"
+   },
+   "bbb21984-7e94-4ca1-b2ff-260a15c377a4": {
+    "children": [
+     "e936a8cb-2886-4efa-985b-fd8a2da01286"
+    ],
+    "id": "bbb21984-7e94-4ca1-b2ff-260a15c377a4",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Had to feed her now. How long do I need to wait?"
+      ]
+     },
+     "create_time": 1773519820.631902,
+     "end_turn": null,
+     "id": "bbb21984-7e94-4ca1-b2ff-260a15c377a4",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "10a2a315-e090-4635-a848-1212dab21932",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "99da23f2-2675-475c-82fd-89dbb0ef18b8",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "50bb9b4c-9ea1-40f4-aa0f-e940520640a8"
+   },
+   "bbb219ad-06c4-4736-9cd5-6b28c106073e": {
+    "children": [
+     "e10052b0-7f10-4d0f-8afe-6106b6496701"
+    ],
+    "id": "bbb219ad-06c4-4736-9cd5-6b28c106073e",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Can I use linimento for that? Or best pure olive oil?"
+      ]
+     },
+     "create_time": 1776916567.505609,
+     "end_turn": null,
+     "id": "bbb219ad-06c4-4736-9cd5-6b28c106073e",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "c01b8162-afe1-4ecb-90d9-0cde7ac023bc",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "08c37878-8eaf-4383-a2fd-61df743b38a7",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "25335b8a-c889-4c62-9ccc-526fcb270fc7"
+   },
+   "bbb219c4-d3af-41f9-84bd-aa463e957d8e": {
+    "children": [
+     "bbc47010-2b37-4124-ba0b-f97073f1dc41"
+    ],
+    "id": "bbb219c4-d3af-41f9-84bd-aa463e957d8e",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "I burp as you say, not more. Any other positions I could try? Do I maintain the feed windows? You told me to shorten, is that helping?"
+      ]
+     },
+     "create_time": 1773971495.61756,
+     "end_turn": null,
+     "id": "bbb219c4-d3af-41f9-84bd-aa463e957d8e",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "5ac974d8-eaec-44f6-8c6b-9a1fef4b0150",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "a3961bda-80b8-4781-a661-b141065be37d",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "c13fadf3-6bcf-4397-b846-1b9445874c1d"
+   },
+   "bbb219d4-9f72-4373-86f9-9f815a1482e0": {
+    "children": [
+     "13c52c5c-85ca-4c25-8f5c-c21c756d0ea7"
+    ],
+    "id": "bbb219d4-9f72-4373-86f9-9f815a1482e0",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "I've been feeding before. I don't think it would work to do it with her hungry..."
+      ]
+     },
+     "create_time": 1776034029.563734,
+     "end_turn": null,
+     "id": "bbb219d4-9f72-4373-86f9-9f815a1482e0",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "ca0e4376-6d32-4bc7-84d5-268ce263ae30",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "b307fcbb-e46e-4370-b78d-45a5eeed6591",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "4bce5530-25b8-477e-80c9-17dff4130516"
+   },
+   "bbb219e1-c14e-479b-bd0d-67bacba9be28": {
+    "children": [
+     "a0c77003-20b6-406c-a5a0-3a65af131a21"
+    ],
+    "id": "bbb219e1-c14e-479b-bd0d-67bacba9be28",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Dry lips in baby - normal? Peeling a bit now "
+      ]
+     },
+     "create_time": 1774135185.058388,
+     "end_turn": null,
+     "id": "bbb219e1-c14e-479b-bd0d-67bacba9be28",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "f5f7f47b-7e58-46c1-9c0e-45fa83a43b44",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "7bdeade1-16e4-4f89-a7e4-beb8b3df2964",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "5a5663a2-b229-4428-ba3b-01e5cbf82d4b"
+   },
+   "bbb219e9-8dd3-41ba-a90b-4031c9daff0e": {
+    "children": [
+     "a9d66c99-b259-433c-bf77-730b69cf7895"
+    ],
+    "id": "bbb219e9-8dd3-41ba-a90b-4031c9daff0e",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Ok "
+      ]
+     },
+     "create_time": 1775532189.704055,
+     "end_turn": null,
+     "id": "bbb219e9-8dd3-41ba-a90b-4031c9daff0e",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "88e8497e-6b68-42e9-a513-79a6b6df605f",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "4e3e1a4a-f83c-48ef-85c0-366b5bad76f9",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "51d05458-f8ed-448b-a04e-2cabe27c2556"
+   },
+   "bbb219ee-5f0f-4f20-960d-062ffa72d273": {
+    "children": [
+     "3b04f96b-74f6-4b72-9423-8f3cca47768f"
+    ],
+    "id": "bbb219ee-5f0f-4f20-960d-062ffa72d273",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Baby not pooping as much, but getting more only wet diapers. One month old. Was really gassy yesterday and today not pooping much. Seems uncomfortable. Normal? What to do?"
+      ]
+     },
+     "create_time": 1775946774.549658,
+     "end_turn": null,
+     "id": "bbb219ee-5f0f-4f20-960d-062ffa72d273",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "ca7348d2-42f3-4542-8101-cd069bb44656",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "9f3e3a6c-c335-4138-bb4c-2e86a81f00be",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "c2828b39-d13b-4e66-8202-93936728a4ce"
+   },
+   "bbb21a18-07cd-47e3-be87-0a8be76171e8": {
+    "children": [
+     "12fca265-47ab-4c9f-a6cb-a571659d4db2"
+    ],
+    "id": "bbb21a18-07cd-47e3-be87-0a8be76171e8",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Bath 2 or 3 times a week?"
+      ]
+     },
+     "create_time": 1774201925.165857,
+     "end_turn": null,
+     "id": "bbb21a18-07cd-47e3-be87-0a8be76171e8",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "b2d673a2-5ce5-4d06-b285-1f8f9a406a70",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "316ee266-b7b9-4c89-820b-77d959230e2f",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "a0c77003-20b6-406c-a5a0-3a65af131a21"
+   },
+   "bbb21a1b-f54a-4fc3-b954-f5bda2d71796": {
+    "children": [
+     "568b56f5-c5ac-4baa-a65f-ebb856c60b0d"
+    ],
+    "id": "bbb21a1b-f54a-4fc3-b954-f5bda2d71796",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Yesterday was the first night without the sleep sack. I would turn off the AC, but [PERSON_e197e8] keeps obsessing over her being cold... If she is napping on us during the day, no blanket is needed, right?"
+      ]
+     },
+     "create_time": 1775158037.62279,
+     "end_turn": null,
+     "id": "bbb21a1b-f54a-4fc3-b954-f5bda2d71796",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "7d56bda9-a950-4f56-94af-9ab03829a56d",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "6c78afcd-545f-424c-84af-602c4225705a",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "a386e1d0-7910-42b6-a602-c3b6bec1b4a9"
+   },
+   "bbb21a36-3ce2-4b1b-8043-0d6168e1b4bb": {
+    "children": [
+     "8502438b-ff29-40d7-8110-a9f18939007d"
+    ],
+    "id": "bbb21a36-3ce2-4b1b-8043-0d6168e1b4bb",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "I've been doing it sometime between 6 and 8 pm. Change to what time?"
+      ]
+     },
+     "create_time": 1776034099.75032,
+     "end_turn": null,
+     "id": "bbb21a36-3ce2-4b1b-8043-0d6168e1b4bb",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "c092b6b1-087e-4b73-a35e-d1eeabeea4d0",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "a623417d-f45d-4bd2-bb6a-1439473981db",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "13c52c5c-85ca-4c25-8f5c-c21c756d0ea7"
+   },
+   "bbb21a6a-e7fd-4321-8fd6-d2e4472c52b7": {
+    "children": [
+     "cfe61748-6d03-4b4c-a4ce-184d3fe71b13"
+    ],
+    "id": "bbb21a6a-e7fd-4321-8fd6-d2e4472c52b7",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Seedy diaper, sorry "
+      ]
+     },
+     "create_time": 1773454149.32792,
+     "end_turn": null,
+     "id": "bbb21a6a-e7fd-4321-8fd6-d2e4472c52b7",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "d92dc6ca-2406-4108-a04a-2c6cbb77454d",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "80b4e036-c81d-41da-95a1-07cb6079a52b",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "283aec83-b844-431f-a25b-99dae61c194f"
+   },
+   "bbb21a80-5c06-48c7-8653-7b4e30bb9250": {
+    "children": [
+     "120bd784-3cbb-4bce-a497-3ea77a24abde"
+    ],
+    "id": "bbb21a80-5c06-48c7-8653-7b4e30bb9250",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "The pediatrician said that at discharge from the hospital. She hasn't been seen by one since then. She has regained her birth weight after a week. And I can only assume she keeps gaining, looking at diapers. "
+      ]
+     },
+     "create_time": 1773972071.541691,
+     "end_turn": null,
+     "id": "bbb21a80-5c06-48c7-8653-7b4e30bb9250",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "482d9c04-d8e2-41af-9128-5f5259eed897",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "b8b4d63f-aee8-4478-9f8b-722a4c2b5630",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "0106ce30-fe2b-4d87-a800-8544dc871b25"
+   },
+   "bbb21add-bf10-4dff-8d8a-4b8342b52db5": {
+    "children": [
+     "e20ad6cc-141a-44c6-9deb-8ef8df1afdc0"
+    ],
+    "id": "bbb21add-bf10-4dff-8d8a-4b8342b52db5",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Her cramps are getting worse. Not sleeping at night between feeds. Help me troubleshoot. Ask questions to get the info you need to be helpful. "
+      ]
+     },
+     "create_time": 1773970035.170616,
+     "end_turn": null,
+     "id": "bbb21add-bf10-4dff-8d8a-4b8342b52db5",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "afa35376-c30c-47fb-aeca-d4eace5d2203",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "60d97475-6d20-4d90-8f20-940e859c8e48",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "80ed896c-05db-4a70-a1f4-bc677715f4fa"
+   },
+   "bbb21b14-4690-4c3f-be5c-5075285165e3": {
+    "children": [
+     "0106ce30-fe2b-4d87-a800-8544dc871b25"
+    ],
+    "id": "bbb21b14-4690-4c3f-be5c-5075285165e3",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Are you sure about not waking during night time? You've told me that's super important for supply. And the pediatrician did say that too. Why do it now? Am I not risking her weight gain?"
+      ]
+     },
+     "create_time": 1773971917.347706,
+     "end_turn": null,
+     "id": "bbb21b14-4690-4c3f-be5c-5075285165e3",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "ffb21f14-5ddc-4772-9e64-ed65cdd30e44",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "e7c9eb86-5427-4e03-8634-e8f5755867fb",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "e5059144-af2f-4a36-a50f-1f6a8a035d44"
+   },
+   "bbb21b3c-f102-46b1-8f3e-957e15c86bea": {
+    "children": [
+     "602b172b-2928-4339-9568-fc3a374e4438"
+    ],
+    "id": "bbb21b3c-f102-46b1-8f3e-957e15c86bea",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "But is it 2 or 3?"
+      ]
+     },
+     "create_time": 1774201974.114909,
+     "end_turn": null,
+     "id": "bbb21b3c-f102-46b1-8f3e-957e15c86bea",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "6a7eaf34-fb8a-46ab-8f0e-6e6277c19158",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "6a992584-b418-467d-8c83-57f7880a5b05",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "b62974bf-548a-4c6b-aac3-ae6ed76cff27"
+   },
+   "bbb21b4f-215e-42ac-acb6-3bc3511ce7db": {
+    "children": [
+     "3373e997-2341-417d-ac20-b6a3725e8b61"
+    ],
+    "id": "bbb21b4f-215e-42ac-acb6-3bc3511ce7db",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Her lips keep peeling. Is it normal?"
+      ]
+     },
+     "create_time": 1774968795.017622,
+     "end_turn": null,
+     "id": "bbb21b4f-215e-42ac-acb6-3bc3511ce7db",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "3741db9f-541f-4988-85b5-730fa6d20c53",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "90f9e849-a65b-4ddf-8839-98f395e9ee7d",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "114e3629-1942-40a4-94cf-45d9848b7b79"
+   },
+   "bbb21b50-d9ff-430a-99b0-cccdf534ae1f": {
+    "children": [
+     "7943a1bb-325d-4de8-809b-1ad760a4a130"
+    ],
+    "id": "bbb21b50-d9ff-430a-99b0-cccdf534ae1f",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "This is her feeding"
+      ]
+     },
+     "create_time": 1773984358.128046,
+     "end_turn": null,
+     "id": "bbb21b50-d9ff-430a-99b0-cccdf534ae1f",
+     "metadata": {
+      "attachments": [
+       {
+        "id": "file-VxVUrqSxEfyBWaRGXK5QzW",
+        "mime_type": "audio/mpeg",
+        "name": "20 Mar at 04-59.m4a",
+        "size": 393520
+       },
+       {
+        "id": "file-9ngibEs5g15yxT14vjdCVv",
+        "mime_type": "audio/mpeg",
+        "name": "20 Mar at 05-12.m4a",
+        "size": 374941
+       }
+      ],
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "66c66a49-8bfd-4b53-bd20-b68bafaca435",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "cf06097e-69b4-4fd9-abc3-b776e1e19bc7",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "ce0a3497-f65d-41c1-9a71-d18ff3e174f9"
+   },
+   "bbb21b8f-bd7a-409e-b098-efa4b8685d59": {
+    "children": [
+     "d337434d-b722-411c-88a2-d30824334462"
+    ],
+    "id": "bbb21b8f-bd7a-409e-b098-efa4b8685d59",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "What is mineral oil?"
+      ]
+     },
+     "create_time": 1776916625.535769,
+     "end_turn": null,
+     "id": "bbb21b8f-bd7a-409e-b098-efa4b8685d59",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "00969c3e-5e18-468a-92bd-984f5c2049ba",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "58fad89a-0e81-4f5b-a4b4-ddb28eb77d72",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "e10052b0-7f10-4d0f-8afe-6106b6496701"
+   },
+   "bbb21bf1-d213-4dbc-ab9f-a694894aff3c": {
+    "children": [
+     "36bca96a-72f4-4e26-b35f-efdeec61efe3"
+    ],
+    "id": "bbb21bf1-d213-4dbc-ab9f-a694894aff3c",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "What does usually happen with baby hair? Mine was born with a full head of strong hair. It was dark, it's now becoming more brown. What to expect?"
+      ]
+     },
+     "create_time": 1775267367.46421,
+     "end_turn": null,
+     "id": "bbb21bf1-d213-4dbc-ab9f-a694894aff3c",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "2158adcf-9ad1-43bb-afe0-ad761bbf0a59",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "f9f7c94b-85a1-4771-baa3-d8b1e1c3a52f",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "799ed915-3b96-4a9e-9b88-51b15f62bf7d"
+   },
+   "bbb21c90-27df-475f-b4d0-e901378c5e56": {
+    "children": [
+     "4d3b9ab5-f375-41e8-8492-46cedd4f6145"
+    ],
+    "id": "bbb21c90-27df-475f-b4d0-e901378c5e56",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "How much will the tub weight with that amount of water?"
+      ]
+     },
+     "create_time": 1773573570.551709,
+     "end_turn": null,
+     "id": "bbb21c90-27df-475f-b4d0-e901378c5e56",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "ca2ee5fe-1be1-43cc-a5c8-ce2b74b002ab",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "0f7f8ea4-5f70-48cc-9028-38820f123f7c",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "c109e7db-a365-4d6a-8998-4590b3e73237"
+   },
+   "bbb21cb5-63be-413a-aedc-9b3e28d51030": {
+    "children": [
+     "850947d4-d6ac-4065-8370-f91e8a9714b1"
+    ],
+    "id": "bbb21cb5-63be-413a-aedc-9b3e28d51030",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "What about actual morning? Will those 2 hours really make a difference?"
+      ]
+     },
+     "create_time": 1776034164.639846,
+     "end_turn": null,
+     "id": "bbb21cb5-63be-413a-aedc-9b3e28d51030",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "8bb9c8d0-9cd7-4aed-9ee1-2d3f7c802265",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "1d4c556a-4575-4cc7-9139-e222ab060887",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "c7e2e582-f543-4bfe-baa0-239d389a20b0"
+   },
+   "bbb21cc6-63e7-41cb-8e34-2e4246a63fa7": {
+    "children": [
+     "406ac8e3-8191-4e9d-b617-0da118b189f8"
+    ],
+    "id": "bbb21cc6-63e7-41cb-8e34-2e4246a63fa7",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "What can we do to help? Or not to do?"
+      ]
+     },
+     "create_time": 1774128346.467638,
+     "end_turn": null,
+     "id": "bbb21cc6-63e7-41cb-8e34-2e4246a63fa7",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "9620edfd-1053-4407-bf92-7114f9c4a642",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "cb3f30e5-7f88-496a-9508-3642c0976414",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "f70ac69d-d94c-43df-a2dc-e3ccb9fa6054"
+   },
+   "bbb21d14-c26b-48bc-a9c8-849409b38a42": {
+    "children": [
+     "7f637f10-6efd-41db-a8d8-1f29934aaa0e"
+    ],
+    "id": "bbb21d14-c26b-48bc-a9c8-849409b38a42",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "I think she is in control most of the times. Only sometimes, at the beginning, she seems a bit overwhelmed, but gets it under control. Now, she kind of moans and does other sounds."
+      ]
+     },
+     "create_time": 1773984541.826168,
+     "end_turn": null,
+     "id": "bbb21d14-c26b-48bc-a9c8-849409b38a42",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "9a2f5656-bb12-4f21-9003-5952aebd888e",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "9ee6677e-f8cb-4e53-96c7-6437f54b33bc",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "353e24b8-d1b9-4690-9893-4e99c0f018d8"
+   },
+   "bbb21d77-3cc7-4995-a568-a7d2f6550089": {
+    "children": [
+     "ad63d4fc-5b7a-45ae-8d27-a1c3772f8148"
+    ],
+    "id": "bbb21d77-3cc7-4995-a568-a7d2f6550089",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "She is being weighted on Monday. What are the risks of doing this change?"
+      ]
+     },
+     "create_time": 1773972755.565933,
+     "end_turn": null,
+     "id": "bbb21d77-3cc7-4995-a568-a7d2f6550089",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "03dd6697-4f19-4992-80ee-324fd41d633f",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "3b2ed97a-29c8-498f-9709-3540a256d0bd",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "06dc6b17-eaee-4650-9da2-bd439398de9f"
+   },
+   "bbb21de9-bb4c-4391-add4-596ac3d31a8d": {
+    "children": [
+     "353e24b8-d1b9-4690-9893-4e99c0f018d8"
+    ],
+    "id": "bbb21de9-bb4c-4391-add4-596ac3d31a8d",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Explain gulping "
+      ]
+     },
+     "create_time": 1773984421.978694,
+     "end_turn": null,
+     "id": "bbb21de9-bb4c-4391-add4-596ac3d31a8d",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "f7a6ee21-5691-4b37-8ba8-a8e8f8b48c9b",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "4e369a6a-4147-472d-baf6-8dba4c7025c6",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "1e6f45bf-f6e6-4379-8a6e-de51258f7d05"
+   },
+   "bbb21dfe-2557-48b6-a75e-ad01c71a796f": {
+    "children": [
+     "35d761f6-611a-4193-8db0-0e78d15d54b9"
+    ],
+    "id": "bbb21dfe-2557-48b6-a75e-ad01c71a796f",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Explain speedy diaper "
+      ]
+     },
+     "create_time": 1773454116.881776,
+     "end_turn": null,
+     "id": "bbb21dfe-2557-48b6-a75e-ad01c71a796f",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "bd769bc4-435a-4003-bd93-ea7b96f1a7da",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "2ceba3bf-8685-4333-bd4f-9081a31fee5d",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "757a104d-a4ef-4b9b-b47c-b3a475f863e1"
+   },
+   "bbb21dfe-fb71-4bcd-ad06-c8e79c14dbbf": {
+    "children": [
+     "2c1c5dc5-c464-4b7c-9976-ba77dbc8a536"
+    ],
+    "id": "bbb21dfe-fb71-4bcd-ad06-c8e79c14dbbf",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "I think it is getting her active..."
+      ]
+     },
+     "create_time": 1776033850.239221,
+     "end_turn": null,
+     "id": "bbb21dfe-fb71-4bcd-ad06-c8e79c14dbbf",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "a2471856-e893-4565-943e-c979a20aac14",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "43062dab-3b23-48f8-b7f9-f2ad70c37531",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "dcde7297-08fd-452c-9070-334588eafe9f"
+   },
+   "bbb21ec1-b57d-4f39-840b-e3831461054d": {
+    "children": [
+     "5ca45b8d-fad7-4854-b31a-463457f60376"
+    ],
+    "id": "bbb21ec1-b57d-4f39-840b-e3831461054d",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "I want to make sure the sleep sack is the cause before buying more stuff "
+      ]
+     },
+     "create_time": 1775158332.536752,
+     "end_turn": null,
+     "id": "bbb21ec1-b57d-4f39-840b-e3831461054d",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "b842749a-f297-467e-804d-f3e762637342",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "8f45711c-31b8-48b2-8278-0bb078491545",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "c1daace8-476f-400f-aa0e-0fa647b4009d"
+   },
+   "bbb21eca-173f-478c-82f2-3d14df8bec8d": {
+    "children": [
+     "be0c2bf5-10ea-4456-976c-f2e8c2313b7a"
+    ],
+    "id": "bbb21eca-173f-478c-82f2-3d14df8bec8d",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Cleanser?"
+      ]
+     },
+     "create_time": 1776917060.914795,
+     "end_turn": null,
+     "id": "bbb21eca-173f-478c-82f2-3d14df8bec8d",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "4595c3be-8f49-45af-9a1a-ccb2b40db697",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "28cc2776-dff8-4d0d-a0d6-ec73d513c7d8",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "3e69a2ff-5184-4e8f-a005-170a0237851d"
+   },
+   "bbb21ee7-d2a1-43ac-94fd-2f309377f398": {
+    "children": [
+     "1a9bae7a-0a63-44f4-9511-aa13cb59274f"
+    ],
+    "id": "bbb21ee7-d2a1-43ac-94fd-2f309377f398",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Remind me when to test non branded diapers?"
+      ]
+     },
+     "create_time": 1775534300.077821,
+     "end_turn": null,
+     "id": "bbb21ee7-d2a1-43ac-94fd-2f309377f398",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "63e6cb06-b99b-4612-9d3d-ca422655dffb",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "d1ab0435-9334-45df-9f57-73773c3ac583",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "d1889b85-e367-4d49-adc0-91bd9a226bcf"
+   },
+   "bbb21f00-5a35-4379-9317-06e97c41cc8b": {
+    "children": [
+     "7ed36661-b7cf-44d7-b0d8-673e892cada5"
+    ],
+    "id": "bbb21f00-5a35-4379-9317-06e97c41cc8b",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "For how long do diaper sizes usually last? She had been at 0 so dark."
+      ]
+     },
+     "create_time": 1774590832.191238,
+     "end_turn": null,
+     "id": "bbb21f00-5a35-4379-9317-06e97c41cc8b",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "6cdf7ddb-3839-4794-8fd8-75884f89d50a",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "fd62f6a4-8c9a-4a8e-8a09-6b286d4f84b9",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "6eabcc63-5e4d-43d2-b26a-0d1eab253cf0"
+   },
+   "bbb21f18-ef33-4b48-a891-893403060184": {
+    "children": [
+     "088b4d7f-3ec3-4299-b814-98c87887f376"
+    ],
+    "id": "bbb21f18-ef33-4b48-a891-893403060184",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Baby hates changing diapers. Cries the whole time. Normal?"
+      ]
+     },
+     "create_time": 1773368637.751797,
+     "end_turn": null,
+     "id": "bbb21f18-ef33-4b48-a891-893403060184",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "9e2555c8-f1ad-48de-8adc-a4492e72ef3f",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "a8bc594e-3060-4d56-b665-d43c50acb700",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "348f99d3-7e24-4f00-a003-2ac9d4e0ceb5"
+   },
+   "bbb21f74-ddb1-41d4-a9ac-79127fdfd0be": {
+    "children": [
+     "fda7cb5c-6d28-4562-8ea5-f36e002743e6"
+    ],
+    "id": "bbb21f74-ddb1-41d4-a9ac-79127fdfd0be",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "I think she has conjunctivitis... Normal? What can I do?"
+      ]
+     },
+     "create_time": 1775487499.44224,
+     "end_turn": null,
+     "id": "bbb21f74-ddb1-41d4-a9ac-79127fdfd0be",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": false,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "824b3c0c-2753-4a2b-ad82-5109161263b1",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "9cd645b8-7e30-4d46-8292-5374089275ef",
+      "voice_mode_message": false,
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "5114e94b-8621-4597-9b47-2d13578e922f"
+   },
+   "bbb21fbd-7b8c-4d18-b0e5-8c55bd223fab": {
+    "children": [
+     "5e5536c2-02a4-4cce-a5c0-4fe8cb95ee08"
+    ],
+    "id": "bbb21fbd-7b8c-4d18-b0e5-8c55bd223fab",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "user"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Baby has a rash in a small spot in her face. What can I do to help?"
+      ]
+     },
+     "create_time": 1773765954.466454,
+     "end_turn": null,
+     "id": "bbb21fbd-7b8c-4d18-b0e5-8c55bd223fab",
+     "metadata": {
+      "can_save": false,
+      "content_references": [],
+      "dictation": true,
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "image_gen_async": false,
+      "image_results": [],
+      "is_visually_hidden_from_conversation": false,
+      "message_source": null,
+      "real_time_audio_has_video": false,
+      "request_id": "f07df930-6fec-4b9f-8912-f71f6152663d",
+      "resolved_model_slug": "gpt-5-3",
+      "search_queries": [],
+      "search_result_groups": [],
+      "trigger_async_ux": false,
+      "turn_exchange_id": "75a49c9c-d153-4ff2-aa56-7cc640c95c66",
+      "writing_blocks": {}
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "97fe31eb-22bd-4ff2-92aa-906d166115e7"
+   },
+   "bbc47010-2b37-4124-ba0b-f97073f1dc41": {
+    "children": [
+     "bbb21716-5cf5-42c3-b56f-950476c4e336"
+    ],
+    "id": "bbc47010-2b37-4124-ba0b-f97073f1dc41",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "You\u2019re doing a lot right. Let\u2019s fine-tune, not overhaul.\n\n---\n\n## Feeding position (alternatives to laid-back)\n\nSince laid-back didn\u2019t work well, try:\n\n### **1. Upright / koala hold (best for your case)**\n- Baby more **vertical**, straddling your leg  \n- Head higher than tummy  \n- Helps milk flow slower + less air\n\n### **2. Cross-cradle but angled**\n- Keep her body slightly **inclined**, not flat  \n- Head higher than hips\n\n\ud83d\udc49 Goal: **gravity helps you**, but baby still comfortable\n\n---\n\n## Burping positions (rotate, don\u2019t force one)\n\nTry 2\u20133, see what works:\n\n- **Over shoulder (classic)** \u2192 good for big burps  \n- **Sitting upright on your lap** (support chin) \u2192 great for control  \n- **Face-down across your forearm (\u201ctiger in the tree\u201d)** \u2192 excellent for gas relief\n\n---\n\n## Feed timing (important question)\n\nYou asked if shortening helps.\n\n### My take for your situation:\n\ud83d\udc49 **Don\u2019t force strict timing right now**\n\nInstead:\n- Follow **cues + allow cluster feeding**, especially evening  \n- If she wants to feed again soon \u2192 let her\n\nWhy:\n- Smaller, more frequent feeds = **less overload \u2192 less gas pressure**\n\nBUT:\n\n### One tweak that *does* help\nIf she\u2019s clearly uncomfortable:\n- Don\u2019t immediately re-feed as the first fix  \n- Try: upright + burp + small movement first  \n- Then feed if still hungry\n\n---\n\n## High-impact combo for nights\n\nBefore the rough window:\n1. Diaper  \n2. 1\u20132 min bicycle legs  \n3. Feed (upright position)  \n4. Burp  \n5. **Hold upright 20 min**\n\nThis is your best shot at longer sleep stretches.\n\n---\n\n## Quick reality check\nYou\u2019re not missing some magic position.\n\nAt this stage:\n- **Position = marginal gains**\n- **Time + gut maturity = real fix**\n\n---\n\n## Bottom line\n- Try **upright/koala hold** \u2192 best alternative for you  \n- Keep feeds **flexible**, not strict intervals  \n- Prioritize **upright after feeds** over everything else  \n\nIf you want, next step we can check whether this is still \u201cnormal gas\u201d vs early colic pattern \u2014 you\u2019re right on the edge of that window."
+      ]
+     },
+     "create_time": 1773971495.751017,
+     "end_turn": true,
+     "id": "bbc47010-2b37-4124-ba0b-f97073f1dc41",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb219c4-d3af-41f9-84bd-aa463e957d8e",
+      "request_id": "5ac974d8-eaec-44f6-8c6b-9a1fef4b0150",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "a3961bda-80b8-4781-a661-b141065be37d"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb219c4-d3af-41f9-84bd-aa463e957d8e"
+   },
+   "bc4dc43f-5094-440a-ad9a-d240f01b0c68": {
+    "children": [
+     "1e6f45bf-f6e6-4379-8a6e-de51258f7d05"
+    ],
+    "id": "bc4dc43f-5094-440a-ad9a-d240f01b0c68",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773984358.4366124,
+     "end_turn": true,
+     "id": "bc4dc43f-5094-440a-ad9a-d240f01b0c68",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "7943a1bb-325d-4de8-809b-1ad760a4a130",
+      "rebase_developer_message": true,
+      "request_id": "66c66a49-8bfd-4b53-bd20-b68bafaca435",
+      "turn_exchange_id": "cf06097e-69b4-4fd9-abc3-b776e1e19bc7"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "7943a1bb-325d-4de8-809b-1ad760a4a130"
+   },
+   "bd83ec0a-7d49-4f44-856a-d0f54515bb4d": {
+    "children": [
+     "5a5663a2-b229-4428-ba3b-01e5cbf82d4b"
+    ],
+    "id": "bd83ec0a-7d49-4f44-856a-d0f54515bb4d",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1774128346.95325,
+     "end_turn": null,
+     "id": "bd83ec0a-7d49-4f44-856a-d0f54515bb4d",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "406ac8e3-8191-4e9d-b617-0da118b189f8",
+      "request_id": "9620edfd-1053-4407-bf92-7114f9c4a642",
+      "search_result_groups": [],
+      "turn_exchange_id": "cb3f30e5-7f88-496a-9508-3642c0976414"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "406ac8e3-8191-4e9d-b617-0da118b189f8"
+   },
+   "be0c2bf5-10ea-4456-976c-f2e8c2313b7a": {
+    "children": [
+     "bbb212ef-1bb0-4d38-8804-4d950cfd073a"
+    ],
+    "id": "be0c2bf5-10ea-4456-976c-f2e8c2313b7a",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "By \u201ccleanser\u201d I just mean **very mild soap** \u2014 nothing fancy.\n\n## For your baby, use:\n\ud83d\udc49 **Her regular baby wash/shampoo**\n\nExamples:\n- \ue200entity\ue202[\"brand\",\"Mustela\"]\ue201 baby wash  \n- \ue200entity\ue202[\"brand\",\"Uriage B\u00e9b\u00e9\"]\ue201  \n- \ue200entity\ue202[\"brand\",\"Bioderma ABCDerm\"]\ue201  \n\n---\n\n## For eyebrows specifically\n- Put a **tiny drop** on a soft cloth  \n- Add a bit of warm water  \n- Gently wipe\n\n\ud83d\udc49 That\u2019s it \u2014 no separate product needed\n\n---\n\n## What to avoid\n- Adult face cleansers  \n- Anything with perfume or actives  \n- Scrubbing\n\n---\n\n## Bottom line\n\ud83d\udc49 \u201cCleanser\u201d = **your normal gentle baby wash**  \n\ud83d\udc49 You already have what you need\n\n---\n\nNo need to overcomplicate \u2014 this is a simple job."
+      ]
+     },
+     "create_time": 1776917061.228021,
+     "end_turn": true,
+     "id": "be0c2bf5-10ea-4456-976c-f2e8c2313b7a",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [
+       {
+        "alt": "Mustela",
+        "category": "brand",
+        "end_idx": 163,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Mustela\"]\ue201",
+        "metadata": null,
+        "name": "Mustela",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Mustela",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 135,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Uriage B\u00e9b\u00e9",
+        "category": "brand",
+        "end_idx": 210,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Uriage B\u00e9b\u00e9\"]\ue201",
+        "metadata": null,
+        "name": "Uriage B\u00e9b\u00e9",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Uriage B\u00e9b\u00e9",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 178,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Bioderma ABCDerm",
+        "category": "brand",
+        "end_idx": 252,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Bioderma ABCDerm\"]\ue201",
+        "metadata": null,
+        "name": "Bioderma ABCDerm",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Bioderma ABCDerm",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 215,
+        "status": "done",
+        "type": "entity"
+       }
+      ],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21eca-173f-478c-82f2-3d14df8bec8d",
+      "request_id": "4595c3be-8f49-45af-9a1a-ccb2b40db697",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "28cc2776-dff8-4d0d-a0d6-ec73d513c7d8"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21eca-173f-478c-82f2-3d14df8bec8d"
+   },
+   "bf161984-b8f4-445d-865e-cdbca130f8bc": {
+    "children": [
+     "408b899b-0ee5-4e9e-a28a-5dd232258c66"
+    ],
+    "id": "bf161984-b8f4-445d-865e-cdbca130f8bc",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773874309.493094,
+     "end_turn": true,
+     "id": "bf161984-b8f4-445d-865e-cdbca130f8bc",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb2103c-57a2-47c0-962b-33aad468a507",
+      "rebase_developer_message": true,
+      "request_id": "9b16de13-1a9e-439c-93c0-f85df8c0b577",
+      "turn_exchange_id": "55cdfc5c-299c-496e-8680-a797b059731e"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb2103c-57a2-47c0-962b-33aad468a507"
+   },
+   "bf7537b2-ca3a-43fb-ab8d-979fbf44f4db": {
+    "children": [
+     "d283a869-34ff-462f-8e79-9d437ca9a2a4"
+    ],
+    "id": "bf7537b2-ca3a-43fb-ab8d-979fbf44f4db",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1776204408.1098282,
+     "end_turn": true,
+     "id": "bf7537b2-ca3a-43fb-ab8d-979fbf44f4db",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb2130c-6b88-4212-a7fe-3a7d676b15e6",
+      "rebase_developer_message": true,
+      "request_id": "29e6e786-f202-4adb-b9ac-3f27d488828a",
+      "turn_exchange_id": "153bf04c-1d42-40f0-ad45-794efb812273"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb2130c-6b88-4212-a7fe-3a7d676b15e6"
+   },
+   "c0738ab9-b4c3-4b37-895c-9981ea514ba6": {
+    "children": [
+     "e306cc92-6aca-4dab-bf7f-77e02a4f9b2b"
+    ],
+    "id": "c0738ab9-b4c3-4b37-895c-9981ea514ba6",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1776916423.7767053,
+     "end_turn": true,
+     "id": "c0738ab9-b4c3-4b37-895c-9981ea514ba6",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "8e4da5f9-9daf-4b0c-903b-1e84e8757562",
+      "rebase_developer_message": true,
+      "request_id": "1de24a7f-67ba-4658-b9c4-b5134fceae26",
+      "turn_exchange_id": "107232ae-96bd-41d8-9af3-a48450934f52"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "8e4da5f9-9daf-4b0c-903b-1e84e8757562"
+   },
+   "c109e7db-a365-4d6a-8998-4590b3e73237": {
+    "children": [
+     "bbb21c90-27df-475f-b4d0-e901378c5e56"
+    ],
+    "id": "c109e7db-a365-4d6a-8998-4590b3e73237",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Goal: **don\u2019t carry a full tub.** That\u2019s the real hazard.\n\nBest simple setup:\n\n**1. Put the empty tub on the changing station.**  \nLeave it there.\n\n**2. Bring water to the tub, not the tub to the water.**  \nFill a **jug/pitcher** in the bathroom and pour it into the tub.  \nTwo or three trips does it.\n\n**3. Mix temperature there.**  \nAdd a bit of hot water until it feels **body-warm (~37 \u00b0C)**.\n\n**About the kettle idea:**  \nWorks **only if you mix well first**. Never pour very hot water when baby is already inside. Hot spots happen fast.\n\n**Even easier option:**  \n- Bathroom jug: warm water  \n- Add a little **kettle water** to reach temperature  \n- Stir well before baby goes in\n\n**Water depth:**  \nAbout **5\u20138 cm**. Newborn baths need very little water.\n\n**Pro trick:**  \nLay a **warm wet washcloth over her belly/chest** during the bath so she stays warm even with shallow water.\n\nSo the practical workflow:\n1. Tub already on changing table  \n2. Add shallow warm water with a jug  \n3. Adjust temp (kettle if needed)  \n4. Baby in \u2192 quick bath \u2192 towel right next to you\n\nThe elegant engineering principle here: **move small volumes of water, not large containers.** Your back will thank you, and the baby logistics become much smoother."
+      ]
+     },
+     "create_time": 1773573227.674941,
+     "end_turn": true,
+     "id": "c109e7db-a365-4d6a-8998-4590b3e73237",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21176-4b36-4f12-ac91-ee73ed9bd071",
+      "request_id": "bdeebc20-b798-4a8a-9c9f-8551cd069a8b",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "fa74fe7e-dbad-43cf-acba-24684899ab30"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21176-4b36-4f12-ac91-ee73ed9bd071"
+   },
+   "c13fadf3-6bcf-4397-b846-1b9445874c1d": {
+    "children": [
+     "bbb219c4-d3af-41f9-84bd-aa463e957d8e"
+    ],
+    "id": "c13fadf3-6bcf-4397-b846-1b9445874c1d",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Fair question \u2014 no, it\u2019s **not universally worth it**.\n\nLaid-back helps **only if fast flow is the problem**. Your baby *might* have that sometimes, but not clearly severe.\n\nIf she looked uncomfortable \u2192 don\u2019t force it.\n\n---\n\n## Quick way to decide (no guesswork)\n\nLaid-back is worth it **only if you consistently see:**\n- choking/gulping a lot  \n- pulling off coughing  \n- clicking + leaking milk  \n- lots of gas right after feeds\n\nYou said it happens **sometimes**, not always \u2192 so this is probably **not your main lever**.\n\n---\n\n## What matters more for you (based on your pattern)\n\n### 1. Upright time \u2192 increase (this is your biggest win)\nGo from **10 \u2192 20 min** after feeds at night.\n\nThat \u201cfalls asleep then wakes in pain\u201d = classic gas building after putting down too soon.\n\n---\n\n### 2. Don\u2019t over-burp\n\u201cBurping all the time\u201d can actually:\n- interrupt feeds  \n- make her swallow more air\n\nDo:\n- **1 pause mid-feed**\n- **1 solid burp after**\n\nThat\u2019s it.\n\n---\n\n### 3. Accept the evening chaos (but contain it)\nEarly night worsening = **biological**, not something you caused.\n\nWhat helps:\n- cluster feeding is fine  \n- keep stimulation low  \n- hold her more upright/contact\n\n---\n\n### 4. Pre-load relief before the bad window\nBefore that early night stretch:\n- diaper  \n- a bit of **bicycle legs + massage**  \n- then feed\n\nYou\u2019re basically \u201cventing the system\u201d before sleep.\n\n---\n\n## My honest take\nThis doesn\u2019t scream \u201cfix the feeding position.\u201d  \nIt screams **normal gas peak + slightly short upright window**.\n\n---\n\n## Bottom line\n- Skip laid-back if she hates it  \n- Double down on **upright after feeds**  \n- Simplify burping  \n- Ride the phase (annoying but temporary)\n\n---\n\nIf in a couple of days she\u2019s still not settling at all, we can fine-tune further \u2014 but right now you\u2019re very much in **\u201cthis sucks but is normal\u201d territory**, not \u201cyou\u2019re doing something wrong.\u201d"
+      ]
+     },
+     "create_time": 1773970480.093423,
+     "end_turn": true,
+     "id": "c13fadf3-6bcf-4397-b846-1b9445874c1d",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb214aa-d81c-4ae8-ae1a-2f1ac12e110d",
+      "request_id": "fe3dac2e-b71e-483a-9433-56c03d003e24",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "8f0f45d6-a4a4-42de-a81d-fd1f37ca08aa"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb214aa-d81c-4ae8-ae1a-2f1ac12e110d"
+   },
+   "c1daace8-476f-400f-aa0e-0fa647b4009d": {
+    "children": [
+     "bbb21ec1-b57d-4f39-840b-e3831461054d"
+    ],
+    "id": "c1daace8-476f-400f-aa0e-0fa647b4009d",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "You\u2019re right to be cautious \u2014 **blankets at this age need strict rules**.\n\n## Safest way to use a blanket (newborn)\n\n\ud83d\udc49 Only if you follow all of these:\n\n**1. Feet-to-foot position**\n- Baby\u2019s **feet at bottom of crib**\n- Prevents sliding down under blanket\n\n**2. Blanket tucked tightly**\n- Tuck under mattress on both sides + bottom  \n- Like a firm little \u201cpocket\u201d\n\n**3. Height = chest only**\n- Never above chest  \n- Arms **outside** (not wrapped)\n\n**4. Light + breathable only**\n- Muslin or thin cotton  \n- No fluffy/heavy layers\n\n**5. Nothing else in crib**\n- No pillows, bumpers, extra cloths\n\n---\n\n## Your setup (adjusted)\n\nAt ~22\u00b0C:\n- **Short or long sleeve onesie**  \n- **Light muslin blanket (tucked, chest height)**\n\n\ud83d\udc49 That\u2019s safe **if done properly**\n\n---\n\n## Important reality check\nEven when done \u201cright\u201d:\n\ud83d\udc49 Blankets are still **less safe than sleep sacks**\n\nThat\u2019s why guidelines prefer:\n- Sleep sack > blanket\n\n---\n\n## Your situation (practical solution)\n\nYou said your sleep sacks are too warm \u2192 so:\n\n\ud83d\udc49 Use blanket for now  \n\ud83d\udc49 But consider getting a **lightweight sleep sack (0.5 TOG)**\n\nThat\u2019s the ideal long-term fix:\n- No slipping  \n- No re-tucking  \n- Less debate with [PERSON_e197e8]\n\n---\n\n## One key habit\nCheck once after she falls asleep:\n- Did blanket move?  \n- Is neck warm/dry?\n\n---\n\n## Bottom line\n- Blanket can be used **safely with tight rules**  \n- But sleep sack (lightweight) = **easier + safer system**\n\n---\n\nIf you want, I can recommend exactly what TOG works for your room temp so you don\u2019t overbuy again."
+      ]
+     },
+     "create_time": 1775158239.299195,
+     "end_turn": true,
+     "id": "c1daace8-476f-400f-aa0e-0fa647b4009d",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb215fb-4aec-4bb5-bd74-3131b2c0c6a1",
+      "request_id": "1a83644f-b21b-4263-a9c4-f639037b51b6",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "c9b635d2-4bb5-44c1-89d7-f5368cbade6c"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb215fb-4aec-4bb5-bd74-3131b2c0c6a1"
+   },
+   "c20999de-8c6c-4555-97cb-a1abfd4f37cf": {
+    "children": [
+     "bbb21607-8079-4618-b0cf-a92391b538a1"
+    ],
+    "id": "c20999de-8c6c-4555-97cb-a1abfd4f37cf",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "**Yes \u2014 very likely normal newborn skin stuff.**\n\nWhat you\u2019re describing fits a mix of:\n\n## Most likely causes\n\n**1. Heat rash (very common)**\n- Small red bumps on **chest/belly**\n- Worse when warm or layered\n\n**2. Newborn acne (face)**\n- Red bumps that **come and go**\n- Driven by hormones\n\n**3. Dry skin / peeling**\n- Skin still adapting to outside world\n\n---\n\n## What to do (keep it simple)\n\n- Dress her in **one light layer** (don\u2019t overheat)  \n- Keep skin **clean + dry**  \n- Baths **2\u20133\u00d7/week**, lukewarm  \n- Use **no or minimal soap**  \n- For dry patches: small amount of **fragrance-free baby moisturizer** (or just leave it)\n\n---\n\n## What NOT to do\n- No oils or heavy products on face  \n- No scrubbing  \n- No medicated creams unless prescribed\n\n---\n\n## When to worry\n- Rash becomes **very red, swollen, or oozing**  \n- Spreads rapidly or forms crusts  \n- Baby seems uncomfortable or has fever\n\n---\n\n## Bottom line\n\ud83d\udc49 This is classic \u201cnewborn skin chaos\u201d  \n\ud83d\udc49 Peaks in first weeks, settles over **1\u20134 weeks**\n\nTheir skin is basically doing its first live deployment \u2014 a few bugs are expected."
+      ]
+     },
+     "create_time": 1774905573.023834,
+     "end_turn": true,
+     "id": "c20999de-8c6c-4555-97cb-a1abfd4f37cf",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "8caf0e6f-82d6-4ef0-aa92-78f2bdbfc3fe",
+      "request_id": "ba50d109-8dec-4da1-a925-fcd250e68ea8",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "607f26c1-e70e-4b18-b3d0-ebfbb4ec03b1"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "8caf0e6f-82d6-4ef0-aa92-78f2bdbfc3fe"
+   },
+   "c2828b39-d13b-4e66-8202-93936728a4ce": {
+    "children": [
+     "bbb219ee-5f0f-4f20-960d-062ffa72d273"
+    ],
+    "id": "c2828b39-d13b-4e66-8202-93936728a4ce",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Here\u2019s a clean, screenshot-ready table \ud83d\udc47\n\n---\n\n## \ud83e\uddf7 DIAPERS (Portugal \u2013 per unit)\n\n| Tier | Brands | Expected Price |\n|------|--------|---------------|\n| \ud83d\udc8e Premium | \ue200entity\ue202[\"brand\",\"Dodot Sensitive\"]\ue201 | \u20ac0.20 \u2013 \u20ac0.30 |\n| \ud83d\udfe1 Mid | \ue200entity\ue202[\"brand\",\"Dodot Activity\"]\ue201, \ue200entity\ue202[\"brand\",\"Libero\"]\ue201 | \u20ac0.18 \u2013 \u20ac0.26 |\n| \ud83d\udfe2 Budget (best value) | \ue200entity\ue202[\"brand\",\"Lupilu\"]\ue201, \ue200entity\ue202[\"brand\",\"Continente Baby\"]\ue201, \ue200entity\ue202[\"brand\",\"Pingo Doce Baby\"]\ue201 | \u20ac0.10 \u2013 \u20ac0.16 |\n\n---\n\n## \ud83e\uddfb WIPES (per wipe)\n\n| Tier | Brands | Expected Price |\n|------|--------|---------------|\n| \ud83d\udca7 Premium (water wipes) | \ue200entity\ue202[\"brand\",\"WaterWipes\"]\ue201, \ue200entity\ue202[\"brand\",\"Dodot Aqua Pure\"]\ue201 | \u20ac0.025 \u2013 \u20ac0.04 |\n| \ud83d\udfe1 Mid | \ue200entity\ue202[\"brand\",\"Dodot Sensitive Wipes\"]\ue201 | \u20ac0.02 \u2013 \u20ac0.03 |\n| \ud83d\udfe2 Budget (best value) | \ue200entity\ue202[\"brand\",\"Lupilu\"]\ue201, \ue200entity\ue202[\"brand\",\"Continente Baby\"]\ue201 | \u20ac0.012 \u2013 \u20ac0.018 |\n\n---\n\n## \ud83e\udde0 Quick take\n- Diapers: biggest savings = **premium \u2192 budget**  \n- Wipes: switch after ~1\u20132 months \u2192 **cut cost ~50%**  \n\n---\n\nIf you follow just this table, you\u2019ll avoid 90% of overpaying."
+      ]
+     },
+     "create_time": 1775561028.25956,
+     "end_turn": true,
+     "id": "c2828b39-d13b-4e66-8202-93936728a4ce",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [
+       {
+        "alt": "Dodot Sensitive",
+        "category": "brand",
+        "end_idx": 202,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Dodot Sensitive\"]\ue201",
+        "metadata": null,
+        "name": "Dodot Sensitive",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Dodot Sensitive",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 166,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Dodot Activity",
+        "category": "brand",
+        "end_idx": 266,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Dodot Activity\"]\ue201",
+        "metadata": null,
+        "name": "Dodot Activity",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Dodot Activity",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 231,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Libero",
+        "category": "brand",
+        "end_idx": 295,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Libero\"]\ue201",
+        "metadata": null,
+        "name": "Libero",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Libero",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 268,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Lupilu",
+        "category": "brand",
+        "end_idx": 367,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Lupilu\"]\ue201",
+        "metadata": null,
+        "name": "Lupilu",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Lupilu",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 340,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Continente Baby",
+        "category": "brand",
+        "end_idx": 405,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Continente Baby\"]\ue201",
+        "metadata": null,
+        "name": "Continente Baby",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Continente Baby",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 369,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Pingo Doce Baby",
+        "category": "brand",
+        "end_idx": 443,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Pingo Doce Baby\"]\ue201",
+        "metadata": null,
+        "name": "Pingo Doce Baby",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Pingo Doce Baby",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 407,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "WaterWipes",
+        "category": "brand",
+        "end_idx": 619,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"WaterWipes\"]\ue201",
+        "metadata": null,
+        "name": "WaterWipes",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "WaterWipes",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 588,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Dodot Aqua Pure",
+        "category": "brand",
+        "end_idx": 657,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Dodot Aqua Pure\"]\ue201",
+        "metadata": null,
+        "name": "Dodot Aqua Pure",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Dodot Aqua Pure",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 621,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Dodot Sensitive Wipes",
+        "category": "brand",
+        "end_idx": 729,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Dodot Sensitive Wipes\"]\ue201",
+        "metadata": null,
+        "name": "Dodot Sensitive Wipes",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Dodot Sensitive Wipes",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 687,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Lupilu",
+        "category": "brand",
+        "end_idx": 801,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Lupilu\"]\ue201",
+        "metadata": null,
+        "name": "Lupilu",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Lupilu",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 774,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Continente Baby",
+        "category": "brand",
+        "end_idx": 839,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Continente Baby\"]\ue201",
+        "metadata": null,
+        "name": "Continente Baby",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Continente Baby",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 803,
+        "status": "done",
+        "type": "entity"
+       }
+      ],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb2197a-a761-4ee4-b587-02b8ebc45331",
+      "request_id": "830eb907-ebdf-4847-8295-befb0cd3a16c",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "cfed2bdc-6ceb-4bec-83df-8ac42ea4b51c"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb2197a-a761-4ee4-b587-02b8ebc45331"
+   },
+   "c422ba05-e6ed-4153-ab4f-8610ea95dc11": {
+    "children": [
+     "b382f3b8-b907-470a-a387-71fa2b7f3400"
+    ],
+    "id": "c422ba05-e6ed-4153-ab4f-8610ea95dc11",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1774923924.5028584,
+     "end_turn": true,
+     "id": "c422ba05-e6ed-4153-ab4f-8610ea95dc11",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21580-f83b-4f64-9b78-67632b98e9e2",
+      "rebase_developer_message": true,
+      "request_id": "7f11222f-bb16-4183-ba26-11924986d4e0",
+      "turn_exchange_id": "d5da2e75-f488-4a05-8823-b61f70806d18"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb21580-f83b-4f64-9b78-67632b98e9e2"
+   },
+   "c7e2e582-f543-4bfe-baa0-239d389a20b0": {
+    "children": [
+     "bbb21cb5-63be-413a-aedc-9b3e28d51030"
+    ],
+    "id": "c7e2e582-f543-4bfe-baa0-239d389a20b0",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Right now 6\u20138pm is likely hitting her **fussiest / most overstimulated window** \u2192 bath = gasoline on the fire.\n\n## Move it earlier\n\n\ud83d\udc49 Aim for **4:30\u20136:00 pm**\n\n---\n\n## How to choose the exact time\n\nPick a moment when she is:\n- **awake but calm**\n- not overtired  \n- not starving\n\n\ud83d\udc49 That\u2019s the sweet spot\n\n---\n\n## Practical examples\n\n- If she gets fussy around 6:30 \u2192 bathe at **5:30**  \n- If evenings are chaotic from 6 \u2192 bathe closer to **4:30\u20135**\n\n---\n\n## What you\u2019re trying to avoid\nBath right now is:\n\ud83d\udc49 stimulation + already tired baby = meltdown energy\n\nEarlier bath =  \n\ud83d\udc49 stimulation + regulated baby = manageable\n\n---\n\n## Then what\nAfter bath:\n- normal evening chaos happens  \n- but **bath is no longer making it worse**\n\n---\n\n## Bottom line\n\ud83d\udc49 Shift bath **1\u20132 hours earlier than now**  \n\ud83d\udc49 Think: *before the chaos, not inside it*\n\n---\n\nThis is one of those small timing shifts that makes a surprisingly big difference."
+      ]
+     },
+     "create_time": 1776034100.054205,
+     "end_turn": true,
+     "id": "c7e2e582-f543-4bfe-baa0-239d389a20b0",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "0af2e459-3bb3-41e7-961d-d2cfbc0352e4",
+      "request_id": "c092b6b1-087e-4b73-a35e-d1eeabeea4d0",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "a623417d-f45d-4bd2-bb6a-1439473981db"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "0af2e459-3bb3-41e7-961d-d2cfbc0352e4"
+   },
+   "c94ef283-7e2d-478d-a244-4a5c32748d40": {
+    "children": [
+     "bbb2190e-26b2-401d-9673-dec7a4ce3316"
+    ],
+    "id": "c94ef283-7e2d-478d-a244-4a5c32748d40",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Fair \u2014 sounds contradictory, but it\u2019s about **timing and amount**.\n\n## What you\u2019re trying to avoid\n\ud83d\udc49 **Dried milk crust sitting there** \u2192 irritates skin\n\n## What helps\n\ud83d\udc49 **Fresh, thin layer of milk** \u2192 soothing\n\n---\n\n## Simple way to do it\n\nAfter a feed:\n\n1. If lips are **milky/sticky**  \n   \u2192 gently wipe with soft cloth\n\n2. If lips look **dry/peeling**  \n   \u2192 dab **a tiny amount** of fresh breast milk  \n   \u2192 let it air dry\n\n---\n\n## The difference\n- \u274c Old milk sitting = irritating  \n- \u2705 Fresh milk, thin layer = protective\n\n---\n\n## Even simpler rule\n\ud83d\udc49 **Clean \u2192 then (optionally) moisturize with milk**\n\n---\n\nIf it feels like too much fuss, honestly:  \n\ud83d\udc49 You can also **do nothing** \u2014 this resolves on its own in most cases"
+      ]
+     },
+     "create_time": 1774968848.570704,
+     "end_turn": true,
+     "id": "c94ef283-7e2d-478d-a244-4a5c32748d40",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb2152a-dfc6-4a7b-95bb-21e947455dbb",
+      "request_id": "0f84f68a-2431-4bd0-911a-14df0e5fd1e0",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "fc9d1ea7-2181-4354-8492-046b2fc91036"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb2152a-dfc6-4a7b-95bb-21e947455dbb"
+   },
+   "cce7eb38-e563-4a71-8b81-d0b7b7d47fbe": {
+    "children": [
+     "e4a52516-c1be-4790-b2dc-6d4dee3b44a1"
+    ],
+    "id": "cce7eb38-e563-4a71-8b81-d0b7b7d47fbe",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1775157718.7266319,
+     "end_turn": null,
+     "id": "cce7eb38-e563-4a71-8b81-d0b7b7d47fbe",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "06f23624-3e82-4e36-8aff-0d0e693e5e2e",
+      "request_id": "5dc6ffb5-5585-4c32-935b-8212efb11d6b",
+      "search_result_groups": [],
+      "turn_exchange_id": "af41349e-9b49-4496-8dd2-dd567ab31e07"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "06f23624-3e82-4e36-8aff-0d0e693e5e2e"
+   },
+   "ce0a3497-f65d-41c1-9a71-d18ff3e174f9": {
+    "children": [
+     "bbb21b50-d9ff-430a-99b0-cccdf534ae1f"
+    ],
+    "id": "ce0a3497-f65d-41c1-9a71-d18ff3e174f9",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "multimodal_text",
+      "parts": [
+       {
+        "content_type": "audio_transcription",
+        "decoding_id": null,
+        "direction": "out",
+        "text": "If you need anything else as you adjust,"
+       },
+       {
+        "asset_pointer": "sediment://file_00000000768c72469a04e0d5a86cca7e",
+        "content_type": "audio_asset_pointer",
+        "expiry_datetime": "2026-09-16T04:58:25.188108+00:00",
+        "format": "wav",
+        "metadata": {
+         "end": 1.5,
+         "end_timestamp": null,
+         "interruptions": null,
+         "original_audio_source": null,
+         "pretokenized_vq": null,
+         "start": 0.0,
+         "start_timestamp": null,
+         "transcription": null,
+         "word_transcription": null
+        },
+        "size_bytes": 72078,
+        "tool_audio_direction": null
+       }
+      ]
+     },
+     "create_time": 1773982711.310824,
+     "end_turn": true,
+     "id": "ce0a3497-f65d-41c1-9a71-d18ff3e174f9",
+     "metadata": {
+      "can_save": false,
+      "citations": [],
+      "content_references": [],
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "parent_id": "d8991f7b-15cf-485f-a942-f54381d58807",
+      "resolved_model_slug": "gpt-4o",
+      "turn_exchange_id": "76052a96-b45a-4126-b0e3-854bd2d1acd7"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "d8991f7b-15cf-485f-a942-f54381d58807"
+   },
+   "cfe61748-6d03-4b4c-a4ce-184d3fe71b13": {
+    "children": [
+     "bbb21687-1d3b-4eb5-881a-a86f4b9c6026"
+    ],
+    "id": "cfe61748-6d03-4b4c-a4ce-184d3fe71b13",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "**Seedy diaper** = normal newborn breastfed poop.\n\n**What it looks like:**  \n- Yellow / mustard color  \n- Loose, soft  \n- Tiny white \u201cseeds\u201d or grains\n\n**What the seeds are:**  \nLittle bits of **undigested milk fat**. Totally normal.\n\n**Good sign:**  \nMeans baby is digesting breast milk well.\n\n**Typical pattern (first weeks):**  \nSeveral per day, sometimes **after almost every feed**.\n\nCall a doctor only if stools become **white, black (after day 3\u20134), or red**. Otherwise, mustard-seed poop is textbook newborn biology."
+      ]
+     },
+     "create_time": 1773454149.487016,
+     "end_turn": true,
+     "id": "cfe61748-6d03-4b4c-a4ce-184d3fe71b13",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21a6a-e7fd-4321-8fd6-d2e4472c52b7",
+      "request_id": "d92dc6ca-2406-4108-a04a-2c6cbb77454d",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "80b4e036-c81d-41da-95a1-07cb6079a52b"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21a6a-e7fd-4321-8fd6-d2e4472c52b7"
+   },
+   "d1889b85-e367-4d49-adc0-91bd9a226bcf": {
+    "children": [
+     "bbb21ee7-d2a1-43ac-94fd-2f309377f398"
+    ],
+    "id": "d1889b85-e367-4d49-adc0-91bd9a226bcf",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Good \u2014 this is where branding gets sneaky.\n\n## \ud83e\udd47 Top water wipes (true \u201cwater-based\u201d)\n\n### \ue200entity\ue202[\"brand\",\"WaterWipes\"]\ue201\n- ~99.9% water  \n- Gold standard for sensitive skin  \n- Expensive  \n\ud83d\udc49 **Best for early weeks / rash**\n\n---\n\n### \ue200entity\ue202[\"brand\",\"Dodot Aqua Pure\"]\ue201\n- Very similar performance  \n- Slightly more ingredients (still mild)  \n- Often cheaper on promo  \n\ud83d\udc49 **Best value premium**\n\n---\n\n## \ud83d\udfe1 Mid-tier \u201cwater-style\u201d (not pure, but fine)\n\n### \ue200entity\ue202[\"brand\",\"Lupilu Aqua\"]\ue201\n- Not as pure, but still gentle  \n- Much cheaper  \n\ud83d\udc49 Good transition option\n\n---\n\n### \ue200entity\ue202[\"brand\",\"Continente Baby Sensitive Aqua\"]\ue201\n- Same idea as above  \n\ud83d\udc49 Budget-friendly alternative\n\n---\n\n## What actually matters (not the marketing)\n\n- Early weeks: **simpler = safer**  \n- Later: baby skin handles more \u2192 no need to pay premium\n\n---\n\n## My practical recommendation for you\n\n\ud83d\udc49 Right now (rash + newborn):\n- Stick with **WaterWipes or Dodot Aqua Pure**\n\n\ud83d\udc49 In ~2\u20134 weeks:\n- Move to **Lupilu Aqua or normal wipes**\n\n---\n\n## Price sanity check\n\n- Premium water wipes \u2192 aim **\u20ac0.025\u20130.035/wipe**  \n- If above that \u2192 you\u2019re overpaying\n\n---\n\n## Honest take\nWater wipes are great\u2026\n\ud83d\udc49 but **overused for too long by most parents**\n\n---\n\n## Bottom line\n- Use premium now (you\u2019re in the sensitive window)  \n- Plan to downgrade soon  \n- Don\u2019t get locked into premium pricing\n\n---\n\nIf you want, I can help you spot **fake \u201cwater wipes\u201d vs legit ones** \u2014 labels can be misleading."
+      ]
+     },
+     "create_time": 1775534209.642974,
+     "end_turn": true,
+     "id": "d1889b85-e367-4d49-adc0-91bd9a226bcf",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [
+       {
+        "alt": "WaterWipes",
+        "category": "brand",
+        "end_idx": 122,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"WaterWipes\"]\ue201",
+        "metadata": null,
+        "name": "WaterWipes",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "WaterWipes",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 91,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Dodot Aqua Pure",
+        "category": "brand",
+        "end_idx": 271,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Dodot Aqua Pure\"]\ue201",
+        "metadata": null,
+        "name": "Dodot Aqua Pure",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Dodot Aqua Pure",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 235,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Lupilu Aqua",
+        "category": "brand",
+        "end_idx": 488,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Lupilu Aqua\"]\ue201",
+        "metadata": null,
+        "name": "Lupilu Aqua",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Lupilu Aqua",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 456,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Continente Baby Sensitive Aqua",
+        "category": "brand",
+        "end_idx": 626,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Continente Baby Sensitive Aqua\"]\ue201",
+        "metadata": null,
+        "name": "Continente Baby Sensitive Aqua",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Continente Baby Sensitive Aqua",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 575,
+        "status": "done",
+        "type": "entity"
+       }
+      ],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb2104e-3b27-4603-bec4-1cc71b0f69ea",
+      "request_id": "9440f87b-667d-481d-bbfa-19d64d751973",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "a749ddfb-ecf5-4ee7-b84e-dae09b9611bd"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb2104e-3b27-4603-bec4-1cc71b0f69ea"
+   },
+   "d283a869-34ff-462f-8e79-9d437ca9a2a4": {
+    "children": [
+     "bbb213c9-f670-4305-8d05-18b96fdb557e"
+    ],
+    "id": "d283a869-34ff-462f-8e79-9d437ca9a2a4",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "**Yes \u2014 very normal, and often abrupt.**\n\n## Why it flips suddenly\n- Gut maturation isn\u2019t gradual \u2014 it\u2019s more like a **switch**  \n- Absorption improves \u2192 **less waste \u2192 fewer poops**  \n- The \u201cpoop after every feed\u201d reflex starts fading\n\n\ud83d\udc49 So it can literally go:\n**many poops \u2192 almost none overnight**\n\n---\n\n## What matters (same anchors)\nAs long as:\n- Poop is **soft when it comes**  \n- **Wet diapers are good**  \n- Baby is feeding well  \n\n\ud83d\udc49 The pattern doesn\u2019t matter\n\n---\n\n## What you might see next\n- 1\u20133 poops/day  \n- Then maybe **skip a day**  \n- Eventually even **several days between poops** (breastfed)\n\nAll normal.\n\n---\n\n## Why it feels wrong\nYou were used to:\n\ud83d\udc49 constant output = reassurance\n\nNow:\n\ud83d\udc49 silence feels suspicious\n\nBut physiologically, it\u2019s just **efficiency increasing**\n\n---\n\n## Bottom line\n\ud83d\udc49 Abrupt change = normal  \n\ud83d\udc49 Frequency is unreliable \u2014 consistency/softness matters more\n\n---\n\nYou\u2019re seeing a system upgrade, not a problem."
+      ]
+     },
+     "create_time": 1776204408.233474,
+     "end_turn": true,
+     "id": "d283a869-34ff-462f-8e79-9d437ca9a2a4",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bf7537b2-ca3a-43fb-ab8d-979fbf44f4db",
+      "request_id": "29e6e786-f202-4adb-b9ac-3f27d488828a",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "153bf04c-1d42-40f0-ad45-794efb812273"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bf7537b2-ca3a-43fb-ab8d-979fbf44f4db"
+   },
+   "d2bb3cfc-de64-422f-b68d-abdbe8f72729": {
+    "children": [
+     "bbb218ff-8813-45b1-bdcd-d5ede3848f80"
+    ],
+    "id": "d2bb3cfc-de64-422f-b68d-abdbe8f72729",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Short answer: **not long in the beginning \ud83d\ude04**\n\n## Typical duration (rough guide)\n\n- **Size 0 (newborn / <3\u20134 kg)**  \n  \ud83d\udc49 ~**1\u20133 weeks**  \n  (some babies skip it entirely)\n\n- **Size 1 (2\u20135 kg)**  \n  \ud83d\udc49 ~**4\u20138 weeks**\n\n- **Size 2 (3\u20136 kg)**  \n  \ud83d\udc49 ~**1\u20132 months**\n\nThen things slow down a bit.\n\n---\n\n## What actually determines switching (more important than time)\n\nSwitch up when you see:\n- Frequent **blowouts/leaks**  \n- Red marks on thighs/waist  \n- Tabs don\u2019t close comfortably  \n- She\u2019s near the **top of weight range**\n\n---\n\n## Reality check\nSizes overlap a lot \u2192 weight ranges are fuzzy.\n\nMost parents:\n\ud83d\udc49 move up **earlier rather than later** (fewer leaks)\n\n---\n\n## Your situation\nIf she\u2019s already outgrowing size 0:\n\ud83d\udc49 totally normal \u2014 many babies do it fast\n\n---\n\n## Practical tip\nDon\u2019t stockpile early sizes.  \nNewborns grow like they\u2019re on a startup growth curve \u2014 aggressive scaling, no warning."
+      ]
+     },
+     "create_time": 1774590832.427365,
+     "end_turn": true,
+     "id": "d2bb3cfc-de64-422f-b68d-abdbe8f72729",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "7ed36661-b7cf-44d7-b0d8-673e892cada5",
+      "request_id": "6cdf7ddb-3839-4794-8fd8-75884f89d50a",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "fd62f6a4-8c9a-4a8e-8a09-6b286d4f84b9"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "7ed36661-b7cf-44d7-b0d8-673e892cada5"
+   },
+   "d337434d-b722-411c-88a2-d30824334462": {
+    "children": [
+     "bbb21838-f661-453c-940c-b43b1cafe78a"
+    ],
+    "id": "d337434d-b722-411c-88a2-d30824334462",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "**Mineral oil = highly refined, purified oil from petroleum** (sounds scary, but it\u2019s actually very inert and widely used in baby products).\n\n## What matters in practice\n- **No smell, no color**  \n- Doesn\u2019t go rancid  \n- Doesn\u2019t feed yeast/bacteria  \n- Forms a light barrier on skin\n\n\ud83d\udc49 That\u2019s why it\u2019s often better than olive oil for cradle cap\n\n---\n\n## Where you\u2019ll see it\n- \u201c**Paraffinum Liquidum**\u201d on ingredient lists  \n- Baby oils (e.g. \ue200entity\ue202[\"brand\",\"Johnson's Baby Oil\"]\ue201)  \n- Pharmacy products\n\n---\n\n## Is it safe for babies?\n\ud83d\udc49 Yes, when it\u2019s **cosmetic/pharmaceutical grade** (which store products are)\n\n---\n\n## Why it\u2019s useful for cradle cap\n- Softens flakes  \n- Easy to wash off  \n- Doesn\u2019t worsen the underlying cause\n\n---\n\n## How to use (quick)\n- Small amount  \n- 10\u201315 min  \n- Gently brush  \n- Wash\n\n---\n\n## Bottom line\n\ud83d\udc49 Think of it as a **neutral softening oil**, not a \u201cnourishing\u201d one  \n\ud83d\udc49 For this use, **boring = better**\n\n---\n\nIf you want, I can suggest alternatives you likely already have at home that work similarly."
+      ]
+     },
+     "create_time": 1776916625.955351,
+     "end_turn": true,
+     "id": "d337434d-b722-411c-88a2-d30824334462",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [
+       {
+        "alt": "Johnson's Baby Oil",
+        "category": "brand",
+        "end_idx": 481,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Johnson's Baby Oil\"]\ue201",
+        "metadata": null,
+        "name": "Johnson's Baby Oil",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Johnson's Baby Oil",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 442,
+        "status": "done",
+        "type": "entity"
+       }
+      ],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21b8f-bd7a-409e-b098-efa4b8685d59",
+      "request_id": "00969c3e-5e18-468a-92bd-984f5c2049ba",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "58fad89a-0e81-4f5b-a4b4-ddb28eb77d72"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21b8f-bd7a-409e-b098-efa4b8685d59"
+   },
+   "d3a573c5-f691-4fc2-bae7-58682b3e05a3": {
+    "children": [
+     "7d5afe64-d988-4052-be98-e9a2d188638b"
+    ],
+    "id": "d3a573c5-f691-4fc2-bae7-58682b3e05a3",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773982705.516198,
+     "end_turn": true,
+     "id": "d3a573c5-f691-4fc2-bae7-58682b3e05a3",
+     "metadata": {
+      "can_save": false,
+      "is_visually_hidden_from_conversation": true,
+      "rebase_system_message": true
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "ad63d4fc-5b7a-45ae-8d27-a1c3772f8148"
+   },
+   "d5a1b0fe-2c66-4748-b6a0-fd9b735f36fd": {
+    "children": [
+     "757a104d-a4ef-4b9b-b47c-b3a475f863e1"
+    ],
+    "id": "d5a1b0fe-2c66-4748-b6a0-fd9b735f36fd",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Got it \u2014 concise mode. \ud83d\udc4d\n\n**Yes, normal.** Many newborns cry during diaper changes.\n\n**Why:**\n- Cold air / cold wipes  \n- Loss of warmth and containment  \n- Startle reflex  \n- Hunger or tiredness\n\n**Quick fixes:**\n- Warm wipe in your hands  \n- Muslin over chest/belly  \n- Talk or sing while changing  \n- One hand gently on torso for containment  \n- Change after a feed if possible\n\nIf she calms quickly once picked up or fed \u2192 all good."
+      ]
+     },
+     "create_time": 1773383091.895075,
+     "end_turn": true,
+     "id": "d5a1b0fe-2c66-4748-b6a0-fd9b735f36fd",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "2c95bda8-0cab-4306-8355-b94d20b39191",
+      "request_id": "d5b198b3-4223-4c75-8013-a7ab1c5fcc89",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "5c6c935b-e962-4364-9511-4cc77ca7853b"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "2c95bda8-0cab-4306-8355-b94d20b39191"
+   },
+   "d679985d-8531-4f36-bf1d-3ea1afee57b1": {
+    "children": [
+     "bbb21580-f83b-4f64-9b78-67632b98e9e2"
+    ],
+    "id": "d679985d-8531-4f36-bf1d-3ea1afee57b1",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "That combo is where the problem likely is.\n\n\ud83d\udc49 **Warm sleep sack + AC = tricky**  \nBecause:\n- AC cools the air  \n- Sleep sack traps heat around her body  \n- Easy to **overshoot without noticing**\n\n---\n\n## Quick sanity check\n\nTouch her **chest/back/neck during sleep**:\n\n- **Warm + dry** \u2192 perfect  \n- **Warm + slightly sweaty / damp neck** \u2192 too hot  \n- **Cool chest** \u2192 too cold\n\n---\n\n## About your setup\n\n- **Muslin blanket (light)** \u2192 fine  \n- **Warm sleep sack + AC** \u2192 can be **too much**\n\n\ud83d\udc49 Sleep sacks are usually designed for **non-AC stable rooms**\n\n---\n\n## What I\u2019d do (simple, no overthinking)\n\nPick one system:\n\n### Option A (cleanest)\n- AC on (20\u201322\u00b0C)  \n- **Light sleep sack (low TOG) or just onesie**  \n- No extra blanket\n\n### Option B\n- No AC  \n- Warmer sleep sack if needed\n\n\ud83d\udc49 Mixing **AC + warm sack** is where mistakes happen\n\n---\n\n## Why this matters for your situation\n- Overheating \u2192 **worse rash + more discomfort + worse sleep**  \n- Slightly cooler \u2192 babies usually handle well\n\n---\n\n## My call for you\n\ud83d\udc49 Switch to a **lighter sleep sack or remove it when AC is on**\n\n---\n\n## Bottom line\nYou don\u2019t have a \u201c[PERSON_e197e8] vs [PERSON_953b4c]\u201d problem  \nYou have a **system mismatch problem**\n\nFix the combo \u2192 things get simpler fast."
+      ]
+     },
+     "create_time": 1774906342.860476,
+     "end_turn": true,
+     "id": "d679985d-8531-4f36-bf1d-3ea1afee57b1",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb217f5-9f29-4289-94db-6966ac4b5f7b",
+      "request_id": "ba5137f9-b410-44a8-b308-29b4889b1896",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "2350d5ab-45e2-490e-b144-1c65c1e69d25"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb217f5-9f29-4289-94db-6966ac4b5f7b"
+   },
+   "d8991f7b-15cf-485f-a942-f54381d58807": {
+    "children": [
+     "ce0a3497-f65d-41c1-9a71-d18ff3e174f9"
+    ],
+    "id": "d8991f7b-15cf-485f-a942-f54381d58807",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773982711.310106,
+     "end_turn": true,
+     "id": "d8991f7b-15cf-485f-a942-f54381d58807",
+     "metadata": {
+      "can_save": false,
+      "is_visually_hidden_from_conversation": true,
+      "parent_id": "7d5afe64-d988-4052-be98-e9a2d188638b",
+      "rebase_developer_message": true,
+      "turn_exchange_id": "76052a96-b45a-4126-b0e3-854bd2d1acd7"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "7d5afe64-d988-4052-be98-e9a2d188638b"
+   },
+   "d8b37926-2274-4e5d-abe5-e442df10df4c": {
+    "children": [
+     "bbb2118c-eaea-4747-a364-c5fb67180eab"
+    ],
+    "id": "d8b37926-2274-4e5d-abe5-e442df10df4c",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Good \u2014 now you\u2019re playing this right.\n\n## Your situation\n- You already have **38 size 2**\n- You\u2019ll likely switch **soon (within ~2\u20133 weeks)**\n\n---\n\n## How many Size 2 to buy now\n\n\ud83d\udc49 **Buy ~120\u2013160 diapers total (including what you have)**\n\nSo:\n- You have 38  \n- Buy **~80\u2013120 more**\n\n---\n\n## Why this range works\n- Size 2 lasts **longer than size 1** (~1\u20132 months)  \n- Growth slows a bit  \n- Less risk of outgrowing too fast\n\n\ud83d\udc49 This is the first size where **bulk starts making sense**\n\n---\n\n## Strategy (this is key)\n\n- Use current Size 1 during day  \n- Start testing Size 2:\n  - first at night  \n  - then fully switch when leaks start\n\n---\n\n## If you see a good promo (like that Dodot one)\n\ud83d\udc49 You can safely go toward the **higher end (~150 total)**\n\n---\n\n## When NOT to bulk more\n- If fit seems weird  \n- If leaks happen early  \n- If brand not fully tested yet\n\n---\n\n## Bottom line\n- Target: **~120\u2013160 size 2 total**  \n- You already have 38 \u2192 buy **~80\u2013120 more**\n\n---\n\nThis is where you start winning the diaper game \u2014 early sizes = chaos, Size 2 = first real optimization window."
+      ]
+     },
+     "create_time": 1775534011.000573,
+     "end_turn": true,
+     "id": "d8b37926-2274-4e5d-abe5-e442df10df4c",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb215ef-c31b-4b0d-a4d0-d79b914741ed",
+      "request_id": "4b7fd984-4fc5-448f-bf0f-f6e1c4e416e7",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "de4ac060-cf92-47a6-a6bb-db4ff4c3f6d5"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb215ef-c31b-4b0d-a4d0-d79b914741ed"
+   },
+   "db6bc61e-63cb-4e59-817e-3a51b297e229": {
+    "children": [
+     "48509d36-6da4-4e20-b9d6-038ddf8c9423"
+    ],
+    "id": "db6bc61e-63cb-4e59-817e-3a51b297e229",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773562652.202659,
+     "end_turn": true,
+     "id": "db6bc61e-63cb-4e59-817e-3a51b297e229",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb2192e-5ecc-4c33-869f-340b006a63f1",
+      "rebase_developer_message": true,
+      "request_id": "14ba5aa6-f8da-4a4d-a57e-4be929f54902",
+      "turn_exchange_id": "05eda216-3d04-49fa-8c23-14a461226acc"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb2192e-5ecc-4c33-869f-340b006a63f1"
+   },
+   "dcde7297-08fd-452c-9070-334588eafe9f": {
+    "children": [
+     "bbb21dfe-fb71-4bcd-ad06-c8e79c14dbbf"
+    ],
+    "id": "dcde7297-08fd-452c-9070-334588eafe9f",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Good question \u2014 babies go **either way** with baths.\n\n## Signs bath is making her **sleepy**\n- Movements get **slower, relaxed**  \n- Eyes **heavy / staring off**  \n- Less kicking, more \u201cmelting\u201d  \n- Quiet after bath, easy to settle  \n\ud83d\udc49 This is your **night routine gold**\n\n---\n\n## Signs bath is making her **active**\n- Lots of **kicking / flailing**  \n- Wide, alert eyes  \n- Vocal / fussy after  \n- Harder to settle, seems \u201cwired\u201d  \n\ud83d\udc49 Bath is stimulating her\n\n---\n\n## When to check\n\ud83d\udc49 Don\u2019t judge in the bath \u2014 judge **15\u201330 min after**\n\nThat\u2019s the real effect.\n\n---\n\n## How to use this info\n\n### If sleepy\n- Keep bath **before bedtime**\n- Build routine: bath \u2192 feed \u2192 sleep\n\n### If active\n- Move bath to:\n  - earlier evening **or daytime**\n- Keep nights calmer (no stimulation spike)\n\n---\n\n## Subtle factors that change the effect\n- **Temperature**: warmer = more relaxing  \n- **Duration**: too long = stimulating  \n- **Handling**: fast/loud = stimulating  \n- **Timing**: overtired baby \u2192 bath can backfire\n\n---\n\n## Your phase (important)\nAt ~1 month:\n\ud83d\udc49 babies are **unpredictable**\n\u2192 same bath can calm one day, excite the next\n\n---\n\n## Bottom line\n\ud83d\udc49 Look at **after-effect, not during bath**  \n\ud83d\udc49 Then place bath where it works for you\n\n---\n\nIf you want, I can help you design a **simple evening routine** based on how she reacts \u2014 that\u2019s where baths really pay off."
+      ]
+     },
+     "create_time": 1776033769.652028,
+     "end_turn": true,
+     "id": "dcde7297-08fd-452c-9070-334588eafe9f",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "4f470078-e525-4dfd-9a4b-dd31ad952957",
+      "request_id": "1133c94a-6e4f-43f8-9ed5-b8546653133f",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "c68a6923-2821-4da8-ba48-8f9c4a3c0243"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "4f470078-e525-4dfd-9a4b-dd31ad952957"
+   },
+   "dd485191-9c3c-4bf6-9040-3d3f89c69d2d": {
+    "children": [
+     "fa7260b1-81b8-4e3a-bb91-29d464766543"
+    ],
+    "id": "dd485191-9c3c-4bf6-9040-3d3f89c69d2d",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1775534457.8924363,
+     "end_turn": null,
+     "id": "dd485191-9c3c-4bf6-9040-3d3f89c69d2d",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "4f1498a5-26d2-4d1e-a4f4-f987b82c1fbb",
+      "request_id": "e2d38faf-19d3-4b72-b3c7-b1cd8dd7e6bf",
+      "turn_exchange_id": "ad060e34-afb5-4c8e-90b4-5dac9d5df405"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "4f1498a5-26d2-4d1e-a4f4-f987b82c1fbb"
+   },
+   "e001b6dd-1901-43f2-b130-00266740b4ed": {
+    "children": [
+     "eb12abff-8e3f-4273-95cb-f95c5756ec9c"
+    ],
+    "id": "e001b6dd-1901-43f2-b130-00266740b4ed",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1776182906.827532,
+     "end_turn": null,
+     "id": "e001b6dd-1901-43f2-b130-00266740b4ed",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "8532afee-7c61-4d9b-832f-ce6b222191ba",
+      "request_id": "b0d9ce37-b0ee-42e2-96ab-9e6b7b3e9a23",
+      "search_result_groups": [],
+      "turn_exchange_id": "9c2a9c29-22bc-4505-9425-1334bab7fc71"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "8532afee-7c61-4d9b-832f-ce6b222191ba"
+   },
+   "e10052b0-7f10-4d0f-8afe-6106b6496701": {
+    "children": [
+     "bbb21b8f-bd7a-409e-b098-efa4b8685d59"
+    ],
+    "id": "e10052b0-7f10-4d0f-8afe-6106b6496701",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Short answer: **use neither as your first choice**.\n\n## Why\n- **Linimento (lime + olive oil)**  \n  \ud83d\udc49 good for diaper area, **not ideal for scalp/face**  \n  \ud83d\udc49 leaves residue \u2192 can **worsen buildup**\n\n- **Olive oil**  \n  \ud83d\udc49 softens scales, but can **feed the yeast** behind cradle cap  \n  \ud83d\udc49 may make it come back more\n\n---\n\n## Better option\n\ud83d\udc49 **Mineral oil or baby oil** (simple, inert)\n\n- Softens flakes  \n- Doesn\u2019t feed yeast  \n- Easier to wash off\n\n---\n\n## If you only have olive oil\n\ud83d\udc49 You *can* use it occasionally  \n- Small amount  \n- Short contact (10\u201315 min)  \n- Wash off well  \n\nDon\u2019t leave it sitting on skin long-term\n\n---\n\n## For eyebrows (more delicate)\n\ud83d\udc49 Even better:\n- Just warm water + soft cloth  \n- Or tiny bit of mineral oil if needed\n\n---\n\n## Bottom line\n- \u274c Linimento \u2192 skip  \n- \u26a0\ufe0f Olive oil \u2192 ok occasionally, not ideal  \n- \u2705 Mineral/baby oil \u2192 best simple choice\n\n---\n\nYou don\u2019t need anything fancy \u2014 just something that **softens without feeding the problem**."
+      ]
+     },
+     "create_time": 1776916567.756306,
+     "end_turn": true,
+     "id": "e10052b0-7f10-4d0f-8afe-6106b6496701",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb219ad-06c4-4736-9cd5-6b28c106073e",
+      "request_id": "c01b8162-afe1-4ecb-90d9-0cde7ac023bc",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "08c37878-8eaf-4383-a2fd-61df743b38a7"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb219ad-06c4-4736-9cd5-6b28c106073e"
+   },
+   "e1ae9994-1a14-46cf-869d-ed0df77ad5a4": {
+    "children": [
+     "bbb2108f-7a95-445c-bbac-bd28933e682b"
+    ],
+    "id": "e1ae9994-1a14-46cf-869d-ed0df77ad5a4",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Could be \u2014 but in newborns it\u2019s **often not true conjunctivitis**.\n\n## Most common cause at this age\n\ud83d\udc49 **Blocked tear duct (very common)**\n\nLooks like:\n- Sticky/yellow discharge  \n- Eye gets gunky, especially after sleep  \n- White of eye **not very red**\n\n---\n\n## True conjunctivitis (less common)\n- Eye very **red**  \n- Swollen eyelids  \n- Constant discharge\n\n---\n\n## What to do now (safe + useful)\n\n**1. Clean the eye**\n- Sterile saline or boiled/cooled water  \n- Soft gauze  \n- Wipe **inside \u2192 outside**  \n- 2\u20133\u00d7/day or as needed\n\n---\n\n**2. Tear duct massage (key if blocked duct)**\n- Clean finger  \n- Press gently at inner corner of eye (near nose)  \n- Slide **downwards**  \n- 5\u201310 times, a few times/day\n\n---\n\n## When to see a doctor\n- Eye becomes **very red**  \n- Swelling increases  \n- Thick discharge keeps coming back fast  \n- No improvement in **2\u20133 days**  \n- Fever or baby seems unwell\n\n---\n\n## Important\nBlocked ducts can look dramatic but are **benign and common**  \nThey often resolve on their own over weeks/months\n\n---\n\n## Bottom line\n\ud83d\udc49 Most likely: **blocked tear duct, not infection**  \n\ud83d\udc49 Clean + massage is first line  \n\ud83d\udc49 Watch redness \u2014 that\u2019s your key signal\n\n---\n\nIf you want, describe what it looks like (amount, color, redness), and I\u2019ll help you distinguish more confidently."
+      ]
+     },
+     "create_time": 1775487499.955515,
+     "end_turn": true,
+     "id": "e1ae9994-1a14-46cf-869d-ed0df77ad5a4",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "68337cb1-488e-42c8-a6fb-4bba17821b30",
+      "request_id": "824b3c0c-2753-4a2b-ad82-5109161263b1",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "9cd645b8-7e30-4d46-8292-5374089275ef"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "68337cb1-488e-42c8-a6fb-4bba17821b30"
+   },
+   "e20ad6cc-141a-44c6-9deb-8ef8df1afdc0": {
+    "children": [
+     "5e1db441-31b9-466f-9b09-15c1d303f0de"
+    ],
+    "id": "e20ad6cc-141a-44c6-9deb-8ef8df1afdc0",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773970035.2950869,
+     "end_turn": true,
+     "id": "e20ad6cc-141a-44c6-9deb-8ef8df1afdc0",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21add-bf10-4dff-8d8a-4b8342b52db5",
+      "rebase_developer_message": true,
+      "request_id": "afa35376-c30c-47fb-aeca-d4eace5d2203",
+      "turn_exchange_id": "60d97475-6d20-4d90-8f20-940e859c8e48"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb21add-bf10-4dff-8d8a-4b8342b52db5"
+   },
+   "e306cc92-6aca-4dab-bf7f-77e02a4f9b2b": {
+    "children": [
+     "2de10e3b-cacd-4760-a7f4-07a8b36cece1"
+    ],
+    "id": "e306cc92-6aca-4dab-bf7f-77e02a4f9b2b",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1776916423.7768486,
+     "end_turn": null,
+     "id": "e306cc92-6aca-4dab-bf7f-77e02a4f9b2b",
+     "metadata": {
+      "can_save": false,
+      "command": "prompt",
+      "contextual_answers_message_type": "sources_and_filters_prompt",
+      "default_model_slug": "gpt-5-3",
+      "is_contextual_answers_system_message": true,
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "c0738ab9-b4c3-4b37-895c-9981ea514ba6",
+      "request_id": "1de24a7f-67ba-4658-b9c4-b5134fceae26",
+      "turn_exchange_id": "107232ae-96bd-41d8-9af3-a48450934f52"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "c0738ab9-b4c3-4b37-895c-9981ea514ba6"
+   },
+   "e42103a8-9173-4027-a49c-42af469d1b42": {
+    "children": [
+     "bbb21633-6c39-4226-897f-97567f5a8aa7"
+    ],
+    "id": "e42103a8-9173-4027-a49c-42af469d1b42",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Let\u2019s do the math:\n\n- \u20ac32 / 138 = **~\u20ac0.23 per diaper**\n\n## Verdict\n\ud83d\udc49 **Yes \u2014 that\u2019s a good price**\n\n- Not \u201cinsane deal\u201d  \n- But **solid buy range**\n\n---\n\n## Context for \ue200entity\ue202[\"brand\",\"Dodot Sensitive\"]\ue201\n- Great deal \u2192 ~\u20ac0.18\u20130.20  \n- Good deal \u2192 **\u20ac0.20\u20130.25** \u2190 you\u2019re here  \n- Meh \u2192 \u20ac0.28+\n\n---\n\n## Should you buy?\n\ud83d\udc49 Yes, **with one caveat**\n\nDon\u2019t overstock:\n- Size 1 doesn\u2019t last long  \n- Baby might size up soon\n\n---\n\n## Smart move\n- Buy **1 box (maybe 2 max)**  \n- Don\u2019t go all-in\n\n---\n\n## Bottom line\n\ud83d\udc49 \u20ac0.23 = good enough to pull the trigger  \n\ud83d\udc49 Just keep quantities controlled\n\n---\n\nYou\u2019re now officially thinking like someone who won\u2019t overspend on diapers \ud83d\ude04"
+      ]
+     },
+     "create_time": 1775532656.495981,
+     "end_turn": true,
+     "id": "e42103a8-9173-4027-a49c-42af469d1b42",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [
+       {
+        "alt": "Dodot Sensitive",
+        "category": "brand",
+        "end_idx": 206,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Dodot Sensitive\"]\ue201",
+        "metadata": null,
+        "name": "Dodot Sensitive",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Dodot Sensitive",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 170,
+        "status": "done",
+        "type": "entity"
+       }
+      ],
+      "default_model_slug": "gpt-5-3",
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21758-e3be-4be2-abcd-2990a1515cb0",
+      "request_id": "4cb78928-2d0c-45c2-92e2-862bfde06e8c",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "13ffe396-f2fb-42dd-97cf-cf666ab346f2"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21758-e3be-4be2-abcd-2990a1515cb0"
+   },
+   "e4a52516-c1be-4790-b2dc-6d4dee3b44a1": {
+    "children": [
+     "bbb21077-b76f-41ff-8cff-ad1116a156d6"
+    ],
+    "id": "e4a52516-c1be-4790-b2dc-6d4dee3b44a1",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "You\u2019re thinking in the right direction. Heat rash is **very sensitive to environment**, so small tweaks matter.\n\n---\n\n## What heat rash actually is\nBlocked sweat ducts \u2192 sweat gets trapped \u2192 **tiny red bumps**  \nCommon on:\n- chest  \n- back  \n- neck folds  \n\n---\n\n## How fast it improves\n\ud83d\udc49 **24\u201372 hours** after fixing the cause\n\nIf it was the sleep sack, you should start seeing:\n- less redness  \n- fewer new bumps  \nwithin **1\u20132 days**\n\n---\n\n## How to confirm it\u2019s heat-related\n\n**Strong clues it\u2019s heat rash:**\n- Worse in **covered areas** (chest/back)  \n- Better when skin is **cool + exposed**  \n- Comes and goes quickly  \n- Baby otherwise fine\n\n---\n\n## How to pinpoint the cause (practical method)\n\nChange **one variable at a time** for 2\u20133 days:\n\n### Step 1 (you already did)\n- Remove **warm sleep sack**\n\n### Step 2\n- Keep room **stable (20\u201322\u00b0C)**  \n- No layering + blanket + AC combos\n\n### Step 3\n- Observe:\n  - Better \u2192 you found it  \n  - Same \u2192 look at next factor\n\n---\n\n## Other common triggers to check\n\n- **Overdressing** (even one extra layer)  \n- **Skin staying damp** (milk, sweat in folds)  \n- **Synthetic fabrics** (less breathable)  \n- **Contact heat** (long time against your body/carrier)\n\n---\n\n## What helps it heal faster\n- Keep skin **cool and dry**  \n- Loose cotton clothing  \n- Short baths, no heavy products  \n- Air exposure when possible\n\n---\n\n## What NOT to do\n- No thick creams (they trap heat)  \n- No over-bathing  \n- Don\u2019t keep adjusting constantly \u2192 give changes time\n\n---\n\n## If it\u2019s NOT improving after 3\u20134 days\nThen consider:\n- irritation (detergent, fabric)  \n- eczema (less likely this early)  \n\n---\n\n## My take on your case\n\ud83d\udc49 The **warm sleep sack + AC combo** is a very strong suspect  \n\ud83d\udc49 You\u2019ve already removed it \u2014 good move\n\n---\n\n## Bottom line\n- Expect improvement in **1\u20133 days**  \n- Keep things **simple, cool, consistent**  \n- Don\u2019t change 5 things at once or you won\u2019t know what worked\n\n---\n\nYou\u2019re basically debugging a temperature system \u2014 treat it like an experiment, not a guess."
+      ]
+     },
+     "create_time": 1775157718.720539,
+     "end_turn": true,
+     "id": "e4a52516-c1be-4790-b2dc-6d4dee3b44a1",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "cce7eb38-e563-4a71-8b81-d0b7b7d47fbe",
+      "request_id": "5dc6ffb5-5585-4c32-935b-8212efb11d6b",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "af41349e-9b49-4496-8dd2-dd567ab31e07"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "cce7eb38-e563-4a71-8b81-d0b7b7d47fbe"
+   },
+   "e5059144-af2f-4a36-a50f-1f6a8a035d44": {
+    "children": [
+     "bbb21b14-4690-4c3f-be5c-5075285165e3"
+    ],
+    "id": "e5059144-af2f-4a36-a50f-1f6a8a035d44",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Good questions \u2014 this is where nuance matters.\n\n---\n\n## \u201cFlexible feeds\u201d = what exactly?\n\n**Daytime (important):**\n- Don\u2019t let her sleep forever yet  \n- Aim for **~2.5\u20133h max between feeds**  \n\ud83d\udc49 Yes, **wake her if needed**\n\n**Nighttime:**\n- If she\u2019s sleeping \u2192 **don\u2019t wake**  \n- Feed when she wakes/cues\n\n**Evening (your tricky window):**\n- Expect **cluster feeding** (feeds closer together, even every 1\u20132h or less)  \n\ud83d\udc49 This is normal and helpful\n\nSo \u201cflexible\u201d =  \n**structured days, responsive evenings/nights**\n\n---\n\n## About shortening feeds earlier\n\nThat advice was about **not overloading a single feed**.\n\nBut:\n- If she\u2019s feeding calmly \u2192 let her finish  \n- If she\u2019s getting gassy/uncomfortable \u2192 a slightly shorter feed can help\n\n\ud83d\udc49 It\u2019s situational, not a rule\n\n---\n\n## \u201cEdge window\u201d I mentioned\n\nYou\u2019re around the age where babies can show:\n\n### 1. **Normal gas peak** (most likely)\n- Worse in evening  \n- Legs up, grunting  \n- Improves with burping/holding  \n- Comes and goes\n\n### 2. **Early colic pattern** (subset of babies)\n- Predictable **daily crying window** (often evening)  \n- Hard to soothe even when fed/clean  \n- Can last **1\u20133+ hours**\n\n---\n\n## Based on what you told me:\nYou\u2019re still in **normal gas territory**, not clear colic.\n\nWhy:\n- She improves after gas/poop  \n- She feeds well  \n- She does settle eventually\n\n---\n\n## What I\u2019d actually do in your shoes\n\n- **Wake during day** to keep feeds regular  \n- **Let nights happen naturally**  \n- Expect **messy evenings** (don\u2019t fight it too hard)  \n- Focus energy on:\n  - upright after feeds  \n  - calm handling  \n  - pre-empt gas before night\n\n---\n\n## Straight talk\nYou\u2019re in one of the **most annoying newborn phases (weeks 2\u20134)**.\n\nThere\u2019s optimization\u2026 but there\u2019s also a hard truth:\n\ud83d\udc49 some of this is just **ride it out while reducing the peaks**\n\n---\n\nIf in the next days it turns into long, inconsolable crying blocks, tell me \u2014 then we switch strategy toward colic management."
+      ]
+     },
+     "create_time": 1773971689.03684,
+     "end_turn": true,
+     "id": "e5059144-af2f-4a36-a50f-1f6a8a035d44",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21716-5cf5-42c3-b56f-950476c4e336",
+      "request_id": "b0ff0650-5bbf-4b1c-a3d4-087748908f4f",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "00adb26c-91fb-4018-b83b-22a8e9e42e51"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21716-5cf5-42c3-b56f-950476c4e336"
+   },
+   "e5d9a2b8-1222-46ca-bff3-762c386b9b20": {
+    "children": [
+     "5a1e43ae-2313-4855-a50a-804a95f6937a"
+    ],
+    "id": "e5d9a2b8-1222-46ca-bff3-762c386b9b20",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1775534087.65487,
+     "end_turn": null,
+     "id": "e5d9a2b8-1222-46ca-bff3-762c386b9b20",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb2118c-eaea-4747-a364-c5fb67180eab",
+      "request_id": "d1a4c94e-8d57-4efe-b8fc-e746ea5e3e96",
+      "turn_exchange_id": "ba6f27a8-8ea9-4419-8154-1fd0507dea8b"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb2118c-eaea-4747-a364-c5fb67180eab"
+   },
+   "e936a8cb-2886-4efa-985b-fd8a2da01286": {
+    "children": [
+     "bbb2192e-5ecc-4c33-869f-340b006a63f1"
+    ],
+    "id": "e936a8cb-2886-4efa-985b-fd8a2da01286",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "You **don\u2019t really need to wait** with a newborn.\n\n**Best window:** about **10\u201320 minutes after a feed**, mainly so she\u2019s not overly full and spitting up.\n\n**Quick rule:**\n- If she seems **content and awake** \u2192 bath is fine now.  \n- If she\u2019s **milk-drunk and asleep** \u2192 wait until the next wake window.\n\nNo strict safety rule like with swimming. Newborn baths are shallow and calm. Keep it **short and warm** and you\u2019re good."
+      ]
+     },
+     "create_time": 1773519820.762542,
+     "end_turn": true,
+     "id": "e936a8cb-2886-4efa-985b-fd8a2da01286",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21984-7e94-4ca1-b2ff-260a15c377a4",
+      "request_id": "10a2a315-e090-4635-a848-1212dab21932",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "99da23f2-2675-475c-82fd-89dbb0ef18b8"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb21984-7e94-4ca1-b2ff-260a15c377a4"
+   },
+   "eb12abff-8e3f-4273-95cb-f95c5756ec9c": {
+    "children": [
+     "bbb2130c-6b88-4212-a7fe-3a7d676b15e6"
+    ],
+    "id": "eb12abff-8e3f-4273-95cb-f95c5756ec9c",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "**Yes \u2014 completely normal at 1 month.**\n\n## What changed\n- Early weeks: poop after almost every feed  \n- Around now: **poop frequency drops**\n\n\ud83d\udc49 2\u20133 dirty diapers/day is **perfectly fine**\n\n---\n\n## What matters (you\u2019re hitting all of them)\n- ~**6+ wet diapers/day** \u2705  \n- Poop still **soft (not hard pellets)** \u2705  \n- Feeding well, alert periods \u2705  \n\n\ud83d\udc49 That = healthy intake\n\n---\n\n## Why this happens\n- Gut is maturing  \n- Better milk absorption \u2192 **less waste**  \n- Less \u201cautomatic poop after every feed\u201d\n\n---\n\n## Range of normal (breastfed)\n- Multiple poops/day  \n- Or even **1 every few days** (soon)\n\n\ud83d\udc49 As long as it\u2019s soft \u2192 fine\n\n---\n\n## When to worry (not your case)\n- Hard, dry stools  \n- Blood or white/black stool  \n- Few wet diapers  \n- Baby lethargic\n\n---\n\n## Bottom line\n\ud83d\udc49 Fewer poops + good wets = **normal progression**  \n\ud83d\udc49 Actually a sign things are maturing\n\n---\n\nYou\u2019ve just graduated from \u201cconstant poop mode\u201d to \u201cslightly more civilized digestion.\u201d"
+      ]
+     },
+     "create_time": 1776182906.807013,
+     "end_turn": true,
+     "id": "eb12abff-8e3f-4273-95cb-f95c5756ec9c",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "e001b6dd-1901-43f2-b130-00266740b4ed",
+      "request_id": "b0d9ce37-b0ee-42e2-96ab-9e6b7b3e9a23",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "9c2a9c29-22bc-4505-9425-1334bab7fc71"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "e001b6dd-1901-43f2-b130-00266740b4ed"
+   },
+   "eefe2a05-ed5a-4d9e-9152-59cbd2803e6d": {
+    "children": [
+     "bbb2110b-d720-458d-acf4-e134dee58965"
+    ],
+    "id": "eefe2a05-ed5a-4d9e-9152-59cbd2803e6d",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Good question \u2014 this is where you can quietly save a lot over time.\n\n## Reality in Portugal (\ue200entity\ue202[\"brand\",\"Dodot\"]\ue201 Sensitive size 1)\n\nTypical ranges:\n\n- **Bad price:** \u20ac0.35\u20130.45 / diaper  \n- **Normal price:** \u20ac0.25\u20130.32  \n- **Good deal:** \u20ac0.18\u20130.24  \n- **Great deal:** \u2264 \u20ac0.20\n\n---\n\n## What you should aim for\n\ud83d\udc49 **~\u20ac0.20\u20130.25 per diaper**\n\nAnything above that = convenience tax.\n\n---\n\n## Where pricing usually lands\n- \ue200entity\ue202[\"local_business\",\"Continente\",\"Portugal\"]\ue201 / \ue200entity\ue202[\"local_business\",\"Pingo Doce\",\"Portugal\"]\ue201  \n  \u2192 Often overpriced unless promo\n\n- \ue200entity\ue202[\"local_business\",\"Amazon\",\"Portugal\"]\ue201  \n  \u2192 Frequently best for bulk deals\n\n- \ue200entity\ue202[\"local_business\",\"Well's\",\"Portugal\"]\ue201  \n  \u2192 Good promos occasionally\n\n---\n\n## Pro tips (this matters more than brand)\n\n- **Never buy full price** \u2192 diapers are *always* on rotation promos  \n- Bigger boxes = lower unit price (usually)  \n- Watch for **\u201cleve X pague Y\u201d** deals\n\n---\n\n## Honest take\n\ue200entity\ue202[\"brand\",\"Dodot\"]\ue201 Sensitive are great, but:\n\ud83d\udc49 you\u2019re paying a **premium for \u201csensitive\u201d branding**\n\nOnce you\u2019re past newborn stage, many parents switch to:\n- Dodot normal line  \n- or store brands (much cheaper, often fine)\n\n---\n\n## Bottom line\n\ud83d\udc49 Good target: **~\u20ac0.22/diaper**  \n\ud83d\udc49 Only stock up when you hit that range or lower\n\n---\n\nIf you want, I can compare **Dodot vs supermarket brands in Portugal** \u2014 there\u2019s a surprising amount of money on the table there."
+      ]
+     },
+     "create_time": 1775512021.976847,
+     "end_turn": true,
+     "id": "eefe2a05-ed5a-4d9e-9152-59cbd2803e6d",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [
+       {
+        "alt": "Dodot",
+        "category": "brand",
+        "end_idx": 119,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Dodot\"]\ue201",
+        "metadata": null,
+        "name": "Dodot",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Dodot",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 93,
+        "status": "done",
+        "type": "entity"
+       },
+       {
+        "alt": "Continente",
+        "end_idx": 476,
+        "matched_text": "\ue200entity\ue202[\"local_business\",\"Continente\",\"Portugal\"]\ue201",
+        "prefix": null,
+        "prompt_text": "Continente",
+        "refs": [],
+        "render_as": null,
+        "safe_urls": [],
+        "start_idx": 425,
+        "type": "alt_text"
+       },
+       {
+        "alt": "Pingo Doce",
+        "end_idx": 530,
+        "matched_text": "\ue200entity\ue202[\"local_business\",\"Pingo Doce\",\"Portugal\"]\ue201",
+        "prefix": null,
+        "prompt_text": "Pingo Doce",
+        "refs": [],
+        "render_as": null,
+        "safe_urls": [],
+        "start_idx": 479,
+        "type": "alt_text"
+       },
+       {
+        "alt": "Amazon",
+        "end_idx": 617,
+        "matched_text": "\ue200entity\ue202[\"local_business\",\"Amazon\",\"Portugal\"]\ue201",
+        "prefix": null,
+        "prompt_text": "Amazon",
+        "refs": [],
+        "render_as": null,
+        "safe_urls": [],
+        "start_idx": 570,
+        "type": "alt_text"
+       },
+       {
+        "alt": "Well's",
+        "end_idx": 705,
+        "matched_text": "\ue200entity\ue202[\"local_business\",\"Well's\",\"Portugal\"]\ue201",
+        "prefix": null,
+        "prompt_text": "Well's",
+        "refs": [],
+        "render_as": null,
+        "safe_urls": [],
+        "start_idx": 658,
+        "type": "alt_text"
+       },
+       {
+        "alt": "Dodot",
+        "category": "brand",
+        "end_idx": 990,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Dodot\"]\ue201",
+        "metadata": null,
+        "name": "Dodot",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Dodot",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 964,
+        "status": "done",
+        "type": "entity"
+       }
+      ],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "27fe7be5-6d39-4d9f-8165-0af86183bd65",
+      "request_id": "4f60cbba-c9fc-46a4-93bd-23290c8139e0",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "452cda20-6951-49c2-9a73-e91795144fcd"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "27fe7be5-6d39-4d9f-8165-0af86183bd65"
+   },
+   "f53984c4-70a4-40bd-8e1d-e01beb83d4e7": {
+    "children": [
+     "bbb21388-1a0c-4f4b-8403-0c2f7526ee04"
+    ],
+    "id": "f53984c4-70a4-40bd-8e1d-e01beb83d4e7",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Alright \u2014 let\u2019s debug this properly. Answer these and I\u2019ll narrow it down fast:\n\n### Feeding\n1. **Breastfed, formula, or mixed?**  \n2. During feeds: does she **gulp/click/choke** or seem very fast at the breast?  \n3. Do you hear **regular swallowing** or is it chaotic?  \n4. How long are feeds and does she **pull off upset**?\n\n### Gas / behavior\n5. When she cries at night, does she:  \n   - pull legs up?  \n   - arch back?  \n   - go red + grunt?  \n6. Does she **pass gas and improve**, or stays upset?\n\n### Timing pattern\n7. Worst period: **evening (cluster)** or **all night**?  \n8. After feeding at night, does she:  \n   - fall asleep briefly then wake uncomfortable?  \n   - or never settle at all?\n\n### Poop\n9. Still **yellow/seedy and soft**? Any change?  \n10. Frequency: still many per day or slowing?\n\n### Burping / handling\n11. Are you **burping mid-feed**, after, or barely?  \n12. How long do you keep her **upright after feeds**?\n\n### Your side (important)\n13. Do your breasts feel **very full/forceful letdown** (milk spraying, leaking a lot)?  \n14. Any clear link with something you eat? (be honest \u2014 usually no, but checking)\n\n---\n\nReply with quick bullets.  \nThere are a few common culprits here (fast flow, air intake, overtiredness loop), and we\u2019ll zero in and fix what\u2019s actually happening instead of guessing."
+      ]
+     },
+     "create_time": 1773970035.615731,
+     "end_turn": true,
+     "id": "f53984c4-70a4-40bd-8e1d-e01beb83d4e7",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "5e1db441-31b9-466f-9b09-15c1d303f0de",
+      "request_id": "afa35376-c30c-47fb-aeca-d4eace5d2203",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "60d97475-6d20-4d90-8f20-940e859c8e48"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "5e1db441-31b9-466f-9b09-15c1d303f0de"
+   },
+   "f59f56d8-921c-4831-a228-fb503179d70d": {
+    "children": [
+     "348f99d3-7e24-4f00-a003-2ac9d4e0ceb5"
+    ],
+    "id": "f59f56d8-921c-4831-a228-fb503179d70d",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": null,
+     "end_turn": null,
+     "id": "f59f56d8-921c-4831-a228-fb503179d70d",
+     "metadata": {
+      "can_save": false,
+      "contextual_answers_message_type": "identity_prompt",
+      "is_contextual_answers_system_message": true,
+      "is_visually_hidden_from_conversation": true
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "8c9c0535-bb32-4108-8976-fe984131b631"
+   },
+   "f70ac69d-d94c-43df-a2dc-e3ccb9fa6054": {
+    "children": [
+     "bbb21cc6-63e7-41cb-8e34-2e4246a63fa7"
+    ],
+    "id": "f70ac69d-d94c-43df-a2dc-e3ccb9fa6054",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Because the system is basically **unfinished at birth and \u201cboots up\u201d over the first weeks**.\n\n## What\u2019s happening under the hood\n\n**1. Gut is immature**\n- Intestines don\u2019t move smoothly yet (poor coordination)  \n- Gas gets **trapped instead of flowing through**\n\n---\n\n**2. Learning to poop is\u2026 complicated**\n- To poop, babies must:\n  - **tighten abs**\n  - **relax pelvic floor**\n\nThey\u2019re bad at this \u2192 they do both at once \u2192  \n\ud83d\udc49 **grunting, red face, gas buildup**\n\n---\n\n**3. Bacteria are moving in**\n- Gut starts getting colonized after birth  \n- This creates **more gas temporarily**  \n- System is still figuring out balance\n\n---\n\n**4. Nervous system overload (evenings)**\n- By end of day \u2192 overstimulated  \n- Less ability to handle discomfort  \n\ud83d\udc49 same gas feels worse at night\n\n---\n\n**5. Milk intake ramps up**\n- Around weeks 2\u20134 \u2192 feeding increases  \n\ud83d\udc49 more input = more digestion = more gas\n\n---\n\n## Why it peaks specifically around 2\u20134 weeks\nThat\u2019s when:\n- Milk supply is fully in  \n- Baby is eating more  \n- Gut still immature  \n- Bacteria colonization in full swing  \n\n\ud83d\udc49 **perfect storm**\n\n---\n\n## Why it improves after\nBy ~6\u20138 weeks:\n- Gut motility improves  \n- Baby coordinates pushing better  \n- Nervous system matures  \n- Microbiome stabilizes\n\n\ud83d\udc49 same gas \u2192 **less drama**\n\n---\n\n## The blunt truth\nNothing \u201cbreaks\u201d at 2\u20134 weeks.  \nIt\u2019s just the moment where:\n\ud83d\udc49 **input \u2191 but system still sucks at processing**\n\n---\n\nYou\u2019re not seeing a problem appear.  \nYou\u2019re seeing the system **under peak load before it upgrades.**"
+      ]
+     },
+     "create_time": 1773984605.116549,
+     "end_turn": true,
+     "id": "f70ac69d-d94c-43df-a2dc-e3ccb9fa6054",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "0528644f-1bd0-44ec-b574-1172ce550448",
+      "request_id": "9227b2e3-4c6e-47e2-ae8d-49f371858e94",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "43dbc7ae-1093-4cde-a3dc-5f74e8195dbb"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "0528644f-1bd0-44ec-b574-1172ce550448"
+   },
+   "f970ffa8-c806-4d1e-94e2-9638f02f5c38": {
+    "children": [
+     "8caf0e6f-82d6-4ef0-aa92-78f2bdbfc3fe"
+    ],
+    "id": "f970ffa8-c806-4d1e-94e2-9638f02f5c38",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1774905572.6942809,
+     "end_turn": true,
+     "id": "f970ffa8-c806-4d1e-94e2-9638f02f5c38",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "b2d554aa-12c9-4b87-a14f-29d4e1aabdaf",
+      "rebase_developer_message": true,
+      "request_id": "ba50d109-8dec-4da1-a925-fcd250e68ea8",
+      "turn_exchange_id": "607f26c1-e70e-4b18-b3d0-ebfbb4ec03b1"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "b2d554aa-12c9-4b87-a14f-29d4e1aabdaf"
+   },
+   "f9eeb00d-1522-49d6-8c34-6c211fe63b2c": {
+    "children": [
+     "1730de2b-d1b2-4ef9-8bb3-c8f1edd6bc57"
+    ],
+    "id": "f9eeb00d-1522-49d6-8c34-6c211fe63b2c",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1773765954.586588,
+     "end_turn": true,
+     "id": "f9eeb00d-1522-49d6-8c34-6c211fe63b2c",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "5e5536c2-02a4-4cce-a5c0-4fe8cb95ee08",
+      "rebase_developer_message": true,
+      "request_id": "f07df930-6fec-4b9f-8912-f71f6152663d",
+      "turn_exchange_id": "75a49c9c-d153-4ff2-aa56-7cc640c95c66"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "5e5536c2-02a4-4cce-a5c0-4fe8cb95ee08"
+   },
+   "fa7260b1-81b8-4e3a-bb91-29d464766543": {
+    "children": [
+     "bbb2197a-a761-4ee4-b587-02b8ebc45331"
+    ],
+    "id": "fa7260b1-81b8-4e3a-bb91-29d464766543",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Great choice \u2014 \ue200entity\ue202[\"brand\",\"Lupilu\"]\ue201 is one of the best \u201ccheap but works\u201d options.\n\n## \ud83e\uddf7 Diapers (Lupilu)\n\nTypical Portugal pricing:\n\n- **Normal price:** \u20ac0.13\u20130.16 / diaper  \n- **Good deal:** \u20ac0.11\u20130.13  \n- **Very good:** \u2264 \u20ac0.12  \n\n\ud83d\udc49 If you\u2019re paying ~\u20ac0.12\u20130.14 \u2192 you\u2019re doing well\n\n---\n\n## \ud83e\uddfb Wipes (Lupilu)\n\n- **Normal price:** \u20ac0.012\u20130.018 / wipe  \n- **Good deal:** ~\u20ac0.012\u20130.015  \n\n\ud83d\udc49 Basically **half the cost** of premium wipes\n\n---\n\n## Reality vs Dodot\n\n- Diapers: ~**40\u201350% cheaper**  \n- Wipes: ~**50\u201370% cheaper**\n\n---\n\n## What to expect (performance-wise)\n\n- Slightly **bulkier**  \n- Slightly less \u201cpremium feel\u201d  \n- But:\n  \ud83d\udc49 absorption is solid  \n  \ud83d\udc49 totally fine for daytime (and often nights too)\n\n---\n\n## Quick evaluation checklist (first 2 days)\n\n- Any leaks?  \n- Skin reacting?  \n- Fit around legs ok?  \n\nIf all good \u2192 you\u2019ve unlocked **easy savings**\n\n---\n\n## Bottom line\n\ud83d\udc49 Lupilu sweet spot:\n- Diapers: **~\u20ac0.12\u20130.14**  \n- Wipes: **~\u20ac0.012\u20130.015**\n\n---\n\nIf they work for your baby, you just cut one of the biggest recurring costs by half \u2014 not bad for a grocery run \ud83d\ude04"
+      ]
+     },
+     "create_time": 1775534457.839238,
+     "end_turn": true,
+     "id": "fa7260b1-81b8-4e3a-bb91-29d464766543",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [
+       {
+        "alt": "Lupilu",
+        "category": "brand",
+        "end_idx": 42,
+        "entity_data": null,
+        "entity_index": null,
+        "extra_params": null,
+        "id": null,
+        "matched_text": "\ue200entity\ue202[\"brand\",\"Lupilu\"]\ue201",
+        "metadata": null,
+        "name": "Lupilu",
+        "notes": null,
+        "prefix": null,
+        "priority": 1,
+        "prompt_text": "Lupilu",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 15,
+        "status": "done",
+        "type": "entity"
+       }
+      ],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "dd485191-9c3c-4bf6-9040-3d3f89c69d2d",
+      "request_id": "e2d38faf-19d3-4b72-b3c7-b1cd8dd7e6bf",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "ad060e34-afb5-4c8e-90b4-5dac9d5df405"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "dd485191-9c3c-4bf6-9040-3d3f89c69d2d"
+   },
+   "fc76911e-d67f-4e5c-aef6-d5d71d443f44": {
+    "children": [
+     "1d0d4997-f9a9-42b6-a7f9-83084519c6a8"
+    ],
+    "id": "fc76911e-d67f-4e5c-aef6-d5d71d443f44",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1775512226.6042707,
+     "end_turn": null,
+     "id": "fc76911e-d67f-4e5c-aef6-d5d71d443f44",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb2112f-1b5f-4a1c-8093-ac61d6449cb6",
+      "request_id": "7aba375a-43f3-4019-a2fc-5fa4f0b9affd",
+      "turn_exchange_id": "63e5fe35-1a1c-438f-8b53-24d738260846"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb2112f-1b5f-4a1c-8093-ac61d6449cb6"
+   },
+   "fda7cb5c-6d28-4562-8ea5-f36e002743e6": {
+    "children": [
+     "68337cb1-488e-42c8-a6fb-4bba17821b30"
+    ],
+    "id": "fda7cb5c-6d28-4562-8ea5-f36e002743e6",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "system"
+     },
+     "channel": null,
+     "content": {
+      "content_type": "text",
+      "parts": [
+       ""
+      ]
+     },
+     "create_time": 1775487499.5803542,
+     "end_turn": true,
+     "id": "fda7cb5c-6d28-4562-8ea5-f36e002743e6",
+     "metadata": {
+      "can_save": false,
+      "default_model_slug": "gpt-5-3",
+      "is_visually_hidden_from_conversation": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb21f74-ddb1-41d4-a9ac-79127fdfd0be",
+      "rebase_developer_message": true,
+      "request_id": "824b3c0c-2753-4a2b-ad82-5109161263b1",
+      "turn_exchange_id": "9cd645b8-7e30-4d46-8292-5374089275ef"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 0.0
+    },
+    "parent": "bbb21f74-ddb1-41d4-a9ac-79127fdfd0be"
+   },
+   "ff641fef-57b6-48ea-b709-1bf95337da49": {
+    "children": [
+     "97fe31eb-22bd-4ff2-92aa-906d166115e7"
+    ],
+    "id": "ff641fef-57b6-48ea-b709-1bf95337da49",
+    "message": {
+     "author": {
+      "metadata": {},
+      "name": null,
+      "role": "assistant"
+     },
+     "channel": "final",
+     "content": {
+      "content_type": "text",
+      "parts": [
+       "Short answer: **roughly the first 2\u20133 months**.\n\nWhy that window:\n\n- **Weight:** newborn ~3\u20134 kg \u2192 2\u20133-month baby ~5\u20136 kg  \n- **Water + tub:** ~9\u201313 kg  \n- **Total load:** ~14\u201319 kg\n\nThe **\ue200entity\ue202[\"product\",\"IKEA SNIGLAR changing table\"]\ue201 handles that fine. Structurally it\u2019s not close to failure territory.\n\nThe real reason people stop around that age isn\u2019t weight \u2014 it\u2019s **mobility and splash chaos**.\n\nAround **10\u201312 weeks** babies start:\n- kicking hard  \n- twisting  \n- trying mini-rolls  \n\nAt that point the setup becomes **awkward and slippery**, not unsafe structurally but annoying to manage.\n\n**Typical progression**\n- **0\u20132/3 months:** tub on changing table works great  \n- **3\u20135 months:** many move tub to **floor or inside the big bathtub**  \n- **~6 months:** baby usually goes **directly in the big tub**\n\nA practical signal to switch setups: when the bath turns from calm spa session into **tiny dolphin training practice**."
+      ]
+     },
+     "create_time": 1773573980.196441,
+     "end_turn": true,
+     "id": "ff641fef-57b6-48ea-b709-1bf95337da49",
+     "metadata": {
+      "can_save": true,
+      "citations": [],
+      "content_references": [
+       {
+        "alt": "IKEA SNIGLAR changing table",
+        "end_idx": 239,
+        "matched_text": "\ue200entity\ue202[\"product\",\"IKEA SNIGLAR changing table\"]\ue201",
+        "prompt_text": "IKEA SNIGLAR changing table",
+        "refs": [],
+        "safe_urls": [],
+        "start_idx": 189,
+        "type": "alt_text"
+       }
+      ],
+      "default_model_slug": "gpt-5-3",
+      "finish_details": {
+       "stop_tokens": [
+        200002
+       ],
+       "type": "stop"
+      },
+      "gizmo_id": "g-p-69b345fd8c3c8191bff0c8373bb252b1",
+      "is_complete": true,
+      "message_type": "next",
+      "model_slug": "gpt-5-3",
+      "parent_id": "bbb2103e-ba1a-44a6-8100-fd5ba4c71dd5",
+      "request_id": "f1cbe192-d9c3-4678-82a9-2c0dffeddac1",
+      "resolved_model_slug": "gpt-5-3",
+      "search_result_groups": [],
+      "turn_exchange_id": "1245534d-242f-4f79-8d76-def93220c7f3"
+     },
+     "recipient": "all",
+     "status": "finished_successfully",
+     "update_time": null,
+     "weight": 1.0
+    },
+    "parent": "bbb2103e-ba1a-44a6-8100-fd5ba4c71dd5"
+   }
+  },
+  "memory_scope": "project_v2",
+  "moderation_results": [],
+  "title": "Diapers / Hygiene",
+  "update_time": 1776969430.073746,
+  "voice": "glimmer"
+ },
+ {
+  "title": "Image only, no text",
+  "create_time": 1700000000.0,
+  "update_time": 1700000100.0,
+  "conversation_id": "00000000-0000-4000-8000-00000000f1x7",
+  "id": "00000000-0000-4000-8000-00000000f1x7",
+  "current_node": "node-user",
+  "mapping": {
+   "node-root": {
+    "id": "node-root",
+    "parent": null,
+    "children": [
+     "node-user"
+    ],
+    "message": null
+   },
+   "node-user": {
+    "id": "node-user",
+    "parent": "node-root",
+    "children": [],
+    "message": {
+     "id": "msg-user",
+     "author": {
+      "role": "user"
+     },
+     "create_time": 1700000000.0,
+     "content": {
+      "content_type": "multimodal_text",
+      "parts": [
+       {
+        "content_type": "image_asset_pointer",
+        "asset_pointer": "file-service://file-synthetic"
+       }
+      ]
+     },
+     "status": "finished_successfully",
+     "end_turn": true,
+     "weight": 1.0,
+     "metadata": {},
+     "recipient": "all"
+    }
+   }
+  }
+ }
+]

--- a/python/tests/fixtures/chatgpt-fixture-manifest.json
+++ b/python/tests/fixtures/chatgpt-fixture-manifest.json
@@ -1,0 +1,44 @@
+{
+  "plain": {
+    "source_file": "conversations-000.json",
+    "conversation_id": "03c09bbc-29c4-46bf-ba96-4c520ce5bffe",
+    "title": "Visit Geneva in February",
+    "message_nodes": 5
+  },
+  "singleton": {
+    "source_file": "conversations-000.json",
+    "conversation_id": "04926f65-ffdc-4051-b799-8ebc8e02e0fb",
+    "title": "Peer Interview Questions: Chemistry",
+    "message_nodes": 3
+  },
+  "branched": {
+    "source_file": "conversations-000.json",
+    "conversation_id": "07bcdb4c-5ff1-4cb8-bfad-9497c990b01d",
+    "title": "Leadership Skills Assessment",
+    "message_nodes": 7
+  },
+  "long": {
+    "source_file": "conversations-000.json",
+    "conversation_id": "12c1038e-7dee-4cc8-bf08-546eee8e1375",
+    "title": "Vietnam Trip: Culture, Nature, Beach",
+    "message_nodes": 80
+  },
+  "code": {
+    "source_file": "conversations-000.json",
+    "conversation_id": "1d71ba64-6400-4f77-a658-85c6e7cf8fb5",
+    "title": "Sort Good and Bad Topics",
+    "message_nodes": 36
+  },
+  "voice": {
+    "source_file": "conversations-006.json",
+    "conversation_id": "69b37522-0514-8388-9ff0-22290ad067a9",
+    "title": "Diapers / Hygiene",
+    "message_nodes": 255
+  },
+  "empty": {
+    "source_file": "<synthetic>",
+    "conversation_id": "00000000-0000-4000-8000-00000000f1x7",
+    "title": "Image only, no text",
+    "message_nodes": 1
+  }
+}

--- a/python/tests/test_chatgpt_adapter_session_fidelity.py
+++ b/python/tests/test_chatgpt_adapter_session_fidelity.py
@@ -1,0 +1,316 @@
+"""ChatGPT import — session fidelity (plan 2026-07-05, internal repo).
+
+The ChatGPT export has first-class conversation boundaries (title,
+timestamps, mapping tree with current_node). These tests pin the behavior
+that preserves them end-to-end:
+
+  G1  chunks carry conversation_id; the engine groups sessions by it and
+      skips centroid-walk segmentation when explicit boundaries exist
+  G2  mapping traversal follows the canonical current_node -> parent chain
+      (edited/regenerated branches are NOT imported twice)
+  G3  per-message create_time is preserved on chunk messages
+  G4  content_type "code" (content.text) and voice audio transcriptions
+      (multimodal dict parts) are extracted, image-only parts skipped
+  G5  a real export is a zip / directory with conversations-NNN.json splits;
+      zip, directory, and single-file inputs parse identically
+
+Fixture: tests/fixtures/chatgpt-conversations.fixture.json — 7 real
+(anonymized) conversations + 1 synthetic, selected by
+totalreclaw-internal/e2e/chatgpt-import/make-fixture.py. Expected counts
+below were derived from the fixture by that script's companion analysis;
+see the manifest JSON for per-case metadata.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from totalreclaw.import_adapters.chatgpt_adapter import ChatGPTAdapter
+from totalreclaw.import_engine import ImportEngine
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+FIXTURE = FIXTURE_DIR / "chatgpt-conversations.fixture.json"
+MANIFEST = FIXTURE_DIR / "chatgpt-fixture-manifest.json"
+
+# Derived from the fixture (see module docstring):
+#   branched: 5 user/assistant text messages across all branches,
+#             4 on the canonical current_node path
+#   long:     69 across all branches, 61 canonical
+CASE_IDS = {case: m["conversation_id"] for case, m in json.loads(MANIFEST.read_text()).items()}
+CANONICAL_COUNTS = {"plain": 4, "singleton": 2, "branched": 4, "long": 61}
+BFS_COUNTS = {"branched": 5, "long": 69}
+CODE_STRING_PART_COUNT = 13  # string-part msgs in the code conv; content.text adds more
+
+
+def _conversations():
+    return json.loads(FIXTURE.read_text())
+
+
+def _conv(case):
+    cid = CASE_IDS[case]
+    return next(
+        c for c in _conversations()
+        if (c.get("conversation_id") or c.get("id")) == cid
+    )
+
+
+def _parse(convs):
+    adapter = ChatGPTAdapter()
+    return adapter.parse(content=json.dumps(convs))
+
+
+# ── G1: conversation identity on chunks ──────────────────────────────────
+
+
+def test_every_chunk_carries_conversation_id():
+    result = _parse(_conversations())
+    assert result.chunks, result.errors
+    for chunk in result.chunks:
+        assert getattr(chunk, "conversation_id", None), (
+            f"chunk {chunk.title!r} has no conversation_id"
+        )
+
+
+def test_multi_chunk_conversation_shares_one_id():
+    result = _parse([_conv("long")])
+    assert len(result.chunks) > 1  # 61 msgs / CHUNK_SIZE 20 -> 4 chunks
+    ids = {chunk.conversation_id for chunk in result.chunks}
+    assert ids == {CASE_IDS["long"]}
+
+
+def test_conversation_ids_match_export():
+    result = _parse([_conv("plain"), _conv("singleton")])
+    got = {chunk.conversation_id for chunk in result.chunks}
+    assert got == {CASE_IDS["plain"], CASE_IDS["singleton"]}
+
+
+# ── G2: canonical branch traversal ───────────────────────────────────────
+
+
+def test_branched_conversation_imports_canonical_path_only():
+    result = _parse([_conv("branched")])
+    assert result.total_messages == CANONICAL_COUNTS["branched"], (
+        f"expected canonical path ({CANONICAL_COUNTS['branched']} msgs), got "
+        f"{result.total_messages} — regenerated/edited branches must not be "
+        f"imported (BFS over all branches yields {BFS_COUNTS['branched']})"
+    )
+
+
+def test_long_conversation_imports_canonical_path_only():
+    result = _parse([_conv("long")])
+    assert result.total_messages == CANONICAL_COUNTS["long"], (
+        f"expected {CANONICAL_COUNTS['long']} canonical msgs, got "
+        f"{result.total_messages} (all-branches BFS would give {BFS_COUNTS['long']})"
+    )
+
+
+def test_plain_conversation_message_count():
+    result = _parse([_conv("plain")])
+    assert result.total_messages == CANONICAL_COUNTS["plain"]
+
+
+# ── G3: per-message timestamps ───────────────────────────────────────────
+
+
+def test_messages_carry_individual_timestamps():
+    result = _parse([_conv("plain")])
+    msgs = [m for chunk in result.chunks for m in chunk.messages]
+    stamped = [m for m in msgs if m.get("timestamp")]
+    assert len(stamped) == len(msgs), "every message should carry its create_time"
+    # ISO-8601 and non-decreasing along the conversation
+    times = [m["timestamp"] for m in msgs]
+    assert times == sorted(times)
+
+
+def test_chunk_timestamp_is_first_message_time_not_conversation_time():
+    result = _parse([_conv("long")])
+    chunk_times = [c.timestamp for c in result.chunks if c.timestamp]
+    assert len(set(chunk_times)) > 1, (
+        "chunks of a long conversation must not all share the conversation-level "
+        "create_time — per-message times are in the export"
+    )
+
+
+# ── G4: content-type coverage ────────────────────────────────────────────
+
+
+def test_code_messages_extracted_via_content_text():
+    result = _parse([_conv("code")])
+    assert result.total_messages > CODE_STRING_PART_COUNT, (
+        "content_type=code messages store text in content.text, not parts[] — "
+        "they must be extracted"
+    )
+
+
+def test_voice_transcriptions_extracted():
+    conv = _conv("voice")
+    # pull an expected transcription snippet straight from the export
+    snippet = None
+    for node in conv["mapping"].values():
+        msg = node.get("message")
+        if not msg:
+            continue
+        for part in (msg.get("content") or {}).get("parts") or []:
+            if isinstance(part, dict) and part.get("content_type") == "audio_transcription":
+                text = (part.get("text") or "").strip()
+                if len(text) > 10:
+                    snippet = text[:40]
+                    break
+        if snippet:
+            break
+    assert snippet, "fixture must contain an audio_transcription part"
+
+    result = _parse([conv])
+    all_text = " ".join(m.get("text", "") for c in result.chunks for m in c.messages)
+    assert snippet in all_text, "voice transcription text must be imported"
+
+
+def test_image_only_conversation_skipped_with_warning():
+    result = _parse([_conv("empty")])
+    assert result.chunks == []
+    assert result.warnings
+
+
+# ── G5: zip / directory / single-file equivalence ────────────────────────
+
+
+@pytest.fixture()
+def export_layouts(tmp_path):
+    """Materialize the fixture as single-file, split-directory, and zip."""
+    convs = _conversations()
+    single = tmp_path / "conversations.json"
+    single.write_text(json.dumps(convs))
+
+    split_dir = tmp_path / "export"
+    split_dir.mkdir()
+    half = len(convs) // 2
+    (split_dir / "conversations-000.json").write_text(json.dumps(convs[:half]))
+    (split_dir / "conversations-001.json").write_text(json.dumps(convs[half:]))
+
+    zip_path = tmp_path / "chatgpt-export.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.write(split_dir / "conversations-000.json", "conversations-000.json")
+        zf.write(split_dir / "conversations-001.json", "conversations-001.json")
+        zf.writestr("chat.html", "<html></html>")  # present in real exports, ignored
+
+    return single, split_dir, zip_path
+
+
+def test_zip_directory_and_single_file_parse_identically(export_layouts):
+    single, split_dir, zip_path = export_layouts
+    adapter = ChatGPTAdapter()
+
+    results = {
+        "single": adapter.parse(file_path=str(single)),
+        "dir": adapter.parse(file_path=str(split_dir)),
+        "zip": adapter.parse(file_path=str(zip_path)),
+    }
+    for name, res in results.items():
+        assert not res.errors, f"{name}: {res.errors}"
+
+    counts = {name: (len(r.chunks), r.total_messages) for name, r in results.items()}
+    assert len(set(counts.values())) == 1, counts
+
+    id_sets = {
+        name: {c.conversation_id for c in r.chunks} for name, r in results.items()
+    }
+    assert id_sets["single"] == id_sets["dir"] == id_sets["zip"]
+
+
+# ── G1 (engine): explicit boundaries beat centroid-walk ──────────────────
+
+
+class _BatchClient:
+    """Records remember_batch payloads; pretends to be on Gnosis (chain 100)."""
+
+    def __init__(self):
+        self.batches = []
+        self._n = 0
+
+    async def _ensure_chain_id(self):
+        return 100
+
+    async def remember_batch(self, payloads, source=None):
+        self.batches.append({"payloads": list(payloads), "source": source})
+        ids = [f"f{self._n + i}" for i in range(len(payloads))]
+        self._n += len(payloads)
+        return ids
+
+
+def _payloads(client):
+    return [p for b in client.batches for p in b["payloads"]]
+
+
+def test_engine_groups_sessions_by_conversation_id(monkeypatch):
+    """Chunks with explicit conversation ids must NOT go through
+    embedding-based centroid-walk segmentation."""
+    import totalreclaw.session_segmentation as seg
+
+    def _boom(*a, **k):  # pragma: no cover - the point is it is never called
+        raise AssertionError(
+            "segment_sessions must not run for sources with explicit "
+            "conversation boundaries"
+        )
+
+    monkeypatch.setattr(seg, "segment_sessions", _boom)
+
+    parse = _parse([_conv("plain"), _conv("long"), _conv("singleton")])
+    engine = ImportEngine(client=_BatchClient(), llm_extract=None)
+    sessions = engine._group_chunks_into_sessions(parse.chunks)
+
+    # one session per conversation, each containing all of that conversation's chunks
+    by_conv = {}
+    for idx, chunk in enumerate(parse.chunks):
+        by_conv.setdefault(chunk.conversation_id, []).append(idx)
+    assert sorted(map(sorted, sessions)) == sorted(map(sorted, by_conv.values()))
+
+
+def test_end_to_end_sessions_equal_conversations(monkeypatch):
+    """Full process_batch over two conversations -> two sessions, facts of a
+    conversation share one session_id, one Crystal per multi-turn conversation."""
+    import totalreclaw.embedding as emb
+    monkeypatch.setattr(emb, "get_embedding", lambda t: [0.1, 0.2, 0.3])
+
+    async def fake_extract(messages, timestamp):
+        return [{"text": f"fact about {messages[0]['text'][:20]}", "type": "fact", "importance": 8}]
+
+    async def fake_completion(prompt):
+        return (
+            '{"title": "A conversation", "summary": "s", '
+            '"key_outcomes": [], "open_threads": [], "topics_discussed": []}'
+        )
+
+    client = _BatchClient()
+    engine = ImportEngine(
+        client=client,
+        llm_extract=fake_extract,
+        llm_completion=fake_completion,
+        enable_smart_import=False,
+    )
+    result = asyncio.run(
+        engine.process_batch(
+            source="chatgpt",
+            content=json.dumps([_conv("plain"), _conv("branched")]),
+        )
+    )
+    assert result.is_complete, result.errors
+
+    payloads = _payloads(client)
+    assert payloads
+    session_ids = {
+        (p.get("extra_metadata") or {}).get("session_id")
+        for p in payloads
+        if (p.get("extra_metadata") or {}).get("session_id")
+    }
+    assert len(session_ids) == 2, (
+        f"two conversations must map to exactly two sessions, got {len(session_ids)}"
+    )
+    crystals = [
+        p for p in payloads
+        if (p.get("extra_metadata") or {}).get("subtype") == "session_crystal"
+    ]
+    assert len(crystals) == 2

--- a/python/tests/test_chatgpt_adapter_session_fidelity.py
+++ b/python/tests/test_chatgpt_adapter_session_fidelity.py
@@ -260,7 +260,7 @@ def test_engine_groups_sessions_by_conversation_id(monkeypatch):
 
     parse = _parse([_conv("plain"), _conv("long"), _conv("singleton")])
     engine = ImportEngine(client=_BatchClient(), llm_extract=None)
-    sessions = engine._group_chunks_into_sessions(parse.chunks)
+    sessions = asyncio.run(engine._get_session_assignments(parse.chunks))
 
     # one session per conversation, each containing all of that conversation's chunks
     by_conv = {}
@@ -276,7 +276,8 @@ def test_end_to_end_sessions_equal_conversations(monkeypatch):
     monkeypatch.setattr(emb, "get_embedding", lambda t: [0.1, 0.2, 0.3])
 
     async def fake_extract(messages, timestamp):
-        return [{"text": f"fact about {messages[0]['text'][:20]}", "type": "fact", "importance": 8}]
+        # engine contract: messages arrive as [{"role", "content"}]
+        return [{"text": f"fact about {messages[0]['content'][:20]}", "type": "fact", "importance": 8}]
 
     async def fake_completion(prompt):
         return (


### PR DESCRIPTION
## What

Brings the ChatGPT import path on Hermes to parity with the real export format, closing five gaps (internal plan `2026-07-05-chatgpt-import-hermes-plan.md`):

1. **Boundary-aware sessions** — `ConversationChunk` gains `conversation_id`; when chunks carry explicit conversation boundaries the engine groups sessions by them directly (one conversation = one session = one Crystal) and skips centroid-walk semantic segmentation (#367). Segmentation remains the path for boundary-less sources (Gemini) — no regression.
2. **Canonical thread traversal** — mapping tree is walked `current_node` → parent (what the user actually sees) instead of BFS over all branches; edited/regenerated drafts are no longer imported as near-duplicates (real fixture conv: 69 → 61 msgs).
3. **Per-message timestamps** — `message.create_time` preserved on every chunk message; chunk timestamp = first message's time, not the flat conversation-level time.
4. **Content coverage** — `content_type=code` (`content.text`) and voice `audio_transcription` dict parts are now extracted; image pointers skipped.
5. **Real export input shape** — `file_path` accepts the export **zip**, the unpacked folder (`conversations-000..NNN.json` splits), or a legacy single `conversations.json`. Deterministic file ordering keeps resume offsets stable; RAM/size preflight applies to summed uncompressed size.

Plus: `totalreclaw_import_from` schema description + `importing-from-chatgpt.md` guide updated (no unzip step needed).

## Tests

- 14 new tests in `test_chatgpt_adapter_session_fidelity.py` (TDD — committed red first) over an 8-conversation fixture derived from the **anonymized** internal corpus (PII-grepped: emails/phones/names/keys/mnemonic patterns = 0 hits).
- Full suite: **1631 passed, 13 skipped, 1 xfailed**.
- Full-corpus validation against the real 87MB export (internal, 9 split files): 808/808 conversations parsed, 12,082 canonical messages, 12,081 with real timestamps, 0 errors, 0.4s.

## Not in this PR

- imp-2 onboarding nudge + privacy disclosure UX (#244 internal) — separate PR, held for Pedro review (user-facing hard rail).
- Claude adapter conversation boundaries — its adapter is memories-text only today (no conversation export parsing); no boundary to stamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sks1gbonedAkEsawd4LVE