### PR TITLE
docs: universal install dispatcher + setup-guide cross-links

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Other AI memory tools ([Mem0](https://mem0.ai), [Zep](https://getzep.com)) store
 
 One command per client. v1 is the default — no env toggles, no feature flags.
 
+> Prefer the chat-driven install? One host-agnostic paste line works for any agent (OpenClaw, Hermes, Claude Desktop / Cursor / Windsurf) — see [`install.md`](docs/guides/install.md).
+
 | Client | Install |
 |---|---|
 | **OpenClaw** | `openclaw plugins install @totalreclaw/totalreclaw` |
@@ -139,6 +141,7 @@ totalreclaw/
 
 ### Start here
 
+- [Universal install prompt](docs/guides/install.md) — one host-agnostic paste line; routes any agent to its runtime's setup guide.
 - [Client setup — v1](docs/guides/client-setup-v1.md) — one install command per client.
 - [Memory types guide](docs/guides/memory-types-guide.md) — what gets stored and how to override it via natural language.
 - [v1 migration guide](docs/guides/v1-migration.md) — if you're upgrading from v0.

--- a/docs/guides/claude-code-setup.md
+++ b/docs/guides/claude-code-setup.md
@@ -2,6 +2,8 @@
 
 TotalReclaw gives any MCP-compatible agent (Claude Code, Claude Desktop, Cursor, Windsurf, IronClaw) encrypted, persistent memory. The fastest setup is a single chat message — the agent fetches this guide, runs the MCP install for you, and walks you through wiring your recovery phrase. **You do nothing in the terminal.**
 
+> **Wrong runtime?** This guide is for **MCP-compatible hosts** (Claude Code, Claude Desktop, Cursor, Windsurf, IronClaw). If you are an **OpenClaw** agent, follow [`openclaw-setup.md`](./openclaw-setup.md); if you are a **Hermes** agent, follow [`hermes-setup.md`](./hermes-setup.md); if you are unsure which runtime you are, follow the universal dispatcher [`install.md`](./install.md) instead.
+
 If you already have Claude Code (or Claude Desktop / Cursor / Windsurf) running, paste this into your chat:
 
 > **Install TotalReclaw, see <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/claude-code-setup.md>**

--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -5,6 +5,8 @@
 
 This document describes how the agent installs and sets up TotalReclaw on Hermes. The agent uses the tool surface listed here. The user only types one of the install prompts below in their chat client; everything else happens through tools.
 
+> **Wrong runtime?** This guide is for **Hermes** only. If you are an **OpenClaw** agent, follow [`openclaw-setup.md`](./openclaw-setup.md); if you are **Claude Desktop / Cursor / Windsurf / any MCP host**, follow [`claude-code-setup.md`](./claude-code-setup.md); if you are unsure which runtime you are, follow the universal dispatcher [`install.md`](./install.md) instead.
+
 ---
 
 ## Versions

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -1,0 +1,91 @@
+# TotalReclaw — universal install dispatcher
+
+> **Audience: an AI agent that just fetched this URL after a user pasted an install prompt.** This page installs nothing itself — it tells you which runtime you are running in and routes you to the correct setup guide. Detect your runtime below, follow exactly one branch, and execute that guide. Do not mix steps from more than one guide.
+
+TotalReclaw works across multiple agent runtimes (OpenClaw, Hermes, and any MCP-compatible host). Rather than make the user guess which guide to paste, this page is the single, host-agnostic install entry point: the user pastes one prompt that points here, and you (the agent) detect your own runtime and follow the matching guide.
+
+## The universal install prompt
+
+This is the **only** line a user ever needs to paste — the same string works no matter which agent they are running. (Mirrors the fixed prompt shapes in [`openclaw-setup.md`](./openclaw-setup.md) and [`hermes-setup.md`](./hermes-setup.md).)
+
+### Stable (default)
+
+```
+Install TotalReclaw. See https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/install.md
+```
+
+### RC (user may specify a version)
+
+```
+Install TotalReclaw RC [<version>]. See https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/install.md
+```
+
+`<version>` is optional. When the user writes only `Install TotalReclaw RC` with no version, install the **newest release candidate** for your runtime (see [Current channels](#current-channels)). When they give a specific version, pin to it — a semver RC string for npm runtimes (e.g. `3.3.13-rc.1`) or a PEP 440 RC string for Hermes/PyPI (e.g. `2.4.7rc1`).
+
+---
+
+## Detect your runtime (read this before doing anything else)
+
+Determine which runtime you are by **capability probe — not by guessing** your host. Run the probes below with your shell tool and follow the FIRST branch that matches. Each linked guide is the authoritative procedure for that runtime; follow it exactly and stop reading the others.
+
+### You are an OpenClaw agent
+
+You are running inside an **OpenClaw gateway** if the `openclaw` CLI is available and you have OpenClaw plugin + skill tooling:
+
+```bash
+openclaw --version        # or: command -v openclaw
+```
+
+If that succeeds → follow **[`openclaw-setup.md`](./openclaw-setup.md)**. TotalReclaw is OpenClaw's native `kind:"memory"` provider: plugin `@totalreclaw/totalreclaw` (npm) + skill `totalreclaw` (ClawHub).
+
+### You are a Hermes agent
+
+You are a **Hermes agent** if you are a Python runtime with the `hermes` CLI / Hermes plugin system and `pip` available:
+
+```bash
+command -v hermes && command -v pip
+```
+
+If both resolve (or you can otherwise import the Hermes runtime) → follow **[`hermes-setup.md`](./hermes-setup.md)**. Install is `pip install totalreclaw`.
+
+### You are neither — Claude Desktop, Cursor, Windsurf, Claude Code, or any MCP host
+
+If neither `openclaw` nor `hermes` is present, you are an **MCP-compatible host**. TotalReclaw integrates via the MCP server `@totalreclaw/mcp-server`:
+
+→ follow **[`claude-code-setup.md`](./claude-code-setup.md)** (covers Claude Code, Claude Desktop, Cursor, Windsurf, and IronClaw).
+
+### If detection is ambiguous
+
+If you cannot tell which runtime you are (no shell tool, or more than one runtime present), ask the user **one** question — nothing more:
+
+> Which agent are you running — OpenClaw, Hermes, or something else (Claude Desktop / Cursor / Windsurf)?
+
+Then follow the matching guide above.
+
+---
+
+## Current channels
+
+The install commands in each guide are version-agnostic and never go stale. Stable always lands the newest final release; RC always lands the newest pre-release.
+
+| Runtime | Package | Stable | RC (newest pre-release) |
+|---|---|---|---|
+| **OpenClaw** | npm `@totalreclaw/totalreclaw` | `latest` dist-tag | `@rc` dist-tag |
+| **MCP host** | npm `@totalreclaw/mcp-server` | `latest` dist-tag | `@rc` dist-tag |
+| **Hermes** | PyPI `totalreclaw` | newest final | newest pre-release |
+
+To see exactly what each channel currently resolves to (illustrative example, as of 2026-07-15):
+
+```bash
+npm view @totalreclaw/totalreclaw dist-tags   # e.g. latest: 3.3.13, rc: 3.3.13-rc.1
+npm view @totalreclaw/mcp-server dist-tags
+pip index versions totalreclaw                # PyPI
+```
+
+These numbers are examples only — always read them live rather than trusting the figures above.
+
+---
+
+## Why a dispatcher?
+
+TotalReclaw's install prompt used to be host-specific by URL (one guide for OpenClaw, another for Hermes). Pasting the wrong one dead-ended: a Hermes agent reading the OpenClaw guide would try the `openclaw` CLI, fail, and receive advice that did not apply to its runtime. This page makes the prompt host-agnostic — one URL routes every agent to its own runtime's guide.

--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -4,6 +4,8 @@
 
 TotalReclaw gives your OpenClaw agent encrypted, persistent memory. The fastest path is a single chat message — your agent fetches this guide, you and your agent install the plugin together, and the agent walks you through setting up your TotalReclaw account.
 
+> **Wrong runtime?** This guide is for **OpenClaw** only. If you are a **Hermes** agent, follow [`hermes-setup.md`](./hermes-setup.md); if you are **Claude Desktop / Cursor / Windsurf / any MCP host**, follow [`claude-code-setup.md`](./claude-code-setup.md); if you are unsure which runtime you are, follow the universal dispatcher [`install.md`](./install.md) instead.
+
 ## Install prompts
 
 The user pastes one of these three prompts. The shape is fixed; the agent extracts intent from the shape, not from arbitrary phrasing. (Mirrors `hermes-setup.md`'s prompt section.)
@@ -173,7 +175,14 @@ Notes:
   ```
 
   The `rm -rf` targets only the plugin's npm package project dir. It does **not** touch `~/.totalreclaw/credentials.json` (your keys live there, in a different tree) — never read, list, or delete anything under `~/.totalreclaw*`. Then verify the version in Step 2 — it must match the requested build.
-- If either command fails with `command not found` / ENOENT / "not authorized" (managed-service or shell-restricted environment), STOP and tell the user verbatim: *"Your environment doesn't expose the OpenClaw CLI to me. Please install `totalreclaw` from your service's plugins / skills UI, then reply `done`."* Wait for `done` before continuing to Step 2.
+- If either command fails with `command not found` / ENOENT / "not authorized", **do not immediately jump to "managed service" — a missing `openclaw` CLI is the strongest signal that you may simply be the wrong runtime for this guide.** First run a capability probe to check whether you are actually a different runtime:
+  ```bash
+  command -v hermes && command -v pip      # Hermes agent (Python)
+  command -v claude                         # Claude Code / MCP host
+  ```
+  - If that reveals you are a **Hermes** agent or an **MCP host** (Claude Desktop / Cursor / Windsurf), STOP following this guide and consult the universal dispatcher [`install.md`](./install.md), which routes you to [`hermes-setup.md`](./hermes-setup.md) or [`claude-code-setup.md`](./claude-code-setup.md) instead.
+  - If the runtime is genuinely ambiguous, ask the user one question — *"Are you using OpenClaw, Hermes, or a different agent (Claude Desktop / Cursor)?"* — then follow [`install.md`](./install.md).
+  - Only if the probe confirms you really are inside an **OpenClaw** environment that simply doesn't expose host shell to the agent (managed / hosted service, shell-restricted) should you fall back to the plugins-UI path: tell the user verbatim *"Your environment doesn't expose the OpenClaw CLI to me. Please install `totalreclaw` from your service's plugins / skills UI, then reply `done`."* Wait for `done` before continuing to Step 2.
 
 ### Step 2 — Verify the plugin loaded — emit user-visible line 2 on success
 


### PR DESCRIPTION
## What

The agent-install paste line was host-specific by URL (one guide for OpenClaw, another for Hermes). Pasting the wrong one dead-ended: a **Hermes agent reading the OpenClaw guide** tried the `openclaw` CLI, failed, and got plugins-UI advice that didn't apply to its runtime. Neither guide cross-linked the other; the website showed only the Hermes line.

This adds a **universal, host-agnostic dispatcher** and cross-links every setup guide to it.

## Changes

- **`docs/guides/install.md` (new)** — the dispatcher. One universal paste line works for any agent:
  - `Install TotalReclaw. See …/docs/guides/install.md` (stable)
  - `Install TotalReclaw RC [<version>]. See …/docs/guides/install.md` (RC, optional version)
  - Agent-addressed runtime detection by **capability probe** (`openclaw --version` / `command -v hermes && pip` / `command -v claude`), not guessing → routes to `openclaw-setup.md` (OpenClaw), `hermes-setup.md` (Hermes), or `claude-code-setup.md` (Claude Desktop / Cursor / Windsurf / any MCP host via `@totalreclaw/mcp-server`). Ambiguous → one question to the user.
  - Evergreen channel table (npm `latest`/`@rc`, PyPI newest final/pre-release) + dated dist-tags example consistent with `openclaw-setup.md`.
- **`openclaw-setup.md` / `hermes-setup.md` / `claude-code-setup.md`** — `> Wrong runtime?` banner near the top cross-linking the sibling guides + `install.md`.
- **`openclaw-setup.md`** — the missing-`openclaw`-CLI failure branch (the *"Your environment doesn't expose the OpenClaw CLI to me…"* verbatim) now **first probes for a different runtime** (Hermes / MCP host) and consults `install.md` before falling back to the managed-service plugins-UI path.
- **`README.md`** — universal-prompt pointer in Quick Start + `install.md` in the docs list.

Doc-only. `skill/plugin/SKILL.md` untouched (bundled artifact, host-correct by construction). Follow-up website PR points the site's install line at this dispatcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude GLM (cc-glm) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013EDaj45174CK3TbdGytDDD