### PR TITLE
chore(plugin): stage 3.4.1 (= 3.4.0) — version bump + ClawHub display-name fix

### DIFF
--- a/.github/workflows/promote-rc.yml
+++ b/.github/workflows/promote-rc.yml
@@ -381,6 +381,7 @@ jobs:
           # Using legacy `clawhub publish --slug` (CLI 0.8.0). See install step.
           clawhub publish ./skill/plugin \
             --slug totalreclaw \
+            --name "TotalReclaw" \
             --version "$STABLE" \
             --tags "latest,memory,encryption,e2ee,privacy,agent-memory,e2e-encryption,persistent-context" \
             --changelog "Release $STABLE (promoted from RC) -- see https://github.com/p-diogo/totalreclaw/releases/tag/v$STABLE"

--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -216,6 +216,7 @@ jobs:
           # See install step above for full context.
           clawhub publish "$PUBLISH_DIR" \
             --slug "$SLUG" \
+            --name "TotalReclaw" \
             --version "$VERSION" \
             --tags "$TAGS" \
             --changelog "$CHANGELOG"

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "End-to-end encrypted, decentralized memory for OpenClaw. A native kind:memory provider — recall is automatic via memory_search/memory_get, and facts are captured in the background. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', any recall request ('what do you remember about me', 'what's my X'), AND any explicit remember request ('remember X', 'save X')."
-version: 3.3.13
+version: 3.4.1
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz

--- a/skill/plugin/cli/tr-cli-json-output.test.ts
+++ b/skill/plugin/cli/tr-cli-json-output.test.ts
@@ -149,12 +149,12 @@ assert(
 
 // ---------------------------------------------------------------------------
 // 6. PLUGIN_VERSION constant present (auto-synced by sync-version.mjs from
-//    package.json — accept any 3.3.x-rc.N format from rc.9-rc.1 onwards)
+//    package.json — accept any 3.4.x (-rc.N) format)
 // ---------------------------------------------------------------------------
 
 assert(
-  /const PLUGIN_VERSION = '3\.3\.\d+(?:-rc\.\d+)?';/.test(src),
-  "tr-cli.ts: const PLUGIN_VERSION declares a 3.3.x version (auto-synced by sync-version.mjs)",
+  /const PLUGIN_VERSION = '3\.4\.\d+(?:-rc\.\d+)?';/.test(src),
+  "tr-cli.ts: const PLUGIN_VERSION declares a 3.4.x version (auto-synced by sync-version.mjs)",
 );
 
 // ---------------------------------------------------------------------------

--- a/skill/plugin/cli/tr-cli.ts
+++ b/skill/plugin/cli/tr-cli.ts
@@ -68,7 +68,7 @@ const STATE_PATH = CONFIG.onboardingStatePath;
 // Auto-synced by skill/scripts/sync-version.mjs from skill/plugin/package.json::version.
 // Do not edit by hand — running tests will catch drift but the publish workflow
 // rewrites this constant at the start of every npm/ClawHub publish.
-const PLUGIN_VERSION = '3.3.12-rc.10';
+const PLUGIN_VERSION = '3.4.1';
 
 function die(msg: string, code = 1): never {
   process.stderr.write(`tr: ${msg}\n`);

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [

--- a/skill/plugin/skill-md-native.test.ts
+++ b/skill/plugin/skill-md-native.test.ts
@@ -262,8 +262,8 @@ for (const pattern of FORBIDDEN_TOOLBIND_WAIT) {
 // ---------------------------------------------------------------------------
 
 assert(
-  /^version: 3\.3\.(9|1\d)(-rc\.\d+)?$/m.test(pluginSkillMd),
-  'skill/plugin/SKILL.md: frontmatter version is 3.3.9+/3.3.1[0-9] with optional -rc.N (clean stable versions valid in-repo since the #509 publish consolidation)',
+  /^version: 3\.4\.\d+(-rc\.\d+)?$/m.test(pluginSkillMd),
+  'skill/plugin/SKILL.md: frontmatter version is 3.4.x with optional -rc.N (clean stable versions valid in-repo since the #509 publish consolidation)',
 );
 
 // ---------------------------------------------------------------------------

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",


### PR DESCRIPTION
## Why
ClawHub is stuck: a phantom, never-finalized `3.4.0` upload blocks re-publishing `3.4.0` ("Version 3.4.0 already exists"), and the live listing shows `displayName: "Plugin"` instead of `"TotalReclaw"`. npm `latest` is already 3.4.0 (the authoritative install path), so urgency is low — this is channel parity + hygiene.

This stages **3.4.1**, which is **content-identical to 3.4.0** (only the version string changes) so it publishes past the phantom. Verified: `git diff v3.4.0..origin/main -- skill/plugin/` is **empty** — main's plugin subtree is byte-identical to the npm 3.4.0 source.

## Changes
- **Version bump `3.4.0 → 3.4.1`** across all four sites via `sync-version.mjs` (`package.json`, `skill.json`, `SKILL.md`, `tr-cli.ts`). `SKILL.md` (`3.3.13`) and `tr-cli.ts` (`3.3.12-rc.10`) were drifted on main and are realigned. `check-version-drift.mjs` passes.
- **ClawHub display-name fix**: `--name "TotalReclaw"` added to both `clawhub publish` call sites (`promote-rc.yml`, `publish-clawhub.yml`). Fixes `displayName: "Plugin"` → `"TotalReclaw"`. `--name` verified supported on the pinned `clawhub@0.8.0`.

No code/logic changes vs 3.4.0 — version strings + one publish flag only.

## Dispatch (after merge — Pedro's L3 gate)
```bash
# npm (reads committed package.json version)
gh workflow run npm-publish.yml -R p-diogo/totalreclaw -f package=plugin -f release-type=stable
# ClawHub (version-input-driven; direct stable, no RC needed; phantom 3.4.0 doesn't conflict)
gh workflow run publish-clawhub.yml -R p-diogo/totalreclaw -f version=3.4.1 -f release-type=stable -f skill-source=plugin
# verify
npm view @totalreclaw/totalreclaw version                       # -> 3.4.1
npx clawhub@0.23.1 inspect @p-diogo/totalreclaw --versions      # latest 3.4.1, displayName "TotalReclaw"
```

## Notes
- The phantom ClawHub `3.4.0` stays buried (not latest, not in the public version list). `clawhub delete --version 3.4.0` is CLI-blocked ("Skill not found" — the `@thcjp/totalreclaw` squatter breaks slug resolution in the delete/hide mutations, while inspect/scan/scan resolve fine). Cleanup deferred to a ClawHub support issue (also covers the squatter slug-ambiguity + `totalreclaw-canary` hide).
- Merging is safe: `npm-publish.yml` / `publish-clawhub.yml` are `workflow_dispatch` only — no auto-publish on push to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
