### PR TITLE
fix(app): passkey browser-gate copy — Safari 18+/iOS 18+, not 17+

### DIFF
--- a/app/src/pages/BootstrapPage.tsx
+++ b/app/src/pages/BootstrapPage.tsx
@@ -106,7 +106,7 @@ export function BootstrapPage() {
           support it yet.
         </p>
         <p className="mt-3 text-ink-muted">
-          Try a recent Chrome, Edge, or Safari 17+ on a device with Touch ID / Face ID / Windows
+          Try a recent Chrome, Edge, or Safari 18+ (iOS 18+) on a device with Touch ID / Face ID / Windows
           Hello.
         </p>
       </Shell>


### PR DESCRIPTION
One-line copy fix, approved by Pedro as Option E Phase 1 decision D-5 ("ship immediately, standalone"). PRF requires Safari 18+ / iOS 18+; the gate message said 17+, misdirecting real users onto a browser that cannot work. Source: internal `design/option-e-phase1-passkey` browser-support matrix §5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mvnGim5nWoKjwX2A6N4Cv