### PR TITLE
chore(plugin): bump version base to 3.3.13-rc.1 for next RC

### DIFF
--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "End-to-end encrypted, decentralized memory for OpenClaw. A native kind:memory provider — recall is automatic via memory_search/memory_get, and facts are captured in the background. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', any recall request ('what do you remember about me', 'what's my X'), AND any explicit remember request ('remember X', 'save X')."
-version: 3.3.12-rc.13
+version: 3.3.13-rc.1
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.12-rc.12",
+  "version": "3.3.13-rc.1",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "3.3.12-rc.10",
+  "version": "3.3.13-rc.1",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",
@@ -24,7 +24,10 @@
         "mode": {
           "type": "string",
           "required": false,
-          "enum": ["generate", "import"],
+          "enum": [
+            "generate",
+            "import"
+          ],
           "default": "generate",
           "description": "\"generate\" = browser will create a NEW recovery phrase. \"import\" = browser will accept an EXISTING phrase pasted by the user in their browser (never through chat)."
         }
@@ -43,7 +46,13 @@
         "type": {
           "type": "string",
           "required": false,
-          "enum": ["fact", "preference", "decision", "episodic", "goal"],
+          "enum": [
+            "fact",
+            "preference",
+            "decision",
+            "episodic",
+            "goal"
+          ],
           "default": "fact",
           "description": "Type of memory"
         },
@@ -95,7 +104,10 @@
         "format": {
           "type": "string",
           "required": false,
-          "enum": ["json", "markdown"],
+          "enum": [
+            "json",
+            "markdown"
+          ],
           "default": "json",
           "description": "Export format"
         }
@@ -121,7 +133,10 @@
         "source": {
           "type": "string",
           "required": true,
-          "enum": ["mem0", "mcp-memory"],
+          "enum": [
+            "mem0",
+            "mcp-memory"
+          ],
           "description": "Source system to import from"
         }
       }
@@ -149,7 +164,11 @@
       "bins": []
     },
     "emoji": "🧠",
-    "os": ["macos", "linux", "windows"],
+    "os": [
+      "macos",
+      "linux",
+      "windows"
+    ],
     "hooks": {
       "before_agent_start": {
         "priority": 10,
@@ -181,7 +200,13 @@
           "type": {
             "type": "string",
             "required": false,
-            "enum": ["fact", "preference", "decision", "episodic", "goal"],
+            "enum": [
+              "fact",
+              "preference",
+              "decision",
+              "episodic",
+              "goal"
+            ],
             "default": "fact",
             "description": "Type of memory"
           },
@@ -230,7 +255,10 @@
           "format": {
             "type": "string",
             "required": false,
-            "enum": ["json", "markdown"],
+            "enum": [
+              "json",
+              "markdown"
+            ],
             "default": "json",
             "description": "Export format"
           }
@@ -253,7 +281,10 @@
           "source": {
             "type": "string",
             "required": true,
-            "enum": ["mem0", "mcp-memory"],
+            "enum": [
+              "mem0",
+              "mcp-memory"
+            ],
             "description": "Source system to import from"
           },
           "api_key": {
@@ -309,7 +340,10 @@
           "mode": {
             "type": "string",
             "required": false,
-            "enum": ["generate", "import"],
+            "enum": [
+              "generate",
+              "import"
+            ],
             "default": "generate",
             "description": "\"generate\" = browser will create a NEW recovery phrase. \"import\" = browser will accept an EXISTING phrase pasted by the user in their browser (never through chat)."
           }


### PR DESCRIPTION
Bumps the three plugin version sites to `3.3.13-rc.1` so the next RC publishes as **3.3.13-rc.1** (semver-higher than stable 3.3.12 = clean reinstall, not a downgrade). Ships the #507 pairing fix + reinstall/slot robustness in the first 3.3.13 RC. Drift check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EDaj45174CK3TbdGytDDD