### PR TITLE
docs: content-aware Crystal gate in compatibility matrix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,7 @@ Features across OpenClaw plugin (`skill/plugin/`), MCP server (`mcp/`), NanoClaw
 | Pre-reset flush | Yes | -- | -- | -- | -- | -- | OpenClaw only |
 | Session-end flush | -- | -- | -- | Yes (on_session_end) | -- | -- | Hermes plugin flushes unprocessed messages |
 | Session debrief | Yes (hook) | Yes (tool) | Yes (hook) | Yes (hook) | Yes (via MCP tool) | Yes (debrief method) | Captures broader context at session end; max 5 items |
+| Content-aware Crystal gate | -- | -- | -- | Yes (auto) | -- | -- | #434, shipped 2026-07-05. Auto session-debrief Crystal length gate is content-aware: hard floor `< 4` messages never crystallizes; `4-7` messages (2-3 turns) crystallize only with substance (`>= 2` stored facts); `>= 8` messages always qualify. Enforced in `lifecycle.session_debrief`, defended in depth in `generate_crystal`/`generate_debrief`. The explicit `totalreclaw_debrief` tool keeps the simple 4-turn (`< 8`) floor — no stored-fact context to judge substance. Hermes-only — MCP/NanoClaw/ZeroClaw have no auto-extraction pipeline to wire it into. |
 | CLAUDE.md sync | -- | -- | Yes | -- | -- | -- | NanoClaw syncs high-importance facts |
 | Routine-based extraction | -- | -- | -- | -- | Yes (cron) | -- | IronClaw routines engine; see ironclaw-setup.md |
 | Decay handling | -- | -- | -- | -- | -- | Yes (via ZeroClaw) | ZeroClaw applies 7-day half-life at retrieval time |


### PR DESCRIPTION
## What

Docs-only housekeeping. Reflects **PR #434** (already merged to `main` as `536e391`) in the root `CLAUDE.md` **Feature Compatibility Matrix**.

#434 made the Hermes auto session-debrief **Crystal length gate content-aware**:

- **Old rule:** a session only crystallized at ≥ 4 turns (`len(messages) < 8 → skip`).
- **New rule:** hard floor `< 4` messages never crystallizes; `4-7` messages (2-3 turns) crystallize **only if** the session produced substance (`>= 2` stored facts); `>= 8` messages always qualify.
- Enforced in `lifecycle.session_debrief`; defended in depth in `debrief.generate_crystal` / `generate_debrief`.
- The explicit `totalreclaw_debrief` tool keeps its simple 4-turn (`< 8`) floor — it has no stored-fact context to judge substance.

## Change

Adds **one row** ("Content-aware Crystal gate") to the **Automatic Memory** section of the matrix, marked **Hermes-only (auto)**. MCP / NanoClaw / ZeroClaw are `--` by design (no auto-extraction pipeline to wire it into).

## Scope notes

- Per `CLAUDE.md`'s New Feature Checklist: this is a behavior change to an existing feature, so a full new guide isn't warranted — the matrix row is the right surface. The per-conversation-grouping guide (`docs/guides/hermes-session-hygiene.md`, also touched by #434) covers session *boundaries*, a distinct concern from this length/substance *gate*, so it was left as-is.
- **Entity-trapdoor read-side Known Gap:** reviewed against the "Entity-trapdoor recall (read-side)" feature row. Both are internally consistent (#370/#377, Hermes/Python-only read-side, +2.4pp Hit@16, core-hoist Task 5 deferred). It reads cleanly — **no edit needed**, so it was left unchanged.

Every claim in the new row was verified against `python/src/totalreclaw/agent/lifecycle.py`, `agent/debrief.py`, and `hermes/tools.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)