### PR TITLE
fix(memq): preserve original session_id across pending-extract drain

### DIFF
--- a/python/src/totalreclaw/agent/lifecycle.py
+++ b/python/src/totalreclaw/agent/lifecycle.py
@@ -40,6 +40,10 @@ _INTERPRETER_SHUTDOWN_QUOTA_NOTE = (
     "on your next session. No data was lost."
 )
 
+# Sentinel distinguishing "no session override applied" from "override to
+# None" in ``auto_extract``'s save/restore of ``relay._session_id`` (#494).
+_SESSION_OVERRIDE_UNSET = object()
+
 
 def _owner_address(state: "AgentState") -> str:
     """Best-effort lookup of the configured owner address for queue keying.
@@ -187,7 +191,12 @@ def _is_near_duplicate(
     return False
 
 
-def auto_extract(state: "AgentState", mode: str = "turn", llm_config=None) -> list[str]:
+def auto_extract(
+    state: "AgentState",
+    mode: str = "turn",
+    llm_config=None,
+    session_id_override: Optional[str] = None,
+) -> list[str]:
     """Extract facts from conversation and store them.
 
     Tries LLM extraction first, falls back to heuristic if no LLM available.
@@ -199,6 +208,13 @@ def auto_extract(state: "AgentState", mode: str = "turn", llm_config=None) -> li
         mode: "turn" for incremental extraction, "full" for session-end flush.
         llm_config: Optional pre-resolved LLM configuration (e.g. from Hermes config).
             If not provided, ``extract_facts_llm`` falls back to env var detection.
+        session_id_override: When set, the relay session tag (which the relay
+            forwards as ``X-TotalReclaw-Session`` and the server stamps onto
+            ``metadata.session_id``) is temporarily overridden for the duration
+            of this extraction and restored afterwards. Used by the pending-drain
+            path so re-extracted facts carry the ORIGINAL session's id rather
+            than the draining session's (issue #494). An empty override is
+            treated as "no session" (header omitted).
 
     Returns:
         List of stored fact texts (for debrief context).
@@ -220,6 +236,16 @@ def auto_extract(state: "AgentState", mode: str = "turn", llm_config=None) -> li
     if not client:
         return []
 
+    # Drain-path session-id override (issue #494). Temporarily point the relay
+    # session tag at the original session so server-side metadata.session_id is
+    # stamped correctly, then restore. Reading it back inside the shutdown
+    # handler below also lets a re-deferred drain re-enqueue the ORIGINAL id.
+    relay = getattr(client, "_relay", None)
+    _saved_session_id = _SESSION_OVERRIDE_UNSET
+    if session_id_override is not None and relay is not None and hasattr(relay, "_session_id"):
+        _saved_session_id = relay._session_id
+        relay._session_id = session_id_override or None
+
     stored_texts: list[str] = []
 
     try:
@@ -232,9 +258,14 @@ def auto_extract(state: "AgentState", mode: str = "turn", llm_config=None) -> li
         # can't drive any more httpx work, so persist the unprocessed
         # buffer to disk and let the next session drain it. See
         # ``totalreclaw.agent.pending_drain`` and issue #148.
+        #
+        # Persist the source session id (issue #494) so the next-session drain
+        # re-stamps facts with the original session. ``relay._session_id`` here
+        # reflects any active override, so a re-deferred drain preserves it.
         owner = _owner_address(state)
+        source_session_id = getattr(relay, "_session_id", None) if relay is not None else None
         if owner:
-            persisted = enqueue_messages(owner, list(messages))
+            persisted = enqueue_messages(owner, list(messages), session_id=source_session_id)
         else:
             persisted = False
         if persisted:
@@ -259,6 +290,10 @@ def auto_extract(state: "AgentState", mode: str = "turn", llm_config=None) -> li
         # unprocessed is harmless (state dies with the process anyway) and
         # makes the failure visible to any in-process retry path.
         return []
+    finally:
+        # Restore the relay session tag if we overrode it (issue #494).
+        if _saved_session_id is not _SESSION_OVERRIDE_UNSET:
+            relay._session_id = _saved_session_id
 
 
 def _auto_extract_inner(

--- a/python/src/totalreclaw/agent/pending_drain.py
+++ b/python/src/totalreclaw/agent/pending_drain.py
@@ -26,7 +26,13 @@ owner address. Each line carries::
 
     {"owner": "<eoa-or-sa-hex>",
      "queued_at": "<iso8601>",
+     "session_id": "<original-session-id-or-empty>",
      "messages": [{"role": "...", "content": "..."}, ...]}
+
+``session_id`` records the source session's id (issue #494) so the
+next-session drain can stamp re-extracted facts with the ORIGINAL
+session, not the draining one. Absent on records written before #494 —
+drain treats a missing/empty value as "no override" (legacy behavior).
 
 Owner-keying lets a multi-account host (rare today; possible with future
 profile-switching) drain only its own batches. The file lives in
@@ -80,9 +86,16 @@ def _normalize_owners(owner: OwnerSpec) -> frozenset[str]:
 def enqueue_messages(
     owner: str,
     messages: list[dict],
+    session_id: Optional[str] = None,
     path: Optional[Path] = None,
 ) -> bool:
     """Append a batch of unprocessed messages to the pending queue.
+
+    ``session_id`` is the id of the session whose extraction is being
+    deferred. It is persisted so the next-session drain can stamp the
+    re-extracted facts with the ORIGINAL session rather than the draining
+    one (issue #494). ``None``/empty is stored as ``""`` and treated by the
+    reader as "no session override".
 
     Returns ``True`` on success, ``False`` if the disk write fails. A
     ``False`` return is logged at WARNING; callers may use it to decide
@@ -99,6 +112,7 @@ def enqueue_messages(
         record = {
             "owner": owner or "",
             "queued_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "session_id": session_id or "",
             "messages": messages,
         }
         with pending.open("a", encoding="utf-8") as fh:
@@ -119,7 +133,8 @@ def enqueue_messages(
 def drain_pending(
     owner: OwnerSpec,
     path: Optional[Path] = None,
-) -> list[list[dict]]:
+    with_meta: bool = False,
+) -> list:
     """Atomically read + remove all batches matching ``owner``.
 
     ``owner`` is either a single address string or any iterable of address
@@ -130,6 +145,13 @@ def drain_pending(
     Returns a list of message-lists (one per enqueued batch, in arrival
     order). Non-matching batches stay in the file. The file is removed
     when empty.
+
+    When ``with_meta`` is True, each element is instead a dict
+    ``{"messages": [...], "session_id": <str-or-None>}`` so the drain path
+    can stamp re-extracted facts with the batch's original session id
+    (issue #494). ``session_id`` is ``None`` for legacy pre-#494 records
+    that lack the field. The default (``with_meta=False``) preserves the
+    original message-list return shape for existing callers/tests.
 
     Drain on a missing or empty file returns ``[]`` without error — both
     conditions are normal (no prior shutdown loss, or another process
@@ -142,7 +164,7 @@ def drain_pending(
     accept = _normalize_owners(owner)
 
     keep_lines: list[str] = []
-    drained: list[list[dict]] = []
+    drained: list = []
     try:
         raw = pending.read_text(encoding="utf-8")
     except Exception as exc:
@@ -167,7 +189,11 @@ def drain_pending(
             continue
 
         if rec_owner in accept:
-            drained.append(rec_msgs)
+            if with_meta:
+                rec_sid = record.get("session_id") or None
+                drained.append({"messages": rec_msgs, "session_id": rec_sid})
+            else:
+                drained.append(rec_msgs)
         else:
             keep_lines.append(line)
 

--- a/python/src/totalreclaw/hermes/hooks.py
+++ b/python/src/totalreclaw/hermes/hooks.py
@@ -479,7 +479,7 @@ def on_session_start(state: "PluginState", **kwargs) -> None:
     try:
         owners = _owner_addresses(state)
         if owners and has_pending(owners):
-            batches = drain_pending(owners)
+            batches = drain_pending(owners, with_meta=True)
             recovered_count = _drain_into_state(state, batches)
             if recovered_count > 0:
                 logger.info(
@@ -563,9 +563,18 @@ def _maybe_queue_update_notice(state: "PluginState", billing: dict) -> None:
         pass
 
 
-def _drain_into_state(state: "PluginState", batches: list[list[dict]]) -> int:
+def _drain_into_state(state: "PluginState", batches: list) -> int:
     """Replay drained message batches into the agent state and run a
     full-mode auto-extract to land the facts.
+
+    Each ``batches`` element is a ``{"messages": [...], "session_id": <str
+    -or-None>}`` dict from ``drain_pending(..., with_meta=True)``. Batches
+    are extracted ONE AT A TIME so each batch's facts are stamped with the
+    ORIGINAL session's id (issue #494) via ``auto_extract``'s
+    ``session_id_override`` — a single combined extraction could only carry
+    one session tag. ``session_id`` is ``None`` for legacy pre-#494 records,
+    in which case no override is applied (facts keep the draining session's
+    id, the prior behavior).
 
     Returns the total number of messages recovered. Errors during the
     extraction call are logged and swallowed — drain is best-effort.
@@ -576,27 +585,45 @@ def _drain_into_state(state: "PluginState", batches: list[list[dict]]) -> int:
     if not batches:
         return 0
 
+    # Isolate drained content from any pre-existing unprocessed buffer so a
+    # stray message can't get swept into a batch's session-scoped extraction.
+    # (Drain runs early in ``on_session_start``, before the session's own
+    # turns, so this is normally a no-op.)
+    state.mark_messages_processed()
+
     total = 0
-    # Snapshot the original buffer so the active session's own messages
-    # stay intact after the drain. We process drained batches in a
-    # separate state-buffer slice via ``add_message`` + final
-    # ``mark_messages_processed`` so the user-visible session message
-    # buffer keeps the drained content for context.
     for batch in batches:
-        for msg in batch:
+        # Tolerate both the meta-dict shape and a bare message-list (older
+        # callers) so this stays robust to the ``with_meta`` flag.
+        if isinstance(batch, dict):
+            msgs = batch.get("messages") or []
+            session_id = batch.get("session_id") or None
+        else:
+            msgs = batch
+            session_id = None
+
+        added = 0
+        for msg in msgs:
             role = msg.get("role") if isinstance(msg, dict) else None
             content = msg.get("content") if isinstance(msg, dict) else None
             if role and content:
                 state.add_message(role, content)
-                total += 1
+                added += 1
 
-    if total == 0:
-        return 0
+        if added == 0:
+            continue
 
-    try:
-        _auto_extract(state, mode="full", llm_config=_get_hermes_llm_config())
-    except Exception as exc:
-        logger.warning("TotalReclaw: drain-side auto_extract failed: %s", exc)
+        try:
+            _auto_extract(
+                state,
+                mode="full",
+                llm_config=_get_hermes_llm_config(),
+                session_id_override=session_id,
+            )
+        except Exception as exc:
+            logger.warning("TotalReclaw: drain-side auto_extract failed: %s", exc)
+
+        total += added
 
     return total
 

--- a/python/tests/test_issue_148_interpreter_shutdown_drain.py
+++ b/python/tests/test_issue_148_interpreter_shutdown_drain.py
@@ -276,7 +276,7 @@ def test_on_session_start_drains_pending_into_state(pending_path, monkeypatch):
 
     drained_calls: list = []
 
-    def fake_auto_extract(state, mode="turn", llm_config=None):
+    def fake_auto_extract(state, mode="turn", llm_config=None, session_id_override=None):
         drained_calls.append({"mode": mode, "msg_count": len(state._messages)})
         return []
 

--- a/python/tests/test_issue_169_owner_key_stability.py
+++ b/python/tests/test_issue_169_owner_key_stability.py
@@ -279,7 +279,7 @@ def test_on_session_start_drains_eoa_queue_when_sa_eagerly_resolved(
 
     drained_calls: list = []
 
-    def fake_auto_extract(state, mode="turn", llm_config=None):
+    def fake_auto_extract(state, mode="turn", llm_config=None, session_id_override=None):
         drained_calls.append({"mode": mode, "msg_count": len(state._messages)})
         return []
 

--- a/python/tests/test_issue_494_drain_session_id.py
+++ b/python/tests/test_issue_494_drain_session_id.py
@@ -1,0 +1,296 @@
+"""Regression tests for issue #494.
+
+Split-out from #470 (Finding #7, umbrella #466). The mutation half —
+``retype``/``set_scope``/``pin``/``unpin`` dropping ``metadata.session_id``
+— was fixed in p-diogo/totalreclaw#526. This file covers the **drain half**.
+
+The bug
+-------
+When ``hermes chat -q`` hits an interpreter-shutdown race, the unprocessed
+buffer is persisted to ``~/.totalreclaw/.pending_extract.jsonl`` and
+re-extracted at the next ``on_session_start`` (``hooks._drain_into_state``
+→ ``lifecycle.auto_extract``). The server stamps ``metadata.session_id``
+from the relay ``X-TotalReclaw-Session`` header (``relay._session_id``),
+which at drain time carries the *draining* session, not the original. The
+old queue record only persisted ``{owner, queued_at, messages}`` — the
+source session id was never carried — so drained facts got the wrong
+session_id (or null).
+
+The fix
+-------
+* ``pending_drain.enqueue_messages`` persists the source ``session_id``.
+* ``pending_drain.drain_pending(..., with_meta=True)`` returns it per batch
+  (the default no-meta shape is unchanged for existing callers).
+* ``lifecycle.auto_extract`` gains ``session_id_override`` — it temporarily
+  points ``relay._session_id`` at the original session for the duration of
+  the extraction and restores it afterwards. Its shutdown handler persists
+  the (possibly-overridden) ``relay._session_id`` so a re-deferred drain
+  keeps the original.
+* ``hooks._drain_into_state`` extracts each batch separately, passing that
+  batch's original session id as the override.
+
+These tests pin: schema round-trip (persist + read), the write-side
+capture at shutdown, the lifecycle override + restore, and the hooks
+per-batch override.
+"""
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+import pytest
+
+from totalreclaw.agent.loop_runner import InterpreterShutdownError
+from totalreclaw.agent import pending_drain
+from totalreclaw.agent.pending_drain import (
+    drain_pending,
+    enqueue_messages,
+)
+
+
+@pytest.fixture
+def pending_path(tmp_path, monkeypatch):
+    p = tmp_path / ".pending_extract.jsonl"
+    monkeypatch.setattr(pending_drain, "_pending_path", lambda: p)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Fakes — a relay object carrying ``_session_id`` (the header the server
+# stamps onto ``metadata.session_id``) is the piece the issue-148/169 fakes
+# lacked.
+# ---------------------------------------------------------------------------
+
+
+class _FakeRelay:
+    def __init__(self, session_id: Optional[str] = None):
+        self._session_id = session_id
+
+
+class _FakeClient:
+    def __init__(self, *, eoa: str, sa: Optional[str] = None,
+                 session_id: Optional[str] = None, raise_on: str = "never"):
+        self._eoa_address = eoa
+        self._sa_address = sa
+        self._relay = _FakeRelay(session_id)
+        self._raise_on = raise_on
+
+    @property
+    def eoa_address(self) -> str:
+        return self._eoa_address
+
+    @property
+    def resolved_wallet_address(self) -> Optional[str]:
+        return self._sa_address
+
+    async def recall(self, *_a, **_kw):
+        if self._raise_on == "recall":
+            raise InterpreterShutdownError("simulated")
+        return []
+
+    async def remember_batch(self, *_a, **_kw):
+        if self._raise_on == "remember_batch":
+            raise InterpreterShutdownError("simulated")
+        return []
+
+    async def forget(self, *_a, **_kw):
+        return None
+
+
+class _FakeState:
+    def __init__(self, client: _FakeClient, messages: list[dict]):
+        self._client = client
+        self._messages = list(messages)
+        self._last_processed_idx = 0
+        self.quota_warning: Optional[str] = None
+
+    def is_configured(self) -> bool:
+        return True
+
+    def get_client(self):
+        return self._client
+
+    def get_unprocessed_messages(self):
+        return self._messages[self._last_processed_idx:]
+
+    def has_unprocessed_messages(self):
+        return self._last_processed_idx < len(self._messages)
+
+    def mark_messages_processed(self):
+        self._last_processed_idx = len(self._messages)
+
+    def get_max_facts_per_extraction(self):
+        return 5
+
+    def set_quota_warning(self, w: str):
+        self.quota_warning = w
+
+    def add_message(self, role: str, content: str):
+        self._messages.append({"role": role, "content": content})
+
+    def reset_turn_counter(self):
+        pass
+
+    def get_cached_billing(self):
+        return None
+
+    def start_session(self, external_id=None) -> str:
+        return "fake-session-id"
+
+
+# ---------------------------------------------------------------------------
+# 1. Queue schema: enqueue persists session_id, drain(with_meta) returns it.
+# ---------------------------------------------------------------------------
+
+
+def test_enqueue_persists_session_id_and_drain_with_meta_returns_it(pending_path):
+    owner = "0xabc0000000000000000000000000000000000001"
+    msgs = [{"role": "user", "content": "Hi I'm Pedro from Porto."}]
+
+    assert enqueue_messages(owner, msgs, session_id="sess-original-123") is True
+
+    batches = drain_pending(owner, with_meta=True)
+    assert len(batches) == 1
+    assert batches[0]["messages"] == msgs
+    assert batches[0]["session_id"] == "sess-original-123"
+
+
+def test_drain_with_meta_legacy_record_yields_none_session(pending_path):
+    """A record written before #494 has no ``session_id`` field — the reader
+    must degrade to ``None`` (no override), not KeyError."""
+    p = pending_drain._pending_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    legacy = {
+        "owner": "0xabc0000000000000000000000000000000000002",
+        "queued_at": "2026-07-15T00:00:00Z",
+        "messages": [{"role": "user", "content": "legacy"}],
+    }
+    p.write_text(json.dumps(legacy) + "\n", encoding="utf-8")
+
+    batches = drain_pending(legacy["owner"], with_meta=True)
+    assert len(batches) == 1
+    assert batches[0]["messages"] == legacy["messages"]
+    assert batches[0]["session_id"] is None
+
+
+def test_drain_without_meta_preserves_message_list_shape(pending_path):
+    """The default (no ``with_meta``) return contract is unchanged so the
+    existing #148 / #169 callers and tests keep working."""
+    owner = "0xabc0000000000000000000000000000000000003"
+    msgs = [{"role": "user", "content": "hi"}]
+    enqueue_messages(owner, msgs, session_id="s1")
+
+    drained = drain_pending(owner)
+    assert drained == [msgs]
+
+
+# ---------------------------------------------------------------------------
+# 2. Write side: the shutdown handler persists the source session id.
+# ---------------------------------------------------------------------------
+
+
+def test_shutdown_enqueue_persists_source_session_id(pending_path):
+    from totalreclaw.agent.lifecycle import auto_extract
+
+    eoa = "0xdeadbeef00000000000000000000000000000001"
+    state = _FakeState(
+        _FakeClient(eoa=eoa, session_id="live-session-xyz", raise_on="recall"),
+        [{"role": "user", "content": "Hi I'm Pedro."}],
+    )
+
+    assert auto_extract(state, mode="turn") == []
+
+    batches = drain_pending(eoa, with_meta=True)
+    assert len(batches) == 1
+    # Pre-fix this was absent/empty; the drained facts would then get the
+    # NEXT session's id.
+    assert batches[0]["session_id"] == "live-session-xyz"
+
+
+# ---------------------------------------------------------------------------
+# 3. Lifecycle override: relay session tag is swapped during extraction and
+#    restored afterwards.
+# ---------------------------------------------------------------------------
+
+
+def test_auto_extract_overrides_relay_session_then_restores(pending_path, monkeypatch):
+    from totalreclaw.agent import lifecycle
+
+    seen = {}
+
+    def fake_inner(state, mode, llm_config, messages, max_facts, client, stored_texts):
+        seen["session_at_extract"] = client._relay._session_id
+        state.mark_messages_processed()
+        return []
+
+    monkeypatch.setattr(lifecycle, "_auto_extract_inner", fake_inner)
+
+    client = _FakeClient(eoa="0xabc0000000000000000000000000000000000004",
+                         session_id="draining-session")
+    state = _FakeState(client, [{"role": "user", "content": "hello world"}])
+
+    lifecycle.auto_extract(state, mode="full", session_id_override="original-session")
+
+    # During extraction the relay carried the ORIGINAL session.
+    assert seen["session_at_extract"] == "original-session"
+    # After extraction the draining session's tag is restored.
+    assert client._relay._session_id == "draining-session"
+
+
+def test_auto_extract_without_override_leaves_relay_session_untouched(pending_path, monkeypatch):
+    from totalreclaw.agent import lifecycle
+
+    seen = {}
+
+    def fake_inner(state, mode, llm_config, messages, max_facts, client, stored_texts):
+        seen["session_at_extract"] = client._relay._session_id
+        state.mark_messages_processed()
+        return []
+
+    monkeypatch.setattr(lifecycle, "_auto_extract_inner", fake_inner)
+
+    client = _FakeClient(eoa="0xabc0000000000000000000000000000000000005",
+                         session_id="draining-session")
+    state = _FakeState(client, [{"role": "user", "content": "hi"}])
+
+    lifecycle.auto_extract(state, mode="full")  # no override
+
+    assert seen["session_at_extract"] == "draining-session"
+    assert client._relay._session_id == "draining-session"
+
+
+# ---------------------------------------------------------------------------
+# 4. Hooks: each drained batch is extracted with its OWN original session id.
+# ---------------------------------------------------------------------------
+
+
+def test_drain_into_state_applies_per_batch_session_override(pending_path, monkeypatch):
+    from totalreclaw.hermes import hooks
+
+    eoa = "0xdeadbeef00000000000000000000000000000002"
+    enqueue_messages(eoa, [{"role": "user", "content": "from-session-A"}],
+                     session_id="sess-A")
+    enqueue_messages(eoa, [{"role": "user", "content": "from-session-B"}],
+                     session_id="sess-B")
+
+    calls: list = []
+
+    def fake_auto_extract(state, mode="turn", llm_config=None, session_id_override=None):
+        calls.append({
+            "content": state._messages[-1]["content"],
+            "override": session_id_override,
+        })
+        return []
+
+    monkeypatch.setattr(hooks, "_auto_extract", fake_auto_extract)
+    monkeypatch.setattr(hooks, "_get_hermes_llm_config", lambda: None)
+
+    state = _FakeState(_FakeClient(eoa=eoa), [])
+    hooks.on_session_start(state, session_id="new-draining-session")
+
+    # Both batches drained, each stamped with its own ORIGINAL session id —
+    # NOT the new draining session.
+    by_content = {c["content"]: c["override"] for c in calls}
+    assert by_content.get("from-session-A") == "sess-A"
+    assert by_content.get("from-session-B") == "sess-B"
+    assert "new-draining-session" not in by_content.values()


### PR DESCRIPTION
## What broke
In Hermes CLI one-shot mode (`hermes chat -q`), facts recovered after an interpreter-shutdown race were stamped with the **wrong** session id — the next (draining) session's, or null — so the SPA grouped them under the wrong conversation.

## What's fixed
The pending-extract queue now carries the **original** session id, and drain re-extraction stamps each recovered batch with its own source session (via a temporary relay `X-TotalReclaw-Session` override), restoring the draining session afterward.

## Impact after fix
Drained facts land under the conversation they were actually spoken in. Cosmetic SPA session-grouping only; no change to which facts are recovered.

## Verification
Race-path (interpreter shutdown) can't be exercised through a real chat flow, so verification is test-based — the existing `test_issue_148_*` approach. New `test_issue_494_drain_session_id.py` (7 tests: schema round-trip, write-side capture at shutdown, lifecycle override+restore, hooks per-batch) fails on the pre-patch tree (6/7) and passes post-patch. Full sweep of all 16 test files touching these paths: **256 passed**.

---

**Drain half** of totalreclaw-internal#470 (Finding #7, umbrella #466). Mutation half was #526.

Root cause: `enqueue_messages` persisted only `{owner, queued_at, messages}`; the session id is stamped server-side from `relay._session_id`, which at drain time is the draining session. `_drain_into_state` also ran a single combined extraction, so no single carried id could be per-batch-correct.

Fix (3 source files, under the triage 5-file scope guard):
1. `pending_drain` — enqueue persists `session_id`; `drain_pending(..., with_meta=True)` returns it per batch. Default no-meta shape unchanged → existing #148/#169 callers + tests untouched.
2. `lifecycle.auto_extract` — `session_id_override` temporarily points `relay._session_id` at the original session, then restores; shutdown handler persists the (overridden) id so a re-deferred drain keeps the original.
3. `hooks._drain_into_state` — extracts each batch separately with its own original session id.

Backward compat: legacy pre-fix records (no `session_id` field) drain with `None` override → prior behavior, no crash, no data loss.

Ships bundled into the next Hermes RC (no standalone RC publish for a `severity:low` cosmetic fix).

Fixes p-diogo/totalreclaw-internal#494