### PR TITLE
chore(python): open the 2.5.1 line (post-stable-promote base bump)

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,7 +24,7 @@ name = "totalreclaw"
 # now `2.4.5`, so RCs cut as `2.4.5rcN` outrank `2.4.4` and the
 # version-agnostic install path lands them. NEVER leave the base equal to
 # an already-published stable.
-version = "2.5.0"
+version = "2.5.1"
 description = "End-to-end encrypted memory for AI agents — Python client (Memory Taxonomy v1)"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
`totalreclaw` **2.5.0** was promoted to stable on PyPI today (tracker #621 task 2(b)). This applies `pyproject.toml`'s own CRITICAL POST-PROMOTE RULE.

PEP 440 ranks a final release above its own pre-releases (`2.5.0` > `2.5.0rc10`), so leaving the base at `2.5.0` would make every subsequent RC cut as `2.5.0rcN` — and `pip install --pre --upgrade totalreclaw`, the documented "latest RC" path, would silently resolve to **2.5.0 stable** rather than the RC. RCs become unreachable except by exact pin.

This has bitten the project before (the 2.4.4 / rc8–rc10 episode the comment documents). Bumping now rather than discovering it at the next RC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)