### PR TITLE
fix(pair): existing-credentials guard — refuse fresh pair over a live vault (F8)

### DIFF
--- a/python/src/totalreclaw/hermes/pair_tool.py
+++ b/python/src/totalreclaw/hermes/pair_tool.py
@@ -93,6 +93,17 @@ PAIR_SCHEMA: Dict[str, Any] = {
                     "you don't know whether the user is new or returning)."
                 ),
             },
+            "replace_confirmed": {
+                "type": "boolean",
+                "description": (
+                    "Required ONLY when this install is already paired: the "
+                    "tool refuses to start a fresh pair over existing "
+                    "credentials (it would orphan the current vault) unless "
+                    "the user explicitly confirmed they want to REPLACE "
+                    "their account. Never set this without that explicit "
+                    "user confirmation."
+                ),
+            },
         },
     },
 }
@@ -434,6 +445,26 @@ async def pair(args: dict, state: "PluginState", **kwargs) -> str:
         the safest default for agents that don't know whether the user
         has an existing phrase or is creating one fresh.
     """
+    # F8 (#428) — existing-credentials guard. Completing a fresh pair on an
+    # already-configured install mints a NEW phrase / Smart Account and
+    # silently orphans the existing vault. Refuse unless the user explicitly
+    # chose replacement. Message-level guard only — no crypto-path changes.
+    if state.is_configured() and not bool(args.get("replace_confirmed", False)):
+        return json.dumps({
+            "already_configured": True,
+            "message": (
+                "This install is already paired to a TotalReclaw account — "
+                "its credentials are on disk and the vault is reachable. "
+                "Starting a new pair flow would create a DIFFERENT account "
+                "and orphan the existing vault's memories. Tell the user "
+                "their account is already set up. Only if they explicitly "
+                "say they want to REPLACE it with a new/different account, "
+                "call again with replace_confirmed=true. (Restoring this "
+                "same account on another device happens on that device, "
+                "not here.)"
+            ),
+        })
+
     raw_mode = args.get("mode")
     if raw_mode in ("generate", "import", "either"):
         mode = raw_mode

--- a/python/tests/test_pair_existing_credentials_guard.py
+++ b/python/tests/test_pair_existing_credentials_guard.py
@@ -1,0 +1,73 @@
+"""F8 (#428) — pair-tool existing-credentials guard.
+
+rc12 QA: "Set up my TotalReclaw account" on an ALREADY-configured install
+started a fresh pair flow. Completing it would have minted a new phrase /
+Smart Account and silently orphaned the existing vault. The guard refuses
+to start a pair session while credentials exist, unless the agent passes
+replace_confirmed=true after the user explicitly chose to replace.
+
+Message-level guard only — no key material, no crypto-path changes.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _state(configured: bool, monkeypatch):
+    from totalreclaw.hermes.state import PluginState
+    state = PluginState()
+    monkeypatch.setattr(state, "is_configured", lambda: configured)
+    return state
+
+
+def _patch_pair_session(monkeypatch):
+    """Record whether a pair session was actually started."""
+    from totalreclaw.hermes import pair_tool
+    started = []
+
+    async def fake_relay(state, mode):
+        started.append(mode)
+        return "https://pair.example/x", "123456", "2026-07-05T23:59:59Z"
+
+    monkeypatch.setattr(pair_tool, "_pair_relay", fake_relay)
+    monkeypatch.setattr(pair_tool, "_pair_mode", lambda: "relay")
+    return started
+
+
+@pytest.mark.asyncio
+async def test_configured_install_blocks_fresh_pair(monkeypatch):
+    from totalreclaw.hermes import pair_tool
+    started = _patch_pair_session(monkeypatch)
+    state = _state(configured=True, monkeypatch=monkeypatch)
+
+    res = json.loads(await pair_tool.pair({}, state))
+    assert res.get("already_configured") is True
+    assert "replace_confirmed" in res["message"]
+    assert started == [], "no pair session may start while credentials exist"
+
+
+@pytest.mark.asyncio
+async def test_replace_confirmed_proceeds(monkeypatch):
+    from totalreclaw.hermes import pair_tool
+    started = _patch_pair_session(monkeypatch)
+    state = _state(configured=True, monkeypatch=monkeypatch)
+
+    res = json.loads(await pair_tool.pair({"replace_confirmed": True}, state))
+    assert res.get("already_configured") is not True
+    assert res.get("url")
+    assert started, "explicit replacement must start the pair session"
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_install_pairs_without_friction(monkeypatch):
+    from totalreclaw.hermes import pair_tool
+    started = _patch_pair_session(monkeypatch)
+    state = _state(configured=False, monkeypatch=monkeypatch)
+
+    res = json.loads(await pair_tool.pair({}, state))
+    assert res.get("already_configured") is not True
+    assert res.get("url")
+    assert started

--- a/python/tests/test_pair_generate_mode.py
+++ b/python/tests/test_pair_generate_mode.py
@@ -305,6 +305,8 @@ async def test_pair_tool_default_mode_is_either(tmp_path, monkeypatch):
     _pair_tool_mod._SERVER_INSTANCE = None  # type: ignore[attr-defined]
 
     state = MagicMock()
+    # fresh install — F8 guard must not fire (bare MagicMock is truthy)
+    state.is_configured.return_value = False
     # No 'mode' in args.
     result_json = await _pair_tool_mod.pair({}, state)
     payload = json.loads(result_json)
@@ -327,6 +329,8 @@ async def test_pair_tool_accepts_explicit_either(tmp_path, monkeypatch):
     _pair_tool_mod._SERVER_INSTANCE = None  # type: ignore[attr-defined]
 
     state = MagicMock()
+    # fresh install — F8 guard must not fire (bare MagicMock is truthy)
+    state.is_configured.return_value = False
     result_json = await _pair_tool_mod.pair({"mode": "either"}, state)
     payload = json.loads(result_json)
     assert payload["mode"] == "either"
@@ -343,6 +347,8 @@ async def test_pair_tool_generate_or_import_still_honored(tmp_path, monkeypatch)
     from totalreclaw.hermes import pair_tool as _pair_tool_mod
 
     state = MagicMock()
+    # fresh install — F8 guard must not fire (bare MagicMock is truthy)
+    state.is_configured.return_value = False
 
     # generate
     _pair_tool_mod._SERVER_INSTANCE = None  # type: ignore[attr-defined]
@@ -404,6 +410,8 @@ async def test_relay_mode_passes_ui_mode_to_thread_supervisor_when_sidecar_disab
     )
 
     state = MagicMock()
+    # fresh install — F8 guard must not fire (bare MagicMock is truthy)
+    state.is_configured.return_value = False
 
     for mode in ("generate", "import", "either"):
         result_json = await _pair_tool_mod.pair({"mode": mode}, state)
@@ -450,6 +458,8 @@ async def test_relay_mode_passes_ui_mode_via_sidecar_default_path(
     )
 
     state = MagicMock()
+    # fresh install — F8 guard must not fire (bare MagicMock is truthy)
+    state.is_configured.return_value = False
 
     for mode in ("generate", "import", "either"):
         captured.clear()

--- a/python/tests/test_pair_tool_payload.py
+++ b/python/tests/test_pair_tool_payload.py
@@ -51,6 +51,8 @@ async def test_pair_tool_returns_qr_png_and_qr_unicode(tmp_path, monkeypatch):
     _pair_tool_mod._SERVER_INSTANCE = None  # type: ignore[attr-defined]
 
     state = MagicMock()
+    # fresh install — F8 guard must not fire (bare MagicMock is truthy)
+    state.is_configured.return_value = False
     # configure + state.get_client aren't exercised by the pair-tool
     # path under test (only ``_complete_pairing_handler`` closes over
     # state, and that handler is only invoked by the browser POST —
@@ -136,6 +138,8 @@ async def test_pair_tool_payload_never_contains_phrase_material(tmp_path, monkey
     _pair_tool_mod._SERVER_INSTANCE = None  # type: ignore[attr-defined]
 
     state = MagicMock()
+    # fresh install — F8 guard must not fire (bare MagicMock is truthy)
+    state.is_configured.return_value = False
 
     result_json = await _pair_tool_mod.pair({"mode": "generate"}, state)
     payload = json.loads(result_json)


### PR DESCRIPTION
## What (internal #428, rc12 QA F8) — **HELD FOR PEDRO REVIEW (pair-path rail)**

`totalreclaw_pair` on an already-configured install now returns `already_configured` and starts NO pair session — unless `replace_confirmed=true` is passed after the user explicitly chose to replace their account. Prevents the orphaned-vault scenario QA hit (fresh pair started over live credentials).

**Scope discipline:** message-level guard at the top of `pair()` + one schema param. Zero changes to key material, signing, QR/session crypto, or the pair transport.

**Review surface:** the guard copy + the `replace_confirmed` semantics. Note the guard intentionally does NOT offer 'restore existing account here' — restoring onto an already-configured install is the same orphaning operation with different words.

3 new tests (blocked / replace-confirmed proceeds / fresh install frictionless); 7 pre-existing pair tests' bare-MagicMock states marked unconfigured. Suite 1821 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sks1gbonedAkEsawd4LVE