### PR TITLE
fix(plugin): 429-resilient extraction + cheapest-configured-model selection (internal#502 + no hardcoded model)

### DIFF
--- a/skill/plugin/config.ts
+++ b/skill/plugin/config.ts
@@ -317,7 +317,9 @@ export const CONFIG = {
   storeDedupEnabled: true,
 
   // LLM provider API keys (read once, passed to llm-client). Model selection
-  // is entirely automatic via `deriveCheapModel(provider)` — the
+  // is entirely automatic via `resolveExtractionModel()` — it prefers the
+  // cheapest of the user's own configured OpenClaw models (internal#502) and
+  // only falls back to the hardcoded per-provider table as a last resort. The
   // TOTALRECLAW_LLM_MODEL override was removed in v1.
   llmApiKeys: {
     zai: process.env.ZAI_API_KEY || '',

--- a/skill/plugin/extraction/extractor.ts
+++ b/skill/plugin/extraction/extractor.ts
@@ -774,8 +774,9 @@ export async function extractFactsForCompaction(
       { role: 'system', content: COMPACTION_SYSTEM_PROMPT },
       { role: 'user', content: userPrompt },
     ], {
-      // 3.3.1-rc.2: retry transient 429 / timeout (same policy as extractFacts).
-      retry: { attempts: 3, baseDelayMs: 1000 },
+      // #502: inherit chatCompletion's resilient default retry (5 attempts /
+      // 2->32s full-jitter / 60s budget, Retry-After honored) — the old
+      // {attempts:3, baseDelayMs:1000} override was a stale rc.2 leftover.
       timeoutMs: 30_000,
       logger,
     });
@@ -932,8 +933,9 @@ export async function extractDebrief(
       { role: 'system', content: systemPrompt },
       { role: 'user', content: `Review this conversation and provide a debrief:\n\n${conversationText}` },
     ], {
-      // 3.3.1-rc.2: retry transient 429 / timeout.
-      retry: { attempts: 3, baseDelayMs: 1000 },
+      // #502: inherit chatCompletion's resilient default retry (5 attempts /
+      // 2->32s full-jitter / 60s budget, Retry-After honored) — the old
+      // {attempts:3, baseDelayMs:1000} override was a stale rc.2 leftover.
       timeoutMs: 30_000,
     });
 
@@ -1082,7 +1084,9 @@ export async function extractCrystal(
       { role: 'system', content: systemPrompt },
       { role: 'user', content: `Crystallise this session:\n\n${conversationText}` },
     ], {
-      retry: { attempts: 3, baseDelayMs: 1000 },
+      // #502: inherit chatCompletion's resilient default retry (5 attempts /
+      // 2->32s full-jitter / 60s budget, Retry-After honored) — the old
+      // {attempts:3, baseDelayMs:1000} override was a stale rc.2 leftover.
       timeoutMs: 30_000,
     });
 
@@ -1494,7 +1498,9 @@ export async function comparativeRescoreV1(
       // 3.3.1-rc.2: retry transient 429 / timeout (rescore is an inner
       // call after extractFacts — if extraction backs off successfully
       // the rescore usually also passes on first try, but keep symmetry).
-      retry: { attempts: 3, baseDelayMs: 1000 },
+      // #502: inherit chatCompletion's resilient default retry (5 attempts /
+      // 2->32s full-jitter / 60s budget, Retry-After honored) — the old
+      // {attempts:3, baseDelayMs:1000} override was a stale rc.2 leftover.
       timeoutMs: 30_000,
       logger,
     });
@@ -1607,11 +1613,10 @@ export async function extractFacts(
       { role: 'system', content: systemPrompt },
       { role: 'user', content: userPrompt },
     ], {
-      // 3.3.1-rc.2: the headline fix for the rc.1 QA NO-GO — 5/6 extraction
-      // windows failed on zai 429 + timeouts with no retry. 3 attempts with
-      // 1s → 2s → 4s backoff recovers virtually all transient rate-limit
-      // hiccups. Graceful timeout: per-attempt 30s, total worst-case 30+1+30+2+30+4≈97s.
-      retry: { attempts: 3, baseDelayMs: 1000 },
+      // #502: inherit chatCompletion's resilient default retry (5 attempts /
+      // 2s→32s FULL-jitter / 60s budget, Retry-After honored) — the old
+      // {attempts:3, baseDelayMs:1000} override was a stale rc.2 leftover that
+      // undercut the shared default and caused the rc.1/rc.2 429 data loss.
       timeoutMs: 30_000,
       logger,
     });

--- a/skill/plugin/extraction/extractor.ts
+++ b/skill/plugin/extraction/extractor.ts
@@ -775,8 +775,10 @@ export async function extractFactsForCompaction(
       { role: 'user', content: userPrompt },
     ], {
       // #502: inherit chatCompletion's resilient default retry (5 attempts /
-      // 2->32s full-jitter / 60s budget, Retry-After honored) — the old
-      // {attempts:3, baseDelayMs:1000} override was a stale rc.2 leftover.
+      // full-jitter backoff, per-attempt ceiling 2/4/8/16s → ~30s worst-case
+      // over 4 waits, capped by a 60s total budget; Retry-After honored up to
+      // a 60s ceiling) — the old {attempts:3, baseDelayMs:1000} override was a
+      // stale rc.2 leftover that undercut the shared default.
       timeoutMs: 30_000,
       logger,
     });
@@ -934,8 +936,10 @@ export async function extractDebrief(
       { role: 'user', content: `Review this conversation and provide a debrief:\n\n${conversationText}` },
     ], {
       // #502: inherit chatCompletion's resilient default retry (5 attempts /
-      // 2->32s full-jitter / 60s budget, Retry-After honored) — the old
-      // {attempts:3, baseDelayMs:1000} override was a stale rc.2 leftover.
+      // full-jitter backoff, per-attempt ceiling 2/4/8/16s → ~30s worst-case
+      // over 4 waits, capped by a 60s total budget; Retry-After honored up to
+      // a 60s ceiling) — the old {attempts:3, baseDelayMs:1000} override was a
+      // stale rc.2 leftover that undercut the shared default.
       timeoutMs: 30_000,
     });
 
@@ -1085,8 +1089,10 @@ export async function extractCrystal(
       { role: 'user', content: `Crystallise this session:\n\n${conversationText}` },
     ], {
       // #502: inherit chatCompletion's resilient default retry (5 attempts /
-      // 2->32s full-jitter / 60s budget, Retry-After honored) — the old
-      // {attempts:3, baseDelayMs:1000} override was a stale rc.2 leftover.
+      // full-jitter backoff, per-attempt ceiling 2/4/8/16s → ~30s worst-case
+      // over 4 waits, capped by a 60s total budget; Retry-After honored up to
+      // a 60s ceiling) — the old {attempts:3, baseDelayMs:1000} override was a
+      // stale rc.2 leftover that undercut the shared default.
       timeoutMs: 30_000,
     });
 
@@ -1499,8 +1505,10 @@ export async function comparativeRescoreV1(
       // call after extractFacts — if extraction backs off successfully
       // the rescore usually also passes on first try, but keep symmetry).
       // #502: inherit chatCompletion's resilient default retry (5 attempts /
-      // 2->32s full-jitter / 60s budget, Retry-After honored) — the old
-      // {attempts:3, baseDelayMs:1000} override was a stale rc.2 leftover.
+      // full-jitter backoff, per-attempt ceiling 2/4/8/16s → ~30s worst-case
+      // over 4 waits, capped by a 60s total budget; Retry-After honored up to
+      // a 60s ceiling) — the old {attempts:3, baseDelayMs:1000} override was a
+      // stale rc.2 leftover that undercut the shared default.
       timeoutMs: 30_000,
       logger,
     });
@@ -1614,9 +1622,11 @@ export async function extractFacts(
       { role: 'user', content: userPrompt },
     ], {
       // #502: inherit chatCompletion's resilient default retry (5 attempts /
-      // 2s→32s FULL-jitter / 60s budget, Retry-After honored) — the old
-      // {attempts:3, baseDelayMs:1000} override was a stale rc.2 leftover that
-      // undercut the shared default and caused the rc.1/rc.2 429 data loss.
+      // full-jitter backoff, per-attempt ceiling 2/4/8/16s → ~30s worst-case
+      // over 4 waits, capped by a 60s total budget; Retry-After honored up to a
+      // 60s ceiling) — the old {attempts:3, baseDelayMs:1000} override was a
+      // stale rc.2 leftover that undercut the shared default and caused the
+      // rc.1/rc.2 429 data loss.
       timeoutMs: 30_000,
       logger,
     });

--- a/skill/plugin/llm/llm-client-retry.test.ts
+++ b/skill/plugin/llm/llm-client-retry.test.ts
@@ -18,6 +18,7 @@
 import {
   isRetryable,
   chatCompletion,
+  parseRetryAfter,
   LLMUpstreamOutageError,
   isZaiBalanceError,
   zaiFallbackBaseUrl,
@@ -60,6 +61,47 @@ assert(!isRetryable('LLM API 400: bad request'), 'isRetryable: 400 → false');
 assert(!isRetryable('JSON parse error'), 'isRetryable: JSON parse → false');
 
 // ---------------------------------------------------------------------------
+// parseRetryAfter — pure parser for the 429 `Retry-After` header (Part 1.3).
+// Returns the wait in MS (delta-seconds OR HTTP-date delta), floored at 0, or
+// null when absent/unparseable. Does NOT cap — the retry loop applies the
+// 60s ceiling + the exhaustion rule (so this fn can be tested in isolation).
+// ---------------------------------------------------------------------------
+
+// delta-seconds form
+assert(parseRetryAfter(null) === null, 'parseRetryAfter: null → null');
+assert(parseRetryAfter(undefined) === null, 'parseRetryAfter: undefined → null');
+assert(parseRetryAfter('') === null, 'parseRetryAfter: empty → null');
+assert(parseRetryAfter('5') === 5000, 'parseRetryAfter: "5" delta-seconds → 5000ms');
+assert(parseRetryAfter(' 10 ') === 10000, 'parseRetryAfter: trimmed " 10 " → 10000ms');
+assert(parseRetryAfter('0') === 0, 'parseRetryAfter: "0" → 0');
+assert(parseRetryAfter('120') === 120_000, 'parseRetryAfter: returns RAW value (no cap) — "120" → 120000ms');
+
+// HTTP-date form — uses the same Date.parse the parser uses, so the assertion
+// is robust to weekday/format quirks. 30s in the future → 30000ms.
+{
+  const now = Date.UTC(2026, 6, 20, 0, 0, 0); // 2026-07-20T00:00:00Z
+  const dateStr = 'Wed, 21 Oct 2026 07:28:00 GMT';
+  const expected = Date.parse(dateStr) - now;
+  assert(expected > 0, 'parseRetryAfter: fixture HTTP-date is in the future');
+  assert(
+    parseRetryAfter(dateStr, { now: () => now }) === expected,
+    'parseRetryAfter: HTTP-date (future) → now-relative delta ms',
+  );
+}
+
+// HTTP-date in the past → floored to 0 (retry now), NOT negative.
+{
+  const now = Date.UTC(2026, 6, 20, 0, 0, 0);
+  assert(
+    parseRetryAfter('Mon, 01 Jan 2000 00:00:00 GMT', { now: () => now }) === 0,
+    'parseRetryAfter: HTTP-date (past) → 0 (floored, not negative)',
+  );
+}
+
+// Unparseable garbage → null (no digits-only, no valid date).
+assert(parseRetryAfter('not-a-date-or-number') === null, 'parseRetryAfter: garbage → null');
+
+// ---------------------------------------------------------------------------
 // chatCompletion retry harness — we monkey-patch fetch for determinism.
 // ---------------------------------------------------------------------------
 
@@ -94,6 +136,44 @@ function okResponse(content: string): Response {
       choices: [{ message: { content } }],
     }),
   );
+}
+
+/** Like mockResponse but lets the caller add headers (e.g. `retry-after`). */
+function mockResponseWithHeaders(
+  status: number,
+  body: string,
+  headers: Record<string, string>,
+): Response {
+  return new Response(body, {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  });
+}
+
+/**
+ * Patch globalThis.setTimeout to RECORD the delay of each call and resolve
+ * immediately (next microtask) so retry-backoff tests run instantly and the
+ * actual jittered wait can be asserted. Returns the captured delays + a
+ * restore fn. Only call-site setTimeouts (the retry sleeps) are recorded in
+ * practice; we filter to the expected backoff range when asserting.
+ */
+function captureSetTimeoutDelays(): {
+  delays: number[];
+  restore: () => void;
+} {
+  const delays: number[] = [];
+  const realSetTimeout = globalThis.setTimeout;
+  globalThis.setTimeout = ((cb: (...args: unknown[]) => void, ms?: unknown) => {
+    delays.push(typeof ms === 'number' ? ms : 0);
+    queueMicrotask(() => cb());
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  }) as unknown as typeof setTimeout;
+  return {
+    delays,
+    restore: () => {
+      globalThis.setTimeout = realSetTimeout;
+    },
+  };
 }
 
 const testConfig: LLMClientConfig = {
@@ -487,6 +567,124 @@ assert(zaiFallbackBaseUrl('https://custom.proxy/v1') === null, 'zaiFallbackBaseU
 }
 
 // ---------------------------------------------------------------------------
+// Part 1.2 — Full-jitter exponential backoff. The actual wait is
+// random(0, min(cap, base*2^(n-1))). We inject the rng so the bound is
+// deterministic and assert the captured setTimeout delays land in
+// [0, exp_delay] (and hit the extremes at rng 0 / 1).
+// ---------------------------------------------------------------------------
+
+// 4 attempts, base 1000ms, all 503 → 3 retry sleeps (after attempts 1,2,3).
+// exp delays: 1000, 2000, 4000. Max exp = 4000; filter captures to ≤ 4000 to
+// exclude the 30s AbortSignal.timeout timer (if it routes through setTimeout).
+async function jitterScenario(rng: () => number): Promise<number[]> {
+  const getCount = stubFetch([
+    async () => mockResponse(503, '{"error":{"message":"down"}}'),
+    async () => mockResponse(503, '{"error":{"message":"down"}}'),
+    async () => mockResponse(503, '{"error":{"message":"down"}}'),
+    async () => mockResponse(503, '{"error":{"message":"down"}}'),
+  ]);
+  const cap = captureSetTimeoutDelays();
+  try {
+    let thrown: unknown;
+    try {
+      await chatCompletion(testConfig, [{ role: 'user', content: 'hi' }], {
+        retry: { attempts: 4, baseDelayMs: 1000, random: rng },
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    assert(thrown instanceof LLMUpstreamOutageError, `jitter[${rng()}]: all-fail throws LLMUpstreamOutageError`);
+    assert(getCount() === 4, `jitter[${rng()}]: 4 fetches (one per attempt)`);
+    // Keep only the retry-sleep delays (≤ max exp 4000); drop any large timer.
+    return cap.delays.filter((d) => d <= 4000);
+  } finally {
+    cap.restore();
+    restoreFetch();
+  }
+}
+
+{
+  // rng = 0 → every jittered wait is 0 (min bound).
+  const delays = await jitterScenario(() => 0);
+  assert(delays.length === 3, 'jitter rng=0: exactly 3 retry sleeps');
+  assert(delays.every((d) => d === 0), 'jitter rng=0: every wait is 0 (min bound)');
+}
+
+{
+  // rng = 1 → every jittered wait is the full exp delay (max bound).
+  const delays = await jitterScenario(() => 1);
+  assert(delays.length === 3, 'jitter rng=1: exactly 3 retry sleeps');
+  assert(JSON.stringify(delays) === JSON.stringify([1000, 2000, 4000]), `jitter rng=1: waits are full exp [1000,2000,4000] (max bound), got ${JSON.stringify(delays)}`);
+}
+
+{
+  // rng = 0.5 → every wait is strictly inside (0, exp), proving the jitter
+  // is real (not clamped to an endpoint) and within the bound.
+  const delays = await jitterScenario(() => 0.5);
+  const exps = [1000, 2000, 4000];
+  assert(delays.length === 3, 'jitter rng=0.5: exactly 3 retry sleeps');
+  assert(
+    delays.every((d, i) => d > 0 && d < exps[i]),
+    `jitter rng=0.5: every wait strictly inside (0, exp), got ${JSON.stringify(delays)}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Part 1.3 — Honor the 429 `Retry-After` header. The wait is
+// max(jittered_backoff, retry_after); with rng=0 (jittered=0) and a small
+// base delay, the wait must still be ≥ retry_after.
+// ---------------------------------------------------------------------------
+
+{
+  const getCount = stubFetch([
+    // First attempt: 429 carrying Retry-After: 5 (seconds).
+    async () => mockResponseWithHeaders(429, '{"error":{"message":"Rate limit"}}', { 'retry-after': '5' }),
+    async () => okResponse('recovered after retry-after'),
+  ]);
+  const cap = captureSetTimeoutDelays();
+  try {
+    const result = await chatCompletion(testConfig, [{ role: 'user', content: 'hi' }], {
+      // base 100ms → exp(1)=100; rng=0 → jittered=0. Without Retry-After the
+      // wait would be 0. With Retry-After=5s it must be ≥5000.
+      retry: { attempts: 3, baseDelayMs: 100, random: () => 0 },
+    });
+    assert(result === 'recovered after retry-after', 'retry-after: honored → success on 2nd attempt');
+    assert(getCount() === 2, 'retry-after: 2 fetches');
+    const retrySleep = cap.delays.filter((d) => d >= 1000); // the ≥1s wait, not the 30s abort timer
+    assert(retrySleep.length === 1, `retry-after: exactly one retry sleep, got ${JSON.stringify(cap.delays)}`);
+    assert(retrySleep[0] >= 5000, `retry-after: wait ≥ 5000ms (honored), got ${retrySleep[0]}`);
+    // And it equals exactly max(0, 5000) = 5000 (retry-after floors jitter).
+    assert(retrySleep[0] === 5000, `retry-after: wait is exactly 5000ms (max(jitter=0, retry-after)), got ${retrySleep[0]}`);
+  } finally {
+    cap.restore();
+    restoreFetch();
+  }
+}
+
+// Retry-After ABOVE the 60s ceiling → this-cycle-exhausted: throw
+// LLMUpstreamOutageError immediately, do NOT burn retries waiting.
+{
+  const getCount = stubFetch([
+    async () => mockResponseWithHeaders(429, '{"error":{"message":"Rate limit"}}', { 'retry-after': '120' }),
+    async () => okResponse('should-not-reach'),
+  ]);
+  try {
+    let thrown: unknown;
+    try {
+      await chatCompletion(testConfig, [{ role: 'user', content: 'hi' }], {
+        retry: { attempts: 5, baseDelayMs: 1000, random: () => 0.5 },
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    assert(thrown instanceof LLMUpstreamOutageError, 'retry-after>cap: throws LLMUpstreamOutageError (this-cycle-exhausted)');
+    assert(getCount() === 1, 'retry-after>cap: single fetch (no retries burned)');
+  } finally {
+    restoreFetch();
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Retry budget enforcement — when cumulative delay would exceed budgetMs,
 // chatCompletion surfaces LLMUpstreamOutageError early.
 // ---------------------------------------------------------------------------
@@ -494,6 +692,8 @@ assert(zaiFallbackBaseUrl('https://custom.proxy/v1') === null, 'zaiFallbackBaseU
 {
   // attempts: 5, baseDelay: 10ms → delays 10, 20, 40, 80, 160 (cumulative 310ms total over 4 retries).
   // Set budgetMs: 50 → first retry ok (cum=10), 2nd retry (would add 20 → cum=30, ok), 3rd retry (would add 40 → cum=70 > 50 → stop).
+  // random: ()=>1.0 pins full jitter to the max (= the pre-jitter exponential schedule) so the
+  // cumulative-delay arithmetic stays deterministic under the new full-jitter backoff.
   const getCount = stubFetch([
     async () => mockResponse(503, '{"error":{"message":"down"}}'),
     async () => mockResponse(503, '{"error":{"message":"down"}}'),
@@ -505,7 +705,7 @@ assert(zaiFallbackBaseUrl('https://custom.proxy/v1') === null, 'zaiFallbackBaseU
     let thrown: unknown;
     try {
       await chatCompletion(testConfig, [{ role: 'user', content: 'hi' }], {
-        retry: { attempts: 5, baseDelayMs: 10, budgetMs: 50 },
+        retry: { attempts: 5, baseDelayMs: 10, budgetMs: 50, random: () => 1.0 },
       });
     } catch (err) {
       thrown = err;

--- a/skill/plugin/llm/llm-client.test.ts
+++ b/skill/plugin/llm/llm-client.test.ts
@@ -20,7 +20,12 @@
  * test env (no ZAI_API_KEY etc.).
  */
 
-import { initLLMClient, resolveLLMConfig, deriveCheapModel } from './llm-client.js';
+import {
+  initLLMClient,
+  resolveLLMConfig,
+  deriveCheapModel,
+  selectCheapestConfiguredModel,
+} from './llm-client.js';
 
 let passed = 0;
 let failed = 0;
@@ -112,6 +117,97 @@ function restoreEnv(stash: Record<string, string | undefined>): void {
   // "Already cheap" model passes through
   assertEq(deriveCheapModel('openai', 'gpt-4.1-mini'), 'gpt-4.1-mini', 'deriveCheapModel: cheap model passes through');
   assertEq(deriveCheapModel('anthropic', 'claude-haiku-4-5'), 'claude-haiku-4-5', 'deriveCheapModel: haiku passes through');
+}
+
+// ---------------------------------------------------------------------------
+// selectCheapestConfiguredModel — Pedro directive (2026-07-20): the extraction
+// model is the CHEAPEST of the user's OWN configured models, never a baked-in
+// glm constant. Selection rule: filter the configured list by CHEAP_INDICATOR_RE
+// (flash/mini/nano/lite/small/fast/haiku at a word boundary), then tiebreak by
+// smallest maxTokens (cheapness proxy), then lexical for determinism. Returns
+// null when nothing matches so the caller falls to the hardcoded table (tier 4,
+// last resort) instead of inventing a model.
+// ---------------------------------------------------------------------------
+
+{
+  // QA-box case: zai provider lists [glm-5-turbo, glm-4.7, glm-4.5-flash].
+  // Only glm-4.5-flash matches a cheap indicator → selected FROM the user's list.
+  assertEq(
+    selectCheapestConfiguredModel([
+      { id: 'glm-5-turbo' },
+      { id: 'glm-4.7' },
+      { id: 'glm-4.5-flash' },
+    ]),
+    'glm-4.5-flash',
+    'selectCheapestConfiguredModel: QA box picks glm-4.5-flash from configured list',
+  );
+
+  // Harvested from config, NOT the hardcoded table: openai table default is
+  // gpt-4.1-mini, but the user's OWN list has gpt-5-mini → that must win.
+  assertEq(
+    selectCheapestConfiguredModel([
+      { id: 'gpt-5', maxTokens: 400_000 },
+      { id: 'gpt-5-mini', maxTokens: 128_000 },
+    ]),
+    'gpt-5-mini',
+    'selectCheapestConfiguredModel: picks gpt-5-mini from config (NOT table gpt-4.1-mini)',
+  );
+
+  // Tiebreak by smallest maxTokens among cheap-indicator matches.
+  assertEq(
+    selectCheapestConfiguredModel([
+      { id: 'm-mini', maxTokens: 128_000 },
+      { id: 'm-nano', maxTokens: 64_000 },
+    ]),
+    'm-nano',
+    'selectCheapestConfiguredModel: smaller maxTokens wins on a cheap-indicator tie',
+  );
+
+  // Missing maxTokens for all candidates → lexical id tiebreak for determinism.
+  assertEq(
+    selectCheapestConfiguredModel([
+      { id: 'b-flash' },
+      { id: 'a-flash' },
+    ]),
+    'a-flash',
+    'selectCheapestConfiguredModel: lexical tiebreak when maxTokens absent',
+  );
+
+  // A model WITH a small maxTokens ranks above one with unknown maxTokens.
+  assertEq(
+    selectCheapestConfiguredModel([
+      { id: 'z-lite' }, // no maxTokens
+      { id: 'a-lite', maxTokens: 8_000 },
+    ]),
+    'a-lite',
+    'selectCheapestConfiguredModel: known small maxTokens beats unknown maxTokens',
+  );
+
+  // gemini-substring false-positive guard: 'mini' inside 'gemini' must NOT
+  // count as a cheap indicator (CHEAP_INDICATOR_RE word-boundary). Only the
+  // real flash model matches.
+  assertEq(
+    selectCheapestConfiguredModel([
+      { id: 'gemini-2.5-pro' },
+      { id: 'gemini-flash-lite' },
+    ]),
+    'gemini-flash-lite',
+    'selectCheapestConfiguredModel: gemini-substring guard (mini-in-gemini rejected, flash matched)',
+  );
+
+  // No model matches a cheap indicator → null (do NOT invent one).
+  assertEq(
+    selectCheapestConfiguredModel([
+      { id: 'gpt-5' },
+      { id: 'glm-4.7' },
+    ]),
+    null,
+    'selectCheapestConfiguredModel: no cheap match → null (falls to hardcoded table)',
+  );
+
+  // Empty / absent list → null (caller falls to table).
+  assertEq(selectCheapestConfiguredModel([]), null, 'selectCheapestConfiguredModel: empty list → null');
+  assertEq(selectCheapestConfiguredModel(undefined), null, 'selectCheapestConfiguredModel: undefined list → null');
 }
 
 // ---------------------------------------------------------------------------
@@ -309,6 +405,101 @@ function restoreEnv(stash: Record<string, string | undefined>): void {
     cap.infos.some((m) => m.includes('disabled via plugin config')),
     'extraction.enabled=false: info log mentions explicit disable',
   );
+}
+
+// ---------------------------------------------------------------------------
+// Tier 2 with configured models[] — extraction model is harvested as the
+// CHEAPEST of the user's OWN configured models (Pedro directive: no baked-in
+// glm). Proves the configured list is threaded into buildConfigForProvider.
+// ---------------------------------------------------------------------------
+
+{
+  // QA box: zai provider with [glm-5-turbo, glm-4.7, glm-4.5-flash].
+  // primary glm-5-turbo is NOT cheap → cheapest-configured (glm-4.5-flash) wins.
+  const cap = mkLogger();
+  initLLMClient({
+    primaryModel: 'zai/glm-5-turbo',
+    openclawProviders: {
+      zai: {
+        baseUrl: 'https://api.z.ai/api/paas/v4',
+        apiKey: 'zai-key',
+        models: [
+          { id: 'glm-5-turbo', maxTokens: 16_384 },
+          { id: 'glm-4.7', maxTokens: 16_384 },
+          { id: 'glm-4.5-flash', maxTokens: 16_384 },
+        ],
+      },
+    },
+    logger: cap.logger,
+  });
+  const cfg = resolveLLMConfig();
+  assertEq(cfg?.model, 'glm-4.5-flash', 'tier-2 configured: harvests glm-4.5-flash from zai models[] (cheapest-configured)');
+  // Must be logged as resolved from the configured list, not as the hardcoded table.
+  assert(
+    cap.infos.some((m) => m.includes('glm-4.5-flash')),
+    'tier-2 configured: resolved model logged',
+  );
+}
+
+{
+  // Different provider: openai with [gpt-5, gpt-5-mini]. The hardcoded table
+  // says gpt-4.1-mini, but the user's list has gpt-5-mini → that is selected.
+  // This proves we harvest from config, not the table.
+  const cap = mkLogger();
+  initLLMClient({
+    primaryModel: 'openai/gpt-5',
+    openclawProviders: {
+      openai: {
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-openai',
+        models: [
+          { id: 'gpt-5', maxTokens: 400_000 },
+          { id: 'gpt-5-mini', maxTokens: 128_000 },
+        ],
+      },
+    },
+    logger: cap.logger,
+  });
+  const cfg = resolveLLMConfig();
+  assertEq(cfg?.model, 'gpt-5-mini', 'tier-2 configured: harvests gpt-5-mini from openai models[] (NOT table gpt-4.1-mini)');
+}
+
+{
+  // Already-cheap primary is used as-is (tier 2) — configured list is NOT
+  // consulted when the primary itself is cheap.
+  const cap = mkLogger();
+  initLLMClient({
+    primaryModel: 'openai/gpt-5-mini',
+    openclawProviders: {
+      openai: {
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-openai',
+        models: [{ id: 'gpt-5' }, { id: 'gpt-4.1-nano' }],
+      },
+    },
+    logger: cap.logger,
+  });
+  const cfg = resolveLLMConfig();
+  assertEq(cfg?.model, 'gpt-5-mini', 'tier-2 configured: already-cheap primary used as-is (list not consulted)');
+}
+
+{
+  // No cheap indicator in the configured list AND primary not cheap → falls
+  // through to the hardcoded provider table (tier 4, last resort).
+  const cap = mkLogger();
+  initLLMClient({
+    primaryModel: 'openai/gpt-5',
+    openclawProviders: {
+      openai: {
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-openai',
+        models: [{ id: 'gpt-5' }, { id: 'gpt-5-pro' }],
+      },
+    },
+    logger: cap.logger,
+  });
+  const cfg = resolveLLMConfig();
+  assertEq(cfg?.model, 'gpt-4.1-mini', 'tier-2 configured: no cheap match in list → hardcoded table last resort (gpt-4.1-mini)');
 }
 
 // ---------------------------------------------------------------------------

--- a/skill/plugin/llm/llm-client.ts
+++ b/skill/plugin/llm/llm-client.ts
@@ -148,12 +148,20 @@ const CHEAP_INDICATOR_RE = new RegExp(
 );
 
 /**
- * Default cheap extraction model per provider. Exported so callers that
- * resolve a provider WITHOUT knowing the user's primary model (e.g. the
- * auth-profiles.json path) can still pick a sensible model.
+ * LAST-RESORT default cheap extraction model per provider.
+ *
+ * Pedro directive (2026-07-20, internal#502 follow-up): this table is NOT the
+ * production default. The extraction model must be the cheapest of the USER'S
+ * OWN configured models (`models.providers.<provider>.models[]`), resolved by
+ * `selectCheapestConfiguredModel` — never a baked-in glm/claude/gpt constant.
+ * This table is only consulted when no configured model list is available
+ * (the harvested auth-profiles key path, the legacy env-var path, or a
+ * provider whose `models[]` contains NO cheap-indicator match) — i.e. a
+ * best-effort fallback so extraction still has a model id to send. Exported
+ * so callers that resolve a provider WITHOUT a model list can still pick one.
  *
  * 3.3.1 update: haiku is now `claude-haiku-4-5-20251001` (latest cheap
- * Claude as of 2026-04). glm-4.5-flash stays the zai extraction default.
+ * Claude as of 2026-04). glm-4.5-flash stays the zai FALLBACK (not default).
  */
 export const CHEAP_MODEL_BY_PROVIDER: Record<string, string> = {
   zai: 'glm-4.5-flash',
@@ -190,6 +198,105 @@ export function deriveCheapModel(provider: string, primaryModel: string): string
 }
 
 // ---------------------------------------------------------------------------
+// Configured-model selection (Pedro directive 2026-07-20: no baked-in model)
+// ---------------------------------------------------------------------------
+
+/**
+ * A model entry from the user's OpenClaw provider config
+ * (`models.providers.<provider>.models[]`). Real entries carry
+ * `{ id, name, contextWindow, maxTokens }` — NO price field, so cheapness is
+ * proxied by the cheap-tier indicator on the id plus the smallest `maxTokens`.
+ */
+export interface ConfiguredModel {
+  id: string;
+  maxTokens?: unknown;
+  contextWindow?: unknown;
+}
+
+/**
+ * Pick the cheapest model id from the USER'S OWN configured models list.
+ *
+ * Selection rule (Pedro directive):
+ *   a. keep only ids that carry a genuine cheap-tier indicator
+ *      (`CHEAP_INDICATOR_RE`: flash / mini / nano / lite / small / fast /
+ *      haiku at a word boundary — the same regex that rejects the "mini"
+ *      inside "gemini");
+ *   b. among the matches, rank by smallest `maxTokens` (proxy for the
+ *      cheapest/faster tier; `contextWindow` is a secondary proxy when
+ *      `maxTokens` is absent; both absent → largest so a known-small value
+ *      wins), then lexical id for determinism;
+ *   c. if NOTHING matches a cheap indicator, return `null` — do NOT invent a
+ *      model. The caller then falls to the hardcoded `CHEAP_MODEL_BY_PROVIDER`
+ *      table (tier 4, last resort).
+ *
+ * So on the QA box (zai models [glm-5-turbo, glm-4.7, glm-4.5-flash]) this
+ * returns `glm-4.5-flash` *from the user's config*, and for an OpenAI user on
+ * [gpt-5, gpt-5-mini] it returns `gpt-5-mini` — no baked-in model names.
+ */
+export function selectCheapestConfiguredModel(
+  configuredModels: ReadonlyArray<ConfiguredModel> | undefined,
+): string | null {
+  if (!configuredModels || configuredModels.length === 0) return null;
+  const cheap = configuredModels.filter(
+    (m) => m && typeof m.id === 'string' && CHEAP_INDICATOR_RE.test(m.id),
+  );
+  if (cheap.length === 0) return null;
+
+  // Cheapness proxy: smaller output budget = cheaper/faster tier. Missing
+  // maxTokens falls back to contextWindow, then to MAX_SAFE_INTEGER so a model
+  // with a known small budget ranks above one with an unknown budget.
+  const tokenRank = (m: ConfiguredModel): number => {
+    if (typeof m.maxTokens === 'number' && Number.isFinite(m.maxTokens)) return m.maxTokens;
+    if (typeof m.contextWindow === 'number' && Number.isFinite(m.contextWindow)) return m.contextWindow;
+    return Number.MAX_SAFE_INTEGER;
+  };
+
+  cheap.sort((a, b) => {
+    const da = tokenRank(a);
+    const db = tokenRank(b);
+    if (da !== db) return da - db;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+  return cheap[0].id;
+}
+
+/**
+ * Full extraction-model precedence (Pedro directive, 2026-07-20). Returns the
+ * model id AND a short reason so the caller can log which tier fired.
+ *
+ *   1. `modelOverride` — explicit `extraction.model` / `extraction.llm.model`.
+ *   2. the primary model, IF it already carries a cheap-tier indicator.
+ *   3. the cheapest of the user's OWN configured models (`models[]`).
+ *   4. the hardcoded `CHEAP_MODEL_BY_PROVIDER` table — LAST RESORT, only when
+ *      no configured list is available or it has no cheap-indicator match.
+ *   5. the primary model (best-effort).
+ */
+export function resolveExtractionModel(
+  provider: string,
+  opts: {
+    modelOverride?: string;
+    primaryModelHint?: string;
+    configuredModels?: ReadonlyArray<ConfiguredModel>;
+  },
+): { model: string | null; reason: string } {
+  if (opts.modelOverride) {
+    return { model: opts.modelOverride, reason: 'explicit override' };
+  }
+  if (opts.primaryModelHint && CHEAP_INDICATOR_RE.test(opts.primaryModelHint)) {
+    return { model: opts.primaryModelHint, reason: 'primary already cheap' };
+  }
+  const fromConfig = selectCheapestConfiguredModel(opts.configuredModels);
+  if (fromConfig) {
+    return { model: fromConfig, reason: 'cheapest of configured models' };
+  }
+  const fromTable = CHEAP_MODEL_BY_PROVIDER[provider];
+  if (fromTable) {
+    return { model: fromTable, reason: 'hardcoded table (fallback — no cheap model in config)' };
+  }
+  return { model: opts.primaryModelHint ?? null, reason: 'primary model (best-effort)' };
+}
+
+// ---------------------------------------------------------------------------
 // Module-level state
 // ---------------------------------------------------------------------------
 
@@ -222,9 +329,10 @@ interface ExtractionLlmOverride {
 // ---------------------------------------------------------------------------
 
 /**
- * Build an LLMClientConfig for a known provider + apiKey, picking a
- * cheap default model if none is specified. Returns null if the
- * provider is unknown and no baseUrl is available.
+ * Build an LLMClientConfig for a known provider + apiKey, picking the
+ * extraction model via the 5-tier `resolveExtractionModel` precedence.
+ * Returns `{ config, reason }` (reason = which model tier fired, for
+ * logging), or null if the provider is unknown / no model resolves.
  */
 function buildConfigForProvider(
   provider: string,
@@ -233,9 +341,10 @@ function buildConfigForProvider(
     baseUrlOverride?: string;
     modelOverride?: string;
     primaryModelHint?: string;
+    configuredModels?: ReadonlyArray<ConfiguredModel>;
     apiFormatOverride?: 'openai' | 'anthropic';
   } = {},
-): LLMClientConfig | null {
+): { config: LLMClientConfig; reason: string } | null {
   // zai's base URL is resolved via `getZaiBaseUrl()` (reads CONFIG) so
   // the `ZAI_BASE_URL` env override takes effect even when this helper is
   // called with no `baseUrlOverride` (i.e. the env-var fallback tier in
@@ -244,14 +353,15 @@ function buildConfigForProvider(
     provider === 'zai' ? getZaiBaseUrl() : PROVIDER_BASE_URLS[provider] ?? '';
   const baseUrl = (opts.baseUrlOverride ?? defaultForProvider).replace(/\/+$/, '');
   if (!baseUrl) return null;
-  const model =
-    opts.modelOverride ??
-    (opts.primaryModelHint ? deriveCheapModel(provider, opts.primaryModelHint) : null) ??
-    CHEAP_MODEL_BY_PROVIDER[provider];
+  const { model, reason } = resolveExtractionModel(provider, {
+    modelOverride: opts.modelOverride,
+    primaryModelHint: opts.primaryModelHint,
+    configuredModels: opts.configuredModels,
+  });
   if (!model) return null;
   const apiFormat: 'openai' | 'anthropic' =
     opts.apiFormatOverride ?? (provider === 'anthropic' ? 'anthropic' : 'openai');
-  return { apiKey, baseUrl, model, apiFormat };
+  return { config: { apiKey, baseUrl, model, apiFormat }, reason };
 }
 
 /**
@@ -329,14 +439,16 @@ export function initLLMClient(options: {
         ? llmOverride.apiKey.trim()
         : undefined;
     if (provider && apiKey) {
-      const cfg = buildConfigForProvider(provider, apiKey, {
+      const resolved = buildConfigForProvider(provider, apiKey, {
         baseUrlOverride: llmOverride.baseUrl,
         modelOverride: llmOverride.model ?? modelOverride,
         primaryModelHint: modelFromPrimary,
       });
-      if (cfg) {
-        _cachedConfig = cfg;
-        _logger?.info?.(`TotalReclaw extraction LLM: resolved ${provider}/${cfg.model} (plugin config override)`);
+      if (resolved) {
+        _cachedConfig = resolved.config;
+        _logger?.info?.(
+          `TotalReclaw extraction LLM: resolved ${provider}/${resolved.config.model} (plugin config override; model: ${resolved.reason})`,
+        );
         return;
       }
     }
@@ -350,19 +462,20 @@ export function initLLMClient(options: {
     if (providerFromPrimary) {
       const ocProvider = openclawProviders[providerFromPrimary];
       if (ocProvider?.apiKey) {
-        const cfg = buildConfigForProvider(providerFromPrimary, ocProvider.apiKey, {
+        const resolved = buildConfigForProvider(providerFromPrimary, ocProvider.apiKey, {
           baseUrlOverride: ocProvider.baseUrl,
           modelOverride,
           primaryModelHint: modelFromPrimary,
+          configuredModels: ocProvider.models,
           apiFormatOverride:
             ocProvider.api === 'anthropic-messages' || providerFromPrimary === 'anthropic'
               ? 'anthropic'
               : 'openai',
         });
-        if (cfg) {
-          _cachedConfig = cfg;
+        if (resolved) {
+          _cachedConfig = resolved.config;
           _logger?.info?.(
-            `TotalReclaw extraction LLM: resolved ${providerFromPrimary}/${cfg.model} (OpenClaw provider config)`,
+            `TotalReclaw extraction LLM: resolved ${providerFromPrimary}/${resolved.config.model} (OpenClaw provider config; model: ${resolved.reason})`,
           );
           return;
         }
@@ -372,19 +485,20 @@ export function initLLMClient(options: {
       if (!providerConfig?.apiKey) continue;
       const provider = providerName.toLowerCase();
       const firstModelId = providerConfig.models?.[0]?.id;
-      const cfg = buildConfigForProvider(provider, providerConfig.apiKey, {
+      const resolved = buildConfigForProvider(provider, providerConfig.apiKey, {
         baseUrlOverride: providerConfig.baseUrl,
         modelOverride,
         primaryModelHint: firstModelId,
+        configuredModels: providerConfig.models,
         apiFormatOverride:
           providerConfig.api === 'anthropic-messages' || provider === 'anthropic'
             ? 'anthropic'
             : 'openai',
       });
-      if (cfg) {
-        _cachedConfig = cfg;
+      if (resolved) {
+        _cachedConfig = resolved.config;
         _logger?.info?.(
-          `TotalReclaw extraction LLM: resolved ${provider}/${cfg.model} (OpenClaw provider config)`,
+          `TotalReclaw extraction LLM: resolved ${provider}/${resolved.config.model} (OpenClaw provider config; model: ${resolved.reason})`,
         );
         return;
       }
@@ -399,14 +513,14 @@ export function initLLMClient(options: {
     if (providerFromPrimary) {
       const hit = authProfileKeys.find((k) => k.provider === providerFromPrimary);
       if (hit) {
-        const cfg = buildConfigForProvider(providerFromPrimary, hit.apiKey, {
+        const resolved = buildConfigForProvider(providerFromPrimary, hit.apiKey, {
           modelOverride,
           primaryModelHint: modelFromPrimary,
         });
-        if (cfg) {
-          _cachedConfig = cfg;
+        if (resolved) {
+          _cachedConfig = resolved.config;
           _logger?.info?.(
-            `TotalReclaw extraction LLM: resolved ${providerFromPrimary}/${cfg.model} (auth-profiles.json)`,
+            `TotalReclaw extraction LLM: resolved ${providerFromPrimary}/${resolved.config.model} (auth-profiles.json; model: ${resolved.reason})`,
           );
           return;
         }
@@ -419,13 +533,13 @@ export function initLLMClient(options: {
       ...authProfileKeys.filter((k) => !priority.includes(k.provider)),
     ];
     for (const entry of ordered) {
-      const cfg = buildConfigForProvider(entry.provider, entry.apiKey, {
+      const resolved = buildConfigForProvider(entry.provider, entry.apiKey, {
         modelOverride,
       });
-      if (cfg) {
-        _cachedConfig = cfg;
+      if (resolved) {
+        _cachedConfig = resolved.config;
         _logger?.info?.(
-          `TotalReclaw extraction LLM: resolved ${entry.provider}/${cfg.model} (auth-profiles.json)`,
+          `TotalReclaw extraction LLM: resolved ${entry.provider}/${resolved.config.model} (auth-profiles.json; model: ${resolved.reason})`,
         );
         return;
       }
@@ -452,14 +566,14 @@ export function initLLMClient(options: {
     if (keyNames) {
       const apiKey = keyNames.map((n) => CONFIG.llmApiKeys[n]).find(Boolean);
       if (apiKey) {
-        const cfg = buildConfigForProvider(providerFromPrimary, apiKey, {
+        const resolved = buildConfigForProvider(providerFromPrimary, apiKey, {
           modelOverride,
           primaryModelHint: modelFromPrimary,
         });
-        if (cfg) {
-          _cachedConfig = cfg;
+        if (resolved) {
+          _cachedConfig = resolved.config;
           _logger?.info?.(
-            `TotalReclaw extraction LLM: resolved ${providerFromPrimary}/${cfg.model} (env var)`,
+            `TotalReclaw extraction LLM: resolved ${providerFromPrimary}/${resolved.config.model} (env var; model: ${resolved.reason})`,
           );
           return;
         }
@@ -469,10 +583,12 @@ export function initLLMClient(options: {
   for (const [provider, keyName] of envFallback) {
     const apiKey = CONFIG.llmApiKeys[keyName];
     if (!apiKey) continue;
-    const cfg = buildConfigForProvider(provider, apiKey, { modelOverride });
-    if (cfg) {
-      _cachedConfig = cfg;
-      _logger?.info?.(`TotalReclaw extraction LLM: resolved ${provider}/${cfg.model} (env var)`);
+    const resolved = buildConfigForProvider(provider, apiKey, { modelOverride });
+    if (resolved) {
+      _cachedConfig = resolved.config;
+      _logger?.info?.(
+        `TotalReclaw extraction LLM: resolved ${provider}/${resolved.config.model} (env var; model: ${resolved.reason})`,
+      );
       return;
     }
   }
@@ -532,29 +648,45 @@ export function resolveLLMConfig(): LLMClientConfig | null {
 
 /**
  * Options for chatCompletion. `retry` controls the 429 + timeout backoff
- * loop. Defaults to 5 attempts with 2s → 4s → 8s → 16s → 32s backoff
- * (total budget ~62s) — rc.1/rc.2 QA showed multi-minute upstream outages
- * that blew through the rc.2 7s budget. Configurable via
- * `TOTALRECLAW_LLM_RETRY_BUDGET_MS` env (cap on cumulative retry-delay).
+ * loop. Defaults to 5 attempts with 2s → 4s → 8s → 16s → 32s backoff under
+ * FULL jitter (AWS "full jitter": wait = random(0, min(cap, base*2^(n-1)))),
+ * plus `Retry-After` honoring (internal#502). rc.1/rc.2 QA showed
+ * multi-minute upstream outages that blew through the rc.2 7s budget.
+ * Cumulative budget configurable via `TOTALRECLAW_LLM_RETRY_BUDGET_MS` env.
  */
 export interface ChatCompletionOptions {
   maxTokens?: number;
   temperature?: number;
   /**
-   * Retry behaviour. Defaults mirror the rc.3 budget: 5 attempts, 2s base
-   * delay, exponential. Set `attempts: 0` (or `1`) to disable retry. Pass
-   * a `logger` for visibility; without one, retries are silent.
+   * Retry behaviour. Defaults mirror the rc.3/#502 budget: 5 attempts, 2s
+   * base delay, exponential with FULL jitter, `Retry-After` honored. Set
+   * `attempts: 0` (or `1`) to disable retry. Pass a `logger` for visibility;
+   * without one, retries are silent.
    *
    * `budgetMs` caps the cumulative retry-delay time — after an attempt
-   * fails, we compute the next delay and skip it (falling through to the
+   * fails, we compute the next wait and skip it (falling through to the
    * give-up path) if adding it would exceed the budget. Defaults to the
    * value read from `TOTALRECLAW_LLM_RETRY_BUDGET_MS` at module load,
    * which itself defaults to 60_000ms.
+   *
+   * `capMs` (default 60_000) caps any single per-attempt wait, including the
+   * `Retry-After` floor. A `Retry-After` demanding MORE than `capMs` is
+   * treated as "this-cycle-exhausted" — we surface `LLMUpstreamOutageError`
+   * immediately rather than burning retries against a long upstream pause
+   * (the extractor then re-queues the batch for the background poller).
+   *
+   * `random` / `now` are dependency-injected for deterministic tests (the
+   * default `Math.random` / `Date.now` are used in production).
    */
   retry?: {
     attempts?: number;
     baseDelayMs?: number;
     budgetMs?: number;
+    capMs?: number;
+    /** Injectable RNG for the full-jitter wait (default Math.random). */
+    random?: () => number;
+    /** Injectable clock for Retry-After HTTP-date parsing (default Date.now). */
+    now?: () => number;
   };
   logger?: {
     info?: (msg: string) => void;
@@ -564,6 +696,14 @@ export interface ChatCompletionOptions {
   /** Timeout per attempt in ms (default 30_000). */
   timeoutMs?: number;
 }
+
+/**
+ * Default per-attempt retry-delay cap (ms). Also the `Retry-After` ceiling:
+ * a server-demanded wait above this is treated as this-cycle-exhausted
+ * (re-queue for the poller) rather than slept through. Matches the Python
+ * `_RETRY_AFTER_CEILING_S = 60`.
+ */
+export const DEFAULT_RETRY_CAP_MS = 60_000;
 
 /**
  * Default retry budget in ms. Configurable via
@@ -607,6 +747,97 @@ export function isZaiBalanceError(errorMessage: string): boolean {
   return m.includes('insufficient balance') || m.includes('no resource package');
 }
 
+// ---------------------------------------------------------------------------
+// Retry-After (Part 1.3) — pure parser + HTTP-error metadata plumbing
+// ---------------------------------------------------------------------------
+
+/**
+ * A thrown error carrying the HTTP status + raw `Retry-After` header value
+ * from the upstream response. The OpenAI/Anthropic fetch paths attach these
+ * so the retry loop can honor `Retry-After` without re-reading the response.
+ */
+interface HttpError extends Error {
+  httpStatus?: number;
+  retryAfterHeader?: string | null;
+}
+
+/**
+ * Parse a `Retry-After` header (RFC 7231 §7.1.3) into a wait in MS.
+ *
+ * Accepts either:
+ *   - delta-seconds: `"5"` → 5000
+ *   - HTTP-date:     `"Wed, 21 Oct 2026 07:28:00 GMT"` → ms from `now`
+ *
+ * Returns the wait floored at 0 (a past HTTP-date → 0, i.e. retry now), or
+ * `null` when the header is absent / unparseable. Deliberately does NOT cap —
+ * the retry loop applies the 60s ceiling and the "above ceiling → exhausted"
+ * rule, so this parser stays pure and unit-testable. Mirrors the Python
+ * `_retry_after_seconds` helper.
+ */
+export function parseRetryAfter(
+  header: string | null | undefined,
+  opts: { now?: () => number } = {},
+): number | null {
+  if (header == null) return null;
+  const raw = header.trim();
+  if (raw === '') return null;
+
+  // delta-seconds (integer or decimal, per RFC allows decimal).
+  if (/^\d+(\.\d+)?$/.test(raw)) {
+    const secs = parseFloat(raw);
+    if (!Number.isFinite(secs) || secs < 0) return null;
+    return Math.max(0, Math.round(secs * 1000));
+  }
+
+  // HTTP-date (RFC 1123, e.g. "Wed, 21 Oct 2026 07:28:00 GMT").
+  const parsed = Date.parse(raw);
+  if (Number.isFinite(parsed)) {
+    const now = (opts.now ?? Date.now)();
+    return Math.max(0, parsed - now);
+  }
+
+  return null;
+}
+
+/**
+ * Stamp an outgoing HTTP error with the response status + Retry-After header
+ * so the retry loop can honor them. Used by the OpenAI/Anthropic fetch paths.
+ */
+function stampHttpError(
+  err: Error,
+  status: number | undefined,
+  retryAfterHeader: string | null,
+): HttpError {
+  const e = err as HttpError;
+  if (status !== undefined) e.httpStatus = status;
+  e.retryAfterHeader = retryAfterHeader;
+  return e;
+}
+
+/**
+ * Wrap a low-level fetch error in the `LLM call failed: …` envelope while
+ * PRESERVING any HTTP status / Retry-After metadata attached by
+ * `stampHttpError` (so the retry loop still sees them after the wrap).
+ */
+function wrapLlmError(err: unknown): Error {
+  const msg = err instanceof Error ? err.message : String(err);
+  const wrapped: HttpError = new Error(`LLM call failed: ${msg}`);
+  if (err && typeof err === 'object') {
+    const src = err as HttpError;
+    if (src.httpStatus !== undefined) wrapped.httpStatus = src.httpStatus;
+    if (src.retryAfterHeader !== undefined) wrapped.retryAfterHeader = src.retryAfterHeader;
+  }
+  return wrapped;
+}
+
+/** Read the `retryAfterHeader` a wrapped error may be carrying (or undefined). */
+function retryAfterFromError(err: unknown): string | null | undefined {
+  if (err && typeof err === 'object' && 'retryAfterHeader' in err) {
+    return (err as HttpError).retryAfterHeader;
+  }
+  return undefined;
+}
+
 /**
  * Identify the "other" zai endpoint when the current one returns a balance
  * error — CODING ↔ STANDARD. Returns `null` when the URL is neither of
@@ -648,6 +879,9 @@ export async function chatCompletion(
   const attempts = Math.max(1, options?.retry?.attempts ?? 5);
   const baseDelayMs = Math.max(100, options?.retry?.baseDelayMs ?? 2000);
   const budgetMs = Math.max(100, options?.retry?.budgetMs ?? DEFAULT_RETRY_BUDGET_MS);
+  const capMs = Math.max(1000, options?.retry?.capMs ?? DEFAULT_RETRY_CAP_MS);
+  const randomFn = options?.retry?.random ?? Math.random;
+  const nowFn = options?.retry?.now ?? Date.now;
   const timeoutMs = options?.timeoutMs ?? 30_000;
   const logger = options?.logger;
 
@@ -719,8 +953,34 @@ export async function chatCompletion(
         throw err;
       }
 
-      // Compute next delay, but respect the cumulative retry-budget cap.
-      const delayMs = baseDelayMs * Math.pow(2, attempt - 1);
+      // ── Compute the next wait (Part 1.2 + 1.3) ──
+      // Exponential backoff capped per-attempt at `capMs`, then FULL jitter
+      // (AWS "full jitter": wait = random(0, min(cap, base*2^(n-1)))) to
+      // de-synchronize concurrent extraction. Then honor `Retry-After` as a
+      // floor: wait = max(jittered, retry_after).
+      const expDelayMs = Math.min(capMs, baseDelayMs * Math.pow(2, attempt - 1));
+      const jitteredMs = Math.min(expDelayMs, Math.floor(randomFn() * (expDelayMs + 1)));
+
+      const retryAfterHeader = retryAfterFromError(err);
+      const retryAfterMs = parseRetryAfter(retryAfterHeader, { now: nowFn });
+
+      // Retry-After ABOVE the ceiling → the server is signalling a long pause;
+      // don't burn retries against it. Treat as this-cycle-exhausted so the
+      // extractor re-queues the batch for the background poller (Part 1.4).
+      if (retryAfterMs !== null && retryAfterMs > capMs) {
+        logger?.warn?.(
+          `chatCompletion: Retry-After ${retryAfterMs}ms exceeds ${capMs}ms ceiling; surfacing outage after ${attempt} attempts (will re-queue): ${msg.slice(0, 160)}`,
+        );
+        throw new LLMUpstreamOutageError(
+          `LLM upstream outage (Retry-After ${retryAfterMs}ms > ${capMs}ms ceiling after ${attempt} attempts): ${msg.slice(0, 200)}`,
+          attempt,
+          lastStatus,
+        );
+      }
+
+      const delayMs = retryAfterMs !== null ? Math.max(jitteredMs, retryAfterMs) : jitteredMs;
+
+      // Respect the cumulative retry-budget cap.
       if (cumulativeDelayMs + delayMs > budgetMs) {
         logger?.warn?.(
           `chatCompletion: retry budget exhausted (${cumulativeDelayMs}ms used + ${delayMs}ms next > ${budgetMs}ms budget); surfacing outage after ${attempt} attempts: ${msg.slice(0, 160)}`,
@@ -735,13 +995,14 @@ export async function chatCompletion(
 
       // Log only the FIRST retry at INFO to avoid spamming during long
       // outages; subsequent retries are DEBUG (debounced per outage).
+      const waitLabel = retryAfterMs !== null ? `${delayMs}ms (Retry-After honored)` : `${delayMs}ms`;
       if (attempt === 1) {
         logger?.info?.(
-          `chatCompletion: retrying after transient failure (attempt ${attempt}/${attempts}, wait ${delayMs}ms): ${msg.slice(0, 160)}`,
+          `chatCompletion: retrying after transient failure (attempt ${attempt}/${attempts}, wait ${waitLabel}): ${msg.slice(0, 160)}`,
         );
       } else {
         logger?.debug?.(
-          `chatCompletion: retry attempt ${attempt}/${attempts} (wait ${delayMs}ms): ${msg.slice(0, 160)}`,
+          `chatCompletion: retry attempt ${attempt}/${attempts} (wait ${waitLabel}): ${msg.slice(0, 160)}`,
         );
       }
       await new Promise((resolve) => setTimeout(resolve, delayMs));
@@ -879,7 +1140,13 @@ async function chatCompletionOpenAI(
 
     if (!res.ok) {
       const text = await res.text().catch(() => '');
-      throw new Error(`LLM API ${res.status}: ${text.slice(0, 200)}`);
+      // Part 1.3: carry the status + Retry-After header so the retry loop can
+      // honor the server's backoff demand (delta-seconds or HTTP-date).
+      throw stampHttpError(
+        new Error(`LLM API ${res.status}: ${text.slice(0, 200)}`),
+        res.status,
+        res.headers.get('retry-after'),
+      );
     }
 
     const json = (await res.json()) as ChatCompletionResponse;
@@ -909,8 +1176,8 @@ async function chatCompletionOpenAI(
 
     return content;
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(`LLM call failed: ${msg}`);
+    // Wrap preserving any httpStatus / retryAfterHeader stamped above.
+    throw wrapLlmError(err);
   }
 }
 
@@ -964,15 +1231,21 @@ async function chatCompletionAnthropic(
 
     if (!res.ok) {
       const text = await res.text().catch(() => '');
-      throw new Error(`Anthropic API ${res.status}: ${text.slice(0, 200)}`);
+      // Part 1.3: carry the status + Retry-After header (Anthropic also returns
+      // Retry-After on 429) so the retry loop can honor it.
+      throw stampHttpError(
+        new Error(`Anthropic API ${res.status}: ${text.slice(0, 200)}`),
+        res.status,
+        res.headers.get('retry-after'),
+      );
     }
 
     const json = (await res.json()) as AnthropicMessagesResponse;
     const textBlock = json.content?.find((block) => block.type === 'text');
     return textBlock?.text ?? null;
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(`LLM call failed: ${msg}`);
+    // Wrap preserving any httpStatus / retryAfterHeader stamped above.
+    throw wrapLlmError(err);
   }
 }
 

--- a/skill/plugin/llm/llm-client.ts
+++ b/skill/plugin/llm/llm-client.ts
@@ -181,6 +181,14 @@ export const CHEAP_MODEL_BY_PROVIDER: Record<string, string> = {
 /**
  * Derive a cheap/fast model suitable for fact extraction, given the user's
  * provider and primary (potentially expensive) model.
+ *
+ * LEGACY (internal#502): no longer on the live extraction path — the config
+ * builder now calls `resolveExtractionModel()`, which prefers the cheapest of
+ * the user's OWN configured OpenClaw models and only falls back to the
+ * hardcoded `CHEAP_MODEL_BY_PROVIDER` table as a last resort. Kept exported +
+ * unit-tested because it still exercises the shared `CHEAP_INDICATOR_RE`
+ * word-boundary logic and may be imported externally; prefer
+ * `resolveExtractionModel` for new callers.
  */
 export function deriveCheapModel(provider: string, primaryModel: string): string {
   // If already on a cheap model, use it as-is.
@@ -648,11 +656,15 @@ export function resolveLLMConfig(): LLMClientConfig | null {
 
 /**
  * Options for chatCompletion. `retry` controls the 429 + timeout backoff
- * loop. Defaults to 5 attempts with 2s → 4s → 8s → 16s → 32s backoff under
- * FULL jitter (AWS "full jitter": wait = random(0, min(cap, base*2^(n-1)))),
- * plus `Retry-After` honoring (internal#502). rc.1/rc.2 QA showed
- * multi-minute upstream outages that blew through the rc.2 7s budget.
- * Cumulative budget configurable via `TOTALRECLAW_LLM_RETRY_BUDGET_MS` env.
+ * loop. Defaults to 5 attempts, so 4 waits between them, with a per-attempt
+ * ceiling of 2s → 4s → 8s → 16s (the 5th attempt is the final try and does
+ * not wait) under FULL jitter (AWS "full jitter": wait =
+ * random(0, min(cap, base*2^(n-1)))) — worst case ~30s of backoff, capped by
+ * a 60s total budget — plus `Retry-After` honoring up to a 60s ceiling
+ * (internal#502). rc.1/rc.2 QA showed multi-minute upstream outages that blew
+ * through the rc.2 7s budget. Cumulative budget configurable via
+ * `TOTALRECLAW_LLM_RETRY_BUDGET_MS` env; on exhaustion (budget, or a
+ * Retry-After past the ceiling) chatCompletion throws LLMUpstreamOutageError.
  */
 export interface ChatCompletionOptions {
   maxTokens?: number;
@@ -708,8 +720,9 @@ export const DEFAULT_RETRY_CAP_MS = 60_000;
 /**
  * Default retry budget in ms. Configurable via
  * `TOTALRECLAW_LLM_RETRY_BUDGET_MS` env var — read by `config.ts`. Callers
- * can override per-call via `retry.budgetMs`. 60_000ms covers ~8 minutes
- * worth of upstream outages with the 2s→32s schedule.
+ * can override per-call via `retry.budgetMs`. 60_000ms comfortably covers the
+ * default 5-attempt schedule (worst case ~30s of exponential backoff) plus a
+ * single Retry-After wait up to the 60s ceiling.
  *
  * Scanner-isolation note: the env read lives in `config.ts` so this file
  * stays clean of env-harvesting triggers.
@@ -857,8 +870,9 @@ export function zaiFallbackBaseUrl(currentBaseUrl: string): string | null {
  * Supports both OpenAI-compatible format and Anthropic Messages API,
  * determined by `config.apiFormat`.
  *
- * 3.3.1-rc.3 — lifts the retry budget 5 attempts × (2s/4s/8s/16s/32s), total
- * ~62s. Configurable via `TOTALRECLAW_LLM_RETRY_BUDGET_MS`. Adds zai
+ * 3.3.1-rc.3 — lifts the retry budget to 5 attempts (4 waits, per-attempt
+ * ceiling 2s/4s/8s/16s → ~30s worst-case backoff) under a 60s total budget.
+ * Configurable via `TOTALRECLAW_LLM_RETRY_BUDGET_MS`. Adds zai
  * "Insufficient balance" auto-fallback: when a zai 429 carries the balance
  * error body AND we're on one of the two known zai endpoints, we flip to
  * the OTHER endpoint and retry ONCE (accounted for separately from the

--- a/skill/plugin/runtime/config-schema.ts
+++ b/skill/plugin/runtime/config-schema.ts
@@ -46,7 +46,7 @@ export const CONFIG_SCHEMA = {
             },
             model: {
               type: 'string',
-              description: 'Explicit model id. If omitted, deriveCheapModel(provider) picks a sensible default.',
+              description: 'Explicit model id. If omitted, resolveExtractionModel() picks the cheapest of the user\'s configured models, falling back to a per-provider default.',
             },
             apiKey: {
               type: 'string',


### PR DESCRIPTION
Addresses the #502 429 data-loss (which made rc.1/rc.2 QA untestable) + Pedro's directive (2026-07-20): keep the user's own provider (NO OpenRouter), fix the 429s, and stop hardcoding the extraction model.

## Part 1 — 429 resilience
- **Dropped the stale retry override** at all 5 extractor call-sites (`extractor.ts:777/935/1084/1496/1614`) — a rc.2 leftover `{attempts:3, baseDelayMs:1000}` that *undercut* the shared `chatCompletion` default (5 attempts / 2→32s / 60s budget). Extraction now inherits the resilient default. This alone is the highest-value fix.
- **Full jitter** (AWS full-jitter: `wait = random(0, min(cap, base·2ⁿ))`), injectable RNG for deterministic tests.
- **Honor `Retry-After`** (delta-seconds + HTTP-date, capped 60s) — the plugin ignored it; Python already honored it. Exhaustion throws typed `LLMUpstreamOutageError`.

## Part 2 — no hardcoded extraction model
- `selectCheapestConfiguredModel()`: picks the cheapest from the **user's own OpenClaw `models[]`** — cheap-tier-indicator filter (word-boundary, so "mini" inside "gemini" is rejected), `maxTokens` tiebreak, null if none. New 5-tier precedence: explicit override → already-cheap primary → **cheapest configured** → hardcoded table (demoted to LAST RESORT) → primary. On the QA box `[glm-5-turbo, glm-4.7, glm-4.5-flash]` it selects `glm-4.5-flash` *from the user's config*; an OpenAI user on `[gpt-5, gpt-5-mini]` gets `gpt-5-mini`. No baked-in model names in the selected path.

## Verification
- `node run-tests.mjs` **96/96 EXIT=0**; `check-scanner` 0 flags
- Tests cover: full-jitter bound (injected RNG), Retry-After parse (delta + HTTP-date), the selection precedence + the gemini false-positive guard + the maxTokens tiebreak

## Scope / follow-ups
- Plugin-only (the QA-blocked surface). Hermes already has good retry + Retry-After; its cheapest-model change is a follow-up.
- **#553**: Part 1.4 — re-queue rate-limited turns to the `extractd` poller instead of advancing past them (the tail no-data-loss guarantee; deferred because it's a cross-caller `LLMUpstreamOutageError` contract change).

Authorship: cc-glm worker (selection + jitter + Retry-After + tests; died twice on z.ai stream errors) + coordinator completion (override drop, install repair, verification). Rolls into 3.4.0-rc.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SztW6QFyp5t1ux4gW2mW6