### PR TITLE
feat(app): functional vault export — MCP-round-trippable .json/.md + confirm gate (#323)

### DIFF
--- a/app/src/lib/export.test.ts
+++ b/app/src/lib/export.test.ts
@@ -1,0 +1,140 @@
+/**
+ * #323 — vault export serializers.
+ *
+ * The contract under test is MCP round-trip compatibility: the JSON shape
+ * must satisfy `parseJsonContent` in mcp/src/tools/import.ts (a `facts`
+ * array whose items carry `text` + optional `importance`/`type`/`id`), and
+ * the markdown must satisfy `parseMarkdownContent` (`## <text>` sections
+ * split by `---`, `**Importance:**` / `**Type:**` bullets, `ID: \`…\``).
+ * The markdown assertions below literally apply the importer's regexes.
+ */
+import { describe, it, expect } from "vitest";
+import { toExportJson, toExportMarkdown, exportFilename, EXPORT_VERSION } from "./export";
+import type { VaultItem, MemoryClaimV1 } from "./types";
+
+function item(overrides: Partial<MemoryClaimV1> = {}, extra: Partial<VaultItem> = {}): VaultItem {
+  const claim: MemoryClaimV1 = {
+    id: "fact-1",
+    text: "Pedro lives in Porto",
+    type: "claim",
+    source: "user",
+    created_at: "2026-07-01T10:00:00.000Z",
+    schema_version: "1.0",
+    importance: 7,
+    ...overrides,
+  };
+  return {
+    id: claim.id,
+    claim,
+    type: claim.type,
+    pinned: false,
+    createdAt: new Date("2026-07-01T10:00:00.000Z"),
+    rawBlob: "00",
+    blindIndices: [],
+    decayScore: 100,
+    isActive: true,
+    ...extra,
+  };
+}
+
+const NOW = new Date("2026-07-16T00:00:00.000Z");
+
+describe("toExportJson", () => {
+  it("emits the MCP export envelope: version + exported_at + facts[]", () => {
+    const parsed = JSON.parse(toExportJson([item()], NOW));
+    expect(parsed.version).toBe(EXPORT_VERSION);
+    expect(parsed.exported_at).toBe(NOW.toISOString());
+    expect(Array.isArray(parsed.facts)).toBe(true);
+    expect(parsed.facts).toHaveLength(1);
+  });
+
+  it("each fact carries the importer-required keys with exact values", () => {
+    const f = JSON.parse(toExportJson([item()], NOW)).facts[0];
+    expect(f.id).toBe("fact-1");
+    expect(f.text).toBe("Pedro lives in Porto");
+    expect(f.type).toBe("claim");
+    expect(f.importance).toBe(7);
+    expect(f.created_at).toBe("2026-07-01T10:00:00.000Z");
+    expect(f.source).toBe("user");
+    expect(f.metadata).toEqual({ tags: [], source: "user" });
+  });
+
+  it("surfaces optional v1 fields only when present", () => {
+    const rich = JSON.parse(
+      toExportJson(
+        [
+          item({
+            scope: "work",
+            volatility: "stable",
+            reasoning: "chose X because Y",
+            entities: [{ name: "Porto", type: "place" }] as MemoryClaimV1["entities"],
+            agent_name: "John",
+            metadata: { session_id: "s-42" },
+          }),
+        ],
+        NOW,
+      ),
+    ).facts[0];
+    expect(rich.scope).toBe("work");
+    expect(rich.volatility).toBe("stable");
+    expect(rich.reasoning).toBe("chose X because Y");
+    expect(rich.entities).toHaveLength(1);
+    expect(rich.agent_name).toBe("John");
+    expect(rich.metadata.session_id).toBe("s-42");
+
+    const bare = JSON.parse(toExportJson([item()], NOW)).facts[0];
+    for (const k of ["scope", "volatility", "reasoning", "entities", "agent_name", "pin_status"]) {
+      expect(bare).not.toHaveProperty(k);
+    }
+  });
+
+  it("normalizes legacy 0–1 importance to the 1–10 scale and defaults to 5", () => {
+    expect(JSON.parse(toExportJson([item({ importance: 0.9 })], NOW)).facts[0].importance).toBe(9);
+    expect(JSON.parse(toExportJson([item({ importance: undefined })], NOW)).facts[0].importance).toBe(5);
+  });
+});
+
+describe("toExportMarkdown (importer-regex round-trip)", () => {
+  const md = toExportMarkdown(
+    [item(), item({ id: "fact-2", text: "Prefers dark mode", type: "preference", importance: 4 })],
+    NOW,
+  );
+
+  it("parses back with the exact mcp parseMarkdownContent logic", () => {
+    // Verbatim port of mcp/src/tools/import.ts parseMarkdownContent.
+    const sections = md.split(/^---$/m);
+    const facts: Array<{ text: string; importance?: number; type?: string; id?: string }> = [];
+    for (const section of sections) {
+      const headingMatch = section.match(/^##\s+(.+)$/m);
+      if (!headingMatch) continue;
+      const text = headingMatch[1].trim();
+      const impMatch = section.match(/\*\*Importance:\*\*\s*(\d+)/);
+      const typeMatch = section.match(/\*\*Type:\*\*\s*(\w+)/);
+      const idMatch = section.match(/ID:\s*`([^`]+)`/);
+      facts.push({
+        text,
+        importance: impMatch ? parseInt(impMatch[1], 10) : undefined,
+        type: typeMatch?.[1],
+        id: idMatch?.[1],
+      });
+    }
+    expect(facts).toEqual([
+      { text: "Pedro lives in Porto", importance: 7, type: "claim", id: "fact-1" },
+      { text: "Prefers dark mode", importance: 4, type: "preference", id: "fact-2" },
+    ]);
+  });
+
+  it("renders every item plus the export header", () => {
+    expect(md).toContain("# TotalReclaw Export");
+    expect(md).toContain(`**Exported:** ${NOW.toISOString()}`);
+    expect(md).toContain("**Total Facts:** 2");
+    expect(md).toContain("- **Source:** user");
+  });
+});
+
+describe("exportFilename", () => {
+  it("stamps the UTC date", () => {
+    expect(exportFilename("json", NOW)).toBe("totalreclaw-export-20260716.json");
+    expect(exportFilename("md", NOW)).toBe("totalreclaw-export-20260716.md");
+  });
+});

--- a/app/src/lib/export.ts
+++ b/app/src/lib/export.ts
@@ -1,0 +1,107 @@
+/**
+ * Vault export serializers (#323 — one-click plain-text portability).
+ *
+ * Both formats mirror the MCP server's `totalreclaw_export` output
+ * (mcp/src/tools/export.ts) so an SPA export round-trips through the MCP
+ * `totalreclaw_import` tool:
+ *   - JSON: `{ version, exported_at, facts: [...] }` — the importer's
+ *     `parseJsonContent` reads `facts[].text/importance/type/id` and
+ *     tolerates every additional field.
+ *   - Markdown: `## <text>` sections separated by `---` with
+ *     `**Importance:**` / `**Type:**` bullets and an `ID: \`…\`` line —
+ *     exactly what the importer's `parseMarkdownContent` matches.
+ *
+ * Everything here is pure serialization of already-decrypted items; the
+ * plaintext never leaves the browser.
+ */
+import type { VaultItem } from "./types";
+
+export const EXPORT_VERSION = "1.0.0";
+
+/** `totalreclaw-export-YYYYMMDD.<ext>` (UTC date). */
+export function exportFilename(ext: "json" | "md", now: Date = new Date()): string {
+  const ymd = now.toISOString().slice(0, 10).replace(/-/g, "");
+  return `totalreclaw-export-${ymd}.${ext}`;
+}
+
+/** v1 importance is a 1–10 integer; default to the rubric midpoint. */
+function importanceOf(item: VaultItem): number {
+  const raw = item.claim.importance;
+  if (typeof raw !== "number" || Number.isNaN(raw)) return 5;
+  // Legacy blobs occasionally carry the 0–1 normalized scale.
+  const scaled = raw > 0 && raw <= 1 ? raw * 10 : raw;
+  return Math.min(10, Math.max(1, Math.round(scaled)));
+}
+
+function exportedFact(item: VaultItem): Record<string, unknown> {
+  const c = item.claim;
+  const base: Record<string, unknown> = {
+    id: item.id,
+    text: c.text,
+    importance: importanceOf(item),
+    created_at: item.createdAt.toISOString(),
+    type: item.type,
+    source: c.source,
+  };
+  if (c.scope) base.scope = c.scope;
+  if (c.volatility) base.volatility = c.volatility;
+  if (c.reasoning) base.reasoning = c.reasoning;
+  if (c.expires_at) base.expires_at = c.expires_at;
+  if (c.confidence != null) base.confidence = c.confidence;
+  if (c.superseded_by) base.superseded_by = c.superseded_by;
+  if (c.entities?.length) base.entities = c.entities;
+  // Additive fields the MCP export doesn't carry (importers ignore them).
+  if (c.agent_name) base.agent_name = c.agent_name;
+  if (item.pinned) base.pin_status = c.pin_status ?? "pinned";
+  base.metadata = {
+    tags: c.tags ?? [],
+    source: c.source,
+    ...(c.metadata?.session_id ? { session_id: c.metadata.session_id } : {}),
+  };
+  return base;
+}
+
+export function toExportJson(items: VaultItem[], now: Date = new Date()): string {
+  return JSON.stringify(
+    {
+      version: EXPORT_VERSION,
+      exported_at: now.toISOString(),
+      facts: items.map(exportedFact),
+    },
+    null,
+    2,
+  );
+}
+
+export function toExportMarkdown(items: VaultItem[], now: Date = new Date()): string {
+  const lines: string[] = [
+    `# TotalReclaw Export`,
+    ``,
+    `**Exported:** ${now.toISOString()}`,
+    `**Total Facts:** ${items.length}`,
+    ``,
+    `---`,
+    ``,
+  ];
+
+  for (const item of items) {
+    const c = item.claim;
+    lines.push(`## ${c.text}`);
+    lines.push(``);
+    lines.push(`- **Importance:** ${importanceOf(item)}/10`);
+    lines.push(`- **Created:** ${item.createdAt.toISOString()}`);
+    lines.push(`- **Type:** ${item.type}`);
+    lines.push(`- **Source:** ${c.source}`);
+    if (c.scope) lines.push(`- **Scope:** ${c.scope}`);
+    if (c.reasoning) lines.push(`- **Reasoning:** ${c.reasoning}`);
+    if (c.volatility) lines.push(`- **Volatility:** ${c.volatility}`);
+    if (c.tags?.length) lines.push(`- **Tags:** ${c.tags.join(", ")}`);
+    lines.push(``);
+    lines.push(`ID: \`${item.id}\``);
+    lines.push(``);
+    lines.push(`---`);
+    lines.push(``);
+  }
+
+  return lines.join("\n");
+}

--- a/app/src/pages/SettingsPage.tsx
+++ b/app/src/pages/SettingsPage.tsx
@@ -5,7 +5,7 @@ import { useCrypto } from "../contexts/CryptoContext";
 import { useVault } from "../hooks/useVault";
 import { getAccount } from "../lib/api";
 import { AppHeader } from "../components/AppHeader";
-import { relativeDate } from "../lib/format";
+import { toExportJson, toExportMarkdown, exportFilename } from "../lib/export";
 import type { VaultItem } from "../lib/types";
 
 function download(filename: string, content: string, mime: string) {
@@ -18,22 +18,20 @@ function download(filename: string, content: string, mime: string) {
   URL.revokeObjectURL(url);
 }
 
-function toJson(items: VaultItem[]): string {
-  return JSON.stringify(
-    items.map((i) => i.claim),
-    null,
-    2,
-  );
-}
-
-function toMarkdown(items: VaultItem[]): string {
-  const lines = ["# TotalReclaw vault export", ""];
-  for (const i of items) {
-    lines.push(`- **[${i.claim.type}]** ${i.claim.text}`);
-    const meta = [i.claim.source, i.claim.scope, relativeDate(i.createdAt)].filter(Boolean);
-    lines.push(`  - _${meta.join(" · ")}_`);
+/** Sensitive-action gate (#323): the file is unencrypted plaintext. */
+function confirmThenExport(items: VaultItem[], format: "json" | "md") {
+  if (
+    !confirm(
+      `Export ${items.length} memories as ${format === "json" ? ".json" : ".md"}? The file is UNENCRYPTED — anyone who opens it can read your memories. Keep it somewhere safe.`,
+    )
+  ) {
+    return;
   }
-  return lines.join("\n");
+  if (format === "json") {
+    download(exportFilename("json"), toExportJson(items), "application/json");
+  } else {
+    download(exportFilename("md"), toExportMarkdown(items), "text/markdown");
+  }
 }
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
@@ -113,14 +111,14 @@ export function SettingsPage() {
           </p>
           <div className="mt-3 flex gap-2">
             <button
-              onClick={() => download("totalreclaw-vault.json", toJson(items), "application/json")}
+              onClick={() => confirmThenExport(items, "json")}
               disabled={items.length === 0}
               className="rounded-control bg-clay px-4 py-2 text-sm font-semibold text-warm-white hover:bg-clay-deep disabled:opacity-40"
             >
               Export .json
             </button>
             <button
-              onClick={() => download("totalreclaw-vault.md", toMarkdown(items), "text/markdown")}
+              onClick={() => confirmThenExport(items, "md")}
               disabled={items.length === 0}
               className="rounded-control bg-surface px-4 py-2 text-sm font-semibold text-ink ring-1 ring-hairline hover:ring-clay disabled:opacity-40"
             >


### PR DESCRIPTION
Closes #323.

The Settings page already had export buttons, but the payloads weren't round-trippable (bare claim-array JSON; list-style markdown the MCP importer can't parse). This makes the one-click plain-text export real:

- **.json** mirrors the MCP `totalreclaw_export` envelope — `{version, exported_at, facts[]}` with `id/text/importance/created_at/type/source` + optional v1 fields (scope, volatility, reasoning, entities…), plus additive `agent_name`/`pin_status`/`session_id` (ignored by importers). Legacy 0–1 importance normalized to the 1–10 scale.
- **.md** emits the exact `parseMarkdownContent` grammar from `mcp/src/tools/import.ts` (`## <text>` sections, `---` separators, `**Importance:**`/`**Type:**` bullets, `ID:` line) — the test literally re-parses the output with the importer's verbatim regexes and asserts field-exact recovery.
- **Sensitive-action confirm** before download (file is UNENCRYPTED plaintext) + dated filenames (`totalreclaw-export-YYYYMMDD.json/.md`).
- Fully client-side (Blob download; no relay change).

## Verification
- `npx tsc --noEmit` → 0
- `npm test` → 161/161 (17 files; 7 new in `export.test.ts` incl. the importer-regex round-trip)
- `npm run build` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SztW6QFyp5t1ux4gW2mW6