### PR TITLE
test(e2e-batch): fix stale Base Sepolia / dual-chain assumptions

### DIFF
--- a/tests/e2e-batch/batch-e2e.ts
+++ b/tests/e2e-batch/batch-e2e.ts
@@ -1,17 +1,20 @@
 /**
- * E2E Tests: Client Batching, Extraction Config, Dual-Chain Routing, Full Pipeline
+ * E2E Tests: Client Batching, Extraction Config, Single-Chain Gnosis Routing, Full Pipeline
  *
  * Tests against LIVE staging:
  *   - Relay: api-staging.totalreclaw.xyz
- *   - Chain: Base Sepolia (84532)
- *   - Subgraph: totalreclaw---base-sepolia (Graph Studio)
+ *   - Chain: Gnosis mainnet (100) — single-chain for BOTH tiers since ops-1
+ *     (totalreclaw-internal#283, closed 2026-06-05). The legacy Free → Base
+ *     Sepolia (84532) routing is retired; do not reintroduce it here.
+ *   - Subgraph: total-reclaw-gnosis-staging (Graph Studio, staging-isolated
+ *     DataEdge — see the `dataEdgeAddress` resolution below)
  *
  * Test Groups:
  *   A — Relay health + registration (prerequisites)
  *   B — Client batching: 3 facts in 1 UserOp (CRITICAL)
  *   C — Server-side extraction config fields
  *   D — Tombstone + replacement in same batch
- *   E — Dual-chain routing verification
+ *   E — Single-chain Gnosis routing verification
  *   F — Full search pipeline (store → blind-index search → recall)
  *
  * Run:
@@ -26,7 +29,7 @@ import { mnemonicToAccount } from 'viem/accounts';
 import { generateMnemonic } from '@scure/bip39';
 import { wordlist } from '@scure/bip39/wordlists/english';
 import { createPublicClient, http, type Address, type Hex } from 'viem';
-import { baseSepolia } from 'viem/chains';
+import { gnosis } from 'viem/chains';
 import { toSimpleSmartAccount } from 'permissionless/accounts';
 import { createSmartAccountClient } from 'permissionless';
 import { createPimlicoClient } from 'permissionless/clients/pimlico';
@@ -36,7 +39,10 @@ import { createPimlicoClient } from 'permissionless/clients/pimlico';
 // ---------------------------------------------------------------------------
 
 const RELAY_URL = process.env.RELAY_URL || 'https://api-staging.totalreclaw.xyz';
-const CHAIN_ID = 84532; // Base Sepolia
+// Single-chain Gnosis for BOTH tiers since ops-1 (totalreclaw-internal#283,
+// closed 2026-06-05). The legacy Free -> Base Sepolia (84532) split no
+// longer exists — do not branch on tier here.
+const CHAIN_ID = 100; // Gnosis mainnet
 const DEFAULT_DATA_EDGE_ADDRESS = '0xC445af1D4EB9fce4e1E61fE96ea7B8feBF03c5ca' as const;
 const ENTRYPOINT_ADDRESS = '0x0000000071727De22E5E9d8BAf0edAc6f37da032' as const;
 
@@ -266,7 +272,7 @@ async function pollSubgraph(
 
 async function deriveSmartAccountAddress(mnemonic: string): Promise<string> {
   const owner = mnemonicToAccount(mnemonic);
-  const publicClient = createPublicClient({ chain: baseSepolia, transport: http() });
+  const publicClient = createPublicClient({ chain: gnosis, transport: http() });
   const sa = await toSimpleSmartAccount({
     client: publicClient as any,
     owner,
@@ -297,10 +303,10 @@ async function submitBatch(
   const authTransport = http(bundlerUrl, { fetchOptions: { headers } });
 
   const owner = mnemonicToAccount(mnemonic);
-  const publicClient = createPublicClient({ chain: baseSepolia, transport: http() });
+  const publicClient = createPublicClient({ chain: gnosis, transport: http() });
 
   const pimlicoClient = createPimlicoClient({
-    chain: baseSepolia,
+    chain: gnosis,
     transport: authTransport,
     entryPoint: { address: ENTRYPOINT_ADDRESS, version: '0.7' },
   });
@@ -313,7 +319,7 @@ async function submitBatch(
 
   const smartAccountClient = createSmartAccountClient({
     account: smartAccount,
-    chain: baseSepolia,
+    chain: gnosis,
     bundlerTransport: authTransport,
     paymaster: pimlicoClient,
     userOperation: {
@@ -441,7 +447,11 @@ async function testGroupC(keys: ReturnType<typeof generateTestKeys>) {
     console.log(`    max_facts_per_extraction=${res.data.features.max_facts_per_extraction}`);
   });
 
-  await runTest('C3: Free tier defaults are sensible', async () => {
+  // Note: intentionally tier-agnostic. Staging provisions test registrations
+  // as tier=pro via the staging_test_fixture path (relay billing.ts ~line
+  // 174, deliberate — see Group E below), so this only checks the config
+  // bounds are sane, not which tier's defaults produced them.
+  await runTest('C3: Extraction config defaults are sensible', async () => {
     const res = await getBillingStatus(keys.authKeyHex, walletAddress);
     const f = res.data.features;
     assert(f.extraction_interval >= 1 && f.extraction_interval <= 10, `interval ${f.extraction_interval} out of [1,10]`);
@@ -452,24 +462,41 @@ async function testGroupC(keys: ReturnType<typeof generateTestKeys>) {
 }
 
 // =========================================================================
-// TEST GROUP E: Dual-chain routing
+// TEST GROUP E: Single-chain Gnosis routing
+//
+// STALE-ASSUMPTION CLEANUP (2026-08-16, tracker #621): this group used to be
+// "Dual-Chain Routing" and asserted Free-tier -> Base Sepolia (84532) vs.
+// Pro-tier -> Gnosis (100). That split was retired in ops-1
+// (totalreclaw-internal#283, closed 2026-06-05) — BOTH tiers now route to
+// Gnosis mainnet (chain 100) via the same isolated staging DataEdge. Do not
+// reintroduce a tier->chain branch here; the current contract is "every
+// registration gets Gnosis, regardless of tier."
+//
+// Separately: staging registrations sent with `X-TotalReclaw-Test: true`
+// are provisioned as tier=pro by the relay's `staging_test_fixture` path
+// (relay billing.ts ~line 174). This is DELIBERATE test-fixture behavior,
+// not a bug — so E1 below asserts tier=pro rather than trying to force or
+// "fix" the wallet into tier=free.
 // =========================================================================
 
 async function testGroupE(keys: ReturnType<typeof generateTestKeys>) {
-  console.log('\n=== Test Group E: Dual-Chain Routing ===\n');
+  console.log('\n=== Test Group E: Single-Chain Gnosis Routing ===\n');
 
   const walletAddress = '0x' + randomBytes(20).toString('hex');
 
-  // E1: Free tier has correct chain config in features
-  await runTest('E1: Free tier billing shows Base Sepolia chain', async () => {
+  // E1: Test-tier billing shows single-chain Gnosis routing.
+  await runTest('E1: Test-tier billing shows Gnosis chain (single-chain routing)', async () => {
     const res = await getBillingStatus(keys.authKeyHex, walletAddress);
     assert(res.status === 200, `Expected 200, got ${res.status}`);
-    assert(res.data.tier === 'free', `Expected tier=free, got ${res.data.tier}`);
-    // The features dict may include chain info from the tiers table
-    console.log(`    tier=${res.data.tier}, features=${JSON.stringify(res.data.features)}`);
+    // Staging test registrations are provisioned pro by design (see comment
+    // above) — assert that, not tier=free.
+    assert(res.data.tier === 'pro', `Expected tier=pro (staging test-fixture), got ${res.data.tier}`);
+    assert(res.data.chain_id === 100, `Expected chain_id=100 (Gnosis, single-chain post ops-1), got ${res.data.chain_id}`);
+    console.log(`    tier=${res.data.tier}, chain_id=${res.data.chain_id}, features=${JSON.stringify(res.data.features)}`);
   });
 
-  // E2: Bundler proxy accepts free-tier JSON-RPC (supportedEntryPoints)
+  // E2: Bundler proxy accepts JSON-RPC (supportedEntryPoints). Batching/
+  // bundler access is universal post ops-1 — not gated by tier.
   await runTest('E2: Bundler proxy accepts eth_supportedEntryPoints', async () => {
     const res = await relayRequest(
       'POST',
@@ -495,16 +522,21 @@ async function testGroupE(keys: ReturnType<typeof generateTestKeys>) {
     console.log(`    EntryPoints: ${JSON.stringify(res.data.result)}`);
   });
 
-  // E3: Subgraph proxy returns data from Base Sepolia subgraph
-  await runTest('E3: Subgraph proxy returns _meta from Base Sepolia', async () => {
+  // E3: Subgraph proxy returns data from the staging Gnosis subgraph
+  // (total-reclaw-gnosis-staging, on the isolated staging DataEdge).
+  await runTest('E3: Subgraph proxy returns _meta from Gnosis subgraph', async () => {
     const result = await querySubgraph(
       keys.authKeyHex,
       '{ _meta { block { number } } }',
     );
     assert(result?.data?._meta?.block?.number !== undefined, `Expected _meta.block.number`);
     const blockNum = parseInt(result.data._meta.block.number);
-    // Base Sepolia block numbers are > 30M
-    assert(blockNum > 30_000_000, `Block ${blockNum} too low for Base Sepolia (expected >30M)`);
+    // Gnosis mainnet has run since 2018 and was already >47M blocks as of
+    // 2026-08 (verified live against https://rpc.gnosischain.com). 30M is a
+    // safe, monotonically-true lower bound that guards against the subgraph
+    // silently pointing at a fresh/wrong chain (e.g. block 0 on a testnet) —
+    // it does not need bumping over time since Gnosis block height only grows.
+    assert(blockNum > 30_000_000, `Block ${blockNum} too low for Gnosis mainnet (expected >30M)`);
     console.log(`    Subgraph synced to block: ${blockNum}`);
   });
 }
@@ -785,7 +817,7 @@ async function main() {
   console.log(`  TotalReclaw E2E Tests — Batch, Routing, Pipeline`);
   console.log(`${'='.repeat(60)}`);
   console.log(`  Relay:     ${RELAY_URL}`);
-  console.log(`  Chain:     Base Sepolia (${CHAIN_ID})`);
+  console.log(`  Chain:     Gnosis mainnet (${CHAIN_ID})`);
   console.log(`  Groups:    ${groups.length ? groups.join(', ') : 'ALL'}`);
   console.log(`${'='.repeat(60)}\n`);
 
@@ -834,8 +866,9 @@ async function main() {
   // get the current chain tip block and poll _meta until the subgraph passes it.
   const needsSubgraph = bCtx || dCtx || fCtx;
   if (needsSubgraph) {
-    // Get current chain tip (all our txs are confirmed by now)
-    const tipRes = await fetch('https://sepolia.base.org', {
+    // Get current chain tip (all our txs are confirmed by now). Gnosis
+    // mainnet (chain 100) — single-chain for both tiers since ops-1.
+    const tipRes = await fetch('https://rpc.gnosischain.com', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ jsonrpc: '2.0', method: 'eth_blockNumber', params: [], id: 1 }),

--- a/tests/e2e-batch/gnosis-batch-cycle.test.ts
+++ b/tests/e2e-batch/gnosis-batch-cycle.test.ts
@@ -3,15 +3,26 @@
  *
  * Per imp spec §6 T-5 + decomposition §imp item 18.
  *
- * Validates the Path B chain-gate (issue #281 / spec #317):
- *   - Pro-tier wallets on Gnosis (chain 100) MUST submit fact writes
- *     through `executeBatch` (1 UserOp → N Log(bytes) events).
- *   - Free-tier Sepolia keeps single-fact UserOps.
+ * Validates the batch-write path (issue #281 / spec #317):
+ *   - Wallets on Gnosis (chain 100) can submit fact writes through
+ *     `executeBatch` (1 UserOp → N Log(bytes) events).
  *
- * This test covers the Gnosis half: seed a Pro-tier test wallet on staging,
- * submit BATCH_SIZE facts (default 15, env-tunable) as one batched UserOp,
- * poll the subgraph for indexing, recall one fact, and assert the round-trip
- * fact ID matches what was written.
+ * STALE-ASSUMPTION CLEANUP (2026-08-16, tracker #621): this originally
+ * described a "Path B chain-gate" where batching was Pro-only because
+ * Pro ran on Gnosis while Free ran on Base Sepolia (which had a gas-
+ * estimation bug blocking `executeBatch`). That split was retired in ops-1
+ * (totalreclaw-internal#283, closed 2026-06-05) — BOTH tiers now route to
+ * Gnosis, and batching is a universal mechanism, not a tier feature (see
+ * "Storage Mode Support" in the repo root CLAUDE.md). This test still seeds
+ * a pro-tier wallet (staging's test fixture provisions pro by default — see
+ * below) and exercises the Gnosis batch path end-to-end; it is no longer
+ * "half" of a Sepolia/Gnosis pair — batch-e2e.ts's Group B now also runs on
+ * Gnosis, so the two tests cover overlapping ground on the same chain.
+ *
+ * Seed a test wallet on staging, submit BATCH_SIZE facts (default 15,
+ * env-tunable) as one batched UserOp, poll the subgraph for indexing,
+ * recall one fact, and assert the round-trip fact ID matches what was
+ * written.
  *
  * Emits one structured log line on success:
  *
@@ -44,7 +55,7 @@ import { createPimlicoClient } from 'permissionless/clients/pimlico';
 // ---------------------------------------------------------------------------
 
 const RELAY_URL = process.env.RELAY_URL || 'https://api-staging.totalreclaw.xyz';
-const CHAIN_ID = 100; // Gnosis mainnet (Pro-tier path)
+const CHAIN_ID = 100; // Gnosis mainnet — single-chain for both tiers since ops-1
 const DEFAULT_DATA_EDGE_ADDRESS = '0xC445af1D4EB9fce4e1E61fE96ea7B8feBF03c5ca' as const;
 const ENTRYPOINT_ADDRESS = '0x0000000071727De22E5E9d8BAf0edAc6f37da032' as const;
 const BATCH_SIZE = Number(process.env.BATCH_SIZE) || 15;
@@ -444,7 +455,10 @@ async function main(): Promise<void> {
     `register failed: status=${regRes.status} body=${JSON.stringify(regRes.data).slice(0, 200)}`,
   );
 
-  // 3. Confirm relay assigned Pro tier (Gnosis chain).
+  // 3. Confirm relay assigned Pro tier — expected staging test-fixture
+  // behavior (relay billing.ts ~line 174), not a chain-routing assertion:
+  // both tiers route to Gnosis post ops-1, so this checks the fixture, not
+  // "only pro gets Gnosis."
   const billing = await getBillingStatus(keys.authKeyHex, walletAddress);
   assert(
     billing.status === 200,
@@ -452,7 +466,7 @@ async function main(): Promise<void> {
   );
   assert(
     billing.data?.tier === 'pro',
-    `expected tier=pro for test wallet (Pro-tier batch path), got tier=${billing.data?.tier}`,
+    `expected tier=pro for staging test wallet (staging_test_fixture), got tier=${billing.data?.tier}`,
   );
   console.log(`  Pro tier confirmed (features=${JSON.stringify(billing.data?.features ?? {})})`);
 


### PR DESCRIPTION
## Summary

Fixes the smoke-test staleness noted on #621: *"tests/e2e-batch E1/E3 still reference retired Base-Sepolia routing; E1 fails against staging's deliberate test-user→pro provisioning (relay `billing.ts:174`)."*

Since ops-1 (`totalreclaw-internal#283`, closed 2026-06-05) both tiers route to Gnosis mainnet (chain 100); the old Free → Base Sepolia (84532) split is retired.

### `batch-e2e.ts`
- `baseSepolia` viem chain import → `gnosis`, everywhere it was used (smart-account derivation, UserOp submission, chain-tip RPC poll against `sepolia.base.org` → `rpc.gnosischain.com`).
- `CHAIN_ID` `84532` → `100`.
- Test Group E ("Dual-Chain Routing" → "Single-Chain Gnosis Routing"):
  - **E1** no longer asserts `tier === 'free'`. Staging's test-fixture path provisions every test registration as `tier=pro` (relay `billing.ts` ~line 174) — that's deliberate, not a bug, so E1 now asserts `tier === 'pro'` and `chain_id === 100` instead of trying to force free tier.
  - **E3**'s "Base Sepolia block > 30M" sanity check is repointed at Gnosis (verified live against the real chain height, ~47.7M as of 2026-08-16).
- Renamed C3's misleading "Free tier defaults" label — the extraction-config bounds check is tier-agnostic given the staging fixture always returns pro.
- Every changed assumption has an inline comment explaining what was retired and why, so a future reader doesn't "restore" the old expectation.

### `gnosis-batch-cycle.test.ts`
- Comment-only. The header described a "Path B chain-gate" where batching was Pro-only because Free ran on a different (buggy) chain. That framing is stale — batching is now a universal mechanism on single-chain Gnosis. No functional code changed; it was already using the correct `gnosis` viem chain.

### `e2e-449-grouping.ts`
- No changes needed — already chain-agnostic (reads `chain_id`/`data_edge_address` from billing, no hardcoded chain).

## Verification

Ran the full `batch-e2e.ts` suite live against staging (`api-staging.totalreclaw.xyz`), split across a few invocations to respect the ~19-minute IP-global rate limit on `/v1/register`:

- **Group E** (routing): 3/3 pass — `tier=pro, chain_id=100`, staging DataEdge `0xE7a4D2677B686e13775Ba9092631089e35F0BB91` resolved correctly, subgraph synced to real Gnosis block ~47.76M.
- **Group A+C** (health/register, extraction config): 5/5 pass.
- **Group B** (3-fact batch UserOp): 4/4 pass — real on-chain tx `0xf297c0d0...`, indexed by the staging subgraph in 16s.
- **Group D+F** (tombstone+replacement, search pipeline): 7/7 pass — 3 more real on-chain txs, all confirmed and indexed.

**19/19 tests pass across every group**, including 4 real on-chain UserOps submitted to and confirmed on the staging-isolated DataEdge.

`gnosis-batch-cycle.test.ts` (comment-only diff) and `e2e-449-grouping.ts` (unchanged) were syntax/parse-checked with esbuild but not executed live — no functional changes to validate, and re-running them would burn more of the shared registration rate-limit budget for no additional signal.

## Test plan

- [x] Full `batch-e2e.ts` suite (all 6 groups) run live against staging — 19/19 pass
- [x] `gnosis-batch-cycle.test.ts` parse-checked (esbuild), functional code unchanged
- [x] `e2e-449-grouping.ts` reviewed — already correct, no changes made
- [x] Confirmed all tests target staging only (`api-staging.totalreclaw.xyz`), never production

🤖 Generated with [Claude Code](https://claude.com/claude-code)