### PR TITLE
fix(relay): send X-Wallet-Address on subgraph reads so Pro recall hits Gnosis

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,7 +24,7 @@ name = "totalreclaw"
 # now `2.4.5`, so RCs cut as `2.4.5rcN` outrank `2.4.4` and the
 # version-agnostic install path lands them. NEVER leave the base equal to
 # an already-published stable.
-version = "2.4.6"
+version = "2.4.7"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"

--- a/python/src/totalreclaw/relay.py
+++ b/python/src/totalreclaw/relay.py
@@ -317,9 +317,20 @@ class RelayClient:
         params = {}
         if chain:
             params["chain"] = chain
+        # The relay routes /v1/subgraph to the correct chain by looking up
+        # this wallet's tier (Pro → Gnosis, Free → Base Sepolia). It reads the
+        # wallet from the ``X-Wallet-Address`` header and *fails open to free*
+        # when the header is absent. Without it, Pro-tier reads land on the
+        # Base Sepolia subgraph and return 0 rows even though the facts live
+        # on Gnosis — the recall-returns-nothing bug (issue #486). Mirror the
+        # write path (``submit_userop``) and always send the wallet so reads
+        # track the same chain as writes.
+        headers = self._base_headers()
+        if self._wallet_address:
+            headers["X-Wallet-Address"] = self._wallet_address
         resp = await http.post(
             f"{self._relay_url}/v1/subgraph",
-            headers=self._base_headers(),
+            headers=headers,
             json={"query": query, "variables": variables},
             params=params,
         )

--- a/python/tests/test_relay.py
+++ b/python/tests/test_relay.py
@@ -143,3 +143,51 @@ class TestBillingStatusParsing:
         status = await rc.get_billing_status()
         assert status.features is not None
         assert status.features.latest_stable_python is None
+
+
+class TestSubgraphWalletHeader:
+    """issue #486 — recall returned 0 results for Pro vaults.
+
+    The relay routes ``/v1/subgraph`` to the correct chain by reading the
+    ``X-Wallet-Address`` header and looking up the wallet's tier (Pro →
+    Gnosis, Free → Base Sepolia), failing open to *free* when the header is
+    absent. ``query_subgraph`` used to send only ``_base_headers()`` (no
+    wallet), so Pro-tier reads landed on the Base Sepolia subgraph and
+    returned nothing while writes/status/web-app all used Gnosis. Recall,
+    export, and confirm-indexed all go through ``query_subgraph``, so the
+    wallet header must ride along on every subgraph read.
+    """
+
+    def _capturing_relay(self, captured: dict, wallet_address):
+        def _handler(request: httpx.Request) -> httpx.Response:
+            captured["headers"] = request.headers
+            return httpx.Response(200, json={"data": {"facts": []}})
+
+        transport = httpx.MockTransport(_handler)
+        rc = RelayClient(
+            relay_url="https://api-staging.totalreclaw.xyz",
+            auth_key_hex="00" * 32,
+            wallet_address=wallet_address,
+        )
+
+        async def _mock_get_http() -> httpx.AsyncClient:
+            return httpx.AsyncClient(transport=transport, timeout=10.0)
+
+        rc._get_http = _mock_get_http  # type: ignore[assignment]
+        return rc
+
+    @pytest.mark.asyncio
+    async def test_issue_486_query_subgraph_sends_wallet_header(self):
+        wallet = "0x" + "ab" * 20
+        captured: dict = {}
+        rc = self._capturing_relay(captured, wallet)
+        await rc.query_subgraph("query { facts { id } }", {"owner": wallet})
+        # Pre-patch this header was absent → relay fell open to Base Sepolia.
+        assert captured["headers"].get("x-wallet-address") == wallet
+
+    @pytest.mark.asyncio
+    async def test_issue_486_no_wallet_omits_header(self):
+        captured: dict = {}
+        rc = self._capturing_relay(captured, None)
+        await rc.query_subgraph("query { facts { id } }", {})
+        assert "x-wallet-address" not in captured["headers"]


### PR DESCRIPTION
## What broke
On Pro-tier Hermes vaults, `totalreclaw_recall` returned `{"count": 0, "memories": []}` for every query even though `totalreclaw_status` showed 157 writes and the memories were visible in the web app (reported in p-diogo/totalreclaw-internal#486).

## What's fixed
`RelayClient.query_subgraph` now sends the `X-Wallet-Address` header on every subgraph read (mirroring the write path `submit_userop`). The relay uses that header to look up the wallet's tier and route to the right subgraph — Pro → Gnosis (chain 100), Free → Base Sepolia (84532) — and **fails open to Free when the header is absent** (`relay/src/routes/proxy.ts` → `getEffectiveTier`). Header-less reads were landing on the empty Base Sepolia subgraph.

## Impact after fix
Pro-tier `recall` (and `export`, and confirm-indexed reads) now query the Gnosis subgraph where their facts actually live, so recall returns matching memories again. Free-tier behavior is unchanged (Free wallets route to Base Sepolia either way).

## Verification
- New regression test `TestSubgraphWalletHeader::test_issue_486_*` asserts the header is sent on subgraph reads — **fails on the pre-patch tree, passes post-patch**.
- Full `test_relay.py` suite (16) + operations/session/chain-id/retype/pin suites (106) green.
- ⚠️ **E2E gap:** the QA stack has no Pro-tier Gnosis account, so the real-user recall-returns-N flow could not be exercised on this VPS. Root cause is confirmed directly from both the client (`relay.py`) and relay (`proxy.ts`) source. A 30-second confirm on a live Pro vault is the one remaining check — see escalation on the tracking issue.

Refs p-diogo/totalreclaw-internal#486