### PR TITLE
fix(userop): local nonce cache + AA25 nonce-advance wait — sequential batches stop racing one nonce (F3)

### DIFF
--- a/python/src/totalreclaw/userop.py
+++ b/python/src/totalreclaw/userop.py
@@ -91,6 +91,76 @@ async def _get_sender_lock(sender: str) -> asyncio.Lock:
 def _reset_sender_locks_for_tests() -> None:
     """Clear the per-account lock map. Test-only helper."""
     _sender_submission_locks.clear()
+
+
+# ---------------------------------------------------------------------------
+# Local monotonic nonce cache — F3 / internal #423
+# ---------------------------------------------------------------------------
+#
+# The EntryPoint nonce only advances at ON-CHAIN EXECUTION, but this client
+# returns as soon as the bundler accepts an op into its mempool. Sequential
+# submissions (import batches fire back-to-back) therefore re-fetched the
+# SAME nonce while the previous op was unmined -> AA25 -> blind 1+2+4s retry
+# lost the race against ~5s Gnosis blocks -> whole batches dropped (rc12 QA:
+# 15/44 facts stored = only the first batch landed).
+#
+# Fix: remember the next expected nonce per sender and submit with
+# max(chain_nonce, cached). Bundlers accept queued sequential-nonce ops from
+# one sender, so pipelining is preserved. The cache is process-local and
+# self-healing: max() with the chain nonce means external activity or a
+# restart can only correct it upward from reality; an AA25 resets it.
+# Reads/writes happen under the per-sender submission lock.
+_sender_next_nonce: dict[str, int] = {}
+
+
+def _resolve_submission_nonce(sender: str, chain_nonce: int) -> int:
+    """Nonce to submit with: the chain nonce or our pipelined next, whichever is higher."""
+    return max(chain_nonce, _sender_next_nonce.get(sender.lower(), 0))
+
+
+def _record_submitted_nonce(sender: str, nonce: int) -> None:
+    """Record a bundler-accepted submission; never decreases."""
+    key = sender.lower()
+    _sender_next_nonce[key] = max(_sender_next_nonce.get(key, 0), nonce + 1)
+
+
+def _reset_sender_nonce(sender: str) -> None:
+    """Drop the cached nonce (AA25 path) — fall back to chain truth."""
+    _sender_next_nonce.pop(sender.lower(), None)
+
+
+def _reset_nonce_cache_for_tests() -> None:
+    """Clear the nonce cache. Test-only helper."""
+    _sender_next_nonce.clear()
+
+
+async def _await_nonce_advance(
+    http,
+    sender: str,
+    chain_id: int,
+    min_nonce: int,
+    timeout_s: float = 15.0,
+    poll_s: float = 1.5,
+) -> int:
+    """Poll the EntryPoint nonce until it reaches ``min_nonce`` or timeout.
+
+    Used by the AA25 retry path: instead of sleeping blind while the
+    conflicting op mines, wait for the observable signal (nonce advance).
+    RPC errors are tolerated (retry on next poll). Returns the last nonce
+    seen (may be < min_nonce on timeout).
+    """
+    import time as _time
+    deadline = _time.monotonic() + timeout_s
+    last = -1
+    while _time.monotonic() < deadline:
+        try:
+            last = await get_nonce(http, sender, chain_id)
+            if last >= min_nonce:
+                return last
+        except Exception:
+            pass
+        await asyncio.sleep(poll_s)
+    return last
 DATA_EDGE_ADDRESS = "0xC445af1D4EB9fce4e1E61fE96ea7B8feBF03c5ca"
 
 # Chain-specific public RPCs
@@ -437,9 +507,11 @@ async def build_and_send_userop(
         # the nonce and rebuilding the UserOp resolves it.
         for attempt in range(_MAX_NONCE_RETRIES):
             try:
-                # 2. Get nonce from EntryPoint
-                nonce = await get_nonce(http, sender, chain_id)
-                logger.debug("Nonce for %s: %d", sender, nonce)
+                # 2. Get nonce from EntryPoint, pipelined past any of our own
+                #    unmined submissions via the local cache (#423).
+                chain_nonce = await get_nonce(http, sender, chain_id)
+                nonce = _resolve_submission_nonce(sender, chain_nonce)
+                logger.debug("Nonce for %s: chain=%d using=%d", sender, chain_nonce, nonce)
 
                 # 3. Check if account is already deployed
                 code = await _eth_get_code(http, rpc_url, sender)
@@ -551,6 +623,7 @@ async def build_and_send_userop(
                         f"UserOp submission failed: {send_data['error']}"
                     )
 
+                _record_submitted_nonce(sender, nonce)
                 return send_data.get("result", "")
 
             except Exception as e:
@@ -561,7 +634,18 @@ async def build_and_send_userop(
                         attempt + 1,
                         _MAX_NONCE_RETRIES,
                     )
-                    await asyncio.sleep(2 ** attempt)
+                    if "AA25" in err_str:
+                        # #423: drop the pipelined nonce and wait for the
+                        # conflicting op to actually mine (observable as a
+                        # nonce advance) instead of sleeping blind against
+                        # ~5s blocks.
+                        _reset_sender_nonce(sender)
+                        await _await_nonce_advance(
+                            http, sender, chain_id, min_nonce=nonce + 1,
+                            timeout_s=15.0 if attempt else 6.0,
+                        )
+                    else:
+                        await asyncio.sleep(2 ** attempt)
                     continue
                 raise
 
@@ -690,11 +774,13 @@ async def build_and_send_userop_batch(
         # O(1) retries for the batch path vs O(n) for sequential sends.
         for attempt in range(_MAX_NONCE_RETRIES):
             try:
-                # 2. Get nonce from EntryPoint
-                nonce = await get_nonce(http, sender, chain_id)
+                # 2. Get nonce from EntryPoint, pipelined past our own unmined
+                #    submissions via the local cache (#423).
+                chain_nonce = await get_nonce(http, sender, chain_id)
+                nonce = _resolve_submission_nonce(sender, chain_nonce)
                 logger.debug(
-                    "Batch nonce for %s: %d (batch size %d)",
-                    sender, nonce, len(protobuf_payloads),
+                    "Batch nonce for %s: chain=%d using=%d (batch size %d)",
+                    sender, chain_nonce, nonce, len(protobuf_payloads),
                 )
 
                 # 3. Check if account is already deployed
@@ -808,6 +894,7 @@ async def build_and_send_userop_batch(
                         f"Batch UserOp submission failed: {send_data['error']}"
                     )
 
+                _record_submitted_nonce(sender, nonce)
                 return send_data.get("result", "")
 
             except Exception as e:
@@ -820,7 +907,18 @@ async def build_and_send_userop_batch(
                         _MAX_NONCE_RETRIES,
                         len(protobuf_payloads),
                     )
-                    await asyncio.sleep(2 ** attempt)
+                    if "AA25" in err_str:
+                        # #423: drop the pipelined nonce and wait for the
+                        # conflicting op to actually mine (observable as a
+                        # nonce advance) instead of sleeping blind against
+                        # ~5s blocks.
+                        _reset_sender_nonce(sender)
+                        await _await_nonce_advance(
+                            http, sender, chain_id, min_nonce=nonce + 1,
+                            timeout_s=15.0 if attempt else 6.0,
+                        )
+                    else:
+                        await asyncio.sleep(2 ** attempt)
                     continue
                 raise
 

--- a/python/tests/test_nonce_cache_f3.py
+++ b/python/tests/test_nonce_cache_f3.py
@@ -1,0 +1,116 @@
+"""F3 (internal #423) — local monotonic nonce cache + receipt-aware retry.
+
+rc12 QA: 44 import facts chunked 15+15+14 stored only the FIRST 15. Root
+cause: the client never waits for UserOp inclusion, and the EntryPoint
+nonce only advances at execution — so batches 2 and 3 re-fetched batch 1's
+nonce, collided (AA25), and exhausted the ~7s blind retry window while
+Gnosis blocks take ~5s.
+
+The fix: a per-sender local nonce cache lets sequential submissions use
+nonce+1 pipelining (bundlers accept queued sequential-nonce ops), and the
+AA25 retry waits for the chain nonce to actually advance instead of
+sleeping blind.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import totalreclaw.userop as userop
+from totalreclaw.userop import (
+    _resolve_submission_nonce,
+    _record_submitted_nonce,
+    _reset_nonce_cache_for_tests,
+    _await_nonce_advance,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    _reset_nonce_cache_for_tests()
+    yield
+    _reset_nonce_cache_for_tests()
+
+
+class TestNonceCache:
+    def test_no_cache_uses_chain_nonce(self):
+        assert _resolve_submission_nonce("0xAbC", 5) == 5
+
+    def test_cache_wins_when_chain_is_stale(self):
+        """The QA scenario: batch 1 sent with nonce 5 but unmined — chain
+        still reports 5; batch 2 must use 6."""
+        _record_submitted_nonce("0xabc", 5)
+        assert _resolve_submission_nonce("0xABC", 5) == 6
+
+    def test_chain_wins_when_ahead_of_cache(self):
+        """Cache is self-healing: external activity (another device) can
+        advance the chain past our cache."""
+        _record_submitted_nonce("0xabc", 5)
+        assert _resolve_submission_nonce("0xabc", 9) == 9
+
+    def test_sequential_pipeline(self):
+        """Three back-to-back batches with the chain stuck at 5 → 5, 6, 7."""
+        chain = 5
+        n1 = _resolve_submission_nonce("0xabc", chain)
+        _record_submitted_nonce("0xabc", n1)
+        n2 = _resolve_submission_nonce("0xabc", chain)
+        _record_submitted_nonce("0xabc", n2)
+        n3 = _resolve_submission_nonce("0xabc", chain)
+        assert (n1, n2, n3) == (5, 6, 7)
+
+    def test_record_never_decreases(self):
+        _record_submitted_nonce("0xabc", 9)
+        _record_submitted_nonce("0xabc", 3)  # late/out-of-order record
+        assert _resolve_submission_nonce("0xabc", 0) == 10
+
+    def test_reset_on_aa25_falls_back_to_chain(self):
+        _record_submitted_nonce("0xabc", 42)
+        userop._reset_sender_nonce("0xABC")
+        assert _resolve_submission_nonce("0xabc", 5) == 5
+
+    def test_keys_are_case_insensitive(self):
+        _record_submitted_nonce("0xAbCd", 7)
+        assert _resolve_submission_nonce("0xabcd", 0) == 8
+
+
+class TestAwaitNonceAdvance:
+    @pytest.mark.asyncio
+    async def test_returns_when_nonce_reaches_target(self, monkeypatch):
+        seq = [5, 5, 7]
+
+        async def fake_get_nonce(http, sender, chain_id):
+            return seq.pop(0) if seq else 7
+
+        monkeypatch.setattr(userop, "get_nonce", fake_get_nonce)
+        result = await _await_nonce_advance(
+            None, "0xabc", 100, min_nonce=6, timeout_s=5.0, poll_s=0.01,
+        )
+        assert result == 7
+
+    @pytest.mark.asyncio
+    async def test_times_out_returning_last_seen(self, monkeypatch):
+        async def fake_get_nonce(http, sender, chain_id):
+            return 5  # never advances
+
+        monkeypatch.setattr(userop, "get_nonce", fake_get_nonce)
+        result = await _await_nonce_advance(
+            None, "0xabc", 100, min_nonce=6, timeout_s=0.05, poll_s=0.01,
+        )
+        assert result == 5
+
+    @pytest.mark.asyncio
+    async def test_survives_rpc_errors(self, monkeypatch):
+        calls = {"n": 0}
+
+        async def flaky_get_nonce(http, sender, chain_id):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise RuntimeError("rpc hiccup")
+            return 6
+
+        monkeypatch.setattr(userop, "get_nonce", flaky_get_nonce)
+        result = await _await_nonce_advance(
+            None, "0xabc", 100, min_nonce=6, timeout_s=5.0, poll_s=0.01,
+        )
+        assert result == 6


### PR DESCRIPTION
## What (internal #423, rc12 QA F3)

Implements the diagnosis posted on internal#423 (approved mode: independent agent review instead of manual Pedro review).

**Root cause:** the client never waits for UserOp inclusion and the EntryPoint nonce only advances at execution — sequential import batches re-fetched the same nonce, collided (AA25), and the blind ~7s retry window lost against ~5s Gnosis blocks. rc12 QA: 44 facts chunked 15+15+14 → exactly 15 stored (first batch only).

**Fix:**
- Per-sender local nonce cache (under the existing submission mutex): submit with `max(chain_nonce, cached_next)` — sequential batches pipeline 5,6,7 instead of racing 5,5,5. Self-healing via max() with chain truth.
- AA25 retry drops the cache and polls for actual nonce advance (bounded 6s/15s) instead of sleeping blind; AA10 keeps exponential backoff.
- Nonce recorded only on bundler-accepted sends; both submit paths.

**Scope discipline (4337 rail):** nonce selection + retry pacing only — zero changes to key material, signing, factory/initCode, or paymaster request shapes.

10 new tests incl. the exact QA scenario (chain stuck at 5 → 5,6,7); suite **1828 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sks1gbonedAkEsawd4LVE
