### PR TITLE
ci: consolidate plugin npm publishing onto npm-publish.yml (single Trusted Publisher)

### DIFF
--- a/.github/workflows/promote-rc.yml
+++ b/.github/workflows/promote-rc.yml
@@ -37,7 +37,6 @@ on:
           - mcp-server
           - client
           - nanoclaw
-          - plugin
           - core-pypi
           - python-client
           - crate-core
@@ -121,7 +120,7 @@ jobs:
         if: >
           inputs.package == 'core' || inputs.package == 'client' ||
           inputs.package == 'mcp-server' || inputs.package == 'nanoclaw' ||
-          inputs.package == 'plugin' || inputs.package == 'all'
+          inputs.package == 'all'
         run: |
           set -e
           RC="${{ needs.derive-versions.outputs.rc-version }}"
@@ -132,8 +131,7 @@ jobs:
             client) PKGS=("@totalreclaw/client") ;;
             mcp-server) PKGS=("@totalreclaw/mcp-server") ;;
             nanoclaw) PKGS=("@totalreclaw/skill-nanoclaw") ;;
-            plugin) PKGS=("@totalreclaw/totalreclaw") ;;
-            all) PKGS=("@totalreclaw/core" "@totalreclaw/client" "@totalreclaw/mcp-server" "@totalreclaw/skill-nanoclaw" "@totalreclaw/totalreclaw") ;;
+            all) PKGS=("@totalreclaw/core" "@totalreclaw/client" "@totalreclaw/mcp-server" "@totalreclaw/skill-nanoclaw") ;;  # plugin excluded — it publishes via npm-publish.yml only
           esac
           for p in "${PKGS[@]}"; do
             if ! npm view "$p@$RC" version >/dev/null 2>&1; then
@@ -201,7 +199,7 @@ jobs:
     if: >
       (inputs.package == 'core' || inputs.package == 'client' ||
        inputs.package == 'mcp-server' || inputs.package == 'nanoclaw' ||
-       inputs.package == 'plugin' || inputs.package == 'all') &&
+       inputs.package == 'all') &&
       inputs.dry-run == false
     permissions:
       contents: read
@@ -228,8 +226,7 @@ jobs:
             client) PKGS=("@totalreclaw/client") ;;
             mcp-server) PKGS=("@totalreclaw/mcp-server") ;;
             nanoclaw) PKGS=("@totalreclaw/skill-nanoclaw") ;;
-            plugin) PKGS=("@totalreclaw/totalreclaw") ;;
-            all) PKGS=("@totalreclaw/core" "@totalreclaw/client" "@totalreclaw/mcp-server" "@totalreclaw/skill-nanoclaw" "@totalreclaw/totalreclaw") ;;
+            all) PKGS=("@totalreclaw/core" "@totalreclaw/client" "@totalreclaw/mcp-server" "@totalreclaw/skill-nanoclaw") ;;  # plugin excluded — it publishes via npm-publish.yml only
           esac
 
           mkdir -p /tmp/promote

--- a/docs/guides/release-process.md
+++ b/docs/guides/release-process.md
@@ -181,6 +181,22 @@ differ. Ship with the table below in front of you.
    # (stable-version auto-derived to 2.1.0)
    ```
 
+   > **⚠️ The OpenClaw plugin (`@totalreclaw/totalreclaw`) is npm-published ONLY
+   > via `npm-publish.yml` — never `promote-rc.yml`.** npm allows exactly one
+   > Trusted Publisher per package, and the plugin's is `npm-publish.yml` (which
+   > does both `rc` and `stable` via `release-type`). `promote-rc.yml` no longer
+   > lists `plugin` for npm (removed 2026-07-13, consolidation). To promote the
+   > plugin to npm stable, bump `skill/plugin/package.json` to the clean version
+   > (drop the `-rc.N` suffix) and dispatch:
+   > ```bash
+   > gh workflow run npm-publish.yml -f package=plugin -f release-type=stable
+   > ```
+   > This rebuilds from source at the stable version (vs `promote-rc.yml`'s
+   > re-pack of the exact RC tarball — the accepted tradeoff for a single, clean
+   > publisher). The plugin's **ClawHub** promote is unaffected — still
+   > `promote-rc.yml -f package=clawhub` (ClawHub has no Trusted-Publisher
+   > constraint).
+
 6. **Advertise the new stable to the fleet — set `LATEST_STABLE_PYTHON` on BOTH
    relay services.** This is the single env flip that makes the automatic update
    notice fire fleet-wide: the relay serves it in `/v1/billing/status` →


### PR DESCRIPTION
## Why
npm allows **exactly one Trusted Publisher per package**. Both `npm-publish.yml` (rc+stable) and `promote-rc.yml` (re-pack RC→stable) publish `@totalreclaw/totalreclaw`, so registering one deregisters the other. Registering `promote-rc.yml` for the stable promote silently deregistered `npm-publish.yml` → the 3.3.13-rc.1 RC publish failed with E404 PUT.

## What (Option C — consolidate, chosen by Pedro)
- Remove `plugin` from `promote-rc.yml`'s **npm** jobs (dropdown, both `if:`, both `case`, both `all` lists). ClawHub plugin promote is untouched (no TP constraint).
- `npm-publish.yml` becomes the plugin's sole npm publisher — it already does both `rc` and `stable` via `release-type`.
- Documented in `release-process.md`: plugin npm stable = `npm-publish.yml -f package=plugin -f release-type=stable`.

## Operator action (one-time, permanent)
On npmjs.com → `@totalreclaw/totalreclaw` → Settings → Trusted Publisher: point it at **`npm-publish.yml`** (repo `p-diogo/totalreclaw`). `promote-rc.yml` stays the TP for the other npm packages.

## Tradeoff (accepted)
Plugin stable becomes rebuild-from-source (npm-publish.yml) vs re-pack of the exact RC tarball (promote-rc.yml). Deterministic for a TS/docs build from the same commit.

Both workflows validate as YAML. No other package affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EDaj45174CK3TbdGytDDD