### PR TITLE
fix(import): store-result-aware ledger recording (internal#473)

### DIFF
--- a/python/src/totalreclaw/imports/engine.py
+++ b/python/src/totalreclaw/imports/engine.py
@@ -117,6 +117,14 @@ _METADATA_SUBTYPE_SESSION_CRYSTAL = "session_crystal"
 # Valid v1 MemorySource for imported memories (the old "import" was not a valid
 # MemorySource — see #356 Problem 2).
 _IMPORT_PROVENANCE = "external"
+# internal#473 — private per-fact marker stamping the conversation_id a fact was
+# extracted from, threaded through to the store so the store phase can report
+# which conversations ACTUALLY durably stored (extraction success no longer
+# implies a store — the on-chain submit can still raise/revert). Carried on the
+# fact dict and the prepared payload; the real store reads only known keys, so a
+# stray private key is harmless. Crystals (session summaries) carry no single
+# conversation_id and are left unmarked — recording tracks per-conversation facts.
+_IMPORT_CONV_KEY = "__import_conv_id__"
 
 
 def _uuid7() -> str:
@@ -292,14 +300,28 @@ class ImportEngine:
         #: failure doesn't mark it imported and block the natural re-import
         #: recovery. Persists across batches on the instance.
         self._failed_chunk_indices: set[int] = set()
-        #: #466 — conversation_ids that produced ≥1 extracted (→ stored) fact
-        #: this run. Enforces the stored-implies-recorded invariant: a
-        #: multi-chunk conversation whose one sibling 429-failed but whose other
-        #: sibling stored facts MUST still be recorded, else the re-import
-        #: re-extracts it → duplicates (rc7 pre-stable QA shipped 10 dups). Only
-        #: a conversation that stored NOTHING and had a failed chunk stays
-        #: unrecorded (Finding-2 retry). Persists across batches on the instance.
+        #: internal#473 — conversation_ids that ACTUALLY durably stored ≥1 fact
+        #: this run (store-result-aware). Populated AFTER the on-chain store
+        #: completes, from the per-conversation stored map `_store_facts_chunked`
+        #: returns — a fact extracting cleanly no longer counts: the store can
+        #: still raise/revert/drop it. A duplicate skipped client-side also
+        #: counts (those facts already exist on-chain; withholding them would
+        #: make a fully-duplicate conversation re-import forever). This drives
+        #: the store-result-implies-recorded invariant: a conversation that
+        #: stored ≥1 fact is recorded even if a sibling chunk's store failed,
+        #: while a conversation that extracted facts but stored NONE (store
+        #: raised/reverted) stays unrecorded → re-importable (#473). Persists
+        #: across batches on the instance so a straddling conversation records
+        #: once its final batch's store lands.
         self._conv_with_stored_facts: set[str] = set()
+        #: internal#473 — conversation_ids that extracted ≥1 fact this run
+        #: (extraction-derived). Lets the recording filter tell apart the two
+        #: "stored nothing" outcomes: a conversation that extracted facts but
+        #: whose store FAILED must stay unrecorded (re-import retries the
+        #: store), whereas a conversation that extracted NOTHING and had no
+        #: failed chunk is genuinely empty → recorded so re-import doesn't
+        #: churn re-extracting it. Persists across batches on the instance.
+        self._conv_with_extracted_facts: set[str] = set()
 
     # ── Estimate ─────────────────────────────────────────────────────────
 
@@ -709,14 +731,21 @@ class ImportEngine:
                 })
                 reason_counts[zero_reason] = reason_counts.get(zero_reason, 0) + 1
             else:
-                # #466: this chunk produced facts → its conversation stored
-                # facts and MUST be recorded, even if a sibling chunk failed.
+                # internal#473: stamp this chunk's conversation_id onto each
+                # extracted fact so the STORE phase can report which
+                # conversations actually durably stored. Producing facts at
+                # EXTRACTION time no longer implies the conversation stored —
+                # `record_imported_conversations` now runs after the store and
+                # keys on the store result, so a chunk whose facts later
+                # raise/revert on store is NOT recorded (stays re-importable).
                 cid = (
                     getattr(parsed.chunks[global_index], "conversation_id", None)
                     if global_index < len(parsed.chunks) else None
                 )
                 if cid:
-                    self._conv_with_stored_facts.add(cid)
+                    self._conv_with_extracted_facts.add(cid)
+                    for f in extracted:
+                        f[_IMPORT_CONV_KEY] = cid
             facts_extracted += len(extracted)
 
             if is_singleton:
@@ -749,40 +778,6 @@ class ImportEngine:
         # a skipped chunk would never be considered complete and would never get
         # a Crystal. This set persists across batches on the instance.
         self._processed_chunk_indices.update(range(offset, offset + chunks_processed))
-
-        # #436 — record conversations whose EVERY chunk has now been processed
-        # (across all batches so far) into the imported-conversation registry.
-        # A conversation straddling a batch boundary is only recorded once its
-        # final chunk lands, so a partial first import never marks an
-        # incompletely-processed conversation as done. Already-registered
-        # conversations (imported_convs) and ones recorded earlier this run
-        # are skipped.
-        if source:
-            conv_to_indices: dict[str, list[int]] = {}
-            for idx, c in enumerate(parsed.chunks):
-                cid = getattr(c, "conversation_id", None)
-                if cid:
-                    conv_to_indices.setdefault(cid, []).append(idx)
-            newly_complete = [
-                cid for cid, indices in conv_to_indices.items()
-                if cid not in self._recorded_conversations
-                and cid not in imported_convs
-                and all(ix in self._processed_chunk_indices for ix in indices)
-                # #466: stored-implies-recorded. Record when the conversation
-                # produced stored facts OR had no failed chunk. Withhold ONLY
-                # when it stored NOTHING and a chunk failed — that lone case is
-                # a genuine transient failure worth retrying on re-import
-                # (#436-review Finding-2). The old rule ("exclude if ANY chunk
-                # failed") withheld conversations that DID store facts via a
-                # surviving sibling → re-import re-extracted them → dups.
-                and (
-                    cid in self._conv_with_stored_facts
-                    or not any(ix in self._failed_chunk_indices for ix in indices)
-                )
-            ]
-            if newly_complete:
-                record_imported_conversations(source, newly_complete)
-                self._recorded_conversations.update(newly_complete)
 
         # ── Crystal emission (cross-batch complete) ───────────────────────────
         # Emit ONE Crystal per multi-turn session, exactly once, on whichever
@@ -838,9 +833,57 @@ class ImportEngine:
 
         # Store phase: one batched UserOp per ≤15-fact chunk on Gnosis, or
         # per-fact remember() loop on free-tier / unresolvable chain.
-        facts_stored, store_errors, dups_skipped = await self._store_facts_chunked(all_extracted)
+        # internal#473: `_store_facts_chunked` also returns the set of
+        # conversation_ids whose facts were ACTUALLY durably stored (or skipped
+        # as on-chain duplicates) — recording keys on THAT, not on extraction.
+        facts_stored, store_errors, dups_skipped, stored_conv_ids = await self._store_facts_chunked(all_extracted)
         if store_errors:
             errors.extend(store_errors)
+        # Accumulate across batches so a conversation straddling a batch
+        # boundary records once its final batch's store lands.
+        self._conv_with_stored_facts |= stored_conv_ids
+
+        # internal#473 — record conversations whose EVERY chunk has now been
+        # processed (across all batches so far) into the imported-conversation
+        # registry. This runs AFTER the store so the filter keys on what
+        # actually durably stored, not on extraction success. A conversation
+        # straddling a batch boundary is recorded only once its final chunk
+        # lands, so a partial first import never marks an incompletely-
+        # processed conversation as done. Already-registered conversations
+        # (imported_convs) and ones recorded earlier this run are skipped.
+        if source:
+            conv_to_indices: dict[str, list[int]] = {}
+            for idx, c in enumerate(parsed.chunks):
+                cid = getattr(c, "conversation_id", None)
+                if cid:
+                    conv_to_indices.setdefault(cid, []).append(idx)
+            newly_complete = [
+                cid for cid, indices in conv_to_indices.items()
+                if cid not in self._recorded_conversations
+                and cid not in imported_convs
+                and all(ix in self._processed_chunk_indices for ix in indices)
+                # internal#473: store-result-implies-recorded. Record when the
+                # conversation durably stored ≥1 fact, OR when it extracted
+                # NOTHING and had no failed chunk (genuinely empty — recorded so
+                # re-import doesn't churn re-extracting it). Withhold when it
+                # extracted facts but stored NONE — either because the store
+                # raised/reverted (the #473 bug: stays re-importable so the
+                # store is retried) or because a chunk failed extraction
+                # (#436-review Finding-2: a genuine transient failure worth
+                # retrying). A surviving sibling that DID store still records
+                # the whole conversation via the first clause (#466 dup guard,
+                # preserved).
+                and (
+                    cid in self._conv_with_stored_facts
+                    or (
+                        cid not in self._conv_with_extracted_facts
+                        and not any(ix in self._failed_chunk_indices for ix in indices)
+                    )
+                )
+            ]
+            if newly_complete:
+                record_imported_conversations(source, newly_complete)
+                self._recorded_conversations.update(newly_complete)
 
         attempted = chunks_processed - chunks_skipped
         if extraction_failures > 0:
@@ -941,7 +984,10 @@ class ImportEngine:
             }
             for fact in batch
         ]
-        facts_stored, errors, dups_skipped = await self._store_facts_chunked(fact_dicts)
+        # Pre-structured facts carry no conversation_id, so the store-result
+        # conversation set (internal#473 4th return) is intentionally ignored
+        # here — there is no per-conversation ledger to record for flat sources.
+        facts_stored, errors, dups_skipped, _stored_conv_ids = await self._store_facts_chunked(fact_dicts)
 
         return BatchImportResult(
             success=facts_stored > 0 or not errors,
@@ -1491,6 +1537,12 @@ class ImportEngine:
             payload["fact_type"] = fact["fact_type"]
         if fact.get("extra_metadata"):
             payload["extra_metadata"] = fact["extra_metadata"]
+        # internal#473 — thread the per-fact conversation_id marker onto the
+        # payload so the store phase can report which conversations durably
+        # stored. The real store reads only known keys, so this private key is
+        # carried through untouched.
+        if fact.get(_IMPORT_CONV_KEY) is not None:
+            payload[_IMPORT_CONV_KEY] = fact[_IMPORT_CONV_KEY]
         return payload
 
     @staticmethod
@@ -1673,7 +1725,7 @@ class ImportEngine:
     async def _store_facts_chunked(
         self,
         facts: list[dict],
-    ) -> tuple[int, list[str]]:
+    ) -> tuple[int, list[str], int, set[str]]:
         """Store ``facts`` via chunked batched UserOps when the client is on
         Gnosis (chain 100); otherwise via per-fact ``client.remember`` calls.
 
@@ -1683,8 +1735,15 @@ class ImportEngine:
         import gate guarantees ``chain_id == 100`` on this code path; the
         explicit check keeps the cost claim self-verifying.
 
-        Returns ``(facts_stored, errors, dups_skipped)`` so callers can
-        aggregate into the existing ``BatchImportResult`` shape.
+        Returns ``(facts_stored, errors, dups_skipped, stored_conv_ids)`` so
+        callers can aggregate into the existing ``BatchImportResult`` shape.
+        ``stored_conv_ids`` (internal#473) is the set of conversation_ids whose
+        facts were ACTUALLY durably stored this call — the per-conversation
+        stored map the ledger recording now keys on (extraction success no
+        longer implies a store). A fact skipped as an on-chain duplicate also
+        contributes its conversation_id: those facts already exist on-chain,
+        so the conversation is durably stored and must record (else a fully-
+        duplicate conversation re-imports forever).
 
         Dedup (#422): the on-chain pivot removed the relay's 409/fingerprint
         rejection, so duplicates must be skipped CLIENT-SIDE before the
@@ -1694,8 +1753,10 @@ class ImportEngine:
         fingerprint dedup (the same fact extracted twice in one import).
         Both fail open — dedup must never block a store.
         """
+        stored_conv_ids: set[str] = set()
+
         if not facts:
-            return 0, [], 0
+            return 0, [], 0, stored_conv_ids
 
         dups_skipped = 0
 
@@ -1706,6 +1767,12 @@ class ImportEngine:
                 flags = await find_dups([f.get("text", "") for f in facts])
                 if flags and len(flags) == len(facts):
                     kept = [f for f, dup in zip(facts, flags) if not dup]
+                    for f, dup in zip(facts, flags):
+                        # internal#473: a duplicate already exists on-chain →
+                        # its conversation is durably stored; count it so a
+                        # fully-duplicate conversation records.
+                        if dup:
+                            _record_stored_conv(stored_conv_ids, f)
                     dups_skipped += len(facts) - len(kept)
                     facts = kept
         except Exception as e:
@@ -1722,6 +1789,10 @@ class ImportEngine:
             meta = f.get("extra_metadata") or {}
             key = (text_norm, str(meta.get("session_id") or ""))
             if text_norm and key in seen_keys:
+                # internal#473: dropped as an in-batch duplicate of one we're
+                # keeping — the kept sibling stores, so the conversation is
+                # durably stored either way; record it now.
+                _record_stored_conv(stored_conv_ids, f)
                 dups_skipped += 1
                 continue
             seen_keys.add(key)
@@ -1731,7 +1802,7 @@ class ImportEngine:
         if dups_skipped:
             logger.info("Import dedup: skipped %d duplicate fact(s)", dups_skipped)
         if not facts:
-            return 0, [], dups_skipped
+            return 0, [], dups_skipped, stored_conv_ids
 
         chain_id = await self._resolve_chain_id_safely()
         errors: list[str] = []
@@ -1769,7 +1840,7 @@ class ImportEngine:
             wallet = client._wallet_context(chain_id)
 
             async def _store_group(group: list) -> list[str]:
-                return await store_fact_batch(
+                ids = await store_fact_batch(
                     facts=group,
                     wallet=wallet,
                     relay=client._relay,
@@ -1777,6 +1848,17 @@ class ImportEngine:
                     source="import",
                     data_edge_address=client._data_edge_address,
                 )
+                # internal#473: store_fact_batch returns (one id per input
+                # fact, in order) only on full success — a raise propagates
+                # out of this closure before we reach here, so reaching this
+                # point means EVERY fact in the group durably stored. On a
+                # sim-revert halving cascade _store_group_adaptive calls this
+                # closure once per (sub)group that ultimately succeeds, so
+                # recording per-success-group is correct even under partial
+                # failure (failed sub-groups raise and never record).
+                for p in group:
+                    _record_stored_conv(stored_conv_ids, p)
+                return ids
 
             ids, errors = await group_and_store_adaptive(
                 _store_group,
@@ -1788,17 +1870,21 @@ class ImportEngine:
                     "Error limit reached (20). Remaining facts in this batch skipped."
                 ),
             )
-            return len(ids), errors, dups_skipped
+            return len(ids), errors, dups_skipped, stored_conv_ids
 
         # Per-fact fallback: free-tier / non-Gnosis / chain probe failed.
         for fact in facts:
             try:
                 await self._store_fact(fact)
                 facts_stored += 1
+                # internal#473: this fact durably stored → its conversation too.
+                _record_stored_conv(stored_conv_ids, fact)
             except Exception as e:
                 msg = str(e)
                 if '409' in msg or 'duplicate' in msg or 'fingerprint' in msg:
                     logger.debug("Skipped duplicate: %s", fact.get('text', '')[:60])
+                    # Counted as on-chain duplicate → conversation durably stored.
+                    _record_stored_conv(stored_conv_ids, fact)
                 else:
                     errors.append(f"Store failed: {msg}")
                     if len(errors) >= 20:
@@ -1807,7 +1893,7 @@ class ImportEngine:
                         )
                         break
 
-        return facts_stored, errors, dups_skipped
+        return facts_stored, errors, dups_skipped, stored_conv_ids
 
 
 # ── Per-chunk "0 facts" diagnostics (issue #389 follow-up) ──────────────
@@ -1871,3 +1957,15 @@ def _summarize_zero_fact_reasons(reason_counts: dict) -> str:
 def _now_ms() -> int:
     """Current time in milliseconds."""
     return int(time.time() * 1000)
+
+
+def _record_stored_conv(store: set, fact_or_payload) -> None:
+    """internal#473 — record the conversation_id a stored/duplicate fact was
+    extracted from into the per-conversation stored map. Accepts either a raw
+    extracted fact dict or a prepared payload (both carry ``_IMPORT_CONV_KEY``
+    when set); facts with no marker (Crystals, pre-structured facts) are a no-op.
+    """
+    cid = (fact_or_payload or {}).get(_IMPORT_CONV_KEY) if isinstance(
+        fact_or_payload, dict) else None
+    if cid:
+        store.add(cid)

--- a/python/tests/test_batch_sizing_rc4.py
+++ b/python/tests/test_batch_sizing_rc4.py
@@ -145,7 +145,7 @@ def test_sim_revert_halves_and_stores_all(monkeypatch):
     # errors. Store sees group sizes [10, 5, 5].
     calls = _wire_store(monkeypatch, fail_pred=lambda n: n > 5)
     engine = ImportEngine(client=_gnosis_client(), llm_extract=None)
-    stored, errors, dups = asyncio.run(engine._store_facts_chunked(_facts(10)))
+    stored, errors, dups, _conv = asyncio.run(engine._store_facts_chunked(_facts(10)))
     assert stored == 10
     assert errors == []
     assert calls == [10, 5, 5]
@@ -156,7 +156,7 @@ def test_sim_revert_at_single_fact_floor_surfaces_error(monkeypatch):
     # an error rather than silently dropping the fact.
     calls = _wire_store(monkeypatch, fail_pred=lambda n: True)
     engine = ImportEngine(client=_gnosis_client(), llm_extract=None)
-    stored, errors, dups = asyncio.run(engine._store_facts_chunked(_facts(1)))
+    stored, errors, dups, _conv = asyncio.run(engine._store_facts_chunked(_facts(1)))
     assert stored == 0
     assert errors
     assert "Batch store failed" in errors[0]
@@ -170,7 +170,7 @@ def test_sim_revert_partial_floor_failure_stores_the_rest(monkeypatch):
     # exercises a floor error: fail sizes 4 and 1.
     calls = _wire_store(monkeypatch, fail_pred=lambda n: n in (4, 1))
     engine = ImportEngine(client=_gnosis_client(), llm_extract=None)
-    stored, errors, dups = asyncio.run(engine._store_facts_chunked(_facts(4)))
+    stored, errors, dups, _conv = asyncio.run(engine._store_facts_chunked(_facts(4)))
     # [4] reverts → [2],[2] both succeed (size 2 not in fail set).
     assert stored == 4
     assert errors == []
@@ -192,7 +192,7 @@ def test_aa25_with_32500_code_does_not_halve(monkeypatch):
 
     monkeypatch.setattr("totalreclaw.import_engine.store_fact_batch", _raise_aa25)
     engine = ImportEngine(client=_gnosis_client(), llm_extract=None)
-    stored, errors, _ = asyncio.run(engine._store_facts_chunked(_facts(4)))
+    stored, errors, _, _conv = asyncio.run(engine._store_facts_chunked(_facts(4)))
     assert stored == 0
     assert errors  # surfaced
     assert calls == [4]  # exactly one attempt — NOT halved
@@ -211,7 +211,7 @@ def test_sim_revert_without_code_still_halves(monkeypatch):
 
     monkeypatch.setattr("totalreclaw.import_engine.store_fact_batch", _store)
     engine = ImportEngine(client=_gnosis_client(), llm_extract=None)
-    stored, errors, _ = asyncio.run(engine._store_facts_chunked(_facts(4)))
+    stored, errors, _, _conv = asyncio.run(engine._store_facts_chunked(_facts(4)))
     assert stored == 4
     assert errors == []
     assert calls == [4, 2, 2]

--- a/python/tests/test_imp448_shared_batch_sizing.py
+++ b/python/tests/test_imp448_shared_batch_sizing.py
@@ -225,7 +225,7 @@ def test_engine_delegation_reconciles_counts(monkeypatch):
         {"text": f"distinct fact number {i} about something", "type": "fact", "importance": 8}
         for i in range(10)
     ]
-    stored, errors, dups = asyncio.run(engine._store_facts_chunked(facts))
+    stored, errors, dups, _conv = asyncio.run(engine._store_facts_chunked(facts))
     # 10 facts -> one group of 10 -> sim-revert -> halves 5+5 -> all stored.
     assert stored == 10
     assert errors == []

--- a/python/tests/test_imp448_single_pass_regression.py
+++ b/python/tests/test_imp448_single_pass_regression.py
@@ -146,7 +146,7 @@ def test_single_pass_no_duplicate_on_unstorable_floor1_fact(monkeypatch):
     client = _real_client_with_stubbed_store()
     engine = ImportEngine(client=client, llm_extract=None)
 
-    stored, errors, _dups = asyncio.run(engine._store_facts_chunked(_facts(15)))
+    stored, errors, _dups, _conv = asyncio.run(engine._store_facts_chunked(_facts(15)))
 
     # (1) NO duplicate on-chain writes: every distinct STORABLE fact appears in
     # the success log AT MOST ONCE. This is the core regression — the nested

--- a/python/tests/test_imp473_store_result_recording.py
+++ b/python/tests/test_imp473_store_result_recording.py
@@ -1,0 +1,181 @@
+"""internal#473 — ledger recording is store-result-aware, not extracted-implies-
+recorded.
+
+The #466/rc8 fix recorded a conversation at EXTRACTION time, before the on-chain
+store. So a chunk whose facts extracted cleanly but whose ``store_fact_batch``
+then raised/reverted was STILL recorded → never re-importable → its facts were
+silently lost. #473 moves recording AFTER the store and keys it on which
+conversation_ids ACTUALLY durably stored (the store now returns a per-conversation
+stored map).
+
+Three failure modes rc8 left uncovered (its ``_BatchClient.remember_batch`` always
+returned ids — never simulated a store failure):
+
+  (a) extract-succeeds → store-raises  ⇒ conversation NOT recorded (re-import
+      re-extracts + retries the store);
+  (b) multi-chunk conversation: one sibling chunk's fact stores, a sibling's
+      store fails ⇒ recorded (≥1 stored — the #466 dup guard, now store-derived);
+  (c) all-duplicates conversation (store reports dups_skipped, 0 new) ⇒ STILL
+      recorded (the facts already exist on-chain; withholding would loop forever
+      on re-import).
+
+Pure/unit: a recording client + fake adapter; no network, no LLM. Mirrors the
+``_BatchClient`` shape from ``test_rc8_ledger_recording.py`` (the autouse
+conftest shim routes the engine's ``store_fact_batch`` back through this fake's
+``remember_batch`` recorder).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import totalreclaw.import_state as ist
+import totalreclaw.import_engine as ie
+from totalreclaw.import_engine import ImportEngine
+from totalreclaw.import_adapters.types import AdapterParseResult, ConversationChunk
+
+
+class _BatchClient:
+    """Lightweight fake mirroring rc8's ``_BatchClient``.
+
+    ``remember_batch`` raises when ``fail_all`` is set OR any payload text is in
+    ``fail_texts`` — modelling a store that extracts cleanly then raises/reverts
+    on submit. ``find_duplicate_texts`` flags any text in ``dup_texts`` as an
+    on-chain duplicate (the dedup path).
+    """
+
+    def __init__(self, *, fail_all=False, fail_texts=(), dup_texts=()):
+        self.n = 0
+        self.fail_all = fail_all
+        self.fail_texts = tuple(fail_texts)
+        self.dup_texts = tuple(dup_texts)
+
+    async def _ensure_chain_id(self):
+        return 100
+
+    async def remember_batch(self, payloads, source=None):
+        if self.fail_all:
+            raise RuntimeError("bundler rejected the UserOp (paymaster down)")
+        for p in payloads:
+            text = (p or {}).get("text", "") if isinstance(p, dict) else ""
+            if any(marker in text for marker in self.fail_texts):
+                raise RuntimeError(
+                    "-32500 reverted during simulation: store rejected this fact"
+                )
+        ids = [f"f{self.n + i}" for i in range(len(payloads))]
+        self.n += len(payloads)
+        return ids
+
+    async def find_duplicate_texts(self, texts):
+        return [any(d in (t or "") for d in self.dup_texts) for t in texts]
+
+
+def _install_fake_embedding(monkeypatch):
+    import totalreclaw.embedding as emb
+    monkeypatch.setattr(emb, "get_embedding", lambda t: [0.1, 0.2, 0.3])
+
+
+def _chunk(conv_id, text):
+    return ConversationChunk(
+        title=f"{conv_id}:{text[:12]}",
+        messages=[{"role": "user", "text": text},
+                  {"role": "assistant", "text": f"re: {text}"}],
+        timestamp="2026-05-14T09:00:00Z",
+        conversation_id=conv_id,
+    )
+
+
+def _install_adapter(monkeypatch, chunks):
+    class _Adapter:
+        def parse(self, content=None, file_path=None):
+            return AdapterParseResult(
+                facts=[], chunks=list(chunks), total_messages=len(chunks) * 2,
+                warnings=[], errors=[])
+    monkeypatch.setattr(ie, "get_adapter", lambda source: _Adapter())
+
+
+@pytest.fixture(autouse=True)
+def _tmp_state_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(ist, "IMPORT_STATE_DIR", tmp_path / "import-state")
+    yield
+
+
+def _extractor():
+    """One fact per chunk, carrying the chunk's user text so the fake store can
+    raise selectively on it."""
+    async def _extract(messages, timestamp):
+        text = messages[0]["content"]
+        return [{"text": f"fact from {text}", "type": "fact", "importance": 8}]
+    return _extract
+
+
+# ── (a) extract-succeeds → store-raises ⇒ NOT recorded; re-import re-extracts ──
+def test_store_failure_keeps_conversation_unrecorded_and_re_importable(monkeypatch):
+    """The core #473 repro: a chunk extracts a fact, but the store raises. The
+    conversation must NOT be recorded — otherwise its fact is silently lost and
+    re-import skips it forever."""
+    _install_fake_embedding(monkeypatch)
+    chunks = [_chunk("X", "xray one")]
+    _install_adapter(monkeypatch, chunks)
+
+    # Run 1: store raises for every fact.
+    client = _BatchClient(fail_all=True)
+    engine = ImportEngine(client=client, llm_extract=_extractor())
+    result = asyncio.run(engine.process_batch(source="chatgpt", content="x"))
+
+    assert result.facts_stored == 0          # store raised → nothing durable
+    assert result.errors                     # the store failure is surfaced
+    recorded = ist.load_imported_conversations("chatgpt")
+    assert recorded == set(), recorded       # X NOT recorded → stays re-importable
+
+    # Run 2 (re-import): store now succeeds. X was never recorded, so it is
+    # re-processed — its fact is extracted AND durably stored this time, then X
+    # is recorded. This is the recovery the bug used to silently block.
+    client.fail_all = False
+    engine2 = ImportEngine(client=client, llm_extract=_extractor())
+    result2 = asyncio.run(engine2.process_batch(source="chatgpt", content="x"))
+    assert result2.facts_stored >= 1
+    assert "X" in ist.load_imported_conversations("chatgpt")
+
+
+# ── (b) multi-chunk: one sibling stores, sibling's store fails ⇒ recorded ──────
+def test_partial_store_failure_records_conversation_if_sibling_stored(monkeypatch):
+    """#466 dup guard, now store-derived: conversation A spans 2 facts. The
+    combined batch store raises (one fact rejects), halves, and the GOOD half
+    stores while the bad half errors. A stored ≥1 fact ⇒ recorded (so re-import
+    skips it) — even though a sibling fact's store failed."""
+    _install_fake_embedding(monkeypatch)
+    # a0 stores cleanly; a1's fact carries the marker the fake store raises on.
+    chunks = [
+        _chunk("A", "alpha good"),
+        _chunk("A", "alpha kaboom"),
+    ]
+    _install_adapter(monkeypatch, chunks)
+    client = _BatchClient(fail_texts=("kaboom",))
+    engine = ImportEngine(client=client, llm_extract=_extractor())
+    result = asyncio.run(engine.process_batch(source="chatgpt", content="x"))
+
+    assert result.facts_stored >= 1          # the good sibling durably stored
+    assert result.errors                     # the bad sibling's failure surfaced
+    # A recorded because ≥1 fact stored — re-import must skip it (no dups).
+    assert "A" in ist.load_imported_conversations("chatgpt")
+
+
+# ── (c) all-duplicates conversation ⇒ STILL recorded ───────────────────────────
+def test_all_duplicate_conversation_is_recorded(monkeypatch):
+    """The subtlest case: a conversation whose facts are ALL on-chain
+    duplicates (store reports dups_skipped, 0 new). The facts already exist, so
+    the conversation IS durably stored — it must record, or every re-import
+    re-extracts it forever (an infinite loop of zero-fact re-imports)."""
+    _install_fake_embedding(monkeypatch)
+    chunks = [_chunk("C", "charlie dupconv")]
+    _install_adapter(monkeypatch, chunks)
+    # find_duplicate_texts flags C's fact as already on-chain.
+    client = _BatchClient(dup_texts=("dupconv",))
+    engine = ImportEngine(client=client, llm_extract=_extractor())
+    result = asyncio.run(engine.process_batch(source="chatgpt", content="x"))
+
+    assert result.facts_stored == 0          # nothing new written
+    assert result.dups_skipped >= 1          # deduped client-side
+    assert "C" in ist.load_imported_conversations("chatgpt")

--- a/python/tests/test_import_engine_batching.py
+++ b/python/tests/test_import_engine_batching.py
@@ -162,7 +162,7 @@ def test_gnosis_14_facts_all_stored_within_caps(store_mock) -> None:
     client = _make_pro_client()
     engine = ImportEngine(client=client, llm_extract=None)
 
-    facts_stored, errors, _dups = _run(engine._store_facts_chunked(_make_facts(14)))
+    facts_stored, errors, _dups, _conv = _run(engine._store_facts_chunked(_make_facts(14)))
 
     assert errors == []
     assert facts_stored == 14
@@ -176,7 +176,7 @@ def test_gnosis_15_facts_all_stored_within_caps(store_mock) -> None:
     client = _make_pro_client()
     engine = ImportEngine(client=client, llm_extract=None)
 
-    facts_stored, errors, _dups = _run(engine._store_facts_chunked(_make_facts(15)))
+    facts_stored, errors, _dups, _conv = _run(engine._store_facts_chunked(_make_facts(15)))
 
     assert errors == []
     assert facts_stored == 15
@@ -190,7 +190,7 @@ def test_gnosis_30_facts_all_stored_within_caps(store_mock) -> None:
     client = _make_pro_client()
     engine = ImportEngine(client=client, llm_extract=None)
 
-    facts_stored, errors, _dups = _run(engine._store_facts_chunked(_make_facts(30)))
+    facts_stored, errors, _dups, _conv = _run(engine._store_facts_chunked(_make_facts(30)))
 
     assert errors == []
     assert facts_stored == 30
@@ -207,7 +207,7 @@ def test_gnosis_45_facts_split_within_caps(store_mock) -> None:
     client = _make_pro_client()
     engine = ImportEngine(client=client, llm_extract=None)
 
-    facts_stored, errors, _dups = _run(engine._store_facts_chunked(_make_facts(45)))
+    facts_stored, errors, _dups, _conv = _run(engine._store_facts_chunked(_make_facts(45)))
 
     assert errors == []
     assert facts_stored == 45
@@ -225,7 +225,7 @@ def test_gnosis_count_cap_binds_without_embedding(monkeypatch, store_mock) -> No
     client = _make_pro_client()
     engine = ImportEngine(client=client, llm_extract=None)
 
-    facts_stored, errors, _dups = _run(engine._store_facts_chunked(_make_facts(20)))
+    facts_stored, errors, _dups, _conv = _run(engine._store_facts_chunked(_make_facts(20)))
 
     assert errors == []
     assert facts_stored == 20
@@ -277,7 +277,7 @@ def test_free_tier_falls_back_to_per_fact_remember() -> None:
     client = _make_free_client()
     engine = ImportEngine(client=client, llm_extract=None)
 
-    facts_stored, errors, _dups = _run(engine._store_facts_chunked(_make_facts(15)))
+    facts_stored, errors, _dups, _conv = _run(engine._store_facts_chunked(_make_facts(15)))
 
     assert errors == []
     assert facts_stored == 15
@@ -297,7 +297,7 @@ def test_unresolvable_chain_falls_back_to_per_fact() -> None:
     client.remember = AsyncMock(side_effect=_remember)
     engine = ImportEngine(client=client, llm_extract=None)
 
-    facts_stored, errors, _dups = _run(engine._store_facts_chunked(_make_facts(3)))
+    facts_stored, errors, _dups, _conv = _run(engine._store_facts_chunked(_make_facts(3)))
 
     assert errors == []
     assert facts_stored == 3
@@ -316,7 +316,7 @@ def test_gnosis_batch_409_dedup_is_silent(store_mock) -> None:
     store_mock.side_effect = RuntimeError("409 fingerprint duplicate")
     engine = ImportEngine(client=client, llm_extract=None)
 
-    facts_stored, errors, _dups = _run(engine._store_facts_chunked(_make_facts(15)))
+    facts_stored, errors, _dups, _conv = _run(engine._store_facts_chunked(_make_facts(15)))
 
     assert errors == []
     assert facts_stored == 0
@@ -340,7 +340,7 @@ def test_gnosis_batch_partial_id_list_counts_only_returned_ids(monkeypatch, stor
     store_mock.side_effect = _short_batch
     engine = ImportEngine(client=client, llm_extract=None)
 
-    facts_stored, errors, _dups = _run(engine._store_facts_chunked(_make_facts(5)))
+    facts_stored, errors, _dups, _conv = _run(engine._store_facts_chunked(_make_facts(5)))
 
     assert errors == []
     assert store_mock.await_count == 1
@@ -354,7 +354,7 @@ def test_gnosis_batch_non_dedup_error_surfaced(store_mock) -> None:
     store_mock.side_effect = RuntimeError("AA25 nonce zombie")
     engine = ImportEngine(client=client, llm_extract=None)
 
-    facts_stored, errors, _dups = _run(engine._store_facts_chunked(_make_facts(45)))
+    facts_stored, errors, _dups, _conv = _run(engine._store_facts_chunked(_make_facts(45)))
 
     assert facts_stored == 0
     # AA25 is not a sim-size revert → no halving → exactly one error per group.
@@ -366,7 +366,7 @@ def test_empty_input_returns_zero_no_calls(store_mock) -> None:
     client = _make_pro_client()
     engine = ImportEngine(client=client, llm_extract=None)
 
-    facts_stored, errors, _dups = _run(engine._store_facts_chunked([]))
+    facts_stored, errors, _dups, _conv = _run(engine._store_facts_chunked([]))
 
     assert facts_stored == 0
     assert errors == []

--- a/python/tests/test_rc13_import_wave.py
+++ b/python/tests/test_rc13_import_wave.py
@@ -409,7 +409,7 @@ async def test_store_skips_crossvault_and_intracall_duplicates():
         {"text": "User visited  bergen", "type": "episode", "importance": 7}, # intra-call dup (normalized)
         {"text": "User is vegetarian", "type": "preference", "importance": 8},
     ]
-    stored, errors, dups = await engine._store_facts_chunked(facts)
+    stored, errors, dups, _conv = await engine._store_facts_chunked(facts)
     assert not errors
     assert dups == 2
     assert stored == 2
@@ -427,7 +427,7 @@ async def test_dedup_fails_open_when_lookup_errors():
 
     client = _Brittle(known_texts=set())
     engine = ImportEngine(client=client, llm_extract=None)
-    stored, errors, dups = await engine._store_facts_chunked(
+    stored, errors, dups, _conv = await engine._store_facts_chunked(
         [{"text": "unique fact", "type": "claim", "importance": 8}],
     )
     assert stored == 1 and dups == 0 and not errors


### PR DESCRIPTION
## Summary

Fixes the data-loss bug from **internal#473** (verdict comment [4935366014](https://github.com/p-diogo/totalreclaw-internal/issues/473#issuecomment-4935366014)): the imported-conversation ledger was **extracted-implies-recorded**, not **stored-implies-recorded**.

## The bug (failure-mode narrative)

`_process_chunk_batch` recorded a conversation into the imported-ledger at extraction time (`engine.py:784`, keyed on `_conv_with_stored_facts` populated from extraction success at `:718`) **before** `_store_facts_chunked` ran (`:841`). So:

1. A chunk extracts facts → its `conversation_id` is marked "stored" at extraction.
2. The ledger records the conversation immediately.
3. `_store_facts_chunked` then raises/reverts/drops those facts (paymaster reject, gas sim-revert, network) → the facts are **silently lost**.
4. Because the conversation is already recorded, a re-import **skips it forever** → the facts are gone for good.

The compound case (a sibling chunk 429-fails extraction AND the surviving sibling's store also fails) recorded+lost the same way. The #466/rc8 fix traded this correctly against the whole-conversation dup blast-radius, but #473's actual ask — store-result-awareness — was untouched.

## The fix

| AC (issue + verdict) | How |
|---|---|
| **AC1 — move recording AFTER `_store_facts_chunked`** | `record_imported_conversations` relocated to after the store (`engine.py:854`); `_conv_with_stored_facts` is now accumulated from the store result. |
| **AC2 — key on actually-stored conversation_ids** | `_store_facts_chunked` returns a 4th element: the per-conversation stored set. Each extracted fact is stamped with its chunk's `conversation_id` (`_IMPORT_CONV_KEY`), threaded through `_prepare_fact_payload`. Stored conv ids are collected from the Gnosis `_store_group` success path (one id per input fact in order; a raise propagates *before* recording, so per-success-group recording is correct under the #448 halving cascade), the per-fact fallback, and **both** dedup passes. |
| **AC3 — reword stale comments** | The three "stored-implies-recorded" comments (field docstring, extraction loop, recording filter) now describe the store-result-aware semantics truthfully. |

### Subtle cases handled
- **Dup counts as stored** — a fact skipped client-side as an on-chain duplicate already exists, so its conversation is durably stored. A fully-duplicate conversation **must** record or re-imports loop forever. Both the cross-vault fingerprint pass and the intra-call pass feed `_record_stored_conv`.
- **Store-failed-but-extracted stays unrecorded** — added `_conv_with_extracted_facts` so the filter can tell "extracted facts but store failed" (withhold → re-importable, the #473 fix) apart from "extracted nothing, no failure" (record, so re-import doesn't churn re-extracting it). The naive port of the old `or not any(failed chunk)` clause would have re-recorded store failures.
- **#466 sibling-stored semantics preserved** — a conversation that stored ≥1 fact via a surviving sibling still records (now store-derived instead of extraction-derived).

## #448 surface

The store still flows through `operations.group_and_store_adaptive` / `store_fact_batch` — **no signature change to the shared store helpers**, no nesting of halving cascades. Only `_store_facts_chunked`'s *return* widened (3-tuple → 4-tuple); `WalletContext` plumbing intact. Direct-call tests updated mechanically for the unpack (assertions unchanged).

## Tests

New `tests/test_imp473_store_result_recording.py` (modeled on `test_rc8_ledger_recording.py`'s `_BatchClient`):
- **(a)** extract-succeeds → store-raises ⇒ conversation **not** recorded, and a re-import (store now succeeding) re-extracts + stores + records it.
- **(b)** multi-chunk conversation: one sibling fact stores, a sibling's store fails (via the halving cascade) ⇒ **recorded** (≥1 stored).
- **(c)** all-duplicates conversation (`find_duplicate_texts` flags it, `dups_skipped`, 0 new) ⇒ **recorded**.

Every existing test stays green: `test_rc8_ledger_recording.py`, `test_rc13_import_wave.py`, rc4/rc5/rc6 invariant tests, `test_imp448_*`.

## Verification

- `python -m pytest tests -q` → **2210 passed, 39 skipped, 1 xfailed** (baseline 2207 + 3 new).
- `python3 scripts/check-memory-type-sync.py` → OK.
- No relay/on-chain protocol change (store call-path unchanged) → staging E2E not applicable; this is pure client-side engine logic, covered by the unit + failure-mode tests above.

Refs internal#473.

🤖 Generated with [Claude Code](https://claude.com/claude-code)