### PR TITLE
fix(imp-418): bind import-disclosure consent to disclosed LLM provider

### DIFF
--- a/python/src/totalreclaw/hermes/import_tools.py
+++ b/python/src/totalreclaw/hermes/import_tools.py
@@ -302,13 +302,32 @@ def _prior_disclosure_consent(source: str, resume_id: Optional[str] = None) -> b
     Checked by resume paths and by ``totalreclaw_import_batch`` (which the
     agent calls repeatedly after ``import_from`` recorded consent) so the
     user is never re-prompted mid-import.
+
+    internal#418: a persisted consent is honored ONLY when the provider it was
+    disclosed for (``ImportState.disclosure_provider``) still equals the
+    CURRENT resolved provider label. The disclosure exists so the user knows
+    which LLM reads their conversations in cleartext — a silent provider swap
+    must re-fire it. An absent/None ``disclosure_provider`` (a pre-#418 record)
+    is a mismatch → re-prompt once (safe direction: never silently authorize).
     """
     try:
+        # Resolve through the tools module so the test suite's
+        # ``setattr(tools, "_extraction_provider_label", …)`` is authoritative
+        # (see the module docstring's patchability contract).
+        current_provider = _dispatch_module()._extraction_provider_label()
+
+        def _valid(st) -> bool:
+            return bool(
+                st.disclosure_confirmed
+                and st.disclosure_provider is not None
+                and st.disclosure_provider == current_provider
+            )
+
         from totalreclaw import import_state as ist
         if resume_id:
             prior = ist.read_import_state(resume_id)
             if prior is not None:
-                return bool(prior.disclosure_confirmed)
+                return _valid(prior)
         # #460: scan genuine state records ONLY. The previous inline glob of
         # ``*.json`` + ``data.get(...)`` crashed on the #436 conversation
         # registry ledger (``imported-conversations-<source>.json``, a JSON
@@ -318,11 +337,23 @@ def _prior_disclosure_consent(source: str, resume_id: Optional[str] = None) -> b
         # and yields only dict records (belt: exclude by name; braces: skip
         # non-dict payloads).
         for st in ist.iter_import_state_records():
-            if st.source == source and st.disclosure_confirmed:
+            if st.source == source and _valid(st):
                 return True
     except Exception:
         pass
     return False
+
+
+def _current_disclosure_provider() -> str:
+    """The LLM provider label the user would be (or was) shown right now.
+
+    Routed through the ``tools`` module (the monkeypatch surface — see the
+    module docstring) so the test suite's ``setattr(tools,
+    "_extraction_provider_label", …)`` is authoritative. Used both by the
+    disclosure message and to stamp ``ImportState.disclosure_provider`` when
+    consent is recorded (internal#418).
+    """
+    return _dispatch_module()._extraction_provider_label()
 
 
 # Disclosure tokens are one-time, hash-at-rest consent tokens (#437). The
@@ -773,6 +804,7 @@ async def _run_small_import(engine, source, file_path, content, import_id, estim
         estimated_total_facts=estimate.get("estimated_facts", 0),
         estimated_minutes=estimate.get("estimated_minutes", 0),
         disclosure_confirmed=True,
+        disclosure_provider=_current_disclosure_provider(),
     )
     write_import_state(istate)
     try:
@@ -965,6 +997,7 @@ def _spawn_background_import(state, engine, source, file_path, content, import_i
         estimated_minutes=estimated_minutes,
         estimated_completion_iso=eta_iso,
         disclosure_confirmed=True,
+        disclosure_provider=_current_disclosure_provider(),
     )
     write_import_state(istate)
 
@@ -1193,6 +1226,7 @@ async def import_batch(args: dict, state: "PluginState", **kwargs) -> str:
                 dups_skipped=(prior.dups_skipped if prior else 0) + getattr(result, "dups_skipped", 0),
                 file_path=file_path,
                 disclosure_confirmed=True,
+                disclosure_provider=_current_disclosure_provider(),
             ))
         except Exception as state_err:
             logger.warning("import_batch state bookkeeping failed: %s", state_err)

--- a/python/src/totalreclaw/imports/state.py
+++ b/python/src/totalreclaw/imports/state.py
@@ -51,6 +51,13 @@ class ImportState:
     estimated_minutes: int = 0
     estimated_completion_iso: str = ""
     disclosure_confirmed: bool = False
+    #: internal#418 — the LLM provider label the user was SHOWN when they
+    #: consented to the disclosure. A persisted consent only authorizes
+    #: extraction while the SAME provider is still configured; a later provider
+    #: switch re-fires the disclosure instead of silently authorizing the new
+    #: provider. None on pre-#418 records → treated as a mismatch → re-prompt
+    #: once (never silently authorize).
+    disclosure_provider: Optional[str] = None
     #: Set True once the agent has proactively told the user this import
     #: finished (the completion-notification one-shot). Prevents re-announcing
     #: the same completed import on every subsequent turn.

--- a/python/tests/test_imp418_provider_drift.py
+++ b/python/tests/test_imp418_provider_drift.py
@@ -1,0 +1,168 @@
+"""internal#418 — import disclosure consent must bind to the disclosed provider.
+
+The privacy disclosure names the LLM provider that will read the user's past
+conversations in cleartext. Persisted consent (``ImportState.disclosure_confirmed``)
+previously authorized extraction indefinitely regardless of which provider is
+later configured — so consenting while on provider A silently authorized provider
+B after a config switch, with no re-disclosure. The fix stamps the resolved
+provider label into ``disclosure_provider`` when consent is recorded, and
+``_prior_disclosure_consent`` only honors a persisted consent whose recorded
+provider matches the CURRENT provider. An absent/None provider (a pre-#418
+record) is treated as a mismatch → re-prompt once (never silently authorize).
+
+Pure/unit: no network, no LLM, no on-chain writes.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import totalreclaw.import_state as ist
+from totalreclaw.import_state import (
+    ImportState, _coerce_state, write_import_state, read_import_state,
+)
+
+
+def _redirect_state_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(ist, "IMPORT_STATE_DIR", tmp_path / "import-state")
+
+
+def _state_with_tier(tier="pro"):
+    from totalreclaw.hermes.state import PluginState
+    state = PluginState()
+    client = MagicMock()
+    client.status = AsyncMock(return_value=MagicMock(tier=tier))
+    state._client = client
+    return state
+
+
+def _patch_engine(monkeypatch):
+    import totalreclaw.import_engine as ie
+    from totalreclaw.import_adapters import BatchImportResult
+    process = AsyncMock(return_value=BatchImportResult(
+        success=True, batch_offset=0, batch_size=25, chunks_processed=2,
+        total_chunks=2, facts_extracted=3, facts_stored=3,
+        remaining_chunks=0, is_complete=True,
+    ))
+    monkeypatch.setattr(
+        ie.ImportEngine, "estimate",
+        lambda self, **k: {
+            "total_chunks": 2, "estimated_facts": 50,
+            "estimated_minutes": 3, "num_batches": 1, "batch_size": 25,
+        },
+    )
+    monkeypatch.setattr(ie.ImportEngine, "process_batch", lambda self, **k: process(**k))
+    return process
+
+
+def _patch_provider(monkeypatch, label):
+    from totalreclaw.hermes import tools
+    monkeypatch.setattr(tools, "_extraction_provider_label", lambda: label)
+
+
+# ---------------------------------------------------------------------------
+# State field: round-trip + back-compat coercion
+# ---------------------------------------------------------------------------
+
+def test_import_state_roundtrips_disclosure_provider(tmp_path, monkeypatch):
+    _redirect_state_dir(tmp_path, monkeypatch)
+    write_import_state(ImportState(
+        import_id="rt-1", source="chatgpt", status="running",
+        started_at="2026-07-08T00:00:00+00:00", last_updated="x",
+        disclosure_confirmed=True, disclosure_provider="z.ai (GLM)",
+    ))
+    s = read_import_state("rt-1")
+    assert s is not None
+    assert s.disclosure_provider == "z.ai (GLM)"
+
+
+def test_coerce_state_defaults_disclosure_provider_none_for_old_record():
+    """A pre-#418 on-disk record has no disclosure_provider key; loading it
+    must not crash and the field must default to None."""
+    legacy = {
+        "import_id": "old-1", "source": "chatgpt", "status": "completed",
+        "started_at": "2026-01-01T00:00:00+00:00", "last_updated": "x",
+        "disclosure_confirmed": True,
+        # NOTE: no disclosure_provider key — pre-#418 shape
+    }
+    s = _coerce_state(legacy)
+    assert s.disclosure_provider is None
+
+
+# ---------------------------------------------------------------------------
+# Provider drift revokes consent
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_provider_drift_revokes_persisted_consent(tmp_path, monkeypatch):
+    """Consent recorded for provider A must NOT authorize extraction once the
+    current provider is B — the disclosure must re-fire."""
+    _redirect_state_dir(tmp_path, monkeypatch)
+    from totalreclaw.hermes import tools
+    process = _patch_engine(monkeypatch)
+    _patch_provider(monkeypatch, "OpenAI (gpt-4.1)")
+    state = _state_with_tier("pro")
+
+    write_import_state(ImportState(
+        import_id="resume-1", source="chatgpt", status="failed",
+        started_at="2026-07-05T00:00:00+00:00", last_updated="x",
+        disclosure_confirmed=True, disclosure_provider="z.ai (GLM)",
+    ))
+    res = json.loads(await tools.import_from(
+        {"source": "chatgpt", "content": "x", "resume_id": "resume-1"}, state,
+    ))
+    assert res.get("disclosure_required") is True
+    # The re-fired disclosure names the CURRENT provider, not the old one.
+    assert "OpenAI (gpt-4.1)" in res["message"]
+    assert process.await_count == 0  # nothing extracted
+
+
+@pytest.mark.asyncio
+async def test_absent_provider_re_prompts(tmp_path, monkeypatch):
+    """A pre-#418 record (disclosure_provider absent → None) is treated as a
+    mismatch and re-prompts; never silently authorized."""
+    _redirect_state_dir(tmp_path, monkeypatch)
+    from totalreclaw.hermes import tools
+    process = _patch_engine(monkeypatch)
+    _patch_provider(monkeypatch, "z.ai (GLM)")
+    state = _state_with_tier("pro")
+
+    write_import_state(ImportState(
+        import_id="resume-2", source="chatgpt", status="failed",
+        started_at="2026-07-05T00:00:00+00:00", last_updated="x",
+        disclosure_confirmed=True,
+        # disclosure_provider deliberately omitted → None
+    ))
+    res = json.loads(await tools.import_from(
+        {"source": "chatgpt", "content": "x", "resume_id": "resume-2"}, state,
+    ))
+    assert res.get("disclosure_required") is True
+    assert process.await_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Same provider honors consent (no spurious re-prompt)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_same_provider_honors_persisted_consent(tmp_path, monkeypatch):
+    """Consent recorded for provider A, current provider still A → honored,
+    no re-prompt."""
+    _redirect_state_dir(tmp_path, monkeypatch)
+    from totalreclaw.hermes import tools
+    process = _patch_engine(monkeypatch)
+    _patch_provider(monkeypatch, "z.ai (GLM)")
+    state = _state_with_tier("pro")
+
+    write_import_state(ImportState(
+        import_id="resume-3", source="chatgpt", status="failed",
+        started_at="2026-07-05T00:00:00+00:00", last_updated="x",
+        disclosure_confirmed=True, disclosure_provider="z.ai (GLM)",
+    ))
+    res = json.loads(await tools.import_from(
+        {"source": "chatgpt", "content": "x", "resume_id": "resume-3"}, state,
+    ))
+    assert res.get("disclosure_required") is not True
+    assert process.await_count >= 1

--- a/python/tests/test_import_disclosure_and_inputs.py
+++ b/python/tests/test_import_disclosure_and_inputs.py
@@ -131,10 +131,12 @@ async def test_resume_with_prior_consent_skips_disclosure(tmp_path, monkeypatch)
     _patch_provider(monkeypatch)
     state = _state_with_tier("pro")
 
+    # internal#418: consent is honored only when disclosure_provider matches
+    # the CURRENT provider label (here "zai (glm-4.6)" via _patch_provider).
     write_import_state(ImportState(
         import_id="resume-1", source="chatgpt", status="failed",
         started_at="2026-07-05T00:00:00+00:00", last_updated="x",
-        disclosure_confirmed=True,
+        disclosure_confirmed=True, disclosure_provider="zai (glm-4.6)",
     ))
     res = json.loads(await tools.import_from(
         {"source": "chatgpt", "content": "x", "resume_id": "resume-1"}, state,
@@ -330,12 +332,15 @@ async def test_import_batch_honors_persisted_consent(tmp_path, monkeypatch):
     _redirect_state_dir(tmp_path, monkeypatch)
     from totalreclaw.hermes import tools
     process = _patch_engine(monkeypatch)
+    # internal#418: consent is honored only when disclosure_provider matches
+    # the current label, so pin both to the same value here.
+    _patch_provider(monkeypatch)
     state = _state_with_tier("pro")
 
     write_import_state(ImportState(
         import_id="consented", source="chatgpt", status="running",
         started_at="2026-07-05T00:00:00+00:00", last_updated="x",
-        disclosure_confirmed=True,
+        disclosure_confirmed=True, disclosure_provider="zai (glm-4.6)",
     ))
     res = json.loads(await tools.import_batch(
         {"source": "chatgpt", "content": "x", "offset": 0}, state,

--- a/python/tests/test_import_quota_gate_and_notify.py
+++ b/python/tests/test_import_quota_gate_and_notify.py
@@ -225,6 +225,7 @@ async def test_free_tier_is_blocked_with_upgrade_message(monkeypatch):
 async def test_pro_tier_is_not_blocked(tmp_path, monkeypatch):
     _redirect_state_dir(tmp_path, monkeypatch)
     from totalreclaw.hermes import tools
+    monkeypatch.setattr(tools, "_extraction_provider_label", lambda: "z.ai (GLM)")
     called = AsyncMock(return_value=MagicMock(
         facts_stored=3, facts_extracted=3, is_complete=True,
     ))
@@ -233,10 +234,11 @@ async def test_pro_tier_is_not_blocked(tmp_path, monkeypatch):
     state, _client = _state_with_tier("pro")
 
     # rc13 (#421): consent needs the tool-minted token or persisted state.
+    # internal#418: persisted consent must carry the matching provider label.
     write_import_state(ImportState(
         import_id="consent-seed", source="gemini", status="completed",
         started_at="2026-07-05T00:00:00+00:00", last_updated="x",
-        disclosure_confirmed=True, announced=True,
+        disclosure_confirmed=True, announced=True, disclosure_provider="z.ai (GLM)",
     ))
     res = json.loads(await tools.import_from(
         {"source": "gemini", "content": "x"}, state,
@@ -249,6 +251,7 @@ async def test_pro_tier_is_not_blocked(tmp_path, monkeypatch):
 async def test_billing_unreachable_fails_open(tmp_path, monkeypatch):
     _redirect_state_dir(tmp_path, monkeypatch)
     from totalreclaw.hermes import tools
+    monkeypatch.setattr(tools, "_extraction_provider_label", lambda: "z.ai (GLM)")
     called = AsyncMock(return_value=MagicMock(
         facts_stored=1, facts_extracted=1, is_complete=True,
     ))
@@ -258,7 +261,7 @@ async def test_billing_unreachable_fails_open(tmp_path, monkeypatch):
     write_import_state(ImportState(
         import_id="consent-seed", source="gemini", status="completed",
         started_at="2026-07-05T00:00:00+00:00", last_updated="x",
-        disclosure_confirmed=True, announced=True,
+        disclosure_confirmed=True, announced=True, disclosure_provider="z.ai (GLM)",
     ))
     res = json.loads(await tools.import_from(
         {"source": "gemini", "content": "x"}, state,

--- a/python/tests/test_rc13_import_wave.py
+++ b/python/tests/test_rc13_import_wave.py
@@ -207,12 +207,13 @@ async def test_import_batch_writes_state_for_import_status(tmp_path, monkeypatch
     _redirect_state_dir(tmp_path, monkeypatch)
     from totalreclaw.hermes import tools
     _patch_engine(monkeypatch)
+    _patch_provider(monkeypatch)
     state = _state_with_tier("pro")
 
     write_import_state(ImportState(
         import_id="consented", source="chatgpt", status="running",
         started_at="2026-07-05T00:00:00+00:00", last_updated="x",
-        disclosure_confirmed=True,
+        disclosure_confirmed=True, disclosure_provider="zai (glm-4.6)",
     ))
     await tools.import_batch(
         {"source": "chatgpt", "file_path": "/tmp/e.zip", "offset": 0}, state,

--- a/python/tests/test_rc13_import_wave.py
+++ b/python/tests/test_rc13_import_wave.py
@@ -153,7 +153,7 @@ async def test_persisted_consent_still_skips_disclosure(tmp_path, monkeypatch):
     write_import_state(ImportState(
         import_id="resume-1", source="chatgpt", status="failed",
         started_at="2026-07-05T00:00:00+00:00", last_updated="x",
-        disclosure_confirmed=True,
+        disclosure_confirmed=True, disclosure_provider="zai (glm-4.6)",
     ))
     res = json.loads(await tools.import_from(
         {"source": "chatgpt", "content": "x", "resume_id": "resume-1"}, state,
@@ -227,12 +227,13 @@ async def test_import_batch_enforces_pro_gate(tmp_path, monkeypatch):
     _redirect_state_dir(tmp_path, monkeypatch)
     from totalreclaw.hermes import tools
     process = _patch_engine(monkeypatch)
+    _patch_provider(monkeypatch)
     state = _state_with_tier("free")
 
     write_import_state(ImportState(
         import_id="consented", source="chatgpt", status="running",
         started_at="2026-07-05T00:00:00+00:00", last_updated="x",
-        disclosure_confirmed=True,
+        disclosure_confirmed=True, disclosure_provider="zai (glm-4.6)",
     ))
     res = json.loads(await tools.import_batch(
         {"source": "chatgpt", "content": "x", "offset": 0}, state,
@@ -246,6 +247,7 @@ async def test_import_batch_fails_open_when_billing_unreachable(tmp_path, monkey
     _redirect_state_dir(tmp_path, monkeypatch)
     from totalreclaw.hermes import tools
     process = _patch_engine(monkeypatch)
+    _patch_provider(monkeypatch)
     from totalreclaw.hermes.state import PluginState
     state = PluginState()
     client = MagicMock()
@@ -255,7 +257,7 @@ async def test_import_batch_fails_open_when_billing_unreachable(tmp_path, monkey
     write_import_state(ImportState(
         import_id="consented", source="chatgpt", status="running",
         started_at="2026-07-05T00:00:00+00:00", last_updated="x",
-        disclosure_confirmed=True,
+        disclosure_confirmed=True, disclosure_provider="zai (glm-4.6)",
     ))
     res = json.loads(await tools.import_batch(
         {"source": "chatgpt", "content": "x", "offset": 0}, state,

--- a/python/tests/test_rc6_consent_scan.py
+++ b/python/tests/test_rc6_consent_scan.py
@@ -38,6 +38,13 @@ def _write_registry(source="chatgpt", ids=("c1", "c2")):
     record_imported_conversations(source, list(ids))
 
 
+def _pin_provider(monkeypatch, label="z.ai (GLM)"):
+    # internal#418: persisted consent is honored only when disclosure_provider
+    # matches the current label — pin both in tests that write consent.
+    monkeypatch.setattr(tools, "_extraction_provider_label", lambda: label)
+    return label
+
+
 def _state_with_tier(tier="pro"):
     from totalreclaw.hermes.state import PluginState
     state = PluginState()
@@ -57,20 +64,22 @@ def test_prior_consent_with_registry_present_does_not_crash(tmp_path, monkeypatc
 
 def test_prior_consent_finds_real_record_despite_registry(tmp_path, monkeypatch):
     _redirect(tmp_path, monkeypatch)
+    label = _pin_provider(monkeypatch)
     write_import_state(ImportState(
         import_id="s1", source="chatgpt", status="failed",
         started_at="2026-07-06T00:00:00+00:00", last_updated="x",
-        disclosure_confirmed=True))
+        disclosure_confirmed=True, disclosure_provider=label))
     _write_registry("chatgpt")
     assert tools._prior_disclosure_consent("chatgpt") is True
 
 
 def test_disclosure_consent_ok_with_registry_present(tmp_path, monkeypatch):
     _redirect(tmp_path, monkeypatch)
+    label = _pin_provider(monkeypatch)
     write_import_state(ImportState(
         import_id="s2", source="chatgpt", status="running",
         started_at="2026-07-06T00:00:00+00:00", last_updated="x",
-        disclosure_confirmed=True))
+        disclosure_confirmed=True, disclosure_provider=label))
     _write_registry("chatgpt")
     assert tools._disclosure_consent_ok("chatgpt", {}) is True
 
@@ -131,10 +140,11 @@ async def test_two_batch_import_proceeds_after_registry_written(tmp_path, monkey
     import totalreclaw.import_engine as ie
 
     # Prior consent so import_batch's disclosure gate is satisfied.
+    label = _pin_provider(monkeypatch)
     write_import_state(ImportState(
         import_id="batch-src", source="chatgpt", status="running",
         started_at="2026-07-06T00:00:00+00:00", last_updated="x",
-        disclosure_confirmed=True))
+        disclosure_confirmed=True, disclosure_provider=label))
 
     calls = {"n": 0}
 

--- a/python/tests/test_tools_helpers.py
+++ b/python/tests/test_tools_helpers.py
@@ -204,11 +204,14 @@ class TestDisclosureConsentOk:
             {"disclosure_confirmed": True, "disclosure_token": "notarealtoken12"},
         ) is False
 
-    def test_prior_persisted_consent_short_circuits(self, state_dir):
+    def test_prior_persisted_consent_short_circuits(self, state_dir, monkeypatch):
         # A persisted ImportState with disclosure_confirmed makes the
         # import_from -> import_batch loop skip the re-prompt.
+        # internal#418: the persisted consent must carry the SAME provider
+        # label as the current one to be honored.
         from totalreclaw.imports import state as ist
 
+        monkeypatch.setattr(tools, "_extraction_provider_label", lambda: "z.ai (GLM)")
         st = ist.ImportState(
             import_id="imp-1",
             source="chatgpt",
@@ -216,6 +219,7 @@ class TestDisclosureConsentOk:
             started_at="2026-07-07T00:00:00Z",
             last_updated="2026-07-07T00:00:00Z",
             disclosure_confirmed=True,
+            disclosure_provider="z.ai (GLM)",
         )
         ist.write_import_state(st)
         assert tools._disclosure_consent_ok("chatgpt", {}, resume_id="imp-1") is True


### PR DESCRIPTION
Closes p-diogo/totalreclaw-internal#418.

## Problem
Persisted import-disclosure consent (`ImportState.disclosure_confirmed`) did not record **which** LLM provider was disclosed to the user. A user who consented while extraction ran on provider A, then switched Hermes to provider B, had their old consent silently authorize B — and consent never expired. The disclosure exists so the user knows which LLM will read their conversations in cleartext; a silent provider swap defeats it.

## Change (message-level + one state field only)
- **`imports/state.py`**: add `ImportState.disclosure_provider: Optional[str] = None`. The existing tolerant `_coerce_state` loader (filters unknown keys; the field carries a default) means pre-#418 on-disk records load with `None` — **no migration, no crash on coercion**.
- **`hermes/import_tools.py`**:
  - `_prior_disclosure_consent()` resolves the **current** `_extraction_provider_label()` (routed through the `tools` dispatch module so the test suite's `setattr(tools, "_extraction_provider_label", …)` patches remain authoritative) and honors a persisted consent **only** when its `disclosure_provider` equals the current label. Absent/`None` (pre-#418 record) → treated as mismatch → re-prompt once (safe direction: never silently authorize).
  - New `_current_disclosure_provider()` helper; the three consent-writing sites (`_run_small_import`, `_spawn_background_import`, `import_batch` bookkeeping) stamp it, so a fresh post-switch consent records the new provider.

The token handshake, verbatim-relay disclosure message, and the `disclosure_required` response field shape agents depend on are **unchanged**.

## Did not touch
Store path / byte-capping (`_store_group_adaptive`, `_group_payloads_by_size`, `_estimate_payload_bytes`), #436 registry writers, deploy-state/nonce logic, key-derivation / mnemonic / pairing crypto.

## Optional max-age — SKIPPED
A consent max-age needs a dedicated timestamp field (`last_updated` mutates constantly through an import, so it can't anchor the age), plus a new constant, plus checks at the three write sites and the consent reader. The TTL machinery in `consent_tokens.py` is fixed at 1h (`TOKEN_TTL_S`) for one-time tokens — far too short for persisted import consent, where a same-provider resume a day later should *not* re-prompt. It can't be reused cleanly, so a max-age is a separate axis with its own larger constant. Per "do not over-build," skipped; flagged here for a follow-up if wanted.

## Tests
TDD: failing tests committed first (`cbe9073`), then implementation (`13d0eb8`).

New file `tests/test_imp418_provider_drift.py` — **5 tests**:
1. ImportState round-trips `disclosure_provider` (write → read).
2. `_coerce_state` defaults the field to `None` for a pre-#418 record (no crash).
3. Provider drift (recorded A, current B) → consent revoked, disclosure re-fires naming the **current** provider, nothing extracted.
4. Absent provider (pre-#418 record) → re-prompts once, nothing extracted.
5. Same provider both times → consent honored, extraction proceeds.

Updated 4 existing tests across `test_import_disclosure_and_inputs.py`, `test_rc13_import_wave.py`, `test_rc6_consent_scan.py`, `test_tools_helpers.py`, `test_import_quota_gate_and_notify.py` that wrote persisted consent without a provider — they encoded the old (now-fixed) unsafe behavior and now stamp the matching provider, reflecting the new contract.

**Full suite: 2134 passed, 39 skipped, 1 xfailed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)