### PR TITLE
#440 Stage A: persist derived vault key in sessionStorage

### DIFF
--- a/app/src/contexts/CryptoContext.tsx
+++ b/app/src/contexts/CryptoContext.tsx
@@ -30,6 +30,7 @@ import { isPasskeyPrfAvailable } from "../lib/auth/prf-support";
 import { enrolPasskey, getPrfSecret, PrfUnsupportedError } from "../lib/auth/passkey";
 import { wrapKey, unwrapKey, deriveMasterWrapSecret } from "../lib/auth/wrap";
 import { saveVaultRecord, loadVaultRecord, hasAnyVault, clearVault } from "../lib/vault/idb";
+import { saveSessionKeys, loadSessionKeys, clearSessionKeys } from "../lib/vault/session-storage";
 import { registerSession } from "../lib/api";
 
 const SERVER_URL =
@@ -110,9 +111,28 @@ export function CryptoProvider({ children }: { children: ReactNode }) {
   const credIdRef = useRef<Uint8Array | null>(null);
   const queryClient = useQueryClient();
 
+  const enterUnlocked = useCallback(
+    (sk: SessionKeys, sa: string, cid: number) => {
+      setKeysState(sk);
+      setSmartAccount(sa);
+      setChainId(cid);
+      setStatus("unlocked");
+      saveSessionKeys(sk);
+    },
+    [],
+  );
+
   useEffect(() => {
     let cancelled = false;
     (async () => {
+      // Stage A (#440): a same-tab refresh restores straight from
+      // sessionStorage — no passkey re-prompt. Falls through to the normal
+      // locked/no-vault check when absent or malformed.
+      const restored = loadSessionKeys();
+      if (restored) {
+        if (!cancelled) enterUnlocked(restored, restored.walletAddress, restored.chainId);
+        return;
+      }
       const present = await hasAnyVault();
       if (cancelled) return;
       setStatus(present ? "locked" : "no-vault");
@@ -120,17 +140,7 @@ export function CryptoProvider({ children }: { children: ReactNode }) {
     return () => {
       cancelled = true;
     };
-  }, []);
-
-  const enterUnlocked = useCallback(
-    (sk: SessionKeys, sa: string, cid: number) => {
-      setKeysState(sk);
-      setSmartAccount(sa);
-      setChainId(cid);
-      setStatus("unlocked");
-    },
-    [],
-  );
+  }, [enterUnlocked]);
 
   const generatePhrase = useCallback(() => generateRecoveryPhrase(), []);
 
@@ -253,6 +263,7 @@ export function CryptoProvider({ children }: { children: ReactNode }) {
     credIdRef.current?.fill(0);
     credIdRef.current = null;
     setKeysState(null);
+    clearSessionKeys();
     // Drop decrypted plaintext (VaultItem[]) from the react-query cache.
     queryClient.clear();
     setStatus("locked");

--- a/app/src/lib/vault/session-storage.test.ts
+++ b/app/src/lib/vault/session-storage.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { saveSessionKeys, loadSessionKeys, clearSessionKeys } from "./session-storage";
+import type { SessionKeys } from "../types";
+
+// vitest.config.ts runs this suite under environment: "node" (no jsdom), so
+// sessionStorage isn't a global here — stand in a minimal Storage-shaped
+// polyfill, same spirit as idb.test.ts importing fake-indexeddb/auto.
+class MemoryStorage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+beforeEach(() => {
+  (globalThis as { sessionStorage?: unknown }).sessionStorage = new MemoryStorage();
+});
+
+function keys(overrides: Partial<SessionKeys> = {}): SessionKeys {
+  return {
+    authKey: new Uint8Array(32).fill(0x11),
+    encryptionKey: new Uint8Array(32).fill(0x22),
+    authKeyHex: "11".repeat(32),
+    eoaAddress: "0xEoaAddress",
+    walletAddress: "0xWalletAddress",
+    chainId: 100,
+    ...overrides,
+  };
+}
+
+describe("session-storage (Stage A, #440)", () => {
+  it("returns null when nothing is persisted", () => {
+    expect(loadSessionKeys()).toBeNull();
+  });
+
+  it("round-trips a full SessionKeys through sessionStorage", () => {
+    const sk = keys();
+    saveSessionKeys(sk);
+    const restored = loadSessionKeys();
+    expect(restored).not.toBeNull();
+    expect(restored!.authKey).toEqual(sk.authKey);
+    expect(restored!.encryptionKey).toEqual(sk.encryptionKey);
+    expect(restored!.authKeyHex).toBe(sk.authKeyHex);
+    expect(restored!.eoaAddress).toBe(sk.eoaAddress);
+    expect(restored!.walletAddress).toBe(sk.walletAddress);
+    expect(restored!.chainId).toBe(sk.chainId);
+  });
+
+  it("never persists anything resembling a mnemonic — only the two 32-byte derived keys", () => {
+    const sk = keys();
+    saveSessionKeys(sk);
+    const raw = sessionStorage.getItem("totalreclaw-spa:session:v1")!;
+    const parsed = JSON.parse(raw);
+    // Exactly the derived-key fields SessionKeys carries — no extra/mnemonic field.
+    expect(Object.keys(parsed).sort()).toEqual(
+      ["authKey", "authKeyHex", "chainId", "eoaAddress", "encryptionKey", "v", "walletAddress"].sort(),
+    );
+  });
+
+  it("clearSessionKeys removes the persisted session", () => {
+    saveSessionKeys(keys());
+    expect(loadSessionKeys()).not.toBeNull();
+    clearSessionKeys();
+    expect(loadSessionKeys()).toBeNull();
+  });
+
+  it("falls back to null on malformed JSON instead of throwing", () => {
+    sessionStorage.setItem("totalreclaw-spa:session:v1", "{not json");
+    expect(() => loadSessionKeys()).not.toThrow();
+    expect(loadSessionKeys()).toBeNull();
+  });
+
+  it("falls back to null on a wrong schema version", () => {
+    sessionStorage.setItem(
+      "totalreclaw-spa:session:v1",
+      JSON.stringify({ v: 2, authKey: "x", encryptionKey: "x", authKeyHex: "x", walletAddress: "0x0", chainId: 100 }),
+    );
+    expect(loadSessionKeys()).toBeNull();
+  });
+
+  it("falls back to null when required fields are missing", () => {
+    sessionStorage.setItem("totalreclaw-spa:session:v1", JSON.stringify({ v: 1, authKey: "x" }));
+    expect(loadSessionKeys()).toBeNull();
+  });
+
+  it("falls back to null when a key doesn't decode to 32 bytes", () => {
+    const sk = keys();
+    saveSessionKeys(sk);
+    const rec = JSON.parse(sessionStorage.getItem("totalreclaw-spa:session:v1")!);
+    rec.authKey = btoa("too-short");
+    sessionStorage.setItem("totalreclaw-spa:session:v1", JSON.stringify(rec));
+    expect(loadSessionKeys()).toBeNull();
+  });
+
+  it("saveSessionKeys does not throw when sessionStorage is unavailable", () => {
+    (globalThis as { sessionStorage?: unknown }).sessionStorage = {
+      setItem: () => {
+        throw new Error("QuotaExceededError");
+      },
+    };
+    expect(() => saveSessionKeys(keys())).not.toThrow();
+  });
+
+  it("loadSessionKeys returns null when sessionStorage.getItem throws", () => {
+    (globalThis as { sessionStorage?: unknown }).sessionStorage = {
+      getItem: () => {
+        throw new Error("SecurityError");
+      },
+    };
+    expect(loadSessionKeys()).toBeNull();
+  });
+});

--- a/app/src/lib/vault/session-storage.ts
+++ b/app/src/lib/vault/session-storage.ts
@@ -1,0 +1,108 @@
+/**
+ * Stage A (#440) — sessionStorage persistence for the unlocked vault session.
+ *
+ * Kills the "refresh forces a passkey re-auth" annoyance by surviving a
+ * same-tab reload. Cleared automatically on tab close (sessionStorage
+ * semantics) or explicitly on lock/forget-device.
+ *
+ * PHRASE-SAFETY: this persists exactly the `SessionKeys` shape CryptoContext
+ * already holds unlocked in RAM — the derived vault key (`encryptionKey`)
+ * and derived auth key (`authKey`), plus public routing metadata. It NEVER
+ * touches the mnemonic; `SessionKeys` structurally cannot carry one (see
+ * lib/types.ts). Origin-readable, tab-lifetime exposure is the deliberate
+ * Stage A tradeoff — Stage B (IndexedDB wrapped-key + TTL) is deferred.
+ */
+import type { SessionKeys } from "../types";
+
+const STORAGE_KEY = "totalreclaw-spa:session:v1";
+const KEY_LEN = 32;
+
+interface StoredSession {
+  v: 1;
+  authKey: string; // base64
+  encryptionKey: string; // base64
+  authKeyHex: string;
+  eoaAddress: string;
+  walletAddress: string;
+  chainId: number;
+}
+
+function bytesToB64(bytes: Uint8Array): string {
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+function b64ToBytes(s: string): Uint8Array {
+  const bin = atob(s);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+/** Persist the unlocked session so a refresh in this tab can skip the passkey. */
+export function saveSessionKeys(keys: SessionKeys): void {
+  const rec: StoredSession = {
+    v: 1,
+    authKey: bytesToB64(keys.authKey),
+    encryptionKey: bytesToB64(keys.encryptionKey),
+    authKeyHex: keys.authKeyHex,
+    eoaAddress: keys.eoaAddress,
+    walletAddress: keys.walletAddress,
+    chainId: keys.chainId,
+  };
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(rec));
+  } catch {
+    // Storage unavailable/full (private browsing, quota) — non-fatal, the
+    // next load just falls back to the normal passkey unlock.
+  }
+}
+
+/** Restore a persisted session, or null if absent, malformed, or corrupt. */
+export function loadSessionKeys(): SessionKeys | null {
+  let raw: string | null;
+  try {
+    raw = sessionStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+
+  try {
+    const rec = JSON.parse(raw) as Partial<StoredSession>;
+    if (
+      rec.v !== 1 ||
+      typeof rec.authKey !== "string" ||
+      typeof rec.encryptionKey !== "string" ||
+      typeof rec.authKeyHex !== "string" ||
+      typeof rec.walletAddress !== "string" ||
+      typeof rec.chainId !== "number"
+    ) {
+      return null;
+    }
+    const authKey = b64ToBytes(rec.authKey);
+    const encryptionKey = b64ToBytes(rec.encryptionKey);
+    if (authKey.length !== KEY_LEN || encryptionKey.length !== KEY_LEN) return null;
+    return {
+      authKey,
+      encryptionKey,
+      authKeyHex: rec.authKeyHex,
+      eoaAddress: rec.eoaAddress ?? "",
+      walletAddress: rec.walletAddress,
+      chainId: rec.chainId,
+    };
+  } catch {
+    // Malformed JSON / bad base64 — never crash the app over a stale record.
+    return null;
+  }
+}
+
+/** Drop the persisted session (lock / forget-device). */
+export function clearSessionKeys(): void {
+  try {
+    sessionStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
## Summary
- Stage A of #440 (issue stays open for Stage B — IndexedDB wrapped-key + TTL auto-lock, deliberately deferred).
- Persists the unlocked `SessionKeys` to `sessionStorage` on unlock so a same-tab refresh skips the passkey prompt. Restored on app init before falling back to the normal locked/no-vault check.
- Cleared on `lock()` (wired to the existing Lock button in `AppHeader`) and transitively on `forgetDevice()` (which calls `lock()`).
- Malformed/partial sessionStorage (bad JSON, wrong version, missing fields, wrong-length keys, storage access throwing) falls back to `null` — never crashes, just re-triggers the normal passkey flow.

## Phrase-safety
`SessionKeys` (`app/src/lib/types.ts:137-151`) structurally cannot carry the mnemonic — it only has `authKey`, `encryptionKey` (the derived XChaCha20 vault key), `authKeyHex`, `eoaAddress`, `walletAddress`, `chainId`. The comment on the type says as much: "the mnemonic is intentionally NOT held here... never persisted in app-wide state." `sessionKeysFromUnwrapped` in `CryptoContext.tsx` builds this from already-unwrapped bytes post-passkey-unlock; `deriveSessionKeys` (bootstrap/recovery path) also never puts the mnemonic on this object. Persisting `SessionKeys` verbatim to `sessionStorage` is therefore persisting *only* derived, non-reconstructible key material — exactly the invariant in the issue.

New file `app/src/lib/vault/session-storage.ts` serializes exactly those fields (base64 for the two 32-byte keys) under `totalreclaw-spa:session:v1`; nothing else touches storage.

## Files touched
- `app/src/lib/vault/session-storage.ts` (new) — save/load/clear helpers.
- `app/src/lib/vault/session-storage.test.ts` (new) — round-trip, mnemonic-absence assertion (asserts the persisted JSON has exactly the `SessionKeys` field set, nothing extra), malformed-input fallback, storage-unavailable fallback.
- `app/src/contexts/CryptoContext.tsx` — `enterUnlocked` now persists on every unlock path (bootstrap/unlock/unlockWithPhrase all funnel through it); init effect tries sessionStorage restore before the IndexedDB `hasAnyVault` check; `lock()` clears it.

## Test plan
- [x] `npm test` — 105/105 pass (10 new for session-storage; vitest runs in `environment: "node"`, so the test polyfills a minimal in-memory `Storage` the same way `idb.test.ts` polyfills IndexedDB via `fake-indexeddb/auto`)
- [x] `npm run build` (`tsc -b && vite build`) — clean

## Notes
- QA-autopilot (`tools/qa-vault.mjs`) drives the unlock flow — flagging in case this changes its behavior (should be transparent: fresh sessions/incognito still hit the passkey path since sessionStorage starts empty).
- Not merging — flagged for review per crypto-adjacent SPA state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EDaj45174CK3TbdGytDDD