### PR TITLE
ci: fix plugin stable promote (sync-version tr-cli path + npm@11)

### DIFF
--- a/.github/workflows/promote-rc.yml
+++ b/.github/workflows/promote-rc.yml
@@ -251,6 +251,7 @@ jobs:
               fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
               console.log('Repackaging', pkg.name, 'as', pkg.version);
             "
+            npm install -g npm@11
             npm publish --access public --tag latest --ignore-scripts
             cd /tmp/promote
             rm -rf unpacked "$TARBALL"

--- a/skill/scripts/sync-version.mjs
+++ b/skill/scripts/sync-version.mjs
@@ -41,7 +41,7 @@ const pluginDir = resolve(here, '..', 'plugin');
 const pkgPath = resolve(pluginDir, 'package.json');
 const skillMdPath = resolve(pluginDir, 'SKILL.md');
 const skillJsonPath = resolve(pluginDir, 'skill.json');
-const trCliPath = resolve(pluginDir, 'tr-cli.ts');
+const trCliPath = resolve(pluginDir, 'cli', 'tr-cli.ts'); // moved to cli/ in the domain restructure (#476)
 
 const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
 const canonical = pkg.version;


### PR DESCRIPTION
Unblocks the rc.23 → 3.3.12 plugin promote. Two latent bugs (not the RC artifact): (1) `sync-version.mjs` read the pre-restructure `skill/plugin/tr-cli.ts` (moved to `cli/` in #476) → ClawHub stamp ENOENT; (2) `promote-rc.yml` npm job lacked the npm-upgrade → tokenless-OIDC PUT 404 (npm@11 pin, same as #494). Both would break ANY future plugin publish, not just this promote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EDaj45174CK3TbdGytDDD