### PR TITLE
chore(plugin): 3.3.13 stable version (promote 3.3.13-rc.1)

### DIFF
--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "End-to-end encrypted, decentralized memory for OpenClaw. A native kind:memory provider — recall is automatic via memory_search/memory_get, and facts are captured in the background. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', any recall request ('what do you remember about me', 'what's my X'), AND any explicit remember request ('remember X', 'save X')."
-version: 3.3.13-rc.1
+version: 3.3.13
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.13-rc.1",
+  "version": "3.3.13",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [

--- a/skill/plugin/register-command-name.test.ts
+++ b/skill/plugin/register-command-name.test.ts
@@ -273,9 +273,13 @@ const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.jso
 const skillJson = JSON.parse(fs.readFileSync(path.join(__dirname, 'skill.json'), 'utf8'));
 
 // Accept 3.3.7-rc.3+ OR 3.3.8-rc.N+ OR 3.3.9-rc.N+ OR 3.3.10-rc.N+ OR
-// 3.3.<11+>-rc.N (versions bump with each patch wave; 3.3.10 series
-// ships the shell-side `setsid -f` pair detach for the persistent 502).
-const validVersionPattern = /^3\.3\.(7-rc\.[3-9]\d*|8-rc\.\d+|9-rc\.\d+|10-rc\.\d+|1[1-9]-rc\.\d+|[2-9]\d-rc\.\d+|[1-9]\d*\.\d+|[1-9]\d{2,}.*)$/;
+// 3.3.<11+> with an OPTIONAL -rc.N suffix (versions bump with each patch
+// wave; 3.3.10 series ships the shell-side `setsid -f` pair detach for the
+// persistent 502). Clean (suffix-less) versions became valid in-repo when
+// stable publishing consolidated onto npm-publish.yml (#509): the stable
+// publish now carries the clean version in package.json instead of
+// promote-rc.yml re-tagging an rc in-workflow.
+const validVersionPattern = /^3\.3\.(7-rc\.[3-9]\d*|8-rc\.\d+|9-rc\.\d+|10-rc\.\d+|1[1-9](-rc\.\d+)?|[2-9]\d(-rc\.\d+)?|[1-9]\d*\.\d+|[1-9]\d{2,}.*)$/;
 
 assert(
   validVersionPattern.test(packageJson.version),

--- a/skill/plugin/skill-md-native.test.ts
+++ b/skill/plugin/skill-md-native.test.ts
@@ -240,8 +240,8 @@ for (const pattern of FORBIDDEN_TOOLBIND_WAIT) {
 // ---------------------------------------------------------------------------
 
 assert(
-  /^version: 3\.3\.(9|1\d)-rc\./m.test(pluginSkillMd),
-  'skill/plugin/SKILL.md: frontmatter version is 3.3.9-rc.N or 3.3.1[0-9]-rc.N',
+  /^version: 3\.3\.(9|1\d)(-rc\.\d+)?$/m.test(pluginSkillMd),
+  'skill/plugin/SKILL.md: frontmatter version is 3.3.9+/3.3.1[0-9] with optional -rc.N (clean stable versions valid in-repo since the #509 publish consolidation)',
 );
 
 // ---------------------------------------------------------------------------

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "3.3.13-rc.1",
+  "version": "3.3.13",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",


### PR DESCRIPTION
Pedro validated `3.3.13-rc.1` live on pop-os (fresh install → enable → in-process pairing sealed — the exact flow #507 fixed). Promote gate passed. Bumps the three version sites to clean `3.3.13` for the stable publish via `npm-publish.yml -f package=plugin -f release-type=stable` (sole npm publisher post-#509). Drift check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EDaj45174CK3TbdGytDDD