### PR TITLE
docs(guides): truth sweep — pair tool, 18-tool count, current versions, single-chain, Harrier, metered Pro

### DIFF
--- a/docs/guides/beta-tester-guide-detailed.md
+++ b/docs/guides/beta-tester-guide-detailed.md
@@ -1,6 +1,6 @@
 # TotalReclaw — Beta Tester Deep-Dive
 
-**Version:** 3.3.1 (RC line; promotes to 3.3.1 stable)
+**Version:** 3.3.13 (current stable plugin line)
 **Date:** April 2026
 **Audience:** Power users and beta testers who want to tune extraction, understand the encryption pipeline, run E2E validation, or self-host.
 **Time to read:** ~15 minutes.
@@ -70,7 +70,7 @@ When a fact is stored:
 1. Plain text + metadata are encrypted with XChaCha20-Poly1305 (24-byte nonce).
 2. A SHA-256 content fingerprint over the canonical text dedupes duplicates client-side.
 3. Blind search trapdoors are generated for keyword tokens (HMAC-SHA256 with a per-user index secret).
-4. A 384-dim embedding (`Xenova/all-MiniLM-L6-v2`, INT8 quantized) is computed locally for semantic search.
+4. A 640-dim embedding (`onnx-community/harrier-oss-v1-270m-ONNX`, q4, pre-pooled) is computed locally for semantic search.
 5. The encrypted blob, blind indices, content fingerprint, and (for v1) the protobuf-packed taxonomy fields are wrapped in a v=4 outer envelope and submitted via ERC-4337 UserOp to the EventfulDataEdge contract.
 6. The Pimlico paymaster sponsors gas. All writes (free and Pro) go to Gnosis mainnet.
 7. The Graph indexes the on-chain event so it's queryable seconds later.
@@ -79,7 +79,7 @@ When a fact is stored:
 
 When you query:
 
-1. Your query is embedded locally (same MiniLM model).
+1. Your query is embedded locally (same Harrier model).
 2. Blind trapdoors for query tokens are generated.
 3. The relay returns up to several thousand encrypted candidates matching the trapdoors.
 4. The plugin / MCP server / Hermes client decrypts every candidate locally.
@@ -243,7 +243,7 @@ These vars were removed in the v1 env cleanup and are silently ignored:
 
 `TOTALRECLAW_CHAIN_ID`, `TOTALRECLAW_EMBEDDING_MODEL`, `TOTALRECLAW_STORE_DEDUP`, `TOTALRECLAW_LLM_MODEL`, `TOTALRECLAW_SESSION_ID`, `TOTALRECLAW_TAXONOMY_VERSION`, `TOTALRECLAW_CLAIM_FORMAT`, `TOTALRECLAW_DIGEST_MODE`.
 
-All tiers run on Gnosis mainnet; chain selection is no longer user-configurable. Embedding model is fixed (`Xenova/all-MiniLM-L6-v2`). Extraction model is auto-derived from the provider key. v1 taxonomy is always on.
+All tiers run on Gnosis mainnet; chain selection is no longer user-configurable. Embedding model is fixed (`onnx-community/harrier-oss-v1-270m-ONNX`, 640-dim). Extraction model is auto-derived from the provider key. v1 taxonomy is always on.
 
 ---
 
@@ -412,4 +412,4 @@ For implementation depth:
 
 ---
 
-*This guide tracks plugin 3.3.1 / Hermes 2.3.1 / mcp-server 3.2.x / nanoclaw 3.1.x. Stable line: plugin 3.2.3, mcp-server 3.2.0, nanoclaw 3.0.0, Hermes 2.3.0.*
+*This guide tracks plugin 3.3.13 / Hermes 2.4.6 / mcp-server 3.4.0 / nanoclaw 3.0.0 (current stable line).*

--- a/docs/guides/claude-code-setup.md
+++ b/docs/guides/claude-code-setup.md
@@ -14,7 +14,7 @@ Your agent will fetch this page, run the MCP install command, and walk you throu
 
 ## Agent instructions (read this if you are a Claude Code / Claude Desktop / Cursor / Windsurf agent that just fetched this URL)
 
-You have been asked to install TotalReclaw. Run the steps below in order. Do not deviate. **Do not invoke `npx @totalreclaw/mcp-server setup`, `totalreclaw_setup`, or any other phrase-touching CLI / tool — those return the recovery phrase through your context, which violates the phrase-safety rule.** Phrase entry is the user's responsibility.
+You have been asked to install TotalReclaw. Run the steps below in order. Do not deviate. **Do not invoke `npx @totalreclaw/mcp-server setup` or any other phrase-touching CLI / tool — those return the recovery phrase through your context, which violates the phrase-safety rule.** Phrase entry is the user's responsibility.
 
 ### Step 1 — Detect the host runtime
 
@@ -37,7 +37,7 @@ claude mcp add -s user totalreclaw -- npx -y @totalreclaw/mcp-server
 
 This registers `totalreclaw` at user scope (available across all Claude Code sessions). Do NOT pass `-e TOTALRECLAW_RECOVERY_PHRASE=...` here — the user will add the phrase themselves in Step 3 so it never enters your context.
 
-To pin a release candidate: `claude mcp add -s user totalreclaw -- npx -y @totalreclaw/mcp-server@rc` (latest RC) or `@totalreclaw/mcp-server@3.2.3` (pin specific stable / RC version).
+To pin a release candidate: `claude mcp add -s user totalreclaw -- npx -y @totalreclaw/mcp-server@rc` (latest RC) or `@totalreclaw/mcp-server@latest` (current stable).
 
 If the CLI exits cleanly, continue to Step 3. If it fails with `command not found` / ENOENT, fall back to Step 2B.
 
@@ -45,7 +45,7 @@ If the CLI exits cleanly, continue to Step 3. If it fails with `command not foun
 
 Tell the user verbatim:
 
-> *Open your MCP config file ([Claude Desktop on macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`](file:///Users/$USER/Library/Application%20Support/Claude/claude_desktop_config.json), Windows: `%APPDATA%\Claude\claude_desktop_config.json`; Cursor: `.cursor/mcp.json` or Settings → MCP Servers; Windsurf: `~/.codeium/windsurf/mcp_config.json`) and paste the block below into `mcpServers`. Leave the recovery phrase placeholder for now — we'll fill it in next. Reply `done` once the file is saved.*
+> *Open your MCP config file (Claude Desktop on macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`, Windows: `%APPDATA%\Claude\claude_desktop_config.json`; Cursor: `.cursor/mcp.json` or Settings → MCP Servers; Windsurf: `~/.codeium/windsurf/mcp_config.json`) and paste the block below into `mcpServers`. Leave the recovery phrase placeholder for now — we'll fill it in next. Reply `done` once the file is saved.*
 
 ```json
 {
@@ -89,7 +89,7 @@ Once the user replies `done`, ask the agent's own internal toolset (yourself): *
 
 ### Phrase safety (HARD — never break)
 
-NEVER echo, generate, or ask the user to paste a recovery phrase in chat. NEVER invoke `npx @totalreclaw/mcp-server setup`, `totalreclaw_setup`, `npx @totalreclaw/totalreclaw generate-mnemonic`, or any phrase-touching CLI via your shell tool — stdout enters LLM context. The MCP server has NO browser account-setup flow (it's stateless JSON-RPC); the user MUST source their phrase from another TotalReclaw client's account-setup flow (OpenClaw / Hermes browser flow), reuse `~/.totalreclaw/credentials.json` from a prior install, or paste a phrase they generated offline directly into the config file. If the user pastes a phrase in chat anyway: tell them it is compromised and they need to generate a fresh wallet via the OpenClaw or Hermes browser account-setup flow.
+NEVER echo, generate, or ask the user to paste a recovery phrase in chat. NEVER invoke `npx @totalreclaw/mcp-server setup`, `npx @totalreclaw/totalreclaw generate-mnemonic`, or any phrase-touching CLI via your shell tool — stdout enters LLM context. The MCP server has NO browser account-setup flow (it's stateless JSON-RPC); the user MUST source their phrase from another TotalReclaw client's account-setup flow (OpenClaw / Hermes browser flow), reuse `~/.totalreclaw/credentials.json` from a prior install, or paste a phrase they generated offline directly into the config file. If the user pastes a phrase in chat anyway: tell them it is compromised and they need to generate a fresh wallet via the OpenClaw or Hermes browser account-setup flow.
 
 ---
 
@@ -149,7 +149,7 @@ claude mcp add -s user totalreclaw -- npx -y @totalreclaw/mcp-server
 
 Restart the host. Verify by asking *"Do you have access to TotalReclaw memory tools?"*.
 
-> **Pin a specific RC** with `args: ["-y", "@totalreclaw/mcp-server@rc"]` (latest RC) or `@totalreclaw/mcp-server@3.3.1-rc.22` (pinned). Stable is `3.2.3` on the `latest` dist-tag. Check what each tag resolves to: `npm view @totalreclaw/mcp-server dist-tags`.
+> **Pin a specific RC** with `args: ["-y", "@totalreclaw/mcp-server@rc"]` (latest RC) or `@totalreclaw/mcp-server@3.3.1-rc.22` (pinned). Stable is `3.4.0` on the `latest` dist-tag. Check what each tag resolves to: `npm view @totalreclaw/mcp-server dist-tags`.
 
 ---
 
@@ -238,7 +238,7 @@ Upgrade: *"Upgrade my TotalReclaw subscription."*
 
 - **MCP is stateless.** There's no first-run welcome, no lifecycle hooks, and no auto-restart on config change. You restart the host explicitly to pick up new config.
 - **No browser account-setup flow.** The MCP server has no HTTP routes — phrase entry is the user's responsibility (config file, env var, or copying from another client's `credentials.json`). This is by design: keeping crypto secrets out of LLM context is more important than convenience parity with OpenClaw / Hermes.
-- **`totalreclaw_setup` exists but should not be used.** The tool exists for legacy compatibility. It generates a phrase and returns it through MCP tool-output JSON, which means the phrase enters the host LLM's context. The phrase-safety rule forbids this. New installs should always use the workflow in this guide.
+- **Account setup uses `totalreclaw_pair`.** It opens a browser-mediated pairing flow: the agent calls `totalreclaw_pair`, which returns a URL + 6-digit PIN. The user opens the URL in any browser, the browser generates (or imports) the recovery phrase, encrypts it, and uploads ciphertext to the MCP server, which decrypts it in-memory and writes `~/.totalreclaw/credentials.json`. The phrase never enters LLM context, chat, stdout, or logs. After pairing, the user restarts the host so the server re-reads the credentials file and switches out of unconfigured mode.
 
 ---
 

--- a/docs/guides/client-setup-v1.md
+++ b/docs/guides/client-setup-v1.md
@@ -1,6 +1,6 @@
 # Client Setup — v1
 
-**Applies to:** TotalReclaw v1, all clients. Current stable versions: core 2.2.0, plugin 3.2.3, mcp-server 3.2.0, nanoclaw 3.0.0, python 2.3.0.
+**Applies to:** TotalReclaw v1, all clients. Current stable versions: core 2.5.6 (npm; 2.5.5 on PyPI/crates.io), plugin 3.3.13, mcp-server 3.4.0, nanoclaw 3.0.0, python 2.4.6.
 
 One setup page per client. v1 is the default on every client — no env toggles, no feature flags to flip. Pick your platform.
 
@@ -57,7 +57,7 @@ That's it. v1 taxonomy, source-weighted reranking, and the new pin / retype / se
 ## MCP server
 
 **Package:** `@totalreclaw/mcp-server@^3.0.0` (npm).
-**Features:** 19 MCP tools (including 4 new v1 tools: pin, unpin, retype, set_scope). No lifecycle hooks — the host agent invokes tools from context.
+**Features:** 18 MCP tools (including 4 v1 tools: pin, unpin, retype, set_scope). No lifecycle hooks — the host agent invokes tools from context.
 
 ### Install + setup
 
@@ -95,7 +95,7 @@ The IronClaw agent config references the MCP server via the same JSON shape. See
 
 ### Verify
 
-Ask the agent: *"What TotalReclaw tools do you have?"* — you should see 19 tools including `totalreclaw_pin`, `totalreclaw_retype`, `totalreclaw_set_scope`.
+Ask the agent: *"What TotalReclaw tools do you have?"* — you should see 18 tools including `totalreclaw_pin`, `totalreclaw_retype`, `totalreclaw_set_scope`.
 
 **Full guide:** [claude-code-setup.md](./claude-code-setup.md)
 
@@ -122,7 +122,7 @@ If you need to generate a recovery phrase first, run `npx @totalreclaw/mcp-serve
 
 ## Python client
 
-**Package:** `totalreclaw>=2.3.0` (PyPI).
+**Package:** `totalreclaw>=2.4.6` (PyPI).
 **Features:** Hermes Agent plugin with pre_llm_call auto-recall + post_llm_call auto-extract + on_session_finalize debrief. Full tool parity with the OpenClaw plugin: remember / recall / forget / export / status / account-setup (`totalreclaw_pair`) / pin / unpin / retype / set_scope / import_from / upgrade.
 
 ### Install
@@ -180,14 +180,14 @@ The plugin registers automatically with Hermes Agent v0.5.0+.
 
 ## ZeroClaw (Rust crate)
 
-**Crate:** `totalreclaw-memory = "2.0.0"` (crates.io). The `totalreclaw-core` Rust crate (canonical claim proto + crypto + pin state machine) is at 2.2.0.
+**Crate:** `totalreclaw-memory = "2.0.1"` (crates.io). The `totalreclaw-core` Rust crate (canonical claim proto + crypto + pin state machine) is at 2.5.5 on crates.io.
 **Features:** native Rust Memory trait with v1 write path (`store_v1`), cosine + fingerprint dedup, v4 outer protobuf. Designed for ZeroClaw (NEAR AI agent framework) but usable in any Rust app.
 
 ### Add dependency
 
 ```toml
 [dependencies]
-totalreclaw-memory = "2.0.0"
+totalreclaw-memory = "2.0.1"
 ```
 
 ### Use

--- a/docs/guides/feature-comparison.md
+++ b/docs/guides/feature-comparison.md
@@ -2,7 +2,7 @@
 
 TotalReclaw works across multiple AI agent platforms. The core encryption, storage, search pipeline, and v1 taxonomy are identical everywhere -- the differences are in automation (lifecycle hooks) and available tools. This table shows what each platform supports.
 
-All clients ship v1 by default. Stable production versions: core 2.2.0, plugin 3.2.3, mcp-server 3.2.0, nanoclaw 3.0.0, python 2.3.0.
+All clients ship v1 by default. Stable production versions: core 2.5.6 (npm; 2.5.5 on PyPI/crates.io), plugin 3.3.13, mcp-server 3.4.0, nanoclaw 3.0.0, python 2.4.6.
 
 ---
 
@@ -29,7 +29,7 @@ All clients ship v1 by default. Stable production versions: core 2.2.0, plugin 3
 | Set scope (v1) | Yes | Yes | Yes (via MCP) | Yes | Yes (via MCP) | -- |
 | Import from Mem0 / ChatGPT / Claude / Gemini | Yes | Yes | Yes | Yes | Yes | -- |
 | Upgrade to Pro | Yes | Yes | Yes | -- | Yes | -- |
-| Consolidate (bulk dedup) | Yes | Yes | Yes | -- | Yes | -- |
+| Consolidate (bulk dedup) | Self-hosted only | Self-hosted only | Self-hosted only | -- | Self-hosted only | -- |
 | **Dedup** | | | | | | |
 | Cosine near-duplicate prevention | Yes | Yes | Yes | Yes | Yes | Yes |
 | LLM-guided dedup (contradictions) | Yes | -- | Yes | Yes | -- | -- |
@@ -50,11 +50,11 @@ All clients ship v1 by default. Stable production versions: core 2.2.0, plugin 3
 
 **NanoClaw** -- Automatic, like OpenClaw. The NanoClaw agent-runner spawns the MCP server as a background process. Memory is shared within the NanoClaw group. No user setup required -- the admin configures the recovery phrase.
 
-**Hermes (Python)** -- Automatic via pre/post LLM call hooks. LLM extraction with heuristic fallback. Full tool parity with OpenClaw plugin since 2.3.x: remember / recall / forget / export / status / account-setup (`totalreclaw_pair`) / pin / unpin / retype / set_scope / import_from / upgrade. Migrate + consolidate are managed-service-only and exposed via the plugin / MCP server.
+**Hermes (Python)** -- Automatic via pre/post LLM call hooks. LLM extraction with heuristic fallback. Full tool parity with OpenClaw plugin since 2.3.x: remember / recall / forget / export / status / account-setup (`totalreclaw_pair`) / pin / unpin / retype / set_scope / import_from / upgrade. Consolidate is self-hosted-only (no batch delete on the managed service) and is exposed via the plugin / MCP server.
 
 **IronClaw (NEAR AI)** -- Uses the MCP server for tools. No lifecycle hooks -- auto-extraction requires setting up routines (cron). The TEE protects the runtime; TotalReclaw protects the data.
 
-**ZeroClaw (Rust)** -- Native Rust implementation via the Memory trait. Automatic recall and extraction. Includes hot cache, decay handling (7-day half-life), and conflict resolution. Import/migrate not yet implemented.
+**ZeroClaw (Rust)** -- Native Rust implementation via the Memory trait. Automatic recall and extraction. Includes hot cache, decay handling (7-day half-life), and conflict resolution. Import not yet implemented.
 
 ---
 

--- a/docs/guides/importing-from-chatgpt.md
+++ b/docs/guides/importing-from-chatgpt.md
@@ -117,7 +117,7 @@ This parses your data and shows an estimate: `total_chunks`, `est_facts`, `est_m
 ## Tier gating
 
 - **Free tier**: one import lifetime (across all sources). Subsequent attempts are blocked with an upgrade prompt.
-- **Pro tier** ($3.99/mo): unlimited imports. The pre-flight projects the LLM cost vs your subscription; soft warning if the projection exceeds $1.00, hard block above $5.00 (you can override with a flag).
+- **Pro tier**: up to 1,500 memories/month (see [totalreclaw.xyz/pricing](https://totalreclaw.xyz/pricing)). The pre-flight projects the LLM cost vs your subscription; soft warning if the projection exceeds $1.00, hard block above $5.00 (you can override with a flag).
 
 ---
 

--- a/docs/guides/importing-from-gemini.md
+++ b/docs/guides/importing-from-gemini.md
@@ -97,7 +97,7 @@ This is the same trade-off that applies to the `conversations.json` path for Cha
 ## Tier gating
 
 - **Free tier**: one import lifetime (across all sources — Gemini, ChatGPT, Claude, Mem0, MCP-Memory). Subsequent attempts are blocked with an upgrade prompt.
-- **Pro tier** ($3.99/mo): unlimited imports. The pre-flight projects the LLM cost vs your subscription; soft warning if the projection exceeds $1.00, hard block above $5.00 (you can override with a flag).
+- **Pro tier**: up to 1,500 memories/month (see [totalreclaw.xyz/pricing](https://totalreclaw.xyz/pricing)). The pre-flight projects the LLM cost vs your subscription; soft warning if the projection exceeds $1.00, hard block above $5.00 (you can override with a flag).
 
 ---
 

--- a/docs/guides/ironclaw-setup.md
+++ b/docs/guides/ironclaw-setup.md
@@ -2,6 +2,8 @@
 
 Set up TotalReclaw as the encrypted memory layer for your IronClaw agent. Your memories are encrypted on-device before they leave -- IronClaw's TEE protects the runtime, TotalReclaw protects the data at rest.
 
+> **Status (paused 2026-04-18): first-class IronClaw integration is on hold.** There is no `ironclaw mcp add` / `nearai mcp add` CLI and no IronClaw lifecycle hooks. The path below uses the **generic TotalReclaw MCP server** (`@totalreclaw/mcp-server`), which works with any MCP-compatible host, IronClaw included. Because the MCP server has no IronClaw hooks, auto-extraction has to be driven by a cron-style routine (see §5); recall happens when the agent decides to call a tool.
+
 > **Note:** TotalReclaw requires a local IronClaw installation (not NEAR AI hosted). The hosted environment does not include Node.js, which is needed to run the MCP server. Installing TotalReclaw as a "Skill" from ClawHub only injects instructions -- it does not register the tools.
 
 ## Prerequisites
@@ -33,18 +35,22 @@ Verify the connection:
 ironclaw mcp test totalreclaw
 ```
 
-You should see 14 tools including `totalreclaw_setup`.
+You should see 18 tools. Account setup uses `totalreclaw_pair`, which is browser-mediated (see §3).
 
-## 3. Start chatting
+## 3. Pair your account (browser-mediated — recovery phrase never enters chat)
 
-Restart IronClaw and start a conversation. The first time you mention anything worth remembering (e.g. "remember that my name is Pedro"), the agent will:
+Restart IronClaw and start a conversation. The first time you mention anything worth remembering (e.g. "remember that my name is Pedro"), the agent will detect that TotalReclaw is not configured yet and offer to set it up with the `totalreclaw_pair` tool.
 
-1. Detect that TotalReclaw is not configured yet
-2. Ask: "Do you have an existing recovery phrase, or should I generate a new one?"
-3. Generate or import your phrase via the `totalreclaw_setup` tool
-4. Register with the relay, download the embedding model, and activate -- all automatically
+`totalreclaw_pair` opens a short relay session and returns a **URL + 6-digit PIN**. The 12-word recovery phrase is generated (or imported) **in your browser** — never typed into chat:
 
-Your recovery phrase and credentials are saved to `~/.totalreclaw/credentials.json` (owner-only permissions). On subsequent restarts, the MCP server loads them automatically.
+1. The agent calls `totalreclaw_pair` (`mode: "generate"` for a new phrase, or `mode: "import"` to reuse one you already have) and hands you the URL + PIN.
+2. Open the URL on your phone or another browser and enter the PIN.
+3. The browser generates a new 12-word BIP-39 phrase (and asks you to write it down + retype 3 words) — or, in `import` mode, accepts a phrase you paste in the browser.
+4. The browser encrypts the phrase (x25519 ECDH + AES-256-GCM) and uploads ciphertext to the MCP server. The phrase never touches the LLM context, the chat transcript, stdout, or logs.
+5. The MCP server decrypts the phrase in-memory, derives your keys, registers with the relay, and writes `~/.totalreclaw/credentials.json` (mode 0600, owner-only).
+6. **Restart IronClaw** so the MCP server re-reads `credentials.json` and switches out of unconfigured mode. The pairing session expires in ~5 minutes.
+
+On subsequent restarts the MCP server loads `~/.totalreclaw/credentials.json` automatically — no pairing needed.
 
 > **Save your recovery phrase somewhere safe.** It is the only key to your memories. There is no password reset, no recovery, no support ticket that can help. Write it down and store it securely.
 
@@ -103,21 +109,28 @@ If your IronClaw version supports event-triggered routines (e.g., `on_thread_idl
 
 ## Available tools
 
+The MCP server exposes 18 tools. Descriptions are summarized from the tool definitions in `mcp/src/tools/`.
+
 | Tool | Description |
 |------|-------------|
-| `totalreclaw_setup` | Set up TotalReclaw (generate or import recovery phrase) |
-| `totalreclaw_remember` | Store facts in encrypted memory |
-| `totalreclaw_recall` | Search memories by natural language query |
-| `totalreclaw_forget` | Delete a specific memory by ID |
-| `totalreclaw_export` | Export all memories as Markdown or JSON |
-| `totalreclaw_status` | Check billing status and usage |
-| `totalreclaw_import` | Re-import previously exported memories |
-| `totalreclaw_import_from` | Import from Mem0, ChatGPT, Claude, or MCP Memory Server |
-| `totalreclaw_consolidate` | Merge duplicate memories (self-hosted only) |
-| `totalreclaw_upgrade` | Get a Stripe checkout link for Pro |
-| `totalreclaw_debrief` | Summarize and store key takeaways from a session |
-| `totalreclaw_support` | Get help and troubleshooting information |
-| `totalreclaw_account` | View account details and wallet address |
+| `totalreclaw_pair` | Set up the account: browser-mediated recovery-phrase generation or import. Returns a URL + PIN; the phrase is created in the browser and never enters LLM context. |
+| `totalreclaw_remember` | Store an atomic fact proactively (with v1 type, scope, importance). Dedup is automatic. |
+| `totalreclaw_recall` | Search the encrypted vault by natural-language query; top 8 reranked by provenance + semantic + recency. |
+| `totalreclaw_forget` | Permanently remove a memory by `memory_id`, or by query (tombstones up to 50 matches). |
+| `totalreclaw_export` | Export the decrypted vault as Markdown or JSON (one-click portable backup). |
+| `totalreclaw_import` | Restore memories from a prior TotalReclaw export backup (JSON/Markdown). |
+| `totalreclaw_import_from` | Import from Mem0, MCP Memory, ChatGPT, Claude, Gemini, MemoClaw, or JSON/CSV. Dry-run first. |
+| `totalreclaw_import_batch` | Internal chunked-polling helper for large imports (50+ conversations); not meant to be called by name. |
+| `totalreclaw_consolidate` | Cluster near-duplicates and merge each to the best match. **Self-hosted only** (no batch delete on the managed service). |
+| `totalreclaw_status` | Check tier, usage, and quota against the relay billing endpoint. |
+| `totalreclaw_upgrade` | Get a one-time Stripe checkout URL for Pro. |
+| `totalreclaw_debrief` | Store a structured Crystal session summary at the end of a substantive conversation. |
+| `totalreclaw_support` | Get support contact, docs links, and a troubleshooting bundle. Works even when unconfigured. |
+| `totalreclaw_account` | Account overview: wallet, tier, usage, feature flags, and a safe (first + last words only) recovery hint. |
+| `totalreclaw_pin` | Lock a memory against auto-supersession. |
+| `totalreclaw_unpin` | Remove a pin so a memory can be superseded again. |
+| `totalreclaw_retype` | Change a memory's v1 type (e.g. preference → directive). |
+| `totalreclaw_set_scope` | Assign a memory to a scope (work, personal, health, ...). |
 
 ## Pricing
 
@@ -165,7 +178,7 @@ which totalreclaw-mcp
 
 ### "Registration failed"
 
-Check your internet connection. The setup tool needs to reach `api.totalreclaw.xyz` to register.
+Check your internet connection. The pairing flow needs to reach `api.totalreclaw.xyz` to register.
 
 ### "No memories found" on first recall
 

--- a/docs/guides/v1-migration.md
+++ b/docs/guides/v1-migration.md
@@ -67,13 +67,14 @@ All clients do the v0 → v1 mapping automatically when reading existing memorie
 
 ### 3. New MCP tools
 
-Three new tools (on `@totalreclaw/mcp-server@3.0.0` + inherited by NanoClaw + IronClaw):
+Four new tools (on `@totalreclaw/mcp-server@3.0.0` + inherited by NanoClaw + IronClaw):
 
 - `totalreclaw_pin` — lock a memory against auto-supersession.
+- `totalreclaw_unpin` — release a pin so a memory can be superseded again.
 - `totalreclaw_retype` — change a memory's type (e.g. "that is actually a directive, not a preference").
 - `totalreclaw_set_scope` — assign a memory to a scope (work, personal, health, ...).
 
-These are invoked via natural language: "pin that", "that was actually a rule, not a preference", "file that under work". The host LLM picks the right tool.
+These are invoked via natural language: "pin that", "unpin that", "that was actually a rule, not a preference", "file that under work". The host LLM picks the right tool.
 
 See the [memory types guide](./memory-types-guide.md) for examples.
 


### PR DESCRIPTION
Part of the docs production-readiness sweep (Phase A, batch 1 of 4). Closes audit findings 1.4, 2.1, 2.4, 2.6, 4.7 and the guide-side half of 2.5.

## Changes
- **ironclaw-setup.md** — setup flow rewritten around the real `totalreclaw_pair` browser-mediated flow (the guide previously instructed calling `totalreclaw_setup`, which does not exist — setup failed on first try); tool count 14→18; tools table regenerated from the actual `mcp/src/tools/` definitions; paused-integration status note added.
- **feature-comparison.md** — version banner → current stables; phantom `totalreclaw_migrate` references removed (tool deleted in mcp 3.4.0); Consolidate contradiction resolved to self-hosted-only.
- **client-setup-v1.md** — version banner + crate versions → current (`totalreclaw-core` 2.5.5 on crates.io, `totalreclaw-memory` 2.0.1); "19 tools" → 18 (×2).
- **claude-code-setup.md** — install pin `@3.2.3` → `@latest`; "Stable is 3.2.3" → 3.4.0; stale `totalreclaw_setup` references replaced with the pair flow; broken `file:///` link flattened to plain text.
- **beta-tester-guide-detailed.md** — retired MiniLM (384d) → Harrier-OSS-v1-270M (640d) at all three sites; version header/footer → current.
- **importing-from-chatgpt.md / importing-from-gemini.md** — hardcoded "$3.99/mo: unlimited imports" → metered Pro (1,500 memories/month) + pricing-page link.
- **v1-migration.md** — "Three new tools" → "Four" + missing `totalreclaw_unpin` bullet.

## Verification
- All versions verified against live npm/PyPI/crates.io lookups (2026-07-16); tool list/count and descriptions verified against `mcp/src/tools/*.ts` tool definitions.
- Independent model review pass (ground-truth-checked against code + registries, not other docs): 1 real finding (crate version npm/crates mix-up) — fixed; remaining retired-token grep hits are all explicitly-historical "removed env vars" mentions.
- Docs-only; nothing here ships to registries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLFumVFqmN7kSCCDN2ELfp