### PR TITLE
fix(rc8): ledger stored-implies-recorded + pair-replace consent token (internal#466)

### DIFF
--- a/python/src/totalreclaw/hermes/consent_tokens.py
+++ b/python/src/totalreclaw/hermes/consent_tokens.py
@@ -1,0 +1,124 @@
+"""One-time, hash-at-rest consent tokens.
+
+Shared by the import privacy-disclosure gate (#437) and the pair-replace guard
+(#466 Finding-2). A token proves the agent surfaced a specific tool RESPONSE
+this flow before it can assert the user's consent — it forces at least one
+round-trip through the guard's response instead of the agent self-asserting a
+confirmation it never showed the user.
+
+Stored HASHED at rest: the sidecar is named ``{kind}-{sha256(token)[:16]}.pending``
+and holds only ``{kind, subject, minted_at}`` — the raw token appears ONLY in
+the tool response, never on disk. Tokens carry a 1h TTL (expired → not
+redeemable, cleaned up opportunistically on the next mint of that kind).
+
+Limits (documented honestly): this raises the bar to "the token reached the
+agent via the tool response" — it cannot stop a same-trust-domain agent that
+logs its own tool responses and reuses the value. The enforcement goal is
+narrowly "this guard's response was received THIS flow".
+
+Sidecars live under ``import_state.IMPORT_STATE_DIR`` (the ``.pending`` suffix
+keeps them out of the ``*.json`` state-record globs; #460).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from datetime import datetime, timezone
+
+#: Time-to-live for any consent token, in seconds.
+TOKEN_TTL_S = 3600
+
+
+def token_hash(token: str) -> str:
+    """SHA-256 (first 16 hex chars) of a token — the at-rest filename key."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
+
+
+def _state_dir():
+    # Referenced late so tests that monkeypatch IMPORT_STATE_DIR take effect.
+    from totalreclaw import import_state as ist
+    return ist.IMPORT_STATE_DIR
+
+
+def _sidecar_path(kind: str, token: str):
+    return _state_dir() / f"{kind}-{token_hash(token)}.pending"
+
+
+def is_expired(minted_at) -> bool:
+    """True when ``minted_at`` (ISO) is older than the TTL, or is missing /
+    unparseable (fail safe → treat as expired)."""
+    if not isinstance(minted_at, str) or not minted_at:
+        return True
+    try:
+        minted = datetime.fromisoformat(minted_at.replace("Z", "+00:00"))
+    except ValueError:
+        return True
+    return (datetime.now(timezone.utc) - minted).total_seconds() > TOKEN_TTL_S
+
+
+def cleanup_expired(kind: str) -> None:
+    """Best-effort removal of expired ``{kind}-*.pending`` sidecars."""
+    try:
+        for p in _state_dir().glob(f"{kind}-*.pending"):
+            try:
+                data = json.loads(p.read_text())
+            except (OSError, ValueError):
+                try:
+                    p.unlink()
+                except OSError:
+                    pass
+                continue
+            if is_expired(data.get("minted_at")):
+                try:
+                    p.unlink()
+                except OSError:
+                    pass
+    except OSError:
+        pass
+
+
+def mint(kind: str, subject: str) -> str:
+    """Mint + persist a one-time token for ``(kind, subject)``; return the raw
+    token (which the caller MUST return only in the tool response)."""
+    token = uuid.uuid4().hex[:16]
+    try:
+        d = _state_dir()
+        d.mkdir(parents=True, exist_ok=True)
+        cleanup_expired(kind)
+        _sidecar_path(kind, token).write_text(json.dumps({
+            "kind": kind,
+            "subject": subject,
+            "minted_at": datetime.now(timezone.utc).isoformat(),
+        }))
+    except OSError:
+        pass  # worst case: token can't be redeemed → the guard re-shows
+    return token
+
+
+def redeem(kind: str, subject: str, token) -> bool:
+    """Consume a token for ``(kind, subject)``. One-time use; rejects an
+    expired, wrong-kind, or wrong-subject token. Expiry is checked FIRST so a
+    stale sidecar is cleaned up regardless of subject."""
+    if not token or not isinstance(token, str) or not token.isalnum():
+        return False
+    try:
+        path = _sidecar_path(kind, token)
+        if not path.exists():
+            return False
+        data = json.loads(path.read_text())
+        if is_expired(data.get("minted_at")):
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            return False
+        # Bind to the intended kind + subject (the filename hash already binds
+        # the token value). A mismatch leaves the sidecar intact so a
+        # concurrent correct redemption can still succeed.
+        if data.get("kind") != kind or data.get("subject") != subject:
+            return False
+        path.unlink()
+        return True
+    except (OSError, ValueError):
+        return False

--- a/python/src/totalreclaw/hermes/pair_tool.py
+++ b/python/src/totalreclaw/hermes/pair_tool.py
@@ -27,10 +27,17 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
+from . import consent_tokens
+
 if TYPE_CHECKING:
     from .state import PluginState
 
 logger = logging.getLogger(__name__)
+
+#: Subject key for the pair-replace consent token. One account per install, so
+#: a constant subject is sufficient (unlike the disclosure token, keyed by the
+#: import source).
+_PAIR_REPLACE_SUBJECT = "pair"
 
 
 # ---------------------------------------------------------------------------
@@ -100,8 +107,19 @@ PAIR_SCHEMA: Dict[str, Any] = {
                     "tool refuses to start a fresh pair over existing "
                     "credentials (it would orphan the current vault) unless "
                     "the user explicitly confirmed they want to REPLACE "
-                    "their account. Never set this without that explicit "
-                    "user confirmation."
+                    "their account. Must be accompanied by the replace_token "
+                    "from the already_configured response — confirmation "
+                    "without the token is rejected, so you cannot self-assert "
+                    "replacement. Never set this without explicit user "
+                    "confirmation."
+                ),
+            },
+            "replace_token": {
+                "type": "string",
+                "description": (
+                    "One-time token from the already_configured response. "
+                    "Proves the tool's replace warning was surfaced this flow; "
+                    "replace_confirmed without it is rejected."
                 ),
             },
         },
@@ -449,21 +467,37 @@ async def pair(args: dict, state: "PluginState", **kwargs) -> str:
     # already-configured install mints a NEW phrase / Smart Account and
     # silently orphans the existing vault. Refuse unless the user explicitly
     # chose replacement. Message-level guard only — no crypto-path changes.
-    if state.is_configured() and not bool(args.get("replace_confirmed", False)):
-        return json.dumps({
-            "already_configured": True,
-            "message": (
-                "This install is already paired to a TotalReclaw account — "
-                "its credentials are on disk and the vault is reachable. "
-                "Starting a new pair flow would create a DIFFERENT account "
-                "and orphan the existing vault's memories. Tell the user "
-                "their account is already set up. Only if they explicitly "
-                "say they want to REPLACE it with a new/different account, "
-                "call again with replace_confirmed=true. (Restoring this "
-                "same account on another device happens on that device, "
-                "not here.)"
-            ),
-        })
+    #
+    # #466 Finding-2: rc7 QA showed the agent self-asserting replace_confirmed
+    # on an explicit "generate a new phrase" request WITHOUT ever surfacing the
+    # replace warning to the user. Apply the disclosure-token pattern — the
+    # already_configured response mints a one-time replace_token (hashed at
+    # rest, 1h TTL) and replacement now requires BOTH replace_confirmed=true
+    # AND that token, so the agent cannot pre-confirm a replacement it never
+    # showed the user.
+    if state.is_configured():
+        replace_ok = bool(args.get("replace_confirmed", False)) and consent_tokens.redeem(
+            "pair-replace", _PAIR_REPLACE_SUBJECT, args.get("replace_token")
+        )
+        if not replace_ok:
+            token = consent_tokens.mint("pair-replace", _PAIR_REPLACE_SUBJECT)
+            return json.dumps({
+                "already_configured": True,
+                "replace_token": token,
+                "message": (
+                    "This install is already paired to a TotalReclaw account — "
+                    "its credentials are on disk and the vault is reachable. "
+                    "Starting a new pair flow would create a DIFFERENT account "
+                    "and orphan the existing vault's memories. Tell the user "
+                    "their account is already set up. Only if they explicitly "
+                    "say they want to REPLACE it with a new/different account, "
+                    "call again with replace_confirmed=true AND "
+                    f"replace_token=\"{token}\". Confirmation without the token "
+                    "is rejected — you cannot pre-confirm replacement on the "
+                    "user's behalf. (Restoring this same account on another "
+                    "device happens on that device, not here.)"
+                ),
+            })
 
     raw_mode = args.get("mode")
     if raw_mode in ("generate", "import", "either"):

--- a/python/src/totalreclaw/hermes/tools.py
+++ b/python/src/totalreclaw/hermes/tools.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 
 import asyncio
 import atexit
-import hashlib
 import json
 import logging
 import os
 import uuid
+
+from . import consent_tokens
 from dataclasses import asdict
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Optional
@@ -953,115 +954,34 @@ def _prior_disclosure_consent(source: str, resume_id: Optional[str] = None) -> b
     return False
 
 
-# Disclosure tokens expire 1h after mint — a stale token can't be redeemed.
-_DISCLOSURE_TOKEN_TTL_S = 3600
+# Disclosure tokens are one-time, hash-at-rest consent tokens (#437). The
+# generic mint/redeem now live in ``hermes.consent_tokens`` (shared with the
+# pair-replace guard, #466); these thin wrappers pin the ``"disclosure"`` kind
+# and the token subject = the import ``source``.
+_DISCLOSURE_TOKEN_TTL_S = consent_tokens.TOKEN_TTL_S
 
 
 def _disclosure_token_hash(token: str) -> str:
     """SHA-256 (first 16 hex chars) of a disclosure token — the at-rest key."""
-    return hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
-
-
-def _disclosure_token_expired(minted_at) -> bool:
-    """True when a token's ``minted_at`` ISO timestamp is older than the TTL
-    (or is missing / unparseable — treat as expired, fail safe)."""
-    if not isinstance(minted_at, str) or not minted_at:
-        return True
-    try:
-        minted = datetime.fromisoformat(minted_at.replace("Z", "+00:00"))
-    except ValueError:
-        return True
-    age = (datetime.now(timezone.utc) - minted).total_seconds()
-    return age > _DISCLOSURE_TOKEN_TTL_S
-
-
-def _cleanup_expired_disclosure_tokens(state_dir) -> None:
-    """Best-effort removal of expired ``disclosure-*.pending`` sidecars."""
-    try:
-        for p in state_dir.glob("disclosure-*.pending"):
-            try:
-                data = json.loads(p.read_text())
-            except (OSError, ValueError):
-                # Unreadable sidecar — remove it opportunistically.
-                try:
-                    p.unlink()
-                except OSError:
-                    pass
-                continue
-            if _disclosure_token_expired(data.get("minted_at")):
-                try:
-                    p.unlink()
-                except OSError:
-                    pass
-    except OSError:
-        pass
+    return consent_tokens.token_hash(token)
 
 
 def _mint_disclosure_token(source: str) -> str:
     """Mint a one-time token proving the disclosure response was received.
 
-    rc13 (#421): rc12 QA showed the agent composing its OWN consent prompt
-    and self-setting disclosure_confirmed=true — the tool's provider-naming
-    disclosure never reached the user. The token forces at least one
-    round-trip through the disclosure_required response before consent can
-    be asserted.
-
-    #437 (rc5): the token is stored HASHED at rest — the sidecar is named
-    ``disclosure-{sha256(token)[:16]}.pending`` and holds only ``{source,
-    minted_at}``, never the raw token. Previously the filename WAS the token,
-    so a shell-capable agent could read it off disk and self-assert consent
-    without ever relaying the disclosure (observed: an rc4 QA attempt gained
-    consent with a token never redeemed through the flow). Hashing raises the
-    bar to "the token only appears in the tool RESPONSE"; it cannot stop a
-    same-trust-domain agent that logs its own tool responses — the enforcement
-    goal is narrowly "the disclosure response was received THIS flow". Tokens
-    also carry a 1h TTL. Persisted as a sidecar (NOT ``*.json`` — the import
-    state helpers glob that pattern) so it survives a gateway restart
-    mid-consent.
+    rc13 (#421): rc12 QA showed the agent composing its OWN consent prompt and
+    self-setting disclosure_confirmed=true — the tool's provider-naming
+    disclosure never reached the user. The token forces at least one round-trip
+    through the disclosure_required response before consent can be asserted.
+    #437 (rc5): stored HASHED at rest (see :mod:`hermes.consent_tokens`).
     """
-    token = uuid.uuid4().hex[:16]
-    try:
-        from totalreclaw import import_state as ist
-        ist.IMPORT_STATE_DIR.mkdir(parents=True, exist_ok=True)
-        _cleanup_expired_disclosure_tokens(ist.IMPORT_STATE_DIR)
-        (ist.IMPORT_STATE_DIR / f"disclosure-{_disclosure_token_hash(token)}.pending").write_text(
-            json.dumps({
-                "source": source,
-                "minted_at": datetime.now(timezone.utc).isoformat(),
-            })
-        )
-    except OSError:
-        pass  # worst case: token can't be redeemed → disclosure re-shown
-    return token
+    return consent_tokens.mint("disclosure", source)
 
 
 def _redeem_disclosure_token(source: str, token) -> bool:
-    """Consume a pending disclosure token for *source*. One-time use.
-
-    The presented token is HASHED to locate its sidecar (#437) — the raw
-    token is never written to disk. An expired (>1h) token is not redeemable
-    and its sidecar is cleaned up.
-    """
-    if not token or not isinstance(token, str) or not token.isalnum():
-        return False
-    try:
-        from totalreclaw import import_state as ist
-        path = ist.IMPORT_STATE_DIR / f"disclosure-{_disclosure_token_hash(token)}.pending"
-        if not path.exists():
-            return False
-        data = json.loads(path.read_text())
-        if data.get("source") != source:
-            return False
-        if _disclosure_token_expired(data.get("minted_at")):
-            try:
-                path.unlink()
-            except OSError:
-                pass
-            return False
-        path.unlink()
-        return True
-    except (OSError, ValueError):
-        return False
+    """Consume a pending disclosure token for *source*. One-time use; hashed
+    lookup, 1h TTL (see :mod:`hermes.consent_tokens`)."""
+    return consent_tokens.redeem("disclosure", source, token)
 
 
 def _disclosure_consent_ok(source: str, args: dict, resume_id: Optional[str] = None) -> bool:

--- a/python/src/totalreclaw/import_engine.py
+++ b/python/src/totalreclaw/import_engine.py
@@ -382,6 +382,14 @@ class ImportEngine:
         #: failure doesn't mark it imported and block the natural re-import
         #: recovery. Persists across batches on the instance.
         self._failed_chunk_indices: set[int] = set()
+        #: #466 — conversation_ids that produced ≥1 extracted (→ stored) fact
+        #: this run. Enforces the stored-implies-recorded invariant: a
+        #: multi-chunk conversation whose one sibling 429-failed but whose other
+        #: sibling stored facts MUST still be recorded, else the re-import
+        #: re-extracts it → duplicates (rc7 pre-stable QA shipped 10 dups). Only
+        #: a conversation that stored NOTHING and had a failed chunk stays
+        #: unrecorded (Finding-2 retry). Persists across batches on the instance.
+        self._conv_with_stored_facts: set[str] = set()
 
     # ── Estimate ─────────────────────────────────────────────────────────
 
@@ -790,6 +798,15 @@ class ImportEngine:
                     "reason": zero_reason,
                 })
                 reason_counts[zero_reason] = reason_counts.get(zero_reason, 0) + 1
+            else:
+                # #466: this chunk produced facts → its conversation stored
+                # facts and MUST be recorded, even if a sibling chunk failed.
+                cid = (
+                    getattr(parsed.chunks[global_index], "conversation_id", None)
+                    if global_index < len(parsed.chunks) else None
+                )
+                if cid:
+                    self._conv_with_stored_facts.add(cid)
             facts_extracted += len(extracted)
 
             if is_singleton:
@@ -841,9 +858,17 @@ class ImportEngine:
                 if cid not in self._recorded_conversations
                 and cid not in imported_convs
                 and all(ix in self._processed_chunk_indices for ix in indices)
-                # #436 review: never record a conversation any of whose chunks
-                # failed extraction — keep it re-importable.
-                and not any(ix in self._failed_chunk_indices for ix in indices)
+                # #466: stored-implies-recorded. Record when the conversation
+                # produced stored facts OR had no failed chunk. Withhold ONLY
+                # when it stored NOTHING and a chunk failed — that lone case is
+                # a genuine transient failure worth retrying on re-import
+                # (#436-review Finding-2). The old rule ("exclude if ANY chunk
+                # failed") withheld conversations that DID store facts via a
+                # surviving sibling → re-import re-extracted them → dups.
+                and (
+                    cid in self._conv_with_stored_facts
+                    or not any(ix in self._failed_chunk_indices for ix in indices)
+                )
             ]
             if newly_complete:
                 record_imported_conversations(source, newly_complete)

--- a/python/tests/test_pair_existing_credentials_guard.py
+++ b/python/tests/test_pair_existing_credentials_guard.py
@@ -1,10 +1,14 @@
-"""F8 (#428) — pair-tool existing-credentials guard.
+"""F8 (#428) + #466 Finding-2 — pair-tool existing-credentials guard + token.
 
 rc12 QA: "Set up my TotalReclaw account" on an ALREADY-configured install
-started a fresh pair flow. Completing it would have minted a new phrase /
-Smart Account and silently orphaned the existing vault. The guard refuses
-to start a pair session while credentials exist, unless the agent passes
-replace_confirmed=true after the user explicitly chose to replace.
+started a fresh pair flow that would have orphaned the existing vault. The
+guard refuses unless the user explicitly chose to replace.
+
+rc7 QA (#466 Finding-2): the agent SELF-ASSERTED replace_confirmed=true on a
+"generate a new phrase" request without ever surfacing the replace warning.
+The guard now applies the disclosure-token pattern — replacement requires BOTH
+replace_confirmed=true AND a one-time replace_token minted by the
+already_configured response.
 
 Message-level guard only — no key material, no crypto-path changes.
 """
@@ -14,6 +18,15 @@ import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
+import totalreclaw.import_state as ist
+
+
+@pytest.fixture(autouse=True)
+def _tmp_state_dir(tmp_path, monkeypatch):
+    # consent_tokens writes replace-token sidecars under IMPORT_STATE_DIR.
+    monkeypatch.setattr(ist, "IMPORT_STATE_DIR", tmp_path / "import-state")
+    yield
 
 
 def _state(configured: bool, monkeypatch):
@@ -46,19 +59,69 @@ async def test_configured_install_blocks_fresh_pair(monkeypatch):
     res = json.loads(await pair_tool.pair({}, state))
     assert res.get("already_configured") is True
     assert "replace_confirmed" in res["message"]
+    # The response mints a one-time replace_token to gate replacement.
+    assert res.get("replace_token")
     assert started == [], "no pair session may start while credentials exist"
 
 
 @pytest.mark.asyncio
-async def test_replace_confirmed_proceeds(monkeypatch):
+async def test_self_asserted_replace_without_token_rejected(monkeypatch):
+    """#466 Finding-2: replace_confirmed=true WITHOUT the token (the agent
+    self-asserting) must be REJECTED — no pair session starts."""
     from totalreclaw.hermes import pair_tool
     started = _patch_pair_session(monkeypatch)
     state = _state(configured=True, monkeypatch=monkeypatch)
 
     res = json.loads(await pair_tool.pair({"replace_confirmed": True}, state))
+    assert res.get("already_configured") is True
+    assert res.get("replace_token")  # a fresh token is offered
+    assert started == [], "self-asserted replacement must not start a session"
+
+
+@pytest.mark.asyncio
+async def test_replace_with_token_proceeds(monkeypatch):
+    """The token flow: the already_configured response mints a token; a
+    follow-up with replace_confirmed=true AND that token proceeds."""
+    from totalreclaw.hermes import pair_tool
+    started = _patch_pair_session(monkeypatch)
+    state = _state(configured=True, monkeypatch=monkeypatch)
+
+    first = json.loads(await pair_tool.pair({}, state))
+    token = first["replace_token"]
+    res = json.loads(await pair_tool.pair(
+        {"replace_confirmed": True, "replace_token": token}, state))
     assert res.get("already_configured") is not True
     assert res.get("url")
-    assert started, "explicit replacement must start the pair session"
+    assert started, "confirmed replacement with a valid token must start the session"
+
+
+@pytest.mark.asyncio
+async def test_replace_token_is_one_time(monkeypatch):
+    """A redeemed replace_token cannot be reused for a second replacement."""
+    from totalreclaw.hermes import pair_tool
+    started = _patch_pair_session(monkeypatch)
+    state = _state(configured=True, monkeypatch=monkeypatch)
+
+    first = json.loads(await pair_tool.pair({}, state))
+    token = first["replace_token"]
+    # Consume it once.
+    await pair_tool.pair({"replace_confirmed": True, "replace_token": token}, state)
+    started.clear()
+    # Reuse rejected.
+    res = json.loads(await pair_tool.pair(
+        {"replace_confirmed": True, "replace_token": token}, state))
+    assert res.get("already_configured") is True
+    assert started == []
+
+
+def test_consent_tokens_are_kind_isolated(monkeypatch):
+    """A token minted for one kind cannot be redeemed as another (a disclosure
+    token must not satisfy the pair-replace guard, and vice-versa)."""
+    from totalreclaw.hermes import consent_tokens
+    tok = consent_tokens.mint("pair-replace", "pair")
+    assert consent_tokens.redeem("disclosure", "pair", tok) is False
+    assert consent_tokens.redeem("pair-replace", "other", tok) is False
+    assert consent_tokens.redeem("pair-replace", "pair", tok) is True  # correct kind+subject
 
 
 @pytest.mark.asyncio

--- a/python/tests/test_rc5_import_entry.py
+++ b/python/tests/test_rc5_import_entry.py
@@ -363,9 +363,9 @@ def test_token_stored_hashed_not_plaintext(tmp_path, monkeypatch):
     # The raw token must NOT appear in the filename.
     assert token not in files[0].name
     assert files[0].name == f"disclosure-{tools._disclosure_token_hash(token)}.pending"
-    # The file holds only source + minted_at — never the raw token.
+    # The file holds only kind + subject + minted_at — never the raw token.
     data = json.loads(files[0].read_text())
-    assert data == {"source": "chatgpt", "minted_at": data["minted_at"]}
+    assert data == {"kind": "disclosure", "subject": "chatgpt", "minted_at": data["minted_at"]}
     assert token not in files[0].read_text()
 
 

--- a/python/tests/test_rc8_ledger_recording.py
+++ b/python/tests/test_rc8_ledger_recording.py
@@ -1,0 +1,163 @@
+"""rc8 — #466: the #436 conversation ledger must satisfy stored-implies-recorded.
+
+rc7 pre-stable QA: after two completed imports the conversation ledger was NEVER
+written, so a re-import stored 10 duplicates. Root cause: the recording filter
+excluded a conversation if ANY of its chunks failed extraction (#436-review
+Finding-2), but under heavy z.ai 429s a MULTI-CHUNK conversation can have one
+chunk transiently fail while a SIBLING chunk stores facts — so the conversation
+had stored facts yet was withheld from the ledger, and the re-import re-extracted
+it → dups.
+
+The invariant that matters: any conversation whose facts were STORED must be
+recorded (so a re-import skips it). A conversation that produced NO stored facts
+AND had a failed chunk stays unrecorded, so a genuine transient failure is
+retried on re-import (Finding-2).
+
+Pure/unit: a recording client + fake adapter; no network, no LLM.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import totalreclaw.import_state as ist
+import totalreclaw.import_engine as ie
+from totalreclaw.import_engine import ImportEngine
+from totalreclaw.import_adapters.types import AdapterParseResult, ConversationChunk
+
+
+class _BatchClient:
+    def __init__(self):
+        self.n = 0
+
+    async def _ensure_chain_id(self):
+        return 100
+
+    async def remember_batch(self, payloads, source=None):
+        ids = [f"f{self.n + i}" for i in range(len(payloads))]
+        self.n += len(payloads)
+        return ids
+
+
+def _install_fake_embedding(monkeypatch):
+    import totalreclaw.embedding as emb
+    monkeypatch.setattr(emb, "get_embedding", lambda t: [0.1, 0.2, 0.3])
+
+
+def _chunk(conv_id, text):
+    return ConversationChunk(
+        title=f"{conv_id}:{text[:12]}",
+        messages=[{"role": "user", "text": text},
+                  {"role": "assistant", "text": f"re: {text}"}],
+        timestamp="2026-05-14T09:00:00Z",
+        conversation_id=conv_id,
+    )
+
+
+def _install_adapter(monkeypatch, chunks):
+    class _Adapter:
+        def parse(self, content=None, file_path=None):
+            return AdapterParseResult(
+                facts=[], chunks=list(chunks), total_messages=len(chunks) * 2,
+                warnings=[], errors=[])
+    monkeypatch.setattr(ie, "get_adapter", lambda source: _Adapter())
+
+
+@pytest.fixture(autouse=True)
+def _tmp_state_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(ist, "IMPORT_STATE_DIR", tmp_path / "import-state")
+    yield
+
+
+def _flaky_extractor(fail_texts):
+    """Extractor that RAISES for chunks whose text is in fail_texts (simulating
+    a 429 that exhausts the retry budget), else returns one fact."""
+    async def _extract(messages, timestamp):
+        text = messages[0]["content"]
+        if any(f in text for f in fail_texts):
+            raise RuntimeError("LLM upstream outage (z.ai 429 exhausted)")
+        return [{"text": f"fact from {text}", "type": "fact", "importance": 8}]
+    return _extract
+
+
+# ── the exact #466 repro: multi-chunk conversation, one sibling 429-fails ──
+def test_conversation_with_stored_facts_is_recorded_despite_sibling_failure(monkeypatch):
+    _install_fake_embedding(monkeypatch)
+    # Conversation A spans 2 chunks: a0 stores facts, a1 transiently fails.
+    # Conversation B likewise. Single process_batch call completes everything.
+    chunks = [
+        _chunk("A", "alpha one stored"),
+        _chunk("A", "alpha two boom429"),
+        _chunk("B", "bravo one stored"),
+        _chunk("B", "bravo two boom429"),
+    ]
+    _install_adapter(monkeypatch, chunks)
+    engine = ImportEngine(
+        client=_BatchClient(),
+        llm_extract=_flaky_extractor(fail_texts=["boom429"]),
+    )
+
+    result = asyncio.run(engine.process_batch(source="chatgpt", content="x"))
+
+    # Facts WERE stored (from the surviving sibling of each conversation).
+    assert result.facts_stored >= 2
+    # stored-implies-recorded: both conversations must be in the ledger so a
+    # re-import skips them — this is the regression that shipped 10 dups.
+    recorded = ist.load_imported_conversations("chatgpt")
+    assert recorded == {"A", "B"}
+
+
+def test_conversation_with_no_stored_facts_and_failure_stays_unrecorded(monkeypatch):
+    """Finding-2 preserved: a conversation that stored NOTHING and had a failed
+    chunk is NOT recorded, so a re-import retries it."""
+    _install_fake_embedding(monkeypatch)
+    chunks = [
+        _chunk("C", "charlie only boom429"),   # single chunk, fails → 0 facts
+        _chunk("D", "delta one stored"),        # clean conversation
+    ]
+    _install_adapter(monkeypatch, chunks)
+    engine = ImportEngine(
+        client=_BatchClient(),
+        llm_extract=_flaky_extractor(fail_texts=["boom429"]),
+    )
+
+    result = asyncio.run(engine.process_batch(source="chatgpt", content="x"))
+    recorded = ist.load_imported_conversations("chatgpt")
+    assert "D" in recorded          # clean → recorded
+    assert "C" not in recorded      # failed + no facts → stays re-importable
+
+
+def test_single_call_complete_records_in_one_process_batch(monkeypatch):
+    """Hypothesis (a): recording must fire on a single is_complete call, not
+    only on a later batch."""
+    _install_fake_embedding(monkeypatch)
+    chunks = [_chunk("E", "echo stored"), _chunk("F", "foxtrot stored")]
+    _install_adapter(monkeypatch, chunks)
+    engine = ImportEngine(client=_BatchClient(),
+                          llm_extract=_flaky_extractor(fail_texts=[]))
+    result = asyncio.run(engine.process_batch(source="chatgpt", content="x"))
+    assert result.is_complete
+    assert ist.load_imported_conversations("chatgpt") == {"E", "F"}
+
+
+def test_triage_skipped_chunk_does_not_block_recording(monkeypatch):
+    """Hypothesis (b): a conversation whose extra chunk is triage-skipped (not
+    failed) but whose other chunk stores facts is still recorded."""
+    _install_fake_embedding(monkeypatch)
+    # G has 2 chunks; we simulate a skip by having the engine's smart-import
+    # skip decisions mark chunk index 1. Simplest: no smart_ctx, so instead we
+    # cover the "skipped == not failed" path via an empty (0-fact) sibling,
+    # which is the same recording-relevant state (processed, not failed).
+    chunks = [_chunk("G", "golf one stored"), _chunk("G", "golf two empty")]
+    _install_adapter(monkeypatch, chunks)
+
+    async def _extract(messages, timestamp):
+        text = messages[0]["content"]
+        if "empty" in text:
+            return []  # 0 facts, NOT a failure
+        return [{"text": f"fact from {text}", "type": "fact", "importance": 8}]
+
+    engine = ImportEngine(client=_BatchClient(), llm_extract=_extract)
+    asyncio.run(engine.process_batch(source="chatgpt", content="x"))
+    assert "G" in ist.load_imported_conversations("chatgpt")


### PR DESCRIPTION
## rc8 — #466: conversation ledger never written → re-import dups

rc7 FULL pre-stable QA (report: `totalreclaw-internal` `docs/notes/QA-hermes-RC-2.4.6rc7-PRESTABLE-20260708.md`, umbrella #466): everything **GO** except one blocker — after two completed imports the #436 conversation ledger was **never written**, so a re-import stored **10 duplicates**. #463 is exonerated (its diff touches only `agent/lifecycle.py`). TDD (red commit then green). **No merge intended.**

### Item 1 — ledger recording (`import_engine.py`)
**Root cause (hypothesis (c), reproduced):** the recording filter excluded a conversation if **any** of its chunks failed extraction (#436-review Finding-2). Under heavy z.ai 429s a **multi-chunk** conversation can have one chunk transiently 429-fail while a **sibling** chunk stores facts — so the conversation *had stored facts* yet was withheld from the ledger, and the re-import re-extracted it → dups. `test_rc8_ledger_recording::test_conversation_with_stored_facts_is_recorded_despite_sibling_failure` reproduces it (ledger `set()` despite `facts_stored >= 2`).

**Fix — enforce stored-implies-recorded.** Track `_conv_with_stored_facts` (conversation_ids that produced ≥1 extracted → stored fact this run) and record a completed conversation when it **stored facts OR had no failed chunk**. Only a conversation that stored **nothing** *and* had a failed chunk stays unrecorded — so a genuine transient failure is still retried on re-import (Finding-2 preserved). Recording fires on a single `is_complete` `process_batch` call (the single-file QA profile) and across batches; verified reachable from `import_batch`'s fresh-process engine-cache flow.

Hypotheses (a)/(b)/(d) checked and covered by tests: single-call completion records; a triage-skipped (not failed) sibling doesn't block recording; the fire path is per-call (no cross-process engine-state dependency).

### Item 2 — pair-replace consent token (`pair_tool.py`, #466 Finding-2)
rc7 QA showed the agent **self-asserting** `replace_confirmed=true` on a "generate a new phrase" request without ever surfacing the replace warning. Applied the disclosure-token pattern: the `already_configured` response mints a one-time **`replace_token`** (hash-at-rest, 1h TTL) and replacement now requires **both** `replace_confirmed=true` **and** that token. Updated `PAIR_SCHEMA` (added `replace_token`, tightened `replace_confirmed`) + the guard message.

**Generalized** the disclosure-token helpers into `hermes/consent_tokens.py` (one-time, hash-at-rest, `kind`+`subject`-scoped, 1h TTL). `tools.py`'s disclosure functions are now thin wrappers (`kind="disclosure"`, `subject=source`); the pair guard uses `kind="pair-replace"`. Tokens are **kind-isolated** (a disclosure token can't satisfy the pair guard). Sidecar payload generalized to `{kind, subject, minted_at}`.

### Tests
- New `test_rc8_ledger_recording.py` (4): the repro + Finding-2 + single-call + triage-skip.
- New `consent_tokens` kind-isolation test; rewrote the F8 guard tests for the token flow (self-assert rejected, token flow proceeds, one-time, fresh install unaffected); updated the one disclosure payload-shape assertion.
- **Full suite green twice consecutively: 2082 passed, 39 skipped, 1 xfailed** (real `~/.totalreclaw` clean after each run).

### Untouched
The store path (dual-cap/halving/receipt), the #436 registry writers, deploy-state, F5. No key-derivation / mnemonic / signing / pair crypto-path touched — message-level guard only (phrase-safety rail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sks1gbonedAkEsawd4LVE