### PR TITLE
chore(python): bump to 2.4.6 (session-hygiene RC line)

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,11 @@ Hermes Agent plugin are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.6] — unreleased
+
+### Fixed
+- **Per-conversation session hygiene (#429).** Parallel conversations through one Hermes process (e.g. several messaging chats on one bot) collapsed into a single `session_id`, interleaving unrelated memories into one session Crystal. The plugin now **honors the host's `session_id`** — `on_session_start` derives the session key deterministically from the `session_id` Hermes passes, so when the host distinguishes conversations we inherit that boundary (any platform, not just one). Plus an **idle-timeout rollover** (`TOTALRECLAW_SESSION_IDLE_MINUTES`, default 60, `0` disables): a turn after a long gap flushes + debriefs the idle session and starts a fresh one. Host-derived sessions are never idle-rolled. See `docs/guides/hermes-session-hygiene.md`.
+
 ## [2.4.4] — 2026-06-06
 
 Stable line for the `totalreclaw` Python client + `totalreclaw.hermes` plugin, consolidating the 2.4.0 → 2.4.4rc7 cycle. Headline: the client is now **chain-aware** (it reads its chain + DataEdge from the relay, so the managed service's single-chain Gnosis migration needed zero client release), plus a pre-stable QA hardening pass over the install / setup / extraction / delete paths.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,7 +24,7 @@ name = "totalreclaw"
 # now `2.4.5`, so RCs cut as `2.4.5rcN` outrank `2.4.4` and the
 # version-agnostic install path lands them. NEVER leave the base equal to
 # an already-published stable.
-version = "2.4.5"
+version = "2.4.6"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Bumps the python client base to **2.4.6** so RCs can be cut past the released 2.4.5. Ships #429 (per-conversation session hygiene). RC `2.4.6rc1` dispatched from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)