### PR TITLE
fix(rc6): registry ledger in state dir no longer crashes glob scans (#460)

### DIFF
--- a/python/src/totalreclaw/hermes/tools.py
+++ b/python/src/totalreclaw/hermes/tools.py
@@ -934,14 +934,18 @@ def _prior_disclosure_consent(source: str, resume_id: Optional[str] = None) -> b
             prior = ist.read_import_state(resume_id)
             if prior is not None:
                 return bool(prior.disclosure_confirmed)
-        for path in ist.IMPORT_STATE_DIR.glob("*.json"):
-            try:
-                data = json.loads(path.read_text())
-            except (OSError, ValueError):
-                continue
-            if data.get("source") == source and data.get("disclosure_confirmed"):
+        # #460: scan genuine state records ONLY. The previous inline glob of
+        # ``*.json`` + ``data.get(...)`` crashed on the #436 conversation
+        # registry ledger (``imported-conversations-<source>.json``, a JSON
+        # LIST) — ``list.get`` raised AttributeError, which the narrow
+        # ``except (OSError, ValueError)`` missed, bricking import batch 2 and
+        # every re-import. ``iter_import_state_records`` excludes the ledgers
+        # and yields only dict records (belt: exclude by name; braces: skip
+        # non-dict payloads).
+        for st in ist.iter_import_state_records():
+            if st.source == source and st.disclosure_confirmed:
                 return True
-    except OSError:
+    except Exception:
         pass
     return False
 

--- a/python/src/totalreclaw/import_state.py
+++ b/python/src/totalreclaw/import_state.py
@@ -11,7 +11,7 @@ import os
 import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import List, Optional
+from typing import Iterator, List, Optional
 
 IMPORT_STATE_DIR: Path = Path.home() / ".totalreclaw" / "import-state"
 # 2h (#401, was 1h): the 2026-06-29 Gemini run showed individual batches
@@ -111,18 +111,67 @@ def is_import_early_stale(state: ImportState) -> bool:
         return False
 
 
+# ── #460: state-dir file discrimination ───────────────────────────────────
+#
+# IMPORT_STATE_DIR holds import-state RECORDS ({import_id}.json, JSON objects)
+# alongside non-record sidecars — notably the #436 conversation registry
+# ``imported-conversations-<source>.json`` (a JSON LIST) and the disclosure /
+# nudge sentinels. A consumer that globs ``*.json`` and treats every hit as a
+# state dict crashes on the list payload (``list.get`` → AttributeError, which
+# an ``except (OSError, ValueError)`` misses) — it deterministically bricked
+# import batch 2 and every re-import once the registry existed. ALL record
+# scans now go through these guards so a registry file in the same directory
+# can never be parsed as a state record.
+_NON_STATE_JSON_PREFIXES = ("imported-conversations-",)
+
+
+def _is_state_record_file(path: Path) -> bool:
+    """True only for a genuine ``{import_id}.json`` state record — excludes the
+    #436 conversation-registry ledgers (and any future prefixed sidecar)."""
+    name = path.name
+    return name.endswith(".json") and not any(
+        name.startswith(pfx) for pfx in _NON_STATE_JSON_PREFIXES
+    )
+
+
+def _iter_state_files() -> Iterator[Path]:
+    """Yield Paths of genuine state-record files (registry ledgers excluded)."""
+    try:
+        for p in IMPORT_STATE_DIR.glob("*.json"):
+            if _is_state_record_file(p):
+                yield p
+    except OSError:
+        return
+
+
+def iter_import_state_records() -> Iterator[ImportState]:
+    """Yield an :class:`ImportState` for every parseable DICT record in the
+    state dir, skipping registry ledgers and any non-dict / unreadable payload.
+
+    This is the single safe entry point for "scan all import records" — every
+    glob-based consumer routes through it so a non-record JSON file sharing the
+    directory can never crash a scan (#460).
+    """
+    for p in _iter_state_files():
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        try:
+            yield _coerce_state(data)
+        except Exception:
+            continue
+
+
 def read_most_recent_active_import() -> Optional[ImportState]:
     """Return the most recently started running/pending import, or None."""
     try:
-        candidates: List[ImportState] = []
-        for p in IMPORT_STATE_DIR.glob("*.json"):
-            try:
-                data = json.loads(p.read_text(encoding="utf-8"))
-                state = _coerce_state(data)
-                if state.status in ("running", "pending"):
-                    candidates.append(state)
-            except Exception:
-                pass
+        candidates = [
+            s for s in iter_import_state_records()
+            if s.status in ("running", "pending")
+        ]
         if not candidates:
             return None
         return max(candidates, key=lambda s: s.started_at)
@@ -150,18 +199,13 @@ def read_most_recent_import(max_age_hours: int = 48) -> Optional[ImportState]:
         from datetime import datetime, timezone, timedelta
         candidates: List[ImportState] = []
         cutoff = datetime.now(timezone.utc) - timedelta(hours=max_age_hours)
-        for p in IMPORT_STATE_DIR.glob("*.json"):
+        for state in iter_import_state_records():
             try:
-                data = json.loads(p.read_text(encoding="utf-8"))
-                state = _coerce_state(data)
-                try:
-                    updated = datetime.fromisoformat(state.last_updated.replace("Z", "+00:00"))
-                except Exception:
-                    continue
-                if updated > cutoff:
-                    candidates.append(state)
+                updated = datetime.fromisoformat(state.last_updated.replace("Z", "+00:00"))
             except Exception:
-                pass
+                continue
+            if updated > cutoff:
+                candidates.append(state)
         if not candidates:
             return None
         return max(candidates, key=lambda s: s.last_updated)
@@ -177,13 +221,9 @@ def read_completed_unannounced_imports() -> List[ImportState]:
     """
     out: List[ImportState] = []
     try:
-        for p in IMPORT_STATE_DIR.glob("*.json"):
-            try:
-                state = _coerce_state(json.loads(p.read_text(encoding="utf-8")))
-                if state.status == "completed" and not state.announced:
-                    out.append(state)
-            except Exception:
-                pass
+        for state in iter_import_state_records():
+            if state.status == "completed" and not state.announced:
+                out.append(state)
     except Exception:
         pass
     return sorted(out, key=lambda s: s.last_updated)
@@ -217,11 +257,13 @@ def mark_import_nudge_shown() -> None:
 
 
 def any_import_exists() -> bool:
-    """True if any import (running or finished) has ever been recorded."""
-    try:
-        return any(IMPORT_STATE_DIR.glob("*.json"))
-    except OSError:
-        return False
+    """True if any import (running or finished) has ever been recorded.
+
+    Counts only genuine state records — a #436 conversation-registry ledger in
+    the same dir must NOT read as "an import exists" (it would make the
+    onboarding nudge think the user already imported). (#460)
+    """
+    return any(True for _ in _iter_state_files())
 
 
 # ── F2 (#436): per-source imported-conversation registry ──────────────────

--- a/python/tests/test_rc6_consent_scan.py
+++ b/python/tests/test_rc6_consent_scan.py
@@ -1,0 +1,164 @@
+"""rc6 — #460: a registry ledger in the state dir must never crash a scan.
+
+rc5 re-QA: 3/4 entry-point fixes PASS and the store path holds, but ONE new
+deterministic crash bricked completion. The #436 conversation registry
+(``imported-conversations-<source>.json``) is a JSON LIST living in the same
+dir as import-state records. ``_prior_disclosure_consent`` globbed ``*.json``
+and did ``data.get("source")`` — ``list.get`` raises AttributeError, which the
+narrow ``except (OSError, ValueError)`` missed → import crashed on batch 2
+(once the ledger existed) and on ALL re-imports.
+
+Fix: every glob-based scan routes through ``iter_import_state_records`` /
+``_iter_state_files``, which exclude the registry ledgers and skip non-dict
+payloads. All pure/unit: no network, no LLM.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import totalreclaw.import_state as ist
+from totalreclaw.import_state import (
+    ImportState, write_import_state, read_import_state,
+    read_most_recent_active_import, read_most_recent_import,
+    read_completed_unannounced_imports, any_import_exists,
+    iter_import_state_records, record_imported_conversations,
+)
+from totalreclaw.hermes import tools
+
+
+def _redirect(tmp_path, monkeypatch):
+    monkeypatch.setattr(ist, "IMPORT_STATE_DIR", tmp_path / "import-state")
+
+
+def _write_registry(source="chatgpt", ids=("c1", "c2")):
+    # A real #436 ledger: a JSON LIST, written by record_imported_conversations.
+    record_imported_conversations(source, list(ids))
+
+
+def _state_with_tier(tier="pro"):
+    from totalreclaw.hermes.state import PluginState
+    state = PluginState()
+    client = MagicMock()
+    client.status = AsyncMock(return_value=MagicMock(tier=tier))
+    state._client = client
+    return state
+
+
+# ── the crash site ─────────────────────────────────────────────────────────
+def test_prior_consent_with_registry_present_does_not_crash(tmp_path, monkeypatch):
+    _redirect(tmp_path, monkeypatch)
+    _write_registry("chatgpt")  # the JSON-list ledger that used to crash .get
+    # No consented state yet → False, and crucially NO AttributeError.
+    assert tools._prior_disclosure_consent("chatgpt") is False
+
+
+def test_prior_consent_finds_real_record_despite_registry(tmp_path, monkeypatch):
+    _redirect(tmp_path, monkeypatch)
+    write_import_state(ImportState(
+        import_id="s1", source="chatgpt", status="failed",
+        started_at="2026-07-06T00:00:00+00:00", last_updated="x",
+        disclosure_confirmed=True))
+    _write_registry("chatgpt")
+    assert tools._prior_disclosure_consent("chatgpt") is True
+
+
+def test_disclosure_consent_ok_with_registry_present(tmp_path, monkeypatch):
+    _redirect(tmp_path, monkeypatch)
+    write_import_state(ImportState(
+        import_id="s2", source="chatgpt", status="running",
+        started_at="2026-07-06T00:00:00+00:00", last_updated="x",
+        disclosure_confirmed=True))
+    _write_registry("chatgpt")
+    assert tools._disclosure_consent_ok("chatgpt", {}) is True
+
+
+# ── every audited reader is unaffected by a registry file ──────────────────
+def test_iter_records_skips_registry(tmp_path, monkeypatch):
+    _redirect(tmp_path, monkeypatch)
+    write_import_state(ImportState(
+        import_id="rec-1", source="gemini", status="running",
+        started_at="2026-07-06T00:00:00+00:00", last_updated="x"))
+    _write_registry("chatgpt")
+    _write_registry("claude")
+    records = list(iter_import_state_records())
+    assert [r.import_id for r in records] == ["rec-1"]
+
+
+def test_readers_unaffected_by_registry(tmp_path, monkeypatch):
+    _redirect(tmp_path, monkeypatch)
+    write_import_state(ImportState(
+        import_id="active-1", source="gemini", status="running",
+        started_at="2026-07-06T00:00:00+00:00",
+        last_updated="2026-07-06T00:01:00+00:00"))
+    write_import_state(ImportState(
+        import_id="done-1", source="gemini", status="completed",
+        started_at="2026-07-06T00:00:00+00:00",
+        last_updated="2026-07-06T00:02:00+00:00", announced=False))
+    _write_registry("chatgpt")
+
+    assert read_most_recent_active_import().import_id == "active-1"
+    assert read_most_recent_import().import_id == "done-1"
+    assert [s.import_id for s in read_completed_unannounced_imports()] == ["done-1"]
+    assert any_import_exists() is True
+
+
+def test_any_import_exists_false_with_only_registry(tmp_path, monkeypatch):
+    _redirect(tmp_path, monkeypatch)
+    _write_registry("chatgpt")  # only a ledger, no real import records
+    # The ledger must NOT read as "an import exists" (would suppress the nudge).
+    assert any_import_exists() is False
+
+
+def test_readers_do_not_crash_on_registry_only(tmp_path, monkeypatch):
+    _redirect(tmp_path, monkeypatch)
+    _write_registry("chatgpt")
+    _write_registry("gemini")
+    # None of these raise; all return the empty/None result.
+    assert read_most_recent_active_import() is None
+    assert read_most_recent_import() is None
+    assert read_completed_unannounced_imports() == []
+    assert list(iter_import_state_records()) == []
+
+
+# ── the exact #460 repro: two-batch import, registry written after batch 1 ──
+@pytest.mark.asyncio
+async def test_two_batch_import_proceeds_after_registry_written(tmp_path, monkeypatch):
+    _redirect(tmp_path, monkeypatch)
+    from totalreclaw.import_adapters import BatchImportResult
+    import totalreclaw.import_engine as ie
+
+    # Prior consent so import_batch's disclosure gate is satisfied.
+    write_import_state(ImportState(
+        import_id="batch-src", source="chatgpt", status="running",
+        started_at="2026-07-06T00:00:00+00:00", last_updated="x",
+        disclosure_confirmed=True))
+
+    calls = {"n": 0}
+
+    async def _fake_pb(self, **k):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # #436 writes the conversation ledger after the first batch.
+            record_imported_conversations("chatgpt", ["c1", "c2"])
+        return BatchImportResult(
+            success=True, batch_offset=k.get("offset", 0), batch_size=25,
+            chunks_processed=25, total_chunks=50, facts_extracted=5,
+            facts_stored=6, remaining_chunks=25 if calls["n"] == 1 else 0,
+            is_complete=(calls["n"] >= 2), derived_facts=1)
+
+    monkeypatch.setattr(ie.ImportEngine, "process_batch", _fake_pb)
+    state = _state_with_tier("pro")
+
+    r1 = json.loads(await tools.import_batch(
+        {"source": "chatgpt", "content": "x", "offset": 0}, state))
+    # Batch 2 runs AFTER the ledger exists — the consent scan must not crash.
+    r2 = json.loads(await tools.import_batch(
+        {"source": "chatgpt", "content": "x", "offset": 25}, state))
+
+    assert "error" not in r1, r1
+    assert "error" not in r2, r2
+    assert calls["n"] == 2
+    assert r2.get("is_complete") is True


### PR DESCRIPTION
## rc6 — #460: `imported-conversations-*.json` ledger crashes state-dir scans

rc5 re-QA: 3 of 4 entry-point fixes verified **PASS** (fail-loud, disclosure + token-hardening with the provider named verbatim, orphan reap) and the store path holds — but one new **deterministic crash** bricked completion.

`tools.py::_prior_disclosure_consent` globbed `IMPORT_STATE_DIR/*.json` and called `data.get("source")`. The #436 conversation registry file `imported-conversations-<source>.json` is a JSON **LIST**, so `json.loads` succeeds and `list.get` raises `AttributeError` — which the narrow `except (OSError, ValueError)` misses. Result: import crashed on **batch 2** (once the ledger existed) and on **all re-imports** (F2 regressed as a side effect).

### Fix (central, belt-and-braces)
`import_state.py` gains a shared scan entry point:
- `_iter_state_files()` — globs `*.json` but **excludes** the registry ledgers by name (`_NON_STATE_JSON_PREFIXES = ("imported-conversations-",)`).
- `iter_import_state_records()` — yields an `ImportState` only for **dict** payloads, skipping non-dict / unreadable files.

All five `glob("*.json")` consumers now route through it:
- `read_most_recent_active_import`, `read_most_recent_import`, `read_completed_unannounced_imports` — rewritten to iterate the shared records.
- `any_import_exists` — counts only genuine records, so a registry ledger no longer reads as "an import exists" (which would suppress the onboarding nudge).
- `tools.py::_prior_disclosure_consent` — uses the shared iterator instead of its inline glob + `list.get`, and broadens its `except` to `Exception` defensively.

### Tests (`test_rc6_consent_scan.py`)
- consent scan with a registry present → no crash, correct result;
- each audited reader unaffected by a registry file; `any_import_exists` = False on registry-only;
- readers don't crash on a registry-only dir;
- **the exact #460 repro**: a two-batch import where the ledger is written after batch 1 → batch 2 proceeds (no error).

**Full suite green twice consecutively: 1959 passed, 39 skipped, 1 xfailed** (real `~/.totalreclaw` clean after each run).

Untouched: the store path, the #436 registry writers, deploy-state, token hardening. No key-derivation / mnemonic / signing / pair-crypto touched (phrase-safety rail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sks1gbonedAkEsawd4LVE