### PR TITLE
fix(plugin): thread OpenClaw models[] into env-var + auth-profile extraction-model resolution (internal#502 Part 2 wiring gap)

### DIFF
--- a/skill/plugin/llm/llm-client.test.ts
+++ b/skill/plugin/llm/llm-client.test.ts
@@ -503,6 +503,43 @@ function restoreEnv(stash: Record<string, string | undefined>): void {
 }
 
 // ---------------------------------------------------------------------------
+// #502 wiring regression — provider config carries models[] but NO apiKey
+// (key comes from a lower tier: auth-profiles / env var). The configured
+// models[] MUST still be threaded so cheapest-configured selection fires,
+// instead of silently dropping to the hardcoded table. This is the real
+// production shape (found live on the QA box: openclaw.json enumerates
+// zai models[] while the key arrives via ZAI_API_KEY → resolution reached
+// the env-var tier and used the hardcoded fallback). Uses openai so the
+// cheapest-configured model (gpt-4.1-nano) is DISTINCT from the hardcoded
+// table default (gpt-4.1-mini) — the assertion can tell them apart.
+// ---------------------------------------------------------------------------
+
+{
+  // Tier 3 (auth-profiles) carries the key; openclawProviders.openai has
+  // models[] but no apiKey → Tier 2 is skipped, resolution reaches Tier 3.
+  const cap = mkLogger();
+  initLLMClient({
+    primaryModel: 'openai/gpt-5',
+    openclawProviders: {
+      openai: {
+        baseUrl: 'https://api.openai.com/v1',
+        // NO apiKey here — key comes from auth-profiles below.
+        models: [{ id: 'gpt-5', maxTokens: 400_000 }, { id: 'gpt-4.1-nano', maxTokens: 128_000 }],
+      },
+    },
+    authProfileKeys: [{ provider: 'openai', apiKey: 'sk-auth' }],
+    logger: cap.logger,
+  });
+  const cfg = resolveLLMConfig();
+  assertEq(
+    cfg?.model,
+    'gpt-4.1-nano',
+    'tier-3 auth-profiles: configured models[] threaded → cheapest-configured gpt-4.1-nano (NOT hardcoded gpt-4.1-mini)',
+  );
+  assertEq(cfg?.apiKey, 'sk-auth', 'tier-3 auth-profiles: key came from auth-profiles (not the provider object)');
+}
+
+// ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
 

--- a/skill/plugin/llm/llm-client.ts
+++ b/skill/plugin/llm/llm-client.ts
@@ -451,6 +451,11 @@ export function initLLMClient(options: {
         baseUrlOverride: llmOverride.baseUrl,
         modelOverride: llmOverride.model ?? modelOverride,
         primaryModelHint: modelFromPrimary,
+        // #502: even for an explicit provider+key override, honor the user's
+        // configured models[] when the override omits a model — keeps
+        // cheapest-configured selection consistent across every tier (moot when
+        // the override sets a model, since that wins outright).
+        configuredModels: openclawProviders?.[provider]?.models,
       });
       if (resolved) {
         _cachedConfig = resolved.config;

--- a/skill/plugin/llm/llm-client.ts
+++ b/skill/plugin/llm/llm-client.ts
@@ -524,6 +524,10 @@ export function initLLMClient(options: {
         const resolved = buildConfigForProvider(providerFromPrimary, hit.apiKey, {
           modelOverride,
           primaryModelHint: modelFromPrimary,
+          // #502: the key came from auth-profiles, but the user's configured
+          // models[] still lives in the OpenClaw provider config — thread it so
+          // cheapest-configured selection fires even when the key isn't co-located.
+          configuredModels: openclawProviders?.[providerFromPrimary]?.models,
         });
         if (resolved) {
           _cachedConfig = resolved.config;
@@ -543,6 +547,9 @@ export function initLLMClient(options: {
     for (const entry of ordered) {
       const resolved = buildConfigForProvider(entry.provider, entry.apiKey, {
         modelOverride,
+        // #502: thread the OpenClaw-configured models[] for this provider (key
+        // source and models[] source are independent).
+        configuredModels: openclawProviders?.[entry.provider]?.models,
       });
       if (resolved) {
         _cachedConfig = resolved.config;
@@ -577,6 +584,12 @@ export function initLLMClient(options: {
         const resolved = buildConfigForProvider(providerFromPrimary, apiKey, {
           modelOverride,
           primaryModelHint: modelFromPrimary,
+          // #502: the key comes from an env var (e.g. ZAI_API_KEY), but the
+          // user's models[] still lives in the OpenClaw provider config — thread
+          // it so cheapest-configured selection fires instead of silently
+          // dropping to the hardcoded CHEAP_MODEL_BY_PROVIDER table. This is the
+          // common production setup (provider key via env, models[] in config).
+          configuredModels: openclawProviders?.[providerFromPrimary]?.models,
         });
         if (resolved) {
           _cachedConfig = resolved.config;
@@ -591,7 +604,11 @@ export function initLLMClient(options: {
   for (const [provider, keyName] of envFallback) {
     const apiKey = CONFIG.llmApiKeys[keyName];
     if (!apiKey) continue;
-    const resolved = buildConfigForProvider(provider, apiKey, { modelOverride });
+    const resolved = buildConfigForProvider(provider, apiKey, {
+      modelOverride,
+      // #502: env-var key + OpenClaw-configured models[] (independent sources).
+      configuredModels: openclawProviders?.[provider]?.models,
+    });
     if (resolved) {
       _cachedConfig = resolved.config;
       _logger?.info?.(


### PR DESCRIPTION
**Found by live re-QA of 3.4.0-rc.3 on the box.** Follow-up to #554 (which shipped the cheapest-configured-model selection). E2E-verified fix.

## The gap
#554's `resolveExtractionModel` selects the cheapest of the user's configured OpenClaw `models[]` — but only **Tier 2** (provider config with a co-located `apiKey`) threaded that list into the selector. On the common production shape where the provider **key comes from an env var** (`ZAI_API_KEY`) or **auth-profiles** while `models[]` lives in `openclaw.json`, resolution falls through to Tier 3/4 — which did **not** thread `configuredModels` — so it silently used the hardcoded `CHEAP_MODEL_BY_PROVIDER` table instead of the cheapest **configured** model.

## Box evidence (the exact repro)
zai provider: `models[] = [glm-5-turbo, glm-4.7, glm-4.5-flash]`, key via `ZAI_API_KEY`:
```
BEFORE (rc.3): resolved zai/glm-4.5-flash (env var; model: hardcoded table (fallback — no cheap model in config))
AFTER  (fix):  resolved zai/glm-4.5-flash (env var; model: cheapest of configured models)
```
On zai the resolved model coincided (hardcoded zai default == cheapest configured), so **no functional regression** — but it used the hardcoded path Pedro's directive explicitly says to avoid, and for any provider whose cheapest configured model differs from the table it would pick the wrong one.

## Fix
Thread `openclawProviders?.[provider]?.models` into the **Tier 3 (auth-profiles)** and **Tier 4 (env-var)** `buildConfigForProvider` calls. Key source and `models[]` source are independent — the models list is available in `openclawProviders` (passed at index.ts:2611) regardless of where the key resolves.

## Verification
- **Live box E2E**: dist-swapped the fix into `tr-openclaw`, restarted the gateway, confirmed the resolution log flipped (above). `memory_save` still registered (#499 intact).
- **Regression test**: provider config with `models[]` but **no** apiKey (key from auth-profiles) → resolves cheapest **configured** `gpt-4.1-nano`, distinct from the hardcoded table default `gpt-4.1-mini`, so the assertion distinguishes config-harvest from fallback. Prior tests only covered Tier 2.
- Gate **96/96**, scanner **0 flags**.

Rolls into **3.4.0-rc.4** with #554. Not a hard blocker for the 429 fix (#502 Part 1, independent), but required to actually meet the 'cheapest from user config, not hardcoded' directive on the standard env-var setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SztW6QFyp5t1ux4gW2mW6