### PR TITLE
ci(core): exclude submodules from the built-wheel surface diff

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -182,10 +182,33 @@ jobs:
           # (it is decl-derived), but it DOES shrink the built wheel -- which is
           # exactly the discrepancy this diff catches.
           python scripts/check-pyfunction-parity.py --expected-exports | sort > /tmp/expected.txt
+          # Submodules are excluded from the comparison. The expected list is
+          # derived purely from `#[pyfunction]` / `#[pyclass]` declarations, so
+          # it can never contain a module -- meaning any module attribute is
+          # guaranteed to show up as "extra" and fail the diff no matter what
+          # the source says. maturin's layout puts exactly one there: it emits a
+          # `totalreclaw_core/__init__.py` that does `from .totalreclaw_core
+          # import *`, which leaves the inner extension module bound as an
+          # attribute of the same name. That self-reference is present in every
+          # wheel we have ever shipped (verified against the published 2.5.5),
+          # and it is not part of the pyfunction surface this check exists to
+          # police. It only surfaced now because this built-wheel diff (#504,
+          # merged 2026-07-10) had never actually executed in a publish -- the
+          # last real PyPI publish was 2026-06-22, so 2.6.0-rc.2 is its first
+          # run. Filtered names are printed, so this stays visible rather than
+          # silently swallowing a future surprise.
           /tmp/venv/bin/python - <<'PY' | sort > /tmp/actual.txt
+          import sys, types
           import totalreclaw_core as m
+          skipped = []
           for n in sorted(n for n in dir(m) if not n.startswith('_')):
+              if isinstance(getattr(m, n, None), types.ModuleType):
+                  skipped.append(n)
+                  continue
               print(n)
+          if skipped:
+              print('note: excluded submodule attrs from surface diff: '
+                    + ', '.join(skipped), file=sys.stderr)
           PY
           echo "expected exports: $(wc -l < /tmp/expected.txt) | actual wheel surface: $(wc -l < /tmp/actual.txt)"
           /tmp/venv/bin/python - <<'PY'


### PR DESCRIPTION
Unblocks the `totalreclaw-core` 2.6.0 PyPI publish (tracker #621 task 2(a), release plan R1).

## What happened

`publish-pypi.yml`'s built-wheel surface check failed the 2.6.0-rc.2 run ([31943332768](https://github.com/p-diogo/totalreclaw/actions/runs/31943332768)):

```
expected exports: 112 | actual wheel surface: 113
UNEXPECTED exports in built wheel (not in source scan):
  - totalreclaw_core
```

All five wheel builds and the sdist succeeded; only the surface check failed, so `Publish to PyPI` was skipped and **no version was burned**.

## The wheel is fine — the check is too strict

`missing` was **empty**: every declared `#[pyfunction]`/`#[pyclass]` is exported. The only delta is a self-reference — maturin emits `totalreclaw_core/__init__.py` containing `from .totalreclaw_core import *`, leaving the inner extension module bound as an attribute of the same name.

That is not new. It is true of the wheel currently on PyPI and in production:

```
$ pip install totalreclaw-core==2.5.5
>>> 'totalreclaw_core' in dir(totalreclaw_core)
True
```

**It surfaced now because this check had never run in a publish.** #504 merged 2026-07-10; the last real PyPI publish was 2026-06-22 (`016d88ee`). 2.6.0-rc.2 is its first-ever execution, and it failed on a condition that has held for every wheel we have shipped.

## Why filtering modules is correct, not a workaround

The expected list is derived *purely* from declaration scanning, so it can never contain a module. Any module attribute is therefore guaranteed to appear as "extra" no matter what the source says — the comparison was never meaningful for modules. Filtered names print to stderr so a future surprise stays visible.

## Verification

Against the actual rc.2 macOS-arm64 wheel downloaded from the failed run, reproducing CI's numbers exactly:

| capture | expected | actual | missing | extra | result |
|---|---|---|---|---|---|
| old (current `main`) | 112 | 113 | `[]` | `['totalreclaw_core']` | FAIL |
| new (this PR) | 112 | 112 | `[]` | `[]` | PASS |

The real signal this check exists for — a dropped registration shrinking the built wheel — is untouched.

Also verified from that same wheel while it was installed: `derive_bundle_from_mnemonic`, `parse_bundle_v1`, `validate_bundle_v1` all present, and the `derived-bundle-v1` parity fixture reproduces byte-identically from both PyO3 and the published npm WASM build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)