### PR TITLE
feat(hermes): update-available notice + versioned client header

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,7 @@ Features across OpenClaw plugin (`skill/plugin/`), MCP server (`mcp/`), NanoClaw
 | **Billing** | | | | | | |
 | Quota warnings (>80%) | Yes | -- | Yes | Yes | -- | Yes | Injected via on_session_start hook; ZeroClaw via quota_warning() method |
 | 403 handling + cache invalidation | Yes | Yes | Yes | -- | Yes (via MCP) | Yes | ZeroClaw invalidates billing cache on 403, returns QuotaExceeded error |
+| Update-available notice | -- | -- | -- | Yes | -- | -- | Hermes-only. Relay serves `features.latest_stable_python` (set via `LATEST_STABLE_PYTHON` env — dark until configured); client compares vs installed `__version__` (rc<final aware), nudges once/24h via quota-warning channel. Kill-switch `TOTALRECLAW_DISABLE_UPDATE_NOTICE=1`. Fires fleet-wide on the one env flip at each stable promote. |
 | **Search Optimizations** | | | | | | |
 | Hot cache + two-tier search | Yes (managed) | -- | -- | -- | -- | Yes (30 entries, cosine >= 0.85) | Skips remote query if cached query similar |
 | Dynamic candidate pool sizing | Yes | Yes | Yes (via MCP) | -- | Yes (via MCP) | Yes | Server-configurable via billing features; env overrides `CANDIDATE_POOL_MAX_FREE`/`CANDIDATE_POOL_MAX_PRO` |
@@ -225,7 +226,7 @@ Features across OpenClaw plugin (`skill/plugin/`), MCP server (`mcp/`), NanoClaw
 | BM25 + Cosine + RRF reranking | Yes | Yes | Yes (via MCP) | Yes | Yes (via MCP) | Yes | Intent-weighted |
 | Entity-trapdoor recall (read-side) | -- | -- | -- | Yes | -- | -- | #370, shipped 2026-07-03 (#377). Query entities (heuristic) → unkeyed `sha256("entity:"+name)` trapdoors appended to search. +2.4pp Hit@16 at ~2700-fact scale (production-config A/B; Sonnet-gated). Write-side (`entities[]` → blind_indices) shipped across plugin/MCP/Hermes since `ac1b872`; read-side is Hermes-only until other clients un-park. |
 | **Admin & Analytics** | | | | | | |
-| X-TotalReclaw-Client header | Yes | Yes | Yes (via MCP) | Yes | Yes (via MCP) | Yes (rust-client:zeroclaw) | Sent on every relay request |
+| X-TotalReclaw-Client header | Yes | Yes | Yes (via MCP) | Yes | Yes (via MCP) | Yes (rust-client:zeroclaw) | Sent on every relay request. Python client appends its version (`python-client/<version>`) for observability; the relay buckets analytics on the part before the first `/`, so per-release version suffixes don't fragment client-type aggregation. |
 | Admin dashboard | -- | -- | -- | -- | -- | Admin-only (relay service), not a client feature |
 
 ### Storage Mode Support

--- a/docs/guides/env-vars-reference.md
+++ b/docs/guides/env-vars-reference.md
@@ -88,6 +88,18 @@ export TOTALRECLAW_SESSION_ID="qa-rc.22-run-7"
 **When to override:** set during QA runs so log queries can be filtered by session id. Production users do not need to set it.
 **Security:** non-secret. Shows up in relay logs by design. Pick a non-PII tag.
 
+### `TOTALRECLAW_DISABLE_UPDATE_NOTICE`
+
+**Optional.** Kill-switch for the automatic "TotalReclaw X is available" update nudge (Python / Hermes client). When the relay advertises a newer stable than the installed version, the client injects a one-line update reminder at session start (at most once per 24h). Set this to silence it.
+
+```bash
+export TOTALRECLAW_DISABLE_UPDATE_NOTICE=1
+```
+
+**Default:** unset — the notice is enabled. Truthy values (`1`, `true`, `yes`, `on`) disable it.
+**When to override:** you manage updates out-of-band and don't want the reminder, or you're running a pinned build on purpose.
+**Note:** this only suppresses the *notice*. It does not affect installs, and the update itself is always user-initiated (say "update TotalReclaw" — see [hermes-setup.md](hermes-setup.md)).
+
 ### LLM provider keys
 
 **Required if the client needs an LLM** (auto-extraction, LLM-guided dedup, import processing).

--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -50,6 +50,31 @@ The agent exports `TOTALRECLAW_SERVER_URL=https://api-staging.totalreclaw.xyz` a
 
 ---
 
+## Update prompt
+
+TotalReclaw has NO native Hermes update path (`hermes plugins update` is git-clone-only; `hermes update` updates Hermes itself, not a pip plugin). So updates run the same install machinery, re-pointed at the newest **stable**. The user pastes:
+
+```
+Update TotalReclaw. See https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/hermes-setup.md
+```
+
+The agent updates to the newest **stable** and re-binds — **silently**, exactly like install (same HARD RULE: no `pip` / `venv` / interpreter narration). Reuse the **Install procedure below**:
+
+1. **Step 2 with `PIN="totalreclaw"`** (stable channel — `pip install --upgrade` lands the newest final). Run the same `(a)`/`(b)`/`(c)` install-and-verify block. Emit the one `✓ Installed totalreclaw <version>` line only after `(c)`'s RUNTIME verify confirms the Hermes interpreter now imports the new version (guards the same shadow-install trap as a fresh install).
+2. **Step 4 restart request** — re-emit the surface-matched restart line verbatim (Telegram / docker / systemd / launchd / standalone `hermes chat`) so the freshly-upgraded plugin binds. There is no hot-reload for an updated plugin either.
+
+**Budget: ≤3 user-visible lines** — the `✓ Installed` line, the restart line, and (optionally) a one-line "you're up to date on <version>" confirmation after the user's continuation reply. Account setup / pairing is **skipped** on an update (credentials already exist); do NOT re-run it.
+
+### Automatic update notice
+
+The client also nudges on its own. When the relay advertises a newer stable than the installed build, the next session start injects a single line into the agent's context:
+
+> TotalReclaw X is available (you're running Y). Say 'update TotalReclaw' to upgrade.
+
+It fires at most once per 24h across sessions, and only ever when a newer **final** is out (an rc user is nudged when the matching final ships; a user already on a newer rc line is not). Set `TOTALRECLAW_DISABLE_UPDATE_NOTICE=1` to silence it (see [env-vars-reference.md](env-vars-reference.md)). When the user acts on it, follow the **Update prompt** above.
+
+---
+
 ## Conversational style — HARD RULE for install + setup
 
 **The user must NOT see install mechanics. Narrating shell / `pip` / `venv` / interpreter-detection / "let me verify…" during install or setup is a DEFECT** — it spams the chat with garbage (QA regression, 2026-06). This is not aspirational: run every tool/shell step **silently** and emit ONLY the short verbatim lines each procedure names. **Budget for a full install + setup: ≤6 short user-visible lines, total.** If you wrote more than that, you narrated something that should have been silent — delete it.

--- a/docs/guides/release-process.md
+++ b/docs/guides/release-process.md
@@ -181,11 +181,36 @@ differ. Ship with the table below in front of you.
    # (stable-version auto-derived to 2.1.0)
    ```
 
-6. **Generate the changelog.** Dispatch `changelog.yml` for the stable
+6. **Advertise the new stable to the fleet — set `LATEST_STABLE_PYTHON` on BOTH
+   relay services.** This is the single env flip that makes the automatic update
+   notice fire fleet-wide: the relay serves it in `/v1/billing/status` →
+   `features.latest_stable_python`, and every Hermes client compares it against
+   its installed `__version__` and nudges the user to say "update TotalReclaw"
+   (once per 24h). Set it **only after** the PyPI stable publish above has
+   succeeded — advertising a version that isn't installable yet would nudge
+   users toward a `pip install` that resolves to an older build. Use the STABLE
+   version string (no `rc`), e.g. `2.4.5`:
+
+   ```bash
+   # Staging first (verify), then production. Match to the version you just published.
+   railway variables --set "LATEST_STABLE_PYTHON=2.4.5" -s totalreclaw
+   railway variables --set "LATEST_STABLE_PYTHON=2.4.5" -s totalreclaw-production
+   # `railway variables --set` triggers an automatic redeploy; it may time out on
+   # the response yet still apply — re-read to confirm before retrying:
+   railway variables -s totalreclaw --json | grep -i latest_stable_python
+   railway variables -s totalreclaw-production --json | grep -i latest_stable_python
+   ```
+
+   Leaving it unset (or stale at a prior version) is safe — the feature is dark
+   until configured, so the only cost of forgetting this step is that the
+   announcement never fires. Verify with
+   `curl -s https://api.totalreclaw.xyz/v1/billing/status | grep latest_stable_python`.
+
+7. **Generate the changelog.** Dispatch `changelog.yml` for the stable
    version (see "Changelog automation" below). It opens a reviewable PR
    with the auto-generated section; review and merge it.
 
-7. **Announce.** GitHub release, Telegram notification, website update.
+8. **Announce.** GitHub release, Telegram notification, website update.
 
 ## Changelog automation (git-cliff)
 

--- a/python/src/totalreclaw/client.py
+++ b/python/src/totalreclaw/client.py
@@ -27,7 +27,7 @@ from .crypto import (
     DerivedKeys,
 )
 from .lsh import LSHHasher
-from .relay import RelayClient, BillingStatus, _default_relay_url
+from .relay import RelayClient, BillingStatus, _default_relay_url, _client_header_value
 from .reranker import RerankerResult
 from .operations import (
     store_fact,
@@ -349,7 +349,7 @@ class TotalReclaw:
         billing_url = f"{relay_url}/v1/billing/status"
         headers: dict[str, str] = {
             "Authorization": f"Bearer {self._auth_key_hex}",
-            "X-TotalReclaw-Client": self._relay._client_id,
+            "X-TotalReclaw-Client": _client_header_value(self._relay._client_id),
         }
         session_id = getattr(self._relay, "_session_id", None)
         if session_id:

--- a/python/src/totalreclaw/hermes/hooks.py
+++ b/python/src/totalreclaw/hermes/hooks.py
@@ -522,6 +522,43 @@ def on_session_start(state: "PluginState", **kwargs) -> None:
                     f"({pct}%). {nudge}"
                 )
                 logger.info("TotalReclaw: Memory usage >80%% — quota warning set")
+
+            # Update-available nudge (relay-driven fleet announcement).
+            # Fires at most once per 24h across sessions and never clobbers a
+            # pending quota warning (which is more urgent). Gated on the relay
+            # advertising `features.latest_stable_python`; dark otherwise.
+            if not state.get_quota_warning():
+                _maybe_queue_update_notice(state, billing)
+    except Exception:
+        pass
+
+
+def _maybe_queue_update_notice(state: "PluginState", billing: dict) -> None:
+    """Queue a one-line "TotalReclaw X is available" notice via the quota-warning
+    channel when the relay advertises a newer stable than the installed version.
+
+    Rate-limited to once per 24h across sessions (disk sentinel) and suppressed
+    entirely by ``TOTALRECLAW_DISABLE_UPDATE_NOTICE=1``. Best-effort — any error
+    is swallowed so a hook never fails on a cosmetic nudge.
+    """
+    try:
+        from totalreclaw import __version__
+        from totalreclaw.update_notice import maybe_build_update_notice, mark_notified
+
+        features = billing.get("features") or {}
+        latest = features.get("latest_stable_python")
+        if not latest:
+            return
+        notice = maybe_build_update_notice(latest, __version__)
+        if notice:
+            state.set_quota_warning(notice)
+            # Burn the 24h window only after the notice is actually queued.
+            mark_notified()
+            logger.info(
+                "TotalReclaw: update notice queued (installed=%s, latest=%s)",
+                __version__,
+                latest,
+            )
     except Exception:
         pass
 

--- a/python/src/totalreclaw/relay.py
+++ b/python/src/totalreclaw/relay.py
@@ -80,6 +80,27 @@ def _detect_client_id() -> str:
     return "python-client"
 
 
+def _client_version() -> str:
+    """Installed package version, for the observability suffix on the client
+    header. Imported lazily to avoid a circular import
+    (``totalreclaw.__init__`` imports client code that imports this module).
+    Falls back to ``"unknown"`` if the version can't be resolved."""
+    try:
+        from totalreclaw import __version__
+
+        return __version__ or "unknown"
+    except Exception:
+        return "unknown"
+
+
+def _client_header_value(client_id: str) -> str:
+    """Build the ``X-TotalReclaw-Client`` value: ``<client_id>/<version>``
+    (e.g. ``python-client/2.4.5``). The relay buckets analytics on the part
+    before the first ``/``, so appending the version is observability-only and
+    does not fragment client-type aggregation."""
+    return f"{client_id}/{_client_version()}"
+
+
 @dataclass
 class BillingFeatures:
     llm_dedup: bool = False
@@ -89,6 +110,11 @@ class BillingFeatures:
     max_facts_per_extraction: Optional[int] = None
     max_candidate_pool: Optional[int] = None
     recall_top_k: Optional[int] = None
+    # Latest published stable Python-client version (e.g. "2.4.5"), when the
+    # relay advertises one. None ⇒ the relay has not opted into update-notices
+    # (or is an older build) ⇒ the client never nudges. See
+    # ``totalreclaw.update_notice`` for the compare + rate-limit logic.
+    latest_stable_python: Optional[str] = None
 
 
 @dataclass
@@ -213,7 +239,7 @@ class RelayClient:
     def _base_headers(self) -> dict[str, str]:
         headers = {
             "Content-Type": "application/json",
-            "X-TotalReclaw-Client": self._client_id,
+            "X-TotalReclaw-Client": _client_header_value(self._client_id),
         }
         if self._is_test:
             headers["X-TotalReclaw-Test"] = "true"
@@ -230,7 +256,7 @@ class RelayClient:
         http = await self._get_http()
         headers: dict[str, str] = {
             "Content-Type": "application/json",
-            "X-TotalReclaw-Client": self._client_id,
+            "X-TotalReclaw-Client": _client_header_value(self._client_id),
         }
         if self._is_test:
             headers["X-TotalReclaw-Test"] = "true"
@@ -296,6 +322,7 @@ class RelayClient:
                 max_facts_per_extraction=f.get("max_facts_per_extraction"),
                 max_candidate_pool=f.get("max_candidate_pool"),
                 recall_top_k=f.get("recall_top_k"),
+                latest_stable_python=f.get("latest_stable_python"),
             )
         return BillingStatus(
             tier=data["tier"],

--- a/python/src/totalreclaw/update_notice.py
+++ b/python/src/totalreclaw/update_notice.py
@@ -1,0 +1,187 @@
+"""
+Update-notice bookkeeping for the Python (Hermes) client.
+
+Hermes has NO native mechanism for updating a pip/entry-point plugin
+(``hermes plugins update`` is git-clone-only; ``hermes update`` covers Hermes
+itself). So when the relay advertises a newer stable version in the billing
+features (``latest_stable_python``), the client surfaces a one-line nudge via
+the existing quota-warning channel telling the user to say "update TotalReclaw".
+
+Two concerns live here, both pure/testable and framework-agnostic:
+
+1. **Version comparison** (:func:`is_newer_stable`) — a small internal PEP-440
+   comparator, sufficient for our ``MAJOR.MINOR.PATCH`` + optional
+   ``rcN``/``bN``/``aN`` pre-release scheme. We deliberately do NOT add
+   ``packaging`` as a dependency: it is not a declared dep (only transitively
+   present via ``transformers``), and the compare we need is narrow. The one
+   subtlety we get right: an rc of X is OLDER than final X (``2.4.5rc11`` <
+   ``2.4.5``), so an rc user IS nudged when the matching final ships, but a
+   user already on a newer rc line (``2.4.6rc1``) is NOT nudged by an older
+   final (``2.4.5``).
+
+2. **Rate-limit persistence** (:func:`should_notify_now` / :func:`mark_notified`)
+   — one notice per 24h across sessions, tracked by a timestamp sentinel under
+   ``~/.totalreclaw/`` (mirrors the import-onboarding sentinel in
+   ``import_state.py``). Best-effort: a failed read/write degrades to "notify"
+   rather than crashing a hook.
+
+The env kill-switch ``TOTALRECLAW_DISABLE_UPDATE_NOTICE=1`` short-circuits the
+whole feature.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+import time
+from pathlib import Path
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Mirrors ``import_state.IMPORT_STATE_DIR`` — same ~/.totalreclaw/ home so all
+# client-local bookkeeping lives in one place. A timestamp file (unix seconds).
+_STATE_DIR: Path = Path.home() / ".totalreclaw"
+_NOTICE_SENTINEL_NAME = "update-notice-last-shown"
+
+# One notice per 24h across sessions.
+NOTICE_INTERVAL_SECONDS: int = 24 * 60 * 60
+
+# Pre-release phase ordering: alpha < beta < rc < final. Final is represented
+# by the largest sentinel so "no pre-release" always sorts after any of them.
+_PHASE_ORDER = {"a": 0, "b": 1, "rc": 2, "": 3}
+_VERSION_RE = re.compile(
+    r"^\s*v?(\d+)\.(\d+)(?:\.(\d+))?(?:[.\-_]?(a|b|rc|alpha|beta|c)\.?(\d+))?",
+    re.IGNORECASE,
+)
+_PHASE_ALIASES = {"alpha": "a", "beta": "b", "c": "rc", "a": "a", "b": "b", "rc": "rc"}
+
+
+def disabled_by_env() -> bool:
+    """True when ``TOTALRECLAW_DISABLE_UPDATE_NOTICE`` is set to a truthy value."""
+    return os.environ.get("TOTALRECLAW_DISABLE_UPDATE_NOTICE", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def _parse_version(v: str) -> Optional[Tuple[int, int, int, int, int]]:
+    """Parse ``MAJOR.MINOR[.PATCH][rcN]`` into a sortable tuple.
+
+    Returns ``(major, minor, patch, phase_rank, phase_num)`` or ``None`` if the
+    string doesn't look like a version we understand. ``phase_rank`` uses
+    :data:`_PHASE_ORDER` so final (rank 3) sorts after any pre-release; a final
+    release gets ``phase_num = 0`` (unused).
+    """
+    if not v or not isinstance(v, str):
+        return None
+    m = _VERSION_RE.match(v)
+    if not m:
+        return None
+    major = int(m.group(1))
+    minor = int(m.group(2))
+    patch = int(m.group(3)) if m.group(3) is not None else 0
+    phase_tok = (m.group(4) or "").lower()
+    if phase_tok:
+        phase = _PHASE_ALIASES.get(phase_tok, "")
+        phase_num = int(m.group(5)) if m.group(5) is not None else 0
+    else:
+        phase = ""  # final
+        phase_num = 0
+    phase_rank = _PHASE_ORDER.get(phase, 3)
+    return (major, minor, patch, phase_rank, phase_num)
+
+
+def is_newer_stable(latest: Optional[str], installed: Optional[str]) -> bool:
+    """True if ``latest`` is a strictly newer version than ``installed``.
+
+    Handles the rc-vs-final rule correctly:
+
+    * ``is_newer_stable("2.4.5", "2.4.5rc11")`` → True  (final beats its own rc)
+    * ``is_newer_stable("2.4.5", "2.4.6rc1")``  → False (user is ahead on 2.4.6 line)
+    * ``is_newer_stable("2.4.5", "2.4.5")``     → False (equal)
+    * ``is_newer_stable("2.4.5", "2.4.4")``     → True
+    * ``is_newer_stable("2.4.5", "2.5.0")``     → False (installed newer)
+
+    Malformed / missing input ⇒ False (never nudge on bad data).
+    """
+    lp = _parse_version(latest or "")
+    ip = _parse_version(installed or "")
+    if lp is None or ip is None:
+        return False
+    return lp > ip
+
+
+def _sentinel_path() -> Path:
+    return _STATE_DIR / _NOTICE_SENTINEL_NAME
+
+
+def last_notified_at() -> Optional[float]:
+    """Unix timestamp of the last notice shown, or None if never / unreadable."""
+    try:
+        raw = _sentinel_path().read_text(encoding="utf-8").strip()
+        return float(raw)
+    except Exception:
+        return None
+
+
+def within_rate_limit(now: Optional[float] = None) -> bool:
+    """True if a notice was shown within the last :data:`NOTICE_INTERVAL_SECONDS`.
+
+    Used to suppress a repeat notice. A missing/unreadable sentinel ⇒ False
+    (i.e. not rate-limited ⇒ allowed to notify).
+    """
+    last = last_notified_at()
+    if last is None:
+        return False
+    current = time.time() if now is None else now
+    return (current - last) < NOTICE_INTERVAL_SECONDS
+
+
+def mark_notified(now: Optional[float] = None) -> None:
+    """Persist 'notice shown at now' so the next 24h are suppressed.
+
+    Best-effort — a write failure means at most one extra notice, not a crash.
+    """
+    try:
+        _STATE_DIR.mkdir(parents=True, exist_ok=True)
+        current = time.time() if now is None else now
+        _sentinel_path().write_text(str(current), encoding="utf-8")
+    except OSError:
+        pass
+
+
+def build_update_notice(latest: str, installed: str) -> str:
+    """The one-line user-facing nudge string."""
+    return (
+        f"TotalReclaw {latest} is available (you're running {installed}). "
+        f"Say 'update TotalReclaw' to upgrade."
+    )
+
+
+def maybe_build_update_notice(
+    latest: Optional[str],
+    installed: Optional[str],
+    now: Optional[float] = None,
+) -> Optional[str]:
+    """Return the nudge string if a notice should fire right now, else None.
+
+    Combines every gate in one place so the hook stays a two-liner:
+
+    1. kill-switch env not set,
+    2. ``latest`` is a strictly newer stable than ``installed``,
+    3. not within the 24h rate-limit window.
+
+    On a positive result the caller is responsible for calling
+    :func:`mark_notified` after it has actually queued the notice (so a failure
+    to queue doesn't burn the 24h window).
+    """
+    if disabled_by_env():
+        return None
+    if not is_newer_stable(latest, installed):
+        return None
+    if within_rate_limit(now):
+        return None
+    return build_update_notice(latest or "", installed or "")

--- a/python/src/totalreclaw/userop.py
+++ b/python/src/totalreclaw/userop.py
@@ -39,6 +39,7 @@ from .grant import (
     encode_install_signature,
     sign_digest,
 )
+from .relay import _client_header_value
 
 if TYPE_CHECKING:
     from .relay import RelayClient
@@ -412,7 +413,7 @@ async def build_and_send_userop(
     headers = {
         "Content-Type": "application/json",
         "Authorization": f"Bearer {auth_key_hex}",
-        "X-TotalReclaw-Client": client_id,
+        "X-TotalReclaw-Client": _client_header_value(client_id),
         "X-Wallet-Address": wallet_address,
     }
     if session_id:
@@ -662,7 +663,7 @@ async def build_and_send_userop_batch(
     headers = {
         "Content-Type": "application/json",
         "Authorization": f"Bearer {auth_key_hex}",
-        "X-TotalReclaw-Client": client_id,
+        "X-TotalReclaw-Client": _client_header_value(client_id),
         "X-Wallet-Address": wallet_address,
     }
     if session_id:

--- a/python/tests/e2e/update_notice_staging_e2e.py
+++ b/python/tests/e2e/update_notice_staging_e2e.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Staging E2E for the Hermes update-available notice (public #442 / relay #32).
+
+Proves the full path against the LIVE staging relay (which has
+LATEST_STABLE_PYTHON=2.4.5 set):
+
+  1. A real ``GET /v1/billing/status`` against staging carries
+     ``features.latest_stable_python == "2.4.5"`` (relay half is live).
+  2. With a FAKED older installed ``__version__`` (2.4.4), the client's real
+     session-start hook path queues the update notice EXACTLY ONCE.
+  3. A second hook call within the 24h window is SUPPRESSED (disk rate-limit).
+
+SECURITY — the recovery phrase never leaves this process and is never printed.
+Mirrors tests/e2e/entity_trapdoor_staging_e2e.py: phrase read from
+QA_RECOVERY_PHRASE env or the macOS keychain, every output line redacted.
+
+Usage:
+  PYTHONPATH=src python tests/e2e/update_notice_staging_e2e.py
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+import traceback
+from pathlib import Path
+
+STAGING_URL = "https://api-staging.totalreclaw.xyz"
+KEYCHAIN_SERVICE = "totalreclaw-qa-phrase"
+KEYCHAIN_ACCOUNT = "totalreclaw"
+
+FAKE_INSTALLED = "2.4.4"          # older than the staging LATEST_STABLE_PYTHON
+EXPECTED_LATEST = "2.4.5"         # what staging is configured to advertise
+
+
+def load_phrase() -> str:
+    env = (os.environ.get("QA_RECOVERY_PHRASE") or "").strip()
+    if env:
+        return env
+    res = subprocess.run(
+        ["security", "find-generic-password",
+         "-a", KEYCHAIN_ACCOUNT, "-s", KEYCHAIN_SERVICE, "-w"],
+        capture_output=True, text=True,
+    )
+    if res.returncode != 0 or not res.stdout.strip():
+        sys.exit("[e2e] no phrase: set QA_RECOVERY_PHRASE or add the keychain entry.")
+    return res.stdout.strip()
+
+
+def redact(text: str, phrase: str) -> str:
+    if not phrase:
+        return str(text)
+    frags = sorted({phrase, *(p for p in phrase.split() if p)}, key=len, reverse=True)
+    out = str(text)
+    for f in frags:
+        if f:
+            out = out.replace(f, "[REDACTED]")
+    return out
+
+
+async def main() -> int:
+    logging.disable(logging.CRITICAL)  # no library log can carry the phrase
+    phrase = load_phrase()
+
+    def log(msg: str) -> None:
+        print(redact(msg, phrase), flush=True)
+
+    # Fake an OLDER installed version BEFORE importing client code that reads it.
+    import totalreclaw
+    real_version = totalreclaw.__version__
+    totalreclaw.__version__ = FAKE_INSTALLED
+    try:
+        from totalreclaw import TotalReclaw
+        from totalreclaw.hermes.state import PluginState
+        from totalreclaw.hermes import hooks
+        from totalreclaw import update_notice as un
+
+        # Isolate the 24h rate-limit sentinel into a temp dir so the real
+        # ~/.totalreclaw is never touched and the run is deterministic.
+        tmp = Path(tempfile.mkdtemp(prefix="tr-update-e2e-"))
+        un._STATE_DIR = tmp / ".totalreclaw"
+        os.environ.pop("TOTALRECLAW_DISABLE_UPDATE_NOTICE", None)
+
+        log(f"[e2e] installed(faked)={FAKE_INSTALLED} expecting latest={EXPECTED_LATEST}")
+
+        # --- 1. Real staging billing carries latest_stable_python ---
+        client = TotalReclaw(recovery_phrase=phrase, server_url=STAGING_URL, is_test=True)
+        try:
+            # Derive the Smart Account address + register so billing returns the
+            # tier + features payload (an unregistered / address-less wallet gets
+            # an error-shaped response with no `tier`).
+            await client.get_wallet_address()
+            await client._ensure_registered()
+            status = await client._relay.get_billing_status()
+        finally:
+            await client._relay.close()
+
+        feats = status.features
+        latest = getattr(feats, "latest_stable_python", None) if feats else None
+        log(f"[e2e] staging billing: tier={status.tier} latest_stable_python={latest}")
+        if latest != EXPECTED_LATEST:
+            log(f"[e2e] FAIL: expected features.latest_stable_python={EXPECTED_LATEST!r}, got {latest!r}. "
+                f"Is LATEST_STABLE_PYTHON set on staging + deploy live?")
+            return 1
+
+        # Build the billing-cache dict shape the hook consumes.
+        billing = {
+            "tier": status.tier,
+            "free_writes_used": status.free_writes_used,
+            "free_writes_limit": status.free_writes_limit,
+            "features": {"latest_stable_python": latest},
+        }
+
+        # --- 2. Hook queues the notice EXACTLY ONCE ---
+        with _clean_env():
+            state1 = PluginState()
+        hooks._maybe_queue_update_notice(state1, billing)
+        notice = state1.get_quota_warning()
+        log(f"[e2e] first hook call -> notice={notice!r}")
+        if not notice or f"{EXPECTED_LATEST} is available" not in notice:
+            log("[e2e] FAIL: expected an update notice on the first call.")
+            return 1
+        if FAKE_INSTALLED not in notice or "update TotalReclaw" not in notice:
+            log("[e2e] FAIL: notice text malformed (missing installed version or CTA).")
+            return 1
+
+        # --- 3. Second call within the window is SUPPRESSED ---
+        with _clean_env():
+            state2 = PluginState()
+        hooks._maybe_queue_update_notice(state2, billing)
+        second = state2.get_quota_warning()
+        log(f"[e2e] second hook call (within 24h) -> notice={second!r}")
+        if second is not None:
+            log("[e2e] FAIL: notice fired twice within the 24h window (rate-limit broken).")
+            return 1
+
+        log("[e2e] PASS: staging advertises 2.4.5; notice fired once and was suppressed on repeat.")
+        return 0
+    finally:
+        totalreclaw.__version__ = real_version
+
+
+class _clean_env:
+    """Build a PluginState with clean env + no on-disk credentials so the
+    constructor doesn't try to auto-configure from a real vault."""
+    def __enter__(self):
+        from unittest.mock import patch
+        self._p1 = patch.dict(os.environ, {}, clear=True)
+        self._p2 = patch.object(Path, "exists", return_value=False)
+        self._p1.start()
+        self._p2.start()
+        return self
+
+    def __exit__(self, *exc):
+        self._p2.stop()
+        self._p1.stop()
+        return False
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(asyncio.run(main()))
+    except SystemExit:
+        raise
+    except Exception:
+        traceback.print_exc()
+        raise SystemExit(2)

--- a/python/tests/test_hermes_plugin.py
+++ b/python/tests/test_hermes_plugin.py
@@ -761,3 +761,94 @@ class TestRegister:
             )
         # And the approved replacement MUST be present.
         assert "totalreclaw_pair" in tool_names
+
+
+class TestUpdateNoticeHook:
+    """Integration of _maybe_queue_update_notice into the session-start
+    billing-cache flow. Isolates the disk sentinel to a temp dir."""
+
+    @pytest.fixture(autouse=True)
+    def _isolate(self, tmp_path, monkeypatch):
+        from totalreclaw import update_notice as un
+
+        monkeypatch.setattr(un, "_STATE_DIR", tmp_path / ".totalreclaw")
+        monkeypatch.delenv("TOTALRECLAW_DISABLE_UPDATE_NOTICE", raising=False)
+
+    def _billing(self, latest=None, used=0, limit=250, tier="free"):
+        feats = {"recall_top_k": 16}
+        if latest is not None:
+            feats["latest_stable_python"] = latest
+        return {
+            "tier": tier,
+            "free_writes_used": used,
+            "free_writes_limit": limit,
+            "features": feats,
+        }
+
+    def test_queues_notice_when_newer(self, monkeypatch):
+        from totalreclaw.hermes import hooks
+
+        monkeypatch.setattr("totalreclaw.__version__", "2.4.4", raising=False)
+
+        state = _make_state()
+        hooks._maybe_queue_update_notice(state, self._billing(latest="2.4.5"))
+        warn = state.get_quota_warning()
+        assert warn is not None
+        assert "2.4.5 is available" in warn
+        assert "2.4.4" in warn
+
+    def test_no_notice_when_equal(self, monkeypatch):
+        from totalreclaw.hermes import hooks
+
+        monkeypatch.setattr("totalreclaw.__version__", "2.4.5", raising=False)
+        state = _make_state()
+        hooks._maybe_queue_update_notice(state, self._billing(latest="2.4.5"))
+        assert state.get_quota_warning() is None
+
+    def test_no_notice_when_field_absent(self, monkeypatch):
+        from totalreclaw.hermes import hooks
+
+        monkeypatch.setattr("totalreclaw.__version__", "2.4.4", raising=False)
+        state = _make_state()
+        hooks._maybe_queue_update_notice(state, self._billing(latest=None))
+        assert state.get_quota_warning() is None
+
+    def test_kill_switch_suppresses(self, monkeypatch):
+        from totalreclaw.hermes import hooks
+
+        monkeypatch.setenv("TOTALRECLAW_DISABLE_UPDATE_NOTICE", "1")
+        monkeypatch.setattr("totalreclaw.__version__", "2.4.4", raising=False)
+        state = _make_state()
+        hooks._maybe_queue_update_notice(state, self._billing(latest="2.4.5"))
+        assert state.get_quota_warning() is None
+
+    def test_fires_once_within_window(self, monkeypatch):
+        from totalreclaw.hermes import hooks
+
+        monkeypatch.setattr("totalreclaw.__version__", "2.4.4", raising=False)
+
+        state1 = _make_state()
+        hooks._maybe_queue_update_notice(state1, self._billing(latest="2.4.5"))
+        assert state1.get_quota_warning() is not None
+
+        # A second (fresh) session within 24h must NOT re-notify — the disk
+        # sentinel was burned by the first call.
+        state2 = _make_state()
+        hooks._maybe_queue_update_notice(state2, self._billing(latest="2.4.5"))
+        assert state2.get_quota_warning() is None
+
+    def test_rc_user_notified_when_final_ships(self, monkeypatch):
+        from totalreclaw.hermes import hooks
+
+        monkeypatch.setattr("totalreclaw.__version__", "2.4.5rc11", raising=False)
+        state = _make_state()
+        hooks._maybe_queue_update_notice(state, self._billing(latest="2.4.5"))
+        assert state.get_quota_warning() is not None
+
+    def test_newer_rc_user_not_notified(self, monkeypatch):
+        from totalreclaw.hermes import hooks
+
+        monkeypatch.setattr("totalreclaw.__version__", "2.4.6rc1", raising=False)
+        state = _make_state()
+        hooks._maybe_queue_update_notice(state, self._billing(latest="2.4.5"))
+        assert state.get_quota_warning() is None

--- a/python/tests/test_relay.py
+++ b/python/tests/test_relay.py
@@ -1,8 +1,15 @@
 """Tests for TotalReclaw relay client."""
+import httpx
 import pytest
 from unittest.mock import AsyncMock, patch
 
-from totalreclaw.relay import RelayClient, BillingStatus, BillingFeatures, _detect_client_id
+from totalreclaw.relay import (
+    RelayClient,
+    BillingStatus,
+    BillingFeatures,
+    _detect_client_id,
+    _client_header_value,
+)
 
 
 class TestDetectClientId:
@@ -27,7 +34,12 @@ class TestRelayClient:
     def test_base_headers(self, client):
         headers = client._base_headers()
         assert headers["Authorization"] == "Bearer abc123"
-        assert headers["X-TotalReclaw-Client"] == "python-client"
+        # Header now carries an observability version suffix:
+        # `python-client/<version>`. The relay buckets on the part before
+        # the first `/`, so we assert the prefix, not an exact match.
+        assert headers["X-TotalReclaw-Client"].startswith("python-client")
+        assert "/" in headers["X-TotalReclaw-Client"]
+        assert headers["X-TotalReclaw-Client"].split("/", 1)[0] == "python-client"
         assert headers["Content-Type"] == "application/json"
 
     def test_url_strip_trailing_slash(self):
@@ -60,3 +72,74 @@ class TestRelayClient:
     async def test_close_no_http(self):
         c = RelayClient()
         await c.close()  # Should not raise
+
+
+class TestClientHeaderValue:
+    def test_appends_version(self):
+        val = _client_header_value("python-client")
+        assert val.startswith("python-client/")
+        # bucket (before first '/') is preserved for relay analytics
+        assert val.split("/", 1)[0] == "python-client"
+
+    def test_preserves_hermes_bucket(self):
+        val = _client_header_value("python-client:hermes-agent")
+        assert val.split("/", 1)[0] == "python-client:hermes-agent"
+
+    def test_version_is_nonempty(self):
+        from totalreclaw.relay import _client_version
+
+        # Resolves to the installed __version__ (or "unknown" on failure),
+        # never empty.
+        assert _client_version()
+        # And the composed header always has exactly one bucket + version.
+        val = _client_header_value("python-client")
+        assert val.count("/") >= 1
+
+
+class TestBillingStatusParsing:
+    """get_billing_status must parse latest_stable_python from features."""
+
+    def _relay_with_response(self, payload: dict) -> RelayClient:
+        def _handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=payload)
+
+        transport = httpx.MockTransport(_handler)
+        rc = RelayClient(
+            relay_url="https://api-staging.totalreclaw.xyz",
+            auth_key_hex="00" * 32,
+            wallet_address="0x" + "ab" * 20,
+        )
+
+        async def _mock_get_http() -> httpx.AsyncClient:
+            return httpx.AsyncClient(transport=transport, timeout=10.0)
+
+        rc._get_http = _mock_get_http  # type: ignore[assignment]
+        return rc
+
+    @pytest.mark.asyncio
+    async def test_parses_latest_stable_python(self):
+        rc = self._relay_with_response(
+            {
+                "tier": "free",
+                "free_writes_used": 1,
+                "free_writes_limit": 250,
+                "features": {"recall_top_k": 16, "latest_stable_python": "2.4.5"},
+            }
+        )
+        status = await rc.get_billing_status()
+        assert status.features is not None
+        assert status.features.latest_stable_python == "2.4.5"
+
+    @pytest.mark.asyncio
+    async def test_absent_latest_stable_python_is_none(self):
+        rc = self._relay_with_response(
+            {
+                "tier": "free",
+                "free_writes_used": 1,
+                "free_writes_limit": 250,
+                "features": {"recall_top_k": 16},
+            }
+        )
+        status = await rc.get_billing_status()
+        assert status.features is not None
+        assert status.features.latest_stable_python is None

--- a/python/tests/test_update_notice.py
+++ b/python/tests/test_update_notice.py
@@ -1,0 +1,153 @@
+"""Tests for the update-notice bookkeeping (version compare + rate-limit +
+kill-switch). See ``totalreclaw.update_notice``."""
+import time
+
+import pytest
+
+from totalreclaw import update_notice as un
+
+
+# ── version comparison matrix ────────────────────────────────────────────
+class TestIsNewerStable:
+    @pytest.mark.parametrize(
+        "latest,installed,expected",
+        [
+            # basic ordering
+            ("2.4.5", "2.4.4", True),
+            ("2.4.5", "2.4.5", False),
+            ("2.4.5", "2.4.6", False),
+            ("2.4.5", "2.5.0", False),
+            ("2.5.0", "2.4.9", True),
+            ("3.0.0", "2.9.9", True),
+            ("1.9.9", "2.0.0", False),
+            # patch-less installed defaults patch=0
+            ("2.4.1", "2.4", True),
+            ("2.4.0", "2.4", False),
+            # rc-vs-final: a final beats its OWN rc line
+            ("2.4.5", "2.4.5rc11", True),
+            ("2.4.5", "2.4.5rc1", True),
+            # user already ahead on a newer rc line — NOT nudged by older final
+            ("2.4.5", "2.4.6rc1", False),
+            ("2.4.5", "2.5.0rc1", False),
+            # final vs a LOWER final where installed is an rc of that lower one
+            ("2.4.5", "2.4.4rc9", True),
+            # rc latest vs final installed of same base — final installed wins
+            ("2.4.5rc2", "2.4.5", False),
+            # rc latest newer than installed rc on same base
+            ("2.4.5rc5", "2.4.5rc2", True),
+            ("2.4.5rc2", "2.4.5rc5", False),
+            # phase ordering a < b < rc < final
+            ("2.4.5b1", "2.4.5a9", True),
+            ("2.4.5rc1", "2.4.5b9", True),
+            # 'v' prefix tolerated
+            ("v2.4.5", "2.4.4", True),
+            # absent / malformed ⇒ never nudge
+            (None, "2.4.4", False),
+            ("2.4.5", None, False),
+            ("", "2.4.4", False),
+            ("garbage", "2.4.4", False),
+            ("2.4.5", "not-a-version", False),
+        ],
+    )
+    def test_matrix(self, latest, installed, expected):
+        assert un.is_newer_stable(latest, installed) is expected
+
+
+# ── rate-limit persistence ───────────────────────────────────────────────
+class TestRateLimit:
+    @pytest.fixture(autouse=True)
+    def _isolate_state_dir(self, tmp_path, monkeypatch):
+        # Redirect the sentinel dir into a temp path so tests never touch the
+        # real ~/.totalreclaw and don't interfere with each other.
+        monkeypatch.setattr(un, "_STATE_DIR", tmp_path / ".totalreclaw")
+
+    def test_no_sentinel_is_not_rate_limited(self):
+        assert un.last_notified_at() is None
+        assert un.within_rate_limit() is False
+
+    def test_mark_then_within_window(self):
+        un.mark_notified()
+        assert un.last_notified_at() is not None
+        assert un.within_rate_limit() is True
+
+    def test_outside_window_after_24h(self):
+        now = time.time()
+        un.mark_notified(now=now - (un.NOTICE_INTERVAL_SECONDS + 10))
+        # A "now" past the window ⇒ no longer rate-limited.
+        assert un.within_rate_limit(now=now) is False
+
+    def test_just_inside_window(self):
+        now = time.time()
+        un.mark_notified(now=now - (un.NOTICE_INTERVAL_SECONDS - 10))
+        assert un.within_rate_limit(now=now) is True
+
+    def test_unreadable_sentinel_degrades_to_not_limited(self, tmp_path):
+        # Write garbage into the sentinel — parsing fails ⇒ not rate-limited.
+        un._STATE_DIR.mkdir(parents=True, exist_ok=True)
+        un._sentinel_path().write_text("not-a-float", encoding="utf-8")
+        assert un.last_notified_at() is None
+        assert un.within_rate_limit() is False
+
+
+# ── kill-switch ──────────────────────────────────────────────────────────
+class TestKillSwitch:
+    @pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
+    def test_disabled_truthy(self, monkeypatch, val):
+        monkeypatch.setenv("TOTALRECLAW_DISABLE_UPDATE_NOTICE", val)
+        assert un.disabled_by_env() is True
+
+    @pytest.mark.parametrize("val", ["0", "false", "", "no", "off"])
+    def test_not_disabled(self, monkeypatch, val):
+        monkeypatch.setenv("TOTALRECLAW_DISABLE_UPDATE_NOTICE", val)
+        assert un.disabled_by_env() is False
+
+    def test_unset_is_not_disabled(self, monkeypatch):
+        monkeypatch.delenv("TOTALRECLAW_DISABLE_UPDATE_NOTICE", raising=False)
+        assert un.disabled_by_env() is False
+
+
+# ── combined gate: maybe_build_update_notice ─────────────────────────────
+class TestMaybeBuildUpdateNotice:
+    @pytest.fixture(autouse=True)
+    def _isolate(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(un, "_STATE_DIR", tmp_path / ".totalreclaw")
+        monkeypatch.delenv("TOTALRECLAW_DISABLE_UPDATE_NOTICE", raising=False)
+
+    def test_fires_when_newer_and_not_rate_limited(self):
+        notice = un.maybe_build_update_notice("2.4.5", "2.4.4")
+        assert notice is not None
+        assert "2.4.5 is available" in notice
+        assert "2.4.4" in notice
+        assert "update TotalReclaw" in notice
+
+    def test_none_when_not_newer(self):
+        assert un.maybe_build_update_notice("2.4.5", "2.4.5") is None
+        assert un.maybe_build_update_notice("2.4.5", "2.5.0") is None
+
+    def test_none_when_absent(self):
+        assert un.maybe_build_update_notice(None, "2.4.4") is None
+
+    def test_none_when_kill_switch(self, monkeypatch):
+        monkeypatch.setenv("TOTALRECLAW_DISABLE_UPDATE_NOTICE", "1")
+        assert un.maybe_build_update_notice("2.4.5", "2.4.4") is None
+
+    def test_none_when_rate_limited(self):
+        un.mark_notified()  # burn the window
+        assert un.maybe_build_update_notice("2.4.5", "2.4.4") is None
+
+    def test_rc_user_notified_when_final_ships(self):
+        notice = un.maybe_build_update_notice("2.4.5", "2.4.5rc11")
+        assert notice is not None
+        assert "2.4.5 is available" in notice
+
+    def test_newer_rc_user_not_notified_by_older_final(self):
+        assert un.maybe_build_update_notice("2.4.5", "2.4.6rc1") is None
+
+    def test_second_call_within_window_suppressed_after_mark(self):
+        # Simulate the hook: build once, then mark, then the next build in-window
+        # returns None.
+        first = un.maybe_build_update_notice("2.4.5", "2.4.4")
+        assert first is not None
+        un.mark_notified()
+        second = un.maybe_build_update_notice("2.4.5", "2.4.4")
+        assert second is None


### PR DESCRIPTION
Client half of the Hermes **update-notification** flow. Relay half: **p-diogo/totalreclaw-relay#32**.

## Why
Hermes has **no native pip/entry-point plugin update path** (`hermes plugins update` is git-clone-only; `hermes update` updates Hermes itself). So we drive updates through the existing install machinery, re-pointed at the newest stable — and announce availability fleet-wide via the relay.

## Client
- **`relay.py`**: parse `features.latest_stable_python` into `BillingFeatures`.
- **`update_notice.py`** (new): a small internal PEP-440 comparator — **rc-vs-final aware**: an rc of X counts as older than final X (`2.4.5rc11` → nudged when `2.4.5` ships), but a user already on a newer rc line (`2.4.6rc1`) is **not** nudged by an older final (`2.4.5`). **No new dependency** (`packaging` is only transitively present, so we don't rely on it). Disk-persisted **24h rate-limit** via a `~/.totalreclaw` sentinel (mirrors `import_state.py`). Env kill-switch `TOTALRECLAW_DISABLE_UPDATE_NOTICE=1`.
- **`hooks.py`**: queue the one-line notice via the existing quota-warning channel at session start — only when no (more-urgent) quota warning is pending, and only once per 24h across sessions.

## Observability
`X-TotalReclaw-Client` now carries the version: `python-client/<version>`. The relay buckets analytics on the part before the first `/` (tolerant split shipped in the relay PR), so per-release suffixes don't fragment client-type aggregation. Applied at every emission site (relay/client/userop). Existing header assertion relaxed to a prefix check.

## Docs
- `hermes-setup.md`: **Update prompt** (reuse install step 2 with `PIN=totalreclaw` stable + runtime verify + step-4 restart, ≤3 user-visible lines) + automatic-notice explainer.
- `env-vars-reference.md`: `TOTALRECLAW_DISABLE_UPDATE_NOTICE` row.
- `release-process.md`: stable-promote step to set `LATEST_STABLE_PYTHON` on **both** relay services — the one env flip that fires the fleet-wide notice.
- `CLAUDE.md`: feature-matrix rows.

## The one-env-flip story
When the next stable ships: publish to PyPI → `railway variables --set LATEST_STABLE_PYTHON=<ver>` on both relay services. Every Hermes client's next session start sees the new `features.latest_stable_python`, compares it to its installed `__version__`, and nudges the user once/24h. No client release required.

## Tests
Version-compare matrix (older/equal/newer/rc-vs-final both ways/absent/malformed) · rate-limit · kill-switch · hook integration · billing parse · header value. Ships with the next RC train (no publish here). **Full suite: 1781 passed / 39 skipped / 1 xfailed.**

E2E proof against staging (fresh venv, faked-older `__version__`, `LATEST_STABLE_PYTHON=2.4.5` on staging) — appended as a comment once the relay PR is deployed to staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)