### PR TITLE
fix(plugin): publish our own SKILL.md via the manifest `skills` field

### DIFF
--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are docu
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.2] — unreleased
+
+### Fixed
+
+- **The plugin now ships its own agent-facing SKILL.md.** `openclaw.plugin.json` gained `"skills": ["."]`, so OpenClaw publishes the plugin's bundled `SKILL.md` into `~/.openclaw/plugin-skills/` on gateway start. Without it the plugin registered its memory *tools* (`memory_search` / `memory_get` / `memory_save`) but the agent never received the SKILL.md *prose* — the shell-`tr` ban that prevents silent data loss on explicit remembers (3.4.0 / #551), the pairing script, and the natural-language curation phrasing.
+
+  This gap predated the ClawHub retirement: the prose used to arrive via a separate `openclaw skills install totalreclaw`, which fetched the descriptor from ClawHub. That step is gone (#561) — the bare `totalreclaw` slug there is ambiguous with an unaffiliated third-party copy — so an npm-only install has to be self-sufficient, and now is.
+
+  Verified on OpenClaw 2026.6.8 against the real published artifact: `plugin-skills/totalreclaw -> extensions/totalreclaw` and `openclaw skills list` reports `✓ ready 🧠 totalreclaw` sourced from `openclaw-extra`. Guarded by new assertions in `manifest-shape.test.ts` (confirmed to fail when the field is removed).
+
 ## [3.4.1] — 2026-07-30
 
 Content-identical to 3.4.0 (`git diff v3.4.0..v3.4.1 -- skill/plugin/` is empty apart from the version string). The re-label existed only to publish past a reserved `3.4.0` version number on ClawHub. npm `latest` = 3.4.1.

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "End-to-end encrypted, decentralized memory for OpenClaw. A native kind:memory provider — recall is automatic via memory_search/memory_get, and facts are captured in the background. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', any recall request ('what do you remember about me', 'what's my X'), AND any explicit remember request ('remember X', 'save X')."
-version: 3.4.1
+version: 3.4.2
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz

--- a/skill/plugin/cli/tr-cli.ts
+++ b/skill/plugin/cli/tr-cli.ts
@@ -68,7 +68,7 @@ const STATE_PATH = CONFIG.onboardingStatePath;
 // Auto-synced by skill/scripts/sync-version.mjs from skill/plugin/package.json::version.
 // Do not edit by hand — running tests will catch drift but the publish workflow
 // rewrites this constant at the start of every npm/ClawHub publish.
-const PLUGIN_VERSION = '3.4.1';
+const PLUGIN_VERSION = '3.4.2';
 
 function die(msg: string, code = 1): never {
   process.stderr.write(`tr: ${msg}\n`);

--- a/skill/plugin/manifest-shape.test.ts
+++ b/skill/plugin/manifest-shape.test.ts
@@ -246,6 +246,71 @@ let manifest: Record<string, unknown>;
 // 2. JS plugin definition assertions (source inspection)
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// 3. `skills` — the plugin must publish its OWN SKILL.md descriptor.
+//
+// OpenClaw publishes a plugin's skills ONLY when the manifest declares a
+// top-level `skills: string[]` of plugin-root-relative directories:
+//   manifest-*.js   `const skills = normalizeTrimmedStringList(raw.skills)`
+//   plugin-skills-*.js  resolvePluginSkillDirs() ->
+//                         `if (!record.skills || record.skills.length === 0) continue;`
+//                       then symlinks each into `~/.openclaw/plugin-skills/`.
+//
+// Without this field the agent gets the memory TOOLS but never the SKILL.md
+// PROSE (the tr-shell ban, the pairing script, the curation phrasing). Until
+// 2026-07-30 that prose arrived via `openclaw skills install totalreclaw`
+// from ClawHub — a channel we retired (#561), and one whose bare slug is
+// ambiguous with a third-party clone. npm-only install must be self-sufficient.
+//
+// `"."` = the plugin root, which contains SKILL.md directly. OpenClaw's
+// `collectSkillDirTargets` publishes such a directory as-is, and its
+// containment guard accepts the root itself (`isPathInside` returns true when
+// the relative path is ""). Verified on OpenClaw 2026.6.8 against the real
+// published artifact: `plugin-skills/totalreclaw -> extensions/totalreclaw`
+// and `openclaw skills list` reports `✓ ready  🧠 totalreclaw`.
+// ---------------------------------------------------------------------------
+
+{
+  const skills = manifest.skills;
+  assert(
+    Array.isArray(skills) && skills.length > 0,
+    'openclaw.plugin.json declares a non-empty `skills` array (else the agent never receives SKILL.md)',
+  );
+
+  // Every declared entry must resolve to a directory that actually contains a
+  // SKILL.md — a path typo would make OpenClaw log `plugin skill path not
+  // found` and silently publish nothing.
+  const entries = Array.isArray(skills) ? (skills as unknown[]) : [];
+  for (const entry of entries) {
+    const rel = typeof entry === 'string' ? entry : '';
+    const dir = path.resolve(__dirname, rel);
+    const skillMd = path.join(dir, 'SKILL.md');
+    assert(
+      rel.length > 0 && fs.existsSync(skillMd),
+      `skills[] entry ${JSON.stringify(entry)} resolves to a directory containing SKILL.md`,
+    );
+    // The containment guard OpenClaw applies (isPathInsideWithRealpath):
+    // the entry must not escape the plugin root.
+    const relFromRoot = path.relative(__dirname, dir);
+    assert(
+      !relFromRoot.startsWith('..') && !path.isAbsolute(relFromRoot),
+      `skills[] entry ${JSON.stringify(entry)} stays inside the plugin root`,
+    );
+  }
+}
+
+{
+  // The skill directory only reaches users if SKILL.md is in the npm tarball.
+  // `files[]` gates that — dropping SKILL.md there would publish an empty skill.
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(__dirname, 'package.json'), 'utf8'),
+  ) as { files?: string[] };
+  assert(
+    Array.isArray(pkg.files) && pkg.files.includes('SKILL.md'),
+    'package.json files[] ships SKILL.md (the published skill would be empty without it)',
+  );
+}
+
 const indexPath = path.join(__dirname, 'index.ts');
 const indexSrc = fs.readFileSync(indexPath, 'utf8');
 

--- a/skill/plugin/openclaw.plugin.json
+++ b/skill/plugin/openclaw.plugin.json
@@ -6,6 +6,9 @@
   "activation": {
     "onStartup": false
   },
+  "skills": [
+    "."
+  ],
   "contracts": {
     "tools": [
       "memory_search",

--- a/skill/plugin/package-lock.json
+++ b/skill/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/totalreclaw",
-      "version": "3.4.1",
+      "version": "3.4.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",


### PR DESCRIPTION
## The gap

The plugin registers its memory **tools** (`memory_search` / `memory_get` / `memory_save`) but the agent never receives the SKILL.md **prose** — the shell-`tr` ban that prevents silent data loss on explicit remembers ([#551](https://github.com/p-diogo/totalreclaw/pull/551)), the pairing script, the natural-language curation phrasing.

OpenClaw publishes a plugin's skills **only** when the manifest declares a top-level `skills: string[]` of plugin-root-relative directories:

```js
// manifest-*.js
const skills = normalizeTrimmedStringList(raw.skills)

// plugin-skills-*.js — resolvePluginSkillDirs()
if (!record.skills || record.skills.length === 0) continue;
//  … → symlinks each entry into ~/.openclaw/plugin-skills/
```

We never declared it. `skill/plugin/index.ts` doesn't write to the workspace skills dir either.

**This predates #561.** The prose used to arrive via a *separate* `openclaw skills install totalreclaw`, which fetched the descriptor from ClawHub — a step #561 removed, because that bare slug is ambiguous with an unaffiliated third-party copy (`@thcjp/totalreclaw`). An npm-only install has to be self-sufficient, so the gap had to close.

Worth noting how stale that channel had become: the ClawHub-installed skill on the dev machine was **version 1.6.0** while the plugin was on 3.4.x. This isn't a regression repair so much as fixing something that was quietly degraded for a long time.

## The fix

`"skills": ["."]` — the plugin root, which contains `SKILL.md` directly. `collectSkillDirTargets` publishes such a directory as-is, and the containment guard accepts the root itself (`isPathInside` returns `true` when the relative path is `""`).

I tested the alternative shape (a dedicated `skills/totalreclaw/` subdir, which is what OpenClaw's own stock `browser-automation` plugin uses). It works too, but it would mean either moving `SKILL.md` — touching `sync-version.mjs`, `check-version-drift.mjs`, `files[]`, and `skill-md-native.test.ts` — or keeping two copies that can drift. `["."]` is one line and keeps a single source of truth. The tradeoff: the published skill dir is the whole plugin tree rather than a tidy SKILL.md-only dir.

## Verification

On OpenClaw **2026.6.8** (matching pop-os), against the **real published 3.4.1 artifact** with the manifest patched:

```
$ ls -la ~/.openclaw/plugin-skills/
totalreclaw -> /home/pdiogo/.openclaw/extensions/totalreclaw
browser-automation -> /app/dist/extensions/browser/skills/browser-automation

$ openclaw skills list
│ ✓ ready │ 🧠 totalreclaw │ End-to-end encrypted, decentralized memory for  │ openclaw-extra │
│         │                │ OpenClaw. A native kind:memory provider — …     │                │
```

No `plugin skill path not found` / `escapes plugin root` warnings. Confirmed it needs a running gateway — publishing happens at config resolution, not on CLI invocation.

## Regression guard

New assertions in `manifest-shape.test.ts`: the field exists and is non-empty; every entry resolves to a directory containing `SKILL.md`; every entry stays inside the plugin root; and `files[]` still ships `SKILL.md` (otherwise the published skill would be empty). **Confirmed to fail when the field is removed** — `35/36, SOME TESTS FAILED` — so it's a real guard, not a tautology.

## Version

Base bumped **3.4.1 → 3.4.2** so the RC publishes as `3.4.2-rc.1`. `npm-publish.yml` appends `-rc.N` to the *committed* version, and `3.4.1-rc.1` would sort **below** the already-released `3.4.1`.

`latest` stays 3.4.1 until this is QA'd.

- 96/96 plugin test files pass
- `check-version-drift` ✅ (all sites = 3.4.2) · `check-scanner` ✅ (173 files, 0 flags)
- lockfile diff is version-only

## Next

Publish `3.4.2-rc.1` to the `rc` dist-tag, then a manual fresh-install pass on pop-os (clean container, isolated vault, npm-only) using the canonical RC install prompt. The thing to watch: on "remember X", the agent should call `memory_save` rather than shelling out to `tr`. Once that's confirmed, the canonical install guide and the version matrix get updated.
