### PR TITLE
fix(hermes): per-conversation session isolation (parallel-chat fix)

### DIFF
--- a/docs/guides/hermes-session-hygiene.md
+++ b/docs/guides/hermes-session-hygiene.md
@@ -17,36 +17,42 @@ works for any messenger you configure Hermes with.)
 
 ## What changed
 
-Two plugin-side mitigations (no host changes required):
+Three plugin-side mechanisms (no host changes required):
 
-1. **Honor the host's `session_id`.** `on_session_start` now derives the
-   TotalReclaw session key deterministically from the `session_id` Hermes
-   provides. If your host distinguishes conversations (passes a distinct id per
-   chat/topic), TotalReclaw **inherits that boundary** automatically — parallel
-   conversations get separate sessions and separate Crystals.
+1. **Per-conversation session slots (the core fix).** Hermes hands the plugin a
+   per-conversation `session_id` on **every turn** — through its native
+   `MemoryProvider.sync_turn` and the per-turn hooks (its own
+   `self.agent.session_id`, which is distinct per conversation). The plugin now
+   routes each turn to a **slot** keyed by that id: every conversation keeps its
+   **own** message buffer, turn counter, and session id, and finalizes to its
+   **own** Crystal. Even conversations **interleaved in real time** in the same
+   chat no longer mix — each turn lands in the right slot. (Previously the
+   plugin ignored that id and piled every turn into one buffer.)
 
-2. **Idle-timeout rollover.** When TotalReclaw mints its own id (the host does
-   *not* distinguish conversations), a turn that arrives after a long silence
-   **rolls into a fresh session** first: the idle session is flushed +
-   debriefed, then a new `session_id` starts for the incoming turn. A long gap
-   almost always means a new topic, so bursty parallel conversations separated
-   in time stop merging.
+2. **Honor the host's `session_id` at session start.** `on_session_start` also
+   derives its session key from the id Hermes provides, so a host that
+   distinguishes conversations up front inherits that boundary too.
+
+3. **Idle-timeout rollover (fallback).** When TotalReclaw has to mint its own id
+   (a host that supplies no per-conversation id at all), a turn that arrives
+   after a long silence **rolls into a fresh session** first: the idle session
+   is flushed + debriefed, then a new `session_id` starts for the incoming turn.
+   A long gap almost always means a new topic.
 
    - Env: **`TOTALRECLAW_SESSION_IDLE_MINUTES`** (default **60**). Set `0` to
-     disable. Host-derived sessions (case 1) are never idle-rolled — the host
-     owns that boundary.
+     disable. Host-derived / per-conversation sessions are never idle-rolled —
+     the host owns those boundaries.
 
-## What is *not* fixed (host-side)
+## Residual (rare)
 
-If two conversations are **truly interleaved in real time** and Hermes does
-**not** pass a per-conversation id on every turn, the plugin cannot tell the
-turns apart — Hermes' `pre_llm_call` / `post_llm_call` hooks currently carry only
-the message text, no conversation identifier. The complete fix needs the
-**host** to pass its conversation id — whatever the platform uses to identify a
-conversation (a chat id, a thread/topic id, a room id) — into the per-turn hooks;
-the plugin already knows how to scope by it (mechanism 1). This mechanism is
-platform-agnostic: nothing here is specific to any one messenger. Until then,
-the idle rollover covers conversations that are separated in time.
+The per-conversation split relies on the host giving each conversation a
+distinct id per turn — Hermes' native gateway does (it passes its
+per-conversation `self.agent.session_id`). A host that funnels **every**
+conversation through a single **coarse** id (one id reused across unrelated
+conversations in a chat) *and* interleaves them in real time can't be told apart
+from that id alone; those fall back to the idle rollover (time-separated
+conversations still get clean sessions). This is platform-agnostic — nothing
+here is specific to any one messenger.
 
 ## Tips
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -25,6 +25,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (honor the host's conversation id) works for any messenger Hermes is
   configured with (Telegram, WhatsApp, Slack, Matrix, …).
 
+### Fixed
+
+- **Parallel conversations no longer collapse into one mixed session / Crystal.**
+  The Hermes plugin kept a single process-global message buffer + turn counter +
+  session id, so several conversations run in parallel through one Hermes process
+  (e.g. interleaved threads in the same Telegram chat) piled every turn into one
+  buffer and finalized to one **mixed** Crystal — and, because facts were tagged
+  with the coarse id `on_session_start` received, unrelated conversations grouped
+  under one `session_id` in the vault (even across process restarts). The plugin
+  now routes each turn to a **per-conversation slot** keyed by the per-conversation
+  `session_id` Hermes already passes to `MemoryProvider.sync_turn` and the per-turn
+  hooks (its `self.agent.session_id`): each conversation keeps its own buffer, turn
+  counter, and session id, and `on_session_finalize` crystallizes each separately —
+  so even conversations interleaved in real time get clean, separate Crystals.
+  Fully backward-compatible: a host that supplies no per-conversation id keeps the
+  prior single-session behavior. See `docs/guides/hermes-session-hygiene.md`.
+
 ## [2.4.4] — 2026-06-06
 
 Stable line for the `totalreclaw` Python client + `totalreclaw.hermes` plugin, consolidating the 2.4.0 → 2.4.4rc7 cycle. Headline: the client is now **chain-aware** (it reads its chain + DataEdge from the relay, so the managed service's single-chain Gnosis migration needed zero client release), plus a pre-stable QA hardening pass over the install / setup / extraction / delete paths.

--- a/python/src/totalreclaw/agent/state.py
+++ b/python/src/totalreclaw/agent/state.py
@@ -180,6 +180,25 @@ def _extract_mnemonic_from_creds(creds: dict) -> str:
     return alias
 
 
+# Sentinel key for the implicit "default" conversation slot — the live state a
+# host uses when it never supplies a per-conversation id (legacy single-session
+# behavior). A NUL prefix keeps it disjoint from any real host session id.
+_DEFAULT_SLOT_KEY = "\x00default"
+
+# The per-conversation slot = the live AgentState fields that belong to ONE
+# conversation. Everything else (client, billing cache, config, quota) is
+# process-global and shared across conversations.
+_SLOT_FIELDS = (
+    "_messages",
+    "_last_processed_idx",
+    "_turn_count",
+    "_session_id",
+    "_session_id_from_host",
+    "_last_activity",
+    "_pending_extract_buffer",
+)
+
+
 class AgentState:
     """Manages TotalReclaw client lifecycle, turn tracking, and message buffer.
 
@@ -222,6 +241,15 @@ class AgentState:
         self._session_id_from_host: bool = False
         # monotonic() of the last turn — drives idle-timeout session rollover.
         self._last_activity: float = 0.0
+        # Per-conversation session isolation (parallel-chat fix). When the host
+        # supplies a per-conversation id every turn (Hermes
+        # ``MemoryProvider.sync_turn`` / the per-turn hooks), each conversation
+        # gets its OWN slot — message buffer, turn counter, processed index,
+        # session id — so interleaved/parallel conversations no longer collapse
+        # into one session Crystal. Empty ⇒ legacy single-session behavior: the
+        # live attributes above ARE the one and only slot.
+        self._session_slots: dict[str, dict] = {}
+        self._active_conversation_key: Optional[str] = None
         # 2.4.4rc2 (F7) — auto-extract pending-queue tracking. Each
         # post_llm_call appends an entry for the just-completed turn's
         # user message; the totalreclaw_remember tool consults this
@@ -424,6 +452,108 @@ class AgentState:
         """Clear the session id. Idempotent."""
         self._session_id = None
         self._session_id_from_host = False
+
+    # ------------------------------------------------------------------
+    # Per-conversation session slots (parallel-chat fix)
+    #
+    # The live ``_SLOT_FIELDS`` are the *active* conversation. Any other
+    # conversation seen this lifecycle is stashed in ``_session_slots`` keyed
+    # by the host's per-conversation id. ``activate_conversation`` swaps the
+    # active slot; ``stash_active_conversation`` + ``pop_next_conversation``
+    # let a session-finalize sweep crystallize every conversation separately.
+    # When the host never supplies a per-conversation id these stay empty and
+    # every method below is a no-op → byte-identical legacy behavior.
+    # ------------------------------------------------------------------
+    def _ensure_slot_store(self) -> None:
+        """Lazily initialize the slot store. Defensive: legacy ``AgentState``
+        subclasses / test mocks that override ``__init__`` without calling
+        ``super().__init__()`` won't have set these, and every slot method must
+        tolerate that (behave as a fresh single-session state)."""
+        if not hasattr(self, "_session_slots"):
+            self._session_slots = {}
+        if not hasattr(self, "_active_conversation_key"):
+            self._active_conversation_key = None
+
+    def _capture_slot(self) -> dict:
+        return {f: getattr(self, f) for f in _SLOT_FIELDS}
+
+    def _restore_slot(self, slot: dict) -> None:
+        for f in _SLOT_FIELDS:
+            setattr(self, f, slot[f])
+
+    def _blank_live_slot(self) -> None:
+        """Reset the live conversation fields to a fresh, empty slot."""
+        self._messages = []
+        self._last_processed_idx = 0
+        self._turn_count = 0
+        self._pending_extract_buffer = []
+        self._session_id = None
+        self._session_id_from_host = False
+        self._last_activity = 0.0
+
+    def activate_conversation(self, external_id: Optional[str]) -> None:
+        """Route the live per-conversation state to the slot for *external_id*.
+
+        Called once per turn with the host's per-conversation id (Hermes
+        ``sync_turn`` / the per-turn hooks pass it). Each distinct id gets its
+        own message buffer + turn counter + session id, so parallel/interleaved
+        conversations no longer collapse into one session Crystal.
+
+        No-op when *external_id* is falsy (legacy single-session behavior) or
+        already the active conversation.
+        """
+        self._ensure_slot_store()
+        if not external_id or external_id == self._active_conversation_key:
+            return
+        # Stash the currently-live slot so we can come back to it. Skip a still
+        # empty legacy/default slot (the coarse, message-less state that
+        # ``on_session_start`` set up before the first real turn) — it carries
+        # no conversation content worth preserving.
+        if self._active_conversation_key is not None:
+            self._session_slots[self._active_conversation_key] = self._capture_slot()
+        elif self._messages:
+            self._session_slots[_DEFAULT_SLOT_KEY] = self._capture_slot()
+        # Load the target slot if we've seen it, else mint a fresh one whose
+        # session id is derived from the host id (per-conversation, stable).
+        existing = self._session_slots.pop(external_id, None)
+        if existing is not None:
+            self._restore_slot(existing)
+        else:
+            self._blank_live_slot()
+            self._session_id = _session_id_from_host(external_id)
+            self._session_id_from_host = True
+            self._last_activity = time.monotonic()
+        self._active_conversation_key = external_id
+
+    def stash_active_conversation(self) -> None:
+        """Move the live conversation into ``_session_slots`` so a finalize
+        sweep can iterate every conversation (active + previously stashed).
+        Idempotent-ish: leaves the live slot blank afterwards."""
+        self._ensure_slot_store()
+        key = (
+            _DEFAULT_SLOT_KEY
+            if self._active_conversation_key is None
+            else self._active_conversation_key
+        )
+        self._session_slots[key] = self._capture_slot()
+        self._active_conversation_key = None
+        self._blank_live_slot()
+
+    def pop_next_conversation(self) -> bool:
+        """Load one stashed conversation as the live slot. Returns False when
+        none remain. Drives the per-conversation crystallize loop at finalize."""
+        self._ensure_slot_store()
+        if not self._session_slots:
+            return False
+        key, slot = self._session_slots.popitem()
+        self._restore_slot(slot)
+        self._active_conversation_key = None if key == _DEFAULT_SLOT_KEY else key
+        return True
+
+    def reset_conversations(self) -> None:
+        """Drop all stashed conversation slots. Called at session boundaries."""
+        self._session_slots = {}
+        self._active_conversation_key = None
 
     def note_activity(self) -> None:
         """Record that a turn just happened (feeds idle-timeout rollover)."""

--- a/python/src/totalreclaw/hermes/hooks.py
+++ b/python/src/totalreclaw/hermes/hooks.py
@@ -863,15 +863,28 @@ def _resolve_extraction_llm_config(state: "PluginState"):
 
 
 def ingest_turn(
-    state: "PluginState", user_message: str, assistant_response: str
+    state: "PluginState",
+    user_message: str,
+    assistant_response: str,
+    session_id: str = "",
 ) -> None:
     """Record a completed turn and run interval-gated auto-extraction (hook-free).
 
     The shared core of ``post_llm_call``: bookkeeping always runs (the client
     may be configured mid-session); extraction runs only when configured and on
     the Nth turn. Reused by the Hermes ``MemoryProvider.sync_turn`` (§5.2).
-    Mirrors the previous inline ``post_llm_call`` behavior exactly.
+
+    ``session_id`` is the host's per-conversation id (Hermes passes it to
+    ``sync_turn`` and the per-turn hooks). When supplied, the turn is routed to
+    that conversation's own slot — so parallel/interleaved conversations keep
+    separate buffers, turn counters, and session ids, and never collapse into
+    one mixed Crystal. When absent (or a host that hands one coarse id to the
+    whole chat) the behavior is byte-identical to the prior single buffer.
     """
+    # Route this turn to its conversation's slot BEFORE any bookkeeping, so the
+    # turn counter + message buffer + session id all belong to the right chat.
+    if session_id and hasattr(state, "activate_conversation"):
+        state.activate_conversation(session_id)
     # Always track turns and messages (client may be configured mid-session).
     state.increment_turn()
     state.add_message("user", user_message)
@@ -929,6 +942,7 @@ def post_llm_call(state: "PluginState", **kwargs) -> None:
         state,
         kwargs.get("user_message", ""),
         kwargs.get("assistant_response", ""),
+        session_id=kwargs.get("session_id", ""),
     )
 
 
@@ -947,6 +961,22 @@ def on_session_end(state: "PluginState", **kwargs) -> None:
     return None
 
 
+def _finalize_one_conversation(state: "PluginState") -> None:
+    """Flush any unprocessed messages + run the session debrief (Crystal) for
+    the CURRENTLY-ACTIVE conversation slot. Best-effort — never raises."""
+    stored_fact_texts: list[str] = []
+    if state.has_unprocessed_messages():
+        try:
+            stored_fact_texts = _auto_extract(state, mode="full", llm_config=_get_hermes_llm_config())
+        except Exception as e:
+            logger.warning("TotalReclaw on_session_finalize flush failed: %s", e)
+
+    try:
+        _session_debrief(state, stored_fact_texts=stored_fact_texts)
+    except Exception as e:
+        logger.warning("TotalReclaw on_session_finalize debrief failed: %s", e)
+
+
 def on_session_finalize(state: "PluginState", **kwargs) -> None:
     """Comprehensive flush of unprocessed messages + session debrief.
 
@@ -954,31 +984,39 @@ def on_session_finalize(state: "PluginState", **kwargs) -> None:
     finalize). Per-turn auto-extraction runs from ``post_llm_call``; this
     handler catches residual unprocessed messages and runs the session
     debrief while the full conversation buffer is still intact.
+
+    Parallel-chat fix: when the host distinguished conversations for us (per-
+    conversation slots exist), crystallize EACH conversation separately — every
+    chat gets its own clean Crystal instead of one mixed summary. Falls back to
+    a single pass when the host never supplied per-conversation ids.
     """
     if not state.is_configured():
         # memq-3 — still clear the session id we set in on_session_start
         # for unconfigured sessions so the invariant "session_id is None
         # outside an active session" holds in every code path.
         state.end_session()
+        if hasattr(state, "reset_conversations"):
+            state.reset_conversations()
         return
 
     try:
-        stored_fact_texts: list[str] = []
-        if state.has_unprocessed_messages():
-            try:
-                stored_fact_texts = _auto_extract(state, mode="full", llm_config=_get_hermes_llm_config())
-            except Exception as e:
-                logger.warning("TotalReclaw on_session_finalize flush failed: %s", e)
-
-        try:
-            _session_debrief(state, stored_fact_texts=stored_fact_texts)
-        except Exception as e:
-            logger.warning("TotalReclaw on_session_finalize debrief failed: %s", e)
+        if hasattr(state, "stash_active_conversation") and hasattr(state, "pop_next_conversation"):
+            # Stash the live conversation, then crystallize each stashed
+            # conversation on its own. Legacy single-session case stashes ONE
+            # slot and loops exactly once → byte-identical to the old behavior.
+            state.stash_active_conversation()
+            while state.pop_next_conversation():
+                _finalize_one_conversation(state)
+        else:
+            # Legacy state subclass / test mock without slot support.
+            _finalize_one_conversation(state)
     finally:
         state.clear_messages()
         # memq-3 — clear session id alongside the message buffer so the
         # next on_session_start gets a fresh id.
         state.end_session()
+        if hasattr(state, "reset_conversations"):
+            state.reset_conversations()
 
 
 def on_session_reset(state: "PluginState", **kwargs) -> None:
@@ -988,6 +1026,10 @@ def on_session_reset(state: "PluginState", **kwargs) -> None:
     """
     state.clear_messages()
     state.reset_turn_counter()
+    # Drop any stashed parallel-conversation slots too — a reset is a clean
+    # slate across every conversation this lifecycle held.
+    if hasattr(state, "reset_conversations"):
+        state.reset_conversations()
 
 
 # Backward-compatible alias used by tests

--- a/python/src/totalreclaw/hermes/memory_provider.py
+++ b/python/src/totalreclaw/hermes/memory_provider.py
@@ -323,7 +323,16 @@ class TotalReclawMemoryProvider(_MemoryProviderBase):  # type: ignore[misc,valid
         try:
             from .hooks import ingest_turn
 
-            ingest_turn(self._state, user_content, assistant_content)
+            # Forward the host's per-conversation ``session_id`` so parallel
+            # conversations route to separate slots (parallel-chat fix). Hermes
+            # passes its per-conversation ``self.agent.session_id`` here every
+            # turn; ignoring it is what collapsed every chat into one Crystal.
+            ingest_turn(
+                self._state,
+                user_content,
+                assistant_content,
+                session_id=session_id,
+            )
         except Exception as exc:  # pragma: no cover — non-fatal per ABC contract
             logger.warning("TotalReclaw MemoryProvider.sync_turn failed: %s", exc)
 

--- a/python/tests/test_hermes_provider_single_driver.py
+++ b/python/tests/test_hermes_provider_single_driver.py
@@ -96,4 +96,5 @@ class TestPostLlmCallGate:
         with patch.object(hooks, "ingest_turn") as it, \
              patch.object(hooks, "_maybe_reconfigure_from_disk", return_value=False):
             hooks.post_llm_call(s, user_message="u", assistant_response="a")
-        it.assert_called_once_with(s, "u", "a")
+        # session_id forwarded (empty here — no per-conversation id supplied).
+        it.assert_called_once_with(s, "u", "a", session_id="")

--- a/python/tests/test_hermes_shared_memory_entrypoints.py
+++ b/python/tests/test_hermes_shared_memory_entrypoints.py
@@ -74,7 +74,8 @@ class TestPostLlmCallDelegates:
              patch.object(hooks, "ingest_turn") as it:
             hooks.post_llm_call(s, user_message="u", assistant_response="a")
         rc.assert_called_once_with(s)
-        it.assert_called_once_with(s, "u", "a")
+        # session_id forwarded (empty here — no per-conversation id supplied).
+        it.assert_called_once_with(s, "u", "a", session_id="")
 
     def test_post_llm_call_eager_register_on_midsession_pair(self):
         s = _state()

--- a/python/tests/test_memory_provider.py
+++ b/python/tests/test_memory_provider.py
@@ -837,7 +837,9 @@ class TestNativeAutoMemory:
         provider = TotalReclawMemoryProvider(state)
         with patch("totalreclaw.hermes.hooks.ingest_turn") as it:
             provider.sync_turn("u", "a", session_id="s1")
-        it.assert_called_once_with(state, "u", "a")
+        # sync_turn now forwards the per-conversation session_id to ingest_turn
+        # (the parallel-chat fix) — that forwarding IS the delegation contract.
+        it.assert_called_once_with(state, "u", "a", session_id="s1")
 
     def test_sync_turn_accepts_messages_kwarg(self):
         state = _make_state(configured=True)
@@ -846,7 +848,7 @@ class TestNativeAutoMemory:
             provider.sync_turn(
                 "u", "a", session_id="s1", messages=[{"role": "user", "content": "u"}]
             )
-        it.assert_called_once_with(state, "u", "a")
+        it.assert_called_once_with(state, "u", "a", session_id="s1")
 
     def test_sync_turn_swallows_errors(self):
         state = _make_state(configured=True)

--- a/python/tests/test_per_conversation_sessions.py
+++ b/python/tests/test_per_conversation_sessions.py
@@ -1,0 +1,207 @@
+"""Per-conversation session isolation (parallel-chat fix).
+
+Before this fix the Hermes plugin kept ONE process-global message buffer + turn
+counter + session id. When a user ran several conversations in parallel through
+one Hermes process (e.g. interleaved Telegram threads in the same chat), Hermes
+handed the plugin a distinct per-conversation ``session_id`` every turn (via
+``MemoryProvider.sync_turn`` / the per-turn hooks) — but the plugin ignored it,
+so every conversation's turns piled into one buffer and collapsed into one mixed
+session Crystal.
+
+The fix routes each turn to a per-conversation *slot* keyed by that host id, so
+parallel conversations keep separate buffers/turn-counters/session-ids and each
+finalizes to its own clean Crystal. When no per-conversation id is supplied the
+behavior is byte-identical to the prior single buffer (legacy hosts).
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from totalreclaw.agent.state import AgentState, _DEFAULT_SLOT_KEY
+from totalreclaw.hermes import hooks
+from totalreclaw.hermes.state import PluginState
+
+
+def _texts(state) -> list[str]:
+    return [m["content"] for m in state.get_all_messages()]
+
+
+# ── AgentState slot mechanics ────────────────────────────────────────────────
+
+
+class TestSessionSlots:
+    def test_activate_creates_distinct_host_derived_ids(self) -> None:
+        s = AgentState()
+        s.activate_conversation("convA")
+        sid_a = s.session_id
+        s.activate_conversation("convB")
+        sid_b = s.session_id
+        assert sid_a and sid_b and sid_a != sid_b
+        assert s._session_id_from_host is True
+
+    def test_activate_is_deterministic_per_id(self) -> None:
+        """The same host id always maps to the same session id (stable key)."""
+        s1 = AgentState()
+        s1.activate_conversation("conv-42")
+        s2 = AgentState()
+        s2.activate_conversation("conv-42")
+        assert s1.session_id == s2.session_id
+
+    def test_activate_same_id_is_noop(self) -> None:
+        s = AgentState()
+        s.activate_conversation("convA")
+        s.increment_turn()
+        s.add_message("user", "hi")
+        sid_before = s.session_id
+        s.activate_conversation("convA")  # re-activate active conv
+        assert s.session_id == sid_before
+        assert s.turn_count == 1  # not reset
+        assert _texts(s) == ["hi"]
+
+    def test_interleaved_turns_do_not_cross_contaminate(self) -> None:
+        s = AgentState()
+        # A, B, A interleave — the exact shape of Pedro's repro.
+        s.activate_conversation("A"); s.increment_turn(); s.add_message("user", "A1")
+        s.activate_conversation("B"); s.increment_turn(); s.add_message("user", "B1")
+        s.activate_conversation("A"); s.increment_turn(); s.add_message("user", "A2")
+
+        # Active is A: holds only A's messages + A's turn count.
+        assert _texts(s) == ["A1", "A2"]
+        assert s.turn_count == 2
+
+        # Sweep the rest: B holds only B's message.
+        s.stash_active_conversation()
+        found = {}
+        while s.pop_next_conversation():
+            found[s._active_conversation_key] = _texts(s)
+        assert found["A"] == ["A1", "A2"]
+        assert found["B"] == ["B1"]
+
+    def test_no_key_is_legacy_single_session(self) -> None:
+        """Never calling activate_conversation ⇒ one buffer, one finalize slot."""
+        s = AgentState()
+        s.start_session(external_id="coarse-chat")
+        legacy_sid = s.session_id
+        s.increment_turn(); s.add_message("user", "one")
+        s.increment_turn(); s.add_message("user", "two")
+        # Finalize sweep yields exactly one slot (the default), unchanged content.
+        s.stash_active_conversation()
+        slots = []
+        while s.pop_next_conversation():
+            slots.append((s._active_conversation_key, s.session_id, _texts(s)))
+        assert len(slots) == 1
+        key, sid, msgs = slots[0]
+        assert key is None  # default slot restores to the legacy (None) key
+        assert sid == legacy_sid
+        assert msgs == ["one", "two"]
+
+    def test_empty_default_slot_discarded_on_first_activate(self) -> None:
+        """The message-less coarse slot on_session_start sets up is dropped when
+        the first real conversation activates — no empty _DEFAULT slot lingers."""
+        s = AgentState()
+        s.start_session(external_id="coarse-chat")  # empty live slot
+        s.activate_conversation("realconv")
+        assert _DEFAULT_SLOT_KEY not in s._session_slots
+
+    def test_reset_conversations_clears_slots(self) -> None:
+        s = AgentState()
+        s.activate_conversation("A"); s.add_message("user", "A1")
+        s.activate_conversation("B"); s.add_message("user", "B1")
+        assert s._session_slots  # A stashed while B active
+        s.reset_conversations()
+        assert s._session_slots == {}
+        assert s._active_conversation_key is None
+
+
+# ── ingest_turn routing ──────────────────────────────────────────────────────
+
+
+def _configured_state() -> PluginState:
+    with patch.dict(os.environ, {}, clear=True):
+        with patch.object(Path, "exists", return_value=False):
+            state = PluginState()
+    client = MagicMock()
+    client.remember = AsyncMock(return_value="fact-id")
+    client.recall = AsyncMock(return_value=[])
+    state._client = client
+    return state
+
+
+class TestIngestTurnRouting:
+    def test_ingest_routes_by_session_id(self) -> None:
+        state = _configured_state()
+        with patch.object(hooks, "_auto_extract", return_value=[]):
+            hooks.ingest_turn(state, "A: q", "A: a", session_id="convA")
+            hooks.ingest_turn(state, "B: q", "B: a", session_id="convB")
+            hooks.ingest_turn(state, "A: q2", "A: a2", session_id="convA")
+        # Active is convA with its two turns; convB is stashed with one.
+        assert state._active_conversation_key == "convA"
+        assert state.turn_count == 2
+        assert _texts(state) == ["A: q", "A: a", "A: q2", "A: a2"]
+        assert "convB" in state._session_slots
+
+    def test_ingest_without_session_id_is_single_buffer(self) -> None:
+        state = _configured_state()
+        with patch.object(hooks, "_auto_extract", return_value=[]):
+            hooks.ingest_turn(state, "one", "r1")
+            hooks.ingest_turn(state, "two", "r2")
+        assert state._active_conversation_key is None
+        assert state._session_slots == {}
+        assert state.turn_count == 2
+        assert _texts(state) == ["one", "r1", "two", "r2"]
+
+
+# ── End-to-end: interleave → separate Crystals ───────────────────────────────
+
+
+class TestFinalizeSeparatesCrystals:
+    def test_two_interleaved_conversations_finalize_to_two_crystals(self) -> None:
+        """The headline guarantee: two parallel conversations → two DISTINCT
+        Crystals, not one mixed summary."""
+        state = _configured_state()
+        # on_session_start hands the plugin one coarse chat id (the bug source).
+        state.start_session(external_id="telegram:chat:123")
+
+        seen_debriefs: list[tuple] = []
+
+        def fake_debrief(st, stored_fact_texts=None):
+            seen_debriefs.append((st.session_id, tuple(m["content"] for m in st.get_all_messages())))
+            return []
+
+        with patch.object(hooks, "_auto_extract", return_value=[]), \
+             patch.object(hooks, "_session_debrief", side_effect=fake_debrief):
+            # Interleaved turns, each carrying its own per-conversation id.
+            hooks.ingest_turn(state, "book the lisbon flight", "aisle seat, done", session_id="conv-flight")
+            hooks.ingest_turn(state, "best local LLM for a mac", "try gemma", session_id="conv-llm")
+            hooks.ingest_turn(state, "great, thanks", "confirmation sent", session_id="conv-flight")
+            hooks.ingest_turn(state, "does ollama run it", "yes", session_id="conv-llm")
+            hooks.on_session_finalize(state)
+
+        # Two conversations → two debriefs → two crystals.
+        assert len(seen_debriefs) == 2
+        sids = {sid for sid, _ in seen_debriefs}
+        assert len(sids) == 2, "each conversation must get its own session id"
+
+        # And crucially: NO Crystal mixes the two topics.
+        by_topic = {frozenset(msgs): sid for sid, msgs in seen_debriefs}
+        for msgs in by_topic:
+            joined = " ".join(msgs).lower()
+            flight = "lisbon" in joined or "aisle" in joined
+            llm = "gemma" in joined or "ollama" in joined or "local llm" in joined
+            assert not (flight and llm), f"a Crystal mixed both conversations: {msgs}"
+
+    def test_legacy_single_session_still_one_crystal(self) -> None:
+        """No per-conversation ids ⇒ exactly one Crystal (unchanged behavior)."""
+        state = _configured_state()
+        state.start_session(external_id="coarse")
+        seen = []
+        with patch.object(hooks, "_auto_extract", return_value=[]), \
+             patch.object(hooks, "_session_debrief", side_effect=lambda st, stored_fact_texts=None: seen.append(st.session_id) or []):
+            hooks.ingest_turn(state, "u1", "a1")
+            hooks.ingest_turn(state, "u2", "a2")
+            hooks.on_session_finalize(state)
+        assert len(seen) == 1


### PR DESCRIPTION
## The bug (confirmed live on Pedro's production bot)

Running several conversations in parallel through one Hermes process collapsed them into **one mixed session Crystal**, and unrelated conversations grouped under **one `session_id`** in the vault — even across process restarts. Confirmed 2026-07-05: a 17:20 extraction produced 3 facts spanning two interleaved Telegram threads (a flight booking + a local-LLM chat), and the vault showed one session holding facts from **three** different conversations (morning + afternoon, across a gateway restart).

## Root cause

The plugin kept **one process-global** message buffer + turn counter + session id (`_SHARED_STATE`). Two things went wrong:

1. **Collapse:** facts were tagged with `state._session_id`, set from the **coarse chat-level id** that `on_session_start` receives (one id for the whole Telegram DM, stable across restarts) → every conversation in a chat folded into one `session_id`.
2. **Interleave mix:** every turn from every parallel conversation appended to the one shared buffer → extraction and the finalize Crystal saw a mixed bag.

The key finding: **Hermes already hands the plugin a distinct per-conversation `session_id` every turn** — via its native `MemoryProvider.sync_turn(session_id=…, messages=…)` and the per-turn hooks (`self.agent.session_id`, distinct per conversation). The plugin **ignored it** and keyed everything off the coarse `on_session_start` id. (This overturns the previous belief — documented in the session-hygiene guide — that the per-turn hooks carried no conversation id.)

## The fix

`AgentState` becomes **multi-slot**, keyed by the host's per-conversation id:

- **`activate_conversation(external_id)`** swaps the live per-conversation fields (message buffer, turn counter, processed index, session id, last-activity, pending-extract buffer) to that conversation's slot, stashing the previous one. Fresh conversations mint a session id derived from the host id (per-conversation, stable).
- **`ingest_turn`** — the single choke point shared by `sync_turn` and `post_llm_call` — takes the per-conversation `session_id` and activates the right slot **before** any bookkeeping. `sync_turn` (the active driver on the bot) and `post_llm_call` both forward it.
- **`on_session_finalize`** stashes the active slot, then **crystallizes each conversation separately** (`stash_active_conversation` + `pop_next_conversation` loop) — so interleaved conversations produce clean, separate Crystals. `on_session_reset` drops all slots.

**Fully backward-compatible.** When no per-conversation id is supplied (legacy hosts, or a host that hands one coarse id to the whole chat), the slot store stays empty and behavior is **byte-identical** to the prior single buffer. Slot methods are self-initializing, so legacy `AgentState` subclasses / test mocks that skip `super().__init__()` keep working.

## Tests

- New **`test_per_conversation_sessions.py`** (11 tests): interleaved A/B/A turns → **two distinct Crystals with no cross-contamination**; distinct per-conversation session ids; legacy single-session unchanged (one Crystal); empty-default-slot discard; reset clears slots; mock-subclass robustness.
- Also strengthened the `sync_turn`/`post_llm_call` delegation tests to assert `session_id` is forwarded (the core of the fix).
- **Full suite: 1731 passed, 39 skipped, 1 xfailed.**

## Docs

Rewrites `docs/guides/hermes-session-hygiene.md`: the old "What is *not* fixed (host-side)" section (wrongly claiming the per-turn hooks carry no conversation id) becomes a small "Residual (rare)" note — real-time interleaving is now handled in-plugin.

## Follow-ups (not in this PR)

- No version bump — recorded under `[Unreleased]`; folds into the next RC/stable.
- The write-side fix must land **before** the re-crystallize/backfill tool ([#438](https://github.com/p-diogo/totalreclaw/pull/438)) runs, else existing mixed data is re-collapsed mid-migration.
- Real-world confirmation: once this ships in an RC, Pedro re-runs the 2-parallel-chat test on the bot → expect two clean Crystals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)