### PR TITLE
fix(mcp): drop MemoClaw from import_from tool descriptions

### DIFF
--- a/docs/guides/ironclaw-setup.md
+++ b/docs/guides/ironclaw-setup.md
@@ -119,7 +119,7 @@ The MCP server exposes 18 tools. Descriptions are summarized from the tool defin
 | `totalreclaw_forget` | Permanently remove a memory by `memory_id`, or by query (tombstones up to 50 matches). |
 | `totalreclaw_export` | Export the decrypted vault as Markdown or JSON (one-click portable backup). |
 | `totalreclaw_import` | Restore memories from a prior TotalReclaw export backup (JSON/Markdown). |
-| `totalreclaw_import_from` | Import from Mem0, MCP Memory, ChatGPT, Claude, Gemini, MemoClaw, or JSON/CSV. Dry-run first. |
+| `totalreclaw_import_from` | Import from Mem0, MCP Memory, ChatGPT, Claude, Gemini, or JSON/CSV. Dry-run first. |
 | `totalreclaw_import_batch` | Internal chunked-polling helper for large imports (50+ conversations); not meant to be called by name. |
 | `totalreclaw_consolidate` | Cluster near-duplicates and merge each to the best match. **Self-hosted only** (no batch delete on the managed service). |
 | `totalreclaw_status` | Check tier, usage, and quota against the relay billing endpoint. |

--- a/mcp/src/prompts.ts
+++ b/mcp/src/prompts.ts
@@ -59,7 +59,7 @@ Do NOT repeatedly attempt to store memories after a quota error.
 Note: Billing status is cached locally for up to 2 hours. After upgrading to Pro, the new tier may take up to 2 hours to take effect. If the user reports that Pro features are not active after upgrading, suggest restarting their agent to force a billing cache refresh.
 
 ### Importing memories from other tools
-If the user mentions migrating from Mem0, MCP Memory Server, MemoClaw, or any other AI memory tool, offer to use totalreclaw_import_from. Start with dry_run=true to preview, then confirm before importing.
+If the user mentions migrating from Mem0, MCP Memory Server, or any other AI memory tool, offer to use totalreclaw_import_from. Start with dry_run=true to preview, then confirm before importing.
 API keys provided by the user are used only for the import and are never stored.
 
 ### Agent-specific tips
@@ -161,7 +161,7 @@ WHEN NOT TO USE:
 - user already Pro (check totalreclaw_status)
 - unrelated — don't volunteer upgrades`;
 
-export const IMPORT_FROM_TOOL_DESCRIPTION = `Import from Mem0, MCP Memory, ChatGPT, Claude, Gemini, MemoClaw, JSON/CSV.
+export const IMPORT_FROM_TOOL_DESCRIPTION = `Import from Mem0, MCP Memory, ChatGPT, Claude, Gemini, JSON/CSV.
 INVOKE WHEN USER SAYS:
 - "migrate memory from [Mem0/ChatGPT/Claude]"
 - "import my ChatGPT memories" / "here's my Mem0 export"


### PR DESCRIPTION
## Diagnosis

`mcp/src/prompts.ts` advertised "MemoClaw" as an importable source for `totalreclaw_import_from`, but:

- `ImportSource` in `mcp/src/tools/import-from.ts:11` is `'mem0' | 'mcp-memory' | 'chatgpt' | 'claude' | 'gemini'` — no `memoclaw` member.
- The runtime `validSources` array and the JSON-schema `enum` (both in `import-from.ts`) list the same five sources, no MemoClaw.
- There is no MemoClaw adapter anywhere in the pipeline (`skill/plugin/import-adapters/`, `mcp/`, `python/`).

So an agent that took the tool description literally and passed `source: "memoclaw"` got a validation error — the description promised something the enum can't accept.

**Direction chosen: drop the string (not add the enum member).** No MemoClaw product integration exists anywhere in the codebase; adding a `memoclaw` enum value with no backing adapter would just move the dead end one level down (validation would pass, then `loadAdapter('memoclaw')` would fail). Removing the false claim is the correct fix.

## Changes

- `mcp/src/prompts.ts:62` — removed `MemoClaw, ` from the "Importing memories from other tools" prose (kept "or any other AI memory tool" so the sentence still reads naturally, without implying MemoClaw specifically is supported).
- `mcp/src/prompts.ts:164` — removed `MemoClaw, ` from `IMPORT_FROM_TOOL_DESCRIPTION` so the advertised source list matches the `ImportSource` enum exactly (Mem0, MCP Memory, ChatGPT, Claude, Gemini, JSON/CSV).
- `docs/guides/ironclaw-setup.md:122` — the tools table explicitly says "Descriptions are summarized from the tool definitions in `mcp/src/tools/`" and quoted the old description verbatim; updated it to match.

**Left unchanged (intentionally):** `docs/guides/importing-memories.md:198` lists MemoClaw under a "Future Import Sources — planned but not yet implemented" heading. That's already accurate (MemoClaw isn't supported) and doesn't need to change.

## Verification

Full grep for any other reference:
```
grep -rin "memoclaw" . (excluding node_modules/.git)
→ only docs/guides/importing-memories.md:198 remains (the accurate "planned" mention)
```

Build (TS project, enum/description are type-checked at build):
```
$ cd mcp && npm install && npm run build
> @totalreclaw/mcp-server@3.4.0 build
> tsc
BUILD_EXIT=0
```

Full unit test suite:
```
$ npm test
Test Suites: 37 passed, 37 total
Tests:       699 passed, 699 total
Time:        82.825 s
```

No E2E run (not required — this is a static prompt-string change, no staging-touching behavior).

Closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)