### PR TITLE
feat(app): Keeper A.2 Phase 2 — pin/unpin via 2-call supersession batch (#484)

### DIFF
--- a/app/e2e/pin-onchain.mjs
+++ b/app/e2e/pin-onchain.mjs
@@ -1,0 +1,475 @@
+/**
+ * E2E (A.2 Phase 2): STAGING pin/unpin round-trip — 2-call executeBatch
+ * supersession on Gnosis mainnet via the staging relay.
+ *
+ * Exercises the exact SPA write wire: decrypt old blob → rebuild the claim
+ * (full carry-forward + metadata verbatim, core-validated) → re-encrypt →
+ * [tombstone(old,v4), newClaim(v4)] in ONE UserOp via encodeBatchCallTo →
+ * relay /v1/bundler → subgraph. Embedding + blind indices are copied forward
+ * from the old on-chain fact and asserted equal after indexing.
+ *
+ * WebAuthn can't run headless, so this harness signs with the throwaway
+ * account's EOA key DIRECTLY (phrase-safe) — the in-browser path signs the
+ * identical hash via `withMasterKey`, unit-tested in src/lib/auth/master.test.ts.
+ *
+ * PHRASE-SAFETY (L3): a THROWAWAY mnemonic only, cached to the gitignored
+ * `.e2e-secret` and reused across runs (staging /v1/register has an IP-global
+ * ~19-min 429 window — NEVER re-register). The mnemonic + private key are
+ * NEVER printed or logged. Only public data is emitted.
+ *
+ * Run: cd app && node e2e/pin-onchain.mjs
+ */
+import { generateMnemonic } from "@scure/bip39";
+import { wordlist } from "@scure/bip39/wordlists/english.js";
+import { readFileSync, writeFileSync, existsSync, chmodSync } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const require = createRequire(import.meta.url);
+const core = require("@totalreclaw/core");
+
+const RELAY = process.env.RELAY_URL || "https://api-staging.totalreclaw.xyz";
+const CHAIN_ID = 100; // Gnosis mainnet (single-chain)
+const STAGING_DATA_EDGE = "0xE7a4D2677B686e13775Ba9092631089e35F0BB91";
+const PROD_DATA_EDGE = "0xC445af1D4EB9fce4e1E61fE96ea7B8feBF03c5ca";
+const SECRET_FILE = join(dirname(fileURLToPath(import.meta.url)), "..", ".e2e-secret");
+
+const DUMMY_SIG =
+  "0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c";
+
+const out = (m) => console.log(`[e2e] ${m}`);
+let failed = false;
+const check = (name, cond) => {
+  out(`${cond ? "PASS" : "FAIL"} — ${name}`);
+  if (!cond) failed = true;
+};
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function loadOrCreateMnemonic() {
+  if (existsSync(SECRET_FILE)) {
+    out("reusing cached throwaway account (.e2e-secret) — NOT re-registering");
+    return { mnemonic: readFileSync(SECRET_FILE, "utf8").trim(), fresh: false };
+  }
+  const mnemonic = generateMnemonic(wordlist, 128);
+  writeFileSync(SECRET_FILE, mnemonic + "\n", { mode: 0o600 });
+  chmodSync(SECRET_FILE, 0o600);
+  out("generated a fresh throwaway account → cached to gitignored .e2e-secret");
+  return { mnemonic, fresh: true };
+}
+
+async function relayFetch(path, opts = {}, authKeyHex, wallet) {
+  const headers = {
+    "Content-Type": "application/json",
+    "X-TotalReclaw-Client": "ts-spa-vault",
+    "X-TotalReclaw-Test": "true",
+    ...(authKeyHex ? { Authorization: `Bearer ${authKeyHex}` } : {}),
+    ...(wallet ? { "X-Wallet-Address": wallet } : {}),
+    ...(opts.headers || {}),
+  };
+  const res = await fetch(`${RELAY}${path}`, { ...opts, headers });
+  const text = await res.text();
+  return { ok: res.ok, status: res.status, text };
+}
+
+async function bundlerRpc(authKeyHex, wallet, method, params) {
+  const res = await fetch(`${RELAY}/v1/bundler`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-TotalReclaw-Client": "ts-spa-vault",
+      "X-TotalReclaw-Test": "true",
+      Authorization: `Bearer ${authKeyHex}`,
+      "X-Wallet-Address": wallet,
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+  });
+  const json = await res.json();
+  if (json.error) throw new Error(`bundler ${method}: ${JSON.stringify(json.error)}`);
+  return json.result;
+}
+
+async function subgraphQuery(authKeyHex, wallet, query, variables) {
+  const { text } = await relayFetch(
+    "/v1/subgraph",
+    { method: "POST", body: JSON.stringify({ query, variables }) },
+    authKeyHex,
+    wallet,
+  );
+  const json = JSON.parse(text);
+  if (json.errors?.length) throw new Error(`subgraph: ${json.errors.map((e) => e.message).join("; ")}`);
+  return json.data;
+}
+
+async function factById(authKeyHex, wallet, id) {
+  const data = await subgraphQuery(
+    authKeyHex,
+    wallet,
+    `query F($id: ID!) { fact(id: $id) { id isActive encryptedBlob encryptedEmbedding blindIndexEntries { hash } } }`,
+    { id },
+  );
+  return data.fact;
+}
+
+async function activeFacts(authKeyHex, wallet, ownerLower) {
+  const data = await subgraphQuery(
+    authKeyHex,
+    wallet,
+    `query A($owner: Bytes!) { facts(where: { owner: $owner, isActive: true }, first: 1000) { id } }`,
+    { owner: ownerLower },
+  );
+  return data.facts ?? [];
+}
+
+/** Poll until `fn` returns truthy (subgraph indexing) or ~2 min elapse. */
+async function waitFor(fn) {
+  for (let i = 0; i < 30; i++) {
+    await sleep(4000);
+    const v = await fn();
+    if (v) return v;
+  }
+  return null;
+}
+
+/** Build → sponsor → sign → submit → confirm one UserOp (execute or batch). */
+async function submitUserOp(calldataBytes, { authKeyHex, wallet, eoa, needsInitCode }) {
+  const entryPoint = core.getEntryPointAddress();
+  const callData = `0x${Buffer.from(calldataBytes).toString("hex")}`;
+
+  let factory = null;
+  let factoryData = null;
+  if (needsInitCode) {
+    const code = await bundlerRpc(authKeyHex, wallet, "eth_getCode", [wallet, "latest"]);
+    if (!code || code === "0x" || code === "0x0") {
+      factory = core.getSimpleAccountFactory();
+      const ownerPadded = eoa.address.slice(2).toLowerCase().padStart(64, "0");
+      factoryData = `0x5fbfb9cf${ownerPadded}${"0".repeat(64)}`;
+    }
+  }
+
+  const gas = await bundlerRpc(authKeyHex, wallet, "pimlico_getUserOperationGasPrice", []);
+  const fast = gas.fast;
+
+  const senderPadded = wallet.slice(2).toLowerCase().padStart(64, "0");
+  const nonce =
+    (await bundlerRpc(authKeyHex, wallet, "eth_call", [
+      { to: entryPoint, data: `0x35567e1a${senderPadded}${"0".repeat(64)}` },
+      "latest",
+    ])) || "0x0";
+
+  const op = {
+    sender: wallet,
+    nonce,
+    callData,
+    callGasLimit: "0x0",
+    verificationGasLimit: "0x0",
+    preVerificationGas: "0x0",
+    maxFeePerGas: fast.maxFeePerGas,
+    maxPriorityFeePerGas: fast.maxPriorityFeePerGas,
+    signature: DUMMY_SIG,
+  };
+  if (factory) {
+    op.factory = factory;
+    op.factoryData = factoryData;
+  }
+
+  // Batches: estimate gas BEFORE sponsorship (mirror src/lib/userop.ts step 6).
+  try {
+    const est = await bundlerRpc(authKeyHex, wallet, "eth_estimateUserOperationGas", [op, entryPoint]);
+    if (est.callGasLimit) op.callGasLimit = est.callGasLimit;
+    if (est.verificationGasLimit) op.verificationGasLimit = est.verificationGasLimit;
+    if (est.preVerificationGas) op.preVerificationGas = est.preVerificationGas;
+  } catch {
+    /* fall back to paymaster-provided limits */
+  }
+
+  const sponsor = await bundlerRpc(authKeyHex, wallet, "pm_sponsorUserOperation", [op, entryPoint]);
+  Object.assign(op, sponsor);
+
+  const hashHex = core.hashUserOp(JSON.stringify(op), entryPoint, BigInt(CHAIN_ID));
+  op.signature = `0x${core.signUserOp(hashHex, eoa.private_key)}`; // eoa.private_key never logged
+
+  const userOpHash = await bundlerRpc(authKeyHex, wallet, "eth_sendUserOperation", [op, entryPoint]);
+
+  let receipt = null;
+  for (let i = 0; i < 90; i++) {
+    await sleep(2000);
+    try {
+      receipt = await bundlerRpc(authKeyHex, wallet, "eth_getUserOperationReceipt", [userOpHash]);
+      if (receipt) break;
+    } catch {
+      /* not mined yet */
+    }
+  }
+  return { userOpHash, receipt };
+}
+
+// --- claim rebuild (mirrors src/lib/claim.ts:rebuildClaimJson) ---
+function rebuildClaimJson(rawClaimJson, { newId, supersededBy, pinStatus }) {
+  const source = JSON.parse(rawClaimJson);
+  const input = { ...source };
+  input.id = newId;
+  input.superseded_by = supersededBy;
+  input.pin_status = pinStatus;
+  input.schema_version = "1.0";
+  if (typeof input.created_at !== "string" || input.created_at === "")
+    input.created_at = new Date().toISOString();
+  if (input.scope === "unspecified") delete input.scope;
+  if (input.volatility === "updatable") delete input.volatility;
+  if (Array.isArray(input.entities) && input.entities.length === 0) delete input.entities;
+  if (!input.reasoning) delete input.reasoning;
+  if (!input.expires_at) delete input.expires_at;
+  const parsed = JSON.parse(core.validateMemoryClaimV1(JSON.stringify(input)));
+  parsed.schema_version = "1.0";
+  if (input.metadata !== undefined && input.metadata !== null) parsed.metadata = input.metadata;
+  for (const [k, v] of Object.entries(input)) if (!(k in parsed) && v !== undefined) parsed[k] = v;
+  return JSON.stringify(parsed);
+}
+
+const decryptHexBlob = (hex, keyHex) => {
+  const h = hex.startsWith("0x") ? hex.slice(2) : hex;
+  return core.decrypt(Buffer.from(h, "hex").toString("base64"), keyHex);
+};
+
+/** SPA-shaped pin/unpin: idempotency guard + 2-call supersession batch. */
+async function setPinStatus(oldFactId, target, ctx) {
+  const { authKeyHex, wallet, keys, dataEdge } = ctx;
+  const oldFact = await factById(authKeyHex, wallet, oldFactId);
+  if (!oldFact) throw new Error(`fact ${oldFactId} not found`);
+  const plaintext = decryptHexBlob(oldFact.encryptedBlob, keys.encryption_key);
+  const current = JSON.parse(plaintext).pin_status === "pinned" ? "pinned" : "unpinned";
+  if (current === target) return { idempotent: true };
+
+  const newId = randomUUID();
+  const canonicalJson = rebuildClaimJson(plaintext, {
+    newId,
+    supersededBy: oldFactId,
+    pinStatus: target,
+  });
+  const blobHex = Buffer.from(core.encrypt(canonicalJson, keys.encryption_key), "base64").toString("hex");
+
+  const tombstone = core.encodeTombstoneProtobuf(oldFactId, wallet, 4);
+  const newFactPayload = core.encodeFactProtobuf(
+    JSON.stringify({
+      id: newId,
+      timestamp: new Date().toISOString(),
+      owner: wallet,
+      encrypted_blob_hex: blobHex,
+      blind_indices: (oldFact.blindIndexEntries ?? []).map((e) => e.hash), // copied forward
+      decay_score: 1.0,
+      source: target === "pinned" ? "spa_pin" : "spa_unpin",
+      content_fp: "",
+      agent_id: "ts-spa-vault",
+      encrypted_embedding: oldFact.encryptedEmbedding ?? null, // copied forward
+      version: 4,
+    }),
+  );
+  const calldata = core.encodeBatchCallTo(
+    JSON.stringify([Buffer.from(tombstone).toString("hex"), Buffer.from(newFactPayload).toString("hex")]),
+    dataEdge,
+  );
+  const res = await submitUserOp(calldata, { ...ctx, needsInitCode: false });
+  return { idempotent: false, newId, ...res };
+}
+
+// --------------------------------------------------------------------------
+
+const evidence = {};
+try {
+  const { mnemonic, fresh } = loadOrCreateMnemonic();
+  const keys = core.deriveKeysFromMnemonic(mnemonic);
+  const eoa = core.deriveEoa(mnemonic); // private_key NEVER logged
+  const authKeyHex = keys.auth_key;
+  const authKeyHash = createHash("sha256").update(Buffer.from(authKeyHex, "hex")).digest("hex");
+
+  const saRes = await relayFetch(`/v1/smart-account?eoa=${eoa.address}&chain=${CHAIN_ID}`);
+  const wallet = JSON.parse(saRes.text).smart_account.toLowerCase();
+  out(`smart account: ${wallet}`);
+
+  const billingProbe = await relayFetch(`/v1/billing/status?wallet_address=${wallet}`, {}, authKeyHex, wallet);
+  if (billingProbe.status === 401 || fresh) {
+    out("registering throwaway account (once)");
+    const reg = await relayFetch("/v1/register", {
+      method: "POST",
+      body: JSON.stringify({ auth_key_hash: authKeyHash, salt: keys.salt }),
+    });
+    check("register accepted", reg.ok || reg.status === 409);
+    await sleep(1500);
+  } else {
+    out("account already registered — skipping /v1/register");
+  }
+
+  const billing = JSON.parse(
+    (await relayFetch(`/v1/billing/status?wallet_address=${wallet}`, {}, authKeyHex, wallet)).text,
+  );
+  const dataEdge = billing.data_edge_address;
+  out(`relay data_edge_address: ${dataEdge}  (chain_id ${billing.chain_id}, env ${billing.environment})`);
+  check("relay reports the STAGING DataEdge (0xE7a4…), not prod (0xC445…)",
+    dataEdge?.toLowerCase() === STAGING_DATA_EDGE.toLowerCase());
+
+  const ctx = { authKeyHex, wallet, eoa, keys, dataEdge };
+
+  // 1. WRITE a Crystal-shaped fact (metadata is the preservation proof) with a
+  //    real encrypted_embedding value so copy-forward is assertable.
+  const factId = randomUUID();
+  const sessionId = randomUUID();
+  const metadata = {
+    subtype: "session_crystal",
+    session_id: sessionId,
+    key_outcomes: ["a2 pin e2e outcome"],
+    open_threads: ["a2 pin e2e thread"],
+    topics_discussed: ["supersession"],
+  };
+  const claim = {
+    id: factId,
+    text: `A2 pin E2E marker ${factId}`,
+    type: "summary",
+    source: "derived",
+    created_at: new Date().toISOString(),
+    schema_version: "1.0",
+    importance: 9,
+    metadata,
+  };
+  const markerEmbedding = `a2pinE2Eembedding${factId.replaceAll("-", "")}`;
+  const encB64 = core.encrypt(JSON.stringify(claim), keys.encryption_key);
+  const writeCalldata = core.encodeSingleCallTo(
+    core.encodeFactProtobuf(
+      JSON.stringify({
+        id: factId,
+        timestamp: claim.created_at,
+        owner: wallet,
+        encrypted_blob_hex: Buffer.from(encB64, "base64").toString("hex"),
+        blind_indices: core.generateBlindIndices(claim.text),
+        decay_score: 1.0,
+        source: "derived",
+        content_fp: core.generateContentFingerprint(claim.text, keys.dedup_key),
+        agent_id: "a2-pin-e2e",
+        encrypted_embedding: markerEmbedding,
+        version: 4,
+      }),
+    ),
+    dataEdge,
+  );
+  out(`writing throwaway Crystal fact ${factId} …`);
+  const write = await submitUserOp(writeCalldata, { ...ctx, needsInitCode: true });
+  check("write UserOp mined", !!write.receipt);
+  out(`write userOpHash: ${write.userOpHash}`);
+
+  const indexedOld = await waitFor(async () => {
+    const f = await factById(authKeyHex, wallet, factId);
+    return f && f.isActive ? f : null;
+  });
+  check("fact indexed as isActive:true before pin", !!indexedOld);
+  const oldEmbedding = indexedOld?.encryptedEmbedding ?? null;
+  check("old fact carries the marker encryptedEmbedding", oldEmbedding === markerEmbedding);
+  const activeBefore = (await activeFacts(authKeyHex, wallet, wallet)).length;
+
+  // 2. PIN — the 2-call supersession under test.
+  out(`pinning fact ${factId} …`);
+  const pin = await setPinStatus(factId, "pinned", ctx);
+  check("pin UserOp mined", !pin.idempotent && !!pin.receipt);
+  out(`pin userOpHash: ${pin.userOpHash}  new fact: ${pin.newId}`);
+
+  // (1) receipt logs at the STAGING DataEdge only.
+  const pinLogs = pin.receipt?.logs ?? pin.receipt?.receipt?.logs ?? [];
+  check("pin receipt emitted a log at the STAGING DataEdge (0xE7a4…)",
+    pinLogs.some((l) => (l.address || "").toLowerCase() === STAGING_DATA_EDGE.toLowerCase()));
+  check("pin receipt did NOT touch the prod DataEdge (0xC445…)",
+    !pinLogs.some((l) => (l.address || "").toLowerCase() === PROD_DATA_EDGE.toLowerCase()));
+
+  // (2) old fact flips isActive:false.
+  const oldAfterPin = await waitFor(async () => {
+    const f = await factById(authKeyHex, wallet, factId);
+    return f && f.isActive === false ? f : null;
+  });
+  check("subgraph flipped the OLD fact to isActive:false", !!oldAfterPin);
+
+  // (3) new fact exists; decrypted claim: pin_status pinned, superseded_by, metadata intact.
+  const newFact = await waitFor(() => factById(authKeyHex, wallet, pin.newId));
+  check("superseding fact indexed", !!newFact && newFact.isActive === true);
+  let pinnedClaim = null;
+  if (newFact) {
+    pinnedClaim = JSON.parse(decryptHexBlob(newFact.encryptedBlob, keys.encryption_key));
+    check("new claim pin_status === 'pinned'", pinnedClaim.pin_status === "pinned");
+    check("new claim superseded_by === old fact id", pinnedClaim.superseded_by === factId);
+    check("METADATA INTACT through supersession (Crystal fields verbatim)",
+      JSON.stringify(pinnedClaim.metadata) === JSON.stringify(metadata));
+    check("text/type/source/created_at carried forward",
+      pinnedClaim.text === claim.text && pinnedClaim.type === "summary" &&
+      pinnedClaim.source === "derived" && pinnedClaim.created_at === claim.created_at);
+    // (4) embedding copied forward byte-identically.
+    check("new fact encryptedEmbedding EQUALS the old one (copied forward)",
+      newFact.encryptedEmbedding === oldEmbedding);
+  }
+
+  // (6) idempotent pin: pin again while pinned → NO UserOp, no new fact.
+  const activeAfterPin = (await activeFacts(authKeyHex, wallet, wallet)).length;
+  const again = await setPinStatus(pin.newId, "pinned", ctx);
+  check("idempotent pin short-circuits (no UserOp)", again.idempotent === true);
+  const activeAfterIdem = (await activeFacts(authKeyHex, wallet, wallet)).length;
+  check("idempotent pin produced NO new on-chain fact", activeAfterIdem === activeAfterPin);
+
+  // (5) UNPIN — same supersession shape back to 'unpinned'.
+  out(`unpinning fact ${pin.newId} …`);
+  const unpin = await setPinStatus(pin.newId, "unpinned", ctx);
+  check("unpin UserOp mined", !unpin.idempotent && !!unpin.receipt);
+  out(`unpin userOpHash: ${unpin.userOpHash}  new fact: ${unpin.newId}`);
+  const pinnedAfterUnpin = await waitFor(async () => {
+    const f = await factById(authKeyHex, wallet, pin.newId);
+    return f && f.isActive === false ? f : null;
+  });
+  check("pinned fact flipped isActive:false after unpin", !!pinnedAfterUnpin);
+  const unpinnedFact = await waitFor(() => factById(authKeyHex, wallet, unpin.newId));
+  check("unpinned superseding fact indexed", !!unpinnedFact && unpinnedFact.isActive === true);
+  let unpinnedClaim = null;
+  if (unpinnedFact) {
+    unpinnedClaim = JSON.parse(decryptHexBlob(unpinnedFact.encryptedBlob, keys.encryption_key));
+    check("unpinned claim pin_status === 'unpinned'", unpinnedClaim.pin_status === "unpinned");
+    check("unpinned claim superseded_by === pinned fact id", unpinnedClaim.superseded_by === pin.newId);
+    check("metadata STILL intact after second supersession",
+      JSON.stringify(unpinnedClaim.metadata) === JSON.stringify(metadata));
+    check("embedding still copied forward on unpin",
+      unpinnedFact.encryptedEmbedding === oldEmbedding);
+  }
+
+  // Cleanup: tombstone the surviving test fact(s).
+  out("cleanup: tombstoning surviving test facts …");
+  const survivors = [unpin.newId].filter(Boolean);
+  if (survivors.length > 0) {
+    const payloads = survivors.map((id) =>
+      Buffer.from(core.encodeTombstoneProtobuf(id, wallet, 4)).toString("hex"),
+    );
+    const cleanupCalldata =
+      payloads.length === 1
+        ? core.encodeSingleCallTo(Buffer.from(payloads[0], "hex"), dataEdge)
+        : core.encodeBatchCallTo(JSON.stringify(payloads), dataEdge);
+    const cleanup = await submitUserOp(cleanupCalldata, { ...ctx, needsInitCode: false });
+    check("cleanup tombstone mined", !!cleanup.receipt);
+  }
+
+  Object.assign(evidence, {
+    smartAccount: wallet,
+    dataEdge,
+    chainId: billing.chain_id,
+    environment: billing.environment,
+    oldFactId: factId,
+    pinnedFactId: pin.newId,
+    unpinnedFactId: unpin.newId,
+    writeUserOpHash: write.userOpHash,
+    pinUserOpHash: pin.userOpHash,
+    unpinUserOpHash: unpin.userOpHash,
+    idempotentPinSkipped: again.idempotent === true,
+    embeddingCopiedForward: newFact?.encryptedEmbedding === oldEmbedding,
+    metadataIntact: JSON.stringify(pinnedClaim?.metadata) === JSON.stringify(metadata),
+    activeBefore,
+  });
+  out("--- REDACTED EVIDENCE (no secrets) ---");
+  out(JSON.stringify(evidence, null, 2));
+} catch (e) {
+  out(`EXCEPTION: ${e.message}`);
+  failed = true;
+}
+
+out(failed ? "RESULT: FAIL" : "RESULT: PASS");
+process.exit(failed ? 1 : 0);

--- a/app/scripts/gen-golden-pin.mjs
+++ b/app/scripts/gen-golden-pin.mjs
@@ -1,0 +1,115 @@
+/**
+ * Generator for the fixture-(b) PIN golden vectors in
+ * `src/lib/userop.golden.test.ts` (A.2 Phase 2).
+ *
+ * Run ONLY when the wire format changes intentionally, then paste the printed
+ * constants into the test with a note on why:
+ *   cd app && node scripts/gen-golden-pin.mjs
+ *
+ * Everything here is deterministic EXCEPT the XChaCha20 nonce inside the
+ * encrypted claim blob — that's why the blob is captured once and frozen as a
+ * constant (the test proves it still decrypts to the exact pinned claim, and
+ * that the protobuf/calldata/userOpHash over it are byte-stable).
+ *
+ * Uses the public all-zeros-mnemonic test encryption key (crypto.test.ts) —
+ * NOT a secret.
+ */
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { xchacha20poly1305 } from "@noble/ciphers/chacha";
+import { randomBytes } from "node:crypto";
+
+const require = createRequire(import.meta.url);
+const dir = dirname(require.resolve("@totalreclaw/core/web"));
+const core = await import("@totalreclaw/core/web");
+core.initSync({ module: readFileSync(join(dir, "totalreclaw_core_bg.wasm")) });
+
+const STAGING_DATA_EDGE = "0xE7a4D2677B686e13775Ba9092631089e35F0BB91";
+const OWNER = "0x2c0cf74b2b76110708ca431796367779e3738250";
+const OLD_ID = "a2golden00000000000000000000dead"; // fixture (a)'s tombstoned id
+const NEW_ID = "a2golden22222222222222222222feed";
+const FROZEN_TS = "2026-07-15T00:00:00.000+00:00";
+const GOLDEN_ENC_KEY_HEX =
+  "a58fdc56e1d768461d95cd46b49e03727b2eb342ac558b9f3ebf1255b871f703";
+
+// The superseding pinned claim — the shape rebuildClaimJson emits (validated
+// through the same core validator, schema_version + metadata re-attached).
+const claimInput = {
+  id: NEW_ID,
+  text: "A2 golden pin fixture — keep me byte-stable",
+  type: "claim",
+  source: "user",
+  created_at: "2026-06-01T10:20:30.000Z",
+  schema_version: "1.0",
+  scope: "work",
+  importance: 8,
+  superseded_by: OLD_ID,
+  pin_status: "pinned",
+};
+const metadata = {
+  subtype: "session_crystal",
+  session_id: "0197f000-aaaa-7000-8000-abcdefabcdef",
+  key_outcomes: ["golden vector shipped"],
+};
+const validated = JSON.parse(core.validateMemoryClaimV1(JSON.stringify(claimInput)));
+validated.schema_version = "1.0";
+validated.metadata = metadata;
+const canonicalJson = JSON.stringify(validated);
+
+// Encrypt (hex wire: nonce||tag||ct) — mirrors src/lib/crypto.ts encryptBlob.
+const key = Uint8Array.from(Buffer.from(GOLDEN_ENC_KEY_HEX, "hex"));
+const nonce = randomBytes(24);
+const enc = xchacha20poly1305(key, nonce).encrypt(new TextEncoder().encode(canonicalJson));
+const ct = enc.slice(0, enc.length - 16);
+const tag = enc.slice(enc.length - 16);
+const blobHex = Buffer.concat([nonce, tag, ct]).toString("hex");
+
+// Tombstone (frozen field-2 timestamp comes from fixture (a) — regenerate live
+// then splice? No: reuse the SAME frozen tombstone constant from the test.)
+const GOLDEN_TOMBSTONE_HEX =
+  "0a206132676f6c64656e303030303030303030303030303030303030303064656164121d323032362d30372d30395432323a30383a35342e3331332b30303a30301a2a307832633063663734623262373631313037303863613433313739363336373737396533373338323530220031000000000000000038004004";
+
+const pinFactJson = JSON.stringify({
+  id: NEW_ID,
+  timestamp: FROZEN_TS,
+  owner: OWNER,
+  encrypted_blob_hex: blobHex,
+  blind_indices: ["a2goldenblind00000000000000000001", "a2goldenblind00000000000000000002"],
+  decay_score: 1.0,
+  source: "spa_pin",
+  content_fp: "",
+  agent_id: "ts-spa-vault",
+  encrypted_embedding: "a2goldenembeddingcopiedforward00",
+  version: 4,
+});
+const pinFactHex = Buffer.from(core.encodeFactProtobuf(pinFactJson)).toString("hex");
+
+const batchHex = Buffer.from(
+  core.encodeBatchCallTo(JSON.stringify([GOLDEN_TOMBSTONE_HEX, pinFactHex]), STAGING_DATA_EDGE),
+).toString("hex");
+
+const entryPoint = core.getEntryPointAddress();
+const op = {
+  sender: OWNER,
+  nonce: "0x1",
+  callData: `0x${batchHex}`,
+  callGasLimit: "0x30d40",
+  verificationGasLimit: "0x186a0",
+  preVerificationGas: "0xc350",
+  maxFeePerGas: "0xf4240",
+  maxPriorityFeePerGas: "0x7a120",
+  paymaster: "0x0000000000000039cd5e8ae05257ce51c473ddd1",
+  paymasterVerificationGasLimit: "0x186a0",
+  paymasterPostOpGasLimit: "0xc350",
+  paymasterData: "0xabcd",
+  signature: "0x" + "00".repeat(65),
+};
+const userOpHash = core.hashUserOp(JSON.stringify(op), entryPoint, 100n);
+
+console.log("GOLDEN_PIN_CLAIM_JSON =", JSON.stringify(canonicalJson));
+console.log("GOLDEN_PIN_BLOB_HEX =", JSON.stringify(blobHex));
+console.log("GOLDEN_PIN_FACT_PROTOBUF_HEX =", JSON.stringify(pinFactHex));
+console.log("GOLDEN_PIN_BATCH_CALLDATA_HEX =", JSON.stringify(batchHex));
+console.log("ENTRYPOINT =", entryPoint);
+console.log("GOLDEN_PIN_USEROP_HASH =", JSON.stringify(userOpHash));

--- a/app/src/components/ClaimCard.tsx
+++ b/app/src/components/ClaimCard.tsx
@@ -32,13 +32,17 @@ function sourceLabel(source: string): string {
 /** A single memory, set to read. (Ported from the Keeper prototype ClaimCard.)
  *
  *  A.2 curation: when `onForget` is supplied, a subtle "Forget" affordance
- *  appears with an inline confirm. Pin/retype/set_scope land in A.2 Phase 2/3.
- *  With no `onForget`, the card is byte-for-byte the read-only card it was. */
+ *  appears with an inline confirm; when `onTogglePin` is supplied, a "Pin"/
+ *  "Unpin" affordance sits beside it (no confirm — pinning is reversible).
+ *  Retype/set_scope land in A.2 Phase 3. With neither handler, the card is
+ *  byte-for-byte the read-only card it was. */
 export function ClaimCard({
   item,
   style,
   onForget,
   forgetPending = false,
+  onTogglePin,
+  pinPending = false,
 }: {
   item: VaultItem;
   style?: CSSProperties;
@@ -46,6 +50,10 @@ export function ClaimCard({
   onForget?: () => void;
   /** True while the on-chain tombstone is in flight (awaiting the receipt). */
   forgetPending?: boolean;
+  /** Opt-in pin/unpin: 2-call supersession on-chain. Absent → no affordance. */
+  onTogglePin?: () => void;
+  /** True while the pin/unpin supersession batch awaits its receipt. */
+  pinPending?: boolean;
 }) {
   const { claim } = item;
   const type = (claim.type as MemoryTypeV1) ?? "claim";
@@ -93,9 +101,26 @@ export function ClaimCard({
           {claim.reasoning}
         </p>
       )}
-      {onForget && (
+      {(onForget || onTogglePin) && (
         <div className="mt-3 flex items-center justify-end gap-2 text-xs">
-          {forgetPending ? (
+          {onTogglePin &&
+            (pinPending ? (
+              <span className="text-ink-muted" aria-live="polite">
+                {item.pinned ? "Unpinning…" : "Pinning…"}
+              </span>
+            ) : (
+              !confirming &&
+              !forgetPending && (
+                <button
+                  type="button"
+                  onClick={onTogglePin}
+                  className="rounded-pill px-2.5 py-0.5 font-semibold text-ink-muted transition hover:bg-clay-tint hover:text-clay-deep focus:outline-none focus-visible:ring-2 focus-visible:ring-clay"
+                >
+                  {item.pinned ? "Unpin" : "Pin"}
+                </button>
+              )
+            ))}
+          {onForget && (forgetPending ? (
             <span className="text-ink-muted" aria-live="polite">
               Forgetting…
             </span>
@@ -128,7 +153,7 @@ export function ClaimCard({
             >
               Forget
             </button>
-          )}
+          ))}
         </div>
       )}
     </article>

--- a/app/src/hooks/useVault.ts
+++ b/app/src/hooks/useVault.ts
@@ -1,10 +1,11 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { SessionKeys, VaultItem, MemoryClaimV1 } from "../lib/types";
+import { PinStatus, SessionKeys, VaultItem, MemoryClaimV1 } from "../lib/types";
 import {
   exportAllFacts,
   decryptFacts,
   deleteFact,
   batchDeleteFacts,
+  setPinStatus,
   updateClaim,
 } from "../lib/api";
 import { useCrypto } from "../contexts/CryptoContext";
@@ -74,8 +75,11 @@ export function useDeleteFact(keys: SessionKeys | null) {
       return deleteFact(factId, keys, sign);
     },
     onSuccess: (_data, factId) => {
-      qc.setQueryData<VaultItem[]>(VAULT_QUERY_KEY, (prev) =>
-        prev?.filter((it) => it.id !== factId) ?? [],
+      // The vault cache holds VaultData ({items, fetched}), not VaultItem[].
+      qc.setQueryData<VaultData>(VAULT_QUERY_KEY, (prev) =>
+        prev
+          ? { ...prev, items: prev.items.filter((it) => it.id !== factId) }
+          : prev,
       );
     },
   });
@@ -91,8 +95,49 @@ export function useBatchDelete(keys: SessionKeys | null) {
     },
     onSuccess: (_data, ids) => {
       const idSet = new Set(ids);
-      qc.setQueryData<VaultItem[]>(VAULT_QUERY_KEY, (prev) =>
-        prev?.filter((it) => !idSet.has(it.id)) ?? [],
+      qc.setQueryData<VaultData>(VAULT_QUERY_KEY, (prev) =>
+        prev
+          ? { ...prev, items: prev.items.filter((it) => !idSet.has(it.id)) }
+          : prev,
+      );
+    },
+  });
+}
+
+/**
+ * Pin/unpin a memory on-chain (A.2 Phase 2 — 2-call supersession batch).
+ * On receipt, the cached item is reconciled in place: new fact id, new claim
+ * (pin_status + superseded_by), new rawBlob — so an immediate follow-up toggle
+ * rebuilds from the CURRENT on-chain blob without a refetch. Idempotent no-ops
+ * (already in the target state) resolve without touching the cache.
+ */
+export function usePinFact(keys: SessionKeys | null) {
+  const qc = useQueryClient();
+  const sign = useUserOpSigner();
+  return useMutation({
+    mutationFn: ({ item, target }: { item: VaultItem; target: PinStatus }) => {
+      if (!keys) throw new Error("Vault is locked.");
+      return setPinStatus(item, target, keys, sign);
+    },
+    onSuccess: (result, { item, target }) => {
+      if (result.idempotent) return;
+      qc.setQueryData<VaultData>(VAULT_QUERY_KEY, (prev) =>
+        prev
+          ? {
+              ...prev,
+              items: prev.items.map((it) =>
+                it.id === item.id
+                  ? {
+                      ...it,
+                      id: result.newFactId ?? it.id,
+                      claim: result.newClaim ?? it.claim,
+                      pinned: target === "pinned",
+                      rawBlob: result.newBlobHex ?? it.rawBlob,
+                    }
+                  : it,
+              ),
+            }
+          : prev,
       );
     },
   });
@@ -109,17 +154,22 @@ export function useUpdateClaim(keys: SessionKeys) {
       updatedClaim: MemoryClaimV1;
     }) => updateClaim(item, updatedClaim, keys),
     onSuccess: (_data, { item, updatedClaim }) => {
-      qc.setQueryData<VaultItem[]>(VAULT_QUERY_KEY, (prev) =>
-        prev?.map((it) =>
-          it.id === item.id
-            ? {
-                ...it,
-                claim: updatedClaim,
-                type: updatedClaim.type ?? it.type,
-                pinned: updatedClaim.pin_status === "pinned",
-              }
-            : it,
-        ) ?? [],
+      qc.setQueryData<VaultData>(VAULT_QUERY_KEY, (prev) =>
+        prev
+          ? {
+              ...prev,
+              items: prev.items.map((it) =>
+                it.id === item.id
+                  ? {
+                      ...it,
+                      claim: updatedClaim,
+                      type: updatedClaim.type ?? it.type,
+                      pinned: updatedClaim.pin_status === "pinned",
+                    }
+                  : it,
+              ),
+            }
+          : prev,
       );
     },
   });

--- a/app/src/lib/api.test.ts
+++ b/app/src/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { decryptFacts } from "./api";
+import { decryptFacts, setPinStatus } from "./api";
 import { buildTimeline } from "./vault/timeline";
 import { encryptBlob } from "./crypto";
 import { RawFact, SessionKeys } from "./types";
@@ -257,5 +257,54 @@ describe("decryptFacts → metadata round-trip → buildTimeline", () => {
     expect(g.key).toBe(`s:${SESSION_ID}`);
     expect(g.crystal?.id).toBe("crystal-1");
     expect(g.facts.map((f) => f.id)).toEqual(["atom-1"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A.2 Phase 2 — pin/unpin idempotency guard (mirrors mcp/src/tools/pin.ts:667)
+// ---------------------------------------------------------------------------
+
+describe("setPinStatus idempotency (no UserOp on a no-op)", () => {
+  // A sign callback that must never run: an idempotent no-op sends nothing.
+  const mustNotSign = () => {
+    throw new Error("sign() called on an idempotent pin no-op");
+  };
+
+  function vaultItem(pin_status?: "pinned" | "unpinned") {
+    const claim = {
+      id: "f-pin",
+      text: "Prefers dark mode",
+      type: "preference" as const,
+      source: "user" as const,
+      created_at: "2026-07-01T00:00:00.000Z",
+      schema_version: "1.0" as const,
+      ...(pin_status ? { pin_status } : {}),
+    };
+    return {
+      id: "f-pin",
+      claim,
+      type: claim.type,
+      pinned: pin_status === "pinned",
+      createdAt: new Date(claim.created_at),
+      rawBlob: "",
+      blindIndices: [],
+      decayScore: 1,
+      isActive: true,
+    };
+  }
+
+  it("pin on an already-pinned item resolves idempotent with no write", async () => {
+    const res = await setPinStatus(vaultItem("pinned"), "pinned", KEYS, mustNotSign);
+    expect(res).toEqual({ idempotent: true });
+  });
+
+  it("unpin on an explicitly-unpinned item is a no-op", async () => {
+    const res = await setPinStatus(vaultItem("unpinned"), "unpinned", KEYS, mustNotSign);
+    expect(res).toEqual({ idempotent: true });
+  });
+
+  it("unpin when pin_status is ABSENT is a no-op (absence == unpinned)", async () => {
+    const res = await setPinStatus(vaultItem(undefined), "unpinned", KEYS, mustNotSign);
+    expect(res).toEqual({ idempotent: true });
   });
 });

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -11,7 +11,8 @@ import {
   MEMORY_SCOPES,
   SubgraphFact,
 } from "./types";
-import { decryptBlob } from "./crypto";
+import { decryptBlob, encryptBlob } from "./crypto";
+import type { PinStatus } from "./types";
 import { SessionKeys } from "./types";
 // Type-only: erased at compile time, so it does NOT pull the userop/wasm write
 // chunk into the read bundle. The runtime import is dynamic (see deleteFact).
@@ -271,11 +272,12 @@ export function decryptFacts(
 // ---------------------------------------------------------------------------
 // Write path — Keeper A.2 curation writes.
 //
-// Phase 1 (delete/tombstone) is implemented. The @totalreclaw/core WASM +
-// UserOp assembler are lazy-loaded on the FIRST write only (dynamic import) so
-// the 2.3 MB WASM never lands in the read chunk (see wasm.ts / userop.ts).
+// Phase 1 (delete/tombstone) + Phase 2 (pin/unpin via 2-call supersession) are
+// implemented. The @totalreclaw/core WASM + UserOp assembler + claim rebuilder
+// are lazy-loaded on the FIRST write only (dynamic import) so the 2.3 MB WASM
+// never lands in the read chunk (see wasm.ts / userop.ts / claim.ts).
 //
-// Phase 2/3 (pin/unpin/retype/set_scope via 2-call supersession) remain stubs.
+// Phase 3 (retype/set_scope — same supersession engine) remains a stub.
 // ---------------------------------------------------------------------------
 
 const WRITES_NOT_IMPLEMENTED =
@@ -331,7 +333,126 @@ export async function batchDeleteFacts(
   }
 }
 
-// Phase 2/3: pin/unpin/retype/set_scope (2-call supersession) — not yet wired.
+/**
+ * Fetch the on-chain wire fields of a single fact that the browse query
+ * deliberately skips (`encryptedEmbedding` is ~5.2KB/fact) plus its blind
+ * indices (derived `blindIndexEntries`). A supersession write copies both
+ * forward — the text never changes on pin/unpin, so the old search vectors
+ * stay exact. Missing fact → empty fields (the write still proceeds; trapdoor
+ * search simply won't cover the superseding row, same as a Hermes pin).
+ */
+async function fetchFactWireFields(
+  keys: SessionKeys,
+  factId: string,
+): Promise<{ encryptedEmbedding?: string; blindIndices: string[] }> {
+  const query = `
+    query FactWireFields($id: ID!) {
+      fact(id: $id) {
+        encryptedEmbedding
+        blindIndexEntries { hash }
+      }
+    }
+  `;
+  const resp = await apiFetch<
+    SubgraphResponse<{
+      fact: {
+        encryptedEmbedding?: string | null;
+        blindIndexEntries?: Array<{ hash: string }>;
+      } | null;
+    }>
+  >("/v1/subgraph", keys, {
+    method: "POST",
+    body: JSON.stringify({ query, variables: { id: factId } }),
+  });
+  if (resp.errors?.length) {
+    throw new Error(`subgraph: ${resp.errors.map((e) => e.message).join("; ")}`);
+  }
+  const fact = resp.data?.fact;
+  return {
+    encryptedEmbedding: fact?.encryptedEmbedding ?? undefined,
+    blindIndices: (fact?.blindIndexEntries ?? []).map((e) => e.hash),
+  };
+}
+
+/** Result of a pin/unpin write. `idempotent: true` → no UserOp was sent. */
+export interface PinWriteResult {
+  idempotent: boolean;
+  /** The superseding fact's fresh UUID (absent on idempotent no-op). */
+  newFactId?: string;
+  /** The superseding claim (decrypted shape) for optimistic cache updates. */
+  newClaim?: MemoryClaimV1;
+  /** Hex wire blob of the superseding claim (becomes the item's rawBlob). */
+  newBlobHex?: string;
+}
+
+/**
+ * Pin or unpin a memory (A.2 Phase 2) — atomic 2-call `executeBatch`
+ * supersession `[tombstone(old), newClaim(superseded_by=old, pin_status)]`,
+ * mirroring `mcp/src/tools/pin.ts:executePinOperation`.
+ *
+ * Idempotent (pin.ts:667): pinning an already-pinned memory (or unpinning an
+ * unpinned one — absence of `pin_status` counts as unpinned) sends NO UserOp.
+ */
+export async function setPinStatus(
+  item: VaultItem,
+  target: PinStatus,
+  keys: SessionKeys,
+  sign: SignUserOpHash,
+): Promise<PinWriteResult> {
+  const current: PinStatus =
+    item.claim.pin_status === "pinned" ? "pinned" : "unpinned";
+  if (current === target) {
+    return { idempotent: true };
+  }
+
+  const targetChain = await resolveWriteTarget(keys);
+  const [{ loadCore }, { rebuildClaimJson }, { submitSupersession }] =
+    await Promise.all([import("./wasm"), import("./claim"), import("./userop")]);
+  const core = await loadCore();
+
+  // Rebuild from the RAW decrypted blob (not the normalized VaultItem.claim —
+  // normalization clamps enums, which must not leak into the re-encrypted
+  // wire). Full field carry-forward + metadata preservation live in claim.ts.
+  const plaintext = decryptBlob(item.rawBlob, keys.encryptionKey);
+  const newFactId = crypto.randomUUID();
+  const canonicalJson = rebuildClaimJson(core, plaintext, {
+    newId: newFactId,
+    supersededBy: item.id,
+    pinStatus: target,
+  });
+  const newBlobHex = encryptBlob(canonicalJson, keys.encryptionKey);
+
+  // Copy embedding + blind indices forward from the old on-chain fact.
+  const wire = await fetchFactWireFields(keys, item.id);
+  const blindIndices =
+    item.blindIndices.length > 0 ? item.blindIndices : wire.blindIndices;
+
+  const res = await submitSupersession(
+    item.id,
+    {
+      id: newFactId,
+      encryptedBlobHex: newBlobHex,
+      blindIndices,
+      encryptedEmbedding: wire.encryptedEmbedding,
+      source: target === "pinned" ? "spa_pin" : "spa_unpin",
+    },
+    { keys, sign, ...targetChain },
+  );
+  if (!res.success) {
+    throw new Error(
+      "The pin update was submitted but not confirmed on-chain. Try again.",
+    );
+  }
+  return {
+    idempotent: false,
+    newFactId,
+    newClaim: normalizeClaim(JSON.parse(canonicalJson) as MemoryClaimV1),
+    newBlobHex,
+  };
+}
+
+// Phase 3: retype/set_scope (same 2-call supersession engine — claim.ts /
+// submitSupersession are ready for it) — not yet wired.
 export async function updateClaim(
   _item: VaultItem,
   _updatedClaim: MemoryClaimV1,

--- a/app/src/lib/claim.test.ts
+++ b/app/src/lib/claim.test.ts
@@ -1,0 +1,244 @@
+/**
+ * A.2 Phase 2 — supersession claim rebuilder tests.
+ *
+ * Exercises the REAL web-target `@totalreclaw/core` WASM validator (initSync
+ * from disk bytes, like userop.golden.test.ts) — the exact validate-then-
+ * reattach path the browser runs on pin/unpin. The Crystal round-trip test is
+ * the metadata-preservation proof from the plan: pin a Crystal → re-encrypt →
+ * decryptFacts → buildTimeline still buckets under `s:<session_id>` with
+ * `.crystal` set and the item pinned.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { rebuildClaimJson } from "./claim";
+import { decryptFacts } from "./api";
+import { buildTimeline } from "./vault/timeline";
+import { encryptBlob } from "./crypto";
+import type { RawFact, SessionKeys } from "./types";
+
+type Core = typeof import("@totalreclaw/core/web");
+let core: Core;
+
+beforeAll(async () => {
+  const require = createRequire(import.meta.url);
+  const dir = dirname(require.resolve("@totalreclaw/core/web"));
+  core = (await import("@totalreclaw/core/web")) as unknown as Core;
+  (core as unknown as { initSync: (m: { module: Uint8Array }) => void }).initSync({
+    module: readFileSync(join(dir, "totalreclaw_core_bg.wasm")),
+  });
+});
+
+const OVERRIDES = {
+  newId: "11111111-2222-4333-8444-555555555555",
+  supersededBy: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+  pinStatus: "pinned" as const,
+};
+
+const FULL_SOURCE_CLAIM = {
+  id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+  text: "Chose Gnosis over Base because gas is sponsored end-to-end",
+  type: "claim",
+  source: "user",
+  created_at: "2026-06-01T10:20:30.000Z",
+  schema_version: "1.0",
+  scope: "work",
+  volatility: "stable",
+  entities: [{ name: "Gnosis", type: "company" }],
+  reasoning: "gas is sponsored end-to-end",
+  expires_at: "2027-01-01T00:00:00.000Z",
+  importance: 8,
+  confidence: 0.9,
+  tags: ["legacy-tag"],
+  supersedes: ["00000000-0000-4000-8000-000000000000"],
+  agent_name: "John",
+  metadata: {
+    subtype: "session_crystal",
+    session_id: "0197f000-aaaa-7000-8000-abcdefabcdef",
+    key_outcomes: ["shipped the thing"],
+    open_threads: ["follow up on QA"],
+    topics_discussed: ["gnosis", "gas"],
+    custom_future_metadata_key: "must survive",
+  },
+  custom_future_top_level: { keep: true },
+};
+
+describe("rebuildClaimJson — full carry-forward + overrides", () => {
+  it("overrides only id / pin_status / superseded_by; everything else survives", () => {
+    const out = JSON.parse(
+      rebuildClaimJson(core, JSON.stringify(FULL_SOURCE_CLAIM), OVERRIDES),
+    ) as Record<string, unknown>;
+
+    expect(out.id).toBe(OVERRIDES.newId);
+    expect(out.pin_status).toBe("pinned");
+    expect(out.superseded_by).toBe(OVERRIDES.supersededBy);
+
+    // Modeled fields carried forward (created_at preserved, not reset).
+    expect(out.text).toBe(FULL_SOURCE_CLAIM.text);
+    expect(out.type).toBe("claim");
+    expect(out.source).toBe("user");
+    expect(out.created_at).toBe("2026-06-01T10:20:30.000Z");
+    expect(out.schema_version).toBe("1.0");
+    expect(out.scope).toBe("work");
+    expect(out.volatility).toBe("stable");
+    expect(out.entities).toEqual([{ name: "Gnosis", type: "company" }]);
+    expect(out.reasoning).toBe(FULL_SOURCE_CLAIM.reasoning);
+    expect(out.expires_at).toBe(FULL_SOURCE_CLAIM.expires_at);
+    expect(out.importance).toBe(8);
+    expect(out.confidence).toBe(0.9);
+
+    // Unmodeled / future fields survive core's serialize-strip (forward-compat).
+    expect(out.tags).toEqual(["legacy-tag"]);
+    expect(out.supersedes).toEqual(["00000000-0000-4000-8000-000000000000"]);
+    expect(out.agent_name).toBe("John");
+    expect(out.custom_future_top_level).toEqual({ keep: true });
+  });
+
+  it("re-attaches metadata VERBATIM after validation (unknown metadata keys survive)", () => {
+    const out = JSON.parse(
+      rebuildClaimJson(core, JSON.stringify(FULL_SOURCE_CLAIM), OVERRIDES),
+    ) as Record<string, unknown>;
+    // Byte-verbatim: core's typed MemoryMetadataV1 would drop the unknown key.
+    expect(out.metadata).toEqual(FULL_SOURCE_CLAIM.metadata);
+  });
+
+  it("emits pin_status 'unpinned' on the unpin path", () => {
+    const out = JSON.parse(
+      rebuildClaimJson(core, JSON.stringify(FULL_SOURCE_CLAIM), {
+        ...OVERRIDES,
+        pinStatus: "unpinned",
+      }),
+    ) as Record<string, unknown>;
+    expect(out.pin_status).toBe("unpinned");
+  });
+
+  it("applies the canonical omission rules (scope unspecified / volatility updatable / empty optionals)", () => {
+    const src = {
+      id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+      text: "Prefers dark mode in every editor",
+      type: "preference",
+      source: "user-inferred",
+      created_at: "2026-06-01T10:20:30.000Z",
+      schema_version: "1.0",
+      scope: "unspecified",
+      volatility: "updatable",
+      entities: [],
+      reasoning: "",
+    };
+    const out = JSON.parse(
+      rebuildClaimJson(core, JSON.stringify(src), OVERRIDES),
+    ) as Record<string, unknown>;
+    expect("scope" in out).toBe(false);
+    expect("volatility" in out).toBe(false);
+    expect("entities" in out).toBe(false);
+    expect("reasoning" in out).toBe(false);
+    expect(out.pin_status).toBe("pinned");
+  });
+
+  it("rejects a pre-v1 (short-key) blob instead of inventing fields", () => {
+    const v0 = { t: "legacy short-key text", c: "pref", i: 7 };
+    expect(() =>
+      rebuildClaimJson(core, JSON.stringify(v0), OVERRIDES),
+    ).toThrow(/pre-v1/);
+  });
+
+  it("rejects non-JSON plaintext", () => {
+    expect(() => rebuildClaimJson(core, "not json", OVERRIDES)).toThrow(
+      /not a JSON claim/,
+    );
+  });
+
+  it("rejects invalid enum members (core validation is live, not bypassed)", () => {
+    const bad = { ...FULL_SOURCE_CLAIM, type: "not-a-type" };
+    expect(() =>
+      rebuildClaimJson(core, JSON.stringify(bad), OVERRIDES),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Crystal round-trip — the metadata-preservation proof from the plan.
+// ---------------------------------------------------------------------------
+
+const GOLDEN_ENC_KEY_HEX =
+  "a58fdc56e1d768461d95cd46b49e03727b2eb342ac558b9f3ebf1255b871f703";
+const ENC_KEY = new Uint8Array(
+  GOLDEN_ENC_KEY_HEX.match(/../g)!.map((b) => parseInt(b, 16)),
+);
+const KEYS: SessionKeys = {
+  authKey: new Uint8Array(),
+  encryptionKey: ENC_KEY,
+  authKeyHex: "",
+  eoaAddress: "0x0",
+  walletAddress: "0x0",
+  chainId: 100,
+};
+
+function rawFact(id: string, blobHex: string): RawFact {
+  return {
+    id,
+    encrypted_blob: blobHex,
+    blind_indices: [],
+    decay_score: 1,
+    version: 4,
+    source: "",
+    created_at: "2026-07-01T00:00:00.000Z",
+    updated_at: "2026-07-01T00:00:00.000Z",
+    is_active: true,
+  };
+}
+
+describe("Crystal pin round-trip (decrypt → rebuild → re-encrypt → timeline)", () => {
+  it("keeps the session bucket, the crystal flag, and flips pinned:true", () => {
+    const sessionId = "0197f000-aaaa-7000-8000-abcdefabcdef";
+    const crystalClaim = {
+      id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+      text: "Session crystal: shipped A.2 Phase 2 and validated on staging",
+      type: "summary",
+      source: "derived",
+      created_at: "2026-07-01T00:00:00.000Z",
+      schema_version: "1.0",
+      importance: 9,
+      metadata: {
+        subtype: "session_crystal",
+        session_id: sessionId,
+        key_outcomes: ["pin/unpin shipped"],
+        open_threads: ["Phase 3 retype"],
+        topics_discussed: ["supersession"],
+      },
+    };
+
+    // 1. The Crystal as it sits on-chain today.
+    const sourceBlobHex = encryptBlob(JSON.stringify(crystalClaim), ENC_KEY);
+    const [sourceItem] = decryptFacts([rawFact(crystalClaim.id, sourceBlobHex)], KEYS);
+    expect(sourceItem.claim.metadata?.session_id).toBe(sessionId);
+    expect(sourceItem.pinned).toBe(false);
+
+    // 2. Pin it: rebuild from the decrypted rawBlob plaintext + re-encrypt —
+    //    exactly what setPinStatus does.
+    const rebuilt = rebuildClaimJson(
+      core,
+      JSON.stringify(crystalClaim),
+      { newId: "11111111-2222-4333-8444-555555555555", supersededBy: crystalClaim.id, pinStatus: "pinned" },
+    );
+    const newBlobHex = encryptBlob(rebuilt, ENC_KEY);
+
+    // 3. Read the superseding fact back like a fresh vault load.
+    const [pinnedItem] = decryptFacts(
+      [rawFact("11111111-2222-4333-8444-555555555555", newBlobHex)],
+      KEYS,
+    );
+    expect(pinnedItem.pinned).toBe(true);
+    expect(pinnedItem.claim.superseded_by).toBe(crystalClaim.id);
+    expect(pinnedItem.claim.metadata).toEqual(crystalClaim.metadata);
+
+    // 4. The timeline still buckets it as the session's Crystal.
+    const groups = buildTimeline([pinnedItem]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe(`s:${sessionId}`);
+    expect(groups[0].crystal).not.toBeNull();
+    expect(groups[0].crystal!.pinned).toBe(true);
+    expect(groups[0].openThreads).toBe(1);
+  });
+});

--- a/app/src/lib/claim.ts
+++ b/app/src/lib/claim.ts
@@ -1,0 +1,122 @@
+/**
+ * Claim rebuilder for 2-call supersession writes (A.2 Phase 2 — pin/unpin).
+ *
+ * Mirrors `mcp/src/claims-helper.ts:buildV1ClaimBlob` byte-compatibly: the new
+ * claim is the old decrypted claim with ONLY `id` / `pin_status` /
+ * `superseded_by` overridden, canonical omission rules applied (omit `scope`
+ * when `unspecified`, `volatility` when `updatable`), validated through core
+ * `validateMemoryClaimV1`, then `schema_version` + `metadata` re-attached after
+ * validation (core's serde drops default schema_version and round-trips
+ * `metadata` through a TYPED struct that strips unknown keys — the known trap;
+ * re-attaching verbatim is what keeps `session_id` / `subtype:
+ * "session_crystal"` / Crystal lists alive through supersession).
+ *
+ * Beyond the MCP builder, this carries EVERY top-level source field forward —
+ * including ones the SPA's MemoryClaimV1 type doesn't name (`agent_name`,
+ * `tags`, `supersedes`, unknown future fields) — so a pin from the web app
+ * never silently drops another client's data (forward-compat).
+ *
+ * WRITE-path module: reached only via dynamic `import()` from `api.ts`. The
+ * core WASM instance is injected (see `wasm.ts:loadCore`) so node-side tests
+ * can pass an `initSync`-loaded core.
+ */
+import type { PinStatus } from "./types";
+
+/** The single core export this module needs (injected for testability). */
+export interface ClaimValidator {
+  validateMemoryClaimV1(claimJson: string): string;
+}
+
+export interface SupersessionOverrides {
+  /** Fresh UUID for the superseding claim (protobuf field 1 / Fact.id). */
+  newId: string;
+  /** The old fact id being tombstoned — becomes `superseded_by`. */
+  supersededBy: string;
+  /** 'pinned' (pin) or 'unpinned' (unpin) — always emitted explicitly. */
+  pinStatus: PinStatus;
+}
+
+/**
+ * Rebuild the decrypted source claim JSON into the superseding claim JSON.
+ *
+ * `rawClaimJson` is the plaintext of `VaultItem.rawBlob` (NOT the normalized
+ * `VaultItem.claim` — normalization clamps enums, which must not leak into
+ * what we re-encrypt). Returns canonical JSON ready for `encryptBlob`.
+ *
+ * Throws when the source is not a v1-shaped claim (pre-v1 vault entries are
+ * not pin-supported from the web app — same as they aren't readable here).
+ */
+export function rebuildClaimJson(
+  core: ClaimValidator,
+  rawClaimJson: string,
+  overrides: SupersessionOverrides,
+): string {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(rawClaimJson);
+  } catch {
+    throw new Error("Source memory is not a JSON claim.");
+  }
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new Error("Source memory is not a JSON claim.");
+  }
+  const source = raw as Record<string, unknown>;
+  if (
+    typeof source.text !== "string" ||
+    typeof source.type !== "string" ||
+    typeof source.source !== "string"
+  ) {
+    throw new Error(
+      "This memory was written in a pre-v1 format the web app can't rewrite. " +
+        "Use a TotalReclaw agent to pin it.",
+    );
+  }
+
+  // Full carry-forward: spread the decrypted source, override only the three
+  // supersession fields. `created_at` is preserved (the memory's original
+  // creation time — keeps timeline ordering stable through a pin).
+  const input: Record<string, unknown> = { ...source };
+  input.id = overrides.newId;
+  input.superseded_by = overrides.supersededBy;
+  input.pin_status = overrides.pinStatus;
+  input.schema_version = "1.0";
+  if (typeof input.created_at !== "string" || input.created_at === "") {
+    input.created_at = new Date().toISOString();
+  }
+
+  // Canonical omission rules (claims-helper.ts:buildV1ClaimBlob) — defaults
+  // and empty optionals are omitted from the wire, not serialized.
+  if (input.scope === "unspecified") delete input.scope;
+  if (input.volatility === "updatable") delete input.volatility;
+  if (Array.isArray(input.entities) && input.entities.length === 0) delete input.entities;
+  if (!input.reasoning) delete input.reasoning;
+  if (!input.expires_at) delete input.expires_at;
+
+  // Canonicalise + validate via core (throws on schema violations — bad enum
+  // members, text length, etc.). MemoryClaimV1 tolerates unknown fields on
+  // parse but STRIPS them on serialize, so everything unmodeled is re-attached
+  // below from `input`.
+  const validated = core.validateMemoryClaimV1(JSON.stringify(input));
+  const parsed = JSON.parse(validated) as Record<string, unknown>;
+
+  // Re-attach schema_version (core drops it when it equals the default) so
+  // the output matches the plugin/MCP wire byte-for-byte.
+  parsed.schema_version = "1.0";
+
+  // Re-attach `metadata` VERBATIM after validation (claims-helper.ts:418).
+  // Core round-trips metadata through the typed MemoryMetadataV1 struct which
+  // silently drops unknown keys and all-default payloads.
+  if (input.metadata !== undefined && input.metadata !== null) {
+    parsed.metadata = input.metadata;
+  }
+
+  // Forward-compat: restore every top-level field core stripped (agent_name,
+  // tags, supersedes, unknown future fields). Fields core KEPT stay canonical.
+  for (const [key, value] of Object.entries(input)) {
+    if (!(key in parsed) && value !== undefined) {
+      parsed[key] = value;
+    }
+  }
+
+  return JSON.stringify(parsed);
+}

--- a/app/src/lib/userop.golden.test.ts
+++ b/app/src/lib/userop.golden.test.ts
@@ -150,3 +150,118 @@ describe("golden vectors — UserOp hash + signature (viem-derived references)",
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Fixture (b) made REAL (A.2 Phase 2): a frozen 2-call PIN supersession batch —
+// [tombstone(old fact), superseding pinned claim] — with pinned protobuf,
+// executeBatch calldata, and v0.7 userOpHash. Regenerate deliberately with
+// `scripts/gen-golden-pin.mjs` on an intentional wire change (note why).
+// ---------------------------------------------------------------------------
+
+const NEW_PIN_ID = "a2golden22222222222222222222feed";
+const GOLDEN_ENC_KEY_HEX =
+  "a58fdc56e1d768461d95cd46b49e03727b2eb342ac558b9f3ebf1255b871f703";
+
+// The exact canonical claim JSON inside the frozen encrypted blob below
+// (validate-then-reattach output — schema_version + Crystal metadata present).
+const GOLDEN_PIN_CLAIM_JSON =
+  "{\"id\":\"a2golden22222222222222222222feed\",\"text\":\"A2 golden pin fixture — keep me byte-stable\",\"type\":\"claim\",\"source\":\"user\",\"created_at\":\"2026-06-01T10:20:30.000Z\",\"scope\":\"work\",\"importance\":8,\"superseded_by\":\"a2golden00000000000000000000dead\",\"pin_status\":\"pinned\",\"schema_version\":\"1.0\",\"metadata\":{\"subtype\":\"session_crystal\",\"session_id\":\"0197f000-aaaa-7000-8000-abcdefabcdef\",\"key_outcomes\":[\"golden vector shipped\"]}}";
+
+// Captured ONCE from encryptBlob(GOLDEN_PIN_CLAIM_JSON) with the public
+// all-zeros-mnemonic test key — frozen because the XChaCha20 nonce is random.
+const GOLDEN_PIN_BLOB_HEX =
+  "007ec133b1c3d2273e001e2d284d14a29cf79cc4ecc9f33d43bc266d61668d1146a90d86c20736a591d6b6641a6ac63dbdee1dec9d363dcb523b7877b6888316782e67d9c647ec044cd485461ace626c5350a8e35b6ba0f6027b39d70c0bf375caa4f2b9ffd8c4eb2c4de37abadade3d58cd3db19d3002aa2a85af1bc17d9ea6c0a919c429b3fb4a6eca953d5a0cdfa0604297de862af291c0d63fb33b1ec8877bf74c8076465a9e0e1805a3eefacbc177d92871d701315a59b5496667065abb0212d34bce7deb31db7a59460e18be114d3fb2b4a66082f150877f513f974694b470338def5548c95d5727ed1fc3d206ebb397e36cdc6982c29d95e4a94206014614098ba096dae11395ede09db24b2ee9885a8f049f92b74de310bc146ce91bb0eeb9bc503730a333629a065fb289745929743a3a682d9add4c50ca35d58054f58a27cfa0f03d03d6a673eda437e140b2a4ac798113c5736e99f9165ca66a52bec7937339f555782e05c0b39aa7ceeb607218704424702e6baae3e1e79bfd4ee482dd5d9dcfc9d821f4efcbd8a849e0c5e35385c874a7f0b7c5fb2f0acd23e7a984997cdc8b38678b70a5326d8cbf0b37ccdf02533912b3f4e4e35fd248ba2ed5796f8e0e608f78ef048afd242bbf23f90744";
+
+// Frozen protobuf-v4 fact payload over that blob: blind indices + encrypted
+// embedding COPIED FORWARD (the pin write's zero-search-degradation contract),
+// decay_score=1.0, source=spa_pin, agent_id=ts-spa-vault, frozen timestamp.
+const GOLDEN_PIN_FACT_TS = "2026-07-15T00:00:00.000+00:00";
+const GOLDEN_PIN_BLIND_INDICES = [
+  "a2goldenblind00000000000000000001",
+  "a2goldenblind00000000000000000002",
+];
+const GOLDEN_PIN_EMBEDDING = "a2goldenembeddingcopiedforward00";
+const GOLDEN_PIN_FACT_PROTOBUF_HEX =
+  "0a206132676f6c64656e323232323232323232323232323232323232323266656564121d323032362d30372d31355430303a30303a30302e3030302b30303a30301a2a30783263306366373462326237363131303730386361343331373936333637373739653337333832353022d303007ec133b1c3d2273e001e2d284d14a29cf79cc4ecc9f33d43bc266d61668d1146a90d86c20736a591d6b6641a6ac63dbdee1dec9d363dcb523b7877b6888316782e67d9c647ec044cd485461ace626c5350a8e35b6ba0f6027b39d70c0bf375caa4f2b9ffd8c4eb2c4de37abadade3d58cd3db19d3002aa2a85af1bc17d9ea6c0a919c429b3fb4a6eca953d5a0cdfa0604297de862af291c0d63fb33b1ec8877bf74c8076465a9e0e1805a3eefacbc177d92871d701315a59b5496667065abb0212d34bce7deb31db7a59460e18be114d3fb2b4a66082f150877f513f974694b470338def5548c95d5727ed1fc3d206ebb397e36cdc6982c29d95e4a94206014614098ba096dae11395ede09db24b2ee9885a8f049f92b74de310bc146ce91bb0eeb9bc503730a333629a065fb289745929743a3a682d9add4c50ca35d58054f58a27cfa0f03d03d6a673eda437e140b2a4ac798113c5736e99f9165ca66a52bec7937339f555782e05c0b39aa7ceeb607218704424702e6baae3e1e79bfd4ee482dd5d9dcfc9d821f4efcbd8a849e0c5e35385c874a7f0b7c5fb2f0acd23e7a984997cdc8b38678b70a5326d8cbf0b37ccdf02533912b3f4e4e35fd248ba2ed5796f8e0e608f78ef048afd242bbf23f907442a216132676f6c64656e626c696e6430303030303030303030303030303030303030312a216132676f6c64656e626c696e64303030303030303030303030303030303030303231000000000000f03f380140046a206132676f6c64656e656d62656464696e67636f70696564666f72776172643030";
+
+// executeBatch([tombstone(v4), pinnedClaim(v4)]) → staging DataEdge.
+const GOLDEN_PIN_BATCH_CALLDATA_HEX =
+  "47e1da2a000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000002000000000000000000000000e7a4d2677b686e13775ba9092631089e35f0bb91000000000000000000000000e7a4d2677b686e13775ba9092631089e35f0bb910000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000000007c0a206132676f6c64656e303030303030303030303030303030303030303064656164121d323032362d30372d30395432323a30383a35342e3331332b30303a30301a2a3078326330636637346232623736313130373038636134333137393633363737373965333733383235302200310000000000000000380040040000000000000000000000000000000000000000000000000000000000000000000002b80a206132676f6c64656e323232323232323232323232323232323232323266656564121d323032362d30372d31355430303a30303a30302e3030302b30303a30301a2a30783263306366373462326237363131303730386361343331373936333637373739653337333832353022d303007ec133b1c3d2273e001e2d284d14a29cf79cc4ecc9f33d43bc266d61668d1146a90d86c20736a591d6b6641a6ac63dbdee1dec9d363dcb523b7877b6888316782e67d9c647ec044cd485461ace626c5350a8e35b6ba0f6027b39d70c0bf375caa4f2b9ffd8c4eb2c4de37abadade3d58cd3db19d3002aa2a85af1bc17d9ea6c0a919c429b3fb4a6eca953d5a0cdfa0604297de862af291c0d63fb33b1ec8877bf74c8076465a9e0e1805a3eefacbc177d92871d701315a59b5496667065abb0212d34bce7deb31db7a59460e18be114d3fb2b4a66082f150877f513f974694b470338def5548c95d5727ed1fc3d206ebb397e36cdc6982c29d95e4a94206014614098ba096dae11395ede09db24b2ee9885a8f049f92b74de310bc146ce91bb0eeb9bc503730a333629a065fb289745929743a3a682d9add4c50ca35d58054f58a27cfa0f03d03d6a673eda437e140b2a4ac798113c5736e99f9165ca66a52bec7937339f555782e05c0b39aa7ceeb607218704424702e6baae3e1e79bfd4ee482dd5d9dcfc9d821f4efcbd8a849e0c5e35385c874a7f0b7c5fb2f0acd23e7a984997cdc8b38678b70a5326d8cbf0b37ccdf02533912b3f4e4e35fd248ba2ed5796f8e0e608f78ef048afd242bbf23f907442a216132676f6c64656e626c696e6430303030303030303030303030303030303030312a216132676f6c64656e626c696e64303030303030303030303030303030303030303231000000000000f03f380140046a206132676f6c64656e656d62656464696e67636f70696564666f727761726430300000000000000000";
+
+// v0.7 UserOp over the batch calldata (Gnosis chainId 100) — frozen hash.
+const GOLDEN_PIN_USEROP_HASH =
+  "fc974638d47b36133e53bbbec3b770a728a6e4bd37295612354859c0ab42adb6";
+
+describe("golden vectors — fixture (b) REAL: 2-call pin supersession batch", () => {
+  it("the frozen encrypted blob still decrypts to the exact pinned claim (metadata intact)", async () => {
+    const { decryptBlob } = await import("./crypto");
+    const key = fromHex(GOLDEN_ENC_KEY_HEX);
+    const plaintext = decryptBlob(GOLDEN_PIN_BLOB_HEX, key);
+    expect(plaintext).toBe(GOLDEN_PIN_CLAIM_JSON);
+    const claim = JSON.parse(plaintext);
+    expect(claim.pin_status).toBe("pinned");
+    expect(claim.superseded_by).toBe(ID);
+    expect(claim.metadata.subtype).toBe("session_crystal");
+    expect(claim.metadata.session_id).toBe("0197f000-aaaa-7000-8000-abcdefabcdef");
+  });
+
+  it("the pinned-claim fact protobuf (v4, embedding+indices copied forward) is byte-frozen", () => {
+    const got = toHex(
+      core.encodeFactProtobuf(
+        JSON.stringify({
+          id: NEW_PIN_ID,
+          timestamp: GOLDEN_PIN_FACT_TS,
+          owner: OWNER,
+          encrypted_blob_hex: GOLDEN_PIN_BLOB_HEX,
+          blind_indices: GOLDEN_PIN_BLIND_INDICES,
+          decay_score: 1.0,
+          source: "spa_pin",
+          content_fp: "",
+          agent_id: "ts-spa-vault",
+          encrypted_embedding: GOLDEN_PIN_EMBEDDING,
+          version: 4,
+        }),
+      ),
+    );
+    expect(got).toBe(GOLDEN_PIN_FACT_PROTOBUF_HEX);
+    // Copy-forward is visible on the wire: field 13 carries the old embedding.
+    expect(got).toContain(Buffer.from(GOLDEN_PIN_EMBEDDING).toString("hex"));
+  });
+
+  it("executeBatch([tombstone(old), pinnedClaim(new)]) calldata is byte-frozen", () => {
+    const got = toHex(
+      core.encodeBatchCallTo(
+        JSON.stringify([GOLDEN_TOMBSTONE_HEX, GOLDEN_PIN_FACT_PROTOBUF_HEX]),
+        STAGING_DATA_EDGE,
+      ),
+    );
+    expect(got).toBe(GOLDEN_PIN_BATCH_CALLDATA_HEX);
+    expect(got.slice(0, 8)).toBe("47e1da2a"); // executeBatch(address[],uint256[],bytes[])
+    // Both inner calls target the staging DataEdge.
+    expect(got.split("e7a4d2677b686e13775ba9092631089e35f0bb91").length - 1).toBe(2);
+  });
+
+  it("the v0.7 userOpHash over the pin batch (Gnosis, chainId 100) is byte-frozen", () => {
+    const op = {
+      sender: OWNER,
+      nonce: "0x1",
+      callData: `0x${GOLDEN_PIN_BATCH_CALLDATA_HEX}`,
+      callGasLimit: "0x30d40",
+      verificationGasLimit: "0x186a0",
+      preVerificationGas: "0xc350",
+      maxFeePerGas: "0xf4240",
+      maxPriorityFeePerGas: "0x7a120",
+      paymaster: "0x0000000000000039cd5e8ae05257ce51c473ddd1",
+      paymasterVerificationGasLimit: "0x186a0",
+      paymasterPostOpGasLimit: "0xc350",
+      paymasterData: "0xabcd",
+      signature: "0x" + "00".repeat(65),
+    };
+    const hash = core.hashUserOp(
+      JSON.stringify(op),
+      "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+      100n,
+    );
+    expect(hash).toBe(GOLDEN_PIN_USEROP_HASH);
+  });
+});

--- a/app/src/lib/userop.ts
+++ b/app/src/lib/userop.ts
@@ -176,3 +176,58 @@ export async function submitTombstones(
   );
   return submitUserOp(payloads, ctx);
 }
+
+/** The re-encrypted superseding claim, ready for the on-chain protobuf. */
+export interface SupersedingFact {
+  /** Fresh claim UUID (protobuf field 1 / subgraph Fact.id). */
+  id: string;
+  /** Hex wire-format blob (nonce||tag||ct) from `encryptBlob`. */
+  encryptedBlobHex: string;
+  /** Blind indices copied forward from the old on-chain fact (text unchanged). */
+  blindIndices: string[];
+  /** Encrypted embedding copied forward from the old on-chain fact. */
+  encryptedEmbedding?: string;
+  /** Provenance tag for the write (e.g. "spa_pin" / "spa_unpin"). */
+  source: string;
+}
+
+/**
+ * Pin/unpin (A.2 Phase 2): atomic 2-call `executeBatch` supersession —
+ * `[tombstone(oldFactId, v4), newClaim(v4)]` in ONE UserOp (one nonce, one
+ * submission), mirroring `mcp/src/tools/pin.ts` / Python `_change_claim_status`.
+ * Batching is what makes the status flip atomic on-chain: sequential ops raced
+ * a Pimlico mempool quirk that could tombstone the old fact and drop the new.
+ *
+ * decay_score = 1.0 on the new fact (pins are top-priority; unpins revert to
+ * active at full decay). Embedding + blind indices are copied forward — the
+ * text never changes on a pin, so the old search vectors stay exact (no 344 MB
+ * embedding model in the browser, zero search degradation).
+ */
+export async function submitSupersession(
+  oldFactId: string,
+  newFact: SupersedingFact,
+  ctx: WriteContext,
+): Promise<SubmitResult> {
+  const core = await loadCore();
+  const owner = ctx.keys.walletAddress.toLowerCase();
+  const tombstone = core.encodeTombstoneProtobuf(oldFactId, owner, PROTOBUF_VERSION_V4);
+  const claim = core.encodeFactProtobuf(
+    JSON.stringify({
+      id: newFact.id,
+      timestamp: new Date().toISOString(),
+      owner,
+      encrypted_blob_hex: newFact.encryptedBlobHex,
+      blind_indices: newFact.blindIndices,
+      decay_score: 1.0,
+      source: newFact.source,
+      // Empty like the MCP pin path — the relay's per-fact billing doesn't
+      // key on it, and re-sending the old fingerprint could trip server-side
+      // dedup against the fact we're superseding.
+      content_fp: "",
+      agent_id: "ts-spa-vault",
+      encrypted_embedding: newFact.encryptedEmbedding ?? null,
+      version: PROTOBUF_VERSION_V4,
+    }),
+  );
+  return submitUserOp([tombstone, claim], ctx);
+}

--- a/app/src/pages/MemoryPage.tsx
+++ b/app/src/pages/MemoryPage.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense, useCallback, useMemo, useState, type ReactNode } from "react";
 import { clsx } from "clsx";
 import { useCrypto } from "../contexts/CryptoContext";
-import { useVault, useDeleteFact } from "../hooks/useVault";
+import { useVault, useDeleteFact, usePinFact } from "../hooks/useVault";
 import { buildTimeline, importSourceOf, type SessionGroup } from "../lib/vault/timeline";
 import { buildMindGraph, SCOPES, type Scope } from "../lib/vault/mindmap";
 import { AppHeader } from "../components/AppHeader";
@@ -48,8 +48,9 @@ export function MemoryPage() {
 
   const [mode, setMode] = useState<Mode>("list");
   const [panel, setPanel] = useState<PanelView | null>(null);
-  // A.2 curation: on-chain tombstone. Wired into the Facts lens (keys present).
+  // A.2 curation: on-chain tombstone + pin/unpin. Wired into the Facts lens.
   const del = useDeleteFact(keys);
+  const pin = usePinFact(keys);
 
   const [q, setQ] = useState("");
   const [scope, setScope] = useState<MemoryScope | null>(null);
@@ -246,6 +247,11 @@ export function MemoryPage() {
                 Couldn’t forget that memory: {del.error instanceof Error ? del.error.message : String(del.error)}
               </p>
             )}
+            {pin.isError && (
+              <p className="mt-4 rounded-control bg-clay-tint px-3 py-2 text-sm text-clay-deep">
+                Couldn’t update that pin: {pin.error instanceof Error ? pin.error.message : String(pin.error)}
+              </p>
+            )}
             {shownItems.length > 0 ? (
               <div className="mt-6 space-y-3">
                 {shownItems.map((it, i) => (
@@ -255,6 +261,10 @@ export function MemoryPage() {
                     style={{ animationDelay: `${Math.min(i, 8) * 20}ms` }}
                     onForget={() => del.mutate(it.id)}
                     forgetPending={del.isPending && del.variables === it.id}
+                    onTogglePin={() =>
+                      pin.mutate({ item: it, target: it.pinned ? "unpinned" : "pinned" })
+                    }
+                    pinPending={pin.isPending && pin.variables?.item.id === it.id}
                   />
                 ))}
               </div>


### PR DESCRIPTION
Keeper A.2 curation writes, Phase 2: **pin/unpin from the vault SPA**, on top of the Phase 0+1 stack from #498. Closes out the PIN/UNPIN checklist of the A.2 plan. **Phase 3 (retype/set_scope) deferred** — the supersession engine (`claim.ts` + `submitSupersession`) is ready for it.

## What shipped

- **`src/lib/claim.ts`** — supersession claim rebuilder, byte-compatible with `mcp/src/claims-helper.ts:buildV1ClaimBlob`: spread the RAW decrypted source claim, override only `id`/`pin_status`/`superseded_by`, apply the canonical omission rules (`scope: unspecified`, `volatility: updatable`, empty optionals), validate via core WASM `validateMemoryClaimV1`, then re-attach `schema_version` + `metadata` **verbatim** after validation (core round-trips metadata through the typed struct and strips unknown keys — the known trap). Beyond MCP, every unmodeled top-level field (`agent_name`, `tags`, `supersedes`, unknown future fields) is restored post-validation, so a web-app pin never drops another client's data.
- **`src/lib/userop.ts:submitSupersession`** — atomic 2-call `executeBatch` UserOp: `[tombstone(old id, v4), newClaim(new UUID, protobuf v4)]`, one nonce, one submission (same anti-race rationale as Python 2.2.3). `decay_score=1.0`, `agent_id=ts-spa-vault`, `source=spa_pin|spa_unpin`, `content_fp=""` (MCP parity). DataEdge comes from relay billing `data_edge_address` — never hardcoded.
- **`src/lib/api.ts:setPinStatus`** — idempotency short-circuit mirroring `mcp/src/tools/pin.ts:667` (pin-when-pinned / unpin-when-unpinned-or-absent → **no UserOp**, `{idempotent:true}`); targeted subgraph query (`fact(id){encryptedEmbedding blindIndexEntries{hash}}`) to **copy the old fact's embedding + blind indices forward** (text unchanged ⇒ vectors unchanged ⇒ zero search degradation, no in-browser embedding model). The browse query still skips embeddings.
- **UI** — `ClaimCard` grows a quiet Pin/Unpin affordance beside Forget (no confirm; reversible), wired in the Facts lens via `usePinFact`. Optimistic reconcile on receipt updates the cached item in place (new fact id, new claim, new `rawBlob` — so an immediate re-toggle rebuilds from the CURRENT on-chain blob). Drive-by fix: the Phase-1 delete cache reconcilers were typed against `VaultItem[]` but the vault cache holds `VaultData` (`{items, fetched}`) and would have thrown at runtime; all updaters now operate on `VaultData`.
- **Signing discipline untouched**: writes sign through the existing `withMasterKey` (fresh passkey assertion → transient PRF-unwrap → WASM `signUserOp` → zero), exactly like Phase 1. No mnemonic/key material is held, logged, or committed anywhere.

## The supersession shape (canonical, reused verbatim)

```
executeBatch → staging/prod DataEdge (from relay billing)
  call 1: tombstone   {id: old, blob: ∅, decay_score: 0, is_active: 0, version: 4}
  call 2: new claim   {id: new UUID, blob: E(claim′), decay 1.0, version: 4}
          claim′ = claim ⊕ {id: new, superseded_by: old, pin_status: pinned|unpinned}
                   + embedding/blind-indices copied forward from the old fact
```

## Metadata-preservation proof

- Unit: `claim.test.ts` Crystal round-trip — pin a `session_crystal` fixture → re-encrypt → `decryptFacts` → `buildTimeline` still buckets under `s:<session_id>` with `.crystal` set and `pinned:true`; unknown metadata keys survive byte-verbatim.
- On-chain (staging E2E): the superseding fact's decrypted metadata deep-equals the original Crystal metadata after BOTH supersessions (pin, then unpin).

## Golden vector (b) made real

Fixture (b) in `userop.golden.test.ts` is now a **frozen 2-call pin batch**: pinned constants for the superseding-claim protobuf (embedding + indices visibly copied forward on the wire), the `executeBatch` calldata → staging DataEdge, and the v0.7 `userOpHash` on Gnosis (chainId 100) — plus a frozen encrypted blob that must keep decrypting to the exact pinned claim with Crystal metadata intact. A core bump that shifts wire bytes fails loudly in SPA CI. Regenerator committed: `app/scripts/gen-golden-pin.mjs` (the pre-existing frozen two-tombstone batch vector is kept as extra coverage).

## Gates

- `npx tsc --noEmit` → clean.
- `npx vitest run` → **132/132** (16 files) incl. new: batch golden vectors, Crystal round-trip, carry-forward/omission-rule suite, idempotency-never-signs tests. No regressions.
- **Staging E2E** (`app/e2e/pin-onchain.mjs`) → **PASS, 26/26 checks**, redacted evidence:

```json
{
  "smartAccount": "0x73585842a4ad4eebd13a61acdf266fc027079666",
  "dataEdge": "0xE7a4D2677B686e13775Ba9092631089e35F0BB91",
  "chainId": 100, "environment": "staging",
  "oldFactId": "54bfc40d-ed23-40dd-81ce-be39dd5b6ae7",
  "pinnedFactId": "03b6c017-cfb1-4905-b4dc-aa96b2da4b87",
  "unpinnedFactId": "a00309c4-8921-483e-a6fe-e2ac51555999",
  "writeUserOpHash": "0xc6c0ae9483a922579a7daa58e289309644970895ec952d21fa26aec99a5b0646",
  "pinUserOpHash": "0xb65db444f3339a197104782a0bc9715b49839bd397801c8e52126b4e776c0151",
  "unpinUserOpHash": "0x429cf6c226d9d4717347543dfb1d8600d7cb224b00e2aa148aacd8ec46a2f370",
  "idempotentPinSkipped": true,
  "embeddingCopiedForward": true,
  "metadataIntact": true
}
```
  Per-assertion: pin receipt logged at the STAGING DataEdge (0xE7a4…) and never touched prod (0xC445…) ✅ · old fact flipped `isActive:false` ✅ · new fact decrypts to `pin_status:"pinned"` + `superseded_by:old` + metadata verbatim ✅ · `encryptedEmbedding` byte-equal old↔new ✅ · unpin repeats the shape back to `"unpinned"` ✅ · idempotent re-pin sent NO UserOp and created NO fact ✅ · test facts tombstone-cleaned ✅.

## Bundle

Write path stays lazy: `claim.ts` lands as its own async chunk (1.16 kB) alongside `userop` (3.45 kB, +0.44) / `wasm` loader / the 2,163 kB WASM asset — none reachable from the read path. Eager `index-*.js`: 364.63 → 367.40 kB (**+2.77 kB raw / +0.77 kB gzip**), which is the Pin/Unpin affordance + hook + `setPinStatus` orchestration (inherently eager UI code; zero WASM/write machinery).

`.e2e-secret` confirmed gitignored and unstaged.

Closes nothing; part of #484.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
