### PR TITLE
fix(plugin): coalesce digest recompiles — skip on unchanged claim set (#455)

### DIFF
--- a/skill/plugin/digest/digest-injection.test.ts
+++ b/skill/plugin/digest/digest-injection.test.ts
@@ -880,6 +880,144 @@ function fakeDigestBlob(digestVersion: number, compiledAt: string): string {
   digestSync.endRecompile();
 }
 
+// ---------------------------------------------------------------------------
+// Recompile coalescing (#455) — skip repeat recompiles for an unchanged
+// claim set, but never skip a genuinely newer one.
+// ---------------------------------------------------------------------------
+
+// Two calls back-to-back with the SAME recency-probe signal (i.e. the
+// on-chain write from the first recompile hasn't been indexed yet, so the
+// digest still looks stale against the identical set of active claims) →
+// only the first call should fire recompileFn.
+{
+  const { maybeInjectDigest, __resetDigestSyncState } = await import('./digest-sync.js');
+  __resetDigestSyncState();
+
+  const compiledAt = '2026-04-10T00:00:00Z';
+  const nowMs = Date.parse('2026-04-12T00:00:00Z');
+  const digestVersion = 1776000000;
+  const newerMax = digestVersion + 1000;
+  const blob = fakeDigestBlob(digestVersion, compiledAt);
+
+  const call = () =>
+    maybeInjectDigest({
+      owner: '0xabc',
+      authKeyHex: 'ff',
+      encryptionKey: Buffer.alloc(32),
+      mode: 'on',
+      nowMs,
+      loadDeps: {
+        searchSubgraph: async () => [
+          { id: 'digest-claim-id', encryptedBlob: 'dummy', createdAt: String(digestVersion) },
+        ],
+        decryptFromHex: () => blob,
+      },
+      probeDeps: {
+        // Identical recency signal on every call — no new on-chain claim.
+        searchSubgraphBroadened: async () => [{ createdAt: String(newerMax) }],
+      },
+      recompileFn: (prev) => { recompileCalls.push(prev); },
+      logger: { info: () => {}, warn: () => {} },
+    });
+
+  const recompileCalls: Array<string | null> = [];
+  const first = await call();
+  const second = await call();
+
+  assert(first.state === 'stale', 'coalesce: first call → stale state');
+  assert(second.state === 'stale', 'coalesce: second call (unchanged claim set) → still reports stale');
+  assertEq(
+    recompileCalls,
+    ['digest-claim-id'],
+    'coalesce: unchanged claim set → recompile fires once, not twice',
+  );
+}
+
+// A genuinely newer claim set (recency probe advances) after the first
+// recompile MUST still trigger a fresh recompile — the skip is content-aware,
+// not a blanket cooldown.
+{
+  const { maybeInjectDigest, __resetDigestSyncState } = await import('./digest-sync.js');
+  __resetDigestSyncState();
+
+  const compiledAt = '2026-04-10T00:00:00Z';
+  const nowMs = Date.parse('2026-04-12T00:00:00Z');
+  const digestVersion = 1776000000;
+  const blob = fakeDigestBlob(digestVersion, compiledAt);
+  const recompileCalls: Array<string | null> = [];
+
+  const callWithMax = (maxCreatedAt: number) =>
+    maybeInjectDigest({
+      owner: '0xabc',
+      authKeyHex: 'ff',
+      encryptionKey: Buffer.alloc(32),
+      mode: 'on',
+      nowMs,
+      loadDeps: {
+        searchSubgraph: async () => [
+          { id: 'digest-claim-id', encryptedBlob: 'dummy', createdAt: String(digestVersion) },
+        ],
+        decryptFromHex: () => blob,
+      },
+      probeDeps: {
+        searchSubgraphBroadened: async () => [{ createdAt: String(maxCreatedAt) }],
+      },
+      recompileFn: (prev) => { recompileCalls.push(prev); },
+      logger: { info: () => {}, warn: () => {} },
+    });
+
+  await callWithMax(digestVersion + 1000); // first batch's new claims
+  await callWithMax(digestVersion + 1000); // subgraph indexing lag — same set, should skip
+  await callWithMax(digestVersion + 2000); // second batch's new claims — must fire again
+
+  assertEq(
+    recompileCalls,
+    ['digest-claim-id', 'digest-claim-id'],
+    'coalesce: a genuinely newer claim set still fires its own recompile',
+  );
+}
+
+// A fresh __resetDigestSyncState() clears the signature, so a brand-new
+// process (or explicit reset) doesn't inherit a stale skip decision.
+{
+  const { maybeInjectDigest, __resetDigestSyncState } = await import('./digest-sync.js');
+
+  const compiledAt = '2026-04-10T00:00:00Z';
+  const nowMs = Date.parse('2026-04-12T00:00:00Z');
+  const digestVersion = 1776000000;
+  const newerMax = digestVersion + 1000;
+  const blob = fakeDigestBlob(digestVersion, compiledAt);
+  let recompileCalls = 0;
+
+  const call = () =>
+    maybeInjectDigest({
+      owner: '0xabc',
+      authKeyHex: 'ff',
+      encryptionKey: Buffer.alloc(32),
+      mode: 'on',
+      nowMs,
+      loadDeps: {
+        searchSubgraph: async () => [
+          { id: 'digest-claim-id', encryptedBlob: 'dummy', createdAt: String(digestVersion) },
+        ],
+        decryptFromHex: () => blob,
+      },
+      probeDeps: {
+        searchSubgraphBroadened: async () => [{ createdAt: String(newerMax) }],
+      },
+      recompileFn: () => { recompileCalls++; },
+      logger: { info: () => {}, warn: () => {} },
+    });
+
+  __resetDigestSyncState();
+  await call(); // fires — signature was null
+  assert(recompileCalls === 1, 'coalesce: reset → first call after reset always fires');
+
+  __resetDigestSyncState();
+  await call(); // fires again — reset cleared the remembered signature
+  assert(recompileCalls === 2, 'coalesce: __resetDigestSyncState clears the remembered signature');
+}
+
 // Subgraph query failure in loadLatestDigest → treated as "no digest" → first-compile.
 {
   const { maybeInjectDigest, __resetDigestSyncState } = await import('./digest-sync.js');

--- a/skill/plugin/digest/digest-sync.ts
+++ b/skill/plugin/digest/digest-sync.ts
@@ -134,9 +134,30 @@ export function endRecompile(): void {
   _recompileInProgress = false;
 }
 
+/**
+ * Signature of the claim set that drove the last *scheduled* recompile —
+ * the recency probe's `maxCreatedAt` at the moment we called `recompileFn`.
+ * `null` means "no attempt yet", which is distinct from any real timestamp
+ * (including 0 for an empty vault), so the very first attempt is never
+ * mistaken for a repeat.
+ *
+ * Issue #455: a recompile's on-chain write (digest store + previous-digest
+ * tombstone) isn't visible to `loadLatestDigest` until the subgraph indexes
+ * it (can take ~20s). Every `before_agent_start` call in that window still
+ * sees the OLD digest against the SAME unchanged set of active claims, so
+ * `evaluateDigestState` keeps reporting stale+recompile and would fire a
+ * second (third, fourth…) UserOp for content that produces an identical
+ * digest. Tracking the signature we already acted on lets us skip those
+ * repeats while still recompiling the instant a genuinely newer claim
+ * (or a tombstone/supersession, which also bumps the recency probe's
+ * `maxCreatedAt`) shows up.
+ */
+let _lastRecompileSignature: number | null = null;
+
 /** Test-only helper to reset module state between cases. */
 export function __resetDigestSyncState(): void {
   _recompileInProgress = false;
+  _lastRecompileSignature = null;
 }
 
 // ---------------------------------------------------------------------------
@@ -562,7 +583,16 @@ export async function maybeInjectDigest(
   });
 
   if (state.stale && state.recompile && !isRecompileInProgress()) {
-    recompileFn(loaded.claimId);
+    // Coalesce: only fire if the claim set feeding the digest has actually
+    // moved since the last recompile we scheduled. Otherwise we're re-firing
+    // for the same content while the previous write is still propagating
+    // through subgraph indexing — see `_lastRecompileSignature` above.
+    if (probe.maxCreatedAt !== _lastRecompileSignature) {
+      _lastRecompileSignature = probe.maxCreatedAt;
+      recompileFn(loaded.claimId);
+    } else {
+      logger.info('Digest: skip recompile — claim set unchanged');
+    }
   }
 
   const promptText = typeof loaded.digest.prompt_text === 'string' ? loaded.digest.prompt_text : null;


### PR DESCRIPTION
## Summary
- Root cause of the "4 recompiles for 2 extraction batches" observed during rc.20 pop-os QA: `maybeInjectDigest()` fires once per `before_agent_start` call. A scheduled recompile's on-chain write (digest store + previous-digest tombstone) isn't visible to `loadLatestDigest()` until the subgraph indexes it (~20s). Every `before_agent_start` call in that indexing-lag window still sees the OLD digest against the SAME set of active claims, so `evaluateDigestState()` keeps reporting stale+recompile and fires another UserOp (quota + gas) for content that would produce an identical digest.
- Fix: `digest-sync.ts` now tracks the recency-probe signature (`maxCreatedAt`) that drove the last *scheduled* recompile (`_lastRecompileSignature`, reset in `__resetDigestSyncState`). `maybeInjectDigest` skips firing `recompileFn` again while that signature is unchanged, logging `Digest: skip recompile — claim set unchanged`. A genuinely newer claim, tombstone, or supersession always advances `maxCreatedAt` and still fires its own recompile.
- Since `maybeInjectDigest` is the only call site that invokes `recompileFn` (once per invocation), this also satisfies "at most one recompile per cycle" — there's no separate per-store trigger path in this plugin to coalesce against.

## Test plan
- [x] TDD: added 3 new cases to `skill/plugin/digest/digest-injection.test.ts` (unchanged-signal skip, genuinely-newer-signal still fires, reset clears remembered signature). Confirmed RED (stashed the `digest-sync.ts` fix, 2/92 failed with duplicate recompile calls) then GREEN (fix restored, 92/92 passed).
- [x] Full plugin suite: `npm test` → 89/89 files passed.
- [x] Scanner: `npm run check-scanner` → 0 flags (163 files).
- [ ] Staging E2E (on-chain write cadence under a real multi-batch session) — **follow-up before this ships in a release**; the skip/debounce logic itself is fully unit-tested here per plan.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_013EDaj45174CK3TbdGytDDD