### PR TITLE
chore(plugin): open the 3.4.0 line — base version bump (D3)

### DIFF
--- a/skill/plugin/package-lock.json
+++ b/skill/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.13",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/totalreclaw",
-      "version": "3.3.13",
+      "version": "3.4.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.3.13",
+  "version": "3.4.0",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [

--- a/skill/plugin/register-command-name.test.ts
+++ b/skill/plugin/register-command-name.test.ts
@@ -279,7 +279,9 @@ const skillJson = JSON.parse(fs.readFileSync(path.join(__dirname, 'skill.json'),
 // stable publishing consolidated onto npm-publish.yml (#509): the stable
 // publish now carries the clean version in package.json instead of
 // promote-rc.yml re-tagging an rc in-workflow.
-const validVersionPattern = /^3\.3\.(7-rc\.[3-9]\d*|8-rc\.\d+|9-rc\.\d+|10-rc\.\d+|1[1-9](-rc\.\d+)?|[2-9]\d(-rc\.\d+)?|[1-9]\d*\.\d+|[1-9]\d{2,}.*)$/;
+// 3.4+ minor lines (with optional -rc.N) became valid when the 3.4.0 RC line
+// opened (executeBatch revival + AA24 guard, 2026-07-20).
+const validVersionPattern = /^3\.(3\.(7-rc\.[3-9]\d*|8-rc\.\d+|9-rc\.\d+|10-rc\.\d+|1[1-9](-rc\.\d+)?|[2-9]\d(-rc\.\d+)?|[1-9]\d*\.\d+|[1-9]\d{2,}.*)|([4-9]|[1-9]\d+)\.\d+(-rc\.\d+)?)$/;
 
 assert(
   validVersionPattern.test(packageJson.version),

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "3.3.13",
+  "version": "3.4.0",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",


### PR DESCRIPTION
Opens the 3.4.0 RC line per Pedro's D3 approval (2026-07-20): `package.json` + lockfile + `skill.json` 3.3.13 → 3.4.0, so `npm-publish.yml` (which appends `-rc.N` to the base version) can cut **3.4.0-rc.1** carrying the two unreleased changes on main:
- #531 — executeBatch revival (byte-capped adaptive batching, up to ~30× fewer sponsored UserOps per extraction burst)
- #523 — AA24 sponsor-clobber initCode guard

Minor bump because batching is a feature. `register-command-name.test.ts`'s version pattern extended to accept 3.4+ minor lines (was anchored to 3.3.x families).

## Verification
- Full plugin gate `node run-tests.mjs`: 92/92 PASS, EXIT=0 (includes the updated version-pattern test)
- Rebased on current main tip

Next after merge: dispatch `npm-publish.yml` package=plugin release-type=rc rc-number=1 → auto-QA line runs → stable promote stays Pedro's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SztW6QFyp5t1ux4gW2mW6