### PR TITLE
release(mcp): @totalreclaw/mcp-server 3.4.0 — #439 chain fix + dispatch restructure

### DIFF
--- a/CHANGELOG-public.md
+++ b/CHANGELOG-public.md
@@ -2,6 +2,10 @@
 
 > **Note:** This file lists releases promoted to the public registries' stable tags. Active release-candidate work (`@rc` dist-tag on npm, `rcN` on PyPI, etc.) is tracked in the internal release-pipeline tracker, not here.
 
+## @totalreclaw/mcp-server 3.4.0 — Stable release (2026-07-09)
+
+MCP server minor. **Fix:** managed-service writes now consume the relay's billing `chain_id` + `data_edge_address` verbatim (#439) — previously every managed write fell through to a retired default chain + the production DataEdge, breaking staging testability and client-consistency; staging write→read E2E validated. **Restructure:** unified data-driven tool-dispatch table + shared `ToolContext`; `memory_id` is now the canonical id param (`fact_id` kept as alias). **Removed:** the long-deprecated, non-functional `totalreclaw_migrate` tool (minor, not major — no working call site lost it). See `mcp/CHANGELOG.md` for detail.
+
 ## totalreclaw 2.4.4 — Stable promote (2026-06-06)
 
 Hermes client stable line (Python `totalreclaw` 2.3.1 → 2.4.4). This cycle focused on the Hermes integration and the managed service's move to a single chain. (OpenClaw plugin + MCP server are unchanged this cycle.)

--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [3.4.0] - 2026-07-09
+
+Minor release. Bundles the code-health restructure (from the repo-wide desloppify sweep) with the #439 managed-service chain/DataEdge correctness fix. Minor, not major, despite a tool removal — the removed tool was already deprecated + non-functional (see Removed).
+
+### Fixed
+- **[#439] Managed-service writes now consume the relay's billing `chain_id` + `data_edge_address` verbatim.** Previously EVERY managed-mode write (free **and** pro) fell through to the `getSubgraphConfig` default of chain `84532` (Base Sepolia, retired at ops-1) and the **production** DataEdge `0xC445…` — the tier→`chainId=100` flip was dead code, never threaded into the write config. On the staging relay this meant writes landed on the prod DataEdge and were invisible on the staging subgraph; more broadly it was a client-consistency violation vs the Python client + OpenClaw plugin. New `src/subgraph/chain-config.ts` (`resolveChainConfig` / `buildSubgraphOverrides`) resolves both fields from `/v1/billing/status`, carries them on `SubgraphState`, and threads them into all 5 managed-write sites via `stateWriteOverrides`. Default chain flipped `84532 → 100`. The `TOTALRECLAW_DATA_EDGE_ADDRESS` env override still wins over billing. Validated by a staging write→read E2E: a fresh account's write hit the **staging** DataEdge `0xE7a4D2…` (on-chain receipt), indexed on the staging subgraph, recalled back. Sibling of plugin `#402` (chain_id) + `#460` (data_edge_address).
+
+### Changed
+- **Tool dispatch unified into a single data-driven table** (`src/dispatch.ts` + `src/server-setup.ts`). The two parallel self-hosted/managed `switch` statements + per-tool glue are replaced by one router: `TOOL_MANIFEST` (mode-independent tool list), `SUBGRAPH_POLICY` / `HTTP_POLICY` (per-(tool, mode) cross-cutting behaviour as data), and `createCallToolHandler` with handlers injected as pre-bound bundles. Routing order preserved verbatim; behaviour-preserving.
+- **`memory_id` is the canonical id parameter** for pin/unpin/retype/set-scope; `fact_id` is kept as a back-compat alias so existing callers don't break.
+- Handlers take a shared `ToolContext` (dependency-injection bundle) instead of per-handler positional/options variance.
+- Domain restructure: crypto/subgraph/extraction/tools split into subdirectories; several helpers de-async'd where they never awaited.
+
+### Removed
+- **`totalreclaw_migrate` tool deleted.** It was already marked `[DEPRECATED] INVOKE WHEN: never` and was non-functional (the legacy cross-chain migration path it wrapped was retired with single-chain ops-1). No working call site loses functionality — hence a **minor**, not a major, bump. Stale catalogs that still reference it get the standard tool-removed error envelope.
+
 ## [3.2.1] - 2026-04-26
 
 ### Security

--- a/mcp/SKILL.md
+++ b/mcp/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "End-to-end encrypted, decentralized memory for OpenClaw via the totalreclaw MCP server. Set up an account once, then call totalreclaw__totalreclaw_remember and totalreclaw__totalreclaw_recall instead of writing to MEMORY.md / USER.md / local files. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', or any user statement that contains a preference / fact / decision / commitment about themselves."
-version: 3.3.0
+version: 3.4.0
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/mcp-server",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. MCP server with XChaCha20-Poly1305 E2EE, semantic search, import/export, and on-chain storage",
   "homepage": "https://totalreclaw.xyz",
   "main": "dist/index.js",


### PR DESCRIPTION
Prepares `@totalreclaw/mcp-server` 3.4.0 (stable). **Coordinator-approved** republish bundling the desloppify MCP restructure + the #439 chain/DataEdge fix (its staging write→read E2E is already GREEN — verdict on #487).

**Version:** 3.3.0 (unpublished in-dev) → **3.4.0**. npm latest is currently 3.2.1; this is the first publish since. Minor, not major, despite the tool removal — the removed `totalreclaw_migrate` was already `[DEPRECATED] INVOKE WHEN: never` and non-functional (see changelog).

**Contents (delta since 3.2.1):**
- **Fixed #439** — managed writes consume billing `chain_id` + `data_edge_address` verbatim (all 5 write sites; default chain 84532→100; env override still wins). Pre-fix every managed write hit chain 84532 + the prod DataEdge. Staging E2E: fresh account wrote to the STAGING DataEdge `0xE7a4D2…` (on-chain receipt), indexed + recalled.
- **Restructure** — single data-driven dispatch table (`dispatch.ts`/`server-setup.ts`) + shared `ToolContext`; `memory_id` canonical with `fact_id` alias; domain subdir split; de-async'd helpers.
- **Removed** — deprecated/non-functional `totalreclaw_migrate`.

**Gates:** version-drift guard green (SKILL.md ↔ package.json both 3.4.0); local `npm ci && build && test` with core resolved from npm → **679/679, 36 suites**. On merge: dispatch `npm-publish.yml package=mcp-server release-type=stable`, then `verify-publish.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EDaj45174CK3TbdGytDDD