### PR TITLE
chore(core): 2.5.6 — ships ./web subpath export (#500)

### DIFF
--- a/rust/totalreclaw-core/Cargo.lock
+++ b/rust/totalreclaw-core/Cargo.lock
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "totalreclaw-core"
-version = "2.5.5"
+version = "2.5.6"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/rust/totalreclaw-core/Cargo.toml
+++ b/rust/totalreclaw-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "totalreclaw-core"
-version = "2.5.5"
+version = "2.5.6"
 edition = "2021"
 description = "TotalReclaw core — E2EE crypto, reranker, wallet, UserOp, store/search pipelines. Single source of truth for all clients."
 license = "MIT"

--- a/rust/totalreclaw-core/pyproject.toml
+++ b/rust/totalreclaw-core/pyproject.toml
@@ -7,7 +7,7 @@ name = "totalreclaw-core"
 # Keep in lockstep with Cargo.toml [package].version. maturin uses THIS value
 # for the PyPI wheel version; Cargo.toml drives crates.io + the wasm-pack npm
 # package. Both MUST match or the PyPI wheel ships under the wrong version.
-version = "2.5.5"
+version = "2.5.6"
 description = "TotalReclaw crypto core — E2EE, LSH, blind indices, protobuf encoding (Rust)"
 requires-python = ">=3.10"
 license = { text = "MIT" }


### PR DESCRIPTION
Version bump to **2.5.6** to release the new `./web` subpath export (merged in #501).

## Changes
Lockstep bump of all three core version sources (matches the 2.5.5 bump pattern in #380 / #381):
- `rust/totalreclaw-core/Cargo.toml` — drives crates.io + the wasm-pack npm package (`@totalreclaw/core`)
- `rust/totalreclaw-core/Cargo.lock` — the `totalreclaw-core` package entry
- `rust/totalreclaw-core/pyproject.toml` — drives the PyPI wheel version via maturin

No source changes; `./web` subpath already merged in #501.

## Verification
- `cargo test` in `rust/totalreclaw-core/` → **658 passed; 0 failed** (baseline intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)