### PR TITLE
ci: pin npm@11 for OIDC provenance publish (npm 12.0.0 breaks --provenance)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -103,7 +103,9 @@ jobs:
         # legacy token → E404 after NPM_TOKEN expired (the 2026-06-07 core run).
         # Tokenless OIDC (the OIDC token IS the auth) needs npm >= 11.5.1.
         run: |
-          npm install -g npm@latest
+          # Pinned to npm@11 — npm 12.0.0 (latest as of 2026-07-09) ships a broken
+          # --provenance path (Cannot find module 'sigstore'). 11.x publishes fine.
+          npm install -g npm@11
           npm --version
 
       - name: Publish
@@ -246,7 +248,9 @@ jobs:
         # signed sigstore provenance successfully but the PUT 404'd
         # (2026-05-24 run 26374302750).
         run: |
-          npm install -g npm@latest
+          # Pinned to npm@11 — npm 12.0.0 (latest as of 2026-07-09) ships a broken
+          # --provenance path (Cannot find module 'sigstore'). 11.x publishes fine.
+          npm install -g npm@11
           npm --version
 
       - name: Publish
@@ -459,7 +463,9 @@ jobs:
         # Tokenless OIDC (the OIDC token IS the auth) needs npm >= 11.5.1.
         # Mirrors publish-core / publish-mcp-server (migrated off NPM_TOKEN).
         run: |
-          npm install -g npm@latest
+          # Pinned to npm@11 — npm 12.0.0 (latest as of 2026-07-09) ships a broken
+          # --provenance path (Cannot find module 'sigstore'). 11.x publishes fine.
+          npm install -g npm@11
           npm --version
 
       - name: Publish


### PR DESCRIPTION
**Blocker:** the `@totalreclaw/mcp-server` 3.4.0 stable publish (run 29047042668) failed at `npm publish --provenance` with `npm error code MODULE_NOT_FOUND: Cannot find module 'sigstore'`. Build + all 679 tests passed — the failure is purely npm tooling.

**Root cause:** `npm@12.0.0` became `latest` on 2026-07-09; its provenance signing path can't resolve `sigstore`. The workflow's `npm install -g npm@latest` therefore pulls a publish-broken npm. (npm 11.x publishes provenance fine — the OpenClaw plugin rc.20→rc.23 shipped on it days ago via this same workflow.)

**Fix:** pin all 3 publish steps (`publish-core`, `publish-mcp-server`, `publish-plugin` regions) to `npm@11`. Unblocks every package's publish, not just mcp-server. Revisit to `@latest` once npm 12.x fixes the provenance regression.

After merge: re-dispatch `npm-publish package=mcp-server release-type=stable` to ship 3.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EDaj45174CK3TbdGytDDD