### PR TITLE
feat(hermes): content-aware Crystal gate + platform-agnostic session docs

### DIFF
--- a/docs/guides/hermes-session-hygiene.md
+++ b/docs/guides/hermes-session-hygiene.md
@@ -44,9 +44,9 @@ turns apart — Hermes' `pre_llm_call` / `post_llm_call` hooks currently carry o
 the message text, no conversation identifier. The complete fix needs the
 **host** to pass its conversation id — whatever the platform uses to identify a
 conversation (a chat id, a thread/topic id, a room id) — into the per-turn hooks;
-the plugin already knows how to scope by it (mechanism 1). This is platform-
-agnostic: nothing here is specific to any one messenger. Until then, the idle
-rollover covers conversations that are separated in time.
+the plugin already knows how to scope by it (mechanism 1). This mechanism is
+platform-agnostic: nothing here is specific to any one messenger. Until then,
+the idle rollover covers conversations that are separated in time.
 
 ## Tips
 

--- a/docs/guides/hermes-session-hygiene.md
+++ b/docs/guides/hermes-session-hygiene.md
@@ -9,9 +9,11 @@ quality of the grouping depends entirely on when Hermes starts a new session.
 Hermes runs as **one process**. Before this change, the TotalReclaw plugin
 minted **one `session_id` per process lifecycle** and ignored the `session_id`
 Hermes passes to `on_session_start`. If you talk to your agent through **several
-parallel conversations at once** — e.g. multiple Telegram chats / group chats /
-forum topics on the same bot — their turns all landed under the **same
-`session_id`**, so unrelated memories interleaved into **one Crystal**.
+parallel conversations at once** — e.g. several chats, group chats, or forum
+topics on the same messaging platform (Telegram, WhatsApp, Slack, Matrix, …) —
+their turns all landed under the **same `session_id`**, so unrelated memories
+interleaved into **one Crystal**. (Nothing here is platform-specific; the fix
+works for any messenger you configure Hermes with.)
 
 ## What changed
 
@@ -39,10 +41,12 @@ Two plugin-side mitigations (no host changes required):
 If two conversations are **truly interleaved in real time** and Hermes does
 **not** pass a per-conversation id on every turn, the plugin cannot tell the
 turns apart — Hermes' `pre_llm_call` / `post_llm_call` hooks currently carry only
-the message text, no `chat_id` / `message_thread_id`. The complete fix needs the
-**host** to pass a conversation id (e.g. Telegram `chat_id` + `message_thread_id`)
-into the per-turn hooks; the plugin already knows how to scope by it (mechanism
-1). Until then, use idle rollover, or the explicit "new session" fast-follow.
+the message text, no conversation identifier. The complete fix needs the
+**host** to pass its conversation id — whatever the platform uses to identify a
+conversation (a chat id, a thread/topic id, a room id) — into the per-turn hooks;
+the plugin already knows how to scope by it (mechanism 1). This is platform-
+agnostic: nothing here is specific to any one messenger. Until then, the idle
+rollover covers conversations that are separated in time.
 
 ## Tips
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,25 @@ Hermes Agent plugin are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Content-aware Crystal gate.** A session used to need 4 full turns (8
+  messages) before it earned a Crystal, silently dropping crisp 2-3 turn
+  topical exchanges (e.g. "book the Lisbon flight, aisle seat, under $400")
+  even when they produced real, storable facts. The gate is now content-aware:
+  hard floor of 2 turns (`< 4` messages) never crystallizes; a 2-3 turn session
+  (4-7 messages) crystallizes when it produced substance (`>= 2` stored facts);
+  4+ turns always qualify (unchanged). Enforced on the auto path
+  (`session_debrief`) and defended in depth in `generate_crystal` /
+  `generate_debrief`. The explicit `totalreclaw_debrief` tool keeps its 4-turn
+  floor (it has no stored-fact context to judge substance).
+- **Platform-agnostic session-hygiene docs.** `docs/guides/hermes-session-hygiene.md`
+  no longer frames per-conversation grouping around Telegram — the mechanism
+  (honor the host's conversation id) works for any messenger Hermes is
+  configured with (Telegram, WhatsApp, Slack, Matrix, …).
+
 ## [2.4.4] — 2026-06-06
 
 Stable line for the `totalreclaw` Python client + `totalreclaw.hermes` plugin, consolidating the 2.4.0 → 2.4.4rc7 cycle. Headline: the client is now **chain-aware** (it reads its chain + DataEdge from the relay, so the managed service's single-chain Gnosis migration needed zero client release), plus a pre-stable QA hardening pass over the install / setup / extraction / delete paths.

--- a/python/src/totalreclaw/agent/debrief.py
+++ b/python/src/totalreclaw/agent/debrief.py
@@ -179,8 +179,13 @@ async def generate_debrief(
     if not config:
         return []
 
-    # Minimum 4 turns (8 messages) to warrant a debrief
-    if len(messages) < 8:
+    # Content-aware length gate. Hard floor: < 2 turns (4 messages) is too thin
+    # to summarize. Between 4-7 messages, still crystallize IF the session was
+    # substantive (>= 2 stored facts) — a crisp 2-3 turn topical exchange
+    # deserves a Crystal, not just its loose atomic facts.
+    if len(messages) < 4:
+        return []
+    if len(messages) < 8 and len(stored_fact_texts) < 2:
         return []
 
     conversation_text = _truncate_messages(messages)
@@ -337,7 +342,12 @@ async def generate_crystal(
     if not config:
         return None
 
-    if len(messages) < 8:
+    # Content-aware length gate (matches session_debrief). Hard floor of 2 turns
+    # (4 messages); between 4-7 messages, crystallize only a substantive session
+    # (>= 2 stored facts) so a crisp short topical exchange still gets a Crystal.
+    if len(messages) < 4:
+        return None
+    if len(messages) < 8 and len(stored_fact_texts) < 2:
         return None
 
     conversation_text = _truncate_messages(messages)

--- a/python/src/totalreclaw/agent/lifecycle.py
+++ b/python/src/totalreclaw/agent/lifecycle.py
@@ -479,11 +479,19 @@ def session_debrief(
         return []
 
     all_messages = state.get_all_messages()
-    if len(all_messages) < 8:  # Minimum 4 turns
-        return []
 
     if stored_fact_texts is None:
         stored_fact_texts = []
+
+    # Content-aware length gate. Hard floor: < 2 turns (4 messages) is too thin
+    # to summarize. Between 4-7 messages, still crystallize IF the session
+    # produced real content (>= 2 stored facts) — a crisp 2-3 turn topical
+    # exchange (e.g. "book the Lisbon flight, aisle seat, under $400") deserves
+    # its own Crystal, not just loose atomic facts. 4+ turns always qualify.
+    if len(all_messages) < 4:
+        return []
+    if len(all_messages) < 8 and len(stored_fact_texts) < 2:
+        return []
 
     client = state.get_client()
     if not client:

--- a/python/src/totalreclaw/hermes/tools.py
+++ b/python/src/totalreclaw/hermes/tools.py
@@ -638,8 +638,11 @@ async def debrief(args: dict, state: "PluginState", **kwargs) -> str:
         )
 
     # Short-circuit guard so the tool returns a clear explanation to the
-    # agent rather than an empty debrief. Mirrors the < 8-message gate in
-    # ``session_debrief`` itself.
+    # agent rather than an empty debrief. The explicit tool holds a stricter
+    # 4-turn floor than the auto path: ``session_debrief``'s content-aware gate
+    # will crystallize a short 2-3 turn session when it produced >= 2 stored
+    # facts, but the explicit tool has no stored-fact context to judge that, so
+    # it keeps the simple length floor and tells the user to keep chatting.
     all_messages = state.get_all_messages() if hasattr(state, "get_all_messages") else []
     if len(all_messages) < 8:
         return json.dumps({

--- a/python/tests/test_crystal_gate_content_aware.py
+++ b/python/tests/test_crystal_gate_content_aware.py
@@ -1,0 +1,164 @@
+"""Content-aware Crystal length gate.
+
+Historically a session had to reach 4 full turns (8 messages) before it
+earned a Crystal (``len(messages) < 8 → skip``). That silently dropped
+crisp 2-3 turn topical exchanges ("book the Lisbon flight, aisle seat,
+under $400") even when they produced real, storable facts.
+
+The gate is now content-aware:
+
+* Hard floor: ``< 4`` messages (< 2 turns) → never crystallize.
+* 4-7 messages (2-3 turns) → crystallize only if the session produced
+  substance (``>= 2`` stored facts).
+* ``>= 8`` messages (4+ turns) → always qualify, as before.
+
+Two layers enforce it and are covered here:
+
+1. :func:`totalreclaw.agent.lifecycle.session_debrief` — the auto path
+   (``on_session_finalize`` → debrief → Crystal). This is the layer that
+   holds the ``stored_fact_texts`` context, so it is the real decision point.
+2. :func:`totalreclaw.agent.debrief.generate_crystal` — defense in depth,
+   so a direct caller can't slip a trivial session past the gate.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from totalreclaw.agent.debrief import Crystal, generate_crystal
+from totalreclaw.agent.lifecycle import session_debrief
+from totalreclaw.hermes.state import PluginState
+
+
+def _make_state_with_client() -> PluginState:
+    """A configured PluginState whose fake client records ``remember`` calls."""
+    with patch.dict(os.environ, {}, clear=True):
+        with patch.object(Path, "exists", return_value=False):
+            state = PluginState()
+
+    fake_client = MagicMock()
+    remember_return = iter([f"fact-id-{i}" for i in range(1, 10)])
+
+    async def _remember(*args, **kwargs):
+        return next(remember_return)
+
+    fake_client.remember = AsyncMock(side_effect=_remember)
+    fake_client.recall = AsyncMock(return_value=[])
+    state._client = fake_client
+    return state
+
+
+def _seed(state: PluginState, n_messages: int) -> None:
+    for i in range(n_messages):
+        role = "user" if i % 2 == 0 else "assistant"
+        state.add_message(role, f"a substantive message about the Lisbon trip, turn {i}")
+
+
+_CRYSTAL = Crystal(
+    narrative="Booked the Lisbon flight — aisle seat, under $400.",
+    key_outcomes=["flight booked"],
+    open_threads=[],
+    lessons=[],
+    importance=7,
+)
+
+
+async def _fake_generate(*args, **kwargs):
+    return _CRYSTAL
+
+
+# ── session_debrief (auto path — the real decision point) ─────────────────────
+
+
+class TestSessionDebriefGate:
+    def test_hard_floor_gates_below_two_turns(self) -> None:
+        """< 4 messages (< 2 turns) never crystallizes, even with facts."""
+        state = _make_state_with_client()
+        _seed(state, 2)  # 1 turn
+        with patch("totalreclaw.agent.lifecycle.generate_crystal", new=_fake_generate):
+            out = session_debrief(state, stored_fact_texts=["a", "b", "c"])
+        assert out == []
+
+    def test_short_trivial_session_is_gated(self) -> None:
+        """4-7 messages with < 2 stored facts → no Crystal."""
+        state = _make_state_with_client()
+        _seed(state, 6)  # 3 turns
+        with patch("totalreclaw.agent.lifecycle.generate_crystal", new=_fake_generate):
+            out = session_debrief(state, stored_fact_texts=["only one fact"])
+        assert out == []
+
+    def test_short_substantive_session_crystallizes(self) -> None:
+        """4-7 messages WITH >= 2 stored facts → a crisp short topic gets a Crystal."""
+        state = _make_state_with_client()
+        _seed(state, 6)  # 3 turns
+        with patch("totalreclaw.agent.lifecycle.generate_crystal", new=_fake_generate):
+            out = session_debrief(state, stored_fact_texts=["flight", "seat"])
+        assert out == ["fact-id-1"]
+
+    def test_long_session_crystallizes_without_facts(self) -> None:
+        """>= 8 messages (4+ turns) always qualifies — unchanged behaviour."""
+        state = _make_state_with_client()
+        _seed(state, 8)  # 4 turns
+        with patch("totalreclaw.agent.lifecycle.generate_crystal", new=_fake_generate):
+            out = session_debrief(state, stored_fact_texts=[])
+        assert out == ["fact-id-1"]
+
+    def test_stored_fact_texts_none_is_safe(self) -> None:
+        """A short session with no fact context (None) gates cleanly, no crash."""
+        state = _make_state_with_client()
+        _seed(state, 6)
+        with patch("totalreclaw.agent.lifecycle.generate_crystal", new=_fake_generate):
+            out = session_debrief(state, stored_fact_texts=None)
+        assert out == []
+
+
+# ── generate_crystal (defense in depth) ───────────────────────────────────────
+
+
+class TestGenerateCrystalGate:
+    @pytest.mark.asyncio
+    async def test_hard_floor_returns_none(self) -> None:
+        msgs = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "yo"}]
+        with patch("totalreclaw.agent.debrief.detect_llm_config", return_value=MagicMock()):
+            # A truthy config means we reach the length gate; the gate must
+            # short-circuit to None *before* any LLM call.
+            with patch("totalreclaw.agent.debrief.chat_completion", new=AsyncMock()) as llm:
+                out = await generate_crystal(msgs, ["a", "b", "c"])
+        assert out is None
+        llm.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_short_trivial_returns_none(self) -> None:
+        msgs = [{"role": "user", "content": f"m{i}"} for i in range(6)]
+        with patch("totalreclaw.agent.debrief.detect_llm_config", return_value=MagicMock()):
+            with patch("totalreclaw.agent.debrief.chat_completion", new=AsyncMock()) as llm:
+                out = await generate_crystal(msgs, ["only one"])
+        assert out is None
+        llm.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_short_substantive_reaches_llm(self) -> None:
+        """4-7 messages + >= 2 facts passes the gate and calls the LLM."""
+        msgs = [
+            {"role": "user", "content": "book the Lisbon flight"},
+            {"role": "assistant", "content": "aisle seat, under $400 — done"},
+            {"role": "user", "content": "great"},
+            {"role": "assistant", "content": "confirmation sent"},
+        ]
+        fake_response = (
+            '{"narrative": "Booked the Lisbon flight, aisle seat under $400.", '
+            '"key_outcomes": ["flight booked"], "open_threads": [], '
+            '"lessons": [], "importance": 7}'
+        )
+        with patch("totalreclaw.agent.debrief.detect_llm_config", return_value=MagicMock()):
+            with patch(
+                "totalreclaw.agent.debrief.chat_completion",
+                new=AsyncMock(return_value=fake_response),
+            ) as llm:
+                out = await generate_crystal(msgs, ["flight", "seat"])
+        llm.assert_awaited_once()
+        assert out is not None
+        assert out.importance == 7


### PR DESCRIPTION
## Why

Two small, related fast-follows from the Hermes session-hygiene work (#429):

1. **The Crystal length gate was too blunt.** A session had to reach **4 full turns (8 messages)** before it earned a Crystal (`len(messages) < 8 → skip`). That silently dropped **crisp 2-3 turn topical exchanges** — e.g. *"book the Lisbon flight, aisle seat, under $400"* — even when they produced real, storable facts. Pedro flagged exactly this: *"what happens if there's a new session on a clear specific topic that lasts 4 turns only?"*

2. **The session-hygiene guide read as Telegram-specific**, but the mechanism (honor the host's conversation id) is platform-agnostic and must work for **any** messenger Hermes is configured with.

## What changed

### Content-aware Crystal gate
- **Hard floor**: `< 4` messages (< 2 turns) → never crystallize.
- **4-7 messages (2-3 turns)** → crystallize **only if the session produced substance** (`>= 2` stored facts).
- **`>= 8` messages (4+ turns)** → always qualify (unchanged).

Enforced at the real decision point — `lifecycle.session_debrief` (the auto `on_session_finalize` path, which holds the `stored_fact_texts` context) — and **defended in depth** in `generate_crystal` / `generate_debrief`. The explicit `totalreclaw_debrief` tool keeps its simple 4-turn floor (it has no stored-fact context to judge substance); its stale *"mirrors the < 8-message gate in session_debrief"* comment is corrected to explain the intentional divergence.

### Platform-agnostic docs
`docs/guides/hermes-session-hygiene.md` no longer frames per-conversation grouping around Telegram — now explicitly "any messaging platform Hermes is configured with (Telegram, WhatsApp, Slack, Matrix, …)", and the residual host-side fix is described in terms of a generic conversation identifier, not `chat_id`/`message_thread_id`.

## Tests
- New `test_crystal_gate_content_aware.py` — **8 tests** covering the auto path (`session_debrief`) and the `generate_crystal` defense-in-depth gate: hard floor, short-trivial gated, short-substantive crystallizes, long session always qualifies, `None` fact-list safety, and that the gate short-circuits **before** any LLM call.
- Full Python suite: **1694 passed, 39 skipped, 1 xfailed**.

## Notes
- No version bump / RC here — recorded under `[Unreleased]` in `python/CHANGELOG.md`; folds into the next consolidated stable entry (same pattern as the 2.4.4 consolidation).
- Behavioural change is **auto-path only**; existing 4+-turn sessions are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)