### PR TITLE
ci: npm-publish greens on already-published version (rc-number defaults to 1 → silent no-op)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -97,6 +97,23 @@ jobs:
           console.log('RC version:', p.version);
           "
 
+      - name: Guard — refuse to republish an existing version
+        if: inputs.dry-run == false
+        # #456: an omitted `rc-number` silently defaulted to 1, republished
+        # an already-existing rc.1, and the "tolerate already published"
+        # catch in the Publish step below let the job conclude success. Fail
+        # BEFORE we ever attempt the publish so a stale/duplicate version is
+        # loud, not a silent no-op.
+        run: |
+          cd rust/totalreclaw-core/pkg
+          NAME=$(node -e "console.log(require('./package.json').name)")
+          VERSION=$(node -e "console.log(require('./package.json').version)")
+          if npm view "$NAME@$VERSION" version >/dev/null 2>&1; then
+            echo "ERROR: $NAME@$VERSION already published — refusing to republish (bump the version or rc-number)."
+            exit 1
+          fi
+          echo "OK: $NAME@$VERSION not yet published, proceeding"
+
       - name: Upgrade npm to latest (required for tokenless OIDC publish)
         if: inputs.dry-run == false
         # npm 10.x (Node 22) signs provenance with OIDC but still PUTs with a
@@ -177,6 +194,22 @@ jobs:
           console.log('RC version:', p.version);
           "
 
+      - name: Guard — refuse to republish an existing version
+        if: inputs.dry-run == false
+        # #456: an omitted `rc-number` silently defaulted to 1, republished
+        # an already-existing rc.1, and the job still concluded success.
+        # Fail BEFORE we ever attempt the publish so a stale/duplicate
+        # version is loud, not a silent no-op.
+        run: |
+          cd client
+          NAME=$(node -e "console.log(require('./package.json').name)")
+          VERSION=$(node -e "console.log(require('./package.json').version)")
+          if npm view "$NAME@$VERSION" version >/dev/null 2>&1; then
+            echo "ERROR: $NAME@$VERSION already published — refusing to republish (bump the version or rc-number)."
+            exit 1
+          fi
+          echo "OK: $NAME@$VERSION not yet published, proceeding"
+
       - name: Publish
         if: inputs.dry-run == false
         run: |
@@ -238,6 +271,22 @@ jobs:
           fs.writeFileSync('./package.json', JSON.stringify(p, null, 2) + '\n');
           console.log('RC version:', p.version);
           "
+
+      - name: Guard — refuse to republish an existing version
+        if: inputs.dry-run == false
+        # #456: an omitted `rc-number` silently defaulted to 1, republished
+        # an already-existing rc.1, and the job still concluded success.
+        # Fail BEFORE we ever attempt the publish so a stale/duplicate
+        # version is loud, not a silent no-op.
+        run: |
+          cd mcp
+          NAME=$(node -e "console.log(require('./package.json').name)")
+          VERSION=$(node -e "console.log(require('./package.json').version)")
+          if npm view "$NAME@$VERSION" version >/dev/null 2>&1; then
+            echo "ERROR: $NAME@$VERSION already published — refusing to republish (bump the version or rc-number)."
+            exit 1
+          fi
+          echo "OK: $NAME@$VERSION not yet published, proceeding"
 
       - name: Upgrade npm to latest (required for tokenless OIDC publish)
         if: inputs.dry-run == false
@@ -316,6 +365,23 @@ jobs:
           fs.writeFileSync('./package.json', JSON.stringify(p, null, 2) + '\n');
           console.log('RC version:', p.version);
           "
+
+      - name: Guard — refuse to republish an existing version
+        if: inputs.dry-run == false
+        # #456: an omitted `rc-number` silently defaulted to 1, republished
+        # an already-existing rc.1, and the "tolerate already published"
+        # catch in the Publish step below let the job conclude success. Fail
+        # BEFORE we ever attempt the publish so a stale/duplicate version is
+        # loud, not a silent no-op.
+        run: |
+          cd skill-nanoclaw
+          NAME=$(node -e "console.log(require('./package.json').name)")
+          VERSION=$(node -e "console.log(require('./package.json').version)")
+          if npm view "$NAME@$VERSION" version >/dev/null 2>&1; then
+            echo "ERROR: $NAME@$VERSION already published — refusing to republish (bump the version or rc-number)."
+            exit 1
+          fi
+          echo "OK: $NAME@$VERSION not yet published, proceeding"
 
       - name: Publish
         if: inputs.dry-run == false
@@ -455,6 +521,23 @@ jobs:
           cd skill/plugin
           node ../scripts/sync-version.mjs
           node ../scripts/check-version-drift.mjs
+
+      - name: Guard — refuse to republish an existing version
+        if: inputs.dry-run == false
+        # #456: an omitted `rc-number` silently defaulted to 1, republished
+        # an already-existing rc.1, and the "tolerate already published"
+        # catch in the Publish step below let the job conclude success. Fail
+        # BEFORE we ever attempt the publish so a stale/duplicate version is
+        # loud, not a silent no-op.
+        run: |
+          cd skill/plugin
+          NAME=$(node -e "console.log(require('./package.json').name)")
+          VERSION=$(node -e "console.log(require('./package.json').version)")
+          if npm view "$NAME@$VERSION" version >/dev/null 2>&1; then
+            echo "ERROR: $NAME@$VERSION already published — refusing to republish (bump the version or rc-number)."
+            exit 1
+          fi
+          echo "OK: $NAME@$VERSION not yet published, proceeding"
 
       - name: Upgrade npm to latest (required for tokenless OIDC publish)
         if: inputs.dry-run == false


### PR DESCRIPTION
## Summary
- Adds a "Guard — refuse to republish an existing version" step to every `npm publish` job in `.github/workflows/npm-publish.yml` (core, client, mcp-server, nanoclaw, plugin).
- Each guard runs a pre-publish `npm view <pkg>@<version> version` check on the exact version that job is about to publish (read from the same `package.json` the subsequent `npm publish` step uses, after the RC-suffix mutation step has run). If the version already exists on the registry, the job fails loudly with `ERROR: <pkg>@<version> already published — refusing to republish (bump the version or rc-number).` before ever reaching the publish step.
- Guard is skipped when `dry-run == true`.
- Style mirrors the existing "Check npm RCs exist" guard in `promote-rc.yml`.

Fixes the rc.20 incident: dispatching with `release-type=rc` but omitting `rc-number` defaulted to 1, attempted to republish an already-existing `3.3.12-rc.1`, and the existing "tolerate already published" catch in the Publish step let the job conclude success silently. This guard catches it before the publish attempt.

Does not implement the issue's optional "auto-derive next rc-number" ask — kept the diff minimal and workflow-only per the required deliverable (the guard).

## Test plan
- [ ] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/npm-publish.yml'))"` — YAML parses (done locally).
- [ ] Manually verified each of the 5 `npm publish` steps now has an immediately-preceding Guard step reading from the same package directory.
- [ ] Dispatch `npm-publish.yml` with `dry-run=true` to confirm the guard step is skipped as expected (not run in this session — no Actions access locally).
- [ ] Dispatch against a package/version already on the registry (e.g. re-run an existing RC) to confirm the guard now fails the job instead of silently succeeding.

Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EDaj45174CK3TbdGytDDD