### PR TITLE
test(plugin): deterministic timing in pair-cli test — de-flake (#479)

### DIFF
--- a/skill/plugin/pairing/pair-cli.test.ts
+++ b/skill/plugin/pairing/pair-cli.test.ts
@@ -99,6 +99,43 @@ async function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
+/**
+ * Deterministic ordering primitives.
+ *
+ * The pair-cli poll loop runs on real timers (interval clamped to 500ms
+ * inside runPairCli) and its side effects — writing the session file,
+ * emitting a status line — land asynchronously. Sleeping a fixed number of
+ * ms and then asserting the side effect happened races the loop: under a
+ * busy CI runner the loop's first tick can slip past the window, so the
+ * intermediate `device_connected` state is overwritten before any tick
+ * observes it (the #479 flake). These helpers wait for the ACTUAL event
+ * instead of guessing a duration; the deadline is only a loud-failure
+ * safety net, never the correctness mechanism.
+ */
+async function waitForSession(sessionsPath: string, deadlineMs = 5000): Promise<PairSession> {
+  const start = Date.now();
+  for (;;) {
+    try {
+      const raw = JSON.parse(fs.readFileSync(sessionsPath, 'utf-8')) as { sessions: PairSession[] };
+      if (raw.sessions && raw.sessions.length > 0) return raw.sessions[0];
+    } catch { /* file not written yet — keep waiting */ }
+    if (Date.now() - start > deadlineMs) {
+      throw new Error(`waitForSession: no session at ${sessionsPath} within ${deadlineMs}ms`);
+    }
+    await sleep(10);
+  }
+}
+
+async function waitForOutput(stream: CaptureStream, needle: string, deadlineMs = 5000): Promise<void> {
+  const start = Date.now();
+  while (!stream.text().includes(needle)) {
+    if (Date.now() - start > deadlineMs) {
+      throw new Error(`waitForOutput: ${JSON.stringify(needle)} not emitted within ${deadlineMs}ms`);
+    }
+    await sleep(10);
+  }
+}
+
 async function main(): Promise<void> {
   // =====================================================================
   // 1-3. Intro copy + QR renderer
@@ -165,8 +202,14 @@ async function main(): Promise<void> {
 
   // =====================================================================
   // 5. Transition: device_connected shows "Browser connected"
-  //    (We use longer delays to guarantee the poll loop observes the
-  //    intermediate state before the terminal flip.)
+  //    Deterministic ordering — no fixed sleeps. We flip to
+  //    `device_connected` and hold there until the poll loop has actually
+  //    emitted "Browser connected", THEN flip to `completed`. Because the
+  //    terminal flip is gated on the observed intermediate output rather
+  //    than a guessed duration, the loop can never race past the
+  //    intermediate state, however slow its first tick is under CI load
+  //    (the #479 flake). The waiter deadline only fails the test loudly if
+  //    the loop never emits at all.
   // =====================================================================
   {
     const tmp = mkTmp();
@@ -179,11 +222,10 @@ async function main(): Promise<void> {
       pollIntervalMs: 30,
       io: io.io,
     });
-    await sleep(200);
-    const raw = JSON.parse(fs.readFileSync(sp, 'utf-8')) as { sessions: PairSession[] };
-    await transitionPairSession(sp, raw.sessions[0].sid, 'device_connected');
-    await sleep(300); // plenty of polls at 30ms each
-    await transitionPairSession(sp, raw.sessions[0].sid, 'completed');
+    const sess = await waitForSession(sp);
+    await transitionPairSession(sp, sess.sid, 'device_connected');
+    await waitForOutput(io.stdout, 'Browser connected');
+    await transitionPairSession(sp, sess.sid, 'completed');
     await p;
     const text = io.stdout.text();
     assert(text.includes('Browser connected'), 'transitions: Browser connected emitted');


### PR DESCRIPTION
## Flake root cause

`pairing/pair-cli.test.ts` block 5 (`transitions: Browser connected emitted`, `not ok 10`) raced the CLI's poll loop with wall-clock sleeps:

```
runPairCli(... pollIntervalMs: 30 ...)   // clamped to 500ms inside runPairCli
await sleep(200);  transition → device_connected
await sleep(300);  transition → completed   // ← fires at test-t≈500ms
```

The poll loop's first tick only starts **after** session creation + QR render + intro writes complete, and the interval is clamped to 500ms (`Math.max(500, …)`). So the first tick lands at `startup + 500ms`. On a busy CI runner, startup is non-zero, pushing the first tick past the `completed` transition — the loop then reads `completed` directly and never observes the intermediate `device_connected`, so `"Browser connected"` is never emitted and the assertion fails. Passes on idle machines because startup ≈ 0 keeps the tick just inside the window.

Reproduced deterministically by delaying the QR callback ~450ms (simulating slow startup): the old logic prints no `"Browser connected"`; `device_connected` is overwritten before any tick sees it.

## The deterministic replacement

No looser tolerance, no `.skip`, assertion unchanged. Instead of guessing a duration, the test now **gates the terminal `completed` flip on the observed intermediate output**:

1. `waitForSession(sp)` — wait for the session file to actually exist (replaces `sleep(200)`).
2. Flip to `device_connected` and **hold** there.
3. `waitForOutput(io.stdout, 'Browser connected')` — wait until the poll loop has actually emitted the intermediate line.
4. Only then flip to `completed`.

Because the loop cannot advance to `completed` until it has already emitted `"Browser connected"`, it can never race past the intermediate state, however slow its first tick is. The waiter deadlines (5s) are a loud-failure safety net, not the correctness mechanism. Two small test-only helpers added next to the existing `sleep` — no production change.

Same slow-startup injection that broke the old logic now PASSES with the new gating.

## Verification

- **30-run loop** (`for i in $(seq 1 30); do npx tsx pairing/pair-cli.test.ts …; done`): **0 fails**.
- Deterministic repro (450ms slow-startup): old logic FAIL → new logic PASS.
- `npm run check-scanner`: **0 flags** (163 files). No `post`/`fetch`/`http.request` token introduced (the file already contains `readFileSync`, so rule 2 would fire otherwise).
- Full plugin suite via the glob runner (`npm test`): **89/89 passed**.

Test-only change — no production seam required. Phrase/crypto handling untouched.

closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EDaj45174CK3TbdGytDDD