### PR TITLE
chore(eval): segmentation eyeball harness + 0.55 validation record

### DIFF
--- a/tools/eval-segmentation/.gitignore
+++ b/tools/eval-segmentation/.gitignore
@@ -1,0 +1,4 @@
+# Eyeball-harness output — contains the reviewer's personal conversation
+# export. Never commit.
+segmentation_eyeball_report.md
+*_eyeball_report.md

--- a/tools/eval-segmentation/README.md
+++ b/tools/eval-segmentation/README.md
@@ -1,0 +1,69 @@
+# Segmentation eyeball harness
+
+A **manual evaluation tool** for the Gemini-import session-segmentation path. It
+runs the **exact production segmentation** over a real Google Takeout export and
+emits a markdown report for a human to eyeball: *are the session groupings
+right? over-merged? over-split?*
+
+This is **not** part of the pytest suite — it needs a real Takeout export plus
+the ~344 MB Harrier ONNX embedding model, so it is run by hand when tuning the
+segmentation threshold / gap.
+
+## What it does
+
+Replays the production Gemini-import pipeline, read-only:
+
+```
+core parse_gemini (via GeminiAdapter)  ->  flatten to turns
+  ->  embed prompt+reply (Harrier 640d, local)  ->  segment_sessions(gap, threshold)
+  ->  markdown report of every multi-turn session + singleton stats
+```
+
+- **No network, no on-chain writes, no LLM calls.** Embedding is the local
+  Harrier ONNX model only.
+- Turn text = `prompt + " " + reply` (capped 1000 chars), per-turn timestamp =
+  the record timestamp (flat Takeout has per-record times).
+- `segment_sessions(timestamps, embeddings, gap_seconds, sim_threshold)` is the
+  shared centroid-walk segmenter (`totalreclaw.crystals.session_segmentation`;
+  prefers the Rust core `totalreclaw_core.segment_sessions`).
+- The report lists every **multi-turn** session (≥2 turns — these are the ones
+  that would mint a Crystal) with turn previews, plus the size histogram and the
+  singleton count (singletons are gated out of Crystal minting by design).
+
+## Usage
+
+From the repo root, with the Python client installed in a venv:
+
+```bash
+PYTHONPATH=python/src .venv/bin/python tools/eval-segmentation/eval_segmentation_eyeball.py \
+    "/path/to/My Activity.html" \
+    [--threshold 0.55] [--gap 1800] \
+    [--out segmentation_eyeball_report.md] [--max-sessions 200]
+```
+
+Defaults match production: `--threshold 0.55`, `--gap 1800` (seconds).
+
+## Validation record (2026-07-14)
+
+Pedro reviewed the report over his real **3,942-record** Gemini Takeout export.
+Verdict: **LOOKS RIGHT** at `threshold=0.55`, `gap=1800s`.
+
+| metric | value |
+|---|---|
+| turns parsed | 3,795 |
+| sessions | 1,651 |
+| singletons (1-turn, gated → no Crystal) | 902 (55%) |
+| multi-turn sessions (≥2 turns → one Crystal each) | 749 |
+| old per-chunk scheme Crystals (for comparison) | ~1,397 |
+
+The new turn-granularity segmentation mints **~46% fewer Crystals** than the old
+per-chunk scheme — almost entirely by collapsing the single-Q&A noise the old
+scheme over-split into separate Crystals. The **≥2-turn Crystal gate stays**.
+
+## Notes
+
+- The harness is intentionally a thin read-only replay — it imports
+  `GeminiAdapter`, `segment_sessions`, and `get_embedding` from the installed
+  client, so it tracks production behaviour automatically as those move.
+- The generated report contains the reviewer's **personal conversation text**;
+  it is git-ignored (see `.gitignore`) and must never be committed.

--- a/tools/eval-segmentation/eval_segmentation_eyeball.py
+++ b/tools/eval-segmentation/eval_segmentation_eyeball.py
@@ -1,0 +1,134 @@
+"""Eyeball harness for Gemini-import session segmentation (read-only).
+
+Runs the EXACT production segmentation path over a real Gemini Takeout export
+and prints a human-readable session report for manual review:
+
+  parse (core parse_gemini via GeminiAdapter) -> flatten turns
+  -> embed prompt+reply (Harrier 640d, local) -> segment_sessions(1800, 0.55)
+
+No network, no on-chain writes, no LLM calls. Output: a markdown report of
+every multi-turn session (these are the ones that would get Crystals) plus
+singleton stats, so a human can judge: are the groupings right? over-merged?
+over-split?
+
+Usage:
+  PYTHONPATH=python/src .venv/bin/python python/eval_segmentation_eyeball.py \
+      "/path/to/My Activity.html" [--threshold 0.55] [--gap 1800] \
+      [--out report.md] [--max-sessions 200]
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("export_path")
+    ap.add_argument("--threshold", type=float, default=0.55)
+    ap.add_argument("--gap", type=int, default=1800)
+    ap.add_argument("--out", default="segmentation_eyeball_report.md")
+    ap.add_argument("--max-sessions", type=int, default=200)
+    args = ap.parse_args()
+
+    from totalreclaw.imports.adapters.gemini_adapter import GeminiAdapter
+    from totalreclaw.crystals.session_segmentation import segment_sessions
+    from totalreclaw.embedding import get_embedding
+
+    print(f"parsing {args.export_path} ...", flush=True)
+    parsed = GeminiAdapter().parse(file_path=args.export_path)
+    if parsed.errors:
+        print("adapter errors:", parsed.errors[:3])
+
+    # Flatten to turns exactly like the engine: user->assistant pairs per
+    # chunk, turn text = prompt + " " + reply (capped 1000 chars), per-turn
+    # timestamp = chunk timestamp (flat Takeout has per-record times).
+    turns: list[tuple[float | None, str, str]] = []  # (ts, text_for_embed, prompt_preview)
+    for chunk in parsed.chunks:
+        ts = None
+        if chunk.timestamp:
+            try:
+                ts = datetime.fromisoformat(
+                    chunk.timestamp.replace("Z", "+00:00")
+                ).timestamp()
+            except ValueError:
+                ts = None
+        msgs = chunk.messages or []
+        i = 0
+        while i < len(msgs):
+            m = msgs[i]
+            role = (m.get("role") or "user") if isinstance(m, dict) else "user"
+            if role != "user":
+                i += 1
+                continue
+            text_u = (m.get("text") or m.get("content") or "") if isinstance(m, dict) else str(m)
+            text_a = ""
+            if i + 1 < len(msgs):
+                nm = msgs[i + 1]
+                if isinstance(nm, dict) and (nm.get("role") == "assistant"):
+                    text_a = nm.get("text") or nm.get("content") or ""
+                    i += 1
+            combined = (text_u + " " + text_a).strip()[:1000]
+            if combined:
+                turns.append((ts, combined, text_u.strip()[:110]))
+            i += 1
+
+    print(f"{len(parsed.chunks)} chunks -> {len(turns)} turns; embedding (Harrier, local)...", flush=True)
+    timestamps = [t[0] for t in turns]
+    embeddings = []
+    for k, (_, text, _) in enumerate(turns):
+        embeddings.append(get_embedding(text))
+        if (k + 1) % 250 == 0:
+            print(f"  embedded {k+1}/{len(turns)}", flush=True)
+
+    groups = segment_sessions(timestamps, embeddings, args.gap, args.threshold)
+
+    sizes = Counter(len(g) for g in groups)
+    multi = [g for g in groups if len(g) >= 2]
+    singletons = sum(1 for g in groups if len(g) == 1)
+
+    def fmt_ts(ts: float | None) -> str:
+        if ts is None:
+            return "??"
+        return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d %H:%M")
+
+    lines = [
+        f"# Segmentation eyeball report",
+        f"",
+        f"- export: `{args.export_path}`",
+        f"- turns: **{len(turns)}**  |  sessions: **{len(groups)}**  |  "
+        f"singletons: **{singletons}** ({100*singletons/max(1,len(groups)):.0f}%) — no Crystal  |  "
+        f"multi-turn: **{len(multi)}** — one Crystal each",
+        f"- params: threshold={args.threshold}, gap={args.gap}s",
+        f"- size histogram: " + ", ".join(f"{n}-turn×{c}" for n, c in sorted(sizes.items())[:12]),
+        f"",
+        f"## Multi-turn sessions (each would become ONE Crystal)",
+        f"",
+        f"Judge: do the turns in each session belong together? Any session mixing",
+        f"unrelated topics = over-merge. Any conversation you remember as one",
+        f"chat split across adjacent sessions = over-split.",
+        f"",
+    ]
+    shown = 0
+    for gi, g in enumerate(groups):
+        if len(g) < 2 or shown >= args.max_sessions:
+            continue
+        shown += 1
+        t0, t1 = turns[g[0]][0], turns[g[-1]][0]
+        lines.append(f"### Session {gi} — {len(g)} turns — {fmt_ts(t0)} → {fmt_ts(t1)} UTC")
+        for idx in g:
+            lines.append(f"- [{fmt_ts(turns[idx][0])}] {turns[idx][2]}")
+        lines.append("")
+    if shown >= args.max_sessions:
+        lines.append(f"_(truncated at {args.max_sessions} sessions)_")
+
+    with open(args.out, "w") as f:
+        f.write("\n".join(lines))
+    print(f"\nwrote {args.out} — sessions={len(groups)} singletons={singletons} multi={len(multi)} (showing {shown})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Productionizes the Gemini-import segmentation eyeball harness: moves it from `python/eval_segmentation_eyeball.py` to `tools/eval-segmentation/` (next to the other QA/ops helpers), adds a README, and records the 2026-07-14 validation result.

## Why

The harness is a hand-run tuning tool for the session-segmentation threshold/gap. It was sitting loose under `python/` (where it doesn't belong — that's the client package). It belongs in `tools/` with `qa-vault.mjs`, and it needs a usage + validation record so the `threshold=0.55 / gap=1800s` decision is captured next to the code.

## Changes

- **`tools/eval-segmentation/eval_segmentation_eyeball.py`** — moved verbatim. Read-only / no-network / no LLM, unchanged logic. Replays the exact production path: core `parse_gemini` (`GeminiAdapter`) → flatten turns → embed prompt+reply (Harrier 640d, local) → `segment_sessions(gap, threshold)` → markdown report. Lazy imports resolve against `PYTHONPATH=python/src`, so the move needs no code edits.
- **`tools/eval-segmentation/README.md`** — what it does, usage command, and the validation record.
- **`tools/eval-segmentation/.gitignore`** — keeps the generated report (reviewer's personal conversation text) out of git.

**Not added to pytest** — it needs a real Takeout export + the ~344MB ONNX model; it's a manual eval tool.

## Validation (2026-07-14)

Pedro reviewed the report over his real **3,942-record** export. Verdict: **LOOKS RIGHT** at `threshold=0.55`, `gap=1800s`.

| metric | value |
|---|---|
| turns | 3,795 |
| sessions | 1,651 |
| singletons (1-turn, gated → no Crystal) | 902 (55%) |
| multi-turn Crystals (≥2 turns) | 749 |
| old per-chunk scheme Crystals | ~1,397 |

~46% fewer Crystals than the old per-chunk scheme — almost entirely by collapsing single-Q&A noise. The ≥2-turn Crystal gate stays.

## Verification

- `python -m py_compile tools/eval-segmentation/eval_segmentation_eyeball.py` → OK
- `git diff --cached --name-only` confirmed only the 3 new files staged (no stray report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)