### PR TITLE
docs: fresh-eyes triage — human/agent setup split, pair-flow reconcile, IronClaw caveats, import gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ One command per client. v1 is the default — no env toggles, no feature flags.
 | Client | Install |
 |---|---|
 | **OpenClaw** | `openclaw plugins install @totalreclaw/totalreclaw` |
-| **Claude Desktop / Cursor / Windsurf** | `npx @totalreclaw/mcp-server setup` |
+| **Claude Desktop / Cursor / Windsurf** | `npx @totalreclaw/mcp-server setup` — run it yourself in a terminal, never via your AI agent (the wizard prints your recovery phrase, which must not enter the agent's context) |
 | **NanoClaw** | add `TOTALRECLAW_RECOVERY_PHRASE` to deployment env |
 | **Python / Hermes** | `pip install totalreclaw` |
 | **Rust / ZeroClaw** | `cargo add totalreclaw-memory` |
-| **IronClaw** | via MCP server — see [IronClaw setup](docs/guides/ironclaw-setup.md) |
+| **IronClaw** | via the generic MCP server (first-class integration paused) — see [IronClaw setup](docs/guides/ironclaw-setup.md) |
 
 Then set one env var on your host:
 
@@ -78,7 +78,7 @@ v1 shipped across every client in April 2026. Highlights:
 - **Source-weighted reranking** — user-authored claims consistently rank above assistant-regurgitated noise. Structurally fixes the [97.8% junk problem](https://github.com/mem0ai/mem0/issues/4573) documented in other memory systems.
 - **3 new MCP tools** — `totalreclaw_pin`, `totalreclaw_retype`, `totalreclaw_set_scope`. Invoked by natural language ("pin that", "file that under work").
 - **Protobuf v4 wire format** — outer wrapper bump; subgraph schema unchanged.
-- **Env var cleanup** — 6 experimental env vars removed. 5 user-facing env vars remain. See the [env vars reference](docs/guides/env-vars-reference.md).
+- **Env var cleanup** — several experimental env vars removed; a small set of user-facing env vars remain. See the [env vars reference](docs/guides/env-vars-reference.md).
 
 > Benchmark headline: *(placeholder — filled in once phase 2 500-conv run lands 2026-04-18)* — v1's source-weighted reranker preserves recall quality while breaking the importance-clustering pathology.
 
@@ -93,6 +93,8 @@ Already using another AI assistant with memory? Tell your agent:
 - *"Import my Gemini history into TotalReclaw"*
 
 Supported sources: **ChatGPT** (memories or conversations.json), **Claude** (memory export), **Gemini** (Google Takeout), **Mem0** (API or file), **MCP Memory Server** (JSONL). All imports are encrypted client-side before storage. See the [import guide](docs/guides/importing-memories.md).
+
+On the managed service, the free tier includes one lifetime import; re-importing from additional sources is a Pro feature. See [pricing](https://totalreclaw.xyz/pricing).
 
 ## Packages
 
@@ -145,7 +147,7 @@ totalreclaw/
 - [Client setup — v1](docs/guides/client-setup-v1.md) — one install command per client.
 - [Memory types guide](docs/guides/memory-types-guide.md) — what gets stored and how to override it via natural language.
 - [v1 migration guide](docs/guides/v1-migration.md) — if you're upgrading from v0.
-- [Environment variables](docs/guides/env-vars-reference.md) — the 5 env vars that matter.
+- [Environment variables](docs/guides/env-vars-reference.md) — the user-facing env vars that matter.
 - [Feature comparison](docs/guides/feature-comparison.md) — which features work on which client.
 
 ### Per-client setup
@@ -154,7 +156,7 @@ totalreclaw/
 - [Claude Desktop / Cursor / Windsurf](docs/guides/claude-code-setup.md)
 - [NanoClaw](docs/guides/nanoclaw-getting-started.md)
 - [Hermes (Python)](docs/guides/hermes-setup.md)
-- [IronClaw (NEAR AI)](docs/guides/ironclaw-setup.md)
+- [IronClaw (NEAR AI)](docs/guides/ironclaw-setup.md) (first-class integration paused — works via the generic MCP server)
 - [ZeroClaw (Rust)](docs/guides/zeroclaw-setup.md)
 
 ### Specs + architecture

--- a/docs/guides/claude-code-setup.md
+++ b/docs/guides/claude-code-setup.md
@@ -8,7 +8,7 @@ If you already have Claude Code (or Claude Desktop / Cursor / Windsurf) running,
 
 > **Install TotalReclaw, see <https://github.com/p-diogo/totalreclaw/blob/main/docs/guides/claude-code-setup.md>**
 
-Your agent will fetch this page, run the MCP install command, and walk you through getting a recovery phrase into the config without ever printing it in chat. The phrase comes from your browser (via the OpenClaw or Hermes account-setup flow) or from a phrase you already have on file.
+Your agent will fetch this page, run the MCP install command, and walk you through getting a recovery phrase into the config without ever printing it in chat. The phrase comes from a browser-side account-setup flow (the MCP server's own `totalreclaw_pair`, or the OpenClaw / Hermes equivalent), or from a phrase you already have on file.
 
 ---
 
@@ -37,7 +37,7 @@ claude mcp add -s user totalreclaw -- npx -y @totalreclaw/mcp-server
 
 This registers `totalreclaw` at user scope (available across all Claude Code sessions). Do NOT pass `-e TOTALRECLAW_RECOVERY_PHRASE=...` here — the user will add the phrase themselves in Step 3 so it never enters your context.
 
-To pin a release candidate: `claude mcp add -s user totalreclaw -- npx -y @totalreclaw/mcp-server@rc` (latest RC) or `@totalreclaw/mcp-server@latest` (current stable).
+To pin a release candidate: `claude mcp add -s user totalreclaw -- npx -y @totalreclaw/mcp-server@rc` (newest RC line) or `@totalreclaw/mcp-server@latest` (current stable). Prefer `@latest` — the `rc` dist-tag tracks the newest release-candidate and can lag `latest`, so `@rc` is not necessarily newer than stable; use it only to test a specific RC.
 
 If the CLI exits cleanly, continue to Step 3. If it fails with `command not found` / ENOENT, fall back to Step 2B.
 
@@ -89,7 +89,7 @@ Once the user replies `done`, ask the agent's own internal toolset (yourself): *
 
 ### Phrase safety (HARD — never break)
 
-NEVER echo, generate, or ask the user to paste a recovery phrase in chat. NEVER invoke `npx @totalreclaw/mcp-server setup`, `npx @totalreclaw/totalreclaw generate-mnemonic`, or any phrase-touching CLI via your shell tool — stdout enters LLM context. The MCP server has NO browser account-setup flow (it's stateless JSON-RPC); the user MUST source their phrase from another TotalReclaw client's account-setup flow (OpenClaw / Hermes browser flow), reuse `~/.totalreclaw/credentials.json` from a prior install, or paste a phrase they generated offline directly into the config file. If the user pastes a phrase in chat anyway: tell them it is compromised and they need to generate a fresh wallet via the OpenClaw or Hermes browser account-setup flow.
+NEVER echo, generate, or ask the user to paste a recovery phrase in chat. NEVER invoke `npx @totalreclaw/mcp-server setup`, `npx @totalreclaw/totalreclaw generate-mnemonic`, or any phrase-touching CLI via your shell tool — stdout enters LLM context. The MCP server is stateless JSON-RPC (no HTTP server of its own), but it DOES expose a browser-mediated account-setup flow via the `totalreclaw_pair` tool — the phrase is generated/imported in the browser, uploaded as ciphertext, decrypted in-memory, and written to `~/.totalreclaw/credentials.json`, so it never enters your context. Prefer `totalreclaw_pair`; otherwise the user can reuse `~/.totalreclaw/credentials.json` from a prior install, run the OpenClaw / Hermes browser account-setup flow, or paste a phrase they generated offline directly into the config file. If the user pastes a phrase in chat anyway: tell them it is compromised and they need to generate a fresh wallet via a browser account-setup flow (`totalreclaw_pair`, or OpenClaw / Hermes).
 
 ---
 
@@ -149,7 +149,7 @@ claude mcp add -s user totalreclaw -- npx -y @totalreclaw/mcp-server
 
 Restart the host. Verify by asking *"Do you have access to TotalReclaw memory tools?"*.
 
-> **Pin a specific RC** with `args: ["-y", "@totalreclaw/mcp-server@rc"]` (latest RC) or `@totalreclaw/mcp-server@3.3.1-rc.22` (pinned). Stable is `3.4.0` on the `latest` dist-tag. Check what each tag resolves to: `npm view @totalreclaw/mcp-server dist-tags`.
+> **Pin a specific version** with `args: ["-y", "@totalreclaw/mcp-server@latest"]` (stable — recommended) or `@totalreclaw/mcp-server@<specific-rc>` (e.g. `3.4.1-rc.3`) to test a particular RC. Prefer `@latest` in production: the `rc` dist-tag (`@totalreclaw/mcp-server@rc`) tracks the newest release-candidate line and can lag `latest`, so `@rc` is not necessarily newer than stable. Check what each tag resolves to: `npm view @totalreclaw/mcp-server dist-tags`.
 
 ---
 
@@ -161,7 +161,7 @@ Restart the host. Verify by asking *"Do you have access to TotalReclaw memory to
 | Auto-extract every N turns | yes (lifecycle hook) | no — host invokes `totalreclaw_remember` when its prompt tells it to |
 | Pre-compaction flush | yes | no |
 | Session debrief | yes | no (use `totalreclaw_debrief` explicitly) |
-| Browser account-setup flow | yes (`totalreclaw_pair` account-setup tool) | **no** — MCP is stateless JSON-RPC; phrase must come from another client or offline tool |
+| Browser account-setup flow | yes (`totalreclaw_pair` account-setup tool) | yes (`totalreclaw_pair` browser pairing — phrase generated/imported in the browser, never in chat) |
 | First-run welcome | yes (host prepends context on session start) | no — MCP doesn't expose session lifecycle to the server |
 
 MCP is the lowest-overhead integration but the most explicit. You'll talk naturally and the host will still recall / store via tool calls when its context gates fire — you just won't get the every-turn automatic behavior that OpenClaw and Hermes provide.
@@ -237,8 +237,12 @@ Upgrade: *"Upgrade my TotalReclaw subscription."*
 ## MCP-specific notes
 
 - **MCP is stateless.** There's no first-run welcome, no lifecycle hooks, and no auto-restart on config change. You restart the host explicitly to pick up new config.
-- **No browser account-setup flow.** The MCP server has no HTTP routes — phrase entry is the user's responsibility (config file, env var, or copying from another client's `credentials.json`). This is by design: keeping crypto secrets out of LLM context is more important than convenience parity with OpenClaw / Hermes.
-- **Account setup uses `totalreclaw_pair`.** It opens a browser-mediated pairing flow: the agent calls `totalreclaw_pair`, which returns a URL + 6-digit PIN. The user opens the URL in any browser, the browser generates (or imports) the recovery phrase, encrypts it, and uploads ciphertext to the MCP server, which decrypts it in-memory and writes `~/.totalreclaw/credentials.json`. The phrase never enters LLM context, chat, stdout, or logs. After pairing, the user restarts the host so the server re-reads the credentials file and switches out of unconfigured mode.
+- **Three ways to get a recovery phrase in.** The MCP server is stateless JSON-RPC — it has no HTTP server or lifecycle hooks of its own — but it still offers three setup paths:
+  1. **`totalreclaw_pair` (browser flow, agent-safe).** The agent calls `totalreclaw_pair`, which returns a URL + 6-digit PIN. The user opens the URL in any browser, the browser generates (or imports) the recovery phrase, encrypts it, and uploads ciphertext to the MCP server, which decrypts it in-memory and writes `~/.totalreclaw/credentials.json`. The phrase never enters LLM context, chat, stdout, or logs. After pairing, the user restarts the host so the server re-reads the credentials file and switches out of unconfigured mode.
+  2. **`npx @totalreclaw/mcp-server setup` (terminal wizard, human-run only).** The wizard generates a phrase, registers with the relay, and prints a config snippet — including the phrase — to stdout. Because that stdout would enter an agent's context, this is for the **human** to run in their own terminal; an agent must never invoke it via a shell tool.
+  3. **Manual.** The user sources a phrase elsewhere — another client's `~/.totalreclaw/credentials.json`, or a phrase generated offline — and pastes it into the host config env (`TOTALRECLAW_RECOVERY_PHRASE`).
+
+  Keeping crypto secrets out of LLM context is the through-line: `totalreclaw_pair` and the manual path never expose the phrase to the agent, and the terminal wizard is human-only for the same reason.
 
 ---
 

--- a/docs/guides/client-setup-v1.md
+++ b/docs/guides/client-setup-v1.md
@@ -15,7 +15,7 @@ One setup page per client. v1 is the default on every client — no env toggles,
 | NanoClaw (OpenClaw's lightweight variant) | [NanoClaw skill](#nanoclaw-skill) |
 | Python / Hermes Agent | [Python client](#python-client) |
 | Native Rust app / ZeroClaw (NEAR AI) | [ZeroClaw](#zeroclaw-rust-crate) |
-| IronClaw (NEAR AI) | [MCP server via IronClaw](#mcp-server) |
+| IronClaw (NEAR AI) | [MCP server via IronClaw](#mcp-server) (integration paused) |
 
 All clients write to the same vault. If you use multiple clients, use the same 12-word recovery phrase everywhere.
 
@@ -65,7 +65,7 @@ That's it. v1 taxonomy, source-weighted reranking, and the new pin / retype / se
 npx @totalreclaw/mcp-server setup
 ```
 
-The wizard generates a 12-word recovery phrase, registers you with the relay, and prints a config snippet.
+The wizard generates a 12-word recovery phrase, registers you with the relay, and prints a config snippet. Run it yourself in a terminal — never ask your AI agent to run it (the wizard prints your recovery phrase, which must not enter the agent's context).
 
 ### Claude Desktop
 
@@ -154,7 +154,7 @@ async def main():
     await client.remember(
         "Pedro prefers dark mode for all editors",
         fact_type="preference",
-        importance=0.8,
+        importance=0.8,  # 0.0–1.0
     )
 
     results = await client.recall("What does Pedro prefer?")
@@ -169,7 +169,7 @@ asyncio.run(main())
 ### Hermes Agent
 
 ```bash
-pip install totalreclaw[hermes]
+pip install totalreclaw
 ```
 
 The plugin registers automatically with Hermes Agent v0.5.0+.
@@ -202,7 +202,7 @@ memory.store_v1(V1StoreInput {
     source: "user".into(),
     scope: Some("personal".into()),
     volatility: Some("stable".into()),
-    importance: 0.8,
+    importance: 8,  // 1–10 (u8; normalized to 0.0–1.0 on-chain)
     reasoning: None,
 }).await?;
 ```

--- a/docs/guides/env-vars-reference.md
+++ b/docs/guides/env-vars-reference.md
@@ -1,7 +1,7 @@
 # Environment Variables Reference
 
 **Applies to:** TotalReclaw v1 (all clients).
-**Last updated:** 2026-04-25.
+**Last updated:** 2026-07-16.
 
 v1 deliberately removes every env var that was an internal knob pretending to be user configuration. The list below is the **complete** set of env vars that end users or deployment operators should ever need to set.
 
@@ -149,7 +149,6 @@ These env vars existed in earlier versions and are now silently ignored. Delete 
 | `TOTALRECLAW_TAXONOMY_VERSION` | v1 is the only format. No opt-in needed. |
 | `TOTALRECLAW_CLAIM_FORMAT` | Same reason — the v0 `{text, metadata}` shape is gone. |
 | `TOTALRECLAW_DIGEST_MODE` | Digest behaviour is no longer user-configurable. |
-| `TOTALRECLAW_AUTO_RESOLVE_MODE` | Contradiction-resolution policy is managed by the shared core. |
 | `TOTALRECLAW_HOT_RELOAD` | Kept for OpenClaw plugin development only — see plugin README. |
 | `TOTALRECLAW_TWO_TIER_SEARCH` | Merged into the default search path. |
 
@@ -190,7 +189,7 @@ See [client-consistency spec](../specs/totalreclaw/client-consistency.md) for th
 
 | Env var | Purpose |
 |---|---|
-| `TOTALRECLAW_AUTO_RESOLVE_MODE` | Internal emergency kill-switch for the auto-contradiction-resolution loop (`active` / `shadow` / `off`). Not documented to end users; reserved for incident response. |
+| `TOTALRECLAW_AUTO_RESOLVE_MODE` | Internal emergency kill-switch for the auto-contradiction-resolution loop (`active` / `shadow` / `off`). Not part of user-facing config; reserved for incident response only. |
 
 ---
 

--- a/docs/guides/feature-comparison.md
+++ b/docs/guides/feature-comparison.md
@@ -8,7 +8,7 @@ All clients ship v1 by default. Stable production versions: core 2.5.6 (npm; 2.5
 
 ## Platform Feature Matrix
 
-| Feature | OpenClaw | MCP (Claude Desktop, Cursor, Windsurf) | NanoClaw | Hermes (Python) | IronClaw (NEAR AI) | ZeroClaw (Rust) |
+| Feature | OpenClaw | MCP (Claude Desktop, Cursor, Windsurf) | NanoClaw | Hermes (Python) | IronClaw (NEAR AI) — paused | ZeroClaw (Rust) |
 |---------|:-:|:-:|:-:|:-:|:-:|:-:|
 | **Memory Taxonomy v1** | | | | | | |
 | 6-type taxonomy (claim/preference/directive/commitment/episode/summary) | Yes (default) | Yes | Yes (via MCP) | Yes | Yes (via MCP) | Yes |
@@ -40,19 +40,21 @@ All clients ship v1 by default. Stable production versions: core 2.5.6 (npm; 2.5
 | Broadened search fallback | Yes | Yes | Yes | Yes | Yes | Yes |
 | Hot cache (skip remote on repeat) | Yes | -- | -- | -- | -- | Yes |
 
+> **Import is Pro-only on the managed service.** Importing from Mem0 / ChatGPT / Claude / Gemini is a Pro feature on the managed service (the free tier includes one lifetime import). Self-hosted deployments have no such limit.
+
 ---
 
 ## Platform Notes
 
 **OpenClaw** -- Fully automatic. Memory extraction and recall happen via lifecycle hooks with no user intervention. Best experience for users who want set-and-forget memory.
 
-**MCP (Claude Desktop, Cursor, Windsurf)** -- Tools only. The host agent (Claude, Cursor, etc.) decides when to call memory tools based on context. No automatic extraction -- the agent uses tools when contextually appropriate. Setup via `npx @totalreclaw/mcp-server setup`.
+**MCP (Claude Desktop, Cursor, Windsurf)** -- Tools only. The host agent (Claude, Cursor, etc.) decides when to call memory tools based on context. No automatic extraction -- the agent uses tools when contextually appropriate. Setup via `npx @totalreclaw/mcp-server setup` (run it yourself in a terminal, never via your AI agent -- the wizard prints your recovery phrase).
 
 **NanoClaw** -- Automatic, like OpenClaw. The NanoClaw agent-runner spawns the MCP server as a background process. Memory is shared within the NanoClaw group. No user setup required -- the admin configures the recovery phrase.
 
 **Hermes (Python)** -- Automatic via pre/post LLM call hooks. LLM extraction with heuristic fallback. Full tool parity with OpenClaw plugin since 2.3.x: remember / recall / forget / export / status / account-setup (`totalreclaw_pair`) / pin / unpin / retype / set_scope / import_from / upgrade. Consolidate is self-hosted-only (no batch delete on the managed service) and is exposed via the plugin / MCP server.
 
-**IronClaw (NEAR AI)** -- Uses the MCP server for tools. No lifecycle hooks -- auto-extraction requires setting up routines (cron). The TEE protects the runtime; TotalReclaw protects the data.
+**IronClaw (NEAR AI)** -- First-class integration has been paused since 2026-04-18; IronClaw works via the generic MCP server only (no `ironclaw mcp add` CLI, no lifecycle hooks). It uses the MCP server for tools; auto-extraction requires setting up routines (cron). The TEE protects the runtime; TotalReclaw protects the data.
 
 **ZeroClaw (Rust)** -- Native Rust implementation via the Memory trait. Automatic recall and extraction. Includes hot cache, decay handling (7-day half-life), and conflict resolution. Import not yet implemented.
 

--- a/docs/guides/hermes-setup.md
+++ b/docs/guides/hermes-setup.md
@@ -1,7 +1,7 @@
 # TotalReclaw on Hermes — agent setup reference
 
 > **Audience: the AI agent installing TotalReclaw inside a Hermes runtime.**
-> Not for human readers. (A separate user guide will be linked here when it exists.)
+> This is the operational / agent reference — the procedure the agent follows end-to-end. For a human-friendly quick start, see [client-setup-v1.md](./client-setup-v1.md) §Python client.
 
 This document describes how the agent installs and sets up TotalReclaw on Hermes. The agent uses the tool surface listed here. The user only types one of the install prompts below in their chat client; everything else happens through tools.
 

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -68,7 +68,7 @@ Then follow the matching guide above.
 
 ## Current channels
 
-The install commands in each guide are version-agnostic and never go stale. Stable always lands the newest final release; RC always lands the newest pre-release.
+The install commands in each guide are version-agnostic and never go stale. Stable always lands the newest final release; RC always lands the newest pre-release. Note that `rc` can lag `latest`: the `rc` dist-tag points at the newest release-candidate line, which is not necessarily newer than the newest final on `latest` — so prefer `@latest` unless you are deliberately testing a specific RC.
 
 | Runtime | Package | Stable | RC (newest pre-release) |
 |---|---|---|---|


### PR DESCRIPTION
Fixes from a first-time-visitor audit of the docs (part of the production-readiness sweep). Every fix direction was ground-truthed against code before dispatch.

## Changes
- **Human-vs-agent setup split** (README, client-setup-v1, feature-comparison): `npx @totalreclaw/mcp-server setup` is a real, supported human-run terminal wizard (`mcp/src/index.ts:1782`) — but its stdout contains the recovery phrase, so agents must never run it. The docs previously read as self-contradicting (README recommending what the safety guide "forbids"); they now draw the line explicitly.
- **claude-code-setup.md pair-flow reconcile**: the guide simultaneously claimed "the MCP server has NO account-setup flow" and described `totalreclaw_pair`. Rewritten as the coherent three-path story (pair browser flow / human terminal wizard / manual config), verified against `mcp/src/tools/pair.ts`; all agent-scoped phrase-safety rules intact.
- **`pip install totalreclaw[hermes]` → `pip install totalreclaw`** — the extra doesn't exist (pyproject has only `dev`).
- **`importance` ranges documented and corrected**: Python example annotated 0.0–1.0 (`client.py:552`); the Rust example's `importance: 0.8` couldn't compile against `V1StoreInput.importance: u8` (1–10 scale, `store.rs:270`) — fixed to `8` with the range comment.
- **IronClaw paused caveats** on every summary surface that presented it as a live first-class client (README table + list, client-setup-v1, feature-comparison header + notes) — previously disclosed only inside the setup guide itself.
- **Import Pro-gating disclosed** (README + feature-comparison): free tier = one lifetime import on the managed service.
- **`@rc` dist-tag lag notes** (claude-code-setup, install.md): `rc` tracks the newest RC line and can lag `latest` (true today: mcp-server rc=3.3.0-rc.4 < latest=3.4.0); recommend `@latest`.
- **hermes-setup.md** header no longer tells the humans the README sends there "Not for human readers" — now points them to client-setup-v1 §Python.
- **env-vars-reference.md**: `TOTALRECLAW_AUTO_RESOLVE_MODE` was listed as both Removed and a live internal kill-switch; reconciled to kill-switch-only. Stamp refreshed.

## Verification
Independent model review (pinned-base diff, code-verified): APPROVE, zero findings — wizard human-scoping, pair.ts behavior, u8 importance, missing extra, and dist-tag states all confirmed against source/registries; scope exactly the 7 permitted files; forbidden areas (pricing paragraph, badges, Mem0/Zep sentence, specs, deployment.md) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLFumVFqmN7kSCCDN2ELfp