### PR TITLE
feat(app): Keeper A.2 Phase 3 — retype/set_scope supersession (completes #484)

### DIFF
--- a/app/e2e/retype-setscope-onchain.mjs
+++ b/app/e2e/retype-setscope-onchain.mjs
@@ -1,0 +1,514 @@
+/**
+ * E2E (A.2 Phase 3): STAGING retype/set_scope round-trip — 2-call executeBatch
+ * supersession on Gnosis mainnet via the staging relay.
+ *
+ * Exercises the exact SPA write wire (same engine as pin-onchain.mjs, with
+ * `type` / `scope` mutated instead of `pin_status`): decrypt old blob →
+ * rebuild the claim (full carry-forward + metadata verbatim, core-validated,
+ * pin_status carried forward per #117) → re-encrypt → [tombstone(old,v4),
+ * newClaim(v4)] in ONE UserOp via encodeBatchCallTo → relay /v1/bundler →
+ * subgraph. Embedding + blind indices copied forward and asserted byte-equal.
+ *
+ * Flow: write Crystal-shaped fact → retype claim→preference → set_scope
+ * →health → set_scope →"unspecified" (field OMITTED) → pin → retype while
+ * pinned (#117 pin-survival) → idempotent retype (no UserOp) → cleanup.
+ *
+ * WebAuthn can't run headless, so this harness signs with the throwaway
+ * account's EOA key DIRECTLY (phrase-safe) — the in-browser path signs the
+ * identical hash via `withMasterKey`, unit-tested in src/lib/auth/master.test.ts.
+ *
+ * PHRASE-SAFETY (L3): a THROWAWAY mnemonic only, cached to the gitignored
+ * `.e2e-secret` and reused across runs (staging /v1/register has an IP-global
+ * ~19-min 429 window — NEVER re-register). The mnemonic + private key are
+ * NEVER printed or logged. Only public data is emitted.
+ *
+ * Run: cd app && node e2e/retype-setscope-onchain.mjs
+ */
+import { generateMnemonic } from "@scure/bip39";
+import { wordlist } from "@scure/bip39/wordlists/english.js";
+import { readFileSync, writeFileSync, existsSync, chmodSync } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const require = createRequire(import.meta.url);
+const core = require("@totalreclaw/core");
+
+const RELAY = process.env.RELAY_URL || "https://api-staging.totalreclaw.xyz";
+const CHAIN_ID = 100; // Gnosis mainnet (single-chain)
+const STAGING_DATA_EDGE = "0xE7a4D2677B686e13775Ba9092631089e35F0BB91";
+const PROD_DATA_EDGE = "0xC445af1D4EB9fce4e1E61fE96ea7B8feBF03c5ca";
+const SECRET_FILE = join(dirname(fileURLToPath(import.meta.url)), "..", ".e2e-secret");
+
+const DUMMY_SIG =
+  "0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c";
+
+const out = (m) => console.log(`[e2e] ${m}`);
+let failed = false;
+const check = (name, cond) => {
+  out(`${cond ? "PASS" : "FAIL"} — ${name}`);
+  if (!cond) failed = true;
+};
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function loadOrCreateMnemonic() {
+  if (existsSync(SECRET_FILE)) {
+    out("reusing cached throwaway account (.e2e-secret) — NOT re-registering");
+    return { mnemonic: readFileSync(SECRET_FILE, "utf8").trim(), fresh: false };
+  }
+  const mnemonic = generateMnemonic(wordlist, 128);
+  writeFileSync(SECRET_FILE, mnemonic + "\n", { mode: 0o600 });
+  chmodSync(SECRET_FILE, 0o600);
+  out("generated a fresh throwaway account → cached to gitignored .e2e-secret");
+  return { mnemonic, fresh: true };
+}
+
+async function relayFetch(path, opts = {}, authKeyHex, wallet) {
+  const headers = {
+    "Content-Type": "application/json",
+    "X-TotalReclaw-Client": "ts-spa-vault",
+    "X-TotalReclaw-Test": "true",
+    ...(authKeyHex ? { Authorization: `Bearer ${authKeyHex}` } : {}),
+    ...(wallet ? { "X-Wallet-Address": wallet } : {}),
+    ...(opts.headers || {}),
+  };
+  const res = await fetch(`${RELAY}${path}`, { ...opts, headers });
+  const text = await res.text();
+  return { ok: res.ok, status: res.status, text };
+}
+
+async function bundlerRpc(authKeyHex, wallet, method, params) {
+  const res = await fetch(`${RELAY}/v1/bundler`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-TotalReclaw-Client": "ts-spa-vault",
+      "X-TotalReclaw-Test": "true",
+      Authorization: `Bearer ${authKeyHex}`,
+      "X-Wallet-Address": wallet,
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+  });
+  const json = await res.json();
+  if (json.error) throw new Error(`bundler ${method}: ${JSON.stringify(json.error)}`);
+  return json.result;
+}
+
+async function subgraphQuery(authKeyHex, wallet, query, variables) {
+  const { text } = await relayFetch(
+    "/v1/subgraph",
+    { method: "POST", body: JSON.stringify({ query, variables }) },
+    authKeyHex,
+    wallet,
+  );
+  const json = JSON.parse(text);
+  if (json.errors?.length) throw new Error(`subgraph: ${json.errors.map((e) => e.message).join("; ")}`);
+  return json.data;
+}
+
+async function factById(authKeyHex, wallet, id) {
+  const data = await subgraphQuery(
+    authKeyHex,
+    wallet,
+    `query F($id: ID!) { fact(id: $id) { id isActive encryptedBlob encryptedEmbedding blindIndexEntries { hash } } }`,
+    { id },
+  );
+  return data.fact;
+}
+
+async function activeFacts(authKeyHex, wallet, ownerLower) {
+  const data = await subgraphQuery(
+    authKeyHex,
+    wallet,
+    `query A($owner: Bytes!) { facts(where: { owner: $owner, isActive: true }, first: 1000) { id } }`,
+    { owner: ownerLower },
+  );
+  return data.facts ?? [];
+}
+
+/** Poll until `fn` returns truthy (subgraph indexing) or ~2 min elapse. */
+async function waitFor(fn) {
+  for (let i = 0; i < 30; i++) {
+    await sleep(4000);
+    const v = await fn();
+    if (v) return v;
+  }
+  return null;
+}
+
+/** Build → sponsor → sign → submit → confirm one UserOp (execute or batch). */
+async function submitUserOp(calldataBytes, { authKeyHex, wallet, eoa, needsInitCode }) {
+  const entryPoint = core.getEntryPointAddress();
+  const callData = `0x${Buffer.from(calldataBytes).toString("hex")}`;
+
+  let factory = null;
+  let factoryData = null;
+  if (needsInitCode) {
+    const code = await bundlerRpc(authKeyHex, wallet, "eth_getCode", [wallet, "latest"]);
+    if (!code || code === "0x" || code === "0x0") {
+      factory = core.getSimpleAccountFactory();
+      const ownerPadded = eoa.address.slice(2).toLowerCase().padStart(64, "0");
+      factoryData = `0x5fbfb9cf${ownerPadded}${"0".repeat(64)}`;
+    }
+  }
+
+  const gas = await bundlerRpc(authKeyHex, wallet, "pimlico_getUserOperationGasPrice", []);
+  const fast = gas.fast;
+
+  const senderPadded = wallet.slice(2).toLowerCase().padStart(64, "0");
+  const nonce =
+    (await bundlerRpc(authKeyHex, wallet, "eth_call", [
+      { to: entryPoint, data: `0x35567e1a${senderPadded}${"0".repeat(64)}` },
+      "latest",
+    ])) || "0x0";
+
+  const op = {
+    sender: wallet,
+    nonce,
+    callData,
+    callGasLimit: "0x0",
+    verificationGasLimit: "0x0",
+    preVerificationGas: "0x0",
+    maxFeePerGas: fast.maxFeePerGas,
+    maxPriorityFeePerGas: fast.maxPriorityFeePerGas,
+    signature: DUMMY_SIG,
+  };
+  if (factory) {
+    op.factory = factory;
+    op.factoryData = factoryData;
+  }
+
+  // Batches: estimate gas BEFORE sponsorship (mirror src/lib/userop.ts step 6).
+  try {
+    const est = await bundlerRpc(authKeyHex, wallet, "eth_estimateUserOperationGas", [op, entryPoint]);
+    if (est.callGasLimit) op.callGasLimit = est.callGasLimit;
+    if (est.verificationGasLimit) op.verificationGasLimit = est.verificationGasLimit;
+    if (est.preVerificationGas) op.preVerificationGas = est.preVerificationGas;
+  } catch {
+    /* fall back to paymaster-provided limits */
+  }
+
+  const sponsor = await bundlerRpc(authKeyHex, wallet, "pm_sponsorUserOperation", [op, entryPoint]);
+  Object.assign(op, sponsor);
+
+  const hashHex = core.hashUserOp(JSON.stringify(op), entryPoint, BigInt(CHAIN_ID));
+  op.signature = `0x${core.signUserOp(hashHex, eoa.private_key)}`; // eoa.private_key never logged
+
+  const userOpHash = await bundlerRpc(authKeyHex, wallet, "eth_sendUserOperation", [op, entryPoint]);
+
+  let receipt = null;
+  for (let i = 0; i < 90; i++) {
+    await sleep(2000);
+    try {
+      receipt = await bundlerRpc(authKeyHex, wallet, "eth_getUserOperationReceipt", [userOpHash]);
+      if (receipt) break;
+    } catch {
+      /* not mined yet */
+    }
+  }
+  return { userOpHash, receipt };
+}
+
+// --- claim rebuild (mirrors src/lib/claim.ts:rebuildClaimJson, Phase 3) ---
+// pinStatus ABSENT → carried forward from the source verbatim (#117).
+function rebuildClaimJson(rawClaimJson, { newId, supersededBy, pinStatus, newType, newScope }) {
+  const source = JSON.parse(rawClaimJson);
+  const input = { ...source };
+  input.id = newId;
+  input.superseded_by = supersededBy;
+  if (pinStatus !== undefined) input.pin_status = pinStatus;
+  if (newType !== undefined) input.type = newType;
+  if (newScope !== undefined) input.scope = newScope;
+  input.schema_version = "1.0";
+  if (typeof input.created_at !== "string" || input.created_at === "")
+    input.created_at = new Date().toISOString();
+  if (input.scope === "unspecified") delete input.scope;
+  if (input.volatility === "updatable") delete input.volatility;
+  if (Array.isArray(input.entities) && input.entities.length === 0) delete input.entities;
+  if (!input.reasoning) delete input.reasoning;
+  if (!input.expires_at) delete input.expires_at;
+  const parsed = JSON.parse(core.validateMemoryClaimV1(JSON.stringify(input)));
+  parsed.schema_version = "1.0";
+  if (input.metadata !== undefined && input.metadata !== null) parsed.metadata = input.metadata;
+  for (const [k, v] of Object.entries(input)) if (!(k in parsed) && v !== undefined) parsed[k] = v;
+  return JSON.stringify(parsed);
+}
+
+const decryptHexBlob = (hex, keyHex) => {
+  const h = hex.startsWith("0x") ? hex.slice(2) : hex;
+  return core.decrypt(Buffer.from(h, "hex").toString("base64"), keyHex);
+};
+
+/**
+ * SPA-shaped curation supersession: idempotency guard (retype-to-same-type /
+ * set-same-scope / pin-when-pinned → NO UserOp, mirroring api.ts) + the
+ * 2-call batch. `mutation` = { pinStatus? | newType? | newScope? }.
+ */
+async function supersede(oldFactId, mutation, sourceTag, ctx) {
+  const { authKeyHex, wallet, keys, dataEdge } = ctx;
+  const oldFact = await factById(authKeyHex, wallet, oldFactId);
+  if (!oldFact) throw new Error(`fact ${oldFactId} not found`);
+  const plaintext = decryptHexBlob(oldFact.encryptedBlob, keys.encryption_key);
+  const current = JSON.parse(plaintext);
+
+  // Idempotency guards — mirror api.ts (setPinStatus / retypeFact / setFactScope).
+  if (mutation.pinStatus !== undefined) {
+    const cur = current.pin_status === "pinned" ? "pinned" : "unpinned";
+    if (cur === mutation.pinStatus) return { idempotent: true };
+  }
+  if (mutation.newType !== undefined && current.type === mutation.newType)
+    return { idempotent: true };
+  if (mutation.newScope !== undefined && (current.scope ?? "unspecified") === mutation.newScope)
+    return { idempotent: true };
+
+  const newId = randomUUID();
+  const canonicalJson = rebuildClaimJson(plaintext, {
+    newId,
+    supersededBy: oldFactId,
+    ...mutation,
+  });
+  const blobHex = Buffer.from(core.encrypt(canonicalJson, keys.encryption_key), "base64").toString("hex");
+
+  const tombstone = core.encodeTombstoneProtobuf(oldFactId, wallet, 4);
+  const newFactPayload = core.encodeFactProtobuf(
+    JSON.stringify({
+      id: newId,
+      timestamp: new Date().toISOString(),
+      owner: wallet,
+      encrypted_blob_hex: blobHex,
+      blind_indices: (oldFact.blindIndexEntries ?? []).map((e) => e.hash), // copied forward
+      decay_score: 1.0,
+      source: sourceTag,
+      content_fp: "",
+      agent_id: "ts-spa-vault",
+      encrypted_embedding: oldFact.encryptedEmbedding ?? null, // copied forward
+      version: 4,
+    }),
+  );
+  const calldata = core.encodeBatchCallTo(
+    JSON.stringify([Buffer.from(tombstone).toString("hex"), Buffer.from(newFactPayload).toString("hex")]),
+    dataEdge,
+  );
+  const res = await submitUserOp(calldata, { ...ctx, needsInitCode: false });
+  return { idempotent: false, newId, ...res };
+}
+
+/** Assert the standard supersession shape after a mutation UserOp. */
+async function assertSupersession(label, oldId, sup, ctx, { metadata, oldEmbedding }) {
+  const { authKeyHex, wallet, keys } = ctx;
+  check(`${label}: UserOp mined`, !sup.idempotent && !!sup.receipt);
+  const logs = sup.receipt?.logs ?? sup.receipt?.receipt?.logs ?? [];
+  check(`${label}: receipt log at STAGING DataEdge (0xE7a4…)`,
+    logs.some((l) => (l.address || "").toLowerCase() === STAGING_DATA_EDGE.toLowerCase()));
+  check(`${label}: receipt did NOT touch prod DataEdge (0xC445…)`,
+    !logs.some((l) => (l.address || "").toLowerCase() === PROD_DATA_EDGE.toLowerCase()));
+
+  const oldAfter = await waitFor(async () => {
+    const f = await factById(authKeyHex, wallet, oldId);
+    return f && f.isActive === false ? f : null;
+  });
+  check(`${label}: OLD fact flipped isActive:false`, !!oldAfter);
+
+  const newFact = await waitFor(() => factById(authKeyHex, wallet, sup.newId));
+  check(`${label}: superseding fact indexed + active`, !!newFact && newFact.isActive === true);
+  let claim = null;
+  if (newFact) {
+    claim = JSON.parse(decryptHexBlob(newFact.encryptedBlob, keys.encryption_key));
+    check(`${label}: superseded_by === old fact id`, claim.superseded_by === oldId);
+    check(`${label}: METADATA INTACT (Crystal fields verbatim)`,
+      JSON.stringify(claim.metadata) === JSON.stringify(metadata));
+    check(`${label}: encryptedEmbedding byte-equal (copied forward)`,
+      newFact.encryptedEmbedding === oldEmbedding);
+  }
+  return claim;
+}
+
+// --------------------------------------------------------------------------
+
+const evidence = {};
+try {
+  const { mnemonic, fresh } = loadOrCreateMnemonic();
+  const keys = core.deriveKeysFromMnemonic(mnemonic);
+  const eoa = core.deriveEoa(mnemonic); // private_key NEVER logged
+  const authKeyHex = keys.auth_key;
+  const authKeyHash = createHash("sha256").update(Buffer.from(authKeyHex, "hex")).digest("hex");
+
+  const saRes = await relayFetch(`/v1/smart-account?eoa=${eoa.address}&chain=${CHAIN_ID}`);
+  const wallet = JSON.parse(saRes.text).smart_account.toLowerCase();
+  out(`smart account: ${wallet}`);
+
+  const billingProbe = await relayFetch(`/v1/billing/status?wallet_address=${wallet}`, {}, authKeyHex, wallet);
+  if (billingProbe.status === 401 || fresh) {
+    out("registering throwaway account (once)");
+    const reg = await relayFetch("/v1/register", {
+      method: "POST",
+      body: JSON.stringify({ auth_key_hash: authKeyHash, salt: keys.salt }),
+    });
+    check("register accepted", reg.ok || reg.status === 409);
+    await sleep(1500);
+  } else {
+    out("account already registered — skipping /v1/register");
+  }
+
+  const billing = JSON.parse(
+    (await relayFetch(`/v1/billing/status?wallet_address=${wallet}`, {}, authKeyHex, wallet)).text,
+  );
+  const dataEdge = billing.data_edge_address;
+  out(`relay data_edge_address: ${dataEdge}  (chain_id ${billing.chain_id}, env ${billing.environment})`);
+  check("relay reports the STAGING DataEdge (0xE7a4…), not prod (0xC445…)",
+    dataEdge?.toLowerCase() === STAGING_DATA_EDGE.toLowerCase());
+
+  const ctx = { authKeyHex, wallet, eoa, keys, dataEdge };
+
+  // 1. WRITE a Crystal-shaped `claim` fact (metadata is the preservation
+  //    proof) with a marker embedding so copy-forward is byte-assertable.
+  const factId = randomUUID();
+  const sessionId = randomUUID();
+  const metadata = {
+    subtype: "session_crystal",
+    session_id: sessionId,
+    key_outcomes: ["a2 phase3 e2e outcome"],
+    open_threads: ["a2 phase3 e2e thread"],
+    topics_discussed: ["retype", "set_scope"],
+  };
+  const claim = {
+    id: factId,
+    text: `A2 retype/set_scope E2E marker ${factId}`,
+    type: "claim",
+    source: "user",
+    created_at: new Date().toISOString(),
+    schema_version: "1.0",
+    importance: 7,
+    metadata,
+  };
+  const markerEmbedding = `a2p3E2Eembedding${factId.replaceAll("-", "")}`;
+  const encB64 = core.encrypt(JSON.stringify(claim), keys.encryption_key);
+  const writeCalldata = core.encodeSingleCallTo(
+    core.encodeFactProtobuf(
+      JSON.stringify({
+        id: factId,
+        timestamp: claim.created_at,
+        owner: wallet,
+        encrypted_blob_hex: Buffer.from(encB64, "base64").toString("hex"),
+        blind_indices: core.generateBlindIndices(claim.text),
+        decay_score: 1.0,
+        source: "user",
+        content_fp: core.generateContentFingerprint(claim.text, keys.dedup_key),
+        agent_id: "a2-p3-e2e",
+        encrypted_embedding: markerEmbedding,
+        version: 4,
+      }),
+    ),
+    dataEdge,
+  );
+  out(`writing throwaway Crystal fact ${factId} …`);
+  const write = await submitUserOp(writeCalldata, { ...ctx, needsInitCode: true });
+  check("write UserOp mined", !!write.receipt);
+  out(`write userOpHash: ${write.userOpHash}`);
+
+  const indexedOld = await waitFor(async () => {
+    const f = await factById(authKeyHex, wallet, factId);
+    return f && f.isActive ? f : null;
+  });
+  check("fact indexed as isActive:true before retype", !!indexedOld);
+  const oldEmbedding = indexedOld?.encryptedEmbedding ?? null;
+  check("old fact carries the marker encryptedEmbedding", oldEmbedding === markerEmbedding);
+  const shape = { metadata, oldEmbedding };
+
+  // 2. RETYPE claim → preference.
+  out(`retyping ${factId} claim → preference …`);
+  const retype = await supersede(factId, { newType: "preference" }, "spa_retype", ctx);
+  out(`retype userOpHash: ${retype.userOpHash}  new fact: ${retype.newId}`);
+  const retypedClaim = await assertSupersession("retype", factId, retype, ctx, shape);
+  check("retype: new claim type === 'preference'", retypedClaim?.type === "preference");
+  check("retype: created_at preserved (original creation time)",
+    retypedClaim?.created_at === claim.created_at);
+  check("retype: pin_status not invented on an unpinned claim",
+    retypedClaim ? !("pin_status" in retypedClaim) : false);
+
+  // 3. SET_SCOPE → health.
+  out(`setting scope of ${retype.newId} → health …`);
+  const scopeHealth = await supersede(retype.newId, { newScope: "health" }, "spa_set_scope", ctx);
+  out(`set_scope userOpHash: ${scopeHealth.userOpHash}  new fact: ${scopeHealth.newId}`);
+  const healthClaim = await assertSupersession("set_scope(health)", retype.newId, scopeHealth, ctx, shape);
+  check("set_scope(health): scope === 'health'", healthClaim?.scope === "health");
+  check("set_scope(health): type still 'preference' (untouched)", healthClaim?.type === "preference");
+
+  // 4. SET_SCOPE → "unspecified" — the field must be OMITTED on the wire.
+  out(`setting scope of ${scopeHealth.newId} → unspecified …`);
+  const scopeNone = await supersede(scopeHealth.newId, { newScope: "unspecified" }, "spa_set_scope", ctx);
+  out(`set_scope userOpHash: ${scopeNone.userOpHash}  new fact: ${scopeNone.newId}`);
+  const noneClaim = await assertSupersession("set_scope(unspecified)", scopeHealth.newId, scopeNone, ctx, shape);
+  check("set_scope(unspecified): 'scope' field OMITTED from the decrypted claim",
+    noneClaim ? !("scope" in noneClaim) : false);
+
+  // 5. PIN, then RETYPE while pinned — the #117 pin-survival contract.
+  out(`pinning ${scopeNone.newId} …`);
+  const pin = await supersede(scopeNone.newId, { pinStatus: "pinned" }, "spa_pin", ctx);
+  out(`pin userOpHash: ${pin.userOpHash}  new fact: ${pin.newId}`);
+  const pinnedClaim = await assertSupersession("pin", scopeNone.newId, pin, ctx, shape);
+  check("pin: pin_status === 'pinned'", pinnedClaim?.pin_status === "pinned");
+
+  out(`retyping PINNED fact ${pin.newId} preference → commitment …`);
+  const retypePinned = await supersede(pin.newId, { newType: "commitment" }, "spa_retype", ctx);
+  out(`retype-pinned userOpHash: ${retypePinned.userOpHash}  new fact: ${retypePinned.newId}`);
+  const survivedClaim = await assertSupersession("retype-while-pinned", pin.newId, retypePinned, ctx, shape);
+  check("#117 PIN SURVIVED the retype (pin_status === 'pinned')",
+    survivedClaim?.pin_status === "pinned");
+  check("retype-while-pinned: type === 'commitment'", survivedClaim?.type === "commitment");
+
+  // 6. IDEMPOTENT retype: same type → NO UserOp, no new on-chain fact.
+  const activeBefore = (await activeFacts(authKeyHex, wallet, wallet)).length;
+  const again = await supersede(retypePinned.newId, { newType: "commitment" }, "spa_retype", ctx);
+  check("idempotent retype short-circuits (no UserOp)", again.idempotent === true);
+  const activeAfter = (await activeFacts(authKeyHex, wallet, wallet)).length;
+  check("idempotent retype produced NO new on-chain fact", activeAfter === activeBefore);
+
+  // Cleanup: tombstone the surviving test fact.
+  out("cleanup: tombstoning surviving test facts …");
+  const survivors = [retypePinned.newId].filter(Boolean);
+  if (survivors.length > 0) {
+    const payloads = survivors.map((id) =>
+      Buffer.from(core.encodeTombstoneProtobuf(id, wallet, 4)).toString("hex"),
+    );
+    const cleanupCalldata =
+      payloads.length === 1
+        ? core.encodeSingleCallTo(Buffer.from(payloads[0], "hex"), dataEdge)
+        : core.encodeBatchCallTo(JSON.stringify(payloads), dataEdge);
+    const cleanup = await submitUserOp(cleanupCalldata, { ...ctx, needsInitCode: false });
+    check("cleanup tombstone mined", !!cleanup.receipt);
+  }
+
+  Object.assign(evidence, {
+    smartAccount: wallet,
+    dataEdge,
+    chainId: billing.chain_id,
+    environment: billing.environment,
+    oldFactId: factId,
+    retypedFactId: retype.newId,
+    scopeHealthFactId: scopeHealth.newId,
+    scopeUnspecifiedFactId: scopeNone.newId,
+    pinnedFactId: pin.newId,
+    retypedWhilePinnedFactId: retypePinned.newId,
+    writeUserOpHash: write.userOpHash,
+    retypeUserOpHash: retype.userOpHash,
+    setScopeHealthUserOpHash: scopeHealth.userOpHash,
+    setScopeUnspecifiedUserOpHash: scopeNone.userOpHash,
+    pinUserOpHash: pin.userOpHash,
+    retypePinnedUserOpHash: retypePinned.userOpHash,
+    idempotentRetypeSkipped: again.idempotent === true,
+    pinSurvivedRetype: survivedClaim?.pin_status === "pinned",
+    scopeOmittedOnUnspecified: noneClaim ? !("scope" in noneClaim) : false,
+    metadataIntactThroughout:
+      JSON.stringify(survivedClaim?.metadata) === JSON.stringify(metadata),
+  });
+  out("--- REDACTED EVIDENCE (no secrets) ---");
+  out(JSON.stringify(evidence, null, 2));
+} catch (e) {
+  out(`EXCEPTION: ${e.message}`);
+  failed = true;
+}
+
+out(failed ? "RESULT: FAIL" : "RESULT: PASS");
+process.exit(failed ? 1 : 0);

--- a/app/src/components/ClaimCard.test.tsx
+++ b/app/src/components/ClaimCard.test.tsx
@@ -53,3 +53,31 @@ describe("ClaimCard agent provenance (#317)", () => {
     expect(html).toContain("from you");
   });
 });
+
+describe("ClaimCard curation affordances (A.2 Phase 3)", () => {
+  it("stays read-only (no action row) with no handlers", () => {
+    const html = renderToStaticMarkup(<ClaimCard item={item()} />);
+    expect(html).not.toContain("Retype");
+    expect(html).not.toContain("Scope");
+    expect(html).not.toContain("Forget");
+  });
+
+  it("shows Retype and Scope affordances when handlers are supplied", () => {
+    const html = renderToStaticMarkup(
+      <ClaimCard item={item()} onRetype={() => {}} onSetScope={() => {}} />,
+    );
+    expect(html).toContain("Retype");
+    expect(html).toContain("Scope");
+  });
+
+  it("shows pending copy while a retype / rescope is in flight", () => {
+    const retyping = renderToStaticMarkup(
+      <ClaimCard item={item()} onRetype={() => {}} retypePending />,
+    );
+    expect(retyping).toContain("Retyping…");
+    const rescoping = renderToStaticMarkup(
+      <ClaimCard item={item()} onSetScope={() => {}} scopePending />,
+    );
+    expect(rescoping).toContain("Rescoping…");
+  });
+});

--- a/app/src/components/ClaimCard.tsx
+++ b/app/src/components/ClaimCard.tsx
@@ -1,5 +1,6 @@
 import { useState, type CSSProperties } from "react";
-import type { VaultItem, MemoryTypeV1 } from "../lib/types";
+import { MEMORY_TYPES_V1, MEMORY_SCOPES } from "../lib/types";
+import type { VaultItem, MemoryTypeV1, MemoryScope } from "../lib/types";
 import { relativeDate } from "../lib/format";
 import { agentProvenanceLabel } from "../lib/provenance";
 
@@ -29,13 +30,67 @@ function sourceLabel(source: string): string {
   }
 }
 
+const ACTION_BUTTON =
+  "rounded-pill px-2.5 py-0.5 font-semibold text-ink-muted transition hover:bg-clay-tint hover:text-clay-deep focus:outline-none focus-visible:ring-2 focus-visible:ring-clay";
+
+/** Inline pill picker for retype / set-scope — the same quiet affordance
+ *  language as Pin/Forget. The current value is highlighted; choosing it just
+ *  closes the menu (the SPA shows current state, so same-value = no-op). */
+function InlinePicker<T extends string>({
+  label,
+  options,
+  current,
+  onPick,
+  onClose,
+  optionLabel,
+}: {
+  label: string;
+  options: readonly T[];
+  current: T;
+  onPick: (value: T) => void;
+  onClose: () => void;
+  optionLabel?: (value: T) => string;
+}) {
+  return (
+    <div className="flex flex-wrap items-center justify-end gap-1.5" role="group" aria-label={label}>
+      <span className="text-ink-muted">{label}</span>
+      {options.map((opt) => (
+        <button
+          key={opt}
+          type="button"
+          aria-pressed={opt === current}
+          onClick={() => {
+            onClose();
+            if (opt !== current) onPick(opt);
+          }}
+          className={`rounded-pill px-2.5 py-0.5 font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-clay ${
+            opt === current
+              ? "bg-clay-tint text-clay-deep ring-1 ring-clay/40"
+              : "text-ink-muted hover:bg-clay-tint hover:text-clay-deep"
+          }`}
+        >
+          {optionLabel ? optionLabel(opt) : opt}
+        </button>
+      ))}
+      <button
+        type="button"
+        onClick={onClose}
+        className="rounded-pill px-2.5 py-0.5 font-semibold text-ink-muted transition hover:text-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-clay"
+      >
+        Cancel
+      </button>
+    </div>
+  );
+}
+
 /** A single memory, set to read. (Ported from the Keeper prototype ClaimCard.)
  *
  *  A.2 curation: when `onForget` is supplied, a subtle "Forget" affordance
  *  appears with an inline confirm; when `onTogglePin` is supplied, a "Pin"/
  *  "Unpin" affordance sits beside it (no confirm — pinning is reversible).
- *  Retype/set_scope land in A.2 Phase 3. With neither handler, the card is
- *  byte-for-byte the read-only card it was. */
+ *  `onRetype` / `onSetScope` (Phase 3) add "Retype" and "Scope" affordances
+ *  that expand into small inline pickers over the v1 closed enums. With no
+ *  handlers, the card is byte-for-byte the read-only card it was. */
 export function ClaimCard({
   item,
   style,
@@ -43,6 +98,10 @@ export function ClaimCard({
   forgetPending = false,
   onTogglePin,
   pinPending = false,
+  onRetype,
+  retypePending = false,
+  onSetScope,
+  scopePending = false,
 }: {
   item: VaultItem;
   style?: CSSProperties;
@@ -54,6 +113,14 @@ export function ClaimCard({
   onTogglePin?: () => void;
   /** True while the pin/unpin supersession batch awaits its receipt. */
   pinPending?: boolean;
+  /** Opt-in retype: supersession with `type` mutated. Absent → no affordance. */
+  onRetype?: (newType: MemoryTypeV1) => void;
+  /** True while the retype supersession batch awaits its receipt. */
+  retypePending?: boolean;
+  /** Opt-in set-scope: supersession with `scope` mutated ("unspecified" clears). */
+  onSetScope?: (newScope: MemoryScope) => void;
+  /** True while the set-scope supersession batch awaits its receipt. */
+  scopePending?: boolean;
 }) {
   const { claim } = item;
   const type = (claim.type as MemoryTypeV1) ?? "claim";
@@ -62,6 +129,11 @@ export function ClaimCard({
   // so the source/scope/date line below renders unchanged for most memories.
   const provenance = agentProvenanceLabel(claim);
   const [confirming, setConfirming] = useState(false);
+  const [picker, setPicker] = useState<"type" | "scope" | null>(null);
+
+  const hasActions = Boolean(onForget || onTogglePin || onRetype || onSetScope);
+  const anyPending = forgetPending || pinPending || retypePending || scopePending;
+  const currentScope: MemoryScope = claim.scope ?? "unspecified";
 
   return (
     <article
@@ -101,59 +173,102 @@ export function ClaimCard({
           {claim.reasoning}
         </p>
       )}
-      {(onForget || onTogglePin) && (
-        <div className="mt-3 flex items-center justify-end gap-2 text-xs">
-          {onTogglePin &&
-            (pinPending ? (
-              <span className="text-ink-muted" aria-live="polite">
-                {item.pinned ? "Unpinning…" : "Pinning…"}
-              </span>
-            ) : (
-              !confirming &&
-              !forgetPending && (
-                <button
-                  type="button"
-                  onClick={onTogglePin}
-                  className="rounded-pill px-2.5 py-0.5 font-semibold text-ink-muted transition hover:bg-clay-tint hover:text-clay-deep focus:outline-none focus-visible:ring-2 focus-visible:ring-clay"
-                >
-                  {item.pinned ? "Unpin" : "Pin"}
-                </button>
-              )
-            ))}
-          {onForget && (forgetPending ? (
-            <span className="text-ink-muted" aria-live="polite">
-              Forgetting…
-            </span>
-          ) : confirming ? (
-            <>
-              <span className="text-ink-muted">Forget this memory?</span>
-              <button
-                type="button"
-                onClick={() => {
-                  setConfirming(false);
-                  onForget();
-                }}
-                className="rounded-pill bg-clay px-2.5 py-0.5 font-semibold text-warm-white transition hover:bg-clay-deep focus:outline-none focus-visible:ring-2 focus-visible:ring-clay"
-              >
-                Forget
-              </button>
-              <button
-                type="button"
-                onClick={() => setConfirming(false)}
-                className="rounded-pill px-2.5 py-0.5 font-semibold text-ink-muted transition hover:text-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-clay"
-              >
-                Cancel
-              </button>
-            </>
-          ) : (
-            <button
-              type="button"
-              onClick={() => setConfirming(true)}
-              className="rounded-pill px-2.5 py-0.5 font-semibold text-ink-muted transition hover:bg-clay-tint hover:text-clay-deep focus:outline-none focus-visible:ring-2 focus-visible:ring-clay"
-            >
-              Forget
-            </button>
-          ))}
+      {hasActions && (
+        <div className="mt-3 space-y-2 text-xs">
+          {picker === "type" && onRetype && !anyPending && (
+            <InlinePicker
+              label="Type:"
+              options={MEMORY_TYPES_V1}
+              current={type}
+              onPick={onRetype}
+              onClose={() => setPicker(null)}
+            />
+          )}
+          {picker === "scope" && onSetScope && !anyPending && (
+            <InlinePicker
+              label="Scope:"
+              options={MEMORY_SCOPES}
+              current={currentScope}
+              onPick={onSetScope}
+              onClose={() => setPicker(null)}
+              optionLabel={(s) => (s === "unspecified" ? "none" : s)}
+            />
+          )}
+          {picker === null && (
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              {onRetype &&
+                (retypePending ? (
+                  <span className="text-ink-muted" aria-live="polite">
+                    Retyping…
+                  </span>
+                ) : (
+                  !confirming &&
+                  !anyPending && (
+                    <button type="button" onClick={() => setPicker("type")} className={ACTION_BUTTON}>
+                      Retype
+                    </button>
+                  )
+                ))}
+              {onSetScope &&
+                (scopePending ? (
+                  <span className="text-ink-muted" aria-live="polite">
+                    Rescoping…
+                  </span>
+                ) : (
+                  !confirming &&
+                  !anyPending && (
+                    <button type="button" onClick={() => setPicker("scope")} className={ACTION_BUTTON}>
+                      Scope
+                    </button>
+                  )
+                ))}
+              {onTogglePin &&
+                (pinPending ? (
+                  <span className="text-ink-muted" aria-live="polite">
+                    {item.pinned ? "Unpinning…" : "Pinning…"}
+                  </span>
+                ) : (
+                  !confirming &&
+                  !anyPending && (
+                    <button type="button" onClick={onTogglePin} className={ACTION_BUTTON}>
+                      {item.pinned ? "Unpin" : "Pin"}
+                    </button>
+                  )
+                ))}
+              {onForget && (forgetPending ? (
+                <span className="text-ink-muted" aria-live="polite">
+                  Forgetting…
+                </span>
+              ) : confirming ? (
+                <>
+                  <span className="text-ink-muted">Forget this memory?</span>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setConfirming(false);
+                      onForget();
+                    }}
+                    className="rounded-pill bg-clay px-2.5 py-0.5 font-semibold text-warm-white transition hover:bg-clay-deep focus:outline-none focus-visible:ring-2 focus-visible:ring-clay"
+                  >
+                    Forget
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setConfirming(false)}
+                    className="rounded-pill px-2.5 py-0.5 font-semibold text-ink-muted transition hover:text-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-clay"
+                  >
+                    Cancel
+                  </button>
+                </>
+              ) : (
+                !anyPending && (
+                  <button type="button" onClick={() => setConfirming(true)} className={ACTION_BUTTON}>
+                    Forget
+                  </button>
+                )
+              ))}
+            </div>
+          )}
         </div>
       )}
     </article>

--- a/app/src/hooks/useVault.ts
+++ b/app/src/hooks/useVault.ts
@@ -1,12 +1,20 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { PinStatus, SessionKeys, VaultItem, MemoryClaimV1 } from "../lib/types";
+import {
+  MemoryScope,
+  MemoryTypeV1,
+  PinStatus,
+  SessionKeys,
+  VaultItem,
+} from "../lib/types";
 import {
   exportAllFacts,
   decryptFacts,
   deleteFact,
   batchDeleteFacts,
   setPinStatus,
-  updateClaim,
+  retypeFact,
+  setFactScope,
+  type CurationWriteResult,
 } from "../lib/api";
 import { useCrypto } from "../contexts/CryptoContext";
 import { bytesToHex } from "../lib/crypto";
@@ -119,58 +127,78 @@ export function usePinFact(keys: SessionKeys | null) {
       if (!keys) throw new Error("Vault is locked.");
       return setPinStatus(item, target, keys, sign);
     },
-    onSuccess: (result, { item, target }) => {
+    onSuccess: (result, { item }) => {
       if (result.idempotent) return;
-      qc.setQueryData<VaultData>(VAULT_QUERY_KEY, (prev) =>
-        prev
-          ? {
-              ...prev,
-              items: prev.items.map((it) =>
-                it.id === item.id
-                  ? {
-                      ...it,
-                      id: result.newFactId ?? it.id,
-                      claim: result.newClaim ?? it.claim,
-                      pinned: target === "pinned",
-                      rawBlob: result.newBlobHex ?? it.rawBlob,
-                    }
-                  : it,
-              ),
-            }
-          : prev,
-      );
+      reconcileSupersession(qc, item.id, result);
     },
   });
 }
 
-export function useUpdateClaim(keys: SessionKeys) {
+/** Shared cache reconcile for a supersession write: swap the item in place to
+ *  its superseding identity (new fact id, new claim, new rawBlob) so an
+ *  immediate follow-up edit rebuilds from the CURRENT on-chain blob without a
+ *  refetch. Idempotent no-ops never reach this. */
+function reconcileSupersession(
+  qc: ReturnType<typeof useQueryClient>,
+  oldId: string,
+  result: CurationWriteResult,
+) {
+  qc.setQueryData<VaultData>(VAULT_QUERY_KEY, (prev) =>
+    prev
+      ? {
+          ...prev,
+          items: prev.items.map((it) =>
+            it.id === oldId
+              ? {
+                  ...it,
+                  id: result.newFactId ?? it.id,
+                  claim: result.newClaim ?? it.claim,
+                  type: result.newClaim?.type ?? it.type,
+                  pinned: result.newClaim?.pin_status === "pinned",
+                  rawBlob: result.newBlobHex ?? it.rawBlob,
+                }
+              : it,
+          ),
+        }
+      : prev,
+  );
+}
+
+/**
+ * Retype a memory on-chain (A.2 Phase 3 — same 2-call supersession batch as
+ * pin). The card's type tag reflects the new type immediately via the in-place
+ * cache reconcile. Same-type retypes resolve idempotent without a write.
+ */
+export function useRetypeFact(keys: SessionKeys | null) {
   const qc = useQueryClient();
+  const sign = useUserOpSigner();
   return useMutation({
-    mutationFn: ({
-      item,
-      updatedClaim,
-    }: {
-      item: VaultItem;
-      updatedClaim: MemoryClaimV1;
-    }) => updateClaim(item, updatedClaim, keys),
-    onSuccess: (_data, { item, updatedClaim }) => {
-      qc.setQueryData<VaultData>(VAULT_QUERY_KEY, (prev) =>
-        prev
-          ? {
-              ...prev,
-              items: prev.items.map((it) =>
-                it.id === item.id
-                  ? {
-                      ...it,
-                      claim: updatedClaim,
-                      type: updatedClaim.type ?? it.type,
-                      pinned: updatedClaim.pin_status === "pinned",
-                    }
-                  : it,
-              ),
-            }
-          : prev,
-      );
+    mutationFn: ({ item, newType }: { item: VaultItem; newType: MemoryTypeV1 }) => {
+      if (!keys) throw new Error("Vault is locked.");
+      return retypeFact(item, newType, keys, sign);
+    },
+    onSuccess: (result, { item }) => {
+      if (result.idempotent) return;
+      reconcileSupersession(qc, item.id, result);
+    },
+  });
+}
+
+/**
+ * Re-scope a memory on-chain (A.2 Phase 3). "unspecified" clears the scope
+ * (the field is omitted on the wire). Same-scope sets resolve idempotent.
+ */
+export function useSetFactScope(keys: SessionKeys | null) {
+  const qc = useQueryClient();
+  const sign = useUserOpSigner();
+  return useMutation({
+    mutationFn: ({ item, newScope }: { item: VaultItem; newScope: MemoryScope }) => {
+      if (!keys) throw new Error("Vault is locked.");
+      return setFactScope(item, newScope, keys, sign);
+    },
+    onSuccess: (result, { item }) => {
+      if (result.idempotent) return;
+      reconcileSupersession(qc, item.id, result);
     },
   });
 }

--- a/app/src/lib/api.test.ts
+++ b/app/src/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { decryptFacts, setPinStatus } from "./api";
+import { decryptFacts, setPinStatus, retypeFact, setFactScope } from "./api";
 import { buildTimeline } from "./vault/timeline";
 import { encryptBlob } from "./crypto";
 import { RawFact, SessionKeys } from "./types";
@@ -305,6 +305,87 @@ describe("setPinStatus idempotency (no UserOp on a no-op)", () => {
 
   it("unpin when pin_status is ABSENT is a no-op (absence == unpinned)", async () => {
     const res = await setPinStatus(vaultItem(undefined), "unpinned", KEYS, mustNotSign);
+    expect(res).toEqual({ idempotent: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A.2 Phase 3 — retype/set_scope enum validation (BEFORE any network call) +
+// idempotency. Deliberate divergence from the plugin's retype-setscope.ts:
+// the plugin never short-circuits (agents may confirm auto-labels); the SPA
+// shows current state, so same-value = no-op with NO UserOp.
+// ---------------------------------------------------------------------------
+
+const mustNotSign = () => {
+  throw new Error("sign() called on a validation failure or idempotent no-op");
+};
+
+function curationItem(extra: Record<string, unknown> = {}) {
+  const claim = {
+    id: "f-cur",
+    text: "Chose Gnosis over Base",
+    type: "claim" as const,
+    source: "user" as const,
+    created_at: "2026-07-01T00:00:00.000Z",
+    schema_version: "1.0" as const,
+    ...extra,
+  };
+  return {
+    id: "f-cur",
+    claim,
+    type: claim.type as string,
+    pinned: (claim as Record<string, unknown>).pin_status === "pinned",
+    createdAt: new Date(claim.created_at),
+    rawBlob: "",
+    blindIndices: [],
+    decayScore: 1,
+    isActive: true,
+  } as unknown as import("./types").VaultItem;
+}
+
+describe("retypeFact validation + idempotency (no network, no UserOp)", () => {
+  it("rejects a made-up type, naming the v1 enum, before any network call", async () => {
+    await expect(
+      retypeFact(curationItem(), "vibe", KEYS, mustNotSign),
+    ).rejects.toThrow(/claim, preference, directive, commitment, episode, summary/);
+  });
+
+  it.each([
+    ["fact", /claim/],
+    ["context", /claim/],
+    ["decision", /reasoning/],
+    ["episodic", /episode/],
+    ["goal", /commitment/],
+    ["rule", /directive/],
+  ])("rejects legacy v0 token '%s' naming its v1 equivalent", async (v0, v1Hint) => {
+    await expect(
+      retypeFact(curationItem(), v0, KEYS, mustNotSign),
+    ).rejects.toThrow(v1Hint);
+    await expect(
+      retypeFact(curationItem(), v0, KEYS, mustNotSign),
+    ).rejects.toThrow(/legacy v0 type/);
+  });
+
+  it("retype to the SAME type resolves idempotent with no write", async () => {
+    const res = await retypeFact(curationItem(), "claim", KEYS, mustNotSign);
+    expect(res).toEqual({ idempotent: true });
+  });
+});
+
+describe("setFactScope validation + idempotency (no network, no UserOp)", () => {
+  it("rejects an out-of-enum scope before any network call", async () => {
+    await expect(
+      setFactScope(curationItem(), "outer-space", KEYS, mustNotSign),
+    ).rejects.toThrow(/work, personal, health, family, creative, finance, misc, unspecified/);
+  });
+
+  it("setting the scope the item already has is a no-op", async () => {
+    const res = await setFactScope(curationItem({ scope: "health" }), "health", KEYS, mustNotSign);
+    expect(res).toEqual({ idempotent: true });
+  });
+
+  it('setting "unspecified" when scope is ABSENT is a no-op (absence == unspecified)', async () => {
+    const res = await setFactScope(curationItem(), "unspecified", KEYS, mustNotSign);
     expect(res).toEqual({ idempotent: true });
   });
 });

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -272,16 +272,14 @@ export function decryptFacts(
 // ---------------------------------------------------------------------------
 // Write path — Keeper A.2 curation writes.
 //
-// Phase 1 (delete/tombstone) + Phase 2 (pin/unpin via 2-call supersession) are
-// implemented. The @totalreclaw/core WASM + UserOp assembler + claim rebuilder
-// are lazy-loaded on the FIRST write only (dynamic import) so the 2.3 MB WASM
-// never lands in the read chunk (see wasm.ts / userop.ts / claim.ts).
-//
-// Phase 3 (retype/set_scope — same supersession engine) remains a stub.
+// Phase 1 (delete/tombstone), Phase 2 (pin/unpin), and Phase 3 (retype/
+// set_scope) are implemented — the A.2 curation-writes scope is complete.
+// Pin/retype/set_scope all ride the SAME 2-call supersession engine
+// (supersedeClaim below). The @totalreclaw/core WASM + UserOp assembler +
+// claim rebuilder are lazy-loaded on the FIRST write only (dynamic import) so
+// the 2.3 MB WASM never lands in the read chunk (see wasm.ts / userop.ts /
+// claim.ts).
 // ---------------------------------------------------------------------------
-
-const WRITES_NOT_IMPLEMENTED =
-  "This edit isn’t available in the web app yet. Use a TotalReclaw agent (Claude Desktop, OpenClaw, etc.) to modify your vault.";
 
 /**
  * Resolve the authoritative chain + DataEdge for the wallet from the relay's
@@ -374,8 +372,9 @@ async function fetchFactWireFields(
   };
 }
 
-/** Result of a pin/unpin write. `idempotent: true` → no UserOp was sent. */
-export interface PinWriteResult {
+/** Result of a curation write (pin/unpin/retype/set_scope). `idempotent:
+ *  true` → no UserOp was sent. */
+export interface CurationWriteResult {
   idempotent: boolean;
   /** The superseding fact's fresh UUID (absent on idempotent no-op). */
   newFactId?: string;
@@ -385,26 +384,32 @@ export interface PinWriteResult {
   newBlobHex?: string;
 }
 
+/** Back-compat alias (Phase 2 name). */
+export type PinWriteResult = CurationWriteResult;
+
+/** The single-field mutation a curation write applies (see claim.ts). */
+interface ClaimMutation {
+  pinStatus?: PinStatus;
+  newType?: MemoryTypeV1;
+  newScope?: MemoryScope;
+}
+
 /**
- * Pin or unpin a memory (A.2 Phase 2) — atomic 2-call `executeBatch`
- * supersession `[tombstone(old), newClaim(superseded_by=old, pin_status)]`,
- * mirroring `mcp/src/tools/pin.ts:executePinOperation`.
+ * Shared supersession engine (A.2 Phase 2+3) — atomic 2-call `executeBatch`
+ * `[tombstone(old), newClaim(superseded_by=old, one field mutated)]`,
+ * mirroring `mcp/src/tools/pin.ts:executePinOperation` and
+ * `skill/plugin/memory/retype-setscope.ts:rewriteWithMutation`.
  *
- * Idempotent (pin.ts:667): pinning an already-pinned memory (or unpinning an
- * unpinned one — absence of `pin_status` counts as unpinned) sends NO UserOp.
+ * `pin_status` is carried forward verbatim unless the mutation overrides it
+ * explicitly (#117: retype/set_scope must not silently un-pin).
  */
-export async function setPinStatus(
+async function supersedeClaim(
   item: VaultItem,
-  target: PinStatus,
+  mutation: ClaimMutation,
+  sourceTag: string,
   keys: SessionKeys,
   sign: SignUserOpHash,
-): Promise<PinWriteResult> {
-  const current: PinStatus =
-    item.claim.pin_status === "pinned" ? "pinned" : "unpinned";
-  if (current === target) {
-    return { idempotent: true };
-  }
-
+): Promise<CurationWriteResult> {
   const targetChain = await resolveWriteTarget(keys);
   const [{ loadCore }, { rebuildClaimJson }, { submitSupersession }] =
     await Promise.all([import("./wasm"), import("./claim"), import("./userop")]);
@@ -418,7 +423,7 @@ export async function setPinStatus(
   const canonicalJson = rebuildClaimJson(core, plaintext, {
     newId: newFactId,
     supersededBy: item.id,
-    pinStatus: target,
+    ...mutation,
   });
   const newBlobHex = encryptBlob(canonicalJson, keys.encryptionKey);
 
@@ -434,13 +439,13 @@ export async function setPinStatus(
       encryptedBlobHex: newBlobHex,
       blindIndices,
       encryptedEmbedding: wire.encryptedEmbedding,
-      source: target === "pinned" ? "spa_pin" : "spa_unpin",
+      source: sourceTag,
     },
     { keys, sign, ...targetChain },
   );
   if (!res.success) {
     throw new Error(
-      "The pin update was submitted but not confirmed on-chain. Try again.",
+      "The update was submitted but not confirmed on-chain. Try again.",
     );
   }
   return {
@@ -451,15 +456,109 @@ export async function setPinStatus(
   };
 }
 
-// Phase 3: retype/set_scope (same 2-call supersession engine — claim.ts /
-// submitSupersession are ready for it) — not yet wired.
-export async function updateClaim(
-  _item: VaultItem,
-  _updatedClaim: MemoryClaimV1,
-  _keys: SessionKeys,
-  _sign?: SignUserOpHash,
-): Promise<void> {
-  throw new Error(WRITES_NOT_IMPLEMENTED);
+/**
+ * Pin or unpin a memory (A.2 Phase 2).
+ *
+ * Idempotent (pin.ts:667): pinning an already-pinned memory (or unpinning an
+ * unpinned one — absence of `pin_status` counts as unpinned) sends NO UserOp.
+ */
+export async function setPinStatus(
+  item: VaultItem,
+  target: PinStatus,
+  keys: SessionKeys,
+  sign: SignUserOpHash,
+): Promise<CurationWriteResult> {
+  const current: PinStatus =
+    item.claim.pin_status === "pinned" ? "pinned" : "unpinned";
+  if (current === target) {
+    return { idempotent: true };
+  }
+  return supersedeClaim(
+    item,
+    { pinStatus: target },
+    target === "pinned" ? "spa_pin" : "spa_unpin",
+    keys,
+    sign,
+  );
+}
+
+/** Legacy v0 type tokens → the v1 replacement to name in the rejection. */
+const V0_TYPE_EQUIVALENTS: Record<string, string> = {
+  fact: "claim",
+  context: "claim",
+  decision: "claim (put the rationale in the reasoning field)",
+  episodic: "episode",
+  goal: "commitment",
+  rule: "directive",
+};
+
+/**
+ * Re-type a memory (A.2 Phase 3) — supersession with `type` mutated.
+ * `pin_status` is carried forward verbatim (#117: never silently un-pin).
+ *
+ * Validation happens BEFORE any network call: `newType` must be a member of
+ * the v1 closed enum; legacy v0 tokens are rejected with the v1 equivalent.
+ *
+ * Idempotency — deliberate divergence from the plugin: `retype-setscope.ts`
+ * never short-circuits (agent users may be CONFIRMING an auto-extracted
+ * label), but the SPA UI always shows the current type, so retyping to the
+ * same value is a pure no-op → NO UserOp.
+ */
+export async function retypeFact(
+  item: VaultItem,
+  newType: string,
+  keys: SessionKeys,
+  sign: SignUserOpHash,
+): Promise<CurationWriteResult> {
+  if (!MEMORY_TYPES_V1.includes(newType as MemoryTypeV1)) {
+    const v1Equivalent = V0_TYPE_EQUIVALENTS[newType];
+    throw new Error(
+      v1Equivalent
+        ? `"${newType}" is a legacy v0 type that can no longer be written. Use its v1 equivalent instead: ${v1Equivalent}.`
+        : `Invalid memory type "${newType}". Must be one of: ${MEMORY_TYPES_V1.join(", ")}.`,
+    );
+  }
+  if (item.claim.type === newType) {
+    return { idempotent: true };
+  }
+  return supersedeClaim(
+    item,
+    { newType: newType as MemoryTypeV1 },
+    "spa_retype",
+    keys,
+    sign,
+  );
+}
+
+/**
+ * Re-scope a memory (A.2 Phase 3) — supersession with `scope` mutated.
+ * `"unspecified"` is expressed by OMITTING the field in the rebuilt claim
+ * (canonical omission rule — claim.ts). `pin_status` is carried forward
+ * verbatim (#117). Setting the scope the card already shows is a no-op
+ * (same deliberate divergence from the plugin as retypeFact).
+ */
+export async function setFactScope(
+  item: VaultItem,
+  newScope: string,
+  keys: SessionKeys,
+  sign: SignUserOpHash,
+): Promise<CurationWriteResult> {
+  if (!MEMORY_SCOPES.includes(newScope as MemoryScope)) {
+    throw new Error(
+      `Invalid scope "${newScope}". Must be one of: ${MEMORY_SCOPES.join(", ")}.`,
+    );
+  }
+  const current: MemoryScope = item.claim.scope ?? "unspecified";
+  if (current === newScope) {
+    return { idempotent: true };
+  }
+  return supersedeClaim(
+    item,
+    { newScope: newScope as MemoryScope },
+    "spa_set_scope",
+    keys,
+    sign,
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/app/src/lib/claim.test.ts
+++ b/app/src/lib/claim.test.ts
@@ -158,6 +158,103 @@ describe("rebuildClaimJson — full carry-forward + overrides", () => {
 });
 
 // ---------------------------------------------------------------------------
+// A.2 Phase 3 — retype / set_scope mutations through the same rebuilder.
+// ---------------------------------------------------------------------------
+
+describe("rebuildClaimJson — Phase 3 retype/set_scope mutations", () => {
+  const BASE_OVERRIDES = {
+    newId: "22222222-3333-4444-8555-666666666666",
+    supersededBy: FULL_SOURCE_CLAIM.id,
+  };
+
+  it("retype mutates ONLY type; every other field (incl. metadata) survives", () => {
+    const out = JSON.parse(
+      rebuildClaimJson(core, JSON.stringify(FULL_SOURCE_CLAIM), {
+        ...BASE_OVERRIDES,
+        newType: "preference",
+      }),
+    ) as Record<string, unknown>;
+    expect(out.type).toBe("preference");
+    expect(out.id).toBe(BASE_OVERRIDES.newId);
+    expect(out.superseded_by).toBe(FULL_SOURCE_CLAIM.id);
+    expect(out.text).toBe(FULL_SOURCE_CLAIM.text);
+    expect(out.scope).toBe("work");
+    expect(out.created_at).toBe(FULL_SOURCE_CLAIM.created_at);
+    expect(out.metadata).toEqual(FULL_SOURCE_CLAIM.metadata);
+    expect(out.agent_name).toBe("John");
+    expect(out.custom_future_top_level).toEqual({ keep: true });
+  });
+
+  it("#117 pin-survival: retype of a PINNED claim carries pin_status forward", () => {
+    const pinnedSource = { ...FULL_SOURCE_CLAIM, pin_status: "pinned" };
+    const out = JSON.parse(
+      rebuildClaimJson(core, JSON.stringify(pinnedSource), {
+        ...BASE_OVERRIDES,
+        newType: "commitment",
+      }),
+    ) as Record<string, unknown>;
+    expect(out.type).toBe("commitment");
+    expect(out.pin_status).toBe("pinned");
+  });
+
+  it("#117 pin-survival: set_scope of a PINNED claim carries pin_status forward", () => {
+    const pinnedSource = { ...FULL_SOURCE_CLAIM, pin_status: "pinned" };
+    const out = JSON.parse(
+      rebuildClaimJson(core, JSON.stringify(pinnedSource), {
+        ...BASE_OVERRIDES,
+        newScope: "health",
+      }),
+    ) as Record<string, unknown>;
+    expect(out.scope).toBe("health");
+    expect(out.pin_status).toBe("pinned");
+  });
+
+  it("retype of an unpinned claim does not invent a pin_status", () => {
+    const out = JSON.parse(
+      rebuildClaimJson(core, JSON.stringify(FULL_SOURCE_CLAIM), {
+        ...BASE_OVERRIDES,
+        newType: "episode",
+      }),
+    ) as Record<string, unknown>;
+    expect("pin_status" in out).toBe(false);
+  });
+
+  it("set_scope mutates ONLY scope; type + metadata survive", () => {
+    const out = JSON.parse(
+      rebuildClaimJson(core, JSON.stringify(FULL_SOURCE_CLAIM), {
+        ...BASE_OVERRIDES,
+        newScope: "finance",
+      }),
+    ) as Record<string, unknown>;
+    expect(out.scope).toBe("finance");
+    expect(out.type).toBe(FULL_SOURCE_CLAIM.type);
+    expect(out.metadata).toEqual(FULL_SOURCE_CLAIM.metadata);
+  });
+
+  it('set_scope to "unspecified" OMITS the field on the wire (canonical rule)', () => {
+    const out = JSON.parse(
+      rebuildClaimJson(core, JSON.stringify(FULL_SOURCE_CLAIM), {
+        ...BASE_OVERRIDES,
+        newScope: "unspecified",
+      }),
+    ) as Record<string, unknown>;
+    expect("scope" in out).toBe(false);
+    // The rest of the claim is untouched.
+    expect(out.type).toBe(FULL_SOURCE_CLAIM.type);
+    expect(out.metadata).toEqual(FULL_SOURCE_CLAIM.metadata);
+  });
+
+  it("core validation rejects an invalid mutated type (backstop, not bypassed)", () => {
+    expect(() =>
+      rebuildClaimJson(core, JSON.stringify(FULL_SOURCE_CLAIM), {
+        ...BASE_OVERRIDES,
+        newType: "goal" as never, // legacy v0 token — invalid in v1
+      }),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Crystal round-trip — the metadata-preservation proof from the plan.
 // ---------------------------------------------------------------------------
 
@@ -239,6 +336,52 @@ describe("Crystal pin round-trip (decrypt → rebuild → re-encrypt → timelin
     expect(groups[0].key).toBe(`s:${sessionId}`);
     expect(groups[0].crystal).not.toBeNull();
     expect(groups[0].crystal!.pinned).toBe(true);
+    expect(groups[0].openThreads).toBe(1);
+  });
+
+  it("Phase 3: retyping a Crystal keeps the session bucket + crystal flag with the NEW type visible", () => {
+    const sessionId = "0197f111-bbbb-7111-8111-abcdefabcdef";
+    const crystalClaim = {
+      id: "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff",
+      text: "Session crystal: shipped A.2 Phase 3 retype/set_scope",
+      type: "summary",
+      source: "derived",
+      created_at: "2026-07-10T00:00:00.000Z",
+      schema_version: "1.0",
+      importance: 9,
+      pin_status: "pinned", // proves #117 end-to-end through the read path too
+      metadata: {
+        subtype: "session_crystal",
+        session_id: sessionId,
+        key_outcomes: ["retype shipped"],
+        open_threads: ["A.2 wrap-up"],
+        topics_discussed: ["curation"],
+      },
+    };
+
+    // Retype summary → episode via the same engine retypeFact drives.
+    const newId = "33333333-4444-4555-8666-777777777777";
+    const rebuilt = rebuildClaimJson(core, JSON.stringify(crystalClaim), {
+      newId,
+      supersededBy: crystalClaim.id,
+      newType: "episode",
+    });
+    const newBlobHex = encryptBlob(rebuilt, ENC_KEY);
+    const [retypedItem] = decryptFacts([rawFact(newId, newBlobHex)], KEYS);
+
+    // The NEW type is visible, the pin survived, metadata rode verbatim.
+    expect(retypedItem.type).toBe("episode");
+    expect(retypedItem.claim.type).toBe("episode");
+    expect(retypedItem.pinned).toBe(true);
+    expect(retypedItem.claim.metadata).toEqual(crystalClaim.metadata);
+
+    // buildTimeline still buckets it under s:<session_id> with .crystal set
+    // (Crystal identity = metadata.subtype, not the type field).
+    const groups = buildTimeline([retypedItem]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe(`s:${sessionId}`);
+    expect(groups[0].crystal).not.toBeNull();
+    expect(groups[0].crystal!.claim.type).toBe("episode");
     expect(groups[0].openThreads).toBe(1);
   });
 });

--- a/app/src/lib/claim.ts
+++ b/app/src/lib/claim.ts
@@ -1,9 +1,11 @@
 /**
- * Claim rebuilder for 2-call supersession writes (A.2 Phase 2 — pin/unpin).
+ * Claim rebuilder for 2-call supersession writes (A.2 Phase 2 pin/unpin +
+ * Phase 3 retype/set_scope).
  *
  * Mirrors `mcp/src/claims-helper.ts:buildV1ClaimBlob` byte-compatibly: the new
- * claim is the old decrypted claim with ONLY `id` / `pin_status` /
- * `superseded_by` overridden, canonical omission rules applied (omit `scope`
+ * claim is the old decrypted claim with ONLY `id` / `superseded_by` and the
+ * requested mutation (`pin_status`, `type`, or `scope`) overridden, canonical
+ * omission rules applied (omit `scope`
  * when `unspecified`, `volatility` when `updatable`), validated through core
  * `validateMemoryClaimV1`, then `schema_version` + `metadata` re-attached after
  * validation (core's serde drops default schema_version and round-trips
@@ -20,7 +22,7 @@
  * core WASM instance is injected (see `wasm.ts:loadCore`) so node-side tests
  * can pass an `initSync`-loaded core.
  */
-import type { PinStatus } from "./types";
+import type { MemoryScope, MemoryTypeV1, PinStatus } from "./types";
 
 /** The single core export this module needs (injected for testability). */
 export interface ClaimValidator {
@@ -32,8 +34,18 @@ export interface SupersessionOverrides {
   newId: string;
   /** The old fact id being tombstoned — becomes `superseded_by`. */
   supersededBy: string;
-  /** 'pinned' (pin) or 'unpinned' (unpin) — always emitted explicitly. */
-  pinStatus: PinStatus;
+  /**
+   * 'pinned' (pin) or 'unpinned' (unpin). When ABSENT the source claim's
+   * `pin_status` is carried forward verbatim — the #117 contract: a retype or
+   * set_scope of a pinned memory must NOT silently un-pin it.
+   */
+  pinStatus?: PinStatus;
+  /** Phase 3 retype: replace `type`. Callers validate ∈ MEMORY_TYPES_V1 before
+   *  any network call; core `validateMemoryClaimV1` is the backstop here. */
+  newType?: MemoryTypeV1;
+  /** Phase 3 set_scope: replace `scope`. `"unspecified"` is expressed by
+   *  OMITTING the field on the wire (canonical omission rule below). */
+  newScope?: MemoryScope;
 }
 
 /**
@@ -44,7 +56,7 @@ export interface SupersessionOverrides {
  * what we re-encrypt). Returns canonical JSON ready for `encryptBlob`.
  *
  * Throws when the source is not a v1-shaped claim (pre-v1 vault entries are
- * not pin-supported from the web app — same as they aren't readable here).
+ * not curation-supported from the web app — same as they aren't readable here).
  */
 export function rebuildClaimJson(
   core: ClaimValidator,
@@ -68,17 +80,21 @@ export function rebuildClaimJson(
   ) {
     throw new Error(
       "This memory was written in a pre-v1 format the web app can't rewrite. " +
-        "Use a TotalReclaw agent to pin it.",
+        "Use a TotalReclaw agent to edit it.",
     );
   }
 
-  // Full carry-forward: spread the decrypted source, override only the three
-  // supersession fields. `created_at` is preserved (the memory's original
-  // creation time — keeps timeline ordering stable through a pin).
+  // Full carry-forward: spread the decrypted source, override only the
+  // supersession fields + the requested mutation. `created_at` is preserved
+  // (the memory's original creation time — keeps timeline ordering stable
+  // through a curation edit). `pin_status` rides the spread when no explicit
+  // pinStatus override is given (#117 pin-survival contract).
   const input: Record<string, unknown> = { ...source };
   input.id = overrides.newId;
   input.superseded_by = overrides.supersededBy;
-  input.pin_status = overrides.pinStatus;
+  if (overrides.pinStatus !== undefined) input.pin_status = overrides.pinStatus;
+  if (overrides.newType !== undefined) input.type = overrides.newType;
+  if (overrides.newScope !== undefined) input.scope = overrides.newScope;
   input.schema_version = "1.0";
   if (typeof input.created_at !== "string" || input.created_at === "") {
     input.created_at = new Date().toISOString();

--- a/app/src/pages/MemoryPage.tsx
+++ b/app/src/pages/MemoryPage.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense, useCallback, useMemo, useState, type ReactNode } from "react";
 import { clsx } from "clsx";
 import { useCrypto } from "../contexts/CryptoContext";
-import { useVault, useDeleteFact, usePinFact } from "../hooks/useVault";
+import { useVault, useDeleteFact, usePinFact, useRetypeFact, useSetFactScope } from "../hooks/useVault";
 import { buildTimeline, importSourceOf, type SessionGroup } from "../lib/vault/timeline";
 import { buildMindGraph, SCOPES, type Scope } from "../lib/vault/mindmap";
 import { AppHeader } from "../components/AppHeader";
@@ -48,9 +48,12 @@ export function MemoryPage() {
 
   const [mode, setMode] = useState<Mode>("list");
   const [panel, setPanel] = useState<PanelView | null>(null);
-  // A.2 curation: on-chain tombstone + pin/unpin. Wired into the Facts lens.
+  // A.2 curation: on-chain tombstone + pin/unpin + retype/set_scope. Wired
+  // into the Facts lens.
   const del = useDeleteFact(keys);
   const pin = usePinFact(keys);
+  const retype = useRetypeFact(keys);
+  const rescope = useSetFactScope(keys);
 
   const [q, setQ] = useState("");
   const [scope, setScope] = useState<MemoryScope | null>(null);
@@ -252,6 +255,16 @@ export function MemoryPage() {
                 Couldn’t update that pin: {pin.error instanceof Error ? pin.error.message : String(pin.error)}
               </p>
             )}
+            {retype.isError && (
+              <p className="mt-4 rounded-control bg-clay-tint px-3 py-2 text-sm text-clay-deep">
+                Couldn’t retype that memory: {retype.error instanceof Error ? retype.error.message : String(retype.error)}
+              </p>
+            )}
+            {rescope.isError && (
+              <p className="mt-4 rounded-control bg-clay-tint px-3 py-2 text-sm text-clay-deep">
+                Couldn’t change that scope: {rescope.error instanceof Error ? rescope.error.message : String(rescope.error)}
+              </p>
+            )}
             {shownItems.length > 0 ? (
               <div className="mt-6 space-y-3">
                 {shownItems.map((it, i) => (
@@ -265,6 +278,10 @@ export function MemoryPage() {
                       pin.mutate({ item: it, target: it.pinned ? "unpinned" : "pinned" })
                     }
                     pinPending={pin.isPending && pin.variables?.item.id === it.id}
+                    onRetype={(newType) => retype.mutate({ item: it, newType })}
+                    retypePending={retype.isPending && retype.variables?.item.id === it.id}
+                    onSetScope={(newScope) => rescope.mutate({ item: it, newScope })}
+                    scopePending={rescope.isPending && rescope.variables?.item.id === it.id}
                   />
                 ))}
               </div>


### PR DESCRIPTION
Final A.2 curation-writes slice: **retype** and **set_scope** from the Keeper vault SPA, riding the exact 2-call supersession engine shipped for pin/unpin in #514. Closes out the write scope of #484.

## What shipped

- **`retypeFact(item, newType)` / `setFactScope(item, newScope)`** (`app/src/lib/api.ts`) — supersession `[tombstone(old,v4), newClaim(v4, superseded_by=old)]` with `type` / `scope` mutated. The Phase-2 pin path was extracted into a shared `supersedeClaim()`; pin/retype/set_scope are now three thin wrappers over one engine. Embedding + blind indices copied forward byte-identically (text never changes).
- **Enum validation BEFORE any network call** — `newType` ∈ `MEMORY_TYPES_V1`, `newScope` ∈ `MEMORY_SCOPES`. Legacy v0 tokens are rejected with the v1 equivalent named (fact/context→claim, decision→claim + `reasoning`, episodic→episode, goal→commitment, rule→directive).
- **`"unspecified"` scope = field OMITTED** in the rebuilt claim (canonical omission rule in `claim.ts`, now exercised by the mutation path and E2E-proven on the wire).
- **#117 pin-survival contract** — `SupersessionOverrides.pinStatus` is now optional; when absent the source claim's `pin_status` rides the full-field spread verbatim, so retype/set_scope of a pinned memory stays pinned. Unit-tested on both ops + proven on-chain (below).
- **Metadata verbatim** — same rebuilder as #514; Crystal-retype round-trip test proves `buildTimeline` still buckets `s:<session_id>` with `.crystal` set and the NEW type visible.
- **UI** — `Retype` / `Scope` affordances on `ClaimCard` (Facts lens), same quiet pattern as pin/forget: inline pill pickers over the closed enums, current value highlighted, optimistic in-place reconcile (new fact id + claim + rawBlob) via the shared `reconcileSupersession` helper. The type tag updates immediately. One write in flight per card.
- Dead Phase-3 stubs removed (`updateClaim`, `useUpdateClaim`) — the A.2 write surface (delete / pin / unpin / retype / set_scope) is now **complete**.

## Deliberate idempotency divergence from the plugin

`skill/plugin/memory/retype-setscope.ts` **never** short-circuits a same-value retype — agent users may be *confirming* an auto-extracted label. The SPA UI always displays the current type/scope, so retyping to the shown value carries no signal: here **same-value = no-op, NO UserOp** (mirrors the pin idempotency guard). Documented in code at both call sites.

## Gates

- `npx tsc --noEmit` → clean.
- `npx vitest run` → **154/154** (16 files) — +22 new: retype/set_scope mutations through the real WASM validator, #117 pin-survival (both ops), `"unspecified"` omission rule, Crystal-retype round-trip, pre-network enum validation (incl. all six v0 tokens), idempotent no-ops (`sign()` must never run), ClaimCard affordances. Zero regressions.
- **Staging E2E** (`app/e2e/retype-setscope-onchain.mjs`, follows `pin-onchain.mjs` conventions): **52/52 PASS**, all receipts at the STAGING DataEdge `0xE7a4…` only (prod `0xC445…` asserted untouched on every op).

### Redacted E2E evidence (staging, Gnosis chain 100, throwaway account)

```
smartAccount 0x13bd276b777738274a1010754d35c8b4232d8646 · env staging · dataEdge 0xE7a4…
write            0x5202ccf855f514b2a767bf33a3819a5767267c60fcce59d46e5bedc72ac5be71
retype           0xfdbda5d00176b7155538ca09ad508f195a78e66d3d5785f37da5dc3f104d554b  (claim→preference)
set_scope        0xe83281b03b24d4f9c459376cf04dd32b49ed320a7cf9644d4447206191036f88  (→health)
set_scope        0x0052e8e3691e97d36a7b0b06922c65dbdd5944e9fc26344a9f42d352a0b353f9  (→unspecified, field OMITTED ✓)
pin              0x4180957ec316f06df0699c74df9bd7540df41d06c950b46a1c180a74b875719a
retype-pinned    0xae70b3a656091525db0055931c5c3c78510a25b3eb567d391ec6a0cffdd2bca0  (→commitment, PIN SURVIVED ✓ — #117)
idempotent retype → NO UserOp, active-fact count unchanged ✓
per step: old isActive:false ✓ · superseded_by ✓ · metadata (Crystal) verbatim ✓ · encryptedEmbedding byte-equal ✓
cleanup tombstones mined ✓
```

## Bundle

Write path stays lazy — WASM (`2,163.52 kB`) + `claim` + `userop` remain separate async chunks, never in `index-*.js`. Eager chunk delta (base `b857c45` → this PR): `index-*.js` **367.40 → 370.69 kB raw (123.61 → 124.46 kB gzip), +3.29 kB / +0.85 kB gzip** — pure picker UI + hooks. `claim-*.js` async chunk 1.16 → 1.27 kB.

## Closing note

This completes the **A.2 curation-writes scope**: delete (#498), pin/unpin (#514), retype/set_scope (this PR) — all browser-signed via `withMasterKey` (mnemonic-never-at-rest), all through the relay `/v1/bundler`, all byte-compatible with the plugin/MCP claim semantics. Completes #484.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
