### PR TITLE
fix(rc14): import fix wave — #435 deploy-state+receipt, #436 re-import registry, #437 provider label, F5/F6

### DIFF
--- a/python/src/totalreclaw/claims_helper.py
+++ b/python/src/totalreclaw/claims_helper.py
@@ -473,20 +473,30 @@ def read_blob_unified(decrypted: str) -> Dict[str, Any]:
             importance = max(1, min(10, _js_round(float(imp_raw))))
         else:
             importance = 5
+        # F5 (internal#437 follow-up): the write side stores import provenance
+        # (``import_source``, ``session_id``, Crystal fields) in the blob's own
+        # ``metadata`` dict via ``build_canonical_claim_v1(extra_metadata=…)``.
+        # Merge it in FIRST, then let the typed/rebuilt fields win on any key
+        # collision — otherwise recall/export drop import_source + session_id.
+        merged_meta: Dict[str, Any] = {}
+        blob_meta = obj.get("metadata")
+        if isinstance(blob_meta, dict):
+            merged_meta.update(blob_meta)
+        merged_meta.update({
+            "type": obj["type"],
+            "source": obj.get("source", "user-inferred") if isinstance(obj.get("source"), str) else "user-inferred",
+            "scope": obj.get("scope", "unspecified") if isinstance(obj.get("scope"), str) else "unspecified",
+            "volatility": obj.get("volatility", "updatable") if isinstance(obj.get("volatility"), str) else "updatable",
+            "reasoning": obj.get("reasoning") if isinstance(obj.get("reasoning"), str) else None,
+            "importance": importance / 10,
+            "created_at": obj.get("created_at", "") if isinstance(obj.get("created_at"), str) else "",
+            "schema_version": schema_version,
+        })
         return {
             "text": obj["text"],
             "importance": importance,
             "category": map_type_to_category(obj["type"]),
-            "metadata": {
-                "type": obj["type"],
-                "source": obj.get("source", "user-inferred") if isinstance(obj.get("source"), str) else "user-inferred",
-                "scope": obj.get("scope", "unspecified") if isinstance(obj.get("scope"), str) else "unspecified",
-                "volatility": obj.get("volatility", "updatable") if isinstance(obj.get("volatility"), str) else "updatable",
-                "reasoning": obj.get("reasoning") if isinstance(obj.get("reasoning"), str) else None,
-                "importance": importance / 10,
-                "created_at": obj.get("created_at", "") if isinstance(obj.get("created_at"), str) else "",
-                "schema_version": schema_version,
-            },
+            "metadata": merged_meta,
         }
 
     # 2. v0 canonical Claim format: compact short keys {t, c, ...}

--- a/python/src/totalreclaw/hermes/schemas.py
+++ b/python/src/totalreclaw/hermes/schemas.py
@@ -306,7 +306,12 @@ IMPORT_FROM = {
         "without dry_run to process everything. "
         "(4) If >50 chunks: tell the user this is a large import and you'll process "
         "it in batches. Then use totalreclaw_import_batch repeatedly with increasing "
-        "offset, reporting progress after each batch."
+        "offset, reporting progress after each batch. "
+        "NOTE: a large import runs in the BACKGROUND and needs a long-lived Hermes "
+        "process (the gateway/daemon) to finish — a one-shot `hermes chat -q` "
+        "invocation exits before the background task completes, so nothing is "
+        "stored. If the user is running one-shot, either keep the session open or "
+        "drive the import synchronously via totalreclaw_import_batch."
     ),
     "parameters": {
         "type": "object",

--- a/python/src/totalreclaw/hermes/tools.py
+++ b/python/src/totalreclaw/hermes/tools.py
@@ -1029,22 +1029,48 @@ def _disclosure_required_response(source: str, import_id: str, estimate: Optiona
     return json.dumps(payload)
 
 
+def _provider_name_from_base_url(base_url: str) -> str:
+    """Map an LLM endpoint host to a human-readable provider name.
+
+    ``LLMConfig`` carries no ``provider`` field (only base_url/model/…), so
+    the disclosure name is derived from the endpoint host. Unknown hosts
+    fall back to the bare hostname so the disclosure still names *something*
+    concrete rather than a generic placeholder.
+    """
+    if not base_url:
+        return "your configured LLM provider"
+    lower = base_url.lower()
+    if "z.ai" in lower or "bigmodel" in lower:
+        return "z.ai (GLM)"
+    if "openai.com" in lower:
+        return "OpenAI"
+    if "anthropic.com" in lower:
+        return "Anthropic"
+    if "groq" in lower:
+        return "Groq"
+    from urllib.parse import urlparse
+    host = urlparse(base_url).hostname or ""
+    return host or "your configured LLM provider"
+
+
 def _extraction_provider_label() -> str:
     """Human-readable name of the LLM that will read conversation text.
 
-    The privacy disclosure must name the provider explicitly (PRD-IMP G-4);
-    this resolves the same config chain ``_make_extractor`` uses.
+    The privacy disclosure must name the provider explicitly (PRD-IMP G-4;
+    internal#437). ``LLMConfig`` has no ``provider`` field, so we derive the
+    provider name from ``base_url`` and pair it with the model. Resolves the
+    same config chain ``_make_extractor`` uses.
     """
     try:
         from totalreclaw.agent.llm_client import read_hermes_llm_config, detect_llm_config
         config = read_hermes_llm_config() or detect_llm_config()
         if config:
-            provider = getattr(config, "provider", None)
-            model = getattr(config, "model", None)
-            if provider and model:
-                return f"{provider} ({model})"
-            if provider:
-                return str(provider)
+            base_url = getattr(config, "base_url", "") or ""
+            model = getattr(config, "model", "") or ""
+            provider_name = _provider_name_from_base_url(base_url)
+            if model:
+                return f"{provider_name} — model {model}"
+            return provider_name
     except Exception:
         pass
     return "your configured LLM provider"
@@ -1407,7 +1433,10 @@ async def import_from(args: dict, state: "PluginState", **kwargs) -> str:
                 "estimated_completion_iso": eta_iso,
                 "message": (
                     f"Import started in background. ~{estimated_minutes} min for {total_items} chunks. "
-                    "Ask \"how's the import?\" to check progress with totalreclaw_import_status."
+                    "Ask \"how's the import?\" to check progress with totalreclaw_import_status. "
+                    "NOTE: this runs in a background task that needs a long-lived Hermes process "
+                    "(the gateway/daemon) to finish — a one-shot `hermes chat -q` invocation exits "
+                    "before it completes, so keep the session running until the import reports done."
                 ),
             })
 

--- a/python/src/totalreclaw/import_adapters/types.py
+++ b/python/src/totalreclaw/import_adapters/types.py
@@ -79,6 +79,11 @@ class BatchImportResult:
     # ``smart_import`` payload shape (extract_count / skip_count /
     # profile_duration_ms).
     chunks_skipped: int = 0
+    # #436 — conversations dropped BEFORE extraction because they are already
+    # in the per-source imported-conversation registry (re-import guard). Each
+    # distinct dropped conversation is counted once. 0 for fresh imports and
+    # for Gemini (which carries no conversation_id).
+    conversations_skipped: int = 0
     smart_import: Optional[dict] = None
     # Per-chunk "0 facts" diagnostics (issue #389 follow-up): one
     # ``{index, title, reason}`` dict per chunk that produced 0 storable facts

--- a/python/src/totalreclaw/import_engine.py
+++ b/python/src/totalreclaw/import_engine.py
@@ -263,6 +263,11 @@ class ImportEngine:
         self._session_facts_accum: dict[str, list[dict]] = {}
         #: session_ids whose Crystal has already been emitted (emit-once guard):
         self._crystallized_session_ids: set[str] = set()
+        #: #436 — conversation_ids this engine run has already recorded into
+        #: the per-source imported-conversation registry. Prevents re-writing
+        #: the registry for a conversation on every subsequent batch once it
+        #: has been marked complete.
+        self._recorded_conversations: set[str] = set()
 
     # ── Estimate ─────────────────────────────────────────────────────────
 
@@ -545,10 +550,30 @@ class ImportEngine:
         #      preserves input order regardless of completion order), so the
         #      #376 diagnostics, session/Crystal tagging, and per-chunk error
         #      reporting behave exactly as the sequential version did.
+        # #436 — re-import guard. Drop chunks whose conversation is already in
+        # the per-source imported-conversation registry BEFORE extraction, so
+        # a re-import never re-calls the LLM or re-writes the same facts. Each
+        # distinct dropped conversation is counted once into
+        # ``conversations_skipped``. Gemini (no conversation_id) is unaffected.
+        from .import_state import (
+            load_imported_conversations,
+            record_imported_conversations,
+        )
+        imported_convs = load_imported_conversations(source) if source else set()
+        skipped_conv_ids: set[str] = set()
+
         enriched = smart_ctx.enriched_system_prompt if smart_ctx else None
         to_extract: list[tuple[int, ConversationChunk]] = []
         for i, chunk in enumerate(batch):
             global_index = offset + i
+            conv_id = getattr(chunk, "conversation_id", None)
+            if conv_id and conv_id in imported_convs:
+                logger.info(
+                    "import: skipping already-imported conversation %s "
+                    "(chunk %d/%d)", conv_id, global_index + 1, total_chunks,
+                )
+                skipped_conv_ids.add(conv_id)
+                continue
             if smart_ctx is not None:
                 skipped, reason = is_chunk_skipped(global_index, smart_ctx.decisions)
                 if skipped:
@@ -559,6 +584,8 @@ class ImportEngine:
                     chunks_skipped += 1
                     continue
             to_extract.append((global_index, chunk))
+
+        conversations_skipped = len(skipped_conv_ids)
 
         concurrency = _import_concurrency()
         sem: Optional[asyncio.Semaphore] = asyncio.Semaphore(concurrency) if concurrency > 1 else None
@@ -640,6 +667,29 @@ class ImportEngine:
         # a skipped chunk would never be considered complete and would never get
         # a Crystal. This set persists across batches on the instance.
         self._processed_chunk_indices.update(range(offset, offset + chunks_processed))
+
+        # #436 — record conversations whose EVERY chunk has now been processed
+        # (across all batches so far) into the imported-conversation registry.
+        # A conversation straddling a batch boundary is only recorded once its
+        # final chunk lands, so a partial first import never marks an
+        # incompletely-processed conversation as done. Already-registered
+        # conversations (imported_convs) and ones recorded earlier this run
+        # are skipped.
+        if source:
+            conv_to_indices: dict[str, list[int]] = {}
+            for idx, c in enumerate(parsed.chunks):
+                cid = getattr(c, "conversation_id", None)
+                if cid:
+                    conv_to_indices.setdefault(cid, []).append(idx)
+            newly_complete = [
+                cid for cid, indices in conv_to_indices.items()
+                if cid not in self._recorded_conversations
+                and cid not in imported_convs
+                and all(ix in self._processed_chunk_indices for ix in indices)
+            ]
+            if newly_complete:
+                record_imported_conversations(source, newly_complete)
+                self._recorded_conversations.update(newly_complete)
 
         # ── Crystal emission (cross-batch complete) ───────────────────────────
         # Emit ONE Crystal per multi-turn session, exactly once, on whichever
@@ -733,6 +783,7 @@ class ImportEngine:
             duration_ms=_now_ms() - start_ms,
             dups_skipped=dups_skipped,
             chunks_skipped=chunks_skipped,
+            conversations_skipped=conversations_skipped,
             smart_import=smart_import_summary,
             chunk_diagnostics=chunk_diagnostics or None,
         )

--- a/python/src/totalreclaw/import_engine.py
+++ b/python/src/totalreclaw/import_engine.py
@@ -268,6 +268,12 @@ class ImportEngine:
         #: the registry for a conversation on every subsequent batch once it
         #: has been marked complete.
         self._recorded_conversations: set[str] = set()
+        #: #436 review — global chunk indices whose LLM extraction FAILED
+        #: (raised) this run. A conversation touching any of these is excluded
+        #: from the imported-conversation registry so a transient extraction
+        #: failure doesn't mark it imported and block the natural re-import
+        #: recovery. Persists across batches on the instance.
+        self._failed_chunk_indices: set[int] = set()
 
     # ── Estimate ─────────────────────────────────────────────────────────
 
@@ -615,11 +621,20 @@ class ImportEngine:
         # skipped remaining chunks' LLM calls. Under concurrency all calls have
         # already fired by this point, so the cap now only stops *accumulating*
         # later chunks' results (same stored-facts outcome at the cap).
-        for (global_index, chunk), res in zip(to_extract, raw_results):
+        for pos, ((global_index, chunk), res) in enumerate(zip(to_extract, raw_results)):
             if isinstance(res, BaseException):
                 extraction_failures += 1
+                # #436 review: mark this chunk failed so its conversation is
+                # NOT recorded as imported (a transient failure must stay
+                # re-importable).
+                self._failed_chunk_indices.add(global_index)
                 errors.append(f"Extraction failed for chunk '{chunk.title}': {repr(res)}")
                 if len(errors) >= 20:
+                    # Bailing early leaves the rest of this batch's extractions
+                    # unverified — treat them as failed too so their
+                    # conversations aren't recorded on incomplete evidence.
+                    for gi, _ in to_extract[pos + 1:]:
+                        self._failed_chunk_indices.add(gi)
                     break
                 continue
 
@@ -686,6 +701,9 @@ class ImportEngine:
                 if cid not in self._recorded_conversations
                 and cid not in imported_convs
                 and all(ix in self._processed_chunk_indices for ix in indices)
+                # #436 review: never record a conversation any of whose chunks
+                # failed extraction — keep it re-importable.
+                and not any(ix in self._failed_chunk_indices for ix in indices)
             ]
             if newly_complete:
                 record_imported_conversations(source, newly_complete)

--- a/python/src/totalreclaw/import_state.py
+++ b/python/src/totalreclaw/import_state.py
@@ -193,3 +193,57 @@ def any_import_exists() -> bool:
         return any(IMPORT_STATE_DIR.glob("*.json"))
     except OSError:
         return False
+
+
+# ── F2 (#436): per-source imported-conversation registry ──────────────────
+#
+# Re-imports RE-EXTRACT via the LLM, and paraphrase gives every fact a fresh
+# text fingerprint — so text-fingerprint dedup can never catch a re-import.
+# The durable fix records which SOURCE conversations have already been
+# imported (by ``conversation_id``) and drops their chunks before extraction
+# on any later run. Persisted per source so ChatGPT / Claude registries don't
+# collide. Gemini exports carry no conversation_id and are unaffected.
+
+
+def _imported_conversations_path(source: str):
+    # Reference IMPORT_STATE_DIR late (module global) so tests that
+    # monkeypatch it take effect — same pattern as the state helpers.
+    return IMPORT_STATE_DIR / f"imported-conversations-{source}.json"
+
+
+def load_imported_conversations(source: str) -> set:
+    """Return the set of ``conversation_id``s already imported for *source*.
+
+    Tolerates a missing or corrupt registry file (returns an empty set) so a
+    damaged registry degrades to "nothing imported yet" rather than raising.
+    """
+    try:
+        raw = _imported_conversations_path(source).read_text(encoding="utf-8")
+        data = json.loads(raw)
+        if isinstance(data, list):
+            return {str(x) for x in data}
+    except Exception:
+        pass
+    return set()
+
+
+def record_imported_conversations(source: str, ids) -> None:
+    """Add ``ids`` to the imported-conversation registry for *source*.
+
+    Idempotent: merges with the existing registry and de-duplicates. Writes
+    the union back as a JSON list. Best-effort — an IO error is swallowed
+    (a missed record means at worst a future re-import re-processes that
+    conversation, never data loss).
+    """
+    new_ids = {str(x) for x in (ids or [])}
+    if not new_ids:
+        return
+    try:
+        IMPORT_STATE_DIR.mkdir(parents=True, exist_ok=True)
+        existing = load_imported_conversations(source)
+        merged = sorted(existing | new_ids)
+        _imported_conversations_path(source).write_text(
+            json.dumps(merged), encoding="utf-8"
+        )
+    except OSError:
+        pass

--- a/python/src/totalreclaw/userop.py
+++ b/python/src/totalreclaw/userop.py
@@ -134,6 +134,169 @@ def _reset_nonce_cache_for_tests() -> None:
     _sender_next_nonce.clear()
 
 
+# ---------------------------------------------------------------------------
+# Deployed-account cache — F3 / internal #435
+# ---------------------------------------------------------------------------
+#
+# A Smart Account deploys exactly once (its first UserOp carries the factory /
+# initCode; every op after that must NOT). The old code re-derived "is
+# deployed" every submission from ``eth_getCode`` — but ``_eth_get_code``
+# silently read any RPC error as ``"0x"`` (= not deployed). Under import bursts
+# the public Gnosis RPC rate-limits, so a deployed account read as undeployed,
+# the factory was re-attached, and the paymaster reverted the whole batch with
+# ``-32500 "Sender does not implement validateUserOp or factory is not
+# deployed"`` — dropping every fact in it (rc13 QA: 52/78 lost).
+#
+# Fix: a monotonic per-sender "deployed" latch. Once we have ANY proof the
+# account executed on-chain (code present, chain_nonce > 0, a confirmed send,
+# or a sponsor-stage sender-state error), we never attach the factory again.
+# Keys are lowercased addresses; reads/writes happen under the per-sender
+# submission lock. Mirrors the OpenClaw plugin's PR #407 deploy-state cache.
+_sender_deployed: set[str] = set()
+
+
+def _mark_sender_deployed(sender: str) -> None:
+    """Latch a sender as deployed (monotonic — never cleared in-process)."""
+    _sender_deployed.add(sender.lower())
+
+
+def _is_sender_deployed_cached(sender: str) -> bool:
+    return sender.lower() in _sender_deployed
+
+
+def _reset_deployed_cache_for_tests() -> None:
+    """Clear the deployed cache. Test-only helper."""
+    _sender_deployed.clear()
+
+
+def _is_sender_state_error(err_str: str) -> bool:
+    """True when a sponsor/bundler error indicates the account is ALREADY
+    deployed (so re-attaching the factory is the actual fault).
+
+    Covers the paymaster ``-32500`` revert (\"Sender does not implement
+    validateUserOp or factory is not deployed\"), the EntryPoint ``AA10
+    sender already constructed`` code, and the raw \"already constructed\"
+    phrasing. Checked only AFTER an ``AA25`` nonce-conflict has been ruled
+    out (an AA25 revert is also surfaced with code ``-32500``)."""
+    if not err_str:
+        return False
+    return (
+        "already constructed" in err_str          # AA10 / raw phrasing
+        or "AA10" in err_str
+        or "validateUserOp or factory" in err_str  # paymaster -32500 revert
+        or "-32500" in err_str
+    )
+
+
+async def _resolve_is_deployed(
+    http: httpx.AsyncClient, rpc_url: str, sender: str, chain_nonce: int
+) -> bool:
+    """Decide whether ``sender`` is already deployed for THIS submission.
+
+    Resolution order (cheapest, most-authoritative first):
+      1. Deployed cache — once True, always True.
+      2. ``chain_nonce > 0`` — the account has executed ops ⇒ deployed.
+         Skips ``eth_getCode`` entirely (the burst-rate-limited call that
+         caused #435).
+      3. ``eth_getCode`` — non-empty bytecode ⇒ deployed. A hardened
+         ``_eth_get_code`` raises (rather than reading "0x") on an RPC
+         error, so a transient failure propagates into the retry loop
+         instead of being silently misread as undeployed.
+    """
+    key = sender.lower()
+    if key in _sender_deployed:
+        return True
+    if chain_nonce > 0:
+        _sender_deployed.add(key)
+        return True
+    code = await _eth_get_code(http, rpc_url, sender)
+    if code != "0x" and len(code) > 2:
+        _sender_deployed.add(key)
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Batch receipt confirmation — F3 / internal #431
+# ---------------------------------------------------------------------------
+#
+# ``eth_sendUserOperation`` returns as soon as the bundler ACCEPTS the op into
+# its mempool — not when it mines. rc13 QA saw ``facts_stored=26`` while only
+# ~11 landed on-chain, because the batch path returned the hash at accept time
+# and a later on-chain revert (e.g. the #435 factory bug) silently dropped the
+# facts. For the BATCH path only, we now poll ``eth_getUserOperationReceipt``
+# and return the hash ONLY once a receipt reports success — so "stored" means
+# on-chain. The single-fact path keeps accept-time return (auto-extraction
+# latency matters more there and a single dropped fact re-extracts next turn).
+_BATCH_RECEIPT_TIMEOUT_S: float = 60.0
+_BATCH_RECEIPT_POLL_S: float = 3.0
+
+
+def _receipt_success(result: dict) -> Optional[bool]:
+    """Interpret a UserOperation receipt's ``success`` field.
+
+    Returns True/False when the receipt states success, or None when the
+    receipt is absent / doesn't carry a decidable success flag (keep
+    polling). Tolerates both boolean and string ("true"/"false") shapes.
+    """
+    if not isinstance(result, dict):
+        return None
+    success = result.get("success")
+    if isinstance(success, bool):
+        return success
+    if isinstance(success, str):
+        low = success.strip().lower()
+        if low == "true":
+            return True
+        if low == "false":
+            return False
+    return None
+
+
+async def _await_batch_receipt(
+    http: httpx.AsyncClient,
+    relay_url: str,
+    headers: dict,
+    user_op_hash: str,
+    timeout_s: Optional[float] = None,
+    poll_s: Optional[float] = None,
+) -> None:
+    """Poll ``eth_getUserOperationReceipt`` until success, or raise.
+
+    Raises :class:`RuntimeError` on an explicit ``success=false`` receipt or
+    on timeout — the import engine treats either as a FAILED batch (not
+    stored) so ``facts_stored`` reflects on-chain reality.
+    """
+    import time as _time
+    timeout = _BATCH_RECEIPT_TIMEOUT_S if timeout_s is None else timeout_s
+    poll = _BATCH_RECEIPT_POLL_S if poll_s is None else poll_s
+    deadline = _time.monotonic() + timeout
+    while True:
+        try:
+            resp = await _relay_rpc(
+                http, relay_url, headers,
+                "eth_getUserOperationReceipt", [user_op_hash], rpc_id=4,
+            )
+        except Exception as e:
+            logger.debug("receipt poll for %s failed (%s); retrying", user_op_hash, e)
+            resp = {}
+        result = resp.get("result") if isinstance(resp, dict) else None
+        verdict = _receipt_success(result)
+        if verdict is True:
+            return
+        if verdict is False:
+            raise RuntimeError(
+                f"Batch UserOp {user_op_hash} reverted on-chain "
+                f"(receipt.success=false)"
+            )
+        if _time.monotonic() >= deadline:
+            raise RuntimeError(
+                f"Batch UserOp {user_op_hash} not confirmed within "
+                f"{timeout:.0f}s (no successful receipt)"
+            )
+        await asyncio.sleep(poll)
+
+
 async def _await_nonce_advance(
     http,
     sender: str,
@@ -334,16 +497,37 @@ async def _eth_call(
 async def _eth_get_code(
     http: httpx.AsyncClient, rpc_url: str, address: str
 ) -> str:
-    resp = await http.post(
-        rpc_url,
-        json={
-            "jsonrpc": "2.0",
-            "method": "eth_getCode",
-            "params": [address, "latest"],
-            "id": 1,
-        },
+    """Return the deployed bytecode at ``address`` (``"0x"`` when none).
+
+    Hardened for #435: an RPC error (or a body with no ``result``) is NOT
+    read as ``"0x"`` — that silent misread let a rate-limited public RPC
+    report a deployed account as undeployed, re-attaching the factory and
+    reverting the whole batch. We retry once, then raise. The caller only
+    reaches this when the deployed cache is cold AND chain_nonce == 0, so a
+    genuine RPC outage propagating into the retry loop is the safe outcome.
+    """
+    last_err: Optional[str] = None
+    for attempt in range(2):
+        resp = await http.post(
+            rpc_url,
+            json={
+                "jsonrpc": "2.0",
+                "method": "eth_getCode",
+                "params": [address, "latest"],
+                "id": 1,
+            },
+        )
+        body = resp.json()
+        if isinstance(body, dict) and "error" not in body and body.get("result") is not None:
+            return body["result"]
+        last_err = str(body.get("error") if isinstance(body, dict) else body)
+        logger.debug(
+            "eth_getCode for %s returned no usable result (attempt %d/2): %s",
+            address, attempt + 1, last_err,
+        )
+    raise RuntimeError(
+        f"eth_getCode failed for {address} after 2 attempts: {last_err}"
     )
-    return resp.json().get("result", "0x")
 
 
 async def get_nonce(
@@ -513,9 +697,14 @@ async def build_and_send_userop(
                 nonce = _resolve_submission_nonce(sender, chain_nonce)
                 logger.debug("Nonce for %s: chain=%d using=%d", sender, chain_nonce, nonce)
 
-                # 3. Check if account is already deployed
-                code = await _eth_get_code(http, rpc_url, sender)
-                is_deployed = code != "0x" and len(code) > 2
+                # 3. Deployed check (#435): the deployed cache and
+                #    chain_nonce > 0 short-circuit eth_getCode; a getCode RPC
+                #    error now raises instead of silently reading as
+                #    undeployed (which re-attached the factory and reverted
+                #    the batch).
+                is_deployed = await _resolve_is_deployed(
+                    http, rpc_url, sender, chain_nonce
+                )
 
                 # 4. Build partial UserOp with stub signature for gas estimation.
                 #    This specific dummy signature passes ecrecover without
@@ -624,28 +813,37 @@ async def build_and_send_userop(
                     )
 
                 _record_submitted_nonce(sender, nonce)
+                _mark_sender_deployed(sender)  # #435: a confirmed send ⇒ deployed
                 return send_data.get("result", "")
 
             except Exception as e:
                 err_str = str(e)
-                if ("AA25" in err_str or "AA10" in err_str) and attempt < _MAX_NONCE_RETRIES - 1:
+                retryable = attempt < _MAX_NONCE_RETRIES - 1
+                if "AA25" in err_str and retryable:
+                    # #423: nonce conflict — drop the pipelined nonce and wait
+                    # for the conflicting op to mine (observable as a nonce
+                    # advance) instead of sleeping blind against ~5s blocks.
                     logger.warning(
-                        "AA25/AA10 nonce or sender conflict (attempt %d/%d), retrying...",
-                        attempt + 1,
-                        _MAX_NONCE_RETRIES,
+                        "AA25 nonce conflict (attempt %d/%d), retrying...",
+                        attempt + 1, _MAX_NONCE_RETRIES,
                     )
-                    if "AA25" in err_str:
-                        # #423: drop the pipelined nonce and wait for the
-                        # conflicting op to actually mine (observable as a
-                        # nonce advance) instead of sleeping blind against
-                        # ~5s blocks.
-                        _reset_sender_nonce(sender)
-                        await _await_nonce_advance(
-                            http, sender, chain_id, min_nonce=nonce + 1,
-                            timeout_s=15.0 if attempt else 6.0,
-                        )
-                    else:
-                        await asyncio.sleep(2 ** attempt)
+                    _reset_sender_nonce(sender)
+                    await _await_nonce_advance(
+                        http, sender, chain_id, min_nonce=nonce + 1,
+                        timeout_s=15.0 if attempt else 6.0,
+                    )
+                    continue
+                if _is_sender_state_error(err_str) and retryable:
+                    # #435: the account is already deployed — re-attaching the
+                    # factory is the fault. Latch deployed and retry WITHOUT
+                    # the factory (next iteration reads the cache). No
+                    # nonce-advance wait — this is not a nonce conflict.
+                    logger.warning(
+                        "sender-state/redeploy error (attempt %d/%d) — marking "
+                        "deployed and retrying without factory: %s",
+                        attempt + 1, _MAX_NONCE_RETRIES, err_str[:200],
+                    )
+                    _mark_sender_deployed(sender)
                     continue
                 raise
 
@@ -783,9 +981,14 @@ async def build_and_send_userop_batch(
                     sender, chain_nonce, nonce, len(protobuf_payloads),
                 )
 
-                # 3. Check if account is already deployed
-                code = await _eth_get_code(http, rpc_url, sender)
-                is_deployed = code != "0x" and len(code) > 2
+                # 3. Deployed check (#435): the deployed cache and
+                #    chain_nonce > 0 short-circuit eth_getCode; a getCode RPC
+                #    error now raises instead of silently reading as
+                #    undeployed (which re-attached the factory and reverted
+                #    the batch).
+                is_deployed = await _resolve_is_deployed(
+                    http, rpc_url, sender, chain_nonce
+                )
 
                 # 4. Build partial UserOp with stub signature for gas estimation.
                 _STUB_SIGNATURE = (
@@ -894,31 +1097,46 @@ async def build_and_send_userop_batch(
                         f"Batch UserOp submission failed: {send_data['error']}"
                     )
 
+                # Record the accept-time nonce/deploy state, then CONFIRM the
+                # op mined before returning (#431). The nonce advance is
+                # recorded at accept time so a concurrent submission pipelines
+                # correctly; the receipt gate ensures ``facts_stored`` only
+                # counts on-chain-confirmed batches.
                 _record_submitted_nonce(sender, nonce)
-                return send_data.get("result", "")
+                _mark_sender_deployed(sender)  # #435: a confirmed send ⇒ deployed
+                batch_hash = send_data.get("result", "")
+                await _await_batch_receipt(http, relay_url, headers, batch_hash)
+                return batch_hash
 
             except Exception as e:
                 err_str = str(e)
-                if ("AA25" in err_str or "AA10" in err_str) and attempt < _MAX_NONCE_RETRIES - 1:
+                retryable = attempt < _MAX_NONCE_RETRIES - 1
+                if "AA25" in err_str and retryable:
+                    # #423: nonce conflict — drop the pipelined nonce and wait
+                    # for the conflicting op to mine before rebuilding.
                     logger.warning(
-                        "Batch AA25/AA10 nonce or sender conflict "
-                        "(attempt %d/%d, batch size %d), retrying...",
-                        attempt + 1,
-                        _MAX_NONCE_RETRIES,
-                        len(protobuf_payloads),
+                        "Batch AA25 nonce conflict (attempt %d/%d, batch size "
+                        "%d), retrying...",
+                        attempt + 1, _MAX_NONCE_RETRIES, len(protobuf_payloads),
                     )
-                    if "AA25" in err_str:
-                        # #423: drop the pipelined nonce and wait for the
-                        # conflicting op to actually mine (observable as a
-                        # nonce advance) instead of sleeping blind against
-                        # ~5s blocks.
-                        _reset_sender_nonce(sender)
-                        await _await_nonce_advance(
-                            http, sender, chain_id, min_nonce=nonce + 1,
-                            timeout_s=15.0 if attempt else 6.0,
-                        )
-                    else:
-                        await asyncio.sleep(2 ** attempt)
+                    _reset_sender_nonce(sender)
+                    await _await_nonce_advance(
+                        http, sender, chain_id, min_nonce=nonce + 1,
+                        timeout_s=15.0 if attempt else 6.0,
+                    )
+                    continue
+                if _is_sender_state_error(err_str) and retryable:
+                    # #435: account already deployed — latch deployed and
+                    # retry WITHOUT the factory (the sponsor -32500 root
+                    # cause). No nonce-advance wait; this is not a conflict.
+                    logger.warning(
+                        "Batch sender-state/redeploy error (attempt %d/%d, "
+                        "batch size %d) — marking deployed and retrying "
+                        "without factory: %s",
+                        attempt + 1, _MAX_NONCE_RETRIES,
+                        len(protobuf_payloads), err_str[:200],
+                    )
+                    _mark_sender_deployed(sender)
                     continue
                 raise
 

--- a/python/src/totalreclaw/userop.py
+++ b/python/src/totalreclaw/userop.py
@@ -173,19 +173,37 @@ def _is_sender_state_error(err_str: str) -> bool:
     """True when a sponsor/bundler error indicates the account is ALREADY
     deployed (so re-attaching the factory is the actual fault).
 
-    Covers the paymaster ``-32500`` revert (\"Sender does not implement
-    validateUserOp or factory is not deployed\"), the EntryPoint ``AA10
-    sender already constructed`` code, and the raw \"already constructed\"
-    phrasing. Checked only AFTER an ``AA25`` nonce-conflict has been ruled
-    out (an AA25 revert is also surfaced with code ``-32500``)."""
+    Matches ONLY the specific "account already exists" signals:
+      - the paymaster revert \"Sender does not implement validateUserOp or
+        factory is not deployed\" (the #435 root-cause message), and
+      - the EntryPoint ``AA10 sender already constructed`` code / phrasing.
+
+    Deliberately NOT keyed on the bare JSON-RPC code ``-32500``: many
+    UNRELATED failures share it (AA13 initCode-failed, AA21 prefund,
+    AA23 sig, AA31/AA33 paymaster, transient sim errors). Latching those as
+    "deployed" would strip the factory from a FRESH account's first op —
+    whose deploy DEPENDS on the factory — and permanently brick it in-process
+    (the cache is never cleared). AA13 in particular must retry WITH the
+    factory; see the transient-``-32500`` retry branch in the submit loops.
+    Checked only AFTER an ``AA25`` nonce-conflict has been ruled out."""
     if not err_str:
         return False
     return (
         "already constructed" in err_str          # AA10 / raw phrasing
         or "AA10" in err_str
         or "validateUserOp or factory" in err_str  # paymaster -32500 revert
-        or "-32500" in err_str
     )
+
+
+def _is_transient_sim_error(err_str: str) -> bool:
+    """True for a ``-32500`` simulation error that is NOT a redeploy signal.
+
+    A ``-32500`` that :func:`_is_sender_state_error` did not claim (AA13
+    initCode-failed, AA21 prefund, transient sim reverts, …) is treated as
+    transient: rebuild and retry with the deploy state UNCHANGED — the
+    account is NOT latched deployed and a fresh account keeps its factory.
+    Callers must have already ruled out AA25 and the sender-state case."""
+    return bool(err_str) and "-32500" in err_str
 
 
 async def _resolve_is_deployed(
@@ -845,6 +863,19 @@ async def build_and_send_userop(
                     )
                     _mark_sender_deployed(sender)
                     continue
+                if _is_transient_sim_error(err_str) and retryable:
+                    # #435 review: a -32500 that is NOT a redeploy signal
+                    # (AA13 initCode-failed, AA21 prefund, transient sim) —
+                    # do NOT latch deployed or strip the factory. Rebuild and
+                    # retry with the deploy state unchanged (a fresh account
+                    # keeps its factory, which its deploy depends on).
+                    logger.warning(
+                        "transient -32500 sim error (attempt %d/%d) — retrying "
+                        "with unchanged deploy state: %s",
+                        attempt + 1, _MAX_NONCE_RETRIES, err_str[:200],
+                    )
+                    await asyncio.sleep(min(2 ** attempt, 4))
+                    continue
                 raise
 
 
@@ -1137,6 +1168,20 @@ async def build_and_send_userop_batch(
                         len(protobuf_payloads), err_str[:200],
                     )
                     _mark_sender_deployed(sender)
+                    continue
+                if _is_transient_sim_error(err_str) and retryable:
+                    # #435 review: a non-redeploy -32500 (AA13 initCode-failed,
+                    # AA21 prefund, transient sim) — do NOT latch deployed or
+                    # strip the factory. Rebuild and retry with deploy state
+                    # unchanged so a fresh account keeps its (required) factory.
+                    logger.warning(
+                        "Batch transient -32500 sim error (attempt %d/%d, "
+                        "batch size %d) — retrying with unchanged deploy "
+                        "state: %s",
+                        attempt + 1, _MAX_NONCE_RETRIES,
+                        len(protobuf_payloads), err_str[:200],
+                    )
+                    await asyncio.sleep(min(2 ** attempt, 4))
                     continue
                 raise
 

--- a/python/tests/test_blob_metadata_f5.py
+++ b/python/tests/test_blob_metadata_f5.py
@@ -40,8 +40,9 @@ def test_v1_blob_roundtrips_import_metadata():
     assert meta.get("import_source") == "chatgpt"
     assert meta.get("session_id") == "sess-x"
 
-    # ...AND the typed/rebuilt fields are still present.
-    assert meta.get("type") == "fact"
+    # ...AND the typed/rebuilt fields are still present. ("fact" normalizes to
+    # the v1 canonical type "claim" on write.)
+    assert meta.get("type") == "claim"
     assert meta.get("source") == "external"
     assert meta.get("scope") == "personal"
 

--- a/python/tests/test_blob_metadata_f5.py
+++ b/python/tests/test_blob_metadata_f5.py
@@ -1,0 +1,73 @@
+"""F5 read-side — the v1 blob reader dropped the blob's own metadata dict.
+
+``build_canonical_claim_v1(..., extra_metadata={...})`` writes the import
+provenance (``import_source``, ``session_id``, Crystal fields) into the blob's
+``metadata`` object, but ``read_blob_unified``'s v1 branch REBUILT ``metadata``
+from typed fields only, dropping ``import_source`` / ``session_id`` entirely.
+The fix merges the blob's ``metadata`` dict into the returned metadata, with
+the typed/rebuilt fields winning on key collisions.
+"""
+from __future__ import annotations
+
+from totalreclaw.claims_helper import (
+    build_canonical_claim_v1,
+    read_claim_from_blob,
+    read_blob_unified,
+)
+
+
+def _fact(**over):
+    base = {
+        "text": "User relocated to Berlin for a new job",
+        "type": "fact",
+        "source": "external",
+        "scope": "personal",
+    }
+    base.update(over)
+    return base
+
+
+def test_v1_blob_roundtrips_import_metadata():
+    blob = build_canonical_claim_v1(
+        _fact(),
+        importance=8,
+        extra_metadata={"import_source": "chatgpt", "session_id": "sess-x"},
+    )
+    doc = read_claim_from_blob(blob)
+    meta = doc["metadata"]
+
+    # The blob's own metadata survives the read.
+    assert meta.get("import_source") == "chatgpt"
+    assert meta.get("session_id") == "sess-x"
+
+    # ...AND the typed/rebuilt fields are still present.
+    assert meta.get("type") == "fact"
+    assert meta.get("source") == "external"
+    assert meta.get("scope") == "personal"
+
+
+def test_typed_fields_win_on_key_collision():
+    # A blob whose embedded metadata tries to shadow a typed field must not
+    # override the canonical typed value.
+    blob = build_canonical_claim_v1(
+        _fact(source="external"),
+        importance=6,
+        extra_metadata={"source": "user-inferred", "import_source": "gemini"},
+    )
+    meta = read_claim_from_blob(blob)["metadata"]
+    assert meta["source"] == "external"          # typed value wins
+    assert meta["import_source"] == "gemini"     # extra field carried through
+
+
+def test_v0_and_legacy_branches_unaffected():
+    # v0 short-key blob — no embedded metadata dict to merge; must still read.
+    v0 = '{"t":"some text","c":"fact","i":7,"sa":"auto-extraction"}'
+    doc = read_blob_unified(v0)
+    assert doc["text"] == "some text"
+    assert doc["metadata"]["source"] == "auto-extraction"
+
+    # Legacy {text, metadata} doc — metadata already flows through unchanged.
+    legacy = '{"text":"hi","metadata":{"type":"preference","importance":0.9}}'
+    doc = read_blob_unified(legacy)
+    assert doc["text"] == "hi"
+    assert doc["metadata"]["type"] == "preference"

--- a/python/tests/test_chatgpt_adapter_session_fidelity.py
+++ b/python/tests/test_chatgpt_adapter_session_fidelity.py
@@ -269,11 +269,17 @@ def test_engine_groups_sessions_by_conversation_id(monkeypatch):
     assert sorted(map(sorted, sessions)) == sorted(map(sorted, by_conv.values()))
 
 
-def test_end_to_end_sessions_equal_conversations(monkeypatch):
+def test_end_to_end_sessions_equal_conversations(monkeypatch, tmp_path):
     """Full process_batch over two conversations -> two sessions, facts of a
     conversation share one session_id, one Crystal per multi-turn conversation."""
     import totalreclaw.embedding as emb
     monkeypatch.setattr(emb, "get_embedding", lambda t: [0.1, 0.2, 0.3])
+    # #436: process_batch(source="chatgpt") writes the imported-conversation
+    # registry. Redirect it to a tmp dir so this test never persists fixture
+    # conversation_ids to the real ~/.totalreclaw (which would make a re-run
+    # skip every conversation → payloads == []).
+    import totalreclaw.import_state as ist
+    monkeypatch.setattr(ist, "IMPORT_STATE_DIR", tmp_path / "import-state")
 
     async def fake_extract(messages, timestamp):
         # engine contract: messages arrive as [{"role", "content"}]

--- a/python/tests/test_conversation_registry_f436.py
+++ b/python/tests/test_conversation_registry_f436.py
@@ -1,0 +1,173 @@
+"""F2 / internal#436 — re-imports must not re-store the same conversations.
+
+Text-fingerprint dedup can never catch re-imports: a re-import RE-EXTRACTS via
+the LLM and paraphrase yields fresh fingerprints. The fix works at the
+CONVERSATION level — a per-source registry of already-imported
+``conversation_id``s. On a re-import, chunks whose conversation is in the
+registry are dropped BEFORE extraction (the LLM is never called) and counted
+into ``BatchImportResult.conversations_skipped``. A conversation is recorded
+only once ALL of its chunks have been processed (so a conversation straddling
+a batch boundary isn't recorded early).
+
+Gemini (no ``conversation_id``) is unaffected.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+import totalreclaw.import_state as ist
+import totalreclaw.import_engine as ie
+from totalreclaw.import_engine import ImportEngine
+from totalreclaw.import_adapters.types import (
+    AdapterParseResult,
+    ConversationChunk,
+)
+
+
+# ── recording client (Gnosis, records remember_batch payloads) ────────────
+class _BatchClient:
+    def __init__(self):
+        self.batches = []
+        self._n = 0
+
+    async def _ensure_chain_id(self):
+        return 100
+
+    async def remember_batch(self, payloads, source=None):
+        self.batches.append(list(payloads))
+        ids = [f"f{self._n + i}" for i in range(len(payloads))]
+        self._n += len(payloads)
+        return ids
+
+
+def _install_fake_embedding(monkeypatch):
+    import totalreclaw.embedding as emb
+    monkeypatch.setattr(emb, "get_embedding", lambda t: [0.1, 0.2, 0.3])
+
+
+def _chunk(conv_id: str, text: str, ts: str) -> ConversationChunk:
+    return ConversationChunk(
+        title=f"conv {conv_id}",
+        messages=[
+            {"role": "user", "text": text},
+            {"role": "assistant", "text": f"reply about {text}"},
+        ],
+        timestamp=ts,
+        conversation_id=conv_id,
+    )
+
+
+def _install_fake_adapter(monkeypatch, chunks):
+    """Patch get_adapter so parse() returns a fixed chunk list."""
+    class _Adapter:
+        def parse(self, content=None, file_path=None):
+            return AdapterParseResult(
+                facts=[], chunks=list(chunks), total_messages=len(chunks) * 2,
+                warnings=[], errors=[],
+            )
+
+    monkeypatch.setattr(ie, "get_adapter", lambda source: _Adapter())
+
+
+@pytest.fixture(autouse=True)
+def _tmp_state_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(ist, "IMPORT_STATE_DIR", tmp_path / "import-state")
+    yield
+
+
+def _extractor():
+    calls = {"n": 0}
+
+    async def fake_extract(messages, timestamp):
+        calls["n"] += 1
+        return [{"text": "an extracted fact worth keeping", "type": "fact", "importance": 8}]
+
+    return fake_extract, calls
+
+
+# ── registry primitives (import_state) ────────────────────────────────────
+def test_registry_roundtrip():
+    assert ist.load_imported_conversations("chatgpt") == set()
+    ist.record_imported_conversations("chatgpt", ["a", "b"])
+    ist.record_imported_conversations("chatgpt", ["b", "c"])
+    assert ist.load_imported_conversations("chatgpt") == {"a", "b", "c"}
+    # Source-scoped: a different source has its own registry.
+    assert ist.load_imported_conversations("claude") == set()
+
+
+def test_registry_tolerates_corrupt_file(tmp_path, monkeypatch):
+    p = ist.IMPORT_STATE_DIR
+    p.mkdir(parents=True, exist_ok=True)
+    (p / "imported-conversations-chatgpt.json").write_text("{ not json ]")
+    # Corrupt file reads as empty, not an exception.
+    assert ist.load_imported_conversations("chatgpt") == set()
+    # And a subsequent record still works (overwrites the corrupt file).
+    ist.record_imported_conversations("chatgpt", ["x"])
+    assert ist.load_imported_conversations("chatgpt") == {"x"}
+
+
+# ── engine behaviour ──────────────────────────────────────────────────────
+def test_reimport_skips_all_conversations_pre_extraction(monkeypatch):
+    _install_fake_embedding(monkeypatch)
+    chunks = [
+        _chunk("c1", "first topic", "2026-05-14T09:00:00Z"),
+        _chunk("c2", "second topic", "2026-05-14T10:00:00Z"),
+    ]
+    _install_fake_adapter(monkeypatch, chunks)
+
+    # Pre-seed the registry: both conversations already imported.
+    ist.record_imported_conversations("chatgpt", ["c1", "c2"])
+
+    fake_extract, calls = _extractor()
+    client = _BatchClient()
+    engine = ImportEngine(client=client, llm_extract=fake_extract)
+
+    result = asyncio.run(engine.process_batch(source="chatgpt", content="x"))
+
+    assert result.conversations_skipped == 2
+    assert calls["n"] == 0  # extractor never called for skipped conversations
+    assert result.facts_stored == 0
+    assert client.batches == []  # nothing written
+
+
+def test_fresh_import_records_completed_conversations(monkeypatch):
+    _install_fake_embedding(monkeypatch)
+    chunks = [
+        _chunk("c1", "first topic", "2026-05-14T09:00:00Z"),
+        _chunk("c2", "second topic", "2026-05-14T10:00:00Z"),
+    ]
+    _install_fake_adapter(monkeypatch, chunks)
+
+    fake_extract, calls = _extractor()
+    engine = ImportEngine(client=_BatchClient(), llm_extract=fake_extract)
+
+    result = asyncio.run(engine.process_batch(source="chatgpt", content="x"))
+    assert result.conversations_skipped == 0
+    assert calls["n"] == 2
+    # Both conversations fully processed → both recorded.
+    assert ist.load_imported_conversations("chatgpt") == {"c1", "c2"}
+
+
+def test_partial_import_only_records_fully_processed_conversations(monkeypatch):
+    _install_fake_embedding(monkeypatch)
+    # c1 fits in batch 1; c2's two chunks straddle the batch boundary.
+    chunks = [
+        _chunk("c1", "topic one", "2026-05-14T09:00:00Z"),
+        _chunk("c2", "topic two part a", "2026-05-14T10:00:00Z"),
+        _chunk("c2", "topic two part b", "2026-05-14T10:05:00Z"),
+    ]
+    _install_fake_adapter(monkeypatch, chunks)
+
+    fake_extract, _ = _extractor()
+    engine = ImportEngine(client=_BatchClient(), llm_extract=fake_extract)
+
+    # Batch 1: chunks [0, 1] → c1 complete, c2 still has chunk 2 outstanding.
+    asyncio.run(engine.process_batch(source="chatgpt", content="x", offset=0, batch_size=2))
+    assert ist.load_imported_conversations("chatgpt") == {"c1"}
+
+    # Batch 2: chunk [2] → c2 now complete.
+    asyncio.run(engine.process_batch(source="chatgpt", content="x", offset=2, batch_size=2))
+    assert ist.load_imported_conversations("chatgpt") == {"c1", "c2"}

--- a/python/tests/test_conversation_registry_f436.py
+++ b/python/tests/test_conversation_registry_f436.py
@@ -151,6 +151,34 @@ def test_fresh_import_records_completed_conversations(monkeypatch):
     assert ist.load_imported_conversations("chatgpt") == {"c1", "c2"}
 
 
+def test_extraction_failure_does_not_record_conversation(monkeypatch):
+    """Review Finding 2: a conversation whose chunk FAILS extraction must NOT
+    be recorded as imported — otherwise the natural re-import recovery skips
+    it forever. Other (successful) conversations in the same batch are still
+    recorded."""
+    _install_fake_embedding(monkeypatch)
+    chunks = [
+        _chunk("c1", "good topic", "2026-05-14T09:00:00Z"),
+        _chunk("c2", "boom topic", "2026-05-14T10:00:00Z"),
+    ]
+    _install_fake_adapter(monkeypatch, chunks)
+
+    async def flaky_extract(messages, timestamp):
+        # c2's chunk text is "boom topic ..." — raise for it, succeed otherwise.
+        if any("boom" in (m.get("content") or "") for m in messages):
+            raise RuntimeError("transient LLM failure")
+        return [{"text": "an extracted fact worth keeping", "type": "fact", "importance": 8}]
+
+    engine = ImportEngine(client=_BatchClient(), llm_extract=flaky_extract)
+    result = asyncio.run(engine.process_batch(source="chatgpt", content="x"))
+
+    # Batch completed (c1 stored a fact); c2 failed extraction.
+    assert result.facts_stored >= 1
+    recorded = ist.load_imported_conversations("chatgpt")
+    assert "c1" in recorded          # succeeded → recorded
+    assert "c2" not in recorded      # failed → NOT recorded, stays re-importable
+
+
 def test_partial_import_only_records_fully_processed_conversations(monkeypatch):
     _install_fake_embedding(monkeypatch)
     # c1 fits in batch 1; c2's two chunks straddle the batch boundary.

--- a/python/tests/test_deploy_state_f435.py
+++ b/python/tests/test_deploy_state_f435.py
@@ -68,6 +68,18 @@ _SPONSOR_32500 = {
         ),
     }
 }
+# A -32500 that is NOT a redeploy signal (AA13 initCode-failed). Must NOT
+# latch the account deployed / strip the factory — a fresh account's deploy
+# depends on the factory.
+_SPONSOR_AA13 = {
+    "error": {
+        "code": -32500,
+        "message": (
+            "UserOperation reverted during simulation with reason: AA13 "
+            "initCode failed or OOG"
+        ),
+    }
+}
 _RECEIPT_OK = {"result": {"success": True, "receipt": {"transactionHash": "0xabc"}}}
 
 
@@ -218,6 +230,41 @@ async def test_sponsor_32500_marks_deployed_and_retries_without_factory(monkeypa
     assert "factory" in record["sponsor_userops"][0]
     assert "factory" not in record["sponsor_userops"][1]
     assert _SA.lower() in userop._sender_deployed
+
+
+@pytest.mark.asyncio
+async def test_fresh_account_non_redeploy_32500_keeps_factory_not_latched(monkeypatch):
+    """Review Finding 1 (BLOCKER): a non-redeploy -32500 (AA13 initCode-failed)
+    on a FRESH account must NOT latch _sender_deployed or strip the factory —
+    the deploy depends on the factory. Every retry keeps the factory; the
+    account is never bricked in-process."""
+    monkeypatch.setattr(userop, "get_nonce", AsyncMock(return_value=0))  # fresh
+
+    async def _getcode(http, rpc, addr):
+        return "0x"  # genuinely undeployed
+
+    monkeypatch.setattr(userop, "_eth_get_code", _getcode)
+    # Don't actually sleep on the transient-retry backoff.
+    monkeypatch.setattr(userop.asyncio, "sleep", AsyncMock())
+    # Every sponsor attempt returns AA13 → exhausts retries and raises.
+    mock, record = _make_relay_mock([_SPONSOR_AA13, _SPONSOR_AA13, _SPONSOR_AA13])
+    monkeypatch.setattr(userop, "_relay_rpc", mock)
+
+    with pytest.raises(RuntimeError):
+        await userop.build_and_send_userop_batch(
+            sender=_SA, eoa_address=_EOA, eoa_private_key=_KEY,
+            protobuf_payloads=[b"f1", b"f2"], relay_url="https://mock",
+            auth_key_hex="dead", wallet_address=_SA, chain_id=100,
+        )
+
+    # NOT falsely latched deployed — a re-import can still deploy this account.
+    assert _SA.lower() not in userop._sender_deployed
+    # The account retried (>1 sponsor attempt) and EVERY attempt kept the
+    # factory — it was never stripped.
+    assert len(record["sponsor_userops"]) >= 2
+    for uo in record["sponsor_userops"]:
+        assert "factory" in uo
+        assert "factoryData" in uo
 
 
 @pytest.mark.asyncio

--- a/python/tests/test_deploy_state_f435.py
+++ b/python/tests/test_deploy_state_f435.py
@@ -1,0 +1,270 @@
+"""F3 / internal#435 — batch writes must not die at sponsorship with -32500.
+
+Root cause (rc13 QA, 52/78 facts lost): ``_eth_get_code`` silently read any
+RPC error as ``"0x"`` (= not deployed), so the client re-attached the factory /
+initCode to an ALREADY-deployed Smart Account. The paymaster then reverted the
+whole ≤batch UserOp with ``-32500 "Sender does not implement validateUserOp or
+factory is not deployed"`` and every fact in that batch was lost.
+
+Fixes exercised here (all in ``totalreclaw.userop``):
+
+* Deterministic deploy signal: ``chain_nonce > 0`` ⇒ account has executed ops ⇒
+  deployed ⇒ skip ``eth_getCode`` entirely.
+* A module-level ``_sender_deployed`` cache: once deployed, always deployed.
+* Hardened ``_eth_get_code``: an error/absent-result response is NOT read as
+  "undeployed" — it retries once then raises.
+* Sponsor-stage recovery: a ``-32500`` / "already constructed" /
+  "validateUserOp or factory" error marks the sender deployed and retries the
+  build WITHOUT the factory.
+* Receipt confirmation (internal#431) for the BATCH path: the hash is only
+  returned once ``eth_getUserOperationReceipt`` reports ``success=true``; a
+  false receipt or a timeout raises so the import engine counts the batch as
+  FAILED, not stored.
+
+No network: ``get_nonce`` / ``_eth_get_code`` / ``_relay_rpc`` are patched.
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock
+
+from totalreclaw import userop
+
+
+# Deterministic EOA key (same canonical test mnemonic as test_userop_batch).
+def _test_eoa_private_key() -> bytes:
+    from eth_account import Account
+    Account.enable_unaudited_hdwallet_features()
+    acct = Account.from_mnemonic(
+        "abandon abandon abandon abandon abandon abandon abandon abandon "
+        "abandon abandon abandon about",
+        account_path="m/44'/60'/0'/0/0",
+    )
+    return bytes(acct.key)
+
+
+_KEY = _test_eoa_private_key()
+_SA = "0x2c0cf74b2b76110708ca431796367779e3738250"
+_EOA = "0x9858EfFD232B4033E47d90003D41EC34EcaEda94"
+
+
+_VALID_SPONSOR = {
+    "result": {
+        "callGasLimit": "0x186a0",
+        "verificationGasLimit": "0x30d40",
+        "preVerificationGas": "0xc350",
+        "paymaster": "0x0000000000000000000000000000000000000000",
+        "paymasterData": "0x",
+        "paymasterVerificationGasLimit": "0x30d40",
+        "paymasterPostOpGasLimit": "0x30d40",
+    }
+}
+_SPONSOR_32500 = {
+    "error": {
+        "code": -32500,
+        "message": (
+            "UserOperation reverted during simulation with reason: Sender "
+            "does not implement validateUserOp or factory is not deployed"
+        ),
+    }
+}
+_RECEIPT_OK = {"result": {"success": True, "receipt": {"transactionHash": "0xabc"}}}
+
+
+def _make_relay_mock(sponsor_seq, receipt=_RECEIPT_OK):
+    """Return (mock, record) replaying relay JSON-RPC by method.
+
+    ``sponsor_seq`` is a list of sponsor responses consumed one per
+    ``pm_sponsorUserOperation`` call. ``record`` captures every UserOp
+    passed to the sponsor + send stages so tests can assert factory
+    presence.
+    """
+    record = {"sponsor_userops": [], "send_userops": [], "calls": {}}
+
+    async def _mock(http, relay_url, headers, method, params, rpc_id=1):
+        record["calls"][method] = record["calls"].get(method, 0) + 1
+        if method == "pimlico_getUserOperationGasPrice":
+            return {"result": {"fast": {
+                "maxFeePerGas": "0x77359400",
+                "maxPriorityFeePerGas": "0x59682f00",
+            }}}
+        if method == "pm_sponsorUserOperation":
+            record["sponsor_userops"].append(dict(params[0]))
+            i = len(record["sponsor_userops"]) - 1
+            return sponsor_seq[min(i, len(sponsor_seq) - 1)]
+        if method == "eth_sendUserOperation":
+            record["send_userops"].append(dict(params[0]))
+            return {"result": "0xhash"}
+        if method == "eth_getUserOperationReceipt":
+            return receipt
+        raise AssertionError(f"unexpected relay method {method}")
+
+    return _mock, record
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches():
+    userop._reset_deployed_cache_for_tests()
+    userop._reset_nonce_cache_for_tests()
+    userop._reset_sender_locks_for_tests()
+    yield
+    userop._reset_deployed_cache_for_tests()
+    userop._reset_nonce_cache_for_tests()
+    userop._reset_sender_locks_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_nonce_positive_skips_getcode_and_never_attaches_factory(monkeypatch):
+    monkeypatch.setattr(userop, "get_nonce", AsyncMock(return_value=5))
+
+    async def _boom(*a, **k):
+        raise AssertionError("eth_getCode must be skipped when chain_nonce > 0")
+
+    monkeypatch.setattr(userop, "_eth_get_code", _boom)
+    mock, record = _make_relay_mock([_VALID_SPONSOR])
+    monkeypatch.setattr(userop, "_relay_rpc", mock)
+
+    result = await userop.build_and_send_userop_batch(
+        sender=_SA, eoa_address=_EOA, eoa_private_key=_KEY,
+        protobuf_payloads=[b"f1", b"f2"], relay_url="https://mock",
+        auth_key_hex="dead", wallet_address=_SA, chain_id=100,
+    )
+    assert result == "0xhash"
+    sent = record["send_userops"][0]
+    assert "factory" not in sent
+    assert "factoryData" not in sent
+    # deployed cache learned the account is live from nonce>0.
+    assert _SA.lower() in userop._sender_deployed
+
+
+@pytest.mark.asyncio
+async def test_getcode_error_response_is_not_read_as_undeployed():
+    class _Resp:
+        def __init__(self, body):
+            self._body = body
+
+        def json(self):
+            return self._body
+
+    class _Http:
+        def __init__(self, bodies):
+            self._bodies = list(bodies)
+            self.calls = 0
+
+        async def post(self, *a, **k):
+            b = self._bodies[min(self.calls, len(self._bodies) - 1)]
+            self.calls += 1
+            return _Resp(b)
+
+    http = _Http([{"jsonrpc": "2.0", "id": 1,
+                   "error": {"code": -32000, "message": "rate limited"}}])
+    with pytest.raises(Exception):
+        await userop._eth_get_code(http, "https://rpc", _SA)
+    # Must have retried at least once rather than returning "0x" immediately.
+    assert http.calls >= 2
+
+
+@pytest.mark.asyncio
+async def test_deployed_cache_marks_and_persists_across_calls(monkeypatch):
+    monkeypatch.setattr(userop, "get_nonce", AsyncMock(return_value=0))
+    getcode_calls = {"n": 0}
+
+    async def _getcode(http, rpc, addr):
+        getcode_calls["n"] += 1
+        return "0x"  # per getCode the account looks undeployed
+
+    monkeypatch.setattr(userop, "_eth_get_code", _getcode)
+    mock, record = _make_relay_mock([_VALID_SPONSOR])
+    monkeypatch.setattr(userop, "_relay_rpc", mock)
+
+    # First call: undeployed → factory attached → send OK → marks deployed.
+    await userop.build_and_send_userop_batch(
+        sender=_SA, eoa_address=_EOA, eoa_private_key=_KEY,
+        protobuf_payloads=[b"f1"], relay_url="https://mock",
+        auth_key_hex="dead", wallet_address=_SA, chain_id=100,
+    )
+    assert "factory" in record["send_userops"][0]
+    assert _SA.lower() in userop._sender_deployed
+
+    # Second call: cached deployed → no getCode, no factory.
+    await userop.build_and_send_userop_batch(
+        sender=_SA, eoa_address=_EOA, eoa_private_key=_KEY,
+        protobuf_payloads=[b"f2"], relay_url="https://mock",
+        auth_key_hex="dead", wallet_address=_SA, chain_id=100,
+    )
+    assert "factory" not in record["send_userops"][1]
+    assert getcode_calls["n"] == 1  # only the first (uncached) call hit getCode
+
+
+@pytest.mark.asyncio
+async def test_sponsor_32500_marks_deployed_and_retries_without_factory(monkeypatch):
+    monkeypatch.setattr(userop, "get_nonce", AsyncMock(return_value=0))
+
+    async def _getcode(http, rpc, addr):
+        return "0x"  # getCode wrongly reports undeployed (the bug scenario)
+
+    monkeypatch.setattr(userop, "_eth_get_code", _getcode)
+    # gas ok → sponsor -32500 → gas ok → sponsor ok → send ok → receipt ok
+    mock, record = _make_relay_mock([_SPONSOR_32500, _VALID_SPONSOR])
+    monkeypatch.setattr(userop, "_relay_rpc", mock)
+
+    result = await userop.build_and_send_userop_batch(
+        sender=_SA, eoa_address=_EOA, eoa_private_key=_KEY,
+        protobuf_payloads=[b"f1", b"f2", b"f3"], relay_url="https://mock",
+        auth_key_hex="dead", wallet_address=_SA, chain_id=100,
+    )
+    assert result == "0xhash"
+    # First sponsor attempt carried the factory; the retry did NOT.
+    assert "factory" in record["sponsor_userops"][0]
+    assert "factory" not in record["sponsor_userops"][1]
+    assert _SA.lower() in userop._sender_deployed
+
+
+@pytest.mark.asyncio
+async def test_batch_receipt_success_returns(monkeypatch):
+    monkeypatch.setattr(
+        userop, "_relay_rpc",
+        AsyncMock(return_value={"result": {"success": True}}),
+    )
+    # Should not raise.
+    await userop._await_batch_receipt(None, "https://mock", {}, "0xhash")
+
+
+@pytest.mark.asyncio
+async def test_batch_receipt_failure_raises(monkeypatch):
+    monkeypatch.setattr(
+        userop, "_relay_rpc",
+        AsyncMock(return_value={"result": {"success": False}}),
+    )
+    with pytest.raises(RuntimeError):
+        await userop._await_batch_receipt(None, "https://mock", {}, "0xhash")
+
+
+@pytest.mark.asyncio
+async def test_batch_receipt_timeout_raises(monkeypatch):
+    monkeypatch.setattr(userop, "_BATCH_RECEIPT_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(userop, "_BATCH_RECEIPT_POLL_S", 0.01)
+    monkeypatch.setattr(
+        userop, "_relay_rpc",
+        AsyncMock(return_value={"result": None}),  # never confirmed
+    )
+    with pytest.raises(RuntimeError):
+        await userop._await_batch_receipt(None, "https://mock", {}, "0xhash")
+
+
+@pytest.mark.asyncio
+async def test_batch_send_awaits_receipt_before_returning(monkeypatch):
+    """A batch whose receipt never confirms must RAISE, not return the hash —
+    so the import engine counts it FAILED (stored must mean on-chain)."""
+    monkeypatch.setattr(userop, "get_nonce", AsyncMock(return_value=5))
+    monkeypatch.setattr(userop, "_BATCH_RECEIPT_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(userop, "_BATCH_RECEIPT_POLL_S", 0.01)
+    mock, record = _make_relay_mock([_VALID_SPONSOR], receipt={"result": None})
+    monkeypatch.setattr(userop, "_relay_rpc", mock)
+
+    with pytest.raises(RuntimeError):
+        await userop.build_and_send_userop_batch(
+            sender=_SA, eoa_address=_EOA, eoa_private_key=_KEY,
+            protobuf_payloads=[b"f1"], relay_url="https://mock",
+            auth_key_hex="dead", wallet_address=_SA, chain_id=100,
+        )

--- a/python/tests/test_import_background_caveat_f6.py
+++ b/python/tests/test_import_background_caveat_f6.py
@@ -1,0 +1,22 @@
+"""F6 — background import needs a long-lived Hermes process.
+
+A background import spawns an asyncio.Task that outlives the tool call. Under a
+one-shot ``hermes chat -q`` invocation the process exits before the task
+finishes, so nothing is stored. This is a copy-only guard: the background-ack
+message and the IMPORT_FROM schema description must carry the caveat so the
+agent tells the user (same style as the pair tool's long-lived-process note).
+"""
+from __future__ import annotations
+
+from totalreclaw.hermes.schemas import IMPORT_FROM
+
+
+def test_import_from_schema_description_has_long_lived_caveat():
+    desc = IMPORT_FROM["description"].lower()
+    assert "long-lived" in desc or "long lived" in desc
+    assert "one-shot" in desc or "one shot" in desc
+
+
+def test_import_from_schema_mentions_gateway_or_daemon():
+    desc = IMPORT_FROM["description"].lower()
+    assert "gateway" in desc or "daemon" in desc

--- a/python/tests/test_provider_label_f437.py
+++ b/python/tests/test_provider_label_f437.py
@@ -1,0 +1,59 @@
+"""F1 / internal#437 — the privacy disclosure must NAME the provider.
+
+``_extraction_provider_label`` did ``getattr(config, "provider", None)`` but
+``LLMConfig`` has no ``provider`` field (only api_key/base_url/model/api_format),
+so the label always fell through to the generic "your configured LLM provider"
+and the disclosure never told the user which LLM would read their conversations.
+
+The fix derives the provider name from ``config.base_url`` and includes the
+model name. Tests drive REAL ``LLMConfig`` instances through the resolver.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from totalreclaw.agent.llm_client import LLMConfig
+from totalreclaw.hermes import tools
+
+
+def _label_with_config(cfg):
+    with patch("totalreclaw.agent.llm_client.read_hermes_llm_config", return_value=None), \
+         patch("totalreclaw.agent.llm_client.detect_llm_config", return_value=cfg):
+        return tools._extraction_provider_label()
+
+
+def test_zai_label_names_provider_and_model():
+    cfg = LLMConfig(
+        api_key="secret",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        model="glm-4.6",
+        api_format="openai",
+    )
+    label = _label_with_config(cfg)
+    assert "z.ai" in label.lower()
+    assert "glm-4.6" in label
+
+
+def test_openai_label():
+    cfg = LLMConfig(
+        api_key="secret", base_url="https://api.openai.com/v1",
+        model="gpt-4.1-mini", api_format="openai",
+    )
+    label = _label_with_config(cfg)
+    assert "OpenAI" in label
+    assert "gpt-4.1-mini" in label
+
+
+def test_anthropic_label():
+    cfg = LLMConfig(
+        api_key="secret", base_url="https://api.anthropic.com/v1",
+        model="claude-haiku-4-5-20251001", api_format="anthropic",
+    )
+    label = _label_with_config(cfg)
+    assert "Anthropic" in label
+
+
+def test_no_config_falls_back_to_generic():
+    with patch("totalreclaw.agent.llm_client.read_hermes_llm_config", return_value=None), \
+         patch("totalreclaw.agent.llm_client.detect_llm_config", return_value=None):
+        assert tools._extraction_provider_label() == "your configured LLM provider"

--- a/python/tests/test_userop_batch.py
+++ b/python/tests/test_userop_batch.py
@@ -372,6 +372,17 @@ class TestBatchSendRetry:
                         "result": "0xbatchsuccess",
                     }
                 )
+            if method == "eth_getUserOperationReceipt":
+                # #431: the batch path now confirms the op mined before
+                # returning. Report a successful receipt so the retry test
+                # exercises only the AA25 path it targets.
+                return _rpc_response(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": body.get("id", 4),
+                        "result": {"success": True},
+                    }
+                )
             pytest.fail(f"Unexpected RPC method: {method}")
 
         transport = httpx.MockTransport(_dispatch)


### PR DESCRIPTION
## rc14 import fix wave

Addresses the rc13 focused-QA NO-GO (internal umbrella `p-diogo/totalreclaw-internal#420`, findings #435/#436/#437). Root causes were pre-diagnosed; this implements the five fixes TDD (failing-tests commit first, then implementation). **No merge intended — review gate.**

### 1. #435 (BLOCKER) — batch writes died at sponsorship with `-32500`
`python/src/totalreclaw/userop.py`. QA lost 52/78 facts: `_eth_get_code` silently read any RPC error as `"0x"` (= not deployed), so under import-burst rate-limiting the public Gnosis RPC made a **deployed** account look undeployed → factory/initCode re-attached → paymaster reverts the whole ≤batch UserOp with `-32500 "Sender does not implement validateUserOp or factory is not deployed"` → every fact in that batch lost.

- **Hardened `_eth_get_code`**: an `error`/no-`result` response retries once then **raises** instead of reading as `"0x"`.
- **Deterministic deploy signal + monotonic `_sender_deployed` cache**: `chain_nonce > 0` (also: code present / confirmed send / sponsor-stage sender-state error) latches the account deployed and skips `eth_getCode` entirely. Mirrors the OpenClaw plugin PR #407 approach.
- **Sponsor-stage recovery**: an error containing `-32500` / `already constructed` / `validateUserOp or factory` marks the sender deployed and retries **without** the factory (no nonce-advance wait). AA25 is still handled separately as a nonce conflict — checked first so a `-32500`-coded AA25 revert routes correctly.
- **Batch receipt confirmation (#431)**: `build_and_send_userop_batch` now polls `eth_getUserOperationReceipt` (every 3s up to 60s) and returns the hash **only** on `success=true`; a false receipt or timeout raises so the engine counts the batch FAILED (stored must mean on-chain). Single-fact path keeps accept-time return.

### 2. #436 — re-import duplicates
Text-fingerprint dedup can't catch re-imports (re-extraction paraphrases → fresh fingerprints). Fixed at the **conversation** level: a per-source registry (`import_state.load/record_imported_conversations`, persisted as `imported-conversations-<source>.json`). The engine drops chunks whose `conversation_id` is already registered **before** extraction (LLM never called), counts them into the new `BatchImportResult.conversations_skipped`, and records a conversation only once **all** its chunks are processed (cross-batch safe). Gemini (no `conversation_id`) unaffected.

### 3. #437 — disclosure never named the provider
`LLMConfig` has no `provider` field, so `_extraction_provider_label` always fell through to the generic string. Now derives the provider from `base_url` (`z.ai (GLM)` / `OpenAI` / `Anthropic` / `Groq` / bare host) and includes the model.

### 4. F5 read-side — `import_source`/`session_id` dropped by the blob reader
`read_blob_unified`'s v1 branch rebuilt `metadata` from typed fields and dropped the blob's own `metadata` dict. Now merges the blob metadata with typed/rebuilt fields winning on collision — recall/export surface `import_source` + `session_id` again.

### 5. F6 — background import one-shot caveat (copy-only)
The `IMPORT_FROM` schema description and the background-ack message now warn that a background import needs a long-lived Hermes process (gateway/daemon); a one-shot `hermes chat -q` exits before it finishes. No process-detection logic.

## Tests
- New: `test_deploy_state_f435.py`, `test_conversation_registry_f436.py`, `test_provider_label_f437.py`, `test_blob_metadata_f5.py`, `test_import_background_caveat_f6.py`.
- Updated one pre-existing test (`test_userop_batch.py::TestBatchSendRetry::test_aa25_retries_then_succeeds`) to answer the new receipt poll with a success receipt — the AA25 path it targets is otherwise unchanged.
- **Full suite: 1879 passed, 39 skipped, 1 xfailed.**

No key-derivation / mnemonic / signing / pair-crypto code touched (phrase-safety rail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sks1gbonedAkEsawd4LVE