### PR TITLE
chore(python): bump base version 2.4.5 → 2.4.6

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,7 +24,7 @@ name = "totalreclaw"
 # now `2.4.5`, so RCs cut as `2.4.5rcN` outrank `2.4.4` and the
 # version-agnostic install path lands them. NEVER leave the base equal to
 # an already-published stable.
-version = "2.4.5"
+version = "2.4.6"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Bumps the Python client base version `2.4.5 → 2.4.6` so the next RC (`2.4.6rc2`) sorts **above** both the 2.4.5 stable on PyPI and the stray `2.4.6rc1` (from an un-merged bump branch). The publish workflow derives the RC as `<pyproject-base>rc<N>`, so the base must be 2.4.6.

`2.4.6rc2` will bundle everything on main — the 2.4.5rcN accumulation + per-conversation session isolation (#441) + idle Crystal sweep (#443), validated live on the reference bot (clean per-topic facts all day + a real per-topic Crystal minted via the idle sweep).

Version bump only; no code change. RC cut follows once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)