### PR TITLE
Code health (3/5): app type safety + decrypt-path tests (Keeper era)

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -12,7 +12,7 @@
         "@noble/curves": "^1.6.0",
         "@noble/hashes": "^1.8.0",
         "@scure/bip32": "^1.4.0",
-        "@scure/bip39": "^1.4.0",
+        "@scure/bip39": "^2.0.1",
         "@simplewebauthn/browser": "^13.3.0",
         "@tanstack/react-query": "^5.56.2",
         "@tanstack/react-virtual": "^3.10.8",
@@ -1361,14 +1361,35 @@
       }
     },
     "node_modules/@scure/bip39": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
-      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.2.0.tgz",
+      "integrity": "sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "~1.8.0",
-        "@scure/base": "~1.2.5"
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
       },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39/node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }

--- a/app/package.json
+++ b/app/package.json
@@ -15,7 +15,7 @@
     "@noble/curves": "^1.6.0",
     "@noble/hashes": "^1.8.0",
     "@scure/bip32": "^1.4.0",
-    "@scure/bip39": "^1.4.0",
+    "@scure/bip39": "^2.0.1",
     "@simplewebauthn/browser": "^13.3.0",
     "@tanstack/react-query": "^5.56.2",
     "@tanstack/react-virtual": "^3.10.8",

--- a/app/src/lib/api.test.ts
+++ b/app/src/lib/api.test.ts
@@ -33,7 +33,9 @@ const KEYS: SessionKeys = {
 // source/scope, legacy type tokens) which the on-chain blob may legitimately
 // carry from older writers.
 function makeFact(
-  claim: Partial<MemoryClaimV1> & Record<string, unknown>,
+  // Deliberately wide: fixtures inject out-of-enum values a real on-chain
+  // blob may carry; type safety is asserted on the OUTPUT of decryptFacts.
+  claim: Record<string, unknown>,
   overrides: Partial<RawFact> = {},
 ): RawFact {
   const blob = encryptBlob(JSON.stringify(claim), ENC_KEY);

--- a/app/src/lib/api.test.ts
+++ b/app/src/lib/api.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect } from "vitest";
+import { decryptFacts } from "./api";
+import { buildTimeline } from "./vault/timeline";
+import { encryptBlob } from "./crypto";
+import { MemoryClaimV1, RawFact, SessionKeys } from "./types";
+
+// Canonical enc key for the BIP-39 all-zeros test mnemonic (see crypto.test.ts).
+// decryptFacts only touches keys.encryptionKey, so the rest of SessionKeys is
+// stubbed to the minimum the type requires.
+const GOLDEN_ENC_KEY_HEX =
+  "a58fdc56e1d768461d95cd46b49e03727b2eb342ac558b9f3ebf1255b871f703";
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2)
+    out[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  return out;
+}
+
+const ENC_KEY = hexToBytes(GOLDEN_ENC_KEY_HEX);
+
+const KEYS: SessionKeys = {
+  authKey: new Uint8Array(),
+  encryptionKey: ENC_KEY,
+  authKeyHex: "",
+  eoaAddress: "0x0",
+  walletAddress: "0x0",
+  chainId: 84532,
+};
+
+// Build a RawFact whose encrypted_blob is the encrypted JSON of `claim`.
+// `raw` lets us inject fields that violate the MemoryClaimV1 type (out-of-enum
+// source/scope, legacy type tokens) which the on-chain blob may legitimately
+// carry from older writers.
+function makeFact(
+  claim: Partial<MemoryClaimV1> & Record<string, unknown>,
+  overrides: Partial<RawFact> = {},
+): RawFact {
+  const blob = encryptBlob(JSON.stringify(claim), ENC_KEY);
+  return {
+    id: (claim.id as string) ?? "fact-1",
+    encrypted_blob: blob,
+    blind_indices: [],
+    decay_score: 1,
+    version: 4,
+    source: "",
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    is_active: true,
+    ...overrides,
+  };
+}
+
+const baseClaim = {
+  id: "c1",
+  text: "hello",
+  type: "claim",
+  source: "user",
+  created_at: "2026-01-01T00:00:00.000Z",
+  schema_version: "1.0",
+};
+
+describe("decryptFacts", () => {
+  it("decrypts a valid fact into a normalized VaultItem", () => {
+    const items = decryptFacts([makeFact(baseClaim)], KEYS);
+    expect(items).toHaveLength(1);
+    const item = items[0];
+    expect(item.id).toBe("c1");
+    expect(item.claim.text).toBe("hello");
+    expect(item.claim.source).toBe("user");
+    expect(item.type).toBe("claim");
+    expect(item.pinned).toBe(false);
+    expect(item.createdAt).toEqual(new Date("2026-01-01T00:00:00.000Z"));
+    expect(item.decayScore).toBe(1);
+  });
+
+  it("clamps an out-of-enum source to 'external'", () => {
+    const items = decryptFacts(
+      [makeFact({ ...baseClaim, source: "space-alien" })],
+      KEYS,
+    );
+    expect(items[0].claim.source).toBe("external");
+  });
+
+  it("preserves a valid non-default source", () => {
+    const items = decryptFacts(
+      [makeFact({ ...baseClaim, source: "user-inferred" })],
+      KEYS,
+    );
+    expect(items[0].claim.source).toBe("user-inferred");
+  });
+
+  it("clamps an out-of-enum scope to 'unspecified'", () => {
+    const items = decryptFacts(
+      [makeFact({ ...baseClaim, scope: "outer-space" })],
+      KEYS,
+    );
+    expect(items[0].claim.scope).toBe("unspecified");
+  });
+
+  it("preserves a valid scope", () => {
+    const items = decryptFacts(
+      [makeFact({ ...baseClaim, scope: "health" })],
+      KEYS,
+    );
+    expect(items[0].claim.scope).toBe("health");
+  });
+
+  it("leaves an absent scope undefined (not clamped)", () => {
+    const items = decryptFacts([makeFact(baseClaim)], KEYS);
+    expect(items[0].claim.scope).toBeUndefined();
+  });
+
+  it("marks pinned when pin_status is 'pinned'", () => {
+    const items = decryptFacts(
+      [makeFact({ ...baseClaim, pin_status: "pinned" })],
+      KEYS,
+    );
+    expect(items[0].pinned).toBe(true);
+  });
+
+  it("skips undecryptable facts without throwing", () => {
+    const good = makeFact(baseClaim);
+    const corrupt: RawFact = {
+      ...good,
+      id: "corrupt",
+      encrypted_blob: "deadbeef".repeat(10), // valid hex, invalid ciphertext/tag
+    };
+    const items = decryptFacts([corrupt, good], KEYS);
+    expect(items).toHaveLength(1);
+    expect(items[0].id).toBe("c1");
+  });
+
+  it("skips a fact whose plaintext is not valid JSON", () => {
+    // Encrypt a non-JSON payload directly so decrypt succeeds but JSON.parse fails.
+    const blob = encryptBlob("this is not json", ENC_KEY);
+    const fact: RawFact = { ...makeFact(baseClaim), id: "notjson", encrypted_blob: blob };
+    const items = decryptFacts([fact], KEYS);
+    expect(items).toHaveLength(0);
+  });
+
+  it("returns an empty array for an empty input", () => {
+    expect(decryptFacts([], KEYS)).toEqual([]);
+  });
+});
+
+describe("resolveType (via decryptFacts)", () => {
+  it("uses claim.type when it is a valid v1 type", () => {
+    const items = decryptFacts(
+      [makeFact({ ...baseClaim, type: "preference" })],
+      KEYS,
+    );
+    expect(items[0].type).toBe("preference");
+  });
+
+  it("falls back to tags[0] when claim.type is missing", () => {
+    const claim = { ...baseClaim, tags: ["directive", "other"] };
+    delete (claim as Record<string, unknown>).type;
+    const items = decryptFacts([makeFact(claim)], KEYS);
+    expect(items[0].type).toBe("directive");
+  });
+
+  it("passes a legacy v0 type token through the `| string` escape hatch", () => {
+    // v0 tokens (fact, context, decision, episodic, goal, rule) predate the v1
+    // closed enum. resolveType surfaces tags[0] verbatim when it is not a v1 type.
+    const claim = { ...baseClaim, tags: ["decision"] };
+    delete (claim as Record<string, unknown>).type;
+    const items = decryptFacts([makeFact(claim)], KEYS);
+    expect(items[0].type).toBe("decision");
+  });
+
+  it("defaults to 'claim' when neither type nor tags are present", () => {
+    const claim = { ...baseClaim };
+    delete (claim as Record<string, unknown>).type;
+    const items = decryptFacts([makeFact(claim)], KEYS);
+    expect(items[0].type).toBe("claim");
+  });
+
+  it("prefers a valid claim.type over tags[0]", () => {
+    const items = decryptFacts(
+      [makeFact({ ...baseClaim, type: "summary", tags: ["episode"] })],
+      KEYS,
+    );
+    expect(items[0].type).toBe("summary");
+  });
+});
+
+// Regression guard for this merge: the Keeper timeline (lib/vault/timeline.ts)
+// reads claim.metadata directly (session_id + subtype + Crystal lists). The
+// sweep narrowed source/scope and clamps them in normalizeClaim; that clamp
+// must NOT strip the metadata block the timeline depends on. If normalizeClaim
+// ever regresses to dropping unmodeled fields, buildTimeline stops grouping
+// session Crystals — a silent, UI-only break unit-invisible without this test.
+describe("decryptFacts → metadata round-trip → buildTimeline", () => {
+  const SESSION_ID = "0191f0a1-7c3d-7abc-9def-0123456789ab";
+  const crystalClaim = {
+    ...baseClaim,
+    id: "crystal-1",
+    type: "summary",
+    text: "Shipped the entity-trapdoor read side and closed #370.",
+    metadata: {
+      subtype: "session_crystal",
+      session_id: SESSION_ID,
+      key_outcomes: ["merged PR #377", "+2.4pp Hit@16"],
+      open_threads: ["port read-side to OpenClaw"],
+      topics_discussed: ["retrieval", "trapdoors"],
+    },
+  };
+
+  it("retains the full metadata block through decrypt + normalize", () => {
+    const items = decryptFacts([makeFact(crystalClaim)], KEYS);
+    expect(items).toHaveLength(1);
+    const meta = items[0].claim.metadata;
+    expect(meta).toBeDefined();
+    expect(meta?.subtype).toBe("session_crystal");
+    expect(meta?.session_id).toBe(SESSION_ID);
+    expect(meta?.key_outcomes).toEqual(["merged PR #377", "+2.4pp Hit@16"]);
+    expect(meta?.open_threads).toEqual(["port read-side to OpenClaw"]);
+    expect(meta?.topics_discussed).toEqual(["retrieval", "trapdoors"]);
+    // clamp still ran on the sibling axes
+    expect(items[0].claim.source).toBe("user");
+  });
+
+  it("buckets the Crystal under s:<session_id> with .crystal set", () => {
+    const items = decryptFacts([makeFact(crystalClaim)], KEYS);
+    const groups = buildTimeline(items);
+    expect(groups).toHaveLength(1);
+    const g = groups[0];
+    expect(g.key).toBe(`s:${SESSION_ID}`);
+    expect(g.sessionId).toBe(SESSION_ID);
+    expect(g.crystal).not.toBeNull();
+    expect(g.crystal?.id).toBe("crystal-1");
+    expect(g.openThreads).toBe(1);
+  });
+
+  it("groups a Crystal and its atomic facts under one session key", () => {
+    const atomic = {
+      ...baseClaim,
+      id: "atom-1",
+      text: "Prefers k=16 over k=24.",
+      metadata: { session_id: SESSION_ID },
+    };
+    const items = decryptFacts(
+      [makeFact(crystalClaim), makeFact(atomic, { id: "atom-1" })],
+      KEYS,
+    );
+    const groups = buildTimeline(items);
+    expect(groups).toHaveLength(1);
+    const g = groups[0];
+    expect(g.key).toBe(`s:${SESSION_ID}`);
+    expect(g.crystal?.id).toBe("crystal-1");
+    expect(g.facts.map((f) => f.id)).toEqual(["atom-1"]);
+  });
+});

--- a/app/src/lib/api.test.ts
+++ b/app/src/lib/api.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { decryptFacts } from "./api";
 import { buildTimeline } from "./vault/timeline";
 import { encryptBlob } from "./crypto";
-import { MemoryClaimV1, RawFact, SessionKeys } from "./types";
+import { RawFact, SessionKeys } from "./types";
 
 // Canonical enc key for the BIP-39 all-zeros test mnemonic (see crypto.test.ts).
 // decryptFacts only touches keys.encryptionKey, so the rest of SessionKeys is

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -4,7 +4,11 @@ import {
   VaultItem,
   MemoryClaimV1,
   MemoryTypeV1,
+  MemorySource,
+  MemoryScope,
   MEMORY_TYPES_V1,
+  MEMORY_SOURCES,
+  MEMORY_SCOPES,
   SubgraphFact,
 } from "./types";
 import { decryptBlob } from "./crypto";
@@ -33,18 +37,18 @@ async function apiFetch<T>(
   keys: SessionKeys,
   init?: RequestInit,
 ): Promise<T> {
-  const res = await fetch(`${SERVER_URL}${path}`, {
+  const response = await fetch(`${SERVER_URL}${path}`, {
     ...init,
     headers: {
       ...authHeaders(keys),
       ...(init?.headers ?? {}),
     },
   });
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(`API ${path} → ${res.status}: ${body}`);
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(`API ${path} → ${response.status}: ${body}`);
   }
-  return res.json() as Promise<T>;
+  return response.json() as Promise<T>;
 }
 
 /**
@@ -63,7 +67,7 @@ export async function registerSession(keys: SessionKeys): Promise<void> {
   const saltHex = await sha256Hex(
     concat(new TextEncoder().encode("totalreclaw-spa-salt-v1"), keys.authKey),
   );
-  const res = await fetch(`${SERVER_URL}/v1/register`, {
+  const response = await fetch(`${SERVER_URL}/v1/register`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -74,9 +78,9 @@ export async function registerSession(keys: SessionKeys): Promise<void> {
       salt: saltHex,
     }),
   });
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(`register → ${res.status}: ${body}`);
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(`register → ${response.status}: ${body}`);
   }
 }
 
@@ -149,7 +153,7 @@ export async function exportAllFacts(
   const query = opts?.includeInactive ? PAGE_QUERY_ALL : PAGE_QUERY;
 
   for (;;) {
-    const res = await apiFetch<SubgraphResponse<{ facts: SubgraphFact[] }>>(
+    const subgraphResponse = await apiFetch<SubgraphResponse<{ facts: SubgraphFact[] }>>(
       "/v1/subgraph",
       keys,
       {
@@ -165,11 +169,11 @@ export async function exportAllFacts(
       },
     );
 
-    if (res.errors?.length) {
-      throw new Error(`subgraph: ${res.errors.map((e) => e.message).join("; ")}`);
+    if (subgraphResponse.errors?.length) {
+      throw new Error(`subgraph: ${subgraphResponse.errors.map((e) => e.message).join("; ")}`);
     }
 
-    const page = res.data?.facts ?? [];
+    const page = subgraphResponse.data?.facts ?? [];
     for (const fact of page) {
       all.push(subgraphFactToRawFact(fact));
     }
@@ -212,6 +216,25 @@ function resolveType(claim: MemoryClaimV1, tags: string[]): MemoryTypeV1 | strin
   return fromTags ?? "claim";
 }
 
+/**
+ * Coerce the decrypted JSON into a well-typed MemoryClaimV1. On-chain blobs
+ * may carry source/scope strings outside the v1 closed enums (malformed or
+ * future values); we clamp them to safe taxonomy members here so the narrow
+ * types downstream are honest rather than casting blindly.
+ */
+function normalizeClaim(raw: MemoryClaimV1): MemoryClaimV1 {
+  const source: MemorySource = MEMORY_SOURCES.includes(raw.source)
+    ? raw.source
+    : "external";
+  const scope: MemoryScope | undefined =
+    raw.scope === undefined
+      ? undefined
+      : MEMORY_SCOPES.includes(raw.scope)
+        ? raw.scope
+        : "unspecified";
+  return { ...raw, source, scope };
+}
+
 /** Decrypt all raw facts into VaultItems. Skips items that fail decryption. */
 export function decryptFacts(
   facts: RawFact[],
@@ -221,7 +244,7 @@ export function decryptFacts(
   for (const fact of facts) {
     try {
       const plaintext = decryptBlob(fact.encrypted_blob, keys.encryptionKey);
-      const claim = JSON.parse(plaintext) as MemoryClaimV1;
+      const claim = normalizeClaim(JSON.parse(plaintext) as MemoryClaimV1);
       const tags: string[] = claim.tags ?? [];
       items.push({
         id: fact.id,

--- a/app/src/lib/crypto.ts
+++ b/app/src/lib/crypto.ts
@@ -7,7 +7,7 @@
  */
 
 import { validateMnemonic, mnemonicToSeed, generateMnemonic } from "@scure/bip39";
-import { wordlist } from "@scure/bip39/wordlists/english";
+import { wordlist } from "@scure/bip39/wordlists/english.js";
 import { HDKey } from "@scure/bip32";
 import { secp256k1 } from "@noble/curves/secp256k1";
 import { keccak_256 } from "@noble/hashes/sha3";
@@ -137,12 +137,12 @@ async function fetchSmartAccountAddress(
   chainId: number,
 ): Promise<string> {
   const url = `${serverUrl.replace(/\/$/, "")}/v1/smart-account?eoa=${eoa}&chain=${chainId}`;
-  const res = await fetch(url);
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(`smart-account derivation failed (${res.status}): ${body}`);
+  const response = await fetch(url);
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(`smart-account derivation failed (${response.status}): ${body}`);
   }
-  const json = (await res.json()) as { smart_account?: string };
+  const json = (await response.json()) as { smart_account?: string };
   if (!json.smart_account || !/^0x[0-9a-fA-F]{40}$/.test(json.smart_account)) {
     throw new Error("smart-account response missing valid address");
   }

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -9,6 +9,31 @@ export const MEMORY_TYPES_V1 = [
 
 export type MemoryTypeV1 = (typeof MEMORY_TYPES_V1)[number];
 
+/** Provenance axis — closed enum per docs/specs/totalreclaw/memory-taxonomy-v1.md */
+export const MEMORY_SOURCES = [
+  "user",
+  "user-inferred",
+  "assistant",
+  "external",
+  "derived",
+] as const;
+
+export type MemorySource = (typeof MEMORY_SOURCES)[number];
+
+/** Life-domain axis — closed enum per docs/specs/totalreclaw/memory-taxonomy-v1.md */
+export const MEMORY_SCOPES = [
+  "work",
+  "personal",
+  "health",
+  "family",
+  "creative",
+  "finance",
+  "misc",
+  "unspecified",
+] as const;
+
+export type MemoryScope = (typeof MEMORY_SCOPES)[number];
+
 export type PinStatus = "pinned" | "unpinned";
 
 /** Structured entity reference inside a v1 claim (core MemoryEntityV1). */
@@ -43,10 +68,10 @@ export interface MemoryClaimV1 {
   id: string;
   text: string;
   type: MemoryTypeV1;
-  source: string;
+  source: MemorySource;
   created_at: string;
   schema_version: "1.0";
-  scope?: string;
+  scope?: MemoryScope;
   volatility?: string;
   entities?: MemoryEntityV1[];
   reasoning?: string;
@@ -65,7 +90,9 @@ export interface MemoryClaimV1 {
 export interface VaultItem {
   id: string;
   claim: MemoryClaimV1;
-  /** Derived from tags[0] if claim.type is missing (legacy fallback) */
+  /** Derived from tags[0] if claim.type is missing (legacy fallback).
+   *  `| string` retained for legacy v0 on-chain type tokens (fact, context,
+   *  decision, episodic, goal, rule) that predate the v1 closed enum. */
   type: MemoryTypeV1 | string;
   pinned: boolean;
   createdAt: Date;

--- a/app/src/lib/vault/mindmap.test.ts
+++ b/app/src/lib/vault/mindmap.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { buildMindGraph, YOU_ID } from "./mindmap";
-import type { VaultItem } from "../types";
+import type { VaultItem, MemoryScope } from "../types";
 
 let seq = 0;
-function item(scope: string, entities: string[], sessionId?: string): VaultItem {
+function item(scope: MemoryScope, entities: string[], sessionId?: string): VaultItem {
   return {
     id: `i${seq++}`,
     claim: {

--- a/app/src/pages/MemoryPage.tsx
+++ b/app/src/pages/MemoryPage.tsx
@@ -10,7 +10,7 @@ import { Segmented } from "../components/memory/Segmented";
 import { SidePanel, type PanelView } from "../components/memory/SidePanel";
 import { sourceShort, cap } from "../lib/presentation";
 import { count, relativeDate } from "../lib/format";
-import type { VaultItem } from "../lib/types";
+import type { VaultItem, MemoryScope, MemorySource } from "../lib/types";
 
 // Canvas + d3-force stay out of the Memory landing bundle until the Map opens.
 const MindMap = lazy(() =>
@@ -50,8 +50,8 @@ export function MemoryPage() {
   const [panel, setPanel] = useState<PanelView | null>(null);
 
   const [q, setQ] = useState("");
-  const [scope, setScope] = useState<string | null>(null);
-  const [source, setSource] = useState<string | null>(null);
+  const [scope, setScope] = useState<MemoryScope | null>(null);
+  const [source, setSource] = useState<MemorySource | null>(null);
   const [openOnly, setOpenOnly] = useState(false);
 
   const close = useCallback(() => setPanel(null), []);
@@ -61,11 +61,11 @@ export function MemoryPage() {
   const groups = useMemo(() => buildTimeline(items), [items]);
 
   const scopes = useMemo(
-    () => [...new Set(items.map((i) => i.claim.scope).filter((s): s is string => !!s && s !== "unspecified"))].sort(),
+    () => [...new Set(items.map((i) => i.claim.scope).filter((s): s is MemoryScope => !!s && s !== "unspecified"))].sort(),
     [items],
   );
   const sources = useMemo(
-    () => [...new Set(items.map((i) => i.claim.source).filter((s): s is string => !!s))].sort(),
+    () => [...new Set(items.map((i) => i.claim.source).filter((s): s is MemorySource => !!s))].sort(),
     [items],
   );
 


### PR DESCRIPTION
Third of five staged PRs splitting #474, ported onto the #329 Keeper base. Closed source/scope enums + normalizeClaim clamp with a hard contract: claim.metadata passes through untouched — pinned by a regression test asserting a session_crystal fixture survives decryptFacts and buildTimeline buckets it under s:<session_id> with .crystal set. bip39 v2 (byte-parity verified). Reviewer ask (SPA agent): confirm the regression test matches timeline.ts's real grouping-key logic. Gates: tsc 0, 78/78 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018unmCthsW7i1sEQDqUgk1G