### PR TITLE
feat(core): publish --target web WASM as ./web subpath export (#500)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -65,19 +65,81 @@ jobs:
         with:
           version: 'v0.14.0'  # pinned to stop `latest`-tag flake; v0.9.1 lacks --features
 
-      - name: Build WASM
-        run: cd rust/totalreclaw-core && wasm-pack build --target nodejs --out-dir pkg --features wasm
+      - name: Build WASM (nodejs target — bare `@totalreclaw/core` specifier)
+        run: cd rust/totalreclaw-core && wasm-pack build --target nodejs --out-dir pkg/nodejs --features wasm
+
+      - name: Build WASM (web target — `@totalreclaw/core/web` subpath, #500)
+        # Same crate, same version, built a second time with a different
+        # wasm-bindgen glue target. The compiled .wasm is byte-identical to
+        # the nodejs build (verified locally: only the JS wrapper differs;
+        # `wasm-pack --target` does not affect the wasm-opt output). This
+        # gives the vault SPA a browser-safe entry (no `require`/`fs`) with
+        # structural byte-parity to the published nodejs artifact plugin/
+        # mcp/python already depend on — not a separately-built, unverifiable
+        # binary (see totalreclaw#500).
+        run: cd rust/totalreclaw-core && wasm-pack build --target web --out-dir pkg/web --features wasm
 
       - uses: actions/setup-node@v5
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Patch package name for npm scope
+      - name: Compose pkg/package.json (nodejs + web subpath export)
+        # wasm-pack emits a separate package.json per --out-dir, each named
+        # the unscoped "totalreclaw-core". Compose ONE root manifest with an
+        # `exports` map: `.` stays the nodejs build (byte-for-byte unchanged
+        # for existing plugin/mcp/nanoclaw consumers — no breaking change),
+        # `./web` is the new browser-safe build for the vault SPA.
         run: |
           cd rust/totalreclaw-core/pkg
-          # wasm-pack generates "totalreclaw-core" but npm package is "@totalreclaw/core"
-          node -e "const p=require('./package.json'); p.name='@totalreclaw/core'; require('fs').writeFileSync('./package.json', JSON.stringify(p,null,2)+'\n')"
+          node -e "
+          const fs = require('fs');
+          const nodejsPkg = JSON.parse(fs.readFileSync('./nodejs/package.json', 'utf8'));
+
+          const composed = {
+            name: '@totalreclaw/core',
+            description: nodejsPkg.description,
+            version: nodejsPkg.version,
+            license: nodejsPkg.license,
+            repository: nodejsPkg.repository,
+            homepage: nodejsPkg.homepage,
+            keywords: nodejsPkg.keywords,
+            files: ['nodejs/**', 'web/**'],
+            main: './nodejs/totalreclaw_core.js',
+            types: './nodejs/totalreclaw_core.d.ts',
+            exports: {
+              '.': {
+                types: './nodejs/totalreclaw_core.d.ts',
+                default: './nodejs/totalreclaw_core.js'
+              },
+              './web': {
+                types: './web/totalreclaw_core.d.ts',
+                default: './web/totalreclaw_core.js'
+              }
+            }
+          };
+
+          fs.writeFileSync('./package.json', JSON.stringify(composed, null, 2) + '\n');
+          // Only the composed root manifest above governs resolution + npm
+          // packing — drop the per-target manifest wasm-pack generated.
+          fs.rmSync('./nodejs/package.json');
+          // The web build's glue file uses ESM 'export' syntax. Without a
+          // 'type' field on the nearest package.json, Node has to sniff the
+          // file (MODULE_TYPELESS_PACKAGE_JSON perf-overhead warning). Give
+          // it a minimal directory-scoped marker instead of a full manifest
+          // (the root manifest can't declare 'type: module' itself — the
+          // nodejs build's glue file is CommonJS and must stay the default
+          // type for the existing '.' export to resolve correctly).
+          fs.writeFileSync('./web/package.json', JSON.stringify({ type: 'module' }, null, 2) + '\n');
+          // wasm-pack also drops a per-target '.gitignore' containing a bare
+          // '*'. npm's packer respects nested .gitignore/.npmignore files
+          // even with an explicit root 'files' field, so left in place these
+          // silently exclude both target dirs from the published tarball
+          // (verified locally: a 'files'-only compose with the .gitignores
+          // still present produced a 1-file tarball — package.json alone).
+          fs.rmSync('./nodejs/.gitignore', { force: true });
+          fs.rmSync('./web/.gitignore', { force: true });
+          "
           echo "Package name: $(node -e "console.log(require('./package.json').name)")"
           echo "Version: $(node -e "console.log(require('./package.json').version)")"
 

--- a/rust/totalreclaw-core/build-wasm.sh
+++ b/rust/totalreclaw-core/build-wasm.sh
@@ -1,10 +1,22 @@
 #!/usr/bin/env bash
 # Build the WASM package for @totalreclaw/core.
 #
-# wasm-pack emits pkg/package.json with an unscoped `name: "totalreclaw-core"`.
-# Both the plugin and the MCP server consume it as `@totalreclaw/core`, so this
-# script applies the same rename that .github/workflows/npm-publish.yml does
-# in CI. Use this script for any local rebuild against the worktree-built pkg.
+# Builds wasm-bindgen TWICE from the same crate at the same version:
+#   - pkg/nodejs/  (--target nodejs) — existing consumers (plugin, mcp,
+#                   nanoclaw) via the bare `@totalreclaw/core` specifier.
+#   - pkg/web/     (--target web)    — browser/Vite consumers via the
+#                   `@totalreclaw/core/web` subpath (e.g. the vault SPA).
+#
+# The two builds are composed under a single `pkg/package.json` with an
+# `exports` map so `.` resolves to the nodejs build (byte-for-byte
+# unchanged for existing consumers) and `./web` resolves to the web build.
+# See totalreclaw#500.
+#
+# wasm-pack emits a per-target package.json with an unscoped
+# `name: "totalreclaw-core"`. Both the plugin and the MCP server consume
+# it as `@totalreclaw/core`, so this script applies the same rename +
+# composition that .github/workflows/npm-publish.yml does in CI. Use this
+# script for any local rebuild against the worktree-built pkg.
 #
 # Usage: ./build-wasm.sh [extra wasm-pack args]
 
@@ -12,15 +24,60 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 
-wasm-pack build --target nodejs --out-dir pkg --features wasm "$@"
+rm -rf pkg
+wasm-pack build --target nodejs --out-dir pkg/nodejs --features wasm "$@"
+wasm-pack build --target web --out-dir pkg/web --features wasm "$@"
 
 node -e "
 const fs = require('fs');
-const path = './pkg/package.json';
-const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
-pkg.name = '@totalreclaw/core';
-fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
-console.log('Patched pkg/package.json name -> @totalreclaw/core');
+const nodejsPkg = JSON.parse(fs.readFileSync('./pkg/nodejs/package.json', 'utf8'));
+
+const composed = {
+  name: '@totalreclaw/core',
+  description: nodejsPkg.description,
+  version: nodejsPkg.version,
+  license: nodejsPkg.license,
+  repository: nodejsPkg.repository,
+  homepage: nodejsPkg.homepage,
+  keywords: nodejsPkg.keywords,
+  files: ['nodejs/**', 'web/**'],
+  main: './nodejs/totalreclaw_core.js',
+  types: './nodejs/totalreclaw_core.d.ts',
+  exports: {
+    '.': {
+      types: './nodejs/totalreclaw_core.d.ts',
+      default: './nodejs/totalreclaw_core.js'
+    },
+    './web': {
+      types: './web/totalreclaw_core.d.ts',
+      default: './web/totalreclaw_core.js'
+    }
+  }
+};
+
+fs.writeFileSync('./pkg/package.json', JSON.stringify(composed, null, 2) + '\n');
+// Remove the per-target manifests wasm-pack generated — only the composed
+// root manifest above governs resolution + npm packing. Replace pkg/web's
+// with a minimal { type: module } marker: the web build's glue file uses
+// ESM 'export' syntax, and without a 'type' field on the nearest
+// package.json Node has to sniff the file (triggering a
+// MODULE_TYPELESS_PACKAGE_JSON perf-overhead warning). The root manifest
+// can't declare 'type: module' itself — the nodejs build's glue file is
+// CommonJS ('require') and must stay the default type for '.' to resolve
+// correctly for existing consumers.
+fs.rmSync('./pkg/nodejs/package.json');
+fs.writeFileSync('./pkg/web/package.json', JSON.stringify({ type: 'module' }, null, 2) + '\n');
+// wasm-pack also drops a per-target '.gitignore' containing a bare '*'.
+// npm's packer respects nested .gitignore/.npmignore files even when an
+// explicit 'files' field is set on the root manifest, so left in place
+// these silently exclude both target dirs from the published tarball
+// (verified: 'npm pack' with them present produces a 1-file tarball
+// containing only package.json). Strip them so files/** actually ships.
+fs.rmSync('./pkg/nodejs/.gitignore', { force: true });
+fs.rmSync('./pkg/web/.gitignore', { force: true });
+console.log('Composed pkg/package.json -> @totalreclaw/core (nodejs + web)');
 "
 
 echo "Done. Consumers can now \`npm install\` against this pkg/ directory."
+echo "  - bare specifier '@totalreclaw/core'      -> pkg/nodejs (unchanged)"
+echo "  - subpath '@totalreclaw/core/web'          -> pkg/web (new)"


### PR DESCRIPTION
## Summary

Extends the `@totalreclaw/core` npm-publish workflow to build wasm-bindgen **twice** from the same crate at the same version and compose one publishable package:

- `wasm-pack build --target nodejs --out-dir pkg/nodejs` — existing consumers (plugin, mcp, nanoclaw) via the bare `@totalreclaw/core` specifier. **Unchanged output for `.`** — byte-for-byte identical to what those consumers get today.
- `wasm-pack build --target web --out-dir pkg/web` — new, browser-safe (no `require`/`fs`) build for Vite/browser consumers via `@totalreclaw/core/web`. Unblocks the vault SPA's ERC-4337 UserOp encoders (`encodeTombstoneProtobuf`, `encodeSingleCall`, `encodeBatchCall`, `hashUserOp`, `signUserOp`).

Composed `pkg/package.json`:
```jsonc
{
  "name": "@totalreclaw/core",
  "files": ["nodejs/**", "web/**"],
  "main": "./nodejs/totalreclaw_core.js",
  "types": "./nodejs/totalreclaw_core.d.ts",
  "exports": {
    ".":     { "types": "./nodejs/totalreclaw_core.d.ts", "default": "./nodejs/totalreclaw_core.js" },
    "./web": { "types": "./web/totalreclaw_core.d.ts",    "default": "./web/totalreclaw_core.js" }
  }
}
```

Both `.github/workflows/npm-publish.yml` (publish-core job) and `rust/totalreclaw-core/build-wasm.sh` (local rebuild script) updated in lockstep — RC version-suffix step and publish step both still operate on `pkg/package.json` unchanged.

`ci.yml`'s `cross-language-parity` job builds its own throwaway nodejs-only `pkg/` for the parity test at the default out-dir and does not consume the publish layout — verified unaffected, no changes needed there.

## Proof `.` is unchanged for existing consumers

- No consumer deep-imports `@totalreclaw/core/...` (checked all 25 call sites) — all use the bare specifier, so adding `exports` is safe.
- `require('@totalreclaw/core')` from an installed tarball resolves to `pkg/nodejs/totalreclaw_core.js` and all 5 SPA-relevant encoders (`encodeTombstoneProtobuf`, `encodeSingleCall`, `encodeBatchCall`, `hashUserOp`, `signUserOp`) resolve as `function`.
- `main`/`types` top-level fields also point at the nodejs build, for older resolvers that ignore `exports`.

## Byte-parity finding (the whole point of #500)

**The compiled `.wasm` binaries are byte-identical across both targets** — `wasm-pack --target` only changes the JS glue wrapper, not the wasm-opt output:

```
$ shasum -a 256 pkg/nodejs/totalreclaw_core_bg.wasm pkg/web/totalreclaw_core_bg.wasm
ecc30791ecf81c44202bd5ef2246f54ed88de7aee0bd7430f0af65552e434581  pkg/nodejs/totalreclaw_core_bg.wasm
ecc30791ecf81c44202bd5ef2246f54ed88de7aee0bd7430f0af65552e434581  pkg/web/totalreclaw_core_bg.wasm
```

Reproduced across two independent full rebuilds. This means wire-byte parity between the SPA's `./web` import and plugin/mcp/python's `.` import is structural (same wasm bytes, same encoder logic), not something that needs separate assertion — exactly the property #500 asked for, and the thing the vendored-binary stopgap (#498) couldn't offer.

Also confirmed the `./web` glue is browser-safe: no `require(`, no `fs`, no node globals; `export { initSync, __wbg_init as default }` — a proper `default` init function that `fetch()`s the wasm asset (works via a bundler in a real browser; Node's own `fetch` doesn't support `file://`, which is expected — passing an explicit buffer/path to `init()` works identically to the nodejs build, verified).

## `npm pack` contents

Built both targets, composed the manifest, ran `npm pack` on `pkg/`:

```
nodejs/README.md
nodejs/totalreclaw_core_bg.wasm
nodejs/totalreclaw_core_bg.wasm.d.ts
nodejs/totalreclaw_core.d.ts
nodejs/totalreclaw_core.js
package.json
web/package.json
web/README.md
web/totalreclaw_core_bg.wasm
web/totalreclaw_core_bg.wasm.d.ts
web/totalreclaw_core.d.ts
web/totalreclaw_core.js
total files: 12
```

Both dirs present, nothing missing from `files`. Two gotchas found and fixed along the way while composing the manifest (documented inline in both changed files):
1. wasm-pack's per-target `.gitignore` (bare `*`) is respected by npm's packer even with an explicit root `files` field — left in place, `npm pack` produced a 1-file tarball (`package.json` only). Fixed by stripping both nested `.gitignore`s during compose.
2. The web build's ESM glue needs a `{"type":"module"}` marker on `pkg/web/package.json` (a directory-scoped Node module-type signal) to avoid a `MODULE_TYPELESS_PACKAGE_JSON` perf-overhead warning — the root manifest itself can't declare `type: module` since the nodejs build's glue is CommonJS and must stay the default type for `.` to keep working.

Installed the packed tarball into a clean temp project and confirmed both entry points resolve correctly:
```
require('@totalreclaw/core')       -> nodejs build, all 5 encoders typeof 'function'
import('@totalreclaw/core/web')    -> web build, default export is the init fn, encoders typeof 'function' post-init
```

## Follow-up (explicitly not done here)

- **No version bump, no publish.** Shipping `./web` requires a version bump + a gated `npm-publish.yml` dispatch (`package: core`), which is Pedro's release step, not this PR's.
- Once a core version ships `./web`, #498 can swap its vendored binary for `import ... from "@totalreclaw/core/web"` — the 2.4 MB blob never needs to enter `main`.

Closes/unblocks #500. Unblocks #498.