### PR TITLE
chore(core): open the 2.6.0 line — base bump for the embedding-codec release

### DIFF
--- a/rust/totalreclaw-core/Cargo.lock
+++ b/rust/totalreclaw-core/Cargo.lock
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "totalreclaw-core"
-version = "2.5.6"
+version = "2.6.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/rust/totalreclaw-core/Cargo.toml
+++ b/rust/totalreclaw-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "totalreclaw-core"
-version = "2.5.6"
+version = "2.6.0"
 edition = "2021"
 description = "TotalReclaw core — E2EE crypto, reranker, wallet, UserOp, store/search pipelines. Single source of truth for all clients."
 license = "MIT"

--- a/rust/totalreclaw-core/pyproject.toml
+++ b/rust/totalreclaw-core/pyproject.toml
@@ -7,7 +7,7 @@ name = "totalreclaw-core"
 # Keep in lockstep with Cargo.toml [package].version. maturin uses THIS value
 # for the PyPI wheel version; Cargo.toml drives crates.io + the wasm-pack npm
 # package. Both MUST match or the PyPI wheel ships under the wrong version.
-version = "2.5.6"
+version = "2.6.0"
 description = "TotalReclaw crypto core — E2EE, LSH, blind indices, protobuf encoding (Rust)"
 requires-python = ">=3.10"
 license = { text = "MIT" }


### PR DESCRIPTION
Opens the core 2.6.0 line (Cargo.toml + pyproject.toml + lockfile 2.5.6 → 2.6.0). First release to carry the #479 canonical f16 embedding codec (#543) — publishing it + bumping the plugin dep flips TS clients' embedding writes to canonical f16 (feature-detected, #544), which is also the **durable fix for the 3.4.0-rc.1 QA blocker internal#498** (32KB byte cap × ~27KB legacy JSON-embedding payloads ⇒ batch groups of 1; f16 payloads ≈ 4-5KB/fact ⇒ real groups of 6-8).

Minor bump — additive API only. Full native suite green on the bump (see commit).

**Publish gate: Pedro's nod** — a new core line feeds every client; the RC cut (`npm-publish.yml package=core release-type=rc`) is held until he approves the respin plan on internal#497. Merge of this base bump is safe independently (no publish happens on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SztW6QFyp5t1ux4gW2mW6