### PR TITLE
feat(contracts): TotalReclawAccount — revocable session-key signing (P3-1, P3-2, P3-4)

### DIFF
--- a/.github/workflows/forge-test.yml
+++ b/.github/workflows/forge-test.yml
@@ -70,3 +70,77 @@ jobs:
       - name: Snapshot gas (diagnostic)
         run: forge snapshot --check --diff || true
         continue-on-error: true
+
+  forge-test-account:
+    name: Forge Test (TotalReclawAccount)
+    # Option E Phase 3 (P3-1/P3-2/P3-4). This is a SEPARATE job (not a step
+    # folded into `forge-test` above) because `contracts/account/` is a
+    # deliberately SEPARATE Foundry project with its own `foundry.toml` and
+    # `lib/` — see `contracts/account/foundry.toml`'s header comment for
+    # why: adding `account-abstraction`/`openzeppelin-contracts` to the
+    # OUTER project's `lib/`+`remappings.txt` was tried first and reverted,
+    # because solc embeds the full project-wide `settings.remappings` list
+    # into EVERY compiled contract's metadata regardless of whether that
+    # contract uses them — verified to shift `EventfulDataEdge`'s bytecode
+    # and break `test/DataEdgeStagingCreate2.t.sol`'s pinned CREATE2
+    # address for the real, deployed staging DataEdge. Keeping this a
+    # fully separate `forge build`/`forge test` invocation (own working
+    # directory, own project root) is what guarantees the outer job's
+    # compiled artifacts can never be perturbed by this one.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: contracts/account
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Show forge version
+        run: forge --version
+
+      # contracts/account/lib/ is gitignored — install pinned versions
+      # (matching contracts/account/foundry.lock) fresh on every run.
+      - name: Install vendored libs (forge-std, account-abstraction, openzeppelin-contracts)
+        run: |
+          forge install --no-git foundry-rs/forge-std@v1.16.1
+          forge install --no-git OpenZeppelin/openzeppelin-contracts@v5.0.2
+          forge install --no-git eth-infinitism/account-abstraction@v0.7.0
+
+      - name: Build
+        run: forge build --sizes
+
+      # Storage-layout diff gate (B2 mitigation) — TotalReclawAccount must
+      # declare ZERO plain state variables beyond what it inherits from
+      # SimpleAccount; all new session-key state lives in ERC-7201
+      # namespaced storage, which correctly does not appear in solc's
+      # storageLayout output. See script/storage-layout-diff.sh.
+      - name: Storage layout diff (TotalReclawAccount vs SimpleAccount baseline)
+        run: ./script/storage-layout-diff.sh
+
+      # Includes the fork test suite (TotalReclawAccountFork.t.sol), which
+      # forks live Gnosis mainnet against a public RPC
+      # (https://rpc.gnosischain.com by default; override with
+      # GNOSIS_RPC_URL repo/environment secret for a private endpoint with
+      # less exposure to public-RPC rate limits). Read-only — never
+      # broadcasts a transaction. If this specific job is flaky on public
+      # RPC availability, that is a CI-infra follow-up, not a reason to
+      # drop the fork tests — they are the highest-value test in the phase
+      # (phase3-impl spec §3.4) and must keep running on every PR that
+      # touches this contract.
+      - name: Run tests (including fork tests against live Gnosis)
+        env:
+          # GH Actions `||` falls back on an unset/empty secret (empty
+          # string is falsy in expression context) — do NOT rely on
+          # `vm.envOr`'s unset-vs-empty handling here, resolve it in YAML
+          # instead so an absent secret can never resolve to "".
+          GNOSIS_RPC_URL: ${{ secrets.GNOSIS_RPC_URL || 'https://rpc.gnosischain.com' }}
+        run: forge test -vvv

--- a/.gitignore
+++ b/.gitignore
@@ -132,4 +132,12 @@ mcp/package-lock.json
 # Foundry vendored libraries — install via 'forge install foundry-rs/forge-std' from contracts/
 contracts/lib/forge-std/
 contracts/out/
+
+# contracts/account/ is its OWN Foundry project (Option E Phase 3 --
+# TotalReclawAccount), deliberately isolated from contracts/foundry.toml.
+# See contracts/account/foundry.toml's header comment. Libs pinned in
+# contracts/account/foundry.lock, reinstalled by CI and by hand locally.
+contracts/account/lib/
+contracts/account/out/
+contracts/account/cache/
 .desloppify/

--- a/contracts/account/contracts/TotalReclawAccount.sol
+++ b/contracts/account/contracts/TotalReclawAccount.sol
@@ -1,0 +1,670 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.24;
+
+/* solhint-disable avoid-low-level-calls */
+/* solhint-disable no-inline-assembly */
+
+import {SimpleAccount} from "account-abstraction/contracts/samples/SimpleAccount.sol";
+import {IEntryPoint} from "account-abstraction/contracts/interfaces/IEntryPoint.sol";
+import {
+    PackedUserOperation
+} from "account-abstraction/contracts/interfaces/PackedUserOperation.sol";
+import {
+    SIG_VALIDATION_FAILED,
+    SIG_VALIDATION_SUCCESS
+} from "account-abstraction/contracts/core/Helpers.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+/**
+ * @title TotalReclawAccount
+ * @notice Option E Phase 3 (P3-1/P3-2) — a `SimpleAccount` (eth-infinitism
+ *         v0.7.0) subclass that accepts either an owner-EOA signature
+ *         (unchanged stock behaviour) OR a scoped, revocable session-key
+ *         signature. This REPLACES the standalone-module design
+ *         (`SessionKeyModule.sol`, never deployed) — see
+ *         `docs/plans/2026-08-02-option-e-phase3-account-model.md` §5 for
+ *         why a standalone module cannot pass ERC-7562 bundler validation
+ *         (its grant registry keys on `signer`, not on `msg.sender`, so the
+ *         storage it reads during `validateUserOp` is not "associated"
+ *         with the account under [STO-020]/[STO-021]). Putting the
+ *         registry in the account's OWN storage (this file) is
+ *         unconditionally allowed under [STO-010] — "access to the
+ *         'account' storage is always allowed" — with no window
+ *         arithmetic and no dependence on a contested reading of the
+ *         rules.
+ *
+ * LICENSE NOTE: this file inherits directly from eth-infinitism's
+ * `SimpleAccount` (GPL-3.0), so it is licensed GPL-3.0 too (unlike the
+ * rest of this package, which is MIT) — matching the convention other
+ * ERC-4337 wallets that subclass `SimpleAccount` use (e.g. Alchemy's
+ * LightAccount). This is a licensing note, not a security one; flagged
+ * for a sanity check alongside the audit, not resolved unilaterally here.
+ *
+ * THREAT-MODEL CEILING (restate per `docs/specs/cred/phase3-implementation-
+ * spec.md` §0 — do not soften in any doc derived from this file): this
+ * contract makes a host's SIGNING credential scoped and revocable. It does
+ * NOT improve memory confidentiality at a compromised host — the derived
+ * encryption key still materialises in the agent's RAM on every recall,
+ * and every fact's ciphertext is publicly readable from the Gnosis
+ * subgraph regardless of what this contract does.
+ *
+ * ============================================================
+ * WHAT WAS PORTED VERBATIM FROM `SessionKeyModule.sol` (per phase3-impl
+ * spec §3.2 — "re-deriving them is pure risk"):
+ *   - `_grantDigest` and the four EIP-712 typehash/domain constants
+ *     (parity-tested against TS/Python).
+ *   - `_isCallDataInScope` / `_isBatchInScope` / `_inSelectors` — the
+ *     per-inner-call `executeBatch` validation (cred-6 invariant: EVERY
+ *     inner call's target, zero-value and selector are checked
+ *     individually; one out-of-scope inner fails the whole batch. No
+ *     outer-selector shortcut, no first-inner sampling, no partial
+ *     execution).
+ *   - `_recoverEcdsa` with the EIP-2 malleability guard (kept as the
+ *     original hand-rolled assembly implementation rather than swapped
+ *     for `ECDSA.tryRecover`, per the spec's explicit "lift verbatim"
+ *     instruction for this specific helper).
+ *   - Monotonic `_minNonces` replay protection.
+ *   - `_tryDecodeInstallSig` / `_decodeInstallSig` self-external
+ *     try/catch decode pattern (malformed lazy-install blob -> false,
+ *     never a revert that would poison the whole validateUserOp call).
+ *
+ * WHAT CHANGED MECHANICALLY (per phase3-impl spec §3.2's table):
+ *   - `msg.sender` (module's stand-in for account identity) -> `address(this)`.
+ *   - `_grants[account][signer]` / `_minNonces[account][signer]` (module's
+ *     doubly-nested, `signer`-first-in-the-hash storage — the very shape
+ *     that broke ERC-7562) -> `signer -> Grant` / `signer -> nonce` in
+ *     THIS contract's own ERC-7201 namespaced storage.
+ *   - `g.account != msg.sender` -> `g.account != address(this)`.
+ *   - `g.verifyingContract != address(this)` where `this` was the MODULE
+ *     -> `!= address(this)` where `this` is now the ACCOUNT (P3-3 — see
+ *     `_isGrantValid` below). Binds a grant to the thing it authorises;
+ *     closes the CREATE2-redeploy-invalidates-every-grant hazard the
+ *     module design had.
+ *   - `revokeSessionKey(account, signer)` gated `msg.sender == account`
+ *     -> `revokeSessionKey(signer)` gated by the inherited `onlyOwner`
+ *     modifier (accepts the owner EOA directly, or a self-call driven by
+ *     an owner-signed UserOp via `execute(address(this), 0,
+ *     abi.encodeCall(this.revokeSessionKey, (signer)))`).
+ *   - `_smartAccountOwner(account)` (an EXTERNAL call to
+ *     `IAccountWithOwner(account).owner()`, needed because the module and
+ *     the account were different contracts) -> a direct read of the
+ *     inherited `owner` state variable. Strictly better: no external
+ *     call, no CALL-opcode restriction to reason about during
+ *     `validateUserOp`, and `owner` is slot 0 -- always ERC-7562
+ *     [STO-010]-permitted.
+ *
+ * WHAT WAS DELIBERATELY NOT CARRIED FORWARD (phase3-impl spec §3.2
+ * "interface cleanup" instruction): `ISessionKeyModule.sol` declares four
+ * errors, three of which (`SessionKeyScopeMismatch`,
+ * `SessionKeyInvalidSignature`, `SessionKeyReplay`) are never reverted --
+ * the validator fails closed via SIG_VALIDATION_FAILED, which is the
+ * correct ERC-4337 pattern. `SessionKeyModule.sol` itself ALSO declares
+ * two more unused errors (`UnknownGrantVersion`, `InvalidSignatureLength`)
+ * that are never reverted either -- the same defect, one level deeper,
+ * that the spec's line-numbered callout didn't name but the same
+ * principle applies to. This contract declares ZERO custom errors for
+ * the session-key path: every validation failure is a clean
+ * SIG_VALIDATION_FAILED return, and the only revert-shaped auth check
+ * (`revokeSessionKey`) reuses the inherited `onlyOwner` modifier's
+ * existing "only owner" require string rather than inventing a new error
+ * type. The module's `ISessionKeyModule.sol:73` docstring also claimed
+ * `revokeSessionKey`'s caller "MUST be the master wallet of `account`",
+ * which contradicted its own `msg.sender == account` gate (only the
+ * SMART ACCOUNT itself could call it, not the master wallet directly) --
+ * corrected here: `onlyOwner` genuinely accepts the owner EOA directly OR
+ * a self-call, and this doc says so plainly.
+ *
+ * `SessionKeyModule.sol` and `ISessionKeyModule.sol` are left untouched
+ * on disk -- they are dead code (never deployed, per the account-model
+ * memo §6) but still compile and their own test suite
+ * (`test/SessionKeyModule.t.sol`) still exercises them; deleting them is
+ * out of scope for this change.
+ * ============================================================
+ */
+contract TotalReclawAccount is SimpleAccount {
+    // -------------------------------------------------------------------
+    // Constructor-less: the v0.7 canonical EntryPoint is a hardcoded
+    // constant (same address on every chain that has it deployed, Gnosis
+    // included -- verified live against the account-model memo §2.3) so
+    // this contract's CREATE2 init code is bare `type(TotalReclawAccount)
+    // .creationCode` with no constructor-argument encoding required.
+    // -------------------------------------------------------------------
+
+    address internal constant ENTRY_POINT_V07 = 0x0000000071727De22E5E9d8BAf0edAc6f37da032;
+
+    constructor() SimpleAccount(IEntryPoint(ENTRY_POINT_V07)) {
+        // SimpleAccount's constructor calls `_disableInitializers()` --
+        // this implementation instance can never itself be `initialize`d,
+        // exactly like the stock implementation it replaces. Proxies that
+        // upgrade to this implementation keep whatever `_initialized`
+        // state their `Initializable` storage already had (that storage
+        // is untouched by this upgrade -- same base contract, same
+        // ERC-7201 namespace), so an upgraded proxy cannot be
+        // re-initialized to hijack ownership.
+    }
+
+    // -------------------------------------------------------------------
+    // Grant wire-format constants (byte-for-byte identical to
+    // `SessionKeyModule.sol` -- this is a WIRE FORMAT, not an
+    // implementation detail; changing it breaks every existing signed
+    // grant and the cross-language parity fixture).
+    // -------------------------------------------------------------------
+
+    uint8 internal constant GRANT_VERSION = 1;
+
+    /// @dev SimpleAccount.execute(address,uint256,bytes) selector.
+    bytes4 internal constant EXECUTE_SELECTOR = 0xb61d27f6;
+    /// @dev SimpleAccount.executeBatch(address[],uint256[],bytes[]) selector.
+    bytes4 internal constant EXECUTE_BATCH_SELECTOR = 0x47e1da2a;
+
+    bytes32 internal constant DOMAIN_TYPEHASH = keccak256(
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+    );
+    bytes32 internal constant SCOPE_TYPEHASH =
+        keccak256("Scope(address target,bytes4[] selectors,uint256 valueMax)");
+    bytes32 internal constant GRANT_TYPEHASH = keccak256(
+        "SessionKeyPermissionGrant(address account,address signer,Scope scope,uint256 nonce,uint256 issuedAt)Scope(address target,bytes4[] selectors,uint256 valueMax)"
+    );
+    bytes32 internal constant DOMAIN_NAME_HASH = keccak256(bytes("TotalReclawSessionKey"));
+    bytes32 internal constant DOMAIN_VERSION_HASH = keccak256(bytes("1"));
+
+    // -------------------------------------------------------------------
+    // ERC-7201 namespaced storage. `owner` (inherited from SimpleAccount)
+    // occupies slot 0 -- verified live (account-model memo §2.5) and
+    // re-asserted in the fork test after a real upgrade, not by
+    // inspection. This contract declares NO plain state variables of its
+    // own; all new state lives at a namespaced slot computed from a
+    // domain-separated hash, per ERC-7201, so it cannot collide with
+    // slot 0 (or with any future OZ base-contract layout change).
+    // -------------------------------------------------------------------
+
+    struct GrantStorage {
+        uint256 nonce; // grant nonce; 0 = uninstalled
+        uint256 issuedAt; // informational -- never compared to block.timestamp
+        address target; // scope.target (DataEdge address)
+        uint256 valueMax; // always 0 per spec
+        bytes4[] selectors; // scope.selectors (execute, executeBatch)
+    }
+
+    /// @custom:storage-location erc7201:totalreclaw.account.sessionkeys
+    struct SessionKeyStorage {
+        /// @dev `grants[signer]` -- active grant for this session key.
+        ///      `nonce == 0` means "not installed".
+        mapping(address signer => GrantStorage) grants;
+        /// @dev `minNonces[signer]` -- smallest acceptable install nonce.
+        ///      Starts at 1, bumps on revoke to `revokedNonce + 1`.
+        ///      Prevents replay of a revoked grant.
+        mapping(address signer => uint256) minNonces;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("totalreclaw.account.sessionkeys")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant SESSION_KEY_STORAGE_LOCATION =
+        0x93ec0d14d62ae42f5c43c594ab5fc270681dab686d50adb6a516393064aef500;
+
+    function _sessionKeyStorage() private pure returns (SessionKeyStorage storage $) {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            $.slot := SESSION_KEY_STORAGE_LOCATION
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // ABI-decoded calldata layout for the lazy-install UserOp. Field order
+    // and types are byte-for-byte identical to `SessionKeyModule
+    // .PermissionGrant` -- this is the cross-language wire format
+    // (`derived-bundle-v1.md` §4.1's `signing.grant`), not free to change.
+    // `userOp.signature = abi.encode(PermissionGrant, ecdsaSig)` where
+    // `ecdsaSig` is a 65-byte ECDSA signed by the session key over the
+    // RAW userOpHash (see `_validateSessionKeySignature` for why this is
+    // NOT the EIP-191-prefixed hash the owner path uses).
+    // -------------------------------------------------------------------
+
+    struct PermissionGrant {
+        uint8 version;
+        address account;
+        address signer;
+        address target;
+        bytes4[] selectors;
+        uint256 valueMax;
+        uint256 nonce;
+        uint256 issuedAt;
+        uint256 chainId;
+        address verifyingContract;
+        bytes masterSignature; // 65-byte ECDSA from master wallet over the EIP-712 digest
+    }
+
+    // -------------------------------------------------------------------
+    // Events. See the "WHAT WAS DELIBERATELY NOT CARRIED FORWARD" note
+    // above for why there are no custom errors here.
+    // -------------------------------------------------------------------
+
+    /// @notice Emitted on the first UserOp that uses a fresh session key
+    ///         (lazy-install pattern -- no separate `installSessionKey()`
+    ///         call). `signer` is indexed (not `account`, unlike the
+    ///         module's event) -- the emitter's address already IS the
+    ///         account, so indexing it again is redundant.
+    event SessionKeyInstalled(address indexed signer, uint256 nonce);
+
+    /// @notice Emitted when the owner (EOA or self-call) revokes a session
+    ///         key. Idempotent -- revoking an unknown or already-revoked
+    ///         signer is a no-op and does NOT re-emit this event.
+    event SessionKeyRevoked(address indexed signer);
+
+    // -------------------------------------------------------------------
+    // _validateSignature -- the one genuinely dangerous function in this
+    // contract (audit-risk memo §3 item 2). Owner-first ordering is
+    // load-bearing: see the NatSpec on `_validateSignature` below.
+    // -------------------------------------------------------------------
+
+    /// @inheritdoc SimpleAccount
+    ///
+    /// @dev DEVIATION FROM A LITERAL PORT, FLAGGED EXPLICITLY: stock
+    ///      `SimpleAccount._validateSignature` calls `ECDSA.recover`
+    ///      (not `tryRecover`), which REVERTS the whole `validateUserOp`
+    ///      call for any signature that is not a well-formed 65-byte
+    ///      (r,s,v) blob. A session-key lazy-install signature is a much
+    ///      longer `abi.encode(PermissionGrant, ecdsaSig)` blob -- a
+    ///      literal "try owner's exact code path first" port would
+    ///      REVERT on every lazy-install UserOp before ever reaching the
+    ///      session-key branch, making the entire feature non-functional
+    ///      (not merely insecure -- inert). `ECDSA.tryRecover` is used
+    ///      instead, and any non-`NoError` outcome is treated as "not the
+    ///      owner, keep going" rather than reverting.
+    ///
+    ///      Why this preserves "byte-identical to stock for the owner
+    ///      path": for a genuine 65-byte signature, `tryRecover`'s
+    ///      success/failure and recovered address are IDENTICAL to
+    ///      `recover`'s -- same `ecrecover` call, same EIP-2 malleability
+    ///      guard (`RecoverError.InvalidSignatureS`), same zero-address
+    ///      guard (`RecoverError.InvalidSignature`). The only observable
+    ///      difference is the FAILURE MODE for a malformed 65-byte owner
+    ///      attempt: stock reverts the whole `validateUserOp`; this
+    ///      contract instead falls through to the session-key branch
+    ///      and, if that also fails, returns SIG_VALIDATION_FAILED
+    ///      cleanly. No input that stock would have ACCEPTED is rejected
+    ///      here, and no input stock would have REJECTED is accepted
+    ///      here -- only the shape of "rejected" changes for inputs that
+    ///      were never going to succeed anyway.
+    ///
+    ///      One case worth naming precisely: could a genuine session-key
+    ///      signature accidentally trip a revert in stock's semantics if
+    ///      we HAD used `ECDSA.recover` here? `ecrecover`'s "returns
+    ///      address(0)" failure mode depends only on `(v, r, s)`, never
+    ///      on the hash being checked against -- a real signature
+    ///      produced by a real private key over ANY hash has a `r` that
+    ///      decompresses to a valid curve point, so `ecrecover` will not
+    ///      spuriously return zero when checked against the WRONG
+    ///      (owner-path) hash either. The malleability guard is likewise
+    ///      a pure function of `s`, independent of which hash is being
+    ///      checked. So `ECDSA.recover` would not have spuriously
+    ///      reverted on a well-formed session-key signature -- but
+    ///      `tryRecover` is still the correct choice, because it is the
+    ///      only one of the two that does not revert on the
+    ///      DIFFERENT-LENGTH lazy-install blob, and using it uniformly
+    ///      (rather than length-branching before deciding which ECDSA
+    ///      entry point to call) keeps this function's control flow
+    ///      simple and auditable.
+    function _validateSignature(PackedUserOperation calldata userOp, bytes32 userOpHash)
+        internal
+        override
+        returns (uint256 validationData)
+    {
+        // 1. Owner path -- tried first, and for any input stock SimpleAccount
+        //    would have accepted or rejected, this produces the identical
+        //    verdict. See the deviation note above for the one behavioural
+        //    difference (soft-fail vs revert on a malformed non-owner-shaped
+        //    signature) and why it is required, not incidental.
+        bytes32 ethSignedHash = MessageHashUtils.toEthSignedMessageHash(userOpHash);
+        (address recoveredOwner, ECDSA.RecoverError ownerErr,) =
+            ECDSA.tryRecover(ethSignedHash, userOp.signature);
+        if (ownerErr == ECDSA.RecoverError.NoError && recoveredOwner == owner) {
+            return SIG_VALIDATION_SUCCESS;
+        }
+
+        // 2. Session-key path -- only reached when the owner path did not
+        //    match. An account that has been upgraded but never paired
+        //    with a session key has an empty session-key storage
+        //    namespace, so every UserOp falls through to here and is
+        //    rejected exactly as it would have been rejected by stock
+        //    SimpleAccount (no owner match -> SIG_VALIDATION_FAILED).
+        return _validateSessionKeySignature(userOp, userOpHash);
+    }
+
+    /// @dev Steady-state (65-byte) and lazy-install (abi-encoded grant +
+    ///      65-byte session signature) paths, ported from
+    ///      `SessionKeyModule.validateSessionKeyUserOp` with the
+    ///      mechanical changes documented in the contract-level NatSpec.
+    function _validateSessionKeySignature(PackedUserOperation calldata userOp, bytes32 userOpHash)
+        private
+        returns (uint256)
+    {
+        bytes calldata sig = userOp.signature;
+        SessionKeyStorage storage $ = _sessionKeyStorage();
+
+        // Steady-state path: 65-byte raw ECDSA over the RAW userOpHash --
+        // deliberately NOT EIP-191-prefixed, unlike the owner path above.
+        // This must match whatever the session-key signer actually
+        // produces client-side (python/src/totalreclaw/userop.py
+        // `sign_userop_with_session_key`, P3-8) -- a prefix mismatch here
+        // would produce a signature that "looks valid" but recovers to
+        // the wrong address, silently rejecting every legitimate
+        // steady-state UserOp. Pinned in the fork test.
+        if (sig.length == 65) {
+            address signer = _recoverEcdsa(userOpHash, sig);
+            if (signer == address(0)) return SIG_VALIDATION_FAILED;
+
+            GrantStorage storage g = $.grants[signer];
+            if (g.nonce == 0) return SIG_VALIDATION_FAILED;
+
+            if (!_isCallDataInScope(userOp.callData, g.target, g.selectors)) {
+                return SIG_VALIDATION_FAILED;
+            }
+            return SIG_VALIDATION_SUCCESS;
+        }
+
+        // Lazy-install path: signature is abi.encode(PermissionGrant, ecdsaSig).
+        (bool ok, PermissionGrant memory grant, bytes memory ecdsaSig) = _tryDecodeInstallSig(sig);
+        if (!ok) return SIG_VALIDATION_FAILED;
+
+        // Verify the session signer first -- cheap, fails fast on tampered
+        // signatures before touching the (more expensive) grant checks.
+        address installSigner = _recoverEcdsa(userOpHash, ecdsaSig);
+        if (installSigner == address(0) || installSigner != grant.signer) {
+            return SIG_VALIDATION_FAILED;
+        }
+
+        if (!_isGrantValid(grant)) return SIG_VALIDATION_FAILED;
+
+        // Replay protection -- nonce must be at-or-above the minimum.
+        uint256 minN = $.minNonces[grant.signer];
+        if (minN == 0) minN = 1; // first install
+        if (grant.nonce < minN) return SIG_VALIDATION_FAILED;
+
+        // Recover the master wallet from the EIP-712 grant signature and
+        // verify it is THIS account's owner. Unlike the standalone-module
+        // design (which needed an external call to
+        // `IAccountWithOwner(account).owner()` because the module and the
+        // account were different contracts), `owner` is a direct
+        // inherited storage read here -- always ERC-7562 [STO-010]
+        // permitted, no external CALL during validateUserOp.
+        bytes32 digest = _grantDigest(grant);
+        address master = _recoverEcdsa(digest, grant.masterSignature);
+        if (master == address(0)) return SIG_VALIDATION_FAILED;
+        if (master != owner) return SIG_VALIDATION_FAILED;
+
+        // All checks pass -- install the grant.
+        $.grants[grant.signer] = GrantStorage({
+            nonce: grant.nonce,
+            issuedAt: grant.issuedAt,
+            target: grant.target,
+            valueMax: grant.valueMax,
+            selectors: grant.selectors
+        });
+
+        emit SessionKeyInstalled(grant.signer, grant.nonce);
+
+        // After install, validate the actual userOp callData against the
+        // newly-stored scope -- same path the steady-state branch takes.
+        if (!_isCallDataInScope(userOp.callData, grant.target, grant.selectors)) {
+            return SIG_VALIDATION_FAILED;
+        }
+        return SIG_VALIDATION_SUCCESS;
+    }
+
+    // -------------------------------------------------------------------
+    // Mutating -- owner-gated session-key management.
+    // -------------------------------------------------------------------
+
+    /// @notice Revoke a session key. Gated by the inherited `onlyOwner`
+    ///         modifier, which accepts EITHER the owner EOA calling
+    ///         directly, OR a self-call (i.e. an owner-signed UserOp
+    ///         whose callData is `execute(address(this), 0,
+    ///         abi.encodeCall(this.revokeSessionKey, (signer)))`) -- the
+    ///         pattern the SPA's "revoke" button uses. Idempotent:
+    ///         revoking an unknown or already-revoked signer is a silent
+    ///         no-op (no revert, no duplicate event).
+    function revokeSessionKey(address signer) external onlyOwner {
+        SessionKeyStorage storage $ = _sessionKeyStorage();
+        GrantStorage storage g = $.grants[signer];
+        if (g.nonce == 0) {
+            // Already revoked or never installed -- idempotent no-op.
+            return;
+        }
+
+        // Bump the min-nonce so this grant cannot be re-played even with
+        // the original signed payload.
+        $.minNonces[signer] = g.nonce + 1;
+        delete $.grants[signer];
+
+        emit SessionKeyRevoked(signer);
+    }
+
+    // -------------------------------------------------------------------
+    // Views.
+    // -------------------------------------------------------------------
+
+    function isSessionKeyActive(address signer) external view returns (bool) {
+        return _sessionKeyStorage().grants[signer].nonce != 0;
+    }
+
+    function getSessionKeyGrant(address signer)
+        external
+        view
+        returns (uint256 nonce, uint256 issuedAt, bytes4[] memory selectors, address target)
+    {
+        GrantStorage storage g = _sessionKeyStorage().grants[signer];
+        return (g.nonce, g.issuedAt, g.selectors, g.target);
+    }
+
+    /// @notice External read-only wrapper around `_grantDigest`, so tests
+    ///         and off-chain tooling (SPA grant signing, future core
+    ///         PyO3/WASM bindings) compute the EIP-712 digest via the
+    ///         actual production code path -- never a hand-copied mirror
+    ///         of it. (`SessionKeyModule.t.sol`'s `_grantDigestExt` was
+    ///         exactly such a mirror, with a comment admitting both copies
+    ///         had to be updated together; this wrapper is the fix.)
+    function grantDigest(PermissionGrant calldata g) external pure returns (bytes32) {
+        return _grantDigest(g);
+    }
+
+    // -------------------------------------------------------------------
+    // Internal helpers -- ported verbatim from `SessionKeyModule.sol`
+    // except where the contract-level NatSpec documents a mechanical
+    // change.
+    // -------------------------------------------------------------------
+
+    /// @dev `try`/`catch` wrapper around `abi.decode` so a malformed
+    ///      install signature returns `(false, ...)` instead of
+    ///      reverting the whole `validateUserOp` callback.
+    function _tryDecodeInstallSig(bytes calldata sig)
+        internal
+        view
+        returns (bool ok, PermissionGrant memory grant, bytes memory ecdsaSig)
+    {
+        if (sig.length < 0x40) return (false, grant, ecdsaSig);
+
+        try this._decodeInstallSig(sig) returns (PermissionGrant memory g, bytes memory s) {
+            return (true, g, s);
+        } catch {
+            return (false, grant, ecdsaSig);
+        }
+    }
+
+    /// @dev Public-but-only-self entry for the try/catch above. External
+    ///      so the catch sees revert data cleanly.
+    function _decodeInstallSig(bytes calldata sig)
+        external
+        pure
+        returns (PermissionGrant memory grant, bytes memory ecdsaSig)
+    {
+        (grant, ecdsaSig) = abi.decode(sig, (PermissionGrant, bytes));
+    }
+
+    /// @dev Static grant-shape validation. Does NOT check the signature --
+    ///      that lives in the caller, which recovers the master wallet
+    ///      only once.
+    ///
+    ///      `g.verifyingContract != address(this)` is the P3-3 binding:
+    ///      in the module design `this` was the MODULE; here it is the
+    ///      ACCOUNT itself. This is a value change in what gets signed
+    ///      off-chain, not a schema change -- same field, same type.
+    function _isGrantValid(PermissionGrant memory g) internal view returns (bool) {
+        if (g.version != GRANT_VERSION) return false;
+        if (g.account != address(this)) return false; // grant binds to THIS account
+        if (g.chainId != block.chainid) return false; // cross-chain replay guard
+        if (g.verifyingContract != address(this)) return false; // P3-3: account-binding
+        if (g.valueMax != 0) return false; // session keys cannot move ETH
+        if (g.target == address(0)) return false;
+        if (g.signer == address(0)) return false;
+        if (g.selectors.length == 0) return false;
+        if (g.masterSignature.length != 65) return false;
+        return true;
+    }
+
+    /// @dev EIP-712 digest. Ported verbatim from
+    ///      `SessionKeyModule._grantDigest` -- pure math over the grant's
+    ///      OWN fields (including `g.chainId` / `g.verifyingContract` as
+    ///      given, never re-derived from `block.chainid` /
+    ///      `address(this)`), because the digest must match whatever was
+    ///      actually signed off-chain before we know if it will validate.
+    function _grantDigest(PermissionGrant memory g) internal pure returns (bytes32) {
+        bytes32 scopeHash = keccak256(
+            abi.encode(
+                SCOPE_TYPEHASH, g.target, keccak256(abi.encodePacked(g.selectors)), g.valueMax
+            )
+        );
+        bytes32 structHash = keccak256(
+            abi.encode(GRANT_TYPEHASH, g.account, g.signer, scopeHash, g.nonce, g.issuedAt)
+        );
+        bytes32 domainSep = keccak256(
+            abi.encode(
+                DOMAIN_TYPEHASH,
+                DOMAIN_NAME_HASH,
+                DOMAIN_VERSION_HASH,
+                g.chainId,
+                g.verifyingContract
+            )
+        );
+        return keccak256(abi.encodePacked(hex"1901", domainSep, structHash));
+    }
+
+    /// @dev Scope validation for both `execute` and `executeBatch` outer
+    ///      calls. Ported verbatim from `SessionKeyModule
+    ///      ._isCallDataInScope` -- no reference to `msg.sender` in the
+    ///      original, so no mechanical change needed here either.
+    function _isCallDataInScope(
+        bytes calldata callData,
+        address grantTarget,
+        bytes4[] memory allowedSelectors
+    ) internal view returns (bool) {
+        if (callData.length < 4) return false;
+        bytes4 outerSel = bytes4(callData[:4]);
+
+        // Selector must be in the SA-level allowlist.
+        if (!_inSelectors(outerSel, allowedSelectors)) return false;
+
+        if (outerSel == EXECUTE_SELECTOR) {
+            // execute(address target, uint256 value, bytes data)
+            if (callData.length < 4 + 32 * 3) return false;
+            (address innerTarget, uint256 value,) =
+                abi.decode(callData[4:], (address, uint256, bytes));
+            return innerTarget == grantTarget && value == 0;
+        }
+
+        if (outerSel == EXECUTE_BATCH_SELECTOR) {
+            // executeBatch(address[] targets, uint256[] values, bytes[] datas).
+            // Per the cred-6 invariant: every inner call is individually
+            // validated. First non-match -> false; no partial-execution
+            // semantics, no outer-selector-passes shortcut.
+            try this._decodeExecuteBatch(callData[4:]) returns (
+                address[] memory targets, uint256[] memory values, bytes[] memory datas
+            ) {
+                return _isBatchInScope(targets, values, datas, grantTarget, allowedSelectors);
+            } catch {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    /// @dev Public-but-only-self entry for the try/catch decode of the
+    ///      executeBatch payload. Ported verbatim.
+    function _decodeExecuteBatch(bytes calldata payload)
+        external
+        pure
+        returns (address[] memory targets, uint256[] memory values, bytes[] memory datas)
+    {
+        (targets, values, datas) = abi.decode(payload, (address[], uint256[], bytes[]));
+    }
+
+    /// @dev Per-inner-call scope assertion. Ported verbatim from
+    ///      `SessionKeyModule._isBatchInScope` -- the load-bearing cred-6
+    ///      invariant: returns true ONLY when EVERY inner call's target,
+    ///      zero-value, and selector all pass.
+    function _isBatchInScope(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory datas,
+        address grantTarget,
+        bytes4[] memory allowedSelectors
+    ) internal pure returns (bool) {
+        uint256 n = targets.length;
+        if (n == 0) return false;
+        if (values.length != n || datas.length != n) return false;
+
+        for (uint256 i = 0; i < n; i++) {
+            if (targets[i] != grantTarget) return false;
+            if (values[i] != 0) return false;
+
+            bytes memory inner = datas[i];
+            if (inner.length < 4) return false;
+
+            // First 4 bytes of `inner` -- in-memory layout is
+            // (length: 32 bytes)(data...), so mload at offset 0x20 yields
+            // a word whose top 4 bytes are the selector.
+            bytes4 innerSel;
+            // solhint-disable-next-line no-inline-assembly
+            assembly {
+                innerSel := mload(add(inner, 0x20))
+            }
+            if (!_inSelectors(innerSel, allowedSelectors)) return false;
+        }
+        return true;
+    }
+
+    function _inSelectors(bytes4 needle, bytes4[] memory hay) internal pure returns (bool) {
+        for (uint256 i = 0; i < hay.length; i++) {
+            if (hay[i] == needle) return true;
+        }
+        return false;
+    }
+
+    /// @dev Minimal ECDSA recover (r, s, v). Ported verbatim from
+    ///      `SessionKeyModule._recoverEcdsa` rather than swapped for
+    ///      `ECDSA.tryRecover` -- functionally equivalent (same EIP-2
+    ///      malleability guard), but the spec calls this out by name as
+    ///      one of the best-tested pieces of the original file, so it is
+    ///      lifted as-is rather than re-derived. Returns address(0) on
+    ///      malformed input or `s` in the upper half of the curve order.
+    function _recoverEcdsa(bytes32 digest, bytes memory sig) internal pure returns (address) {
+        if (sig.length != 65) return address(0);
+
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            r := mload(add(sig, 0x20))
+            s := mload(add(sig, 0x40))
+            v := byte(0, mload(add(sig, 0x60)))
+        }
+        // EIP-2 malleability guard
+        if (uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {
+            return address(0);
+        }
+        if (v != 27 && v != 28) return address(0);
+        return ecrecover(digest, v, r, s);
+    }
+}

--- a/contracts/account/foundry.lock
+++ b/contracts/account/foundry.lock
@@ -1,0 +1,20 @@
+{
+  "lib/forge-std": {
+    "tag": {
+      "name": "v1.16.1",
+      "rev": "620536fa5277db4e3fd46772d5cbc1ea0696fb43"
+    }
+  },
+  "lib/openzeppelin-contracts": {
+    "tag": {
+      "name": "v5.0.2",
+      "rev": "dbb6104ce834628e473d2173bbc9d47f81a9eec3"
+    }
+  },
+  "lib/account-abstraction": {
+    "tag": {
+      "name": "v0.7.0",
+      "rev": "7af70c8993a6f42973f520ae0752386a5032abe7"
+    }
+  }
+}

--- a/contracts/account/foundry.toml
+++ b/contracts/account/foundry.toml
@@ -34,6 +34,11 @@ test = "test"
 out = "out"
 libs = ["lib"]
 solc_version = "0.8.24"
+# Deterministic CREATE2: strip the appended metadata hash so `creationCode`
+# is a pure function of (source, solc version, optimizer settings) and the
+# predicted implementation address reproduces on any machine/toolchain.
+bytecode_hash = "none"
+cbor_metadata = false
 optimizer = true
 optimizer_runs = 200
 via_ir = false

--- a/contracts/account/foundry.toml
+++ b/contracts/account/foundry.toml
@@ -1,0 +1,45 @@
+# Foundry config for `TotalReclawAccount` (Option E Phase 3, P3-1/P3-2).
+#
+# WHY THIS IS A SEPARATE FOUNDRY PROJECT FROM `contracts/foundry.toml`,
+# NOT JUST A NEW FILE IN THE EXISTING ONE:
+#
+# `TotalReclawAccount` subclasses eth-infinitism's `SimpleAccount`, which
+# needs the real `account-abstraction` (v0.7.0) and `openzeppelin-contracts`
+# (v5.0.2) packages as Foundry libs. Adding those libs' directories (or a
+# `remappings.txt` naming them) under the SHARED `contracts/lib/` /
+# `contracts/remappings.txt` was tried first and reverted: solc embeds the
+# FULL, PROJECT-WIDE `settings.remappings` list into every compiled
+# contract's metadata, REGARDLESS of whether that specific contract
+# actually imports anything through those remappings. Verified empirically:
+# adding the two new remapping lines (with no other change, not even the
+# lib directories present) shifted `EventfulDataEdge`'s compiled bytecode
+# and broke `test/DataEdgeStagingCreate2.t.sol`'s pinned CREATE2 address
+# assertion for the STAGING DataEdge (`0xE7a4D2677B686e13775Ba9092631089e35F0BB91`,
+# a REAL deployed contract) — a self-inflicted, purely incidental bytecode
+# change to a contract this PR has nothing to do with. A nested Foundry
+# project (its own `foundry.toml`, `lib/`, `remappings.txt`) is the only
+# way to add `account-abstraction`/`openzeppelin-contracts` without that
+# collateral effect: `forge` resolves the project root as the nearest
+# `foundry.toml` walking up from the working directory, so a `forge build`
+# / `forge test` run from THIS directory never sees, and cannot perturb,
+# the outer project's compiler settings or vendored libs.
+#
+# Run from here: `cd contracts/account && forge build && forge test`.
+# CI wiring: `.github/workflows/forge-test.yml` (separate job/step, see
+# comment there for why it must not be folded into the outer job).
+
+[profile.default]
+src = "contracts"
+test = "test"
+out = "out"
+libs = ["lib"]
+solc_version = "0.8.24"
+optimizer = true
+optimizer_runs = 200
+via_ir = false
+extra_output = ["storageLayout"]
+
+[fmt]
+line_length = 100
+tab_width = 4
+bracket_spacing = false

--- a/contracts/account/remappings.txt
+++ b/contracts/account/remappings.txt
@@ -1,0 +1,3 @@
+@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
+account-abstraction/=lib/account-abstraction/
+forge-std/=lib/forge-std/src/

--- a/contracts/account/script/storage-layout-diff.sh
+++ b/contracts/account/script/storage-layout-diff.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Option E Phase 3 (P3-4) — storage-layout diff CI gate.
+#
+# `TotalReclawAccount` MUST declare zero plain state variables beyond what
+# it inherits from `SimpleAccount` (B2 mitigation: a state variable that
+# collides with `owner` at slot 0 is catastrophic and silent, per
+# `docs/plans/2026-08-02-option-e-phase3-audit-risk.md` §2). All new
+# session-key state lives in ERC-7201 namespaced storage, accessed via a
+# fixed-slot inline-assembly getter, which does NOT show up in solc's
+# `storageLayout.storage` array — so the strongest possible assertion of
+# "no new plain state variables" is: this array is BYTE-IDENTICAL between
+# `TotalReclawAccount` and the `SimpleAccount` it subclasses.
+#
+# `contracts/account/foundry.toml` already sets `extra_output =
+# ["storageLayout"]`; this script is what consumes it (the phase3-impl
+# spec §3.1/§3.4 note that nothing did, before this).
+#
+# Usage: contracts/account/script/storage-layout-diff.sh
+# Exit 0 = layouts match. Exit 1 = they differ (or either inspect failed).
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+echo "Building..."
+forge build >/dev/null
+
+echo "Inspecting TotalReclawAccount storage layout..."
+forge inspect TotalReclawAccount storageLayout --json > /tmp/tra-storage-layout.json
+
+echo "Inspecting SimpleAccount (the deployed baseline's implementation contract) storage layout..."
+forge inspect SimpleAccount storageLayout --json > /tmp/simple-account-storage-layout.json
+
+# Compare only the `.storage` array (slot, offset, type, label) — the
+# `.types` dictionary can differ trivially in ordering/naming without any
+# real layout difference, so it is not part of the gate.
+python3 - <<'PY'
+import json
+import sys
+
+with open("/tmp/tra-storage-layout.json") as f:
+    tra = json.load(f)["storage"]
+with open("/tmp/simple-account-storage-layout.json") as f:
+    simple = json.load(f)["storage"]
+
+def normalize(entries):
+    return [
+        {"slot": e["slot"], "offset": e["offset"], "label": e["label"], "type": e["type"]}
+        for e in entries
+    ]
+
+tra_n = normalize(tra)
+simple_n = normalize(simple)
+
+if tra_n != simple_n:
+    print("STORAGE LAYOUT MISMATCH — TotalReclawAccount declares state that", file=sys.stderr)
+    print("SimpleAccount does not (or vice versa). This is exactly the B2", file=sys.stderr)
+    print("failure class (silent slot-0 collision risk) — do not deploy.", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("TotalReclawAccount:", file=sys.stderr)
+    for e in tra_n:
+        print(f"  slot {e['slot']:>3} offset {e['offset']} {e['label']}: {e['type']}", file=sys.stderr)
+    print("SimpleAccount:", file=sys.stderr)
+    for e in simple_n:
+        print(f"  slot {e['slot']:>3} offset {e['offset']} {e['label']}: {e['type']}", file=sys.stderr)
+    sys.exit(1)
+
+print(f"OK — {len(tra_n)} plain state variable(s), byte-identical between TotalReclawAccount and SimpleAccount:")
+for e in tra_n:
+    print(f"  slot {e['slot']:>3} offset {e['offset']} {e['label']}: {e['type']}")
+PY

--- a/contracts/account/test/TotalReclawAccount.t.sol
+++ b/contracts/account/test/TotalReclawAccount.t.sol
@@ -1,0 +1,689 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {
+    PackedUserOperation
+} from "account-abstraction/contracts/interfaces/PackedUserOperation.sol";
+import {SimpleAccount} from "account-abstraction/contracts/samples/SimpleAccount.sol";
+import {TotalReclawAccount} from "../contracts/TotalReclawAccount.sol";
+
+/**
+ * @title TotalReclawAccountTest
+ * @notice Option E Phase 3 (P3-4) — fast, non-forked unit tests for
+ *         `TotalReclawAccount`. Every test here deploys a FRESH
+ *         `ERC1967Proxy` pointing at a freshly-deployed implementation
+ *         and initialises it with a Foundry-controlled owner keypair --
+ *         exactly the deployment shape `SimpleAccountFactory.createAccount`
+ *         produces on-chain (account-model memo §2.2 / §4.1), just without
+ *         needing network access. The REAL, already-deployed,
+ *         already-in-use account (`0x2c0CF74B2b76110708CA431796367779e3738250`)
+ *         is exercised separately in `TotalReclawAccountFork.t.sol`, which
+ *         is the only place state-PRESERVATION (as opposed to
+ *         state-correctness) can meaningfully be asserted.
+ */
+contract TotalReclawAccountTest is Test {
+    TotalReclawAccount internal implementation;
+    TotalReclawAccount internal account;
+
+    address internal owner;
+    uint256 internal ownerPriv;
+    address internal signer;
+    uint256 internal signerPriv;
+
+    /// @dev Must match `TotalReclawAccount.ENTRY_POINT_V07`. Duplicated
+    ///      here deliberately -- it is a public, canonical, chain-fixed
+    ///      address (not a formula or secret), the same convention the
+    ///      pre-existing test file uses for `DATA_EDGE`.
+    address internal constant ENTRY_POINT = 0x0000000071727De22E5E9d8BAf0edAc6f37da032;
+
+    address internal constant DATA_EDGE = 0xC445af1D4EB9fce4e1E61fE96ea7B8feBF03c5ca;
+    bytes4 internal constant EXECUTE_SEL = 0xb61d27f6;
+    bytes4 internal constant EXECUTE_BATCH_SEL = 0x47e1da2a;
+
+    function setUp() public {
+        implementation = new TotalReclawAccount();
+
+        (owner, ownerPriv) = makeAddrAndKey("owner");
+        (signer, signerPriv) = makeAddrAndKey("signer");
+
+        bytes memory initData = abi.encodeCall(SimpleAccount.initialize, (owner));
+        ERC1967Proxy proxy = new ERC1967Proxy(address(implementation), initData);
+        account = TotalReclawAccount(payable(address(proxy)));
+    }
+
+    // ============================================================
+    // Constructor-less / CREATE2 determinism.
+    // ============================================================
+
+    /// @dev Pinned-address test, mirroring `DataEdgeStagingCreate2.t.sol
+    ///      :69` -- NOT `SessionKeyModule.t.sol:86`'s tautological
+    ///      version. `test_create2_address_unchanged_after_module_install`
+    ///      recomputes `keccak256(0xff || factory || salt || initCodeHash)`
+    ///      under different `vm.chainId` values and asserts the two
+    ///      recomputations agree with EACH OTHER -- but `block.chainid` is
+    ///      not an input to that expression at all, so it cannot fail
+    ///      regardless of bytecode; it is not a real test. This test
+    ///      instead pins the predicted address against an INDEPENDENTLY
+    ///      hardcoded literal, so an accidental change to the constructor,
+    ///      inheritance order, or compiler settings that alters
+    ///      `type(TotalReclawAccount).creationCode` surfaces as a failing
+    ///      assertion.
+    ///
+    ///      NOTE: this salt is a placeholder for THIS TEST ONLY, chosen to
+    ///      follow the existing `totalreclaw.<ContractName>.v1` naming
+    ///      convention (`DeploySessionKeyModule.SESSION_KEY_MODULE_SALT_V1`).
+    ///      It does not commit to an actual deployment salt -- that is
+    ///      decided by `2026-08-02-phase3-contract-deployment-plan.md`
+    ///      (out of scope for P3-1/P3-2/P3-4). If a different salt is
+    ///      chosen there, update this pin to match.
+    ///
+    ///      ALSO NOTE: solc's default metadata hash embeds a hash of the
+    ///      exact source text, so this pin is sensitive to ANY edit to
+    ///      `TotalReclawAccount.sol` -- including a pure `forge fmt`
+    ///      reformat, not just logic changes. That is intentional (it is
+    ///      what makes the test catch a real drift), but it means the pin
+    ///      legitimately needs regenerating after routine formatting too;
+    ///      that is not a sign anything is wrong. Nothing is deployed at
+    ///      this address yet, so regenerating it here has zero cost --
+    ///      contrast with `DataEdgeStagingCreate2.t.sol`'s pin, which
+    ///      tracks a REAL deployed contract and must never be "fixed" by
+    ///      just updating the literal.
+    bytes32 internal constant TOTAL_RECLAW_ACCOUNT_SALT_V1 =
+        keccak256("totalreclaw.TotalReclawAccount.v1");
+
+    function _predictImplAddress(bytes32 salt) internal pure returns (address) {
+        bytes32 initCodeHash = keccak256(abi.encodePacked(type(TotalReclawAccount).creationCode));
+        return address(
+            uint160(
+                uint256(
+                    keccak256(abi.encodePacked(bytes1(0xff), CREATE2_FACTORY, salt, initCodeHash))
+                )
+            )
+        );
+    }
+
+    function test_pinned_implementation_create2_address() public pure {
+        assertEq(
+            _predictImplAddress(TOTAL_RECLAW_ACCOUNT_SALT_V1),
+            0x25D4E71865E8A47F010219526A618f950a8f86B4,
+            "TotalReclawAccount predicted implementation address drifted - update the deployment plan's pinned value if intentional"
+        );
+    }
+
+    function test_create2_address_is_chain_independent() public {
+        // Genuinely exercises chain-independence, unlike the banned test:
+        // this asserts the SAME salt+bytecode produce the SAME address
+        // across chains, which is what CREATE2 guarantees and what a
+        // constructor that reads `block.chainid` (this one does not) would
+        // break.
+        uint256 original = block.chainid;
+        vm.chainId(100); // Gnosis
+        address onGnosis = _predictImplAddress(TOTAL_RECLAW_ACCOUNT_SALT_V1);
+        vm.chainId(1); // Ethereum mainnet, for contrast
+        address onMainnet = _predictImplAddress(TOTAL_RECLAW_ACCOUNT_SALT_V1);
+        vm.chainId(original);
+        assertEq(onGnosis, onMainnet, "CREATE2 address must be chain-independent");
+    }
+
+    // ============================================================
+    // Storage layout -- slot 0 stays `owner` after real proxy init.
+    // ============================================================
+
+    function test_slot_zero_is_owner_after_proxy_init() public view {
+        bytes32 raw = vm.load(address(account), bytes32(uint256(0)));
+        assertEq(address(uint160(uint256(raw))), owner, "slot 0 must be `owner` after initialize()");
+        assertEq(account.owner(), owner);
+    }
+
+    // ============================================================
+    // Owner path -- must behave like stock SimpleAccount for genuine
+    // owner signatures, and must NOT revert (only soft-fail) for
+    // signatures that are not owner-shaped, so the session-key branch is
+    // reachable. See `TotalReclawAccount._validateSignature`'s NatSpec
+    // for the full reasoning.
+    // ============================================================
+
+    function test_owner_signed_userop_validates() public {
+        bytes32 userOpHash = keccak256("owner-userop");
+        bytes memory sig = _signOwnerStyle(ownerPriv, userOpHash);
+        PackedUserOperation memory op = _makePackedOp(_executeCallData(DATA_EDGE, 0, hex"00"), sig);
+
+        vm.prank(ENTRY_POINT);
+        uint256 vd = account.validateUserOp(op, userOpHash, 0);
+        assertEq(vd, 0, "genuine owner signature must validate, exactly like stock SimpleAccount");
+    }
+
+    function test_owner_signed_userop_with_wrong_key_falls_through_and_fails() public {
+        (, uint256 attackerPriv) = makeAddrAndKey("attacker");
+        bytes32 userOpHash = keccak256("wrong-owner-key");
+        bytes memory sig = _signOwnerStyle(attackerPriv, userOpHash);
+        PackedUserOperation memory op = _makePackedOp(_executeCallData(DATA_EDGE, 0, hex"00"), sig);
+
+        vm.prank(ENTRY_POINT);
+        uint256 vd = account.validateUserOp(op, userOpHash, 0);
+        // No session key installed either, so this must cleanly fail --
+        // not revert.
+        assertEq(vd, 1, "wrong-key owner-shaped signature must SIG_VALIDATION_FAILED, not revert");
+    }
+
+    /// @dev Regression test for the documented `_validateSignature`
+    ///      deviation: a signature that is neither a well-formed 65-byte
+    ///      owner-style signature NOR a valid lazy-install blob must NOT
+    ///      revert `validateUserOp` -- it must return SIG_VALIDATION_FAILED
+    ///      cleanly. A literal port of stock's `ECDSA.recover` (which
+    ///      reverts on a malformed non-65-byte input) would fail this
+    ///      test by reverting instead of returning 1.
+    function test_malformed_signature_does_not_revert() public {
+        bytes32 userOpHash = keccak256("garbage-sig");
+        bytes memory garbage = hex"deadbeef"; // 4 bytes -- not 65, not a decodable grant blob
+        PackedUserOperation memory op =
+            _makePackedOp(_executeCallData(DATA_EDGE, 0, hex"00"), garbage);
+
+        vm.prank(ENTRY_POINT);
+        uint256 vd = account.validateUserOp(op, userOpHash, 0);
+        assertEq(vd, 1, "malformed signature must SIG_VALIDATION_FAILED, never revert");
+    }
+
+    function test_validateUserOp_reverts_when_not_called_by_entrypoint() public {
+        bytes32 userOpHash = keccak256("direct-call");
+        bytes memory sig = _signOwnerStyle(ownerPriv, userOpHash);
+        PackedUserOperation memory op = _makePackedOp(_executeCallData(DATA_EDGE, 0, hex"00"), sig);
+
+        vm.expectRevert(bytes("account: not from EntryPoint"));
+        account.validateUserOp(op, userOpHash, 0);
+    }
+
+    // ============================================================
+    // Session-key path -- lazy install, steady state, replay, scope.
+    // ============================================================
+
+    function test_first_call_installs_grant_and_emits_event() public {
+        bytes4[] memory sels = _twoSelectors();
+        TotalReclawAccount.PermissionGrant memory grant = _buildGrant(signer, DATA_EDGE, sels, 1);
+
+        bytes32 userOpHash = keccak256("first-userop");
+        bytes memory ecdsaSig = _signWithKey(signerPriv, userOpHash);
+        bytes memory sig = abi.encode(grant, ecdsaSig);
+        PackedUserOperation memory op =
+            _makePackedOp(_executeCallData(DATA_EDGE, 0, hex"deadbeef"), sig);
+
+        vm.expectEmit(true, false, false, true, address(account));
+        emit TotalReclawAccount.SessionKeyInstalled(signer, 1);
+
+        vm.prank(ENTRY_POINT);
+        uint256 vd = account.validateUserOp(op, userOpHash, 0);
+        assertEq(vd, 0, "first install + execute must succeed");
+
+        assertTrue(account.isSessionKeyActive(signer));
+        (uint256 n,,, address tgt) = account.getSessionKeyGrant(signer);
+        assertEq(n, 1);
+        assertEq(tgt, DATA_EDGE);
+    }
+
+    function test_steady_state_userop_after_install_succeeds() public {
+        _installGrant(1);
+
+        bytes32 hash2 = keccak256("steady-state");
+        bytes memory ecdsaSig = _signWithKey(signerPriv, hash2);
+        PackedUserOperation memory op =
+            _makePackedOp(_executeCallData(DATA_EDGE, 0, hex"42"), ecdsaSig);
+
+        vm.prank(ENTRY_POINT);
+        uint256 vd = account.validateUserOp(op, hash2, 0);
+        assertEq(vd, 0, "steady-state UserOp must succeed without re-sending the grant");
+    }
+
+    function test_validate_rejects_unknown_target() public {
+        _installGrant(1);
+
+        bytes32 userOpHash = keccak256("wrong-target");
+        bytes memory ecdsaSig = _signWithKey(signerPriv, userOpHash);
+        bytes memory cd = _executeCallData(address(0xDEAD), 0, hex"00");
+        PackedUserOperation memory op = _makePackedOp(cd, ecdsaSig);
+
+        vm.prank(ENTRY_POINT);
+        uint256 vd = account.validateUserOp(op, userOpHash, 0);
+        assertEq(vd, 1, "out-of-scope target must SIG_VALIDATION_FAILED");
+    }
+
+    function test_validate_rejects_unknown_selector() public {
+        bytes4[] memory onlyExecute = new bytes4[](1);
+        onlyExecute[0] = EXECUTE_SEL;
+        TotalReclawAccount.PermissionGrant memory grant =
+            _buildGrant(signer, DATA_EDGE, onlyExecute, 1);
+        bytes32 installHash = keccak256("install-1");
+        bytes memory installSig = abi.encode(grant, _signWithKey(signerPriv, installHash));
+        PackedUserOperation memory installOp =
+            _makePackedOp(_executeCallData(DATA_EDGE, 0, hex"00"), installSig);
+        vm.prank(ENTRY_POINT);
+        assertEq(account.validateUserOp(installOp, installHash, 0), 0);
+
+        bytes32 hash2 = keccak256("batch-attempt");
+        bytes memory ecdsaSig = _signWithKey(signerPriv, hash2);
+        bytes memory batchCallData = abi.encodePacked(EXECUTE_BATCH_SEL, hex"00");
+        PackedUserOperation memory op = _makePackedOp(batchCallData, ecdsaSig);
+
+        vm.prank(ENTRY_POINT);
+        uint256 vd = account.validateUserOp(op, hash2, 0);
+        assertEq(vd, 1, "out-of-scope selector must SIG_VALIDATION_FAILED");
+    }
+
+    function test_validate_invalid_signature_returns_failed() public {
+        _installGrant(1);
+
+        bytes32 userOpHash = keccak256("op-x");
+        (, uint256 attackerPriv) = makeAddrAndKey("attacker-session");
+        bytes memory badSig = _signWithKey(attackerPriv, userOpHash);
+        PackedUserOperation memory op =
+            _makePackedOp(_executeCallData(DATA_EDGE, 0, hex"00"), badSig);
+
+        vm.prank(ENTRY_POINT);
+        uint256 vd = account.validateUserOp(op, userOpHash, 0);
+        assertEq(vd, 1, "wrong signer must SIG_VALIDATION_FAILED");
+    }
+
+    function test_nonzero_value_rejected() public {
+        _installGrant(1);
+
+        bytes32 userOpHash = keccak256("eth-transfer");
+        bytes memory ecdsaSig = _signWithKey(signerPriv, userOpHash);
+        bytes memory cd = _executeCallData(DATA_EDGE, 1 ether, hex"00");
+        PackedUserOperation memory op = _makePackedOp(cd, ecdsaSig);
+
+        vm.prank(ENTRY_POINT);
+        uint256 vd = account.validateUserOp(op, userOpHash, 0);
+        assertEq(vd, 1, "non-zero value must SIG_VALIDATION_FAILED");
+    }
+
+    function test_replay_nonce_protection() public {
+        _installGrant(1);
+        vm.prank(owner);
+        account.revokeSessionKey(signer);
+
+        TotalReclawAccount.PermissionGrant memory grant =
+            _buildGrant(signer, DATA_EDGE, _twoSelectors(), 1);
+        bytes32 hash2 = keccak256("replay-attempt");
+        bytes memory sig = abi.encode(grant, _signWithKey(signerPriv, hash2));
+        PackedUserOperation memory op = _makePackedOp(_executeCallData(DATA_EDGE, 0, hex"00"), sig);
+
+        vm.prank(ENTRY_POINT);
+        uint256 vd = account.validateUserOp(op, hash2, 0);
+        assertEq(vd, 1, "replayed nonce must SIG_VALIDATION_FAILED");
+
+        TotalReclawAccount.PermissionGrant memory grant2 =
+            _buildGrant(signer, DATA_EDGE, _twoSelectors(), 2);
+        bytes32 hash3 = keccak256("fresh-nonce");
+        bytes memory sig2 = abi.encode(grant2, _signWithKey(signerPriv, hash3));
+        PackedUserOperation memory op2 =
+            _makePackedOp(_executeCallData(DATA_EDGE, 0, hex"00"), sig2);
+
+        vm.prank(ENTRY_POINT);
+        uint256 vd2 = account.validateUserOp(op2, hash3, 0);
+        assertEq(vd2, 0, "fresh nonce must succeed after revoke");
+    }
+
+    function test_cross_chain_grant_replay_rejected() public {
+        TotalReclawAccount.PermissionGrant memory grant =
+            _buildGrant(signer, DATA_EDGE, _twoSelectors(), 1);
+        grant.chainId = 999; // not block.chainid
+        grant.masterSignature = _signWithKey(ownerPriv, account.grantDigest(grant));
+
+        bytes32 userOpHash = keccak256("cross-chain");
+        bytes memory sig = abi.encode(grant, _signWithKey(signerPriv, userOpHash));
+        PackedUserOperation memory op = _makePackedOp(_executeCallData(DATA_EDGE, 0, hex"00"), sig);
+
+        vm.prank(ENTRY_POINT);
+        uint256 vd = account.validateUserOp(op, userOpHash, 0);
+        assertEq(vd, 1, "cross-chain replay must be rejected");
+    }
+
+    function test_master_signature_mismatch_rejects() public {
+        (, uint256 attackerPriv) = makeAddrAndKey("attacker-master");
+
+        TotalReclawAccount.PermissionGrant memory grant =
+            _buildGrant(signer, DATA_EDGE, _twoSelectors(), 1);
+        bytes32 digest = account.grantDigest(grant);
+        grant.masterSignature = _signWithKey(attackerPriv, digest);
+
+        bytes32 userOpHash = keccak256("forged-master");
+        bytes memory sig = abi.encode(grant, _signWithKey(signerPriv, userOpHash));
+        PackedUserOperation memory op = _makePackedOp(_executeCallData(DATA_EDGE, 0, hex"00"), sig);
+
+        vm.prank(ENTRY_POINT);
+        uint256 vd = account.validateUserOp(op, userOpHash, 0);
+        assertEq(vd, 1, "forged master signature must be rejected");
+    }
+
+    /// @dev P3-3: a grant whose `verifyingContract` is NOT this account
+    ///      (e.g. a stale grant signed against some other address, or a
+    ///      would-be module address) must be rejected. This is the
+    ///      concrete regression test for the module -> account binding
+    ///      change documented in `_isGrantValid`.
+    function test_grant_rejects_wrong_verifying_contract() public {
+        TotalReclawAccount.PermissionGrant memory grant =
+            _buildGrant(signer, DATA_EDGE, _twoSelectors(), 1);
+        grant.verifyingContract = address(0xBEEF); // not address(account)
+        grant.masterSignature = _signWithKey(ownerPriv, account.grantDigest(grant));
+
+        bytes32 userOpHash = keccak256("wrong-verifying-contract");
+        bytes memory sig = abi.encode(grant, _signWithKey(signerPriv, userOpHash));
+        PackedUserOperation memory op = _makePackedOp(_executeCallData(DATA_EDGE, 0, hex"00"), sig);
+
+        vm.prank(ENTRY_POINT);
+        uint256 vd = account.validateUserOp(op, userOpHash, 0);
+        assertEq(vd, 1, "grant not bound to this account must be rejected");
+    }
+
+    function test_grant_rejects_wrong_account_binding() public {
+        TotalReclawAccount.PermissionGrant memory grant =
+            _buildGrant(signer, DATA_EDGE, _twoSelectors(), 1);
+        grant.account = address(0xBEEF); // not address(account)
+        grant.masterSignature = _signWithKey(ownerPriv, account.grantDigest(grant));
+
+        bytes32 userOpHash = keccak256("wrong-account-binding");
+        bytes memory sig = abi.encode(grant, _signWithKey(signerPriv, userOpHash));
+        PackedUserOperation memory op = _makePackedOp(_executeCallData(DATA_EDGE, 0, hex"00"), sig);
+
+        vm.prank(ENTRY_POINT);
+        uint256 vd = account.validateUserOp(op, userOpHash, 0);
+        assertEq(vd, 1, "grant bound to a different account must be rejected");
+    }
+
+    // ============================================================
+    // Revocation -- owner-gated, idempotent, actually blocks reuse.
+    // ============================================================
+
+    function test_revoke_idempotent() public {
+        vm.prank(owner);
+        account.revokeSessionKey(signer); // never installed -- no-op, no revert
+        assertFalse(account.isSessionKeyActive(signer));
+
+        _installGrant(1);
+        assertTrue(account.isSessionKeyActive(signer));
+
+        vm.expectEmit(true, false, false, false, address(account));
+        emit TotalReclawAccount.SessionKeyRevoked(signer);
+        vm.prank(owner);
+        account.revokeSessionKey(signer);
+        assertFalse(account.isSessionKeyActive(signer));
+
+        vm.prank(owner);
+        account.revokeSessionKey(signer); // already revoked -- no-op, no revert, no 2nd event
+    }
+
+    function test_revoke_reverts_for_non_owner_caller() public {
+        _installGrant(1);
+        (address stranger,) = makeAddrAndKey("stranger");
+
+        vm.prank(stranger);
+        vm.expectRevert(bytes("only owner"));
+        account.revokeSessionKey(signer);
+    }
+
+    /// @dev Exercises the SPA's actual revoke pattern: an owner-signed
+    ///      UserOp whose callData is `execute(address(this), 0,
+    ///      abi.encodeCall(revokeSessionKey, (signer)))`, routed through
+    ///      `_requireFromEntryPointOrOwner` -> `execute` -> an inner call
+    ///      back to `address(this)`, landing on `onlyOwner`'s self-call
+    ///      branch (`msg.sender == address(this)`).
+    function test_revoke_via_self_call_execute_pattern() public {
+        _installGrant(1);
+        assertTrue(account.isSessionKeyActive(signer));
+
+        bytes memory revokeCalldata = abi.encodeCall(account.revokeSessionKey, (signer));
+        vm.prank(owner);
+        account.execute(address(account), 0, revokeCalldata);
+
+        assertFalse(account.isSessionKeyActive(signer));
+    }
+
+    function test_is_session_key_active_false_after_revoke() public {
+        _installGrant(1);
+        assertTrue(account.isSessionKeyActive(signer));
+        vm.prank(owner);
+        account.revokeSessionKey(signer);
+        assertFalse(account.isSessionKeyActive(signer));
+    }
+
+    function test_get_session_key_grant_empty_for_unknown_signer() public view {
+        (uint256 n, uint256 iAt, bytes4[] memory sels, address tgt) =
+            account.getSessionKeyGrant(address(0x1234));
+        assertEq(n, 0);
+        assertEq(iAt, 0);
+        assertEq(sels.length, 0);
+        assertEq(tgt, address(0));
+    }
+
+    // ============================================================
+    // executeBatch scope invariant (cred-6) -- the six tests ported from
+    // `SessionKeyModule.t.sol:424-591`, adapted to call `validateUserOp`
+    // (pranked as the EntryPoint) against a real deployed proxy instead
+    // of a MockSmartAccount trampoline into the standalone module.
+    // ============================================================
+
+    function test_malformed_executeBatch_calldata_rejected() public {
+        _installGrant(1);
+
+        bytes32 hash2 = keccak256("malformed-batch");
+        bytes memory ecdsaSig = _signWithKey(signerPriv, hash2);
+        bytes memory batchCallData = abi.encodePacked(EXECUTE_BATCH_SEL, hex"00");
+        PackedUserOperation memory op = _makePackedOp(batchCallData, ecdsaSig);
+
+        vm.prank(ENTRY_POINT);
+        uint256 vd = account.validateUserOp(op, hash2, 0);
+        assertEq(vd, 1, "malformed executeBatch payload must SIG_VALIDATION_FAILED");
+    }
+
+    function test_batch_rejects_out_of_scope_inner_call() public {
+        _installGrant(1);
+
+        address[] memory targets = new address[](3);
+        uint256[] memory values = new uint256[](3);
+        bytes[] memory datas = new bytes[](3);
+        targets[0] = DATA_EDGE;
+        targets[1] = DATA_EDGE;
+        targets[2] = address(0xBADC0DE); // out-of-scope target
+        for (uint256 i = 0; i < 3; i++) {
+            values[i] = 0;
+            datas[i] = abi.encodePacked(EXECUTE_SEL, uint256(i));
+        }
+
+        bytes32 h = keccak256("out-of-scope-inner");
+        bytes memory sig = _signWithKey(signerPriv, h);
+        bytes memory cd = abi.encodePacked(EXECUTE_BATCH_SEL, abi.encode(targets, values, datas));
+        PackedUserOperation memory op = _makePackedOp(cd, sig);
+
+        vm.prank(ENTRY_POINT);
+        uint256 vd = account.validateUserOp(op, h, 0);
+        assertEq(vd, 1, "single out-of-scope inner must fail the whole batch");
+    }
+
+    function test_batch_accepts_all_in_scope_inner_calls() public {
+        _installGrant(1);
+
+        bytes memory cd = _inScopeBatchCallData(3);
+        bytes32 h = keccak256("all-in-scope-3");
+        bytes memory sig = _signWithKey(signerPriv, h);
+        PackedUserOperation memory op = _makePackedOp(cd, sig);
+
+        vm.prank(ENTRY_POINT);
+        uint256 vd = account.validateUserOp(op, h, 0);
+        assertEq(vd, 0, "all-in-scope batch must SIG_VALIDATION_SUCCESS");
+    }
+
+    function test_batch_rejects_nonzero_value_inner() public {
+        _installGrant(1);
+
+        address[] memory targets = new address[](2);
+        uint256[] memory values = new uint256[](2);
+        bytes[] memory datas = new bytes[](2);
+        targets[0] = DATA_EDGE;
+        targets[1] = DATA_EDGE;
+        values[0] = 0;
+        values[1] = 1 wei;
+        datas[0] = abi.encodePacked(EXECUTE_SEL, uint256(0));
+        datas[1] = abi.encodePacked(EXECUTE_SEL, uint256(1));
+
+        bytes32 h = keccak256("nonzero-value-inner");
+        bytes memory sig = _signWithKey(signerPriv, h);
+        bytes memory cd = abi.encodePacked(EXECUTE_BATCH_SEL, abi.encode(targets, values, datas));
+        PackedUserOperation memory op = _makePackedOp(cd, sig);
+
+        vm.prank(ENTRY_POINT);
+        uint256 vd = account.validateUserOp(op, h, 0);
+        assertEq(vd, 1, "any nonzero value in batch must SIG_VALIDATION_FAILED");
+    }
+
+    function test_batch_rejects_out_of_scope_inner_selector() public {
+        bytes4[] memory onlyBatch = new bytes4[](1);
+        onlyBatch[0] = EXECUTE_BATCH_SEL;
+
+        TotalReclawAccount.PermissionGrant memory grant =
+            _buildGrant(signer, DATA_EDGE, onlyBatch, 1);
+        bytes32 installH = keccak256("install-batch-only");
+        bytes memory installCd = _batchWithSingleInner(EXECUTE_BATCH_SEL);
+        bytes memory installSig = abi.encode(grant, _signWithKey(signerPriv, installH));
+        PackedUserOperation memory installOp = _makePackedOp(installCd, installSig);
+        vm.prank(ENTRY_POINT);
+        assertEq(
+            account.validateUserOp(installOp, installH, 0),
+            0,
+            "install must succeed with all-in-scope inner"
+        );
+
+        bytes memory cd = _batchWithSingleInner(EXECUTE_SEL);
+        bytes32 h = keccak256("inner-sel-bad");
+        bytes memory sig = _signWithKey(signerPriv, h);
+        PackedUserOperation memory op = _makePackedOp(cd, sig);
+
+        vm.prank(ENTRY_POINT);
+        uint256 vd = account.validateUserOp(op, h, 0);
+        assertEq(vd, 1, "inner selector not in grant must SIG_VALIDATION_FAILED");
+    }
+
+    function test_batch_rejects_empty_batch() public {
+        _installGrant(1);
+
+        address[] memory targets = new address[](0);
+        uint256[] memory values = new uint256[](0);
+        bytes[] memory datas = new bytes[](0);
+
+        bytes32 h = keccak256("empty-batch");
+        bytes memory sig = _signWithKey(signerPriv, h);
+        bytes memory cd = abi.encodePacked(EXECUTE_BATCH_SEL, abi.encode(targets, values, datas));
+        PackedUserOperation memory op = _makePackedOp(cd, sig);
+
+        vm.prank(ENTRY_POINT);
+        uint256 vd = account.validateUserOp(op, h, 0);
+        assertEq(vd, 1, "empty executeBatch must SIG_VALIDATION_FAILED");
+    }
+
+    // ============================================================
+    // Helpers.
+    // ============================================================
+
+    function _twoSelectors() internal pure returns (bytes4[] memory s) {
+        s = new bytes4[](2);
+        s[0] = EXECUTE_SEL;
+        s[1] = EXECUTE_BATCH_SEL;
+    }
+
+    function _buildGrant(
+        address _signer,
+        address _target,
+        bytes4[] memory _selectors,
+        uint256 _nonce
+    ) internal view returns (TotalReclawAccount.PermissionGrant memory g) {
+        g.version = 1;
+        g.account = address(account);
+        g.signer = _signer;
+        g.target = _target;
+        g.selectors = _selectors;
+        g.valueMax = 0;
+        g.nonce = _nonce;
+        g.issuedAt = block.timestamp;
+        g.chainId = block.chainid;
+        g.verifyingContract = address(account); // P3-3: bound to the ACCOUNT
+        g.masterSignature = _signWithKey(ownerPriv, account.grantDigest(g));
+    }
+
+    function _installGrant(uint256 nonce) internal {
+        TotalReclawAccount.PermissionGrant memory grant =
+            _buildGrant(signer, DATA_EDGE, _twoSelectors(), nonce);
+        bytes32 userOpHash = keccak256(abi.encode("install-helper", nonce));
+        bytes memory sig = abi.encode(grant, _signWithKey(signerPriv, userOpHash));
+        PackedUserOperation memory op = _makePackedOp(_executeCallData(DATA_EDGE, 0, hex"00"), sig);
+
+        vm.prank(ENTRY_POINT);
+        uint256 vd = account.validateUserOp(op, userOpHash, 0);
+        assertEq(vd, 0, "_installGrant helper: install must succeed");
+    }
+
+    /// @dev Owner-path signature: EIP-191-prefixed, matching stock
+    ///      SimpleAccount / `sign_user_op_hash` (`userop.py`).
+    function _signOwnerStyle(uint256 privKey, bytes32 userOpHash)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        bytes32 ethSigned =
+            keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", userOpHash));
+        return _signWithKey(privKey, ethSigned);
+    }
+
+    /// @dev Session-key path signature: raw digest, NO EIP-191 prefix --
+    ///      see `_validateSessionKeySignature`'s NatSpec for why this must
+    ///      match `sign_userop_with_session_key` (`userop.py`, P3-8).
+    function _signWithKey(uint256 privKey, bytes32 digest) internal pure returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privKey, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _executeCallData(address tgt, uint256 value, bytes memory data)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodePacked(EXECUTE_SEL, abi.encode(tgt, value, data));
+    }
+
+    function _inScopeBatchCallData(uint256 n) internal pure returns (bytes memory) {
+        address[] memory targets = new address[](n);
+        uint256[] memory values = new uint256[](n);
+        bytes[] memory datas = new bytes[](n);
+        for (uint256 i = 0; i < n; i++) {
+            targets[i] = DATA_EDGE;
+            values[i] = 0;
+            datas[i] = abi.encodePacked(EXECUTE_SEL, uint256(i));
+        }
+        return abi.encodePacked(EXECUTE_BATCH_SEL, abi.encode(targets, values, datas));
+    }
+
+    function _batchWithSingleInner(bytes4 innerSel) internal pure returns (bytes memory) {
+        address[] memory targets = new address[](1);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory datas = new bytes[](1);
+        targets[0] = DATA_EDGE;
+        values[0] = 0;
+        datas[0] = abi.encodePacked(innerSel, uint256(0));
+        return abi.encodePacked(EXECUTE_BATCH_SEL, abi.encode(targets, values, datas));
+    }
+
+    function _makePackedOp(bytes memory callData, bytes memory sig)
+        internal
+        view
+        returns (PackedUserOperation memory op)
+    {
+        op.sender = address(account);
+        op.nonce = 0;
+        op.initCode = "";
+        op.callData = callData;
+        op.accountGasLimits = 0;
+        op.preVerificationGas = 0;
+        op.gasFees = 0;
+        op.paymasterAndData = "";
+        op.signature = sig;
+    }
+}

--- a/contracts/account/test/TotalReclawAccount.t.sol
+++ b/contracts/account/test/TotalReclawAccount.t.sol
@@ -104,10 +104,35 @@ contract TotalReclawAccountTest is Test {
         );
     }
 
+    /// @dev This assertion is only meaningful if `creationCode` is
+    ///      REPRODUCIBLE. It is not reproducible by default: foundry's
+    ///      default `bytecode_hash = "ipfs"` appends a hash of the solc
+    ///      metadata JSON to the deployed bytecode, and that JSON varies
+    ///      with toolchain details beyond the pinned `solc_version` — so
+    ///      the same source compiled on two machines yields two different
+    ///      `creationCode` values and therefore two different CREATE2
+    ///      addresses. Caught exactly that way: this test passed locally
+    ///      and failed in CI with a different predicted address
+    ///      (0x7D12D9f0… vs the then-pinned 0x25D4E718…).
+    ///
+    ///      `foundry.toml` now sets `bytecode_hash = "none"` +
+    ///      `cbor_metadata = false`, which strips the trailer and makes
+    ///      `creationCode` a pure function of (source, solc version,
+    ///      optimizer settings). The address below is the post-fix value.
+    ///
+    ///      This matters well beyond the test: the deployment plan pins a
+    ///      CREATE2 address, and a pin that depends on WHO compiled the
+    ///      contract is not a pin at all — nobody could independently
+    ///      reproduce or verify the deployed implementation.
+    ///
+    ///      Trade-off accepted: stripping the metadata hash makes
+    ///      block-explorer source verification marginally less automatic
+    ///      (no metadata-hash match). Exact-settings verification still
+    ///      works, and determinism is worth more here.
     function test_pinned_implementation_create2_address() public pure {
         assertEq(
             _predictImplAddress(TOTAL_RECLAW_ACCOUNT_SALT_V1),
-            0x25D4E71865E8A47F010219526A618f950a8f86B4,
+            0x6d17938F29072B3b7E883d410076B0D73676Cf34,
             "TotalReclawAccount predicted implementation address drifted - update the deployment plan's pinned value if intentional"
         );
     }

--- a/contracts/account/test/TotalReclawAccountFork.t.sol
+++ b/contracts/account/test/TotalReclawAccountFork.t.sol
@@ -1,0 +1,382 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {
+    PackedUserOperation
+} from "account-abstraction/contracts/interfaces/PackedUserOperation.sol";
+import {IEntryPoint} from "account-abstraction/contracts/interfaces/IEntryPoint.sol";
+import {SimpleAccount} from "account-abstraction/contracts/samples/SimpleAccount.sol";
+import {SimpleAccountFactory} from "account-abstraction/contracts/samples/SimpleAccountFactory.sol";
+import {TotalReclawAccount} from "../contracts/TotalReclawAccount.sol";
+
+/**
+ * @title TotalReclawAccountForkTest
+ * @notice Option E Phase 3 (P3-4) — "the highest-value test in the phase"
+ *         (phase3-impl spec §3.4). Forks live Gnosis mainnet, upgrades the
+ *         REAL, already-deployed, already-in-use Smart Account
+ *         (`0x2c0CF74B2b76110708CA431796367779e3738250`, 66 UserOps of
+ *         history as of the block this was last verified against — see
+ *         the PR description for the live `cast` output), and asserts the
+ *         upgrade is exactly as behaviour-preserving as the account-model
+ *         memo's on-chain simulation (§2.4) predicted.
+ *
+ *         READ-ONLY. This forks a public RPC and never broadcasts a
+ *         transaction — every state change here (`vm.prank` + a call) is
+ *         local to the forked EVM instance Foundry spins up in-process and
+ *         is discarded when the test ends.
+ *
+ *         Network dependency: needs an RPC endpoint. Defaults to the
+ *         public `https://rpc.gnosischain.com` (same one used throughout
+ *         this investigation and in `hardhat.config.ts`'s default);
+ *         override with `GNOSIS_RPC_URL` if you have a private endpoint
+ *         and want less exposure to public-RPC flakiness/rate limits.
+ */
+contract TotalReclawAccountForkTest is Test {
+    // Live Gnosis mainnet addresses. Verified live 2026-08-17 (owner(),
+    // ERC-1967 implementation slot, EntryPoint nonce, and the factory's
+    // accountImplementation() all re-checked via `cast call`/`cast
+    // storage` against https://rpc.gnosischain.com immediately before
+    // writing this file — see the PR description for the exact commands
+    // and output). Re-verify before contract freeze; these are exactly
+    // the kind of addresses the account-model memo (§2) warns can need
+    // re-confirming as ecosystem state moves.
+    address internal constant REAL_ACCOUNT = 0x2c0CF74B2b76110708CA431796367779e3738250;
+    address internal constant REAL_OWNER = 0x9858EfFD232B4033E47d90003D41EC34EcaEda94;
+    address internal constant FACTORY = 0x91E60e0613810449d098b0b5Ec8b51A0FE8c8985;
+    address internal constant ENTRY_POINT = 0x0000000071727De22E5E9d8BAf0edAc6f37da032;
+    /// @dev Staging DataEdge (`0xE7a4D2…`) — used as an arbitrary-but-
+    ///      realistic grant target in the signature-path test below. Not
+    ///      actually written to (validateUserOp only, no execute).
+    address internal constant DATA_EDGE_STAGING = 0xE7a4D2677B686e13775Ba9092631089e35F0BB91;
+
+    /// @dev ERC-1967 implementation slot:
+    ///      bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1).
+    bytes32 internal constant ERC1967_IMPL_SLOT =
+        0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+    bytes4 internal constant EXECUTE_SEL = 0xb61d27f6;
+    bytes4 internal constant EXECUTE_BATCH_SEL = 0x47e1da2a;
+
+    function _fork() internal {
+        string memory rpc = vm.envOr("GNOSIS_RPC_URL", string("https://rpc.gnosischain.com"));
+        vm.createSelectFork(rpc);
+    }
+
+    // ============================================================
+    // Test 1 — the real, already-in-use account. State preservation only
+    // (no signing needed: we do not have REAL_OWNER's private key, and we
+    // should not need it — vm.prank spoofs msg.sender, which is all
+    // `_onlyOwner()` and `_requireFromEntryPointOrOwner()` check).
+    // ============================================================
+
+    function test_fork_upgrade_preserves_real_account_state() public {
+        _fork();
+
+        SimpleAccount realAccount = SimpleAccount(payable(REAL_ACCOUNT));
+
+        address ownerBefore = realAccount.owner();
+        bytes32 slot0Before = vm.load(REAL_ACCOUNT, bytes32(uint256(0)));
+        uint256 nonceBefore = IEntryPoint(ENTRY_POINT).getNonce(REAL_ACCOUNT, 0);
+
+        assertEq(ownerBefore, REAL_OWNER, "sanity: live owner must match the last-verified value");
+
+        TotalReclawAccount newImpl = new TotalReclawAccount();
+
+        // Owner EOA calls upgradeToAndCall DIRECTLY. This is exactly the
+        // "escape hatch" path verified live in the account-model memo §2.4
+        // (its 2nd `cast call` simulation, `--from` the owner EOA) and
+        // written down as the B1 mitigation in the audit-risk memo §5:
+        // no bundler, no paymaster, no UserOp signature needed.
+        vm.prank(REAL_OWNER);
+        realAccount.upgradeToAndCall(address(newImpl), "");
+
+        // ---- the account-model memo's own state-preservation claims, re-asserted post-upgrade ----
+        assertEq(realAccount.owner(), ownerBefore, "owner() must be unchanged after upgrade");
+        assertEq(
+            vm.load(REAL_ACCOUNT, bytes32(uint256(0))),
+            slot0Before,
+            "raw slot 0 must be byte-identical after upgrade"
+        );
+        assertEq(
+            IEntryPoint(ENTRY_POINT).getNonce(REAL_ACCOUNT, 0),
+            nonceBefore,
+            "EntryPoint nonce must be unchanged by the upgrade itself (no UserOp was submitted)"
+        );
+        assertEq(
+            address(uint160(uint256(vm.load(REAL_ACCOUNT, ERC1967_IMPL_SLOT)))),
+            address(newImpl),
+            "proxy must now delegate to TotalReclawAccount (upgrade actually landed)"
+        );
+
+        // Functional continuity beyond just reading storage: the owner EOA
+        // can still drive execute() directly post-upgrade, exactly as
+        // before (0-value, no-op call to itself -- proves the
+        // owner-authorization path still works end to end, not just that
+        // a view function returns the same value).
+        vm.prank(REAL_OWNER);
+        realAccount.execute(REAL_OWNER, 0, "");
+    }
+
+    function test_fork_upgrade_is_idempotent_on_real_account() public {
+        _fork();
+        SimpleAccount realAccount = SimpleAccount(payable(REAL_ACCOUNT));
+        TotalReclawAccount newImpl = new TotalReclawAccount();
+
+        vm.prank(REAL_OWNER);
+        realAccount.upgradeToAndCall(address(newImpl), "");
+        assertEq(
+            address(uint160(uint256(vm.load(REAL_ACCOUNT, ERC1967_IMPL_SLOT)))), address(newImpl)
+        );
+
+        // Running the exact same upgrade a second time must not revert or
+        // change anything further (account-model memo §7's rollout plan
+        // explicitly calls out upgrade idempotence as a requirement, and
+        // §2.4 confirms an OZ v5 UUPS no-op re-upgrade to the SAME address
+        // succeeds).
+        vm.prank(REAL_OWNER);
+        realAccount.upgradeToAndCall(address(newImpl), "");
+        assertEq(
+            address(uint160(uint256(vm.load(REAL_ACCOUNT, ERC1967_IMPL_SLOT)))),
+            address(newImpl),
+            "re-running the same upgrade must be harmless"
+        );
+    }
+
+    // ============================================================
+    // Test 2 — a FRESH account, deployed through the REAL, LIVE factory
+    // (same factory + same baseline implementation the real account
+    // above was originally created with), owned by a Foundry-controlled
+    // keypair so the full validateUserOp signature paths can actually be
+    // exercised (we do not, and should not, have REAL_OWNER's private
+    // key). This is what lets this file assert the three signature-shaped
+    // bullets the spec calls for: owner-signed validates, session-key
+    // validates, out-of-scope does not.
+    // ============================================================
+
+    /// @dev Split into four smaller tests (each calling this + `_installSessionKey`
+    ///      helper below) rather than one large function -- the original,
+    ///      single-function version tripped solc's "stack too deep" under
+    ///      the legacy (non-IR) codegen this package deliberately keeps
+    ///      (see `foundry.toml`'s `via_ir = false`, matching the outer
+    ///      project). Splitting is also better test hygiene: one failure
+    ///      now names exactly which property broke.
+    function test_fork_owner_signed_userop_validates_on_factory_account() public {
+        (TotalReclawAccount account,, uint256 freshOwnerPriv,,) = _deployFreshUpgradedAccount();
+
+        bytes32 ownerOpHash = keccak256("fork-owner-op");
+        bytes memory ownerSig = _signOwnerStyle(freshOwnerPriv, ownerOpHash);
+        PackedUserOperation memory ownerOp = _makePackedOp(
+            address(account), _executeCallData(DATA_EDGE_STAGING, 0, hex"00"), ownerSig
+        );
+
+        vm.prank(ENTRY_POINT);
+        assertEq(
+            account.validateUserOp(ownerOp, ownerOpHash, 0),
+            0,
+            "owner-signed UserOp must validate post-upgrade, on the real factory + real baseline impl"
+        );
+    }
+
+    function test_fork_session_key_validates_on_factory_account() public {
+        (
+            TotalReclawAccount account,
+            address freshOwner,
+            uint256 freshOwnerPriv,
+            address freshSigner,
+            uint256 freshSignerPriv
+        ) = _deployFreshUpgradedAccount();
+        _installSessionKey(account, freshOwner, freshOwnerPriv, freshSigner, freshSignerPriv, 1);
+        assertTrue(account.isSessionKeyActive(freshSigner));
+
+        bytes32 steadyHash = keccak256("fork-steady-state");
+        bytes memory steadySig = _signWithKey(freshSignerPriv, steadyHash);
+        PackedUserOperation memory steadyOp = _makePackedOp(
+            address(account), _executeCallData(DATA_EDGE_STAGING, 0, hex"01"), steadySig
+        );
+
+        vm.prank(ENTRY_POINT);
+        assertEq(
+            account.validateUserOp(steadyOp, steadyHash, 0),
+            0,
+            "session-key steady-state UserOp must validate"
+        );
+    }
+
+    function test_fork_out_of_scope_userop_rejected_on_factory_account() public {
+        (
+            TotalReclawAccount account,
+            address freshOwner,
+            uint256 freshOwnerPriv,
+            address freshSigner,
+            uint256 freshSignerPriv
+        ) = _deployFreshUpgradedAccount();
+        _installSessionKey(account, freshOwner, freshOwnerPriv, freshSigner, freshSignerPriv, 1);
+
+        bytes32 badHash = keccak256("fork-out-of-scope");
+        bytes memory badSig = _signWithKey(freshSignerPriv, badHash);
+        PackedUserOperation memory badOp = _makePackedOp(
+            address(account),
+            _executeCallData(address(0xBADC0DE), 0, hex"00"), // wrong target
+            badSig
+        );
+
+        vm.prank(ENTRY_POINT);
+        assertEq(
+            account.validateUserOp(badOp, badHash, 0),
+            1,
+            "out-of-scope target must SIG_VALIDATION_FAILED, even on a real upgraded factory-deployed account"
+        );
+    }
+
+    /// @dev B4 mitigation, exercised end to end on a real, upgraded,
+    ///      factory-deployed account: revoke actually blocks reuse, not
+    ///      just flips a view function.
+    function test_fork_revocation_blocks_reuse_on_factory_account() public {
+        (
+            TotalReclawAccount account,
+            address freshOwner,
+            uint256 freshOwnerPriv,
+            address freshSigner,
+            uint256 freshSignerPriv
+        ) = _deployFreshUpgradedAccount();
+        _installSessionKey(account, freshOwner, freshOwnerPriv, freshSigner, freshSignerPriv, 1);
+
+        vm.prank(freshOwner);
+        account.revokeSessionKey(freshSigner);
+        assertFalse(account.isSessionKeyActive(freshSigner));
+
+        bytes32 revokedHash = keccak256("fork-post-revoke");
+        bytes memory revokedSig = _signWithKey(freshSignerPriv, revokedHash);
+        PackedUserOperation memory revokedOp = _makePackedOp(
+            address(account), _executeCallData(DATA_EDGE_STAGING, 0, hex"00"), revokedSig
+        );
+
+        vm.prank(ENTRY_POINT);
+        assertEq(
+            account.validateUserOp(revokedOp, revokedHash, 0),
+            1,
+            "a revoked session key must no longer validate"
+        );
+    }
+
+    // ============================================================
+    // Helpers.
+    // ============================================================
+
+    /// @dev Forks Gnosis, deploys a fresh account through the REAL, LIVE
+    ///      factory (owned by a Foundry-controlled keypair, since we do
+    ///      not and should not have REAL_OWNER's private key), and
+    ///      upgrades it to a fresh `TotalReclawAccount` implementation --
+    ///      the same factory + same baseline implementation the real
+    ///      account in test 1 was originally created with.
+    function _deployFreshUpgradedAccount()
+        internal
+        returns (
+            TotalReclawAccount account,
+            address freshOwner,
+            uint256 freshOwnerPriv,
+            address freshSigner,
+            uint256 freshSignerPriv
+        )
+    {
+        _fork();
+
+        (freshOwner, freshOwnerPriv) = makeAddrAndKey("fork-fresh-owner");
+        (freshSigner, freshSignerPriv) = makeAddrAndKey("fork-fresh-signer");
+
+        SimpleAccountFactory factory = SimpleAccountFactory(FACTORY);
+        uint256 salt = uint256(keccak256("totalreclaw.fork-test.v1"));
+        address predicted = factory.getAddress(freshOwner, salt);
+        SimpleAccount fresh = factory.createAccount(freshOwner, salt);
+        require(
+            address(fresh) == predicted, "helper: factory address must match its own prediction"
+        );
+
+        TotalReclawAccount newImpl = new TotalReclawAccount();
+        vm.prank(freshOwner);
+        SimpleAccount(payable(address(fresh))).upgradeToAndCall(address(newImpl), "");
+
+        account = TotalReclawAccount(payable(address(fresh)));
+    }
+
+    /// @dev Signs and validates a lazy-install session-key UserOp so
+    ///      subsequent test bodies can start from "a session key is
+    ///      installed" without re-deriving the grant-construction
+    ///      boilerplate (also what kept the original single-function
+    ///      version under the stack-too-deep ceiling).
+    function _installSessionKey(
+        TotalReclawAccount account,
+        address, /* freshOwner */
+        uint256 freshOwnerPriv,
+        address freshSigner,
+        uint256 freshSignerPriv,
+        uint256 nonce
+    ) internal {
+        bytes4[] memory sels = new bytes4[](2);
+        sels[0] = EXECUTE_SEL;
+        sels[1] = EXECUTE_BATCH_SEL;
+
+        TotalReclawAccount.PermissionGrant memory grant;
+        grant.version = 1;
+        grant.account = address(account);
+        grant.signer = freshSigner;
+        grant.target = DATA_EDGE_STAGING;
+        grant.selectors = sels;
+        grant.valueMax = 0;
+        grant.nonce = nonce;
+        grant.issuedAt = block.timestamp;
+        grant.chainId = block.chainid;
+        grant.verifyingContract = address(account); // P3-3: bound to the account
+        grant.masterSignature = _signWithKey(freshOwnerPriv, account.grantDigest(grant));
+
+        bytes32 installHash = keccak256(abi.encode("fork-install", nonce));
+        bytes memory installSig = abi.encode(grant, _signWithKey(freshSignerPriv, installHash));
+        PackedUserOperation memory installOp = _makePackedOp(
+            address(account), _executeCallData(DATA_EDGE_STAGING, 0, hex"00"), installSig
+        );
+
+        vm.prank(ENTRY_POINT);
+        uint256 vd = account.validateUserOp(installOp, installHash, 0);
+        require(vd == 0, "helper: session-key lazy-install must succeed");
+    }
+
+    function _signOwnerStyle(uint256 privKey, bytes32 userOpHash)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        bytes32 ethSigned =
+            keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", userOpHash));
+        return _signWithKey(privKey, ethSigned);
+    }
+
+    function _signWithKey(uint256 privKey, bytes32 digest) internal pure returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privKey, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _executeCallData(address tgt, uint256 value, bytes memory data)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodePacked(EXECUTE_SEL, abi.encode(tgt, value, data));
+    }
+
+    function _makePackedOp(address sender, bytes memory callData, bytes memory sig)
+        internal
+        pure
+        returns (PackedUserOperation memory op)
+    {
+        op.sender = sender;
+        op.nonce = 0;
+        op.initCode = "";
+        op.callData = callData;
+        op.accountGasLimits = 0;
+        op.preVerificationGas = 0;
+        op.gasFees = 0;
+        op.paymasterAndData = "";
+        op.signature = sig;
+    }
+}

--- a/contracts/contracts/SessionKeyModule.sol
+++ b/contracts/contracts/SessionKeyModule.sol
@@ -263,6 +263,20 @@ contract SessionKeyModule is ISessionKeyModule {
         return (g.nonce, g.issuedAt, g.selectors, g.target);
     }
 
+    /// @notice External read-only wrapper around `_grantDigest`, added
+    ///         (P3-4, Phase 3) so tests compute the EIP-712 grant digest
+    ///         via the actual production code path instead of a
+    ///         hand-copied mirror of it. Before this existed,
+    ///         `test/SessionKeyModule.t.sol`'s `_grantDigestExt` was such
+    ///         a mirror, with a comment admitting both copies had to be
+    ///         updated together — exactly the kind of duplication that
+    ///         let the §2 `bytes4[]` selector-hashing bug ship in the
+    ///         Python client without a test catching it. Pure function,
+    ///         zero behaviour change to the validator itself.
+    function grantDigest(PermissionGrant calldata g) external pure returns (bytes32) {
+        return _grantDigest(g);
+    }
+
     // -------------------------------------------------------------------------
     // Internal helpers
     // -------------------------------------------------------------------------

--- a/contracts/test/SessionKeyModule.t.sol
+++ b/contracts/test/SessionKeyModule.t.sol
@@ -753,38 +753,20 @@ contract SessionKeyModuleTest is Test {
         return _signWithKey(masterPriv, digest);
     }
 
-    /// @dev Mirror of `SessionKeyModule._grantDigest`. Kept in the test file
-    ///      so the parity contract (cred-9) can also pull from here. If the
-    ///      module hash construction changes, update both.
+    /// @dev Calls the PRODUCTION digest computation (`SessionKeyModule
+    ///      .grantDigest`, an external pure wrapper around the internal
+    ///      `_grantDigest`) instead of hand-copying the EIP-712 hashing
+    ///      formula. Previously this function WAS a hand-copied mirror of
+    ///      `_grantDigest`, with a comment admitting both copies had to be
+    ///      updated together — precisely the kind of duplication that let
+    ///      the §2 `bytes4[]` selector-hashing bug ship in the Python
+    ///      client (`grant.py`) without any test catching it (phase3-impl
+    ///      spec §3.4 "de-duplicate the EIP-712 logic"). Fixed by adding a
+    ///      real production entry point instead of a second copy.
     function _grantDigestExt(
         SessionKeyModule.PermissionGrant memory g
-    ) internal pure returns (bytes32) {
-        bytes32 domainTypeHash = keccak256(
-            "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
-        );
-        bytes32 scopeTypeHash = keccak256(
-            "Scope(address target,bytes4[] selectors,uint256 valueMax)"
-        );
-        bytes32 grantTypeHash = keccak256(
-            "SessionKeyPermissionGrant(address account,address signer,Scope scope,uint256 nonce,uint256 issuedAt)Scope(address target,bytes4[] selectors,uint256 valueMax)"
-        );
-
-        bytes32 scopeHash = keccak256(
-            abi.encode(scopeTypeHash, g.target, keccak256(abi.encodePacked(g.selectors)), g.valueMax)
-        );
-        bytes32 structHash = keccak256(
-            abi.encode(grantTypeHash, g.account, g.signer, scopeHash, g.nonce, g.issuedAt)
-        );
-        bytes32 domainSep = keccak256(
-            abi.encode(
-                domainTypeHash,
-                keccak256(bytes("TotalReclawSessionKey")),
-                keccak256(bytes("1")),
-                g.chainId,
-                g.verifyingContract
-            )
-        );
-        return keccak256(abi.encodePacked(hex"19_01", domainSep, structHash));
+    ) internal view returns (bytes32) {
+        return module.grantDigest(g);
     }
 
     function _signWithKey(uint256 privKey, bytes32 digest) internal pure returns (bytes memory) {


### PR DESCRIPTION
## Summary

Implements work-leaves **P3-1, P3-2, P3-4** of Option E Phase 3 (revocable session-key signing), per `docs/specs/cred/phase3-implementation-spec.md` §3.1–3.4 in the private repo. **Do not merge** — this is unaudited code touching the one function that can permanently brick a user's vault (audit-risk memo §1); it needs a real review pass and the external audit (D2) before it goes anywhere near a real account.

- **P3-1** — `TotalReclawAccount`: a `SimpleAccount` (eth-infinitism v0.7.0) subclass overriding `_validateSignature` to accept an owner-EOA signature (tried first, byte-identical to stock) or a scoped, revocable session-key signature.
- **P3-2** — validator logic ported from `SessionKeyModule.sol` (never deployed — replaced by this design per the account-model memo §5, which found the standalone-module design cannot pass ERC-7562 bundler validation).
- **P3-4** — 35 tests (29 fast unit + 6 read-only fork tests against live Gnosis), plus a storage-layout-diff CI gate.

**D1 (account model: UUPS over kernel v3) is recorded as approved** per session context; PF-1/PF-2 (Pimlico sponsorship of self-targeted UserOps, relay `eth_call` constraints) are noted as still open in the source docs but don't block this contract-and-tests leaf.

## What was ported verbatim vs. rewritten

**Verbatim from `SessionKeyModule.sol`** (spec: "re-deriving them is pure risk"):
- `_grantDigest` + the four EIP-712 typehash/domain constants
- `_isCallDataInScope` / `_isBatchInScope` / `_inSelectors` (the cred-6 per-inner-call `executeBatch` invariant)
- `_recoverEcdsa` with the EIP-2 malleability guard
- Monotonic `_minNonces` replay protection
- `_tryDecodeInstallSig` / `_decodeInstallSig` self-external try/catch decode pattern

**Mechanically changed** (per the spec's table): `msg.sender`→`address(this)`; `_grants[account][signer]`/`_minNonces[account][signer]` (module storage, the shape ERC-7562 rejects) → `signer`-keyed maps in the account's own ERC-7201 namespaced storage; `g.verifyingContract != address(this)` now binds to the **account** (P3-3, folds out of the module→account move for free); `revokeSessionKey(account, signer)` gated `msg.sender == account` → `revokeSessionKey(signer)` gated by the inherited `onlyOwner` (accepts the owner EOA directly or a self-call — the SPA's exact revoke pattern, tested); `_smartAccountOwner()`'s external call → a direct `owner` storage read (strictly better: no external call during validation, and `owner` is slot 0, always ERC-7562 [STO-010]-permitted).

**Not carried forward** (interface cleanup, spec §3.2): `ISessionKeyModule.sol`'s three dead errors, plus two more in `SessionKeyModule.sol` itself I found by the same principle (`UnknownGrantVersion`, `InvalidSignatureLength` — declared, never reverted). `TotalReclawAccount` declares **zero custom errors**: validation fails closed via `SIG_VALIDATION_FAILED`, and `revokeSessionKey` reuses the inherited `onlyOwner`'s existing require. The old files are left untouched on disk (still compile, still tested by their own suite) — deleting them is a separate call, not asked for in this work-leaf.

**One genuinely rewritten piece, flagged for scrutiny** — `_validateSignature`'s owner path uses `ECDSA.tryRecover` instead of stock's `ECDSA.recover`. See "Uncertainty" below; this is not a stylistic choice, it's required for the feature to function at all.

**Small additive fix in `SessionKeyModule.sol`** (in scope per spec §3.4's explicit line-numbered callout): a `grantDigest` external pure wrapper, so `SessionKeyModule.t.sol`'s `_grantDigestExt` calls the production digest path instead of hand-copying the EIP-712 formula — the exact duplication pattern that let the §2 `bytes4[]` selector-hashing bug ship in `grant.py` unnoticed (that Python fix is P3-0, out of scope here).

## Structural note: `contracts/account/` is a separate Foundry project

Not a stylistic choice — adding `account-abstraction`/`openzeppelin-contracts` to the *outer* `contracts/lib/` + a `contracts/remappings.txt` was tried first and **reverted** after it broke an unrelated, currently-passing, real-deployed-contract test: solc embeds the full project-wide `settings.remappings` list into *every* compiled contract's metadata, regardless of whether that contract imports anything through them. Verified empirically — adding just the two new remapping lines (nothing else) shifted `EventfulDataEdge`'s bytecode enough to break `test/DataEdgeStagingCreate2.t.sol`'s pinned CREATE2 address for the real, live staging DataEdge (`0xE7a4D2677B686e13775Ba9092631089e35F0BB91`). A fully separate Foundry project root (`contracts/account/foundry.toml`, own `lib/`, own `remappings.txt`) is the only fix that leaves the outer project's compiled output byte-for-byte unaffected. Re-verified after every change in this PR: **26/26 tests still pass, unchanged, in the outer `contracts/` project.**

CI: added a second job (`forge-test-account`) to `.github/workflows/forge-test.yml`, isolated the same way — its own working directory, own lib install, own `forge build`/`forge test` invocation.

## Fork-test results (real output)

```
Ran 6 tests for test/TotalReclawAccountFork.t.sol:TotalReclawAccountForkTest
[PASS] test_fork_out_of_scope_userop_rejected_on_factory_account() (gas: 3022680)
[PASS] test_fork_owner_signed_userop_validates_on_factory_account() (gas: 2856206)
[PASS] test_fork_revocation_blocks_reuse_on_factory_account() (gas: 2946701)
[PASS] test_fork_session_key_validates_on_factory_account() (gas: 3024192)
[PASS] test_fork_upgrade_is_idempotent_on_real_account() (gas: 2699499)
[PASS] test_fork_upgrade_preserves_real_account_state() (gas: 2706752)
Suite result: ok. 6 passed; 0 failed; 0 skipped
```

`test_fork_upgrade_preserves_real_account_state` forks live Gnosis mainnet, takes the real deployed account `0x2c0CF74B2b76110708CA431796367779e3738250` (66 UserOps of history as of the block last checked — re-verified live via `cast` immediately before writing the test: `owner()` = `0x9858EfFD232B4033E47d90003D41EC34EcaEda94`, ERC-1967 impl slot = `0x68641DE71cfEa5a5d0D29712449Ee254bb1400C2`, factory `accountImplementation()` matches), upgrades it via the owner EOA's direct `upgradeToAndCall` (the audit-risk memo §5 escape hatch — no bundler, no signature needed, `vm.prank` spoofs `msg.sender`), and asserts `owner()`, raw slot 0, and the EntryPoint nonce are all byte-unchanged, plus that the owner can still drive `execute()` directly post-upgrade. A second test proves upgrade idempotence on the same real account.

Since I don't (and shouldn't) hold the real owner's private key, the three signature-shaped assertions (owner-signed validates, session-key validates, out-of-scope doesn't) run against a **fresh** account deployed through the same real, live factory + real baseline implementation, owned by a Foundry-controlled keypair — same factory, same deployment pattern, controllable signing.

Full suite: **35/35 passing** (29 unit + 6 fork). Unit suite is network-free (fresh `ERC1967Proxy` + controlled keys) and covers the six `executeBatch` scope-invariant tests ported from `SessionKeyModule.t.sol:424-591`, plus grant-binding, replay, malleability, and revocation edge cases.

## Storage-layout gate

`contracts/account/script/storage-layout-diff.sh` wires `forge inspect ... storageLayout` (already emitted per `foundry.toml`, never consumed before this) as a real CI gate — B2 mitigation (a colliding state variable at slot 0 is catastrophic and silent). Current output:

```
OK — 1 plain state variable(s), byte-identical between TotalReclawAccount and SimpleAccount:
  slot   0 offset 0 owner: t_address
```

`TotalReclawAccount` declares zero plain state variables; all session-key state lives in ERC-7201 namespaced storage (fixed slot, inline assembly), which correctly doesn't show up here at all.

## The two traps the spec called out — confirmed avoided

1. Did **not** port `SessionKeyModule.t.sol:86`'s `test_create2_address_unchanged_after_module_install` (tautological — `block.chainid` isn't an input to the expression it re-derives twice). Wrote a real pinned-address test instead (`test_pinned_implementation_create2_address`), mirroring `DataEdgeStagingCreate2.t.sol:69`'s independently-hardcoded-literal pattern. Note: this pin is a **placeholder salt**, not a commitment to a real deployment address — that's decided by the (out-of-scope) deployment plan.
2. Did **not** carry forward `ISessionKeyModule.sol`'s dead errors or its incorrect "MUST be the master wallet" docstring — see "not carried forward" above.

## Uncertainty — flagged, not smoothed over

**The one thing I want a second pair of eyes on hardest:** `_validateSignature`'s owner path calls `ECDSA.tryRecover` instead of stock `SimpleAccount`'s `ECDSA.recover`. I did not do this casually — I traced it to a real correctness requirement: stock's `ECDSA.recover` **reverts** on any signature that isn't a well-formed 65-byte blob, and a session-key lazy-install signature is a much longer `abi.encode(PermissionGrant, ecdsaSig)` blob. A literal "try owner's exact code path first" port would revert the *entire* `validateUserOp` on every lazy-install UserOp before ever reaching the session-key branch — not merely insecure, structurally inert (the feature would never work). I reasoned through why this doesn't create a NEW acceptance the way that matters (traced `ecrecover`'s "returns zero" failure mode as a pure function of `(v,r,s)`, independent of which hash is checked — documented at length in the function's NatSpec) but this is exactly the kind of reasoning I'd want an auditor with real EIP-4337 depth to either confirm or refute, not take on my say-so. It's the same territory the audit-risk memo names as B1 (owner path broken → account bricked forever) and lists as reason #1 for external review.

Secondary, lower-stakes items I'm reasonably but not 100% confident on:
- License: `TotalReclawAccount.sol` is `GPL-3.0` (not this repo's usual `MIT`) because it directly inherits from eth-infinitism's GPL-3.0 `SimpleAccount`. Flagged in the file's own NatSpec as a licensing question for a sanity check, not resolved unilaterally.
- The pinned CREATE2 salt (`totalreclaw.TotalReclawAccount.v1`) is a test-only placeholder, not a deployment commitment — the actual deployment plan (out of scope here) may choose differently, in which case the pin needs updating to match, which is cheap since nothing is deployed at that address yet.
- I did not attempt to also exercise the upgrade path through a full `EntryPoint.handleOps` simulation (deposit funding, gas estimation) — fork tests prank as the EntryPoint directly for `validateUserOp`, which is a standard, narrower, and I believe sufficient test technique for what's being asserted, but it's a real scope choice worth naming.

## Constraints honored

- Never deployed anything, never sent a transaction — fork tests are `vm.createSelectFork` + local pranks/calls, discarded at test end.
- Worked only in this worktree; did not touch the shared checkout.
- Out of scope, untouched: core Rust (P3-5), Python client (P3-6+), SPA (P3-13), subgraph (P3-14), P3-15 docs (`CLAUDE.md`/`SECURITY.md` — separate work-leaf).
- No CHANGELOG entry: `CHANGELOG-public.md` tracks packages promoted to stable registries; nothing here is released or deployed yet.

## Test plan

- [x] `cd contracts/account && forge build --sizes` — compiler run successful
- [x] `cd contracts/account && forge test -vv` — 35/35 passing (29 unit + 6 live-Gnosis fork)
- [x] `cd contracts/account && ./script/storage-layout-diff.sh` — layouts byte-identical
- [x] `cd contracts && forge test` — 26/26 passing, unchanged (outer project untouched)
- [ ] Real code review (Pedro / Fable per the crypto-review convention)
- [ ] External audit (D2, blocked-on-Pedro per the audit-risk memo)
- [ ] E2E staging (PF-1 sponsorship check, bundler acceptance — separate work-leaves)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
