### PR TITLE
feat(app): 30-day sliding TTL on the wrapped-key vault record (#440)

### DIFF
--- a/app/src/contexts/CryptoContext.tsx
+++ b/app/src/contexts/CryptoContext.tsx
@@ -30,7 +30,13 @@ import { isPasskeyPrfAvailable } from "../lib/auth/prf-support";
 import { enrolPasskey, getPrfSecret, PrfUnsupportedError } from "../lib/auth/passkey";
 import { wrapKey, unwrapKey, deriveMasterWrapSecret } from "../lib/auth/wrap";
 import { runWithMasterKey } from "../lib/auth/master";
-import { saveVaultRecord, loadVaultRecord, hasAnyVault, clearVault } from "../lib/vault/idb";
+import {
+  saveVaultRecord,
+  loadVaultRecord,
+  hasAnyVault,
+  clearVault,
+  refreshVaultRecordTtl,
+} from "../lib/vault/idb";
 import { saveSessionKeys, loadSessionKeys, clearSessionKeys } from "../lib/vault/session-storage";
 import { registerSession } from "../lib/api";
 
@@ -205,6 +211,10 @@ export function CryptoProvider({ children }: { children: ReactNode }) {
     credIdRef.current = credId;
     // Idempotent: ensures the relay user row exists (cheap; needed on fresh relay state).
     await registerSession(sk).catch(() => {});
+    // Sliding TTL (#440): a successful unlock re-news created_at so an active
+    // vault never ages out. Best-effort — a write failure must not block unlock
+    // (the worst case is the record eventually expiring into re-bootstrap).
+    await refreshVaultRecordTtl(rec).catch(() => {});
     enterUnlocked(sk, rec.smart_account, rec.chain_id);
   }, [enterUnlocked]);
 

--- a/app/src/contexts/CryptoContext.tsx
+++ b/app/src/contexts/CryptoContext.tsx
@@ -274,7 +274,14 @@ export function CryptoProvider({ children }: { children: ReactNode }) {
     const { prfSecret } = await getPrfSecret({ credentialId: credId });
     try {
       credIdRef.current = credId;
-      return await runWithMasterKey(rec.wrapped_master_key, prfSecret, fn);
+      const result = await runWithMasterKey(rec.wrapped_master_key, prfSecret, fn);
+      // #440 sliding TTL: this path is also a successful passkey unlock (fresh
+      // PRF assertion per call), and it's the only unlock a long-lived tab
+      // restored from sessionStorage ever performs — without the refresh here
+      // an active curator's record could age out mid-session. Best-effort,
+      // mirroring unlock().
+      refreshVaultRecordTtl(rec).catch(() => {});
+      return result;
     } finally {
       prfSecret.fill(0);
     }

--- a/app/src/lib/vault/idb.test.ts
+++ b/app/src/lib/vault/idb.test.ts
@@ -1,16 +1,23 @@
 import "fake-indexeddb/auto";
 import { describe, it, expect, beforeEach } from "vitest";
-import { clear } from "idb-keyval";
+import { clear, keys } from "idb-keyval";
 import {
   saveVaultRecord,
   loadVaultRecord,
   hasAnyVault,
   clearVault,
+  isVaultRecordExpired,
+  refreshVaultRecordTtl,
+  VAULT_RECORD_TTL_SECONDS,
   type VaultRecord,
 } from "./idb";
 import { wrapKey } from "../auth/wrap";
 
-function record(sa: string): VaultRecord {
+// Mirrors the storage prefix in idb.ts (not exported) so tests can assert a
+// record was actually DELETED from IndexedDB, not merely hidden by the TTL.
+const PREFIX = "totalreclaw-spa:vault:";
+
+function record(sa: string, createdAt: number = Math.floor(Date.now() / 1000)): VaultRecord {
   const secret = new Uint8Array(32).fill(7);
   const key = new Uint8Array(32).fill(9);
   return {
@@ -21,8 +28,12 @@ function record(sa: string): VaultRecord {
     wrapped_vault_key: wrapKey(key, secret),
     wrapped_auth_key: wrapKey(key, secret),
     wrapped_master_key: wrapKey(key, secret),
-    created_at: 1_700_000_000,
+    created_at: createdAt,
   };
+}
+
+async function vaultKeysInIdb(): Promise<string[]> {
+  return (await keys()).map(String).filter((k) => k.startsWith(PREFIX));
 }
 
 beforeEach(async () => {
@@ -64,5 +75,66 @@ describe("vault idb store", () => {
     await saveVaultRecord(rec);
     await clearVault(rec.smart_account);
     expect(await hasAnyVault()).toBe(false);
+  });
+});
+
+describe("vault record TTL (#440)", () => {
+  it("treats a record exactly at the TTL as still live (strict >)", () => {
+    const created = 1_000_000;
+    const atTtl = record("0x000000000000000000000000000000000000000d", created);
+    // age == TTL  -> live
+    expect(isVaultRecordExpired(atTtl, created + VAULT_RECORD_TTL_SECONDS)).toBe(false);
+    // age == TTL + 1s -> expired
+    expect(isVaultRecordExpired(atTtl, created + VAULT_RECORD_TTL_SECONDS + 1)).toBe(true);
+  });
+
+  it("loads a fresh record normally (an active user is unaffected)", async () => {
+    const sa = "0x000000000000000000000000000000000000000e";
+    await saveVaultRecord(record(sa)); // created_at = now
+    expect(await hasAnyVault()).toBe(true);
+    expect((await loadVaultRecord(sa))?.smart_account).toBe(sa);
+  });
+
+  it("purges a record older than the TTL on load — reads as absent and is gone from IDB", async () => {
+    const sa = "0x000000000000000000000000000000000000000f";
+    const expiredAt = Math.floor(Date.now() / 1000) - VAULT_RECORD_TTL_SECONDS - 60;
+    await saveVaultRecord(record(sa, expiredAt));
+    expect(await loadVaultRecord(sa)).toBeNull();
+    // DELETED, not merely hidden — no vault key remains in IndexedDB:
+    expect(await vaultKeysInIdb()).toEqual([]);
+    expect(await hasAnyVault()).toBe(false);
+  });
+
+  it("purges an expired record on the no-SA (first-vault) load path", async () => {
+    const sa = "0x0000000000000000000000000000000000000010";
+    const expiredAt = Math.floor(Date.now() / 1000) - VAULT_RECORD_TTL_SECONDS - 60;
+    await saveVaultRecord(record(sa, expiredAt));
+    expect(await loadVaultRecord()).toBeNull();
+    expect(await vaultKeysInIdb()).toEqual([]);
+  });
+
+  it("hasAnyVault purges an expired record and reports no vault", async () => {
+    const sa = "0x0000000000000000000000000000000000000011";
+    const expiredAt = Math.floor(Date.now() / 1000) - VAULT_RECORD_TTL_SECONDS - 60;
+    await saveVaultRecord(record(sa, expiredAt));
+    expect(await hasAnyVault()).toBe(false);
+    expect(await vaultKeysInIdb()).toEqual([]);
+  });
+
+  it("refreshVaultRecordTtl bumps created_at to ~now (sliding TTL), preserving wrapped keys", async () => {
+    const sa = "0x0000000000000000000000000000000000000012";
+    const stale = record(sa, 1_700_000_000); // would otherwise be long expired
+    await saveVaultRecord(stale);
+    await refreshVaultRecordTtl(stale);
+    const loaded = await loadVaultRecord(sa);
+    expect(loaded).not.toBeNull();
+    const now = Math.floor(Date.now() / 1000);
+    expect(loaded!.created_at).toBeGreaterThanOrEqual(now - 2);
+    expect(loaded!.created_at).toBeLessThanOrEqual(now);
+    // Only the timestamp moved — identity + wrapped keys are byte-identical.
+    expect(loaded!.smart_account).toBe(sa);
+    expect(loaded!.wrapped_vault_key).toEqual(stale.wrapped_vault_key);
+    expect(loaded!.wrapped_auth_key).toEqual(stale.wrapped_auth_key);
+    expect(loaded!.wrapped_master_key).toEqual(stale.wrapped_master_key);
   });
 });

--- a/app/src/lib/vault/idb.ts
+++ b/app/src/lib/vault/idb.ts
@@ -20,26 +20,85 @@ export interface VaultRecord {
 }
 
 const PREFIX = "totalreclaw-spa:vault:";
+
+/**
+ * Defense-in-depth sliding TTL on the wrapped-key record (#440).
+ *
+ * The record already stores only passkey-wrapped keys — the mnemonic is NEVER
+ * at rest (design §4.5) — so this is not a primary secrets control. It bounds
+ * how long an abandoned device's wrapped keys survive in IndexedDB: a record
+ * older than this is treated as absent on load (deleted; the UI falls back to
+ * the normal passkey re-bootstrap / recovery-phrase flow).
+ * `refreshVaultRecordTtl` bumps `created_at` on every successful passkey
+ * unlock, so an actively-used vault never ages out — only an idle one does.
+ */
+export const VAULT_RECORD_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
 const recordKey = (sa: string) => PREFIX + sa.toLowerCase();
 
 export async function saveVaultRecord(rec: VaultRecord): Promise<void> {
   await set(recordKey(rec.smart_account), rec);
 }
 
+/**
+ * Is a record past its TTL? The clock is injected so the boundary is testable
+ * exactly: a record whose age EQUALS the TTL is still live (strict `>`).
+ */
+export function isVaultRecordExpired(rec: VaultRecord, now: number): boolean {
+  return now - rec.created_at > VAULT_RECORD_TTL_SECONDS;
+}
+
+/**
+ * Sliding-TTL refresh: bump `created_at` to now and re-save. Call on every
+ * successful passkey unlock so an active vault never ages out (#440). Wrapped
+ * keys are carried through byte-identical — only the timestamp moves.
+ */
+export async function refreshVaultRecordTtl(rec: VaultRecord): Promise<void> {
+  await saveVaultRecord({ ...rec, created_at: nowSeconds() });
+}
+
+/** Return `rec` only if it is live; otherwise delete it (treated as absent) and return null. */
+async function liveOrNull(rec: VaultRecord | null): Promise<VaultRecord | null> {
+  if (!rec || !isVaultRecordExpired(rec, nowSeconds())) return rec;
+  await del(recordKey(rec.smart_account));
+  return null;
+}
+
 /** Load by Smart Account, or (when omitted) the first vault on this device. */
 export async function loadVaultRecord(smartAccount?: string): Promise<VaultRecord | null> {
   if (smartAccount) {
-    return ((await get<VaultRecord>(recordKey(smartAccount))) as VaultRecord | undefined) ?? null;
+    const rec = ((await get<VaultRecord>(recordKey(smartAccount))) as VaultRecord | undefined) ?? null;
+    return liveOrNull(rec);
   }
   const all = await keys();
   const first = all.map(String).find((k) => k.startsWith(PREFIX));
   if (!first) return null;
-  return ((await get<VaultRecord>(first)) as VaultRecord | undefined) ?? null;
+  const rec = ((await get<VaultRecord>(first)) as VaultRecord | undefined) ?? null;
+  return liveOrNull(rec);
 }
 
+/**
+ * Any live wrapped-key record on this device? Expired records encountered here
+ * are treated as absent — deleted — so a device whose only record has aged out
+ * reports `false` and the UI falls back to bootstrap/recovery (#440).
+ */
 export async function hasAnyVault(): Promise<boolean> {
   const all = await keys();
-  return all.map(String).some((k) => k.startsWith(PREFIX));
+  const vaultKeys = all.map(String).filter((k) => k.startsWith(PREFIX));
+  let anyLive = false;
+  for (const k of vaultKeys) {
+    const rec = (await get<VaultRecord>(k)) as VaultRecord | undefined;
+    if (rec && !isVaultRecordExpired(rec, nowSeconds())) {
+      anyLive = true;
+    } else if (rec) {
+      await del(k); // expired → purge
+    }
+  }
+  return anyLive;
 }
 
 /** Remove a vault's wrapped keys from THIS device. On-chain data is untouched. */


### PR DESCRIPTION
Closes #440 — the remaining Stage-B delta per the 2026-07-16 scoping (the IndexedDB wrapped-key store itself shipped with the passkey arc). Decision (Pedro, D4): **30 days, refreshed on every successful passkey unlock**.

## What ships
- `VAULT_RECORD_TTL_SECONDS = 30d` in `lib/vault/idb.ts`; `isVaultRecordExpired` (strict `>`, exactly-at-TTL is live), purge-on-load in BOTH `loadVaultRecord` branches and `hasAnyVault` (expired record deleted from IDB → UI falls back to /bootstrap with its recovery-phrase path — traced, no dead end).
- **Sliding refresh** after successful unwrap in `unlock()` AND (review finding) in `withMasterKey()` — the latter is the only unlock a sessionStorage-restored tab ever performs, so without it an active curator's record could age out mid-session.
- Mnemonic-never-at-rest invariant untouched: no changes under `lib/auth/`; refresh re-stores byte-identical wrapped keys with a bumped `created_at` (pinned by test); schema stays v1, valid records load exactly as before.

## Verification
- `tsc --noEmit` 0 · vitest **167/167** (6 new TTL tests, written red→green — 5 observed red against TTL-less code) · build OK — worker run + coordinator independent re-run + post-review-fix run
- Sonnet-high review: APPROVE — purge coverage verified on every path (no idb-keyval bypass), refresh strictly after successful unwrap, no ms/seconds mismatch, no legacy missing-`created_at` case exists; its one LOW finding (withMasterKey refresh) is included here.

Implementation: GLM worker (cc-glm) + coordinator review-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SztW6QFyp5t1ux4gW2mW6