### PR TITLE
docs: proactive recall best practices (grounded in real auto-recall)

### DIFF
--- a/docs/guides/proactive-recall-best-practices.md
+++ b/docs/guides/proactive-recall-best-practices.md
@@ -1,0 +1,111 @@
+# Proactive Recall Best Practices for Personal Agents
+
+> **Audience:** LLM agents running TotalReclaw as a memory provider (Hermes, OpenClaw, Claude Desktop / Claude Code via MCP, etc.).
+> **Scope:** When an agent should call `totalreclaw_recall` *itself*, on top of whatever automatic recall its host performs.
+
+## How automatic recall actually works
+
+TotalReclaw's automatic recall is **narrower than most agents assume** — knowing exactly what it does (and does not) do is the whole point of this guide.
+
+### Hermes (Python client)
+
+Hermes wires TotalReclaw through lifecycle hooks in `totalreclaw/hermes/hooks.py`:
+
+- **`pre_llm_call` — auto-recall, first turn only.** On the *first* turn of a session (`is_first_turn`), the plugin runs `auto_recall(user_message, state, top_k=8)` and injects the result into that turn's context as a `## Relevant memories from TotalReclaw` block. The query is the user's **first message, verbatim**.
+- **`post_llm_call` — auto-extraction, every N turns.** This writes memories (`turn_count % extraction_interval == 0`); it does **not** read or inject anything. Extraction ≠ recall — don't confuse the two.
+
+There is **no per-turn automatic recall.** After turn 1, memories enter the conversation only when the agent explicitly calls `totalreclaw_recall`. There is no background prefetch, no recall cache, and no `<memory-context>` refresh on later turns.
+
+### OpenClaw plugin
+
+OpenClaw's `before_agent_start` hook auto-recalls before each message (see `skill/plugin/README.md`). This is broader than Hermes (per-message, not first-turn-only), but it is still **query-driven** by the current message.
+
+### MCP hosts (Claude Desktop, Claude Code)
+
+No lifecycle hooks at all — the host agent must call `totalreclaw_recall` explicitly for every recall. All of the practices below apply with full force.
+
+### What every path shares
+
+Recall is **query-driven**: it searches for memories semantically related to whatever text it was handed. The retrieval pipeline (BM25 + cosine + RRF + source-weighted rerank, `top_k` default 8/16 by tier) is sharp on specific queries, and it has a **server-side broadened fallback** — when the trapdoor search returns zero hits for a vague query, the relay returns the owner's recent facts instead. But nothing decides *for* the agent that a recall is worth doing on turn 5, or that a standing directive should be loaded before the user re-triggers it.
+
+## The gaps automatic recall leaves
+
+1. **Low-signal session openers.** First-turn recall keys on the first message. "continue", "hey", "where were we?" carry no topical signal, so the recall is weak (the broadened fallback returns *recent* facts, not necessarily the *relevant* ones).
+2. **No mid-session recall (Hermes/MCP).** After turn 1, a topic shift to something discussed weeks ago surfaces nothing automatically. The agent has to ask for it.
+3. **Directives and standing preferences never load on their own.** A `directive` like "never mention X" or a preference like "always answer concisely" is only surfaced if a query happens to match it — yet these should shape *every* turn. This is the single biggest source of user-visible re-corrections.
+
+## Best practices (do these today — no code changes)
+
+### 1. Session-start recall when the opener is low-signal
+
+If the first message has no topical hook ("continue", "where were we?", a bare greeting), the automatic first-turn recall has nothing to work with. Call recall yourself with a broad profile query:
+
+```
+totalreclaw_recall(query="user preferences directives active projects recent commitments", top_k=8)
+```
+
+Skip this when the first message already has clear topical signal — the automatic first-turn recall (Hermes) or `before_agent_start` (OpenClaw) already covered it. Don't duplicate it.
+
+### 2. Preference / directive check before acting on the user's behalf
+
+Before a recommendation or an action that depends on the user's standing preferences or rules, recall that domain — even if nothing in the current context mentions it:
+
+```
+totalreclaw_recall(query="user preferences for <domain>; always/never rules", top_k=5)
+```
+
+Examples: recommending a restaurant → dietary restrictions; suggesting a library → tech-stack preferences; drafting a message → tone/style directives.
+
+### 3. Topic-shift recall (especially mid-session)
+
+Because there is no automatic recall after turn 1 on Hermes/MCP, **you** are the only thing that will surface history when the user pivots. Recall when:
+
+- the user moves to a domain you haven't touched this session,
+- they name a project / person / place you have no context for,
+- they say "we talked about this" / "do you remember…".
+
+```
+totalreclaw_recall(query="<topic> decisions next steps context", top_k=8)
+```
+
+### 4. When recall returns 0, broaden — don't give up
+
+If `totalreclaw_recall` returns nothing for a query where memories should exist, retry once with a **broader** query (fewer, more general terms). The pipeline's server-side broadened fallback already widens vague queries, so a second, looser call often surfaces what a narrow one missed. There is no separate "session search" tool — broadening the recall query *is* the fallback.
+
+### 5. Read what's already injected first
+
+On the turn where auto-recall fired (turn 1 on Hermes; every turn on OpenClaw), a `## Relevant memories from TotalReclaw` block is already in your context. Read it before deciding whether an extra recall is warranted — if it covers the topic, don't spend a tool call repeating it.
+
+## Anti-patterns
+
+- ❌ **Recalling on every turn regardless.** Wastes tokens and calls. Recall when the situation (session-start / preference-dependent / topic-shift) calls for it.
+- ❌ **Recalling with the user's message verbatim** when auto-recall already ran on it — that duplicates the automatic pass. Use a *broader* or *different* angle (profile / directives) instead.
+- ❌ **Ignoring the injected `## Relevant memories` block** and recalling blind.
+- ❌ **Recalling without acting on the result.** If it won't change your answer, don't call it.
+- ❌ **Recall chains** (recall → recall → recall in one turn). One or two targeted calls per turn is the ceiling.
+
+## Decision matrix
+
+| Situation | Action | Priority |
+|-----------|--------|----------|
+| New session, low-signal opener ("continue") | Broad profile recall (§1) | High |
+| User asks about their preferences / history | `totalreclaw_recall` before answering | High |
+| About to recommend / act on a preference | Preference-check recall (§2) | High |
+| User shifts to a topic from a past session | Topic-shift recall (§3) | Medium |
+| Auto-injected block seems thin | One supplementary recall, broader query | Medium |
+| Recall returned 0 unexpectedly | Retry once, broader query (§4) | Medium |
+| First message already had clear topical signal | Nothing — auto-recall covered it | — |
+
+## Future: automated session-start sweep (proposed, not implemented)
+
+The §1 practice is a *manual* fix for the low-signal-opener and directive-loading gaps. The automated version is a small, well-scoped enhancement — **not the new subsystem it might sound like**, because the infrastructure already exists:
+
+- First-turn recall already runs in `pre_llm_call` (`is_first_turn`), and its result is already injected via the returned `{"context": …}`.
+- The only change: on the first turn, **also** run one broad recall for durable, always-relevant context (`directive` + `preference` + active `commitment` memories) and merge it with the message-keyed recall — so standing rules load regardless of what the opener says.
+
+This is deliberately the *minimal* option:
+
+- **Adopt:** one extra broad recall on turn 1, scoped to directive/preference/commitment types, reusing the existing injection path.
+- **Reject for v1:** running 2–3 parallel recalls on *every* session start (fixed latency + relay load on the many sessions that don't need it); and passing recall results through an extra LLM call to synthesize a "user brief" (adds per-session latency/cost and front-loads a dense personal profile into every system prompt — a token and privacy cost even for throwaway sessions).
+
+Tracked as a follow-up; until it ships, §1 is the way to close the gap.

--- a/python/src/totalreclaw/hermes/SKILL.md
+++ b/python/src/totalreclaw/hermes/SKILL.md
@@ -61,6 +61,13 @@ Auto-fires once per session via the `on_session_end` hook (when the gateway clos
 - **First-person factual query** ("do I / what's my / where do I / what did I say about / what do you know about me / am I supposed to / when did I …") → `totalreclaw_recall` FIRST, then answer from returned facts. If 0 results, say so honestly — DO NOT fabricate from session context. This is non-negotiable: agents MUST call `totalreclaw_recall` even when the answer appears to be in the current context window. Hermes' built-in `USER.md` cache is local; the TotalReclaw vault is canonical + cross-device.
 - **Specific-fact lookups** ("what's my AWS account ID?") → `totalreclaw_recall` with a tight query. The reranker (BM25 + cosine + RRF + source-weighted) is sharper on specific queries.
 
+**Proactive recall — auto-recall only fires on turn 1.** The plugin auto-recalls once, on the first turn, keyed on the user's first message; after that, nothing surfaces memories except your own `totalreclaw_recall` calls. So call recall yourself when:
+- the session opener is low-signal ("continue", "where were we?", a bare greeting) → recall a broad profile: `totalreclaw_recall("user preferences directives active projects recent commitments")`. The first-turn auto-recall had no topical signal to work with.
+- you're about to recommend or act on a standing preference/rule → recall that domain first, even if nothing in context mentions it (directives like "never mention X" don't auto-load).
+- the user shifts to a topic from a past session ("we talked about this", names a project you have no context for) → recall with topic keywords; there is no mid-session auto-recall to catch it.
+
+If a recall returns 0 where memories should exist, retry once with a *broader* query (there is no separate "session search" tool — broadening the query is the fallback). Don't recall every turn, don't re-recall the same message auto-recall already used, and read any injected `## Relevant memories` block before adding a call. Full guidance: [`docs/guides/proactive-recall-best-practices.md`](../../../../docs/guides/proactive-recall-best-practices.md).
+
 ### Mutating existing facts
 
 Pattern is always **recall first → mutate second**, because the mutation tools need `fact_id`:


### PR DESCRIPTION
Rewrites the proactive-recall guide against **ground truth**. The original draft was built on a fabricated pipeline — `prefetch()`, `recall_for_query()`, `queue_prefetch_all()`, a `session_search` fallback tool, and a `<memory-context>` injection fence — **none of which exist in the codebase** (verified: 0 hits across `python/src`). An agent following it would call a nonexistent tool and rely on a recall cadence that isn't real.

## What the rewrite corrects to
- **Hermes auto-recall = `pre_llm_call`, first turn only**, `auto_recall(user_message, top_k=8)`, injected as a `## Relevant memories from TotalReclaw` block. There is **no per-turn recall** and no prefetch cache.
- **`post_llm_call` = auto-extraction** (writes) every N turns — not recall.
- **OpenClaw** = `before_agent_start` per-message; **MCP** = no hooks.
- **Empty-recall fallback = broaden the query** (the pipeline's server-side broadened fallback), not a nonexistent `session_search`.

## Other changes
- Retargets the agent-facing note from **`skill/SKILL.md`** (deleted in the #476 plugin restructure) to **`python/src/totalreclaw/hermes/SKILL.md`**, the current Hermes skill doc, slotted into its existing "Recall — when + how" section.
- Drops the unverifiable competitor comparison table.
- Folds the **"welcome sweep"** idea in honestly: first-turn recall already exists, so the real enhancement is just loading directives/preferences on turn 1 regardless of opener. Documented as a proposed, **not-implemented** follow-up (scoped to one extra broad recall; multi-query and LLM-synthesis variants rejected for v1) and filed separately as an enhancement issue.

The genuinely useful guidance — session-start recall on low-signal openers, preference/directive checks before acting, topic-shift recall (which matters *more* than the original implied, since there's no mid-session auto-recall) — is kept and corrected.