### PR TITLE
fix(#470): preserve metadata.session_id across pin/retype/set_scope rewrites

### DIFF
--- a/python/src/totalreclaw/operations.py
+++ b/python/src/totalreclaw/operations.py
@@ -1451,6 +1451,18 @@ async def _change_claim_status(
         default_source_agent="python-client",
     )
 
+    # Preserve the source blob's ``metadata`` dict across the pin/unpin
+    # rewrite (internal#470 / Finding #7). ``_project_source_to_v1`` returns
+    # only the v1 provenance fields, so without re-attaching ``metadata``
+    # the session_id / import_source stamp (core #463) is dropped and the
+    # superseding active fact comes back with ``session_id: null``. Only v1
+    # sources carry the field; v0 short-key blobs predate it.
+    carried_metadata = (
+        raw_claim_obj.get("metadata")
+        if is_v1_source and isinstance(raw_claim_obj.get("metadata"), dict)
+        else None
+    )
+
     new_fact_id = str(uuid.uuid4())
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
     pin_status_wire = "pinned" if target_status == "p" else "unpinned"
@@ -1474,6 +1486,7 @@ async def _change_claim_status(
         superseded_by=fact_id,
         claim_id=new_fact_id,
         pin_status=pin_status_wire,
+        extra_metadata=carried_metadata,
     )
 
     # 5. Encrypt + build FactPayload at protobuf v=4.

--- a/python/src/totalreclaw/retype_setscope.py
+++ b/python/src/totalreclaw/retype_setscope.py
@@ -393,6 +393,26 @@ async def _rewrite_with_mutation(
             ),
         }
 
+    # Preserve the source blob's ``metadata`` dict across the rewrite
+    # (internal#470 / Finding #7). ``_project_from_decrypted`` returns a
+    # fixed 10-key v1 shape that intentionally omits ``metadata``, so the
+    # session_id / import_source / Crystal provenance stamped by
+    # ``build_canonical_claim_v1(extra_metadata=…)`` (core #463) would
+    # otherwise be dropped on every retype/set_scope — the superseding
+    # active fact would come back with ``session_id: null``. Carry the
+    # whole dict verbatim; v0 short-key blobs predate the field, so
+    # ``carried_metadata`` stays ``None`` and the blob is byte-identical.
+    try:
+        _src_obj = _json.loads(plaintext)
+        carried_metadata = (
+            _src_obj.get("metadata")
+            if isinstance(_src_obj, dict)
+            and isinstance(_src_obj.get("metadata"), dict)
+            else None
+        )
+    except (ValueError, TypeError):
+        carried_metadata = None
+
     # 3. Apply mutation. previous_X is captured before the mutation so the
     # response matches the TS RetypeSetScopeResult shape.
     previous_type = current["type"]
@@ -423,6 +443,7 @@ async def _rewrite_with_mutation(
             superseded_by=fact_id,
             claim_id=new_fact_id,
             pin_status=next_state.get("pin_status"),
+            extra_metadata=carried_metadata,
         )
     except Exception as exc:
         return {

--- a/python/tests/test_pin_unpin.py
+++ b/python/tests/test_pin_unpin.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 import totalreclaw_core
+from totalreclaw.claims_helper import build_canonical_claim_v1
 from totalreclaw.crypto import derive_keys_from_mnemonic, encrypt, decrypt
 from totalreclaw.operations import pin_fact, unpin_fact
 from totalreclaw.relay import RelayClient
@@ -275,6 +276,96 @@ class TestPinFact:
         assert "c" not in parsed
         assert "st" not in parsed
         assert "sup" not in parsed
+
+    @pytest.mark.asyncio
+    @patch("totalreclaw.operations.build_and_send_userop_batch", new_callable=AsyncMock)
+    async def test_pin_preserves_session_id_metadata(self, mock_send, keys):
+        """Regression shield for internal#470 / Finding #7.
+
+        Pinning a v1 fact that carries the core #463 ``session_id`` stamp
+        MUST re-attach ``metadata`` onto the superseding pinned fact.
+        Before the fix ``_project_source_to_v1`` returned only provenance
+        fields, so the pin rewrite dropped ``metadata`` and the active
+        pinned fact came back with ``session_id: null``.
+        """
+        # v1 source blob carrying the session_id / import provenance stamp.
+        class _Fact:
+            pass
+
+        src = _Fact()
+        src.text = "Porto is on the coast"
+        src.type = "claim"
+        src.source = "user"
+        src.scope = None
+        src.reasoning = None
+        src.entities = None
+        src.confidence = 0.9
+        src.volatility = None
+        v1_blob = build_canonical_claim_v1(
+            src,
+            importance=7,
+            created_at="2026-07-08T10:00:00.000Z",
+            claim_id="stamped-fact",
+            extra_metadata={"session_id": "9a49ff69-sess", "import_source": "chatgpt"},
+        )
+        assert json.loads(v1_blob)["metadata"]["session_id"] == "9a49ff69-sess"
+
+        relay = AsyncMock(spec=RelayClient)
+        relay._relay_url = "https://api.totalreclaw.xyz"
+        relay._auth_key_hex = "deadbeef"
+        relay._client_id = "test"
+
+        async def query(query_str, variables, chain=None):
+            if "fact(id" in query_str or "id: $id" in query_str:
+                return {
+                    "data": {
+                        "fact": {
+                            "id": "stamped-fact",
+                            "owner": OWNER.lower(),
+                            "encryptedBlob": _encrypted_hex(v1_blob, keys.encryption_key),
+                            "encryptedEmbedding": None,
+                            "decayScore": "0.7",
+                            "timestamp": "1760000000",
+                            "createdAt": "1760000000",
+                            "isActive": True,
+                            "contentFp": "abc123",
+                        }
+                    }
+                }
+            return {"data": {}}
+
+        relay.query_subgraph = AsyncMock(side_effect=query)
+
+        captured: list[list[bytes]] = []
+
+        async def capture(**kwargs):
+            captured.append(kwargs["protobuf_payloads"])
+            return "0xok"
+
+        mock_send.side_effect = capture
+
+        await pin_fact(
+            fact_id="stamped-fact",
+            keys=keys,
+            owner=OWNER,
+            relay=relay,
+            eoa_private_key=EOA_PRIVATE_KEY,
+            eoa_address=EOA_ADDRESS,
+            sender=OWNER,
+        )
+
+        new_payload = captured[0][1]
+        encrypted_blob_bytes = _extract_protobuf_bytes_field(new_payload, field_number=4)
+        plaintext = decrypt(
+            base64.b64encode(encrypted_blob_bytes).decode("ascii"), keys.encryption_key
+        )
+        parsed = json.loads(plaintext)
+        assert parsed.get("metadata", {}).get("session_id") == "9a49ff69-sess", (
+            "pin must preserve metadata.session_id — internal#470 regression"
+        )
+        assert parsed["metadata"]["import_source"] == "chatgpt"
+        assert parsed["pin_status"] == "pinned"
+        assert parsed["superseded_by"] == "stamped-fact"
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_retype_setscope.py
+++ b/python/tests/test_retype_setscope.py
@@ -73,6 +73,7 @@ def _build_v1_blob(
     pin_status: str | None = None,
     importance: int = 7,
     confidence: float = 0.9,
+    extra_metadata: dict | None = None,
 ) -> str:
     """Produce a v1.1 ``MemoryClaimV1`` JSON blob matching the production builder."""
 
@@ -94,6 +95,7 @@ def _build_v1_blob(
         created_at="2026-04-25T10:00:00.000Z",
         claim_id=fact_id,
         pin_status=pin_status,
+        extra_metadata=extra_metadata,
     )
 
 
@@ -455,6 +457,67 @@ class TestExecuteRetype:
         )
         assert parsed["type"] == "preference"
         assert parsed["superseded_by"] == "pinned-fact"
+
+    @pytest.mark.asyncio
+    @patch("totalreclaw.retype_setscope.build_and_send_userop_batch", new_callable=AsyncMock)
+    async def test_retype_preserves_session_id_metadata(self, mock_send, keys):
+        """Regression shield for internal#470 / Finding #7.
+
+        The rewrite MUST carry the source blob's ``metadata`` dict (the
+        core #463 ``session_id`` stamp + import provenance) onto the
+        superseding fact. Before this fix ``_project_from_decrypted``
+        dropped ``metadata`` entirely, so a retype returned an active fact
+        with ``session_id: null`` — breaking SPA session grouping.
+        """
+        mock_send.return_value = "0xabc"
+        existing_blob = _build_v1_blob(
+            fact_id="stamped-fact",
+            text="Halibut is my favorite fish",
+            fact_type="claim",
+            extra_metadata={
+                "session_id": "9a49ff69-sess",
+                "import_source": "chatgpt",
+            },
+        )
+        # Sanity-check the fixture carries the stamp.
+        assert json.loads(existing_blob)["metadata"]["session_id"] == "9a49ff69-sess"
+
+        relay = _build_relay_mock(keys, fact_id="stamped-fact", blob=existing_blob)
+
+        captured: list[list[bytes]] = []
+
+        async def capture(**kwargs):
+            captured.append(kwargs["protobuf_payloads"])
+            return "0xok"
+
+        mock_send.side_effect = capture
+
+        await execute_retype(
+            fact_id="stamped-fact",
+            new_type="preference",
+            keys=keys,
+            owner=OWNER,
+            relay=relay,
+            eoa_private_key=EOA_PRIVATE_KEY,
+            eoa_address=EOA_ADDRESS,
+            sender=OWNER,
+        )
+
+        encrypted_blob_bytes = _extract_protobuf_bytes_field(
+            captured[0][1], field_number=4
+        )
+        plaintext = decrypt(
+            base64.b64encode(encrypted_blob_bytes).decode("ascii"),
+            keys.encryption_key,
+        )
+        parsed = json.loads(plaintext)
+        assert parsed.get("metadata", {}).get("session_id") == "9a49ff69-sess", (
+            "retype must preserve metadata.session_id — internal#470 regression"
+        )
+        # Full provenance dict rides through, not just session_id.
+        assert parsed["metadata"]["import_source"] == "chatgpt"
+        assert parsed["type"] == "preference"
+        assert parsed["superseded_by"] == "stamped-fact"
 
 
 class TestExecuteSetScope:


### PR DESCRIPTION
## What broke
After pin / retype / set_scope / unpin on a fact, the superseding active memory came back with `session_id: null` — the core #463 session-grouping stamp was silently dropped, so the SPA couldn't group a conversation's facts with its Crystal (QA Finding #7, Hermes rc.2.4.6rc7 pre-stable, umbrella p-diogo/totalreclaw-internal#466).

## What's fixed
The two tool-rewrite paths (`retype_setscope.py::_rewrite_with_mutation`, `operations.py::_change_claim_status`) now surface the source blob's `metadata` dict and pass it through `build_canonical_claim_v1(extra_metadata=…)`. The whole provenance dict rides through (`session_id` **and** `import_source`), not just session_id. v1 sources only — v0 short-key blobs predate the field and stay byte-identical.

## Impact after fix
Renaming (retype), rescoping, or pinning/unpinning a fact preserves its session_id + import provenance. SPA session grouping survives curation edits.

## Verification
Full Python suite green (2214 passed). Two new regression tests decrypt the actually-emitted protobuf blob and assert `metadata.session_id` survives a retype and a pin — they **fail on baseline `main`** (session_id `None`) and **pass on this branch**. Given severity:low + a deterministic unit proof over the real ciphertext, no dedicated staging RC was cut; the fix lands on `main` to bundle into the next 2.4.7 RC alongside the sibling Finding fixes.

Scoped follow-up (not in this PR): the drain re-extraction path (`pending_drain`/`hooks`/`lifecycle`) also doesn't carry the original session_id — a distinct mechanism (queue-schema change) tracked separately.

Closes p-diogo/totalreclaw-internal#470