### PR TITLE
ci: drop transitional WASM core-build step — consume @totalreclaw/core from npm (#489)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,15 +60,6 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: 'v0.14.0'
-      - name: Build @totalreclaw/core (WASM) [transitional]
-        run: |
-          cd rust/totalreclaw-core
-          wasm-pack build --target nodejs --out-dir pkg --features wasm
-          node -e "const p=require('./pkg/package.json'); p.name='@totalreclaw/core'; require('fs').writeFileSync('./pkg/package.json', JSON.stringify(p,null,2)+'\n')"
       - uses: actions/setup-node@v5
         with:
           node-version: '22'
@@ -199,25 +190,8 @@ jobs:
       ONNXRUNTIME_NODE_INSTALL_CUDA: skip
     steps:
       - uses: actions/checkout@v5
-      # NOTE: The `mcp` package now depends on `@totalreclaw/core@^2.0.0` from
-      # npm (previously a `file:` dep against the local wasm-pack output). The
-      # local WASM build below is now dead code — `npm install` resolves core
-      # from the registry, never from the local `pkg/` directory. It is kept
-      # transitionally so this job continues to green out on branches that
-      # still carry the old `file:` dep. Once `@totalreclaw/core@2.x` is live
-      # on npm AND no branch references the `file:` dep, the
-      # `dtolnay/rust-toolchain`, `wasm-pack-action`, and
-      # `Build @totalreclaw/core (WASM)` steps can be removed in a cleanup PR.
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: 'v0.14.0'  # pinned to stop `latest`-tag flake; v0.9.1 lacks --features
-      - name: Build @totalreclaw/core (WASM) [transitional — safe to drop once core@2.x is on npm]
-        run: |
-          cd rust/totalreclaw-core
-          wasm-pack build --target nodejs --out-dir pkg --features wasm
-          # wasm-pack emits package name "totalreclaw-core"; consumers expect "@totalreclaw/core"
-          node -e "const p=require('./pkg/package.json'); p.name='@totalreclaw/core'; require('fs').writeFileSync('./pkg/package.json', JSON.stringify(p,null,2)+'\n')"
+      # `mcp` depends on `@totalreclaw/core@^2.5.x` from npm — `npm install`
+      # resolves it from the registry, so no local WASM build is needed here.
       - uses: actions/setup-node@v5
         with:
           node-version: '22'

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -207,25 +207,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: 'v0.14.0'  # pinned to stop `latest`-tag flake; v0.9.1 lacks --features
-
-      # NOTE: `mcp/package.json` used to depend on `@totalreclaw/core` via a
-      # `file:` dep, which required building the WASM pkg locally. It now
-      # depends on `@totalreclaw/core@^2.0.0` from npm, which the
-      # `publish-core` job above already published. This step is therefore
-      # dead code and can be removed in a cleanup PR once no branch carries
-      # the old `file:` dep.
-      - name: "Build @totalreclaw/core (WASM) [transitional — safe to drop]"
-        run: |
-          cd rust/totalreclaw-core
-          wasm-pack build --target nodejs --out-dir pkg --features wasm
-          # wasm-pack emits package name "totalreclaw-core"; historically mcp consumed it as "@totalreclaw/core" via file: dep
-          node -e "const p=require('./pkg/package.json'); p.name='@totalreclaw/core'; require('fs').writeFileSync('./pkg/package.json', JSON.stringify(p,null,2)+'\n')"
-
+      # `mcp/package.json` depends on `@totalreclaw/core@^2.5.x` from npm,
+      # which the `publish-core` job above already published. `npm install`
+      # resolves it from the registry — no local WASM build is needed.
       - uses: actions/setup-node@v5
         with:
           node-version: '22'


### PR DESCRIPTION
Fixes #489.

## The flake
The transitional **"Build @totalreclaw/core (WASM)"** CI step downloaded `wasm-pack` + `binaryen` from GitHub CDNs at build time and flaked (404 / 504 / timeout), failing jobs **before their real checks ran** — it caused 4 red jobs across PRs #487/#488 on 2026-07-09.

## The drop (coordinator decision)
Don't retry-harden a step we don't need. `@totalreclaw/core` is published on npm at **2.5.5**, and every consuming package already depends on it via a semver range (`mcp` `^2.5.3`, `skill/plugin` `^2.5.3`), so `npm install` resolves core **from the registry**. The old `file:` dep that the local WASM build once served is long gone, making the build **pure dead code**.

Dropped the step (and its now-unused `dtolnay/rust-toolchain` / `jetli/wasm-pack-action` setup where it served only this build) from:

- **ci.yml `Phrase Safety`** — built `mcp/dist` for the dist scan; mcp resolves core from npm, so the local build was unused.
- **ci.yml `MCP Server Tests`** — the step was already labelled transitional dead code.
- **npm-publish.yml `publish-mcp-server`** — same `[transitional — safe to drop]` step; `publish-core` already publishes core to npm *before* this job runs, and mcp's `^2.5.3` range resolves it.

## Deliberately kept
- **ci.yml `Cross-Language Parity Tests`** — the parity test loads `rust/totalreclaw-core/pkg/totalreclaw_core.js` **directly** via `createRequire`; it genuinely needs a fresh local WASM build.
- **npm-publish.yml `publish-core`** — that job's whole purpose is to build + publish the WASM pkg.

`Rust Core Tests` and `rust/` source are untouched — this is CI + dependency-resolution only, no runtime behaviour change.

## Version-consistency note
Any lockstep concern is covered by the pinned npm version (`@totalreclaw/core@^2.5.x`): CI now tests against the **exact published core** that clients ship against, rather than a from-source WASM build that could drift from the registry artifact.

## Verification (local, core resolved from npm 2.5.5)
- `cd mcp && npm ci-equivalent && npm run build && npm test` → **679/679 tests pass**, build clean.
- `cd skill/plugin && npm install && npm test` → **89/89 test files pass**.
- Grep confirms zero remaining `wasm-pack`/`binaryen` references in the touched jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EDaj45174CK3TbdGytDDD