### PR TITLE
fix(#507): query embeddings fail fast on cold embedder bundle (S-PAIR-FRESH)

### DIFF
--- a/skill/plugin/embedding/embedding.ts
+++ b/skill/plugin/embedding/embedding.ts
@@ -31,6 +31,7 @@
 import os from 'node:os';
 import path from 'node:path';
 import { loadEmbedder } from './embedder-loader.js';
+import { resolveCacheLayout, quickCacheProbe } from './embedder-cache.js';
 
 interface ModelConfig {
   /** Semantic model id surfaced to claims via `embedding_model_id`. */
@@ -140,6 +141,54 @@ let autoModel: any = null;
 let activeModel: ModelConfig | null = null;
 
 /**
+ * Thrown by `generateEmbedding` when an interactive *query* embedding is
+ * requested but the embedder bundle isn't ready yet and loading it would
+ * require a cold ~700 MB download (issue #507). The recall call sites
+ * (`before_agent_start` hook, recall tool) catch this and fall back to
+ * word-only trapdoors, so the user's turn returns promptly instead of
+ * blocking on the download. Distinct type so callers / tests can tell the
+ * fast-fail path apart from a genuine transport/extraction failure.
+ */
+export class EmbedderNotReadyError extends Error {
+  constructor(message = 'embedder bundle not ready — skipping cold load for query embedding') {
+    super(message);
+    this.name = 'EmbedderNotReadyError';
+  }
+}
+
+/**
+ * Cheap, synchronous, network-free probe: can we embed *right now* without
+ * triggering a cold bundle download? True when the model is already loaded
+ * in memory OR the bundle is present on disk (a `manifest.json` at the
+ * version-root, which `loadEmbedder` writes only after a fully downloaded +
+ * extracted + integrity-verified bundle). Reuses `quickCacheProbe`, which is
+ * a pure filesystem read — it never reaches the network.
+ */
+export function isEmbedderReady(): boolean {
+  if (activeModel) return true;
+  try {
+    const cfg = activeRuntimeConfig();
+    return quickCacheProbe(resolveCacheLayout(cfg.cacheRoot)).hasManifest;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Decide whether a cold embedder load should be deferred (issue #507).
+ *
+ * Interactive query embeddings (`isQuery: true`) must never block the user's
+ * turn on a ~700 MB first-use download: on a fresh install the background
+ * prefetch is still running, so we fail fast and let the caller degrade to
+ * word-only recall. Once the prefetch lands, subsequent turns embed normally.
+ * Write/store embeddings (no `isQuery`) always take the blocking load so
+ * facts are guaranteed to be embedded.
+ */
+export function shouldDeferColdEmbedderLoad(options?: { isQuery?: boolean }): boolean {
+  return Boolean(options?.isQuery) && !isEmbedderReady();
+}
+
+/**
  * Generate an embedding vector for the given text.
  *
  * On first call, downloads the embedder bundle (transformers + onnxruntime
@@ -153,6 +202,13 @@ export async function generateEmbedding(
   options?: { isQuery?: boolean },
 ): Promise<number[]> {
   if (!activeModel) {
+    // Issue #507: never block an interactive query turn on a cold ~700 MB
+    // bundle download. If this is a query and the bundle isn't ready yet,
+    // fail fast so the recall call site falls back to word-only trapdoors;
+    // the background prefetch keeps filling the cache for later turns.
+    if (shouldDeferColdEmbedderLoad(options)) {
+      throw new EmbedderNotReadyError();
+    }
     activeModel = getModelConfig();
     const cfg = activeRuntimeConfig();
     console.error(

--- a/skill/plugin/embedding/test_issue_507_query_cold_start_no_block.test.ts
+++ b/skill/plugin/embedding/test_issue_507_query_cold_start_no_block.test.ts
@@ -1,0 +1,138 @@
+/**
+ * test_issue_507_query_cold_start_no_block.test.ts — Regression for #507.
+ *
+ * S-PAIR-FRESH: on a fresh install the ~700 MB embedder bundle is still being
+ * downloaded (background prefetch) when the first user message arrives. The
+ * `before_agent_start` recall hook calls `generateEmbedding(prompt, { isQuery:
+ * true })`, whose cold path used to `await loadEmbedder()` — blocking the whole
+ * interactive turn on the download until the client's 180s timeout fired.
+ *
+ * The fix: query embeddings fail fast (throw `EmbedderNotReadyError`) when the
+ * bundle isn't ready on disk / in memory, so the recall call site degrades to
+ * word-only trapdoors and the turn returns promptly. Write/store embeddings
+ * (no `isQuery`) still take the blocking load so facts are always embedded.
+ *
+ * These assertions are network-free: they exercise the readiness probe and the
+ * fast-fail branch against a temp cache dir, never reaching GitHub Releases.
+ *
+ * Run with: npx tsx test_issue_507_query_cold_start_no_block.test.ts
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  configureEmbedder,
+  generateEmbedding,
+  isEmbedderReady,
+  shouldDeferColdEmbedderLoad,
+  EmbedderNotReadyError,
+} from './embedding.ts';
+import { resolveCacheLayout, BUNDLE_FORMAT_VERSION } from './embedder-cache.ts';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, name: string): void {
+  const n = passed + failed + 1;
+  if (condition) {
+    console.log(`ok ${n} - ${name}`);
+    passed++;
+  } else {
+    console.log(`not ok ${n} - ${name}`);
+    failed++;
+  }
+}
+
+const HEX64 = 'a'.repeat(64);
+
+/** A shape-valid manifest so `quickCacheProbe` reports the bundle present. */
+function writeValidManifest(cacheRoot: string): void {
+  const layout = resolveCacheLayout(cacheRoot);
+  fs.mkdirSync(layout.versionRoot, { recursive: true });
+  fs.writeFileSync(
+    layout.manifestPath,
+    JSON.stringify({
+      version: BUNDLE_FORMAT_VERSION,
+      model_id: 'harrier-oss-270m-q4',
+      dimension: 640,
+      tarball_sha256: HEX64,
+      tarball_size_bytes: 0,
+      files: [],
+    }),
+    'utf8',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 1. Bundle NOT ready (empty cache dir): probe is false, and only *queries*
+//    defer the cold load — writes still take the blocking path.
+// ---------------------------------------------------------------------------
+{
+  const emptyCache = fs.mkdtempSync(path.join(os.tmpdir(), 'tr-507-empty-'));
+  configureEmbedder({ cacheRoot: emptyCache, rcTag: '3.4.0-rc.2' });
+
+  assert(isEmbedderReady() === false, 'not-ready: isEmbedderReady() is false with no bundle on disk');
+  assert(
+    shouldDeferColdEmbedderLoad({ isQuery: true }) === true,
+    'not-ready: query embedding defers the cold load',
+  );
+  assert(
+    shouldDeferColdEmbedderLoad({ isQuery: false }) === false,
+    'not-ready: write embedding does NOT defer (still block-and-download)',
+  );
+  assert(
+    shouldDeferColdEmbedderLoad(undefined) === false,
+    'not-ready: default (no options) is treated as a write — no defer',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 2. A query embedding fails FAST (no network) when the bundle isn't ready —
+//    this is the actual #507 fix: the interactive turn must not block on the
+//    download.
+// ---------------------------------------------------------------------------
+{
+  const emptyCache = fs.mkdtempSync(path.join(os.tmpdir(), 'tr-507-query-'));
+  configureEmbedder({ cacheRoot: emptyCache, rcTag: '3.4.0-rc.2' });
+
+  let caught: unknown = null;
+  const start = Date.now();
+  try {
+    await generateEmbedding('remember that my name is Pedro', { isQuery: true });
+  } catch (err) {
+    caught = err;
+  }
+  const elapsedMs = Date.now() - start;
+
+  assert(caught instanceof EmbedderNotReadyError, 'query cold-start: throws EmbedderNotReadyError');
+  assert(elapsedMs < 1_000, `query cold-start: fails fast (${elapsedMs}ms < 1000ms, no download attempted)`);
+}
+
+// ---------------------------------------------------------------------------
+// 3. Bundle present on disk: probe flips to ready, and queries stop deferring
+//    (they proceed to the normal in-memory load path once prefetch lands).
+// ---------------------------------------------------------------------------
+{
+  const readyCache = fs.mkdtempSync(path.join(os.tmpdir(), 'tr-507-ready-'));
+  writeValidManifest(readyCache);
+  configureEmbedder({ cacheRoot: readyCache, rcTag: '3.4.0-rc.2' });
+
+  assert(isEmbedderReady() === true, 'ready: isEmbedderReady() is true once the bundle manifest is on disk');
+  assert(
+    shouldDeferColdEmbedderLoad({ isQuery: true }) === false,
+    'ready: query embedding no longer defers — proceeds to normal load',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log(`# fail: ${failed}`);
+console.log(`# ${passed}/${passed + failed} passed`);
+if (failed > 0) {
+  console.log('SOME TESTS FAILED');
+  process.exit(1);
+}
+console.log('ALL TESTS PASSED');


### PR DESCRIPTION
## What broke
On a brand-new install, the very first message could hang and time out at 180s (a 240s retry then worked) while the embedder model was still downloading in the background.

## What's fixed
The memory-recall query path now returns immediately (falling back to word-only recall) when the embedder bundle isn't ready yet, instead of blocking the whole turn on the ~700MB first-use download. Fact-writing still waits for the embedder so nothing is stored un-embedded.

## Impact after fix
First turn on a fresh install responds promptly; once the background prefetch finishes, later turns get full semantic recall automatically. No more first-attempt pairing/chat timeout.

## Verification
Deterministic regression test `test_issue_507_query_cold_start_no_block.test.ts` (network-free): query cold-start throws `EmbedderNotReadyError` in ~1ms (no download attempted), writes still block-and-download, and the probe flips to ready once the bundle manifest is on disk. All embedder-*/reranker unit tests still pass. The cold-start timing race is hard to E2E deterministically; full E2E rides the in-flight rc.3 respin QA sweep.

Root cause: `before_agent_start` recall hook called `generateEmbedding(prompt, { isQuery: true })`, whose cold path `await`ed `loadEmbedder()` and blocked the interactive turn on the bundle download. Fix is a single-file change in `skill/plugin/embedding/embedding.ts` (cheap network-free `quickCacheProbe` readiness gate + fast-fail for queries). Crosses no phrase-safety/pair-crypto rail — `validateMnemonic` and the pair flow are untouched.

No version bump here on purpose: this severity:low fix is meant to ride the in-flight **3.4.0-rc.3 respin** bundled with the #504/#505 blocker fixes, rather than trigger a standalone RC. The respin coordinator cuts the version at publish time.

Closes p-diogo/totalreclaw-internal#507
Umbrella: p-diogo/totalreclaw-internal#503 (Finding D)
QA report: docs/notes/QA-openclaw-RC-3.4.0-rc.2-20260720.md (internal)