### PR TITLE
docs(changelog): add plugin 3.4.5 section to CHANGELOG-public.md

### DIFF
--- a/CHANGELOG-public.md
+++ b/CHANGELOG-public.md
@@ -2,6 +2,10 @@
 
 > **Note:** This file lists releases promoted to the public registries' stable tags. Active release-candidate work (`@rc` dist-tag on npm, `rcN` on PyPI, etc.) is tracked in the internal release-pipeline tracker, not here.
 
+## @totalreclaw/totalreclaw (OpenClaw plugin) 3.4.5 — patch release (2026-09-06)
+
+- **Fixed: `tr remember` / `tr forget` in human mode reported failure for operations that had already succeeded on-chain** ([#639](https://github.com/p-diogo/totalreclaw/issues/639)). Both human-mode success logs printed an undefined variable — `result.txHash`, where the batch-submit result in scope is named `submitResult` — so once the UserOp had landed, the log line itself threw `ReferenceError: result is not defined` and the surrounding catch reported `remember failed` for a write that was in fact committed on-chain. The invited consequence is the double-store: believing the first attempt failed, a user or agent would run it again. The `--json` path (agent callers) was never affected; only the human-readable log lied. The fix is two tokens. This release also adds static regression assertions covering human-mode output and an ungated `npm run typecheck` handle — the package build runs `tsc --noCheck` (transpile-only), which is exactly why this class shipped.
+
 ## Option E Phase 2 — `derived-bundle-v1` credential bundle (2026-08-16)
 
 One coordinated release train across three packages, published in strict order (core → Python → MCP) because every client consumes the same derivation through WASM or PyO3.


### PR DESCRIPTION
## What

The v3.4.5 stable publish (`npm-publish.yml` run 34064384607, success) shipped its GitHub Release with the **stub notes** — no plugin 3.4.5 section existed in `CHANGELOG-public.md` at the dispatch SHA, because the #639 changelog entry landed only in `skill/plugin/CHANGELOG.md`.

This PR adds the visitor-facing 3.4.5 section, then backfills the release body via `gh release edit v3.4.5 --notes-file` — the same notes-backfill path the workflow itself implements for exactly this case (stable release first created with stub, matching section exists later).

## Verification

- Ran the workflow's exact extraction script (`isPluginHeading` + `hasVersionToken`) against the edited file: section found, extracted cleanly (output shown in session).
- `scripts/check-docs.sh` passes.
- This is the verification #613 asked for at the next plugin stable promote: the #574 mechanism works when a section exists; the operational rule it exposes is **every plugin stable release needs its CHANGELOG-public.md section merged before (or immediately after) dispatching the publish**.

Closes #613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)