### PR TITLE
fix(ci): populate GitHub Release notes from CHANGELOG-public.md

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -721,6 +721,7 @@ jobs:
           fi
           echo "Release tag: $TAG"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "plugin-version=$PLUGIN_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Build embedder bundle
         run: |
@@ -728,11 +729,94 @@ jobs:
           node scripts/build-embedder-bundle.mjs --out-dir dist/embedder
           ls -la dist/embedder/
 
+      # Pulls release notes from CHANGELOG-public.md so the Releases tab
+      # (a prominent visitor surface) says something real instead of the
+      # generic embedder-bundle stub (#574). RCs are never listed in
+      # CHANGELOG-public.md (see its header note) so this always misses for
+      # `release-type=rc` and falls back to the stub below — expected.
+      - name: Extract release notes from CHANGELOG-public.md
+        id: notes
+        run: |
+          PLUGIN_VERSION="${{ steps.tag.outputs.plugin-version }}"
+          cat > /tmp/extract-release-notes.cjs <<'NODE_EOF'
+          const fs = require('fs');
+
+          const version = process.argv[2];
+          const changelogPath = process.argv[3];
+          const outPath = process.argv[4];
+
+          function isPluginHeading(line) {
+            return (
+              line.includes('@totalreclaw/totalreclaw') ||
+              line.includes('(OpenClaw plugin)')
+            );
+          }
+
+          // Match `version` as a whole token within the heading line so
+          // "3.4.2" doesn't match "13.4.2" or "3.4.20".
+          function hasVersionToken(line, ver) {
+            let idx = 0;
+            for (;;) {
+              idx = line.indexOf(ver, idx);
+              if (idx === -1) return false;
+              const before = idx === 0 ? '' : line[idx - 1];
+              const after = line[idx + ver.length] || '';
+              const okBefore = !/[0-9.]/.test(before);
+              const okAfter = !/[0-9.]/.test(after);
+              if (okBefore && okAfter) return true;
+              idx += 1;
+            }
+          }
+
+          if (!version) {
+            process.exit(1);
+          }
+
+          let content;
+          try {
+            content = fs.readFileSync(changelogPath, 'utf8');
+          } catch (e) {
+            process.exit(1);
+          }
+
+          const lines = content.split('\n');
+          const headingIdx = [];
+          for (let i = 0; i < lines.length; i++) {
+            if (lines[i].startsWith('## ')) headingIdx.push(i);
+          }
+
+          let matchStart = -1;
+          let matchEnd = lines.length;
+          for (let k = 0; k < headingIdx.length; k++) {
+            const i = headingIdx[k];
+            if (isPluginHeading(lines[i]) && hasVersionToken(lines[i], version)) {
+              matchStart = i;
+              matchEnd = k + 1 < headingIdx.length ? headingIdx[k + 1] : lines.length;
+              break;
+            }
+          }
+
+          if (matchStart === -1) {
+            process.exit(1);
+          }
+
+          const section = lines.slice(matchStart, matchEnd).join('\n').replace(/\s+$/, '') + '\n';
+          fs.writeFileSync(outPath, section);
+          console.log('Extracted release notes for plugin version ' + version);
+          NODE_EOF
+          if node /tmp/extract-release-notes.cjs "$PLUGIN_VERSION" CHANGELOG-public.md /tmp/release-notes.md; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No matching CHANGELOG-public.md section for plugin version $PLUGIN_VERSION; falling back to stub notes."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Ensure GitHub Release exists for the tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ steps.tag.outputs.tag }}"
+          NOTES_FOUND="${{ steps.notes.outputs.found }}"
           # `gh release view` exits non-zero if the release doesn't exist.
           if ! gh release view "$TAG" >/dev/null 2>&1; then
             echo "Creating GitHub Release for tag $TAG"
@@ -740,13 +824,31 @@ jobs:
             if [ "${{ inputs.release-type }}" = "rc" ]; then
               FLAGS="--prerelease"
             fi
-            gh release create "$TAG" \
-              --title "$TAG" \
-              --notes "Auto-generated release for embedder bundle attachment. See CHANGELOG-public.md for details." \
-              $FLAGS \
-              --target "${GITHUB_SHA}"
+            if [ "$NOTES_FOUND" = "true" ]; then
+              gh release create "$TAG" \
+                --title "$TAG" \
+                --notes-file /tmp/release-notes.md \
+                $FLAGS \
+                --target "${GITHUB_SHA}"
+            else
+              gh release create "$TAG" \
+                --title "$TAG" \
+                --notes "Auto-generated release for embedder bundle attachment. See CHANGELOG-public.md for details." \
+                $FLAGS \
+                --target "${GITHUB_SHA}"
+            fi
           else
             echo "Release $TAG already exists; will upload bundle assets to it."
+            # Notes-only backfill: if a stable release was first created with
+            # the stub (e.g. this job re-ran after the release existed but
+            # notes extraction previously missed) and a matching section now
+            # exists, refresh just the notes text. Never touches assets or
+            # --prerelease status; skipped entirely for RCs since they never
+            # have a matching CHANGELOG-public.md section.
+            if [ "${{ inputs.release-type }}" != "rc" ] && [ "$NOTES_FOUND" = "true" ]; then
+              echo "Backfilling release notes for existing release $TAG"
+              gh release edit "$TAG" --notes-file /tmp/release-notes.md
+            fi
           fi
 
       - name: Upload embedder bundle + manifest


### PR DESCRIPTION
## Summary

Every GitHub Release body read the generic stub — *"Auto-generated release for embedder bundle attachment. See CHANGELOG-public.md for details."* — even for the latest stable plugin release. The Releases tab is a prominent visitor surface and said nothing real. This fixes the pipeline so it never recurs.

## Corrected file location (issue said `promote-rc.yml` — that's wrong)

Issue #574 pointed at `promote-rc.yml`. I verified in this worktree that's incorrect:

- `promote-rc.yml`'s `backfill-stable-tag` job only backfills the stable **git tag** — it never calls `gh release create`/`gh release edit`.
- The stub actually lives in **`.github/workflows/npm-publish.yml`**, job `publish-embedder-bundle`, step "Ensure GitHub Release exists for the tag" (`gh release create ... --notes "Auto-generated release for embedder bundle attachment..."`).
- **Only the plugin (`@totalreclaw/totalreclaw`) creates GitHub Releases at all** — the Release exists purely to host `embedder-v1.tar.gz`, which the plugin downloads at first `embed()` call. Every other package (core, mcp-server, client, nanoclaw, python, crates) is registry-only and never creates a GitHub Release. So this is entirely a plugin-pipeline fix, scoped to `npm-publish.yml`.

## What changed

In `publish-embedder-bundle`:
1. **"Compute release tag"** now also emits `plugin-version` as a step output (needed downstream; it was previously a step-local shell var).
2. **New step "Extract release notes from CHANGELOG-public.md"** writes a small Node script to `/tmp/extract-release-notes.cjs` (`.cjs`, not `.mjs` — Node forces ESM on `.mjs` regardless of nearby `package.json`, which would break the `require('fs')` call) and runs it:
   - Finds the first `^## ` heading that (a) is a plugin heading (`@totalreclaw/totalreclaw` or `(OpenClaw plugin)` in the text) and (b) contains the exact plugin version as a whole token (boundary-checked against surrounding digits/dots, so `3.4.2` doesn't match `13.4.2` or `3.4.20`).
   - Emits from that heading up to (not including) the next `^## `.
   - Exits non-zero (no file written) if nothing matches — RCs are **never listed** in `CHANGELOG-public.md` (see its own header note), so this step always misses for `release-type=rc` and correctly falls through to the stub. That's expected, not a bug.
3. **"Ensure GitHub Release exists for the tag"** now branches on whether notes were found: `--notes-file /tmp/release-notes.md` when found, else the original stub text (unchanged). `--prerelease` behavior for RCs is untouched.
4. **Nice-to-have, scoped tightly:** if the release already exists (idempotent re-run) and this is a **stable** promote (never RC) and a matching section was found, `gh release edit "$TAG" --notes-file ...` backfills just the notes text. This never touches assets, never changes `--prerelease` status, and is skipped entirely for RCs.

## Hard constraints honored

- **Assets untouched.** The asset-upload step (`gh release upload ... --clobber`) is unmodified — this PR only ever calls `--notes`/`--notes-file`/`gh release edit --notes-file`.
- **No release deletion**, ever.
- **RCs unaffected in practice**: `CHANGELOG-public.md`'s header note confirms RCs aren't tracked there, so the extractor always misses for `release-type=rc` and the stub + `--prerelease` flag are preserved exactly as before.

## Local extraction evidence (real `CHANGELOG-public.md`, ran outside CI — no Actions runner available here)

Ran the exact extraction logic (byte-identical to what's embedded in the workflow, aside from the `.cjs` filename) against the real file:

**(a) `3.4.1` → the "ClawHub retired" section (not core/mcp):**
```
Extracted release notes for plugin version 3.4.1
exit=0
## @totalreclaw/totalreclaw (OpenClaw plugin) 3.4.1 — ClawHub retired, npm is the only channel (2026-07-30)
...
- **Install is `openclaw plugins install @totalreclaw/totalreclaw`.** ...
```
(single heading in output, confirmed via `grep -n "^## "`)

**(b) `3.3.13` → the combined "3.3.12 / 3.3.13" section:**
```
Extracted release notes for plugin version 3.3.13
exit=0
## @totalreclaw/totalreclaw (OpenClaw plugin) 3.3.12 / 3.3.13 — Stable promote (2026-07-06 / 2026-07-15)
... (full section through "See `skill/plugin/CHANGELOG.md` for detail.")
```
(single heading in output)

**(c) `9.9.9` (non-existent) → no match, exit 1, no file written:**
```
exit code: 1
ls: /tmp/out-c.md: No such file or directory
```
→ caller falls back to the stub, as designed.

**(d) No cross-section bleed:** verified via `grep -n "^## "` on both (a) and (b) outputs — each contains exactly one heading line (its own), confirming the slice stops before the next `## `.

**Extra edge cases also verified:**
- `2.5.6` (real version, but only exists as a **core** section, not plugin) → no match (exit 1). Confirms the plugin-heading gate works, not just the version match.
- `3.4` (substring of `3.4.1`/`3.4.0`) → no match (exit 1). Confirms word-boundary matching.
- `13.13` → no match (exit 1). Sanity check.

## YAML validation

`actionlint` is not installed in this environment. Ran `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/npm-publish.yml'))"` → parses clean, both before and after the edit.

## Live validation — explicitly NOT done here

Per CLAUDE.md's E2E mandate, this needs a real Actions run to fully validate (there's no Actions runner available in this environment). **Live end-to-end validation will happen at the next plugin stable promote** — that run will exercise the full step (tag compute → extract → `gh release create --notes-file`) against the real `CHANGELOG-public.md` and a real GitHub Release. I'm stating this explicitly rather than papering over it.

## Risk / uncertainty

- The heredoc-embedded Node script relies on `.cjs` forcing CommonJS regardless of any `package.json` `"type"` setting nearby in `/tmp` — verified locally, but the CI runner's exact `/tmp` layout wasn't independently checked (should be a non-issue since `/tmp` has no `package.json` in either environment).
- If a future CHANGELOG-public.md section header format changes (e.g. drops `(OpenClaw plugin)` and `@totalreclaw/totalreclaw` both from the heading text), the plugin-heading gate would need updating — flagged here for awareness, not blocking.

## Note on issue scope

Issue #574 also has a **Part B** (moving the `rc` npm dist-tag for `@totalreclaw/mcp-server`) that requires npm auth and is being handled separately by the orchestrator. Not auto-closing the issue — leaving it open for Part B.

Addresses #574 (release-notes injection, Part A); Part B (mcp-server dist-tag) handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)