### PR TITLE
fix(plugin): consume relay billing data_edge_address verbatim (#460)

### DIFF
--- a/skill/plugin/billing-cache.test.ts
+++ b/skill/plugin/billing-cache.test.ts
@@ -2,8 +2,9 @@
  * Tests for billing-cache.ts (3.0.7 extraction).
  *
  * Covers round-trip read/write, TTL expiry, corrupt-cache fallback, and
- * missing-file fallback. Also verifies the chain-id sync side-effect on both
- * read and write paths.
+ * missing-file fallback. Also verifies the chain-id sync side-effect (#402)
+ * and the DataEdge-address sync + env → billing → WASM-default resolution
+ * order via getSubgraphConfig (#460), on both read and write paths.
  *
  * Run with: npx tsx billing-cache.test.ts
  *
@@ -25,8 +26,21 @@ process.env.HOME = TEST_HOME;
 // the test location. Node ESM caches by URL; these are the first imports.
 const { readBillingCache, writeBillingCache, BILLING_CACHE_PATH, BILLING_CACHE_TTL } =
   await import('./billing-cache.js');
-const { CONFIG, __resetChainIdOverrideForTests } = await import('./config.js');
+const { CONFIG, __resetChainIdOverrideForTests, __resetDataEdgeAddressOverrideForTests } =
+  await import('./config.js');
+// getSubgraphConfig exercises the full env → billing → WASM-default DataEdge
+// resolution order (#460). Imported after the HOME override above.
+const { getSubgraphConfig } = await import('./subgraph-store.js');
 import type { BillingCache } from './billing-cache.js';
+
+// WASM-baked default DataEdge (the PRODUCTION contract). Captured with no env
+// override + no billing override so the DataEdge tests below can assert the
+// "fall through to WASM default" branch without hardcoding the address.
+delete process.env.TOTALRECLAW_DATA_EDGE_ADDRESS;
+__resetDataEdgeAddressOverrideForTests();
+const WASM_DEFAULT_DATA_EDGE = getSubgraphConfig().dataEdgeAddress;
+// Staging DataEdge — what the staging relay returns in `data_edge_address`.
+const STAGING_DATA_EDGE = '0xE7a4D2677B686e13775Ba9092631089e35F0BB91';
 
 let passed = 0;
 let failed = 0;
@@ -115,6 +129,11 @@ function resetCache(): void {
   );
   assertEq(read?.chain_id, 100, 'readBillingCache: chain_id round-trips');
   assertEq(read?.checked_at, now, 'readBillingCache: checked_at round-trips');
+  assertEq(
+    read?.data_edge_address,
+    undefined,
+    'readBillingCache: data_edge_address absent round-trips as undefined',
+  );
 
   // Side-effect (#402): Free tier no longer flips to 84532 — the relay's
   // authoritative chain_id (100) is applied verbatim.
@@ -174,6 +193,147 @@ function resetCache(): void {
   const read = readBillingCache();
   assertEq(read?.chain_id, 84532, 'readBillingCache: chain_id persists + round-trips');
   assertEq(CONFIG.chainId, 84532, 'readBillingCache: re-syncs chain_id verbatim on cold load');
+}
+
+// ---------------------------------------------------------------------------
+// data_edge_address is authoritative and consumed verbatim (#460)
+//
+// The relay routes each environment to its own DataEdge (staging is on-chain
+// isolated). Before this fix getSubgraphConfig resolved the contract as
+// `CONFIG.dataEdgeAddress || WASM-default` — so against the staging relay,
+// writes mined on the PROD DataEdge (WASM default) while reads came from the
+// staging subgraph → empty recall + phantom "stored=N". Fix: billing's
+// `data_edge_address` is the middle term of env → billing → WASM-default.
+// ---------------------------------------------------------------------------
+
+{
+  // Sanity: with no env + no billing override, getSubgraphConfig falls through
+  // to the WASM-baked (PROD) default.
+  resetCache();
+  delete process.env.TOTALRECLAW_DATA_EDGE_ADDRESS;
+  __resetDataEdgeAddressOverrideForTests();
+  assertEq(
+    getSubgraphConfig().dataEdgeAddress,
+    WASM_DEFAULT_DATA_EDGE,
+    'getSubgraphConfig: no env + no billing → WASM default (prod DataEdge)',
+  );
+}
+
+{
+  // RED under the old code: billing supplies the staging DataEdge, but
+  // getSubgraphConfig ignored it and returned the WASM prod default. After the
+  // fix the relay value is consumed verbatim.
+  resetCache();
+  delete process.env.TOTALRECLAW_DATA_EDGE_ADDRESS;
+  __resetChainIdOverrideForTests();
+  __resetDataEdgeAddressOverrideForTests();
+  writeBillingCache({
+    tier: 'free',
+    free_writes_used: 0,
+    free_writes_limit: 250,
+    chain_id: 100,
+    data_edge_address: STAGING_DATA_EDGE,
+    checked_at: Date.now(),
+  });
+  assertEq(
+    getSubgraphConfig().dataEdgeAddress,
+    STAGING_DATA_EDGE,
+    'getSubgraphConfig: billing data_edge_address consumed verbatim (staging, not prod default)',
+  );
+}
+
+{
+  // Missing data_edge_address (older relay / partial payload) → fall through to
+  // the WASM default (unchanged behavior — never a stale value).
+  resetCache();
+  delete process.env.TOTALRECLAW_DATA_EDGE_ADDRESS;
+  __resetDataEdgeAddressOverrideForTests();
+  writeBillingCache({
+    tier: 'free',
+    free_writes_used: 0,
+    free_writes_limit: 250,
+    chain_id: 100,
+    checked_at: Date.now(),
+  });
+  assertEq(
+    getSubgraphConfig().dataEdgeAddress,
+    WASM_DEFAULT_DATA_EDGE,
+    'getSubgraphConfig: missing data_edge_address → WASM default (no override)',
+  );
+}
+
+{
+  // Malformed data_edge_address (not an 0x-address) is ignored → WASM default,
+  // and the override is CLEARED (does not leak a prior valid value).
+  resetCache();
+  delete process.env.TOTALRECLAW_DATA_EDGE_ADDRESS;
+  __resetDataEdgeAddressOverrideForTests();
+  writeBillingCache({
+    tier: 'free',
+    free_writes_used: 0,
+    free_writes_limit: 250,
+    chain_id: 100,
+    data_edge_address: 'not-an-address',
+    checked_at: Date.now(),
+  });
+  assertEq(
+    getSubgraphConfig().dataEdgeAddress,
+    WASM_DEFAULT_DATA_EDGE,
+    'getSubgraphConfig: malformed data_edge_address ignored → WASM default',
+  );
+}
+
+{
+  // Explicit operator env override wins over billing (#460 item 4).
+  resetCache();
+  __resetDataEdgeAddressOverrideForTests();
+  const ENV_DATA_EDGE = '0x1111111111111111111111111111111111111111';
+  process.env.TOTALRECLAW_DATA_EDGE_ADDRESS = ENV_DATA_EDGE;
+  writeBillingCache({
+    tier: 'free',
+    free_writes_used: 0,
+    free_writes_limit: 250,
+    chain_id: 100,
+    data_edge_address: STAGING_DATA_EDGE,
+    checked_at: Date.now(),
+  });
+  assertEq(
+    getSubgraphConfig().dataEdgeAddress,
+    ENV_DATA_EDGE,
+    'getSubgraphConfig: env override wins over billing data_edge_address',
+  );
+  delete process.env.TOTALRECLAW_DATA_EDGE_ADDRESS;
+}
+
+{
+  // Cold-load restart: a persisted data_edge_address re-syncs the override on
+  // readBillingCache (fresh process, override reset).
+  resetCache();
+  delete process.env.TOTALRECLAW_DATA_EDGE_ADDRESS;
+  __resetDataEdgeAddressOverrideForTests();
+  writeBillingCache({
+    tier: 'free',
+    free_writes_used: 0,
+    free_writes_limit: 250,
+    chain_id: 100,
+    data_edge_address: STAGING_DATA_EDGE,
+    checked_at: Date.now(),
+  });
+  // Simulate a cold process: clear the in-memory override, then read from disk.
+  __resetDataEdgeAddressOverrideForTests();
+  assertEq(
+    getSubgraphConfig().dataEdgeAddress,
+    WASM_DEFAULT_DATA_EDGE,
+    'pre-read: DataEdge override reset → WASM default',
+  );
+  const read = readBillingCache();
+  assertEq(read?.data_edge_address, STAGING_DATA_EDGE, 'readBillingCache: data_edge_address persists + round-trips');
+  assertEq(
+    getSubgraphConfig().dataEdgeAddress,
+    STAGING_DATA_EDGE,
+    'readBillingCache: re-syncs data_edge_address verbatim on cold load',
+  );
+  __resetDataEdgeAddressOverrideForTests();
 }
 
 // ---------------------------------------------------------------------------

--- a/skill/plugin/billing-cache.ts
+++ b/skill/plugin/billing-cache.ts
@@ -14,6 +14,9 @@
  *   - keeps the chain-id override in sync with the relay's authoritative
  *     `chain_id` (after ops-1 both tiers are on Gnosis 100; the client consumes
  *     the relay value verbatim — see `syncChainIdFromBilling`)
+ *   - keeps the DataEdge-address override in sync with the relay's
+ *     authoritative `data_edge_address` (staging vs prod contract; consumed
+ *     verbatim — see `syncDataEdgeAddressFromBilling`, #460)
  *   - does NOT import anything that performs outbound I/O
  *
  * Do NOT add any outbound-request call to this file — a single match for
@@ -24,7 +27,10 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { CONFIG, setChainIdOverride } from './config.js';
+import { CONFIG, setChainIdOverride, setDataEdgeAddressOverride } from './config.js';
+
+/** A plausible EVM address — anything else from billing is ignored (#460). */
+const DATA_EDGE_ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -57,6 +63,13 @@ export interface BillingCache {
    * source of truth, so the client consumes this verbatim (#402).
    */
   chain_id?: number;
+  /**
+   * Authoritative DataEdge contract address from the relay
+   * `/v1/billing/status` response. Staging returns the isolated staging
+   * DataEdge, production the prod DataEdge; the client consumes this verbatim
+   * so writes and reads land on the same contract (#460).
+   */
+  data_edge_address?: string;
   checked_at: number;
 }
 
@@ -83,6 +96,34 @@ export function syncChainIdFromBilling(chainId: number | undefined): void {
 }
 
 // ---------------------------------------------------------------------------
+// DataEdge-address sync
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply the relay's authoritative `data_edge_address` to the runtime DataEdge
+ * override. Mirrors `syncChainIdFromBilling`.
+ *
+ * The relay routes each environment to its own DataEdge (staging is on-chain
+ * isolated). If the client ignores this and uses the WASM-baked default (the
+ * PROD DataEdge), writes against the staging relay mine on the prod contract
+ * while reads come from the staging subgraph → empty recall + phantom
+ * "stored=N" success (#460).
+ *
+ * A missing / malformed `data_edge_address` (older relay, partial payload,
+ * junk) clears the override (`null`) so resolution falls through to the WASM
+ * default — never a stale value. Only a plausible address
+ * (`0x` + 40 hex) is honored. Called from `readBillingCache` and
+ * `writeBillingCache` so every cache read or write keeps the override in sync.
+ * Idempotent. The explicit env override (`TOTALRECLAW_DATA_EDGE_ADDRESS`)
+ * still wins — it is the first term in `getSubgraphConfig`.
+ */
+export function syncDataEdgeAddressFromBilling(address: string | undefined): void {
+  setDataEdgeAddressOverride(
+    typeof address === 'string' && DATA_EDGE_ADDRESS_RE.test(address) ? address : null,
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Read / write
 // ---------------------------------------------------------------------------
 
@@ -99,9 +140,10 @@ export function readBillingCache(): BillingCache | null {
     if (!fs.existsSync(BILLING_CACHE_PATH)) return null;
     const raw = JSON.parse(fs.readFileSync(BILLING_CACHE_PATH, 'utf-8')) as BillingCache;
     if (!raw.checked_at || Date.now() - raw.checked_at > BILLING_CACHE_TTL) return null;
-    // Keep chain override in sync with the persisted authoritative chain_id
-    // across process restarts.
+    // Keep chain + DataEdge overrides in sync with the persisted authoritative
+    // values across process restarts.
     syncChainIdFromBilling(raw.chain_id);
+    syncDataEdgeAddressFromBilling(raw.data_edge_address);
     return raw;
   } catch {
     return null;
@@ -121,7 +163,9 @@ export function writeBillingCache(cache: BillingCache): void {
   } catch {
     // Best-effort — don't block on cache write failure.
   }
-  // Sync chain override AFTER the write so in-process UserOp signing picks
-  // up the correct chain immediately, even if the disk write failed.
+  // Sync chain + DataEdge overrides AFTER the write so in-process UserOp
+  // signing + subgraph reads pick up the correct chain and contract
+  // immediately, even if the disk write failed.
   syncChainIdFromBilling(cache.chain_id);
+  syncDataEdgeAddressFromBilling(cache.data_edge_address);
 }

--- a/skill/plugin/config.ts
+++ b/skill/plugin/config.ts
@@ -122,6 +122,39 @@ export function __resetChainIdOverrideForTests(): void {
   _chainIdOverride = null;
 }
 
+/**
+ * Runtime override for the DataEdge contract address, set after the relay
+ * billing response is read. The relay returns an authoritative
+ * `data_edge_address` in `/v1/billing/status` (staging routes to the isolated
+ * staging DataEdge, production to the prod DataEdge). Chain-aware clients MUST
+ * consume it verbatim — otherwise writes mine on the WASM-baked prod DataEdge
+ * while reads hit the relay's subgraph, so recall silently returns empty
+ * against staging (#460). Mirrors `_chainIdOverride`.
+ *
+ * `null` means "no billing override" → fall through to the WASM default. The
+ * explicit operator env override (`TOTALRECLAW_DATA_EDGE_ADDRESS`, exposed as
+ * `CONFIG.dataEdgeAddress`) always wins over this.
+ */
+let _dataEdgeAddressOverride: string | null = null;
+
+export function setDataEdgeAddressOverride(address: string | null): void {
+  _dataEdgeAddressOverride = address;
+}
+
+/**
+ * Read the billing-sourced DataEdge override (or `''` when unset). Used by
+ * `getSubgraphConfig` as the middle term of the env → billing → WASM-default
+ * resolution order (#460).
+ */
+export function getDataEdgeAddressOverride(): string {
+  return _dataEdgeAddressOverride ?? '';
+}
+
+/** Reset the DataEdge override — used by tests. */
+export function __resetDataEdgeAddressOverrideForTests(): void {
+  _dataEdgeAddressOverride = null;
+}
+
 export const CONFIG = {
   // Core — recoveryPhrase reads from override first, then env var.
   // Use getRecoveryPhrase() for dynamic access; this property is for
@@ -235,7 +268,14 @@ export const CONFIG = {
   get chainId(): number {
     return _chainIdOverride ?? 100;
   },
-  dataEdgeAddress: process.env.TOTALRECLAW_DATA_EDGE_ADDRESS || '',
+  // Explicit operator env override for the DataEdge contract. Stays env-only:
+  // it is the FIRST term of `getSubgraphConfig`'s env → billing → WASM-default
+  // resolution order, so it wins over the relay's authoritative
+  // `data_edge_address` (see `getDataEdgeAddressOverride` / #460). Getter, not
+  // a literal, so it reflects the live env rather than freezing at module load.
+  get dataEdgeAddress(): string {
+    return process.env.TOTALRECLAW_DATA_EDGE_ADDRESS || '';
+  },
   entryPointAddress: process.env.TOTALRECLAW_ENTRYPOINT_ADDRESS || '',
   rpcUrl: process.env.TOTALRECLAW_RPC_URL || '',
 

--- a/skill/plugin/index.ts
+++ b/skill/plugin/index.ts
@@ -1007,14 +1007,15 @@ async function initialize(logger: OpenClawPluginApi['logger']): Promise<void> {
           const tier = billingData.tier as string;
           const expiresAt = billingData.expires_at as string | undefined;
           // Populate billing cache for future use. Copy the relay's
-          // authoritative chain_id so it lands on disk and drives the runtime
-          // chain override verbatim (#402).
+          // authoritative chain_id + data_edge_address so they land on disk and
+          // drive the runtime chain + DataEdge overrides verbatim (#402, #460).
           writeBillingCache({
             tier: tier || 'free',
             free_writes_used: (billingData.free_writes_used as number) ?? 0,
             free_writes_limit: (billingData.free_writes_limit as number) ?? 0,
             features: billingData.features as BillingCache['features'] | undefined,
             chain_id: billingData.chain_id as number | undefined,
+            data_edge_address: billingData.data_edge_address as string | undefined,
             checked_at: Date.now(),
           });
           if (tier === 'pro' && expiresAt) {
@@ -4785,6 +4786,8 @@ const plugin = {
                   features: billingData.features as BillingCache['features'] | undefined,
                   // Relay's authoritative chain_id → drives the chain override verbatim (#402).
                   chain_id: billingData.chain_id as number | undefined,
+                  // Relay's authoritative data_edge_address → drives the DataEdge override verbatim (#460).
+                  data_edge_address: billingData.data_edge_address as string | undefined,
                   checked_at: Date.now(),
                 };
                 writeBillingCache(cache);

--- a/skill/plugin/subgraph-store.ts
+++ b/skill/plugin/subgraph-store.ts
@@ -21,7 +21,7 @@ function getWasm() {
   if (!_wasm) _wasm = requireWasm('@totalreclaw/core');
   return _wasm;
 }
-import { CONFIG } from './config.js';
+import { CONFIG, getDataEdgeAddressOverride } from './config.js';
 import { buildRelayHeaders } from './relay-headers.js';
 import { rpcRequest, rpcWithRetry } from './relay.js';
 import { signUserOp } from './vault-crypto.js';
@@ -844,7 +844,10 @@ export function isSubgraphMode(): boolean {
  *   - TOTALRECLAW_SELF_HOSTED -- set "true" to use self-hosted server (default: managed service)
  *
  * Chain ID is no longer configurable via env — it is auto-detected from the
- * relay billing response (free = Base Sepolia, Pro = Gnosis mainnet).
+ * relay billing response (post-ops-1 both tiers are on Gnosis mainnet, chain
+ * 100). The DataEdge contract address is likewise consumed from the relay's
+ * authoritative `data_edge_address` (env override still wins, WASM default is
+ * the final fallback — see the `dataEdgeAddress` resolution below, #460).
  */
 export function getSubgraphConfig(): SubgraphStoreConfig {
   return {
@@ -853,7 +856,12 @@ export function getSubgraphConfig(): SubgraphStoreConfig {
     mnemonic: CONFIG.recoveryPhrase,
     cachePath: CONFIG.cachePath,
     chainId: CONFIG.chainId,
-    dataEdgeAddress: CONFIG.dataEdgeAddress || getWasm().getDataEdgeAddress(),
+    // Resolution order (#460): explicit operator env override → relay billing
+    // `data_edge_address` (verbatim) → WASM-baked default. The relay routes
+    // each environment to its own DataEdge (staging is on-chain isolated), so
+    // consuming its value keeps writes + reads on the same contract; without
+    // the middle term staging writes mined on the prod default → empty recall.
+    dataEdgeAddress: CONFIG.dataEdgeAddress || getDataEdgeAddressOverride() || getWasm().getDataEdgeAddress(),
     entryPointAddress: CONFIG.entryPointAddress || getWasm().getEntryPointAddress(),
     rpcUrl: CONFIG.rpcUrl || undefined,
   };


### PR DESCRIPTION
## Summary

Byte-mirror of the rc.20 `chain_id` verbatim fix (3787ad6), applied to the DataEdge contract address — a **staging-testability + client-consistency fix**.

The relay's `/v1/billing/status` returns an authoritative `data_edge_address` (staging routes to the isolated staging DataEdge `0xE7a4D2…`, production to the prod DataEdge `0xC445af…`), and the Python client already consumes it. The TS plugin's `getSubgraphConfig()` never read it — it resolved the contract as `CONFIG.dataEdgeAddress || getWasm().getDataEdgeAddress()`, i.e. the env override (normally unset) or the WASM-baked **PROD** default. Against the staging relay this mines writes on the **prod** DataEdge while reads come from the **staging** subgraph → empty recall + phantom `stored=N` success.

Found live by **rc.21 auto-QA** (internal#402, QA PR internal#443): the "lost" facts were all on the prod subgraph. Fixes #460.

## Fix (mirrors 3787ad6's override-setter mechanism)

- **`billing-cache.ts`**: add `BillingCache.data_edge_address`; new `syncDataEdgeAddressFromBilling(addr)` validates a plausible `0x`-address (`/^0x[0-9a-fA-F]{40}$/`) → sets the override, else clears it (never a stale value). Called from `readBillingCache` + `writeBillingCache` next to the `chain_id` sync, so cold-load restarts re-sync from disk.
- **`config.ts`**: `setDataEdgeAddressOverride` / `getDataEdgeAddressOverride` / `__resetDataEdgeAddressOverrideForTests` mirror the `chain_id` override; `CONFIG.dataEdgeAddress` is now a getter (live env, not frozen at module load).
- **`index.ts`**: both billing-fetch sites copy `data_edge_address` into the cache object alongside `chain_id`.
- **`subgraph-store.ts` `getSubgraphConfig`**: resolution order becomes `CONFIG.dataEdgeAddress (env override) || getDataEdgeAddressOverride() (relay billing) || getWasm().getDataEdgeAddress() (WASM default)`. The explicit operator env override `TOTALRECLAW_DATA_EDGE_ADDRESS` still wins.

## TDD (`billing-cache.test.ts`)

- billing `data_edge_address: 0xE7a4D2…` → `getSubgraphConfig().dataEdgeAddress` returns it verbatim — **RED under old code** (returned the prod WASM default `0xC445af…`).
- missing / malformed `data_edge_address` → WASM default (unchanged).
- env override set → env wins over billing.
- write → read round-trip preserves + re-syncs on a cold process.

Full plugin suite green, build green, `check-scanner` 0 flags.

## Impact

**NOT user-facing on prod** — the WASM default already resolves to the correct prod DataEdge there. This unblocks staging E2E and aligns with the CLAUDE.md contract "clients consume the relay's `data_edge_address` verbatim." The MCP server likely has the same gap (tracked separately alongside #439).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EDaj45174CK3TbdGytDDD