### PR TITLE
fix(#470): carry metadata.session_id through pin/retype/set_scope rewrites

### DIFF
--- a/python/src/totalreclaw/operations.py
+++ b/python/src/totalreclaw/operations.py
@@ -1222,6 +1222,14 @@ def _project_source_to_v1(
             "entities": v1_entities,
             "importance": importance,
             "confidence": confidence,
+            # Preserve the additive metadata dict (session_id #463,
+            # import_source #356, …) so a pin/unpin rewrite doesn't strip
+            # it. Issue #470: mutations dropped metadata.session_id.
+            "metadata": (
+                source_claim.get("metadata")
+                if isinstance(source_claim.get("metadata"), dict)
+                else None
+            ),
         }
 
     # v0 short-key source: {t, c, cf, i, sa, ea, ...} → upgrade to v1.
@@ -1280,6 +1288,8 @@ def _project_source_to_v1(
         "entities": v1_entities or None,
         "importance": importance,
         "confidence": confidence,
+        # v0 blobs predate the #463 metadata stamp — nothing to carry.
+        "metadata": None,
     }
 
 
@@ -1474,6 +1484,9 @@ async def _change_claim_status(
         superseded_by=fact_id,
         claim_id=new_fact_id,
         pin_status=pin_status_wire,
+        # Carry the source blob's metadata (session_id, …) across the
+        # rewrite so session-grouping survives pin/unpin (#470).
+        extra_metadata=v1_view.get("metadata"),
     )
 
     # 5. Encrypt + build FactPayload at protobuf v=4.

--- a/python/src/totalreclaw/retype_setscope.py
+++ b/python/src/totalreclaw/retype_setscope.py
@@ -217,6 +217,14 @@ def _project_from_decrypted(decrypted: str) -> Optional[ProjectedFact]:
             "importance": importance,
             "confidence": confidence,
             "pin_status": pin_status,
+            # Preserve the additive metadata dict (session_id #463,
+            # import_source #356, …) so a retype/set_scope rewrite doesn't
+            # strip it. Issue #470: mutations dropped metadata.session_id.
+            "metadata": (
+                obj.get("metadata")
+                if isinstance(obj.get("metadata"), dict)
+                else None
+            ),
         }
 
     # 2. v0 short-key blob — upgrade to v1 shape on the fly.
@@ -269,6 +277,8 @@ def _project_from_decrypted(decrypted: str) -> Optional[ProjectedFact]:
             "confidence": confidence,
             # v0 short-key blobs may carry ``st: "p"`` — treat as pinned.
             "pin_status": "pinned" if obj.get("st") == "p" else None,
+            # v0 blobs predate the #463 metadata stamp — nothing to carry.
+            "metadata": None,
         }
 
     return None
@@ -423,6 +433,9 @@ async def _rewrite_with_mutation(
             superseded_by=fact_id,
             claim_id=new_fact_id,
             pin_status=next_state.get("pin_status"),
+            # Carry the source blob's metadata (session_id, …) across the
+            # rewrite so session-grouping survives retype/set_scope (#470).
+            extra_metadata=next_state.get("metadata"),
         )
     except Exception as exc:
         return {

--- a/python/tests/test_pin_unpin.py
+++ b/python/tests/test_pin_unpin.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 import totalreclaw_core
+from totalreclaw.claims_helper import build_canonical_claim_v1
 from totalreclaw.crypto import derive_keys_from_mnemonic, encrypt, decrypt
 from totalreclaw.operations import pin_fact, unpin_fact
 from totalreclaw.relay import RelayClient
@@ -885,3 +886,149 @@ def _extract_protobuf_bytes_field(payload: bytes, field_number: int) -> bytes | 
         else:
             raise ValueError(f"Unsupported wire type {wt}")
     return None
+
+
+# ---------------------------------------------------------------------------
+# Issue #470 — pin/unpin must preserve the #463 metadata.session_id stamp
+# ---------------------------------------------------------------------------
+
+
+def _v1_blob_with_session(*, fact_id: str, text: str, session_id: str, pin_status=None) -> str:
+    """v1.1 blob carrying ``metadata.session_id`` (the #463 stamp shape)."""
+
+    class _Fact:
+        pass
+
+    fact = _Fact()
+    fact.text = text
+    fact.type = "claim"
+    fact.source = "user"
+    fact.scope = None
+    fact.reasoning = None
+    fact.entities = None
+    fact.confidence = 0.9
+    fact.volatility = None
+    return build_canonical_claim_v1(
+        fact,
+        importance=7,
+        created_at="2026-04-25T10:00:00.000Z",
+        claim_id=fact_id,
+        pin_status=pin_status,
+        extra_metadata={"session_id": session_id},
+    )
+
+
+def _v1_relay_mock(keys, *, fact_id: str, blob: str) -> AsyncMock:
+    relay = AsyncMock(spec=RelayClient)
+    relay._relay_url = "https://api.totalreclaw.xyz"
+    relay._auth_key_hex = "deadbeef"
+    relay._client_id = "test"
+
+    async def query(query_str, variables, chain=None):
+        if "fact(id" in query_str or "id: $id" in query_str:
+            return {
+                "data": {
+                    "fact": {
+                        "id": fact_id,
+                        "owner": OWNER.lower(),
+                        "encryptedBlob": _encrypted_hex(blob, keys.encryption_key),
+                        "encryptedEmbedding": None,
+                        "decayScore": "0.7",
+                        "timestamp": "1760000000",
+                        "createdAt": "1760000000",
+                        "isActive": True,
+                        "contentFp": "abc123",
+                    }
+                }
+            }
+        return {"data": {}}
+
+    relay.query_subgraph = AsyncMock(side_effect=query)
+    return relay
+
+
+class TestIssue470PinPreservesSessionId:
+    """The #463 session_id stamp must survive a pin/unpin rewrite.
+
+    Before the fix, the pin path projected the source claim to v1 and
+    rebuilt the blob without carrying ``extra_metadata`` through, dropping
+    ``metadata.session_id`` so a curated fact lost its per-conversation
+    grouping in the vault reader.
+    """
+
+    @pytest.fixture
+    def keys(self):
+        return derive_keys_from_mnemonic(TEST_MNEMONIC)
+
+    def _decrypt_new(self, captured, keys):
+        new_payload = captured[0][1]
+        encrypted_blob_bytes = _extract_protobuf_bytes_field(new_payload, field_number=4)
+        plaintext = decrypt(
+            base64.b64encode(encrypted_blob_bytes).decode("ascii"), keys.encryption_key
+        )
+        return json.loads(plaintext)
+
+    @pytest.mark.asyncio
+    @patch("totalreclaw.operations.build_and_send_userop_batch", new_callable=AsyncMock)
+    async def test_issue_470_pin_preserves_session_id(self, mock_send, keys):
+        blob = _v1_blob_with_session(
+            fact_id="halibut-fact", text="Halibut is my favorite fish", session_id="sess-h-1"
+        )
+        relay = _v1_relay_mock(keys, fact_id="halibut-fact", blob=blob)
+        captured: list[list[bytes]] = []
+
+        async def capture(**kwargs):
+            captured.append(kwargs["protobuf_payloads"])
+            return "0xok"
+
+        mock_send.side_effect = capture
+
+        await pin_fact(
+            fact_id="halibut-fact",
+            keys=keys,
+            owner=OWNER,
+            relay=relay,
+            eoa_private_key=EOA_PRIVATE_KEY,
+            eoa_address=EOA_ADDRESS,
+            sender=OWNER,
+        )
+
+        parsed = self._decrypt_new(captured, keys)
+        assert parsed["pin_status"] == "pinned"
+        assert parsed.get("metadata", {}).get("session_id") == "sess-h-1", (
+            "pin must preserve metadata.session_id — issue #470 regression"
+        )
+
+    @pytest.mark.asyncio
+    @patch("totalreclaw.operations.build_and_send_userop_batch", new_callable=AsyncMock)
+    async def test_issue_470_unpin_preserves_session_id(self, mock_send, keys):
+        blob = _v1_blob_with_session(
+            fact_id="porto-fact",
+            text="I visited Porto last spring",
+            session_id="sess-p-2",
+            pin_status="pinned",
+        )
+        relay = _v1_relay_mock(keys, fact_id="porto-fact", blob=blob)
+        captured: list[list[bytes]] = []
+
+        async def capture(**kwargs):
+            captured.append(kwargs["protobuf_payloads"])
+            return "0xok"
+
+        mock_send.side_effect = capture
+
+        await unpin_fact(
+            fact_id="porto-fact",
+            keys=keys,
+            owner=OWNER,
+            relay=relay,
+            eoa_private_key=EOA_PRIVATE_KEY,
+            eoa_address=EOA_ADDRESS,
+            sender=OWNER,
+        )
+
+        parsed = self._decrypt_new(captured, keys)
+        assert parsed["pin_status"] == "unpinned"
+        assert parsed.get("metadata", {}).get("session_id") == "sess-p-2", (
+            "unpin must preserve metadata.session_id — issue #470 regression"
+        )

--- a/python/tests/test_retype_setscope.py
+++ b/python/tests/test_retype_setscope.py
@@ -991,3 +991,168 @@ class TestNaturalLanguageSurface:
         assert "work" in desc
         # "File that under" or "put that under" — the canonical NL hooks.
         assert "under" in desc
+
+
+def _build_v1_blob_with_session(
+    *,
+    fact_id: str,
+    text: str,
+    session_id: str,
+    fact_type: str = "claim",
+    pin_status: str | None = None,
+) -> str:
+    """v1.1 blob carrying ``metadata.session_id`` — the #463 stamp shape."""
+
+    class _Fact:
+        pass
+
+    fact = _Fact()
+    fact.text = text
+    fact.type = fact_type
+    fact.source = "user"
+    fact.scope = None
+    fact.reasoning = None
+    fact.entities = None
+    fact.confidence = 0.9
+    fact.volatility = None
+    return build_canonical_claim_v1(
+        fact,
+        importance=7,
+        created_at="2026-04-25T10:00:00.000Z",
+        claim_id=fact_id,
+        pin_status=pin_status,
+        extra_metadata={"session_id": session_id},
+    )
+
+
+class TestIssue470SessionIdPreservation:
+    """Regression shield for issue #470.
+
+    The #463 session_id stamp (``metadata.session_id`` on the encrypted
+    blob) must survive a retype / set_scope rewrite. Before the fix the
+    tool-rewrite path rebuilt the v1 blob without carrying ``extra_metadata``
+    through, silently dropping the stamp so a vault reader (SPA) lost the
+    per-conversation grouping for any fact the user later curated.
+    """
+
+    @pytest.fixture
+    def keys(self):
+        return derive_keys_from_mnemonic(TEST_MNEMONIC)
+
+    def _decrypt_new_blob(self, captured, keys):
+        encrypted_blob_bytes = _extract_protobuf_bytes_field(
+            captured[0][1], field_number=4
+        )
+        plaintext = decrypt(
+            base64.b64encode(encrypted_blob_bytes).decode("ascii"),
+            keys.encryption_key,
+        )
+        return json.loads(plaintext)
+
+    @pytest.mark.asyncio
+    @patch("totalreclaw.retype_setscope.build_and_send_userop_batch", new_callable=AsyncMock)
+    async def test_issue_470_retype_preserves_session_id(self, mock_send, keys):
+        existing_blob = _build_v1_blob_with_session(
+            fact_id="halibut-fact",
+            text="Halibut is my favorite fish",
+            session_id="sess-halibut-001",
+        )
+        # Sanity-check the fixture carries the stamp.
+        assert json.loads(existing_blob)["metadata"]["session_id"] == "sess-halibut-001"
+
+        relay = _build_relay_mock(keys, fact_id="halibut-fact", blob=existing_blob)
+        captured: list[list[bytes]] = []
+
+        async def capture(**kwargs):
+            captured.append(kwargs["protobuf_payloads"])
+            return "0xok"
+
+        mock_send.side_effect = capture
+
+        await execute_retype(
+            fact_id="halibut-fact",
+            new_type="preference",
+            keys=keys,
+            owner=OWNER,
+            relay=relay,
+            eoa_private_key=EOA_PRIVATE_KEY,
+            eoa_address=EOA_ADDRESS,
+            sender=OWNER,
+        )
+
+        parsed = self._decrypt_new_blob(captured, keys)
+        assert parsed["type"] == "preference"
+        assert parsed["superseded_by"] == "halibut-fact"
+        assert parsed.get("metadata", {}).get("session_id") == "sess-halibut-001", (
+            "retype must preserve metadata.session_id — issue #470 regression"
+        )
+
+    @pytest.mark.asyncio
+    @patch("totalreclaw.retype_setscope.build_and_send_userop_batch", new_callable=AsyncMock)
+    async def test_issue_470_set_scope_preserves_session_id(self, mock_send, keys):
+        existing_blob = _build_v1_blob_with_session(
+            fact_id="porto-fact",
+            text="I visited Porto last spring",
+            session_id="sess-porto-002",
+        )
+        relay = _build_relay_mock(keys, fact_id="porto-fact", blob=existing_blob)
+        captured: list[list[bytes]] = []
+
+        async def capture(**kwargs):
+            captured.append(kwargs["protobuf_payloads"])
+            return "0xok"
+
+        mock_send.side_effect = capture
+
+        await execute_set_scope(
+            fact_id="porto-fact",
+            new_scope="work",
+            keys=keys,
+            owner=OWNER,
+            relay=relay,
+            eoa_private_key=EOA_PRIVATE_KEY,
+            eoa_address=EOA_ADDRESS,
+            sender=OWNER,
+        )
+
+        parsed = self._decrypt_new_blob(captured, keys)
+        assert parsed["scope"] == "work"
+        assert parsed.get("metadata", {}).get("session_id") == "sess-porto-002", (
+            "set_scope must preserve metadata.session_id — issue #470 regression"
+        )
+
+    @pytest.mark.asyncio
+    @patch("totalreclaw.retype_setscope.build_and_send_userop_batch", new_callable=AsyncMock)
+    async def test_issue_470_retype_no_metadata_stays_clean(self, mock_send, keys):
+        """A source blob with no metadata must not gain a spurious key."""
+        existing_blob = _build_v1_blob(
+            fact_id="plain-fact",
+            text="No session stamp here",
+            fact_type="claim",
+        )
+        assert "metadata" not in json.loads(existing_blob)
+
+        relay = _build_relay_mock(keys, fact_id="plain-fact", blob=existing_blob)
+        captured: list[list[bytes]] = []
+
+        async def capture(**kwargs):
+            captured.append(kwargs["protobuf_payloads"])
+            return "0xok"
+
+        mock_send.side_effect = capture
+
+        await execute_retype(
+            fact_id="plain-fact",
+            new_type="preference",
+            keys=keys,
+            owner=OWNER,
+            relay=relay,
+            eoa_private_key=EOA_PRIVATE_KEY,
+            eoa_address=EOA_ADDRESS,
+            sender=OWNER,
+        )
+
+        parsed = self._decrypt_new_blob(captured, keys)
+        assert "metadata" not in parsed, (
+            "no-metadata source must stay byte-clean (no empty metadata key)"
+        )


### PR DESCRIPTION
## What broke
Curating a fact (pin/unpin/retype/set_scope) in Hermes silently wiped its per-conversation `session_id`, so the vault reader could no longer group that fact with its conversation.

## What's fixed
The pin/unpin (`operations.py`) and retype/set_scope (`retype_setscope.py`) rewrite paths now carry the source blob's `metadata` dict through to the new superseding blob (via `build_canonical_claim_v1(extra_metadata=…)`), preserving `metadata.session_id` (and #356 `import_source`). v0 legacy blobs predate the stamp → unchanged; metadata-less blobs stay byte-identical.

## Impact after fix
The #463 session_id stamp survives curation, so vault session-grouping stays intact after a user pins/retypes/rescopes a fact. No crypto/phrase/paymaster surface touched — pure metadata plumbing on already-decrypted blobs.

## Verification
Red→green regression tests in `test_retype_setscope.py` + `test_pin_unpin.py` assert session_id survives each of the four rewrites (fail pre-patch, pass post-patch) + a no-metadata-stays-clean guard. Full python suite: 2217 passed, 39 skipped, 0 failures.

Root cause: #484 Keeper A.2 supersession rework didn't carry `extra_metadata`. Drain re-extraction was investigated and is NOT the source of the observed null (it re-stamps with the current session id); scope kept narrow to the rewrite paths per the finding's own recommendation.

Closes #470
Umbrella #466 (already closed on 2.4.6 stable-promote); this sub-issue tracked independently.