### PR TITLE
docs(changelog): catch-up — core 2.5.6, plugin 3.3.12/3.3.13, python 2.4.6, code-health arc

### DIFF
--- a/CHANGELOG-public.md
+++ b/CHANGELOG-public.md
@@ -2,9 +2,59 @@
 
 > **Note:** This file lists releases promoted to the public registries' stable tags. Active release-candidate work (`@rc` dist-tag on npm, `rcN` on PyPI, etc.) is tracked in the internal release-pipeline tracker, not here.
 
+## @totalreclaw/totalreclaw (OpenClaw plugin) 3.3.12 / 3.3.13 — Stable promote (2026-07-06 / 2026-07-15)
+
+The `rc.20 → rc.23` stabilization arc that restored a working fresh-user onboarding path, plus the publish-pipeline fix that finally landed the stable line on npm.
+
+### 3.3.12 — stabilization arc (2026-07-06)
+
+- **Onboarding CLI restored.** `openclaw totalreclaw <sub>` had thrown `ReferenceError: tr is not defined` on every RC since the native rewrite — fresh users had no onboarding path. The `registerCli` `tr`-scope is now wired correctly. (#452)
+- **Native install slot-selection + chain verbatim.** The plugin no longer writes `plugins.slots.memory` (OpenClaw's native install owns the slot; `openclaw plugins enable totalreclaw` is the idempotent bind), `chain_id` is consumed verbatim from billing, and the trajectory poller lifecycle is hardened. (#446)
+- **DataEdge → calldata.** The relay-reported DataEdge address is threaded into the WASM calldata encoders so managed writes hit the correct (staging vs production) contract — sibling of MCP #439 and the chain_id fix. (#462, #465; closes #460)
+
+### 3.3.13 — stable promote (2026-07-15)
+
+- **npm stable-promote unblocked.** 3.3.12 had reached ClawHub but the npm promote was blocked on Trusted Publisher registration; publishing is consolidated behind a single Trusted Publisher (#509) with the `sync-version` + npm@11 fixes (#497), so the stable line now publishes to npm.
+- **Digest-recompile coalescing.** Digest recompiles are skipped when the claim set is unchanged — a perf/quota fix on the hot write path. (#499; closes #455)
+- **Reinstall-robust install flow** documented (enable-slot bind + orphan-package cleanup; `--force` is never the fix). (#507)
+
+See `skill/plugin/CHANGELOG.md` for detail.
+
+## @totalreclaw/core / totalreclaw-core 2.5.6 — Stable release (2026-07-10)
+
+- **`./web` browser WASM subpath export.** Core now publishes a `--target web` WASM build under a `./web` subpath, so browser-bundle consumers (the vault SPA and other pure-browser integrations) import core's WASM without a Node polyfill. (#501; closes #500)
+- **Publishing hardened.** Publish CI is pinned to npm@11 (npm 12.0.0 breaks `--provenance` / tokenless-OIDC PUT) (#494), and a built-wheel surface check enforces pyfunction↔registration parity so the PyO3 binding surface can't silently drift. (#504; closes #503)
+- **Additive import-segmentation exports.** Also carries the additive WASM exports from the #368 import-segmentation hoist (`segmentSessions`, the flat per-turn `parseGemini` view) — non-breaking for existing importers. (#466)
+
+See `rust/totalreclaw-core/CHANGELOG.md` for detail.
+
 ## @totalreclaw/mcp-server 3.4.0 — Stable release (2026-07-09)
 
 MCP server minor. **Fix:** managed-service writes now consume the relay's billing `chain_id` + `data_edge_address` verbatim (#439) — previously every managed write fell through to a retired default chain + the production DataEdge, breaking staging testability and client-consistency; staging write→read E2E validated. **Restructure:** unified data-driven tool-dispatch table + shared `ToolContext`; `memory_id` is now the canonical id param (`fact_id` kept as alias). **Removed:** the long-deprecated, non-functional `totalreclaw_migrate` tool (minor, not major — no working call site lost it). See `mcp/CHANGELOG.md` for detail.
+
+## totalreclaw 2.4.6 — Stable promote (2026-07-08)
+
+Hermes client stable (Python `totalreclaw` 2.4.5 → 2.4.6): session-isolation + import-fidelity + provenance cycle.
+
+- **Per-conversation session isolation.** Parallel conversations / messenger topics each get their own buffer + turn counter + session id, so each mints its own Crystal instead of one mixed blob. (#441)
+- **Idle Crystal sweep.** A topic idle past `TOTALRECLAW_SESSION_IDLE_MINUTES` (default 60) crystallizes on another topic's turn — Crystals mint even when the host's session-reset watcher is disarmed. (#443)
+- **Write-side `session_id` stamp.** The active conversation's `session_id` is stamped into `metadata.session_id` on both atomic facts and the session-end Crystal, enabling the SPA to group memories by real conversation. (#463)
+- **Agent-instance provenance.** `agent_name` (env `TOTALRECLAW_AGENT_NAME`) rides the encrypted inner blob so recall/export render "John (Hermes)". (#473, #317)
+- **ChatGPT import line.** Conversations become import sessions (#430) with byte-capped batching + halve-on-sim-revert + 240s receipt wait (#461), hashed disclosure tokens + orphan reaping + accounting (#468), an import fix wave (deploy-state/receipt, re-import registry, provider label) (#454), and ledger hardening (#470, #480).
+- **Update-available notice.** The relay serves `features.latest_stable_python`; the client nudges once/24h when a newer stable exists (kill-switch `TOTALRECLAW_DISABLE_UPDATE_NOTICE=1`). (#442)
+
+Full client detail: `python/CHANGELOG.md` → `[2.4.6]`.
+
+## Code-health consolidation — desloppify arc (2026-07-07 / 2026-07-08)
+
+Repo-wide code-health sweep that landed alongside the 2.4.6 / mcp 3.4.0 / 3.3.12 releases — dead-code removal, restructure behind stable adapters, and test activation across every surface. No user-facing behavior change by design.
+
+- **rust / mcp / client / server** — dead-code removal and ~33 never-running tests activated across the shared crates and self-hosted surfaces; the mcp dispatch-table restructure is detailed in the mcp 3.4.0 entry above. (#475)
+- **skill/plugin** — `index.ts` carved into 15 domain modules (env reads centralized in `config.ts`/`entry.ts`; `tr-cli` moved to `cli/`). (#476)
+- **app (Keeper)** — type-safety hardening + decrypt-path tests for the vault SPA. (#477)
+- **python** — behavior fixes (ledger/accounting, consent-token handling) and the `imports/` package split (import tools separated from `tools.py`; old paths shim-aliased). (#478, #482)
+
+Net: dead code removed, surfaces restructured behind stable adapters, and the test suite grew by ~200 tests.
 
 ## totalreclaw 2.4.4 — Stable promote (2026-06-06)
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,22 @@ Hermes Agent plugin are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.6] — 2026-07-08
+
+Hermes client stable (2.4.5 → 2.4.6): session-isolation + import-fidelity + provenance cycle. (Note: 2.4.5 was likewise promoted without a dated header in this file; items that shipped between 2.4.4 and this entry accumulated under `[Unreleased]` below.)
+
+### Added
+
+- **[#441] Per-conversation session isolation.** Parallel conversations / messenger topics each get their own buffer + turn counter + session id (keyed by the per-conversation `session_id` Hermes passes to `sync_turn` / per-turn hooks), so each mints its own Crystal instead of one mixed blob. Backward-compatible (empty slot store ⇒ legacy single-session).
+- **[#443] Idle Crystal sweep.** A topic idle past `TOTALRECLAW_SESSION_IDLE_MINUTES` (default 60) crystallizes on another topic's turn (`AgentState.find_idle_slots` / `sweep_idle_slots`), so Crystals mint even when Hermes `session_reset: none` disarms the host's finalize watcher.
+- **[#463] Write-side `session_id` stamp.** The active conversation's `session_id` is stamped into `metadata.session_id` on both atomic facts and the session-end Crystal (encrypted-blob only). Enables the SPA to group memories by real conversation; degrades to time-gap grouping where absent.
+- **[#473] Agent-instance provenance (`agent_name`, #317).** `agent_name` (env `TOTALRECLAW_AGENT_NAME` or explicit `remember(agent_name=…)`) rides the encrypted inner blob as a top-level key so recall/export render "John (Hermes)". Additive metadata; no on-chain/subgraph schema change.
+- **[#442] Update-available notice + versioned client header.** The relay serves `features.latest_stable_python`; the client compares against installed `__version__` (rc-aware) and nudges once/24h via the quota-warning channel. Kill-switch `TOTALRECLAW_DISABLE_UPDATE_NOTICE=1`.
+
+### Changed
+
+- **ChatGPT import line.** Conversations become import sessions (#430) with byte-capped batching + halve-on-sim-revert + 240s receipt wait (#461), hashed disclosure tokens + orphan reaping + accounting (#468), an import fix wave — deploy-state/receipt, re-import registry, provider label (#454) — and ledger hardening (#470, #480).
+
 ## [Unreleased]
 
 ### Changed

--- a/rust/totalreclaw-core/CHANGELOG.md
+++ b/rust/totalreclaw-core/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to `@totalreclaw/core` / `totalreclaw-core` are documented h
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.6] - 2026-07-10
+
+Browser-bundle WASM + publishing hardening. (Note: the intervening `2.3.x`–`2.5.5` core releases were not individually logged in this file; this entry catches up the current stable surface.)
+
+### Added
+
+- **[#501] `./web` browser WASM subpath export (closes #500).** A `--target web` WASM build is published under a `./web` subpath so browser-bundle consumers (the vault SPA, other pure-browser integrations) can import core's WASM without a Node polyfill. Previously the published WASM targeted Node and required `Buffer`/`fs` shims in a browser bundle.
+- **[#466] Additive import-segmentation WASM exports (from the #368 hoist).** `segmentSessions` and the flat per-turn `parseGemini` view are exported from the bundler/web builds. Additive — no behavior change for existing importers.
+
+### Changed
+
+- **[#494] Publish CI pinned to npm@11.** npm 12.0.0 breaks `npm publish --provenance` (`Cannot find module 'sigstore'`) and the tokenless-OIDC PUT, so every core/npm publish step is pinned to npm@11.
+- **[#504] Built-wheel surface check for pyfunction↔registration parity (closes #503).** A CI check compares the PyO3 `#[pyfunction]` set against the `pymodule!` registration table on the built wheel, so a binding that's defined but never registered (or vice-versa) fails CI instead of silently disappearing from the PyPI surface.
+
 ## [2.2.0] - 2026-04-19
 
 ### Added

--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.13] — 2026-07-15
+
+Stable promote of `3.3.13-rc.1`. Bundles a write-path perf fix and lands the consolidated npm publishing path that finally moved the stable line onto npm (3.3.12 had reached ClawHub but the npm promote was blocked on Trusted Publisher registration).
+
+### Fixed
+
+- **[#499] Digest-recompile coalescing — skip on unchanged claim set.** Digests were recompiled once per on-chain UserOp store batch, burning quota on writes whose underlying claim set hadn't changed. Recompiles are now coalesced/skipped when the claim set is unchanged — a perf/quota fix on the hot write path. Closes #455.
+
+### Changed
+
+- **npm stable-promote unblocked.** Plugin npm publishing is consolidated onto `npm-publish.yml` behind a single registered Trusted Publisher (#509), with the `sync-version` tr-cli path + npm@11 fixes (#497). The stable promote now publishes to npm; 3.3.12 had reached ClawHub only.
+- **Reinstall-robust install flow** documented — the install always runs `openclaw plugins enable totalreclaw` (idempotent slot-bind) and recovers a reinstall over leftover config via uninstall + orphan-package cleanup (`rm -rf ~/.openclaw/npm/projects/*totalreclaw-totalreclaw*`); `--force` is explicitly never the fix. (#507)
+
+## [3.3.12] — 2026-07-06
+
+Stable promote concluding the `rc.1 → rc.23` arc. The headline is restoring a working fresh-user onboarding path (`openclaw totalreclaw <sub>` had thrown `ReferenceError: tr is not defined` on every published RC since the native rewrite) plus managed-write correctness fixes that are siblings of MCP #439.
+
+### Fixed
+
+- **[#452] Onboarding CLI restored.** `registerCli` import/upgrade wiring referenced an undeclared `tr`, dead-ing the entire `openclaw totalreclaw <sub>` CLI since the native rewrite. The `tr`-scope is wired correctly; fresh users have an onboarding path again.
+- **[#446] Native install slot-selection + chain verbatim + poller lifecycle.** The plugin no longer writes `plugins.slots.memory` — OpenClaw's native install owns the memory slot (with `openclaw plugins enable totalreclaw` as the idempotent bind), so a reinstall over leftover config can't silently leave the plugin `Status: disabled`. `chain_id` is consumed verbatim from the relay billing response, and the trajectory poller lifecycle is hardened.
+- **[#462], [#465] DataEdge → calldata.** The relay-reported `data_edge_address` is threaded from `/v1/billing/status` into the WASM calldata encoders, so managed writes hit the correct (staging vs production) contract instead of falling through to the production default. Sibling of MCP #439 and the chain_id fix. Closes #460.
+
 ## [3.3.12-rc.5] — 2026-05-09
 
 Final RC for the 3.3.12 stable promote. Behavioral fix: Pedro's Pop-OS Telegram QA (zai/glm-5-turbo) on rc.4 found the agent storing user statements in `MEMORY.md` / `USER.md` via `write` tool calls instead of calling `totalreclaw_remember`. 28 `write` calls observed in one session, 0 TotalReclaw tool calls — facts never reached the chain. Root cause: SKILL.md trigger language was permissive ("call when the user asks") and the agent's default file-write reflex won out. rc.5 makes the memory-storage rule the TOP RULE of SKILL.md with an explicit prohibition on `write`/`edit` against `MEMORY.md`/`USER.md`, an exhaustive trigger-phrase list (preference / identity / decision / commitment / possessive-assertion patterns), and a multi-fact-per-message instruction so blob-style packing does not happen.


### PR DESCRIPTION
Closes the CHANGELOG gap for several stable releases shipped since 2026-07-06 that had no public entry. Stable-only, reverse-chronological, every claim traced to a merged PR (spot-checked via `gh pr view`).

## Added

**CHANGELOG-public.md** (4 new sections):
- **plugin 3.3.12 / 3.3.13** — `rc.20→rc.23` stabilization: onboarding CLI restored (#452), native slot-selection + chain verbatim (#446), DataEdge→calldata (#462/#465, closes #460); 3.3.13 = npm stable-promote unblock (#509/#497) + digest-recompile coalesce (#499, closes #455) + reinstall-robust install flow (#507).
- **core 2.5.6** — `./web` browser WASM subpath export (#501, closes #500), npm@11 publish pin (#494), built-wheel pyfunction↔registration surface check (#504, closes #503), additive `segmentSessions`/`parseGemini` WASM exports (#466).
- **python 2.4.6** — per-conversation session isolation (#441), idle Crystal sweep (#443), write-side `session_id` stamp (#463), `agent_name` provenance (#473/#317), ChatGPT import line (#430/#461/#468/#454/#470/#480), update-notify (#442).
- **Code-health consolidation (desloppify arc)** — cross-cutting themed section (#475–#478, #482). Used the `2.4.4` "cross-cutting infra" precedent (ec5a3ed) for a non-release engineering section; mcp dispatch-table detail deliberately kept in the existing 3.4.0 entry to avoid double-logging.

**Per-package** (matching the public+per-package pattern from e609dd0 / ec5a3ed):
- `skill/plugin/CHANGELOG.md` → `[3.3.13]`, `[3.3.12]`
- `rust/totalreclaw-core/CHANGELOG.md` → `[2.5.6]`
- `python/CHANGELOG.md` → `[2.4.6]`

## Found already present (not duplicated)
- **mcp 3.4.0** — entry existed (e609dd0); referenced from the code-health section but not re-written.

## Omitted (by design)
- **python 2.4.7rc1** — the file's top note declares it stable-only; RCs live in the internal release-pipeline tracker. Skipped.
- Plugin 3.3.13 "pairing fixes" — no public pairing PR lands in the 3.3.13 window (internal #484 is SPA Keeper work, not plugin). Omitted rather than guessed.

## Notes
- Avoided citing `#402`: the plugin stabilization PRs reference the *internal* onboarding issue #402, but public #402 is an unrelated qa-autopilot regression. Cited the PRs (#446/#452) without the issue ref.
- `python/CHANGELOG.md` had 2.4.5 + 2.4.6 changes lumped under `[Unreleased]`; this PR adds a `[2.4.6]` header above `[Unreleased]` without reorganizing it (left for the python maintainer).
- `rust/totalreclaw-core/CHANGELOG.md` topped out at `[2.2.0]`; `[2.5.6]` notes that intervening 2.3.x–2.5.5 releases weren't individually logged.

Do not merge on auto-green — want a quick eyeball on the per-release attributions first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)