### PR TITLE
fix(plugin): pin @totalreclaw/core 2.6.0-rc.1 — real f16 embedding writes (closes internal#498)

### DIFF
--- a/skill/plugin/embedding/embedding-codec.test.ts
+++ b/skill/plugin/embedding/embedding-codec.test.ts
@@ -169,11 +169,23 @@ check('write-path: core-present encode aborts (throws) on NaN — fail-closed', 
   assert.throws(() => encodeEmbeddingPayloadWithCore(bad, spy), /fail-closed|finite/i);
 });
 
-check('default write-path falls back to JSON when core codec unavailable', () => {
-  // Installed published core (2.5.6) predates the codec -> resolveCoreCodec()
-  // returns null in this environment -> legacy JSON.
-  const payload = encodeEmbeddingPayload(FIXTURE.unit_vector);
+check('write-path falls back to legacy JSON when NO core codec is present', () => {
+  // Install-agnostic: drive the injectable seam with a null core rather than
+  // relying on the ambient @totalreclaw/core version (which now varies —
+  // 2.6.0-rc.1+ ships the codec and correctly writes canonical f16, older
+  // cores write JSON). `null` deterministically exercises the legacy branch.
+  const payload = encodeEmbeddingPayloadWithCore(FIXTURE.unit_vector, null);
   assert.ok(payload.trimStart().startsWith('['));
+});
+
+check('write-path emits canonical f16 (not JSON) when a core codec IS present', () => {
+  // The #479 Part B goal + the #498 batching fix: with a real core codec the
+  // write path produces the compact canonical payload, never the fat JSON
+  // array. Driven via the seam so it holds regardless of the installed core.
+  const spy = makeSpyCore();
+  const payload = encodeEmbeddingPayloadWithCore(FIXTURE.unit_vector, spy);
+  assert.ok(!payload.trimStart().startsWith('['), 'canonical payload must not be JSON');
+  assert.deepEqual(spy.seen, FIXTURE.unit_vector, 'core encoder received the vector');
 });
 
 // ---------------------------------------------------------------------------

--- a/skill/plugin/package-lock.json
+++ b/skill/plugin/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@scure/bip39": "^2.2.0",
         "@totalreclaw/client": "^1.3.0",
-        "@totalreclaw/core": "^2.5.3",
+        "@totalreclaw/core": "2.6.0-rc.1",
         "qrcode": "^1.5.4",
         "qrcode-terminal": "^0.12.0",
         "ws": "^8.18.3"
@@ -817,9 +817,9 @@
       "license": "MIT"
     },
     "node_modules/@totalreclaw/core": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@totalreclaw/core/-/core-2.5.3.tgz",
-      "integrity": "sha512-W0lVgV5lv6VsIts/YOU32msSUh5Jj4hCir+MRKub+KhB5wb9nGbYNaj7MBH1DewMI8Rp6TGgfSr7gr3iV/sqmw==",
+      "version": "2.6.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@totalreclaw/core/-/core-2.6.0-rc.1.tgz",
+      "integrity": "sha512-d3wbavhELtaI4XDDbeiTGrjePIFHadUmxFZgLhr73qKTxucGp09XZV9KAlw1dJ5gxPhYd9J2ohOs0R7WneSn/A==",
       "license": "MIT"
     },
     "node_modules/@types/node": {

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@scure/bip39": "^2.2.0",
     "@totalreclaw/client": "^1.3.0",
-    "@totalreclaw/core": "^2.5.3",
+    "@totalreclaw/core": "2.6.0-rc.1",
     "qrcode": "^1.5.4",
     "qrcode-terminal": "^0.12.0",
     "ws": "^8.18.3"


### PR DESCRIPTION
**Closes the 3.4.0-rc.1 QA blocker internal#498** (executeBatch 'all Batch group of 1').

## Root cause (not a batching-logic bug)
The 32KB byte cap × the plugin's legacy **~27KB-per-fact JSON embeddings** mathematically forces singleton groups — `groupPayloadsBySize` was working exactly as designed. #479 Part B feature-detects the core codec and flips the write to canonical f16, but only fires with a core that HAS the codec — and the dep was `^2.5.3`, a **caret range that excludes the `2.6.0-rc.1` prerelease** (npm won't pull a higher-version prerelease into a caret range), so the build silently kept using stable 2.5.6 (no codec). Pinned to `2.6.0-rc.1` (first core carrying the #479 codec, published today).

## Proof this fixes #498
With the pinned core, `encodeEmbeddingPayload(640-d)` returns a **1708-char canonical f16 base64 payload, not the ~5KB JSON array** — a fact drops ~27KB → ~4-5KB, so the 32KB cap fits **6-8 facts per group** instead of 1. Verified directly against the installed 2.6.0-rc.1.

## Also
- Fixed `embedding-codec.test.ts`'s environment-dependent assertion (it hard-coded 'installed core predates the codec → JSON', now false with the pinned core) to drive the injectable core seam — install-agnostic — plus a new check that a present codec emits f16 not JSON.
- Follow-up filed (#548): the staging batch E2E omits `encryptedEmbedding`, the fidelity gap that let #498 slip past #531's green E2E.

## Verification
- `node run-tests.mjs` **93/93 EXIT=0**; `check-scanner` 0 flags
- f16 write-path probe against 2.6.0-rc.1: 1708-char canonical payload (not JSON)

This is the first of two rc.2 changes; #499 write-tool fix follows, then the `3.4.0-rc.2` cut. Authoritative validation is the box re-QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SztW6QFyp5t1ux4gW2mW6