### PR TITLE
fix(python): auto-migration silently no-ops inside a running event loop

### DIFF
--- a/python/src/totalreclaw/hermes/auto_migrate.py
+++ b/python/src/totalreclaw/hermes/auto_migrate.py
@@ -249,18 +249,37 @@ def _resolve_smart_account(mnemonic: str, creds: dict) -> Optional[str]:
     if isinstance(cached, str) and cached.strip():
         return cached.strip()
 
+    from totalreclaw.agent.loop_runner import run_sync
     from totalreclaw.client import _derive_smart_account_address
 
+    # Use the process-wide background loop rather than asyncio.run here.
+    # This call site is sync but is NOT guaranteed to be outside a running
+    # event loop: `register()` is a plain `def`, but the host that calls it
+    # may well be driving an asyncio gateway, and this function's original
+    # comment anticipated exactly that. The previous hand-rolled fallback
+    # did not survive it:
+    #
+    #   asyncio.run(coro)                 -> RuntimeError inside a running
+    #                                        loop, AND leaves `coro` never
+    #                                        awaited (RuntimeWarning)
+    #   except RuntimeError:
+    #       new_event_loop().run_until_complete(coro2)
+    #                                     -> "Cannot run the event loop
+    #                                        while another loop is running"
+    #
+    # That second RuntimeError is raised from inside an `except` clause, so
+    # the `except Exception` below never sees it. It propagated to
+    # `maybe_migrate`'s blanket handler, which logs at DEBUG and returns
+    # False — i.e. on such a host the migration silently never happened and
+    # nothing above debug level said so. `run_sync` schedules onto a
+    # persistent loop on a SEPARATE thread via run_coroutine_threadsafe, so
+    # it is correct from both a bare sync context and inside a running loop.
+    #
+    # Only reached when the address is not already cached on disk, which is
+    # precisely the oldest install shape: a plaintext {"mnemonic": ...}
+    # credentials.json with no scope_address.
     try:
-        return asyncio.run(_derive_smart_account_address(mnemonic))
-    except RuntimeError:
-        # Already inside a running event loop (e.g. a programmatically
-        # driven host) — asyncio.run refuses to nest. Spin a fresh loop.
-        loop = asyncio.new_event_loop()
-        try:
-            return loop.run_until_complete(_derive_smart_account_address(mnemonic))
-        finally:
-            loop.close()
+        return run_sync(_derive_smart_account_address(mnemonic))
     except Exception:  # noqa: BLE001 — network failure is non-fatal here
         logger.debug(
             "auto_migrate: Smart Account RPC derivation failed", exc_info=True

--- a/python/tests/test_auto_migrate.py
+++ b/python/tests/test_auto_migrate.py
@@ -447,3 +447,85 @@ def test_migrated_vault_can_still_decrypt_pre_migration_facts(
 
     decrypted = decrypt(ciphertext, post_migration_client._keys.encryption_key)
     assert decrypted == plaintext
+
+
+# ---------------------------------------------------------------------------
+# Smart Account resolution when the address is NOT cached on disk
+#
+# Every fixture above writes `scope_address`, which short-circuits
+# `_resolve_smart_account` before it ever derives the address over RPC. That
+# is why the nested-event-loop defect below survived the original test suite:
+# the broken branch was simply never reached.
+#
+# The uncached shape is not exotic — it is the OLDEST install shape, a
+# plaintext {"mnemonic": ...} credentials.json with no scope_address.
+# ---------------------------------------------------------------------------
+
+
+def _write_legacy_plaintext_uncached(home: Path) -> Path:
+    """Legacy plaintext creds with NO cached scope_address/wallet_address."""
+    path = _creds_dir(home) / "credentials.json"
+    path.write_text(json.dumps({"mnemonic": TEST_MNEMONIC}))
+    return path
+
+
+@pytest.fixture
+def stub_sa_rpc(monkeypatch):
+    """Stub the Smart Account RPC derivation — no network in unit tests."""
+    import totalreclaw.client as client_mod
+
+    async def _fake(mnemonic: str) -> str:
+        return TEST_SMART_ACCOUNT
+
+    monkeypatch.setattr(client_mod, "_derive_smart_account_address", _fake)
+
+
+def test_uncached_smart_account_migrates_from_sync_context(
+    isolated_home: Path, fake_keychain, stub_sa_rpc
+) -> None:
+    """Baseline: with no cached address, a bare sync caller still migrates."""
+    creds_path = _write_legacy_plaintext_uncached(isolated_home)
+
+    assert auto_migrate.maybe_migrate() is True
+
+    creds = json.loads(creds_path.read_text())
+    assert creds["version"] == 2
+    assert "mnemonic" not in creds
+
+
+def test_uncached_smart_account_migrates_from_inside_a_running_loop(
+    isolated_home: Path, fake_keychain, stub_sa_rpc
+) -> None:
+    """Regression: migration must work when plugin load sits inside a loop.
+
+    `register()` is a plain `def`, but nothing guarantees the host calling it
+    is outside an event loop — an asyncio-driven gateway calling a sync
+    plugin entrypoint is the normal case, and `_resolve_smart_account`'s own
+    comment anticipated it.
+
+    Pre-fix this failed silently rather than loudly, which is the dangerous
+    part: `asyncio.run()` raised RuntimeError inside the running loop (leaving
+    the coroutine un-awaited), the `except RuntimeError` fallback called
+    `run_until_complete` on a fresh loop and raised "Cannot run the event loop
+    while another loop is running", and because that second raise happens
+    *inside* an except clause the sibling `except Exception` never caught it.
+    It surfaced to `maybe_migrate`'s blanket handler, which logs at DEBUG and
+    returns False — so the host simply never migrated and said nothing.
+    """
+    import asyncio
+
+    creds_path = _write_legacy_plaintext_uncached(isolated_home)
+
+    async def driver() -> bool:
+        # Exactly how an async host invokes a sync plugin entrypoint.
+        return auto_migrate.maybe_migrate()
+
+    assert asyncio.run(driver()) is True, (
+        "migration silently no-opped when called from inside a running event "
+        "loop — the pre-fix nested-loop failure"
+    )
+
+    creds = json.loads(creds_path.read_text())
+    assert creds["version"] == 2
+    assert "mnemonic" not in creds
+    assert "recovery_phrase" not in creds


### PR DESCRIPTION
🚨 **Blocks the 2.5.0 stable promote** (tracker #621 task 2(b)). Found by the Phase 2 staging E2E — scenario **S3** (migration of a real, non-empty vault) — run against the published `2.5.0rc1` wheel.

## Symptom

The migration didn't happen, and nothing said so:

```
auto_migrate.py:222: RuntimeWarning: coroutine '_derive_smart_account_address' was never awaited
migrated: False
version: None | has mnemonic: True
```

## Cause

`_resolve_smart_account` hand-rolled a nested-loop fallback that fails twice inside a running loop:

```python
try:
    return asyncio.run(_derive_smart_account_address(mnemonic))   # (1)
except RuntimeError:
    loop = asyncio.new_event_loop()
    return loop.run_until_complete(_derive_smart_account_address(mnemonic))  # (2)
except Exception:
    ... return None
```

1. `asyncio.run` raises `RuntimeError` inside a running loop **and** leaves its coroutine un-awaited.
2. The fallback raises `RuntimeError: Cannot run the event loop while another loop is running`.

Because (2) raises from *inside* an `except` clause, the sibling `except Exception` never catches it. It propagates to `maybe_migrate`'s blanket handler:

```python
except Exception:  # noqa: BLE001 — must never crash plugin load
    logger.debug(..., exc_info=True)
    return False
```

**So the headline feature of this release silently never happens, at DEBUG level, forever.** That is the same silent-no-op shape that motivated raising the core floor in #626 — this one is reachable independently of the core version.

## Empirically scoped

| call context | cached `scope_address`? | result |
|---|---|---|
| sync | any | ✅ migrates |
| sync | absent | ✅ migrates |
| **inside running loop** | present | ✅ short-circuits before the bug |
| **inside running loop** | **absent** | ❌ **silent no-op** |

The affected shape is the **oldest install**: a plaintext `{"mnemonic": ...}` `credentials.json` with no `scope_address`.

`register()` is a plain `def`, but nothing guarantees its caller is outside an event loop — an asyncio gateway invoking a sync plugin entrypoint is ordinary, and the deleted comment (*"e.g. a programmatically driven host"*) shows the case was anticipated, just handled incorrectly.

## Why the suite missed it

Every fixture in `test_auto_migrate.py` writes `scope_address`, which short-circuits `_resolve_smart_account` before the RPC branch. The broken code was never reached by any test.

## Fix

Use `agent/loop_runner.py::run_sync` — the module this repo already built for exactly this problem (its docstring documents the same class of event-loop bug). It schedules onto a persistent loop on a **separate thread** via `run_coroutine_threadsafe`, so it is correct from a bare sync context *and* from inside a running loop.

## Verification

Two regression tests on the uncached shape:

- sync context — passes before **and** after (proves the scoping is exact)
- inside a running loop — **fails before**, passes after

```
reverted:  1 failed, 1 passed   ← in-loop case fails on old code
with fix:  2 passed
full:      2457 passed, 4 skipped, 1 xfailed
```

After this merges: re-cut `2.5.0rc2`, re-run S3, then promote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)