### PR TITLE
docs(install): document the short install URL alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Other AI memory tools ([Mem0](https://mem0.ai), [Zep](https://getzep.com)) store
 
 One command per client. v1 is the default — no env toggles, no feature flags.
 
-> Prefer the chat-driven install? One host-agnostic paste line works for any agent (OpenClaw, Hermes, Claude Desktop / Cursor / Windsurf) — see [`install.md`](docs/guides/install.md).
+> Prefer the chat-driven install? Paste one host-agnostic line into any agent (OpenClaw, Hermes, Claude Desktop / Cursor / Windsurf): `Install TotalReclaw. See https://totalreclaw.xyz/install` — a short alias for the universal dispatcher ([`install.md`](docs/guides/install.md)).
 
 | Client | Install |
 |---|---|

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -14,6 +14,8 @@ This is the **only** line a user ever needs to paste — the same string works n
 Install TotalReclaw. See https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/install.md
 ```
 
+> Short form (same destination): `Install TotalReclaw. See https://totalreclaw.xyz/install` — `totalreclaw.xyz/install` redirects here. Either form works; agents that can't follow redirects should use the GitHub URL above. The GitHub URL is canonical and stays primary in these docs (they must not depend on the website being up).
+
 ### RC (user may specify a version)
 
 ```


### PR DESCRIPTION
## What

`https://totalreclaw.xyz/install` now 302-redirects to `docs/guides/install.md` (website `_redirects`, merged in website [#6](https://github.com/p-diogo/totalreclaw-website/pull/6)). Document the short form as an equivalent alias while keeping the GitHub URL canonical inside the repo.

## Changes
- **`docs/guides/install.md`** — add a short-form note directly under the universal paste-line: `Install TotalReclaw. See https://totalreclaw.xyz/install`. The GitHub URL stays **canonical / primary** so the docs work even when the website is down. Notes that either form works and that redirect-averse agents should use the GitHub URL.
- **`README.md`** — Quick Start now surfaces the paste-line using the short URL as an alias for the dispatcher, with `install.md` still linked as the canonical target.

## Not touched (by design)
- Per-guide paste-lines in `openclaw-setup.md` / `hermes-setup.md` / `claude-code-setup.md` (they reference their own guides).
- `skill/plugin/SKILL.md`.

Doc-only; no code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude GLM (cc-glm) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013EDaj45174CK3TbdGytDDD