### PR TITLE
fix(#471): filter vault-surfacing/pin meta-instructions from extraction

### DIFF
--- a/python/src/totalreclaw/agent/extraction.py
+++ b/python/src/totalreclaw/agent/extraction.py
@@ -884,6 +884,75 @@ def _filter_product_meta_facts(facts: List[ExtractedFact]) -> List[ExtractedFact
     return kept
 
 
+#: Instructions ABOUT the vault's own surfacing / pin behaviour. These are
+#: meta-directives to the memory system ("surface it every time", "pin this",
+#: "keep it at the top"), not durable user facts. Extraction occasionally
+#: mis-classifies such an imperative as a `[preference]` and stores an
+#: orphaned fragment ("it surfaced every time") — Finding #6, issue #471.
+#:
+#: DELIBERATELY narrow. The v1 taxonomy has a legitimate ``directive`` type
+#: (e.g. "always call me by my first name"), so this must NOT catch general
+#: imperatives — only self-referential recall/surfacing/pin behaviour. The
+#: anchor verbs ``surface`` and ``pin`` are the memory-behaviour vocabulary;
+#: generic verbs ("show", "remind") are excluded to keep false positives near
+#: zero ("I show up on time every day" is a genuine self-description).
+_MEMORY_SURFACING_META_PATTERNS = (
+    # "(I want it) surfaced every time" / "surface it each time" / "always surface"
+    r"\bsurfac(?:e|ed|es|ing)\b.*\b(?:every\s+time|each\s+time|always|whenever|again)\b",
+    r"\b(?:every\s+time|each\s+time|always|whenever)\b.*\bsurfac(?:e|ed|es|ing)\b",
+    # pin / keep-at-top surfacing directives about a memory item
+    r"\bpin(?:ned|ning)?\s+(?:it|this|that|these|those)\b",
+    r"\bkeep\b.*\b(?:surfac|pinned|at\s+the\s+top|top\s+of|always\s+visible)\b",
+    # explicit "surface it every time" imperative to the memory system
+    r"\bsurface\s+(?:it|this|that|them)\s+(?:every\s+time|each\s+time|always)\b",
+)
+
+
+def is_memory_surfacing_instruction(text: str) -> bool:
+    """Return True if ``text`` is a meta-instruction about the vault's own
+    surfacing / pin behaviour rather than a durable user fact.
+
+    Finding #6 (issue #471): a pin request ("I want it surfaced every time")
+    was mis-extracted and stored as an orphaned ``[preference]`` fragment
+    ("it surfaced every time"). Such utterances instruct the *memory system*
+    how to present items; they are not preferences/claims worth storing.
+
+    High precision by design — anchored on the memory-behaviour verbs
+    ``surface`` / ``pin`` so genuine directives and self-descriptions
+    ("always call me by my first name", "I show up on time every day")
+    flow through untouched. Companion to :func:`is_product_meta_request`.
+    """
+    if not isinstance(text, str) or not text:
+        return False
+    lower = text.lower().strip()
+    for pat in _MEMORY_SURFACING_META_PATTERNS:
+        if re.search(pat, lower, flags=re.IGNORECASE):
+            return True
+    return False
+
+
+def _filter_instruction_fragment_facts(
+    facts: List[ExtractedFact],
+) -> List[ExtractedFact]:
+    """Drop facts that read as vault-surfacing / pin meta-instructions.
+
+    Finding #6 (issue #471). Runs as a final pass alongside the Bug #9
+    product-meta filter. Dropped facts are logged at INFO so operators can
+    confirm the filter is not over-aggressive.
+    """
+    kept: List[ExtractedFact] = []
+    for f in facts:
+        if is_memory_surfacing_instruction(f.text):
+            logger.info(
+                "_filter_instruction_fragment_facts: dropping surfacing-instruction "
+                "fact: %r",
+                f.text[:80],
+            )
+            continue
+        kept.append(f)
+    return kept
+
+
 # ---------------------------------------------------------------------------
 # Main extraction entry points
 # ---------------------------------------------------------------------------
@@ -1057,6 +1126,10 @@ async def extract_facts_llm(
     # Bug #9: drop product-meta / setup requests before they hit the vault.
     facts = _filter_product_meta_facts(facts)
 
+    # Finding #6 (#471): drop vault-surfacing / pin meta-instructions that get
+    # mis-extracted as orphaned preference fragments.
+    facts = _filter_instruction_fragment_facts(facts)
+
     # Bug #8: collapse near-identical facts within the batch, and against
     # existing vault entries with embeddings. Runs last so importance
     # bumps are already applied (the surviving fact wins with its final
@@ -1177,6 +1250,9 @@ async def extract_facts_compaction(
 
     # Bug #9: filter product-meta requests.
     facts = _filter_product_meta_facts(facts)
+
+    # Finding #6 (#471): filter vault-surfacing / pin meta-instructions.
+    facts = _filter_instruction_fragment_facts(facts)
 
     # Bug #8: in-batch + cross-existing cosine dedup.
     facts = deduplicate_facts_by_embedding(

--- a/python/tests/test_issue_471_surfacing_instruction_filter.py
+++ b/python/tests/test_issue_471_surfacing_instruction_filter.py
@@ -1,0 +1,115 @@
+"""Regression tests for issue #471 (QA Finding #6).
+
+Extraction occasionally captured a user *instruction phrase* about the vault's
+own surfacing behaviour as a durable fact. The QA repro: the pin request
+"I want it surfaced every time" was mis-extracted and stored as an orphaned
+``[preference]`` fragment ("it surfaced every time").
+
+Fix: a high-precision post-filter (``is_memory_surfacing_instruction`` /
+``_filter_instruction_fragment_facts``) drops vault-surfacing / pin
+meta-instructions before storage, mirroring the Bug #9 product-meta filter.
+
+These assertions FAIL on the pre-patch tree (no filter → fragment survives)
+and PASS on the post-patch tree.
+"""
+from __future__ import annotations
+
+from totalreclaw.agent.extraction import (
+    ExtractedFact,
+    is_memory_surfacing_instruction,
+    _filter_instruction_fragment_facts,
+)
+
+
+class TestIssue471SurfacingInstructionDetection:
+    """The detector flags surfacing/pin meta-instructions."""
+
+    def test_flags_the_qa_reported_fragment(self):
+        # The exact orphaned fragment that reached the vault.
+        assert is_memory_surfacing_instruction("it surfaced every time") is True
+
+    def test_flags_the_full_pin_request(self):
+        assert is_memory_surfacing_instruction(
+            "I want it surfaced every time"
+        ) is True
+
+    def test_flags_surfacing_variants(self):
+        assert is_memory_surfacing_instruction("surface this every time") is True
+        assert is_memory_surfacing_instruction("always surface that") is True
+        assert is_memory_surfacing_instruction(
+            "surface it each time I ask"
+        ) is True
+
+    def test_flags_pin_directives(self):
+        assert is_memory_surfacing_instruction("pin this") is True
+        assert is_memory_surfacing_instruction("pin it to the top") is True
+        assert is_memory_surfacing_instruction(
+            "keep it at the top of my memories"
+        ) is True
+
+    def test_empty_and_non_string_are_safe(self):
+        assert is_memory_surfacing_instruction("") is False
+        assert is_memory_surfacing_instruction(None) is False  # type: ignore[arg-type]
+
+
+class TestIssue471GenuineFactsPassThrough:
+    """The filter must NOT catch legitimate facts, preferences, or the v1
+    ``directive`` type (rules/commands the user genuinely wants stored)."""
+
+    def test_allows_genuine_directive(self):
+        # v1 `directive` type — a real stored rule, not a surfacing instruction.
+        assert is_memory_surfacing_instruction(
+            "Always call me by my first name"
+        ) is False
+
+    def test_allows_self_descriptions_with_frequency_words(self):
+        assert is_memory_surfacing_instruction(
+            "I show up on time every day"
+        ) is False
+        assert is_memory_surfacing_instruction(
+            "I check my email every morning"
+        ) is False
+        assert is_memory_surfacing_instruction(
+            "I always arrive early to meetings"
+        ) is False
+
+    def test_allows_ordinary_preferences(self):
+        assert is_memory_surfacing_instruction("I prefer dark mode") is False
+        assert is_memory_surfacing_instruction(
+            "My favorite editor is Vim"
+        ) is False
+        assert is_memory_surfacing_instruction(
+            "I like my coffee black"
+        ) is False
+
+
+class TestIssue471FilterList:
+    """``_filter_instruction_fragment_facts`` drops the fragment fact and keeps
+    the genuine ones in a mixed batch."""
+
+    def test_drops_only_the_surfacing_fragment(self):
+        surfacing = ExtractedFact(
+            text="it surfaced every time",
+            type="preference", importance=6, action="ADD",
+        )
+        genuine_pref = ExtractedFact(
+            text="User prefers dark mode",
+            type="preference", importance=7, action="ADD",
+        )
+        genuine_directive = ExtractedFact(
+            text="Always call the user by their first name",
+            type="directive", importance=8, action="ADD",
+        )
+
+        kept = _filter_instruction_fragment_facts(
+            [surfacing, genuine_pref, genuine_directive]
+        )
+
+        texts = [f.text for f in kept]
+        assert "it surfaced every time" not in texts
+        assert "User prefers dark mode" in texts
+        assert "Always call the user by their first name" in texts
+        assert len(kept) == 2
+
+    def test_empty_batch_is_safe(self):
+        assert _filter_instruction_fragment_facts([]) == []


### PR DESCRIPTION
## What broke
Hermes stored an orphaned fact `[pref] "it surfaced every time"` — a fragment of the user's pin request "I want it surfaced every time" — as if it were a preference.

## What's fixed
Extraction now drops self-referential *memory-surfacing / pin* meta-instructions (a new high-precision post-filter next to the Bug #9 product-meta filter), so these instruction fragments never reach the vault.

## Impact after fix
Vault stops accumulating instruction-fragment noise. Genuine facts, preferences, and legitimate v1 `directive` rules ("always call me by my first name") are untouched — the filter is anchored on the memory-behaviour verbs `surface`/`pin`.

## Verification
`test_issue_471_*` (10 cases: fragment dropped, genuine facts/directives/self-descriptions preserved) + full extraction suite green (157 passed). Deterministic post-filter — unit-verified, same as Bug #9 (a live re-capture of this probabilistic LLM behaviour is unreliable + blocked on VPS: no Pro vault, one-shot chat defers auto-extract).

---
Narrow fix — scope: 1 source file + 1 test. QA source: `docs/notes/QA-hermes-RC-2.4.6rc7-PRESTABLE-20260708.md` (internal), umbrella #466 Finding #6. Rides the next coordinated 2.4.7 RC (no standalone RC — 2.4.6 is stable-promoted).

Closes #471