### PR TITLE
fix(npm): ship a root README for @totalreclaw/core, pin npm for nanoclaw

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -143,6 +143,22 @@ jobs:
           echo "Package name: $(node -e "console.log(require('./package.json').name)")"
           echo "Version: $(node -e "console.log(require('./package.json').version)")"
 
+      - name: Copy repo README into the composed package root (#577)
+        # wasm-pack writes ITS OWN generic README.md into each --out-dir
+        # (pkg/nodejs/README.md, pkg/web/README.md), but npm only reads a
+        # README at the PACKAGE ROOT (pkg/README.md here) to populate the
+        # registry's readme/readmeFilename metadata — which is what
+        # renders on the npmjs.com package page. The composed root
+        # manifest above never got a root README, so every published
+        # @totalreclaw/core (through 2.6.0) shipped with NO README on npm
+        # at all: `npm view @totalreclaw/core readme` returned "No README
+        # data found", confirmed by unpacking a published tarball — only
+        # nodejs/README.md + web/README.md existed, nothing at the
+        # tarball root. Ship the repo's real, hand-maintained README
+        # instead (same file crates.io + PyPI already use via
+        # Cargo.toml's `readme = "README.md"`).
+        run: cp rust/totalreclaw-core/README.md rust/totalreclaw-core/pkg/README.md
+
       - name: Apply RC version suffix (rc mode only)
         if: inputs.release-type == 'rc'
         run: |
@@ -444,6 +460,28 @@ jobs:
             exit 1
           fi
           echo "OK: $NAME@$VERSION not yet published, proceeding"
+
+      - name: Upgrade npm to latest (defense-in-depth, #577)
+        if: inputs.dry-run == false
+        # @totalreclaw/skill-nanoclaw currently has NO README on npm
+        # (`npm view @totalreclaw/skill-nanoclaw readme` returns empty),
+        # even though the published 3.0.0 tarball DOES contain a real
+        # root README.md (unlike @totalreclaw/core's issue — this is a
+        # different mechanism, not the nested-wasm-pack-outdir bug).
+        # Observed: the registry's top-level readme/readmeFilename fields
+        # mirror whichever publish happened most recently BY WALL-CLOCK
+        # TIME, not whichever carries the `latest` dist-tag — and this
+        # package's most recent publish was an RC on 2026-04-25
+        # (3.1.1-rc.19), published with whatever npm ships by default on
+        # this runner (no pin), with no stable publish since to overwrite
+        # it with good data. core/mcp-server/plugin already pin npm@11
+        # (documented npm 12.0.0 --provenance/OIDC regression elsewhere
+        # in this workflow); pin it here too so the next publish (RC or
+        # stable) runs on the same known-good npm CLI instead of an
+        # unpinned default that has drifted before.
+        run: |
+          npm install -g npm@11
+          npm --version
 
       - name: Publish
         if: inputs.dry-run == false

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -192,7 +192,7 @@ jobs:
           fi
           echo "OK: $NAME@$VERSION not yet published, proceeding"
 
-      - name: Upgrade npm to latest (required for tokenless OIDC publish)
+      - name: Pin npm to 11 (required for tokenless OIDC publish)
         if: inputs.dry-run == false
         # npm 10.x (Node 22) signs provenance with OIDC but still PUTs with a
         # legacy token → E404 after NPM_TOKEN expired (the 2026-06-07 core run).
@@ -366,7 +366,7 @@ jobs:
           fi
           echo "OK: $NAME@$VERSION not yet published, proceeding"
 
-      - name: Upgrade npm to latest (required for tokenless OIDC publish)
+      - name: Pin npm to 11 (required for tokenless OIDC publish)
         if: inputs.dry-run == false
         # The npm CLI shipped with Node 22 (npm 10.x) signs provenance with
         # OIDC but still expects a legacy auth token for the actual PUT.
@@ -461,7 +461,7 @@ jobs:
           fi
           echo "OK: $NAME@$VERSION not yet published, proceeding"
 
-      - name: Upgrade npm to latest (defense-in-depth, #577)
+      - name: Pin npm to 11 (defense-in-depth, #577)
         if: inputs.dry-run == false
         # @totalreclaw/skill-nanoclaw currently has NO README on npm
         # (`npm view @totalreclaw/skill-nanoclaw readme` returns empty),
@@ -640,7 +640,7 @@ jobs:
           fi
           echo "OK: $NAME@$VERSION not yet published, proceeding"
 
-      - name: Upgrade npm to latest (required for tokenless OIDC publish)
+      - name: Pin npm to 11 (required for tokenless OIDC publish)
         if: inputs.dry-run == false
         # npm 10.x (Node 22) signs provenance with OIDC but still PUTs with a
         # legacy token → E404 after NPM_TOKEN expired (the 2026-06-07 core run).

--- a/rust/totalreclaw-core/README.md
+++ b/rust/totalreclaw-core/README.md
@@ -19,11 +19,22 @@ Used natively by [`totalreclaw-memory`](https://crates.io/crates/totalreclaw-mem
 - `wasm` — WASM bindings via `wasm-bindgen` (consumed by `@totalreclaw/core` npm package).
 - `python` / `python-extension` — PyO3 bindings (consumed by `totalreclaw-core` PyPI package).
 
-## Usage
+## Installation
+
+```bash
+# TypeScript / JavaScript (WASM)
+npm install @totalreclaw/core
+```
+
+```bash
+# Python (PyO3)
+pip install totalreclaw-core
+```
 
 ```toml
+# Rust
 [dependencies]
-totalreclaw-core = "2.0"
+totalreclaw-core = "2"
 ```
 
 Most Rust users should depend on [`totalreclaw-memory`](https://crates.io/crates/totalreclaw-memory), which bundles core into a high-level `Memory` trait.


### PR DESCRIPTION
## Summary

`@totalreclaw/core` publishes to npm with **no README at all** — confirmed by `npm view @totalreclaw/core readme` (`ERROR: No README data found!`) and by unpacking the published `2.6.0` tarball, which contains `nodejs/README.md` and `web/README.md` but nothing at the tarball root (npm only reads a **root-level** README to populate registry metadata / the npmjs.com page).

**Root cause**: `publish-core` in `.github/workflows/npm-publish.yml` builds WASM twice (`--target nodejs` and `--target web`, into `pkg/nodejs/` and `pkg/web/`), then composes one root `pkg/package.json` with an `exports` map. `wasm-pack` drops its own generic `README.md` into each `--out-dir`, but the compose step never places anything at `pkg/` root — so the registry never sees a README.

I also audited the other four npm packages this repo publishes, since the task was not to assume they're all fine:

| Package | README on npm? | Notes |
|---|---|---|
| `@totalreclaw/core` | ❌ **Broken** (fixed here) | No root README in the composed `pkg/` tree — the nested-wasm-pack-outdir bug. |
| `@totalreclaw/mcp-server` | ✅ Fine | — |
| `@totalreclaw/client` | ✅ Fine | — |
| `@totalreclaw/totalreclaw` (OpenClaw plugin) | ✅ Fine | — |
| `@totalreclaw/skill-nanoclaw` | ❌ **Also broken**, different mechanism | Its published `3.0.0` tarball *does* contain a real root `README.md`. Evidence: the registry's top-level `readme`/`readmeFilename` fields appear to mirror whichever publish happened most recently **by wall-clock time**, not whichever carries the `latest` dist-tag. Nanoclaw's most recent publish was an RC on 2026-04-25 (`3.1.1-rc.19`) — no stable publish has landed since to overwrite that with good metadata. |

## Changes

1. **`.github/workflows/npm-publish.yml` (`publish-core` job)** — new step `Copy repo README into the composed package root (#577)` that copies `rust/totalreclaw-core/README.md` into `pkg/README.md` right after the compose step. This is the same README file already used by crates.io + PyPI via `Cargo.toml`'s `readme = "README.md"`, so this makes all three registries consistent instead of generating something new.

2. **`rust/totalreclaw-core/README.md`** — light edit: added an `## Installation` section with `npm install @totalreclaw/core` / `pip install totalreclaw-core` / the existing Cargo snippet, since this file now doubles as the npm landing page too. No product claims added — kept accurate to what the crate actually does (shared Rust core, WASM/PyO3 bindings, crypto/claim/derivation primitives).

3. **`.github/workflows/npm-publish.yml` (`publish-nanoclaw` job)** — added the same `npm install -g npm@11` pin already used by `publish-core`/`publish-mcp-server`/`publish-plugin` (for the documented npm 12.0.0 `--provenance`/OIDC regression), as a defense-in-depth step so the next nanoclaw publish runs on a known-good npm CLI. **This is a best-effort mitigation, not a structural fix** — nanoclaw's package already ships a correct root README in its tarball, so the fix here is about making sure the *next publish's* npm CLI reliably attaches it to the registry metadata. Worth re-checking `npm view @totalreclaw/skill-nanoclaw readme` after the next nanoclaw publish (RC or stable) to confirm it self-healed; if it doesn't, that points to an actual ongoing bug needing further investigation.

## Verification

Built both wasm-pack targets locally (`wasm-pack build --target nodejs --out-dir pkg/nodejs --features wasm` and the `web` equivalent), ran the exact compose script from the workflow verbatim, then compared `npm pack --dry-run` before/after applying the new copy step:

- **Before**: 12 files, tarball contents `nodejs/README.md`, `web/README.md` — no root README.
- **After**: 13 files, `npm publish --dry-run` shows `README.md` at the tarball root in its own "Tarball Contents" report (the same code path npm uses to populate registry readme metadata at real publish time).

## Important — takes effect at next publish only

**No publish was run and no workflow was dispatched as part of this PR** (releases are CI-only, dispatched by the repo owner). This fix changes what the **next** publish of each affected package produces:

- `@totalreclaw/core` — next publish (RC or stable) will carry a real README.
- `@totalreclaw/skill-nanoclaw` — next publish (RC or stable) should self-heal the currently-empty registry readme; recommend verifying with `npm view @totalreclaw/skill-nanoclaw readme` after that publish lands.

Until then, the currently-published `@totalreclaw/core@2.6.0` and `@totalreclaw/skill-nanoclaw@3.0.0` on npm remain README-less.

Refs #577.