### PR TITLE
fix(plugin): human-mode tr remember/forget crash after successful on-chain write (#639)

### DIFF
--- a/docs/guides/openclaw-setup.md
+++ b/docs/guides/openclaw-setup.md
@@ -36,6 +36,8 @@ Install TotalReclaw RC <version> against the staging relay (TOTALRECLAW_SERVER_U
 
 The agent exports `TOTALRECLAW_SERVER_URL=https://api-staging.totalreclaw.xyz` in the install / setup shell before any TotalReclaw command. Without this env var, both stable AND RC installs default to the production relay `api.totalreclaw.xyz`.
 
+> If QA drives the standalone `tr` CLI directly (`node .../dist/cli/tr-cli.js`, e.g. the pair fallback), also export `TOTALRECLAW_DATA_EDGE_ADDRESS=0xE7a4D2677B686e13775Ba9092631089e35F0BB91` — the CLI never fetches billing, so it silently defaults to the **production** DataEdge even with `TOTALRECLAW_SERVER_URL` on staging, and its writes land on production chain data.
+
 ## What this is and where it comes from
 
 TotalReclaw is open-source memory tooling for OpenClaw. The plugin is published by `p-diogo` (GitHub-verified) at:

--- a/skill/plugin/CHANGELOG.md
+++ b/skill/plugin/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [3.4.5] — 2026-09-06
+
+### Fixed
+
+- **[#639] `tr remember` / `tr forget` in human mode (no `--json`) reported failure for operations that had already succeeded on-chain.** Both human-mode success logs referenced an undefined variable — `result.txHash` where the batch-submit result in scope is named `submitResult` — so once the UserOp had landed, the template literal threw `ReferenceError: result is not defined`, the surrounding catch swallowed it, and the user saw `remember failed: result is not defined` (same for `forget`) for a write that was in fact committed on-chain. The worst consequence is the invited re-run: believing the first attempt failed, a user or agent would store the fact (or tombstone) a second time. The `--json` path was never affected — it reads `submitResult` correctly — so agent callers got truthful output; only the human-readable log lied. The fix is two tokens: both logs now print `submitResult.txHash`. ([#639](https://github.com/p-diogo/totalreclaw/issues/639))
+
+  **Why no gate caught it:** the package build runs `tsc --noCheck` (transpile-only) and the package had no typecheck script at all, so nothing ever type-checked `cli/tr-cli.ts`; the existing CLI test asserted only `--json`-mode output shape via static source analysis, leaving human mode with zero coverage. This release adds an ungated `npm run typecheck` (`tsc --noEmit`) as a follow-up handle — the tree still carries ~30 pre-existing type errors unrelated to this fix, so it is deliberately NOT wired into any gate (test runner, CI, prepack) yet — plus static regression assertions in `cli/tr-cli-json-output.test.ts` that both handlers' human-mode success logs report `submitResult.txHash` and contain no unqualified `result.txHash` (verified to fail against the pre-fix source).
+
 # Changelog
 
 All notable changes to `@totalreclaw/totalreclaw` (the OpenClaw plugin) are documented here.

--- a/skill/plugin/SKILL.md
+++ b/skill/plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: totalreclaw
 description: "End-to-end encrypted, decentralized memory for OpenClaw. A native kind:memory provider — recall is automatic via memory_search/memory_get, and facts are captured in the background. Trigger on 'install TotalReclaw', 'set up TotalReclaw', 'restore my recovery phrase', any recall request ('what do you remember about me', 'what's my X'), AND any explicit remember request ('remember X', 'save X')."
-version: 3.4.4
+version: 3.4.5
 author: TotalReclaw Team
 license: MIT
 homepage: https://totalreclaw.xyz

--- a/skill/plugin/cli/tr-cli-json-output.test.ts
+++ b/skill/plugin/cli/tr-cli-json-output.test.ts
@@ -262,6 +262,41 @@ assert(
 );
 
 // ---------------------------------------------------------------------------
+// 9. Human-mode success logs reference the in-scope result variable (#639)
+//    Regression guard: the human-mode (no --json) success logs in
+//    cmdRemember / cmdForget logged `result.txHash` while the variable in
+//    scope is `submitResult` — so a successful on-chain write crashed with
+//    "ReferenceError: result is not defined", which the surrounding catch
+//    surfaced as "remember failed: result is not defined" (same for forget),
+//    inviting a re-run that would double-write. The build is transpile-only
+//    (`tsc --noCheck`) and nothing type-checked this file, so the class was
+//    never compiler-caught. The negative check is anchored with a lookbehind
+//    so the legitimate tail of `submitResult.txHash` is not itself flagged.
+// ---------------------------------------------------------------------------
+
+const bareResultTxHash = /(?<!submit)result\.txHash/;
+
+assert(
+  rememberFn !== null && /tx=\$\{submitResult\.txHash/.test(rememberFn[0]),
+  'tr-cli.ts: cmdRemember human-mode success log reports submitResult.txHash (#639 regression)',
+);
+
+assert(
+  rememberFn !== null && !bareResultTxHash.test(rememberFn[0]),
+  'tr-cli.ts: cmdRemember body has no unqualified result.txHash reference (#639 regression)',
+);
+
+assert(
+  forgetFn !== null && /tx=\$\{submitResult\.txHash/.test(forgetFn[0]),
+  'tr-cli.ts: cmdForget human-mode success log reports submitResult.txHash (#639 regression)',
+);
+
+assert(
+  forgetFn !== null && !bareResultTxHash.test(forgetFn[0]),
+  'tr-cli.ts: cmdForget body has no unqualified result.txHash reference (#639 regression)',
+);
+
+// ---------------------------------------------------------------------------
 
 console.log(`\n# ${passed} passed, ${failed} failed`);
 process.exit(failed === 0 ? 0 : 1);

--- a/skill/plugin/cli/tr-cli.ts
+++ b/skill/plugin/cli/tr-cli.ts
@@ -101,7 +101,7 @@ const STATE_PATH = CONFIG.onboardingStatePath;
 // Auto-synced by skill/scripts/sync-version.mjs from skill/plugin/package.json::version.
 // Do not edit by hand — running tests will catch drift but the publish workflow
 // rewrites this constant at the start of every npm/ClawHub publish.
-const PLUGIN_VERSION = '3.4.4';
+const PLUGIN_VERSION = '3.4.5';
 
 function die(msg: string, code = 1): never {
   process.stderr.write(`tr: ${msg}\n`);
@@ -424,7 +424,7 @@ async function cmdRemember(rawArgs: string[]): Promise<void> {
       // isn't worth the latency.
       log(JSON.stringify({ ok: true, id: factId, claim_count: 1 }));
     } else {
-      log(`ok — stored memory (id=${factId}, tx=${result.txHash || 'pending'})`);
+      log(`ok — stored memory (id=${factId}, tx=${submitResult.txHash || 'pending'})`);
     }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -491,7 +491,7 @@ async function cmdForget(rawArgs: string[]): Promise<void> {
     if (jsonMode) {
       log(JSON.stringify({ ok: true, id: factId, tx_hash: submitResult.txHash }));
     } else {
-      log(`ok — tombstoned ${factId} (tx=${result.txHash || 'pending'})`);
+      log(`ok — tombstoned ${factId} (tx=${submitResult.txHash || 'pending'})`);
     }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/skill/plugin/package-lock.json
+++ b/skill/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@totalreclaw/totalreclaw",
-      "version": "3.4.4",
+      "version": "3.4.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/skill/plugin/package.json
+++ b/skill/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@totalreclaw/totalreclaw",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "description": "End-to-end encrypted, agent-portable memory for OpenClaw and any LLM-agent runtime. XChaCha20-Poly1305 with protobuf v4 + on-chain Memory Taxonomy v1 (claim / preference / directive / commitment / episode / summary).",
   "type": "module",
   "keywords": [
@@ -66,6 +66,7 @@
   ],
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.json --noCheck",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "verify-tarball": "node ../scripts/verify-tarball.mjs",
     "test": "node run-tests.mjs",
     "smoke:dist": "npx tsx dist-esm-smoke.test.ts",

--- a/skill/plugin/skill.json
+++ b/skill/plugin/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "totalreclaw",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "description": "End-to-end encrypted memory for AI agents — portable, yours forever. XChaCha20-Poly1305 E2EE: server never sees plaintext.",
   "author": "TotalReclaw Team",
   "license": "MIT",


### PR DESCRIPTION
Fixes #639.

## Root cause

`tr remember` / `tr forget` in **human (non-JSON) mode** reference an undefined `result` variable in their success-log lines — **after** the on-chain UserOp already succeeded:

- `skill/plugin/cli/tr-cli.ts:427` — `tx=${result.txHash || 'pending'}` in `cmdRemember`
- `skill/plugin/cli/tr-cli.ts:494` — same in `cmdForget`

The build is `tsc --noCheck`, so the dangling reference compiled silently. User-visible effect: the write lands on-chain, the CLI throws `ReferenceError: result is not defined`, the user believes it failed and re-runs — double-writing the memory. This is the same class as the 3.3.13 `tr is not defined` onboarding bug.

(The `result.txHash` at `tr-cli.ts:686` is a *different*, in-scope function — verified untouched.)

## The fix (2 lines)

`result.txHash` → `submitResult.txHash` at both sites. Shipped as **3.4.5**. The routing half of #639 (CLI never fetches billing → falls to the PROD DataEdge default) is a behavior change that rides **3.4.6**, not this patch.

## Regression test

`tr-cli-json-output.test.ts` §9 asserts over the extracted function bodies (the file's established convention — lazy regex to the column-0 closing brace):

- positive: `tx=\${submitResult\.txHash` present in both `cmdRemember` and `cmdForget`
- negative: `/(?<!submit)result\.txHash/` absent in both (lookbehind so `submitResult.txHash` isn't self-flagged)

**Pre-fix failure proven mechanically**: run against the `80a9d78` source, both positive asserts fail AND both negative asserts are violated → the test demonstrably catches the bug.

## Review evidence (orchestrator-verified, 12 checks)

- `npm install && npm test` → **99/99 PASS** (incl. the 4 new asserts)
- Typecheck: base tree (`80a9d78`) = **31** errors, fixed tree = **29** — delta exactly the 2 bug errors; the 29 pre-existing errors are unchanged and deliberately not gated (a `typecheck` script is added ungated for local use — follow-up issue filed separately)
- Scanner scope verified: `check-scanner.mjs` walks code extensions only, `.md` out of scope
- CHANGELOG/SKILL.md/skill.json version sync + full 3.4.5 entry verified accurate
- `package-lock.json` version ripple included (matches the `97e5033` 3.4.4 release-prep convention)
- Staging-relay QA note added to `docs/guides/openclaw-setup.md` (standalone `tr` staging runs need `TOTALRECLAW_DATA_EDGE_ADDRESS`; disjoint hunks from #640, merges in either order)

E2E: 2-line logging fix; the plugin-RC gate (S-PAIR-FRESH, which exercises `tr remember`/`tr export` end-to-end on staging) runs before any stable promote and covers the write path.

## Release plan

RC cut via `npm-publish.yml` after merge (CI-only, npm@11). **Stable promote gated on Pedro.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)